### PR TITLE
Guard npm publish behind merged release tags

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -108,9 +108,39 @@ jobs:
           test -f node_modules/graphifyy/src/skills/skill-gemini.toml
           echo "$SKILL_COUNT skill files bundled"
 
+  # Release guard: tags must point to code already merged in the product branch.
+  release-guard:
+    needs: [test, smoke-test]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      RELEASE_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is merged into default branch
+        run: |
+          git fetch origin "${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/${RELEASE_BRANCH}"; then
+            echo "::error::Refusing to publish ${GITHUB_REF_NAME}: ${GITHUB_SHA} is not merged into origin/${RELEASE_BRANCH}."
+            echo "::error::Merge the release PR first, then move/create the release tag on ${RELEASE_BRANCH}."
+            exit 1
+          fi
+
+      - name: Verify package version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match package.json version ${PACKAGE_VERSION}."
+            exit 1
+          fi
+
   # Publish to npm
   publish:
-    needs: [test, smoke-test]
+    needs: release-guard
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:


### PR DESCRIPTION
## Summary
- require release tags to point to commits already merged into the repository default branch before npm publish
- verify tag version matches package.json before publish

## Verification
- ruby YAML parse for .github/workflows/typescript-ci.yml
- git diff --check