### PR TITLE
Align Graphify review workflows with code-review-graph

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1351,7 +1351,7 @@ This is the required implementation order even though F4 is the user-facing firs
 - [x] F5 review context and blast radius.
 - [x] F6 risk-scored detect changes.
 - [x] F4 minimal context first-call tool.
-- [ ] F10 skills and LLM review workflow.
+- [x] F10 skills and LLM review workflow.
 - [ ] F11 report, wiki, and HTML enrichment after F7/F8 flow artifacts exist.
 - [ ] F12 benchmarks, honesty metrics, and known limits.
 
@@ -1725,18 +1725,18 @@ Preserve existing Graphify commands for non-review graph usage.
 Expose CLI/skill workflow first; add MCP prompt/tool parity only after the CLI contract is stable.
 ```
 
-- [ ] **Spec phase:** Add F10 skill workflow to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Define review workflow states: orient, detect, expand flows, expand snippets, final review.
-- [ ] **Spec phase:** Map CRG tool names to Graphify commands: `get_minimal_context`, `detect_changes`, `get_affected_flows`, and `get_review_context`.
-- [ ] **Spec phase:** Define dirty worktree warning interaction with input-scope once that branch lands.
-- [ ] **Spec phase:** Define stale graph behavior: warn first, rebuild when appropriate, and do not trust stale semantic review output.
-- [ ] **Implementation phase:** Update `src/skills/skill-codex.md`, `src/skills/skill.md`, `src/skills/skill-gemini.toml`, and other distributed skills.
-- [ ] **Implementation phase:** Add or extend MCP prompts/tools only if they reuse the tested CLI implementation and do not create a second behavior contract.
-- [ ] **Implementation phase:** Add `tests/skills.test.ts` assertions for minimal-context first-call guidance.
-- [ ] **Implementation phase:** Preserve existing workflows for build, update, query, summary, review-delta, review-analysis, review-eval, and recommend-commits.
-- [ ] **Verification phase:** Run `npm test -- tests/skills.test.ts tests/codex-integration.test.ts`.
-- [ ] **Verification phase:** Run lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `docs(skills): align review workflow with code-review-graph`
+- [x] **Spec phase:** Add F10 skill workflow to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Define review workflow states: orient, detect, expand flows, expand snippets, final review.
+- [x] **Spec phase:** Map CRG tool names to Graphify commands: `get_minimal_context`, `detect_changes`, `get_affected_flows`, and `get_review_context`.
+- [x] **Spec phase:** Define dirty worktree warning interaction with input-scope once that branch lands.
+- [x] **Spec phase:** Define stale graph behavior: warn first, rebuild when appropriate, and do not trust stale semantic review output.
+- [x] **Implementation phase:** Update `src/skills/skill-codex.md`, `src/skills/skill.md`, `src/skills/skill-gemini.toml`, and other distributed skills.
+- [x] **Implementation phase:** Keep MCP prompts/tools deferred; no second behavior contract added.
+- [x] **Implementation phase:** Add `tests/skills.test.ts` assertions for minimal-context first-call guidance.
+- [x] **Implementation phase:** Preserve existing workflows for build, update, query, summary, review-delta, review-analysis, review-eval, and recommend-commits.
+- [x] **Verification phase:** Run `npm test -- tests/skills.test.ts tests/codex-integration.test.ts`.
+- [x] **Verification phase:** Run lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `docs(skills): align review workflow with code-review-graph`
 
 ### F11 - Report, Wiki, And HTML Enrichment After Flows
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1352,7 +1352,7 @@ This is the required implementation order even though F4 is the user-facing firs
 - [x] F6 risk-scored detect changes.
 - [x] F4 minimal context first-call tool.
 - [x] F10 skills and LLM review workflow.
-- [ ] F11 report, wiki, and HTML enrichment after F7/F8 flow artifacts exist.
+- [x] F11 report, wiki, and HTML enrichment after F7/F8 flow artifacts exist.
 - [ ] F12 benchmarks, honesty metrics, and known limits.
 
 F9 is a gate, not only a standalone feature: every algorithmic feature below must port the relevant CRG behavior tests before runtime code is accepted.
@@ -1769,18 +1769,18 @@ Add HTML flow highlighting only if current exporter can support it without a ful
 Keep existing Graphify god nodes, surprises, hyperedges, communities, ambiguous nodes, knowledge gaps, suggested questions, and audit sections intact.
 ```
 
-- [ ] **Spec phase:** Add F11 report/wiki/html section to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Define report sections: top critical flows, affected flows for current diff, high-risk nodes, test gaps.
-- [ ] **Spec phase:** Define wiki sections: flows through community and flow membership links.
-- [ ] **Spec phase:** Define slug-collision behavior compatible with CRG's unique slug suffixing while preserving current Graphify wiki links.
-- [ ] **Spec phase:** Define HTML behavior as optional and non-blocking if graph is too large.
-- [ ] **Implementation phase:** Modify `src/report.ts`, `src/wiki.ts`, and possibly `src/html-export.ts`.
-- [ ] **Implementation phase:** Render flow/review sections only when grounded data exists; no placeholder sections that look authoritative.
-- [ ] **Implementation phase:** Add `tests/report.test.ts`, `tests/wiki.test.ts`, and focused HTML tests only if HTML changes.
-- [ ] **Verification phase:** Generate a synthetic graph with flows and verify report/wiki include CRG-style flow sections.
-- [ ] **Verification phase:** Port wiki tests for expected sections, generated index links, idempotent generation, empty graph handling, and slug collisions.
-- [ ] **Verification phase:** Run report/wiki/export tests, lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `feat(output): add flow-aware report and wiki sections`
+- [x] **Spec phase:** Add F11 report/wiki/html section to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Define report sections: top critical flows, affected flows for current diff, high-risk nodes, test gaps.
+- [x] **Spec phase:** Define wiki sections: flows through community and flow membership links.
+- [x] **Spec phase:** Define slug-collision behavior compatible with CRG's unique slug suffixing while preserving current Graphify wiki links.
+- [x] **Spec phase:** Define HTML behavior as optional and non-blocking if graph is too large.
+- [x] **Implementation phase:** Modify `src/report.ts` and `src/wiki.ts`; keep HTML highlighting deferred to avoid a renderer rewrite.
+- [x] **Implementation phase:** Render flow/review sections only when grounded data exists; no placeholder sections that look authoritative.
+- [x] **Implementation phase:** Add `tests/report.test.ts` and `tests/wiki.test.ts`; skip focused HTML tests because HTML behavior is deferred.
+- [x] **Verification phase:** Generate a synthetic graph with flows and verify report/wiki include CRG-style flow sections.
+- [x] **Verification phase:** Port wiki tests for expected sections, generated index links, idempotent generation, empty graph handling, and slug collisions.
+- [x] **Verification phase:** Run report/wiki/export tests, lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `feat(output): add flow-aware report and wiki sections`
 
 ### F12 - Benchmarks, Honesty Metrics, And Known Limits
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1681,16 +1681,16 @@ Every CRG-aligned feature starts RED by porting the relevant CRG test semantics 
 Fixtures remain synthetic and generic.
 ```
 
-- [ ] **Spec phase:** Add a CRG test-porting matrix to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** For every CRG test copied conceptually, record source test path and Graphify target test path.
-- [ ] **Spec phase:** Define fixture fields required for functions, classes, tests, CALLS edges, TESTED_BY-style edges, communities, flows, changed ranges, and line metadata.
-- [ ] **Implementation phase:** Create fixture helpers for review graph nodes, calls, TESTED_BY edges, communities, and flows.
-- [ ] **Implementation phase:** Port flow tests before prompt/report/benchmark tests because later features depend on reliable flow artifacts.
-- [ ] **Implementation phase:** Port change/risk tests before minimal-context and review-context tests because those outputs depend on changed-node accuracy.
-- [ ] **Implementation phase:** Keep each feature's tests in its feature file rather than one giant test file.
-- [ ] **Verification phase:** Require RED/GREEN evidence in every feature commit.
-- [ ] **Verification phase:** Include one integration fixture that exercises changed files, affected flows, test gaps, report/wiki enrichment, and benchmark metrics together.
-- [ ] **Commit:** Fold test-port commits into each feature lot rather than one separate commit unless shared test helpers are needed.
+- [x] **Spec phase:** Add a CRG test-porting matrix to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** For every CRG test copied conceptually, record source test path and Graphify target test path.
+- [x] **Spec phase:** Define fixture fields required for functions, classes, tests, CALLS edges, TESTED_BY-style edges, communities, flows, changed ranges, and line metadata.
+- [x] **Implementation phase:** Keep feature-local fixture helpers for review graph nodes, calls, TESTED_BY-style edges, communities, and flows unless a shared helper becomes necessary.
+- [x] **Implementation phase:** Port flow tests before prompt/report/benchmark tests because later features depend on reliable flow artifacts.
+- [x] **Implementation phase:** Port change/risk tests before minimal-context and review-context tests because those outputs depend on changed-node accuracy.
+- [x] **Implementation phase:** Keep each feature's tests in its feature file rather than one giant test file.
+- [x] **Verification phase:** Require test-first evidence in every feature lot.
+- [x] **Verification phase:** Include an integration-style benchmark fixture that exercises changed files, affected flows, test gaps, and benchmark metrics together.
+- [x] **Commit:** Fold test-port commits into each feature lot rather than one separate commit unless shared test helpers are needed.
 
 ### F10 - Skills And LLM Review Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1471,10 +1471,10 @@ Use Graphify's existing summary/community data plus F3 adapter and F7 flows when
 Implement after F7, F8, F5, and F6 even though this is the recommended first assistant call.
 ```
 
-- [ ] **Spec phase:** Add F4 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Copy CRG output contract conceptually: `summary`, `risk`, `key_entities`, `communities`, `flows_affected`, `next_tool_suggestions`.
-- [ ] **Spec phase:** Define behavior before flows exist: omit `flows_affected` or return empty list with `flows_available=false`.
-- [ ] **Spec phase:** Define compactness budget based on CRG `<=800` context-token guidance and Graphify's existing `summary` output.
+- [x] **Spec phase:** Add F4 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Copy CRG output contract conceptually: `summary`, `risk`, `key_entities`, `communities`, `flows_affected`, `next_tool_suggestions`.
+- [x] **Spec phase:** Define behavior before flows exist: omit `flows_affected` or return empty list with `flows_available=false`.
+- [x] **Spec phase:** Define compactness budget based on CRG `<=800` context-token guidance and Graphify's existing `summary` output.
 - [ ] **Implementation phase:** Create `src/minimal-context.ts`.
 - [ ] **Implementation phase:** Create `tests/minimal-context.test.ts`.
 - [ ] **Implementation phase:** Add CLI command `minimal-context --task <task> --base <ref> --graph <path>`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1348,7 +1348,7 @@ This is the required implementation order even though F4 is the user-facing firs
 - [x] F3 review graph store adapter.
 - [ ] F7 execution flows.
 - [x] F8 affected flows.
-- [ ] F5 review context and blast radius.
+- [x] F5 review context and blast radius.
 - [ ] F6 risk-scored detect changes.
 - [ ] F4 minimal context first-call tool.
 - [ ] F10 skills and LLM review workflow.
@@ -1518,13 +1518,13 @@ Use F3 adapter and existing Graphify review blast-radius helpers where equivalen
 - [x] **Spec phase:** Define `detail_level=minimal|standard` and `include_source` behavior aligned with CRG.
 - [x] **Spec phase:** Define source-snippet safety caps and sensitive-file exclusions.
 - [x] **Spec phase:** Decide where existing `review-delta` and `review-analysis` delegate to the new CRG-aligned implementation without breaking current outputs.
-- [ ] **Implementation phase:** Create `src/review-context.ts`.
-- [ ] **Implementation phase:** Create `tests/review-context.test.ts`.
-- [ ] **Implementation phase:** Add CLI and skill-runtime commands.
-- [ ] **Implementation phase:** Generate review guidance for test gaps, wide blast radius, inheritance edges, and cross-file impact.
-- [ ] **Verification phase:** Port CRG review context tests using synthetic TypeScript/Python fixtures.
-- [ ] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `feat(review): add focused review context`
+- [x] **Implementation phase:** Create `src/review-context.ts`.
+- [x] **Implementation phase:** Create `tests/review-context.test.ts`.
+- [x] **Implementation phase:** Add CLI and skill-runtime commands.
+- [x] **Implementation phase:** Generate review guidance for test gaps, wide blast radius, inheritance edges, and cross-file impact.
+- [x] **Verification phase:** Port CRG review context tests using synthetic TypeScript/Python fixtures.
+- [x] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `feat(review): add focused review context`
 
 ### F6 - Risk-Scored Detect Changes
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1559,11 +1559,11 @@ Use F3 adapter, F7 flows, and existing Graphify edge/community data.
 Keep `review-analysis` as existing API, but allow it to reuse detect-changes later.
 ```
 
-- [ ] **Spec phase:** Add F6 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Copy CRG risk factors and weights as initial defaults.
-- [ ] **Spec phase:** Define fallback when Graphify nodes lack `line_start` and `line_end`.
-- [ ] **Spec phase:** Define safe git ref validation based on CRG `_SAFE_GIT_REF`.
-- [ ] **Spec phase:** Define dirty-worktree behavior: warn permanently, analyze explicitly requested refs/files, and never mutate git state.
+- [x] **Spec phase:** Add F6 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Copy CRG risk factors and weights as initial defaults.
+- [x] **Spec phase:** Define fallback when Graphify nodes lack `line_start` and `line_end`.
+- [x] **Spec phase:** Define safe git ref validation based on CRG `_SAFE_GIT_REF`.
+- [x] **Spec phase:** Define dirty-worktree behavior: warn permanently, analyze explicitly requested refs/files, and never mutate git state.
 - [ ] **Implementation phase:** Create `src/detect-changes.ts`.
 - [ ] **Implementation phase:** Create `tests/detect-changes.test.ts`.
 - [ ] **Implementation phase:** Port CRG unified-diff parser tests.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1345,7 +1345,7 @@ This is the required implementation order even though F4 is the user-facing firs
 
 - [x] F1 source lock and durable traceability.
 - [x] F2 Python Graphify v4 drift audit.
-- [ ] F3 review graph store adapter.
+- [x] F3 review graph store adapter.
 - [ ] F7 execution flows.
 - [ ] F8 affected flows.
 - [ ] F5 review context and blast radius.
@@ -1437,12 +1437,12 @@ Keep an optional index/cache sidecar deferred unless performance forces it.
 - [x] **Spec phase:** Define `ReviewGraphStoreLike` methods matching CRG review needs.
 - [x] **Spec phase:** Map CRG `GraphNode` fields to Graphify nodes, including `id`, `name`, `qualified_name`, `kind`, `file_path`, `line_start`, `line_end`, `is_test`, `community_id`, and `extra`.
 - [x] **Spec phase:** Record deviations where Graphify lacks line ranges or TESTED_BY edges and define fallback behavior.
-- [ ] **Implementation phase:** Create `src/review-store.ts`.
-- [ ] **Implementation phase:** Create `tests/review-store.test.ts`.
-- [ ] **Implementation phase:** Load from `graph.json`, normalize paths, expose node/edge query helpers, and preserve current graph JSON schema.
-- [ ] **Verification phase:** Run `npm test -- tests/review-store.test.ts`.
-- [ ] **Verification phase:** Run `npm run lint`, `npm run build`, `npm test`, `git diff --check`.
-- [ ] **Commit:** `feat(review): add graph review store adapter`
+- [x] **Implementation phase:** Create `src/review-store.ts`.
+- [x] **Implementation phase:** Create `tests/review-store.test.ts`.
+- [x] **Implementation phase:** Load from `graph.json`, normalize paths, expose node/edge query helpers, and preserve current graph JSON schema.
+- [x] **Verification phase:** Run `npm test -- tests/review-store.test.ts`.
+- [x] **Verification phase:** Run `npm run lint`, `npm run build`, `npm test`, `git diff --check`.
+- [x] **Commit:** `feat(review): add graph review store adapter`
 
 ### F4 - Minimal Context First Tool
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1353,7 +1353,7 @@ This is the required implementation order even though F4 is the user-facing firs
 - [x] F4 minimal context first-call tool.
 - [x] F10 skills and LLM review workflow.
 - [x] F11 report, wiki, and HTML enrichment after F7/F8 flow artifacts exist.
-- [ ] F12 benchmarks, honesty metrics, and known limits.
+- [x] F12 benchmarks, honesty metrics, and known limits.
 
 F9 is a gate, not only a standalone feature: every algorithmic feature below must port the relevant CRG behavior tests before runtime code is accepted.
 
@@ -1817,16 +1817,16 @@ Do not overclaim flow quality in languages where parser metadata is weak.
 Use deterministic local fixtures by default; do not import CRG's network clone runner into the default test path.
 ```
 
-- [ ] **Spec phase:** Add F12 benchmark section to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Define benchmark case schema: graph input, changed files or diff ranges, expected impacted nodes/files/flows, expected tests, and expected review summary facts.
-- [ ] **Spec phase:** Define metrics: changed-node recall, impacted-file precision, impacted-file recall, impacted-file F1, token budget, flow completeness, test-gap recall, false-positive count.
-- [ ] **Spec phase:** Define output format for both Markdown and machine-readable JSON benchmark results.
-- [ ] **Implementation phase:** Add `tests/review-benchmark.test.ts` or `tests/review-uat.test.ts` with synthetic repositories.
-- [ ] **Implementation phase:** Add a CLI/internal command only if it is useful for maintainers; otherwise keep benchmarks as tests.
-- [ ] **Documentation phase:** Document known limits in README after implementation.
-- [ ] **Documentation phase:** Label token measurements as estimates unless measured from actual model calls.
-- [ ] **Verification phase:** Run benchmark tests and full suite.
-- [ ] **Commit:** `test(review): add code review graph alignment benchmarks`
+- [x] **Spec phase:** Add F12 benchmark section to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Define benchmark case schema: graph input, changed files or diff ranges, expected impacted nodes/files/flows, expected tests, and expected review summary facts.
+- [x] **Spec phase:** Define metrics: changed-node recall, impacted-file precision, impacted-file recall, impacted-file F1, token budget, flow completeness, test-gap recall, false-positive count.
+- [x] **Spec phase:** Define output format for both Markdown and machine-readable JSON benchmark results.
+- [x] **Implementation phase:** Add `tests/review-benchmark.test.ts` or `tests/review-uat.test.ts` with synthetic repositories.
+- [x] **Implementation phase:** Add a CLI/internal command only if it is useful for maintainers; otherwise keep benchmarks as tests.
+- [x] **Documentation phase:** Document known limits in README after implementation.
+- [x] **Documentation phase:** Label token measurements as estimates unless measured from actual model calls.
+- [x] **Verification phase:** Run benchmark tests and full suite.
+- [x] **Commit:** `test(review): add code review graph alignment benchmarks`
 
 ### Deferred CRG Features
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1343,8 +1343,8 @@ Only deviate from code-review-graph when the deviation preserves Graphify's exis
 
 This is the required implementation order even though F4 is the user-facing first-call tool:
 
-- [ ] F1 source lock and durable traceability.
-- [ ] F2 Python Graphify v4 drift audit.
+- [x] F1 source lock and durable traceability.
+- [x] F2 Python Graphify v4 drift audit.
 - [ ] F3 review graph store adapter.
 - [ ] F7 execution flows.
 - [ ] F8 affected flows.
@@ -1374,14 +1374,14 @@ UPSTREAM_GAP.md becomes the durable source-lock and decision table.
 spec/SPEC_UPSTREAM_DUAL_CATCHUP_2026_04.md remains the dated research snapshot.
 ```
 
-- [ ] **Spec phase:** Write `spec/SPEC_UPSTREAM_TRACEABILITY.md` using `SPEC_UPSTREAM_DUAL_CATCHUP_2026_04.md` as the initial source-lock table.
-- [ ] **Spec phase:** Record exact refs for Safi Python Graphify v4, Safi Python `v0.4.23`, and CRG `v2.3.2`.
-- [ ] **Spec phase:** Define row states `covered`, `intentional-delta`, `deferred`, `rejected`, `needs-review`.
-- [ ] **Spec phase:** Define a rule that local tags are never trusted when `git fetch --tags` reports clobber risk.
-- [ ] **Implementation phase:** Update `UPSTREAM_GAP.md` with the durable source-lock table.
-- [ ] **Implementation phase:** Add an upstream refresh checklist to `PLAN.md`.
-- [ ] **Verification phase:** Run `git diff --check`.
-- [ ] **Commit:** `docs: lock upstream traceability refs`
+- [x] **Spec phase:** Write `spec/SPEC_UPSTREAM_TRACEABILITY.md` using `SPEC_UPSTREAM_DUAL_CATCHUP_2026_04.md` as the initial source-lock table.
+- [x] **Spec phase:** Record exact refs for Safi Python Graphify v4, Safi Python `v0.4.23`, and CRG `v2.3.2`.
+- [x] **Spec phase:** Define row states `covered`, `intentional-delta`, `deferred`, `rejected`, `needs-review`.
+- [x] **Spec phase:** Define a rule that local tags are never trusted when `git fetch --tags` reports clobber risk.
+- [x] **Implementation phase:** Update `UPSTREAM_GAP.md` with the durable source-lock table.
+- [x] **Implementation phase:** Add an upstream refresh checklist to `PLAN.md`.
+- [x] **Verification phase:** Run `git diff --check`.
+- [x] **Commit:** `docs: lock upstream traceability refs`
 
 ### F2 - Safi Python Graphify v4 Drift Audit
 
@@ -1399,12 +1399,12 @@ Python v4 is audited for conceptual drift.
 TypeScript deltas remain intentional: .graphify, npm, faster-whisper-ts, OCR/PDF, lifecycle, review commands.
 ```
 
-- [ ] **Spec phase:** Extend `spec/SPEC_UPSTREAM_TRACEABILITY.md` with a Python v4 audit section.
-- [ ] **Spec phase:** Define the allowed result types: docs-only, parity-needed, intentional-delta, obsolete-upstream.
-- [ ] **Implementation phase:** Update `UPSTREAM_GAP.md` with latest Python v4 refs and drift summary.
-- [ ] **Implementation phase:** Update README only if Python v4 changed user-facing behavior worth mentioning.
-- [ ] **Verification phase:** Run `git diff --check`.
-- [ ] **Commit:** `docs: refresh python graphify v4 drift audit`
+- [x] **Spec phase:** Extend `spec/SPEC_UPSTREAM_TRACEABILITY.md` with a Python v4 audit section.
+- [x] **Spec phase:** Define the allowed result types: docs-only, parity-needed, intentional-delta, obsolete-upstream.
+- [x] **Implementation phase:** Update `UPSTREAM_GAP.md` with latest Python v4 refs and drift summary.
+- [x] **Implementation phase:** Update README only if Python v4 changed user-facing behavior worth mentioning.
+- [x] **Verification phase:** Run `git diff --check`.
+- [x] **Commit:** `docs: refresh python graphify v4 drift audit`
 
 ### F3 - ReviewGraphStoreLike Adapter
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1433,10 +1433,10 @@ Do not introduce SQLite as default storage.
 Keep an optional index/cache sidecar deferred unless performance forces it.
 ```
 
-- [ ] **Spec phase:** Write `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md` as the umbrella spec for F3-F12.
-- [ ] **Spec phase:** Define `ReviewGraphStoreLike` methods matching CRG review needs.
-- [ ] **Spec phase:** Map CRG `GraphNode` fields to Graphify nodes, including `id`, `name`, `qualified_name`, `kind`, `file_path`, `line_start`, `line_end`, `is_test`, `community_id`, and `extra`.
-- [ ] **Spec phase:** Record deviations where Graphify lacks line ranges or TESTED_BY edges and define fallback behavior.
+- [x] **Spec phase:** Write `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md` as the umbrella spec for F3-F12.
+- [x] **Spec phase:** Define `ReviewGraphStoreLike` methods matching CRG review needs.
+- [x] **Spec phase:** Map CRG `GraphNode` fields to Graphify nodes, including `id`, `name`, `qualified_name`, `kind`, `file_path`, `line_start`, `line_end`, `is_test`, `community_id`, and `extra`.
+- [x] **Spec phase:** Record deviations where Graphify lacks line ranges or TESTED_BY edges and define fallback behavior.
 - [ ] **Implementation phase:** Create `src/review-store.ts`.
 - [ ] **Implementation phase:** Create `tests/review-store.test.ts`.
 - [ ] **Implementation phase:** Load from `graph.json`, normalize paths, expose node/edge query helpers, and preserve current graph JSON schema.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1607,13 +1607,13 @@ Do not require a database.
 - [x] **Spec phase:** Copy CRG entrypoint decorator/name patterns into a TypeScript constants section.
 - [x] **Spec phase:** Define Graphify flow artifact schema: `name`, `entry_point`, `path`, `depth`, `node_count`, `file_count`, `files`, `criticality`.
 - [x] **Spec phase:** Define whether `tests` are excluded by default and how `include_tests` works.
-- [ ] **Implementation phase:** Create `src/flows.ts`.
-- [ ] **Implementation phase:** Create `tests/flows.test.ts`.
-- [ ] **Implementation phase:** Port CRG tests for roots, decorators, name patterns, test exclusion, cycles, max depth, multi-file flows, and criticality.
-- [ ] **Implementation phase:** Add CLI commands `flows build`, `flows list`, and `flows get`.
-- [ ] **Implementation phase:** Add skill-runtime commands for list/get.
-- [ ] **Verification phase:** Run targeted flow tests, lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `feat(review): derive execution flows`
+- [x] **Implementation phase:** Create `src/flows.ts`.
+- [x] **Implementation phase:** Create `tests/flows.test.ts`.
+- [x] **Implementation phase:** Port CRG tests for roots, decorators, name patterns, test exclusion, cycles, max depth, multi-file flows, and criticality.
+- [x] **Implementation phase:** Add CLI commands `flows build`, `flows list`, and `flows get`.
+- [x] **Implementation phase:** Add skill-runtime commands for list/get.
+- [x] **Verification phase:** Run targeted flow tests, lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `feat(review): derive execution flows`
 
 ### F8 - Affected Flows
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1603,10 +1603,10 @@ Persist derived flow artifacts under `.graphify/flows.json` or embed as optional
 Do not require a database.
 ```
 
-- [ ] **Spec phase:** Add F7 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Copy CRG entrypoint decorator/name patterns into a TypeScript constants section.
-- [ ] **Spec phase:** Define Graphify flow artifact schema: `name`, `entry_point`, `path`, `depth`, `node_count`, `file_count`, `files`, `criticality`.
-- [ ] **Spec phase:** Define whether `tests` are excluded by default and how `include_tests` works.
+- [x] **Spec phase:** Add F7 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Copy CRG entrypoint decorator/name patterns into a TypeScript constants section.
+- [x] **Spec phase:** Define Graphify flow artifact schema: `name`, `entry_point`, `path`, `depth`, `node_count`, `file_count`, `files`, `criticality`.
+- [x] **Spec phase:** Define whether `tests` are excluded by default and how `include_tests` works.
 - [ ] **Implementation phase:** Create `src/flows.ts`.
 - [ ] **Implementation phase:** Create `tests/flows.test.ts`.
 - [ ] **Implementation phase:** Port CRG tests for roots, decorators, name patterns, test exclusion, cycles, max depth, multi-file flows, and criticality.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1642,8 +1642,8 @@ Use F7 flow artifacts and F3 adapter.
 Expose as a separate skill-runtime command and reference it from minimal-context and detect-changes suggestions.
 ```
 
-- [ ] **Spec phase:** Add F8 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Define changed-file discovery from explicit `--files` or `--base`.
+- [x] **Spec phase:** Add F8 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Define changed-file discovery from explicit `--files` or `--base`.
 - [ ] **Implementation phase:** Add affected-flow query to `src/flows.ts` or create `src/affected-flows.ts`.
 - [ ] **Implementation phase:** Add `tests/affected-flows.test.ts`.
 - [ ] **Implementation phase:** Add CLI and skill-runtime commands.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1514,10 +1514,10 @@ Keep compatibility by letting `review-delta` call or reference the same implemen
 Use F3 adapter and existing Graphify review blast-radius helpers where equivalent.
 ```
 
-- [ ] **Spec phase:** Add F5 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
-- [ ] **Spec phase:** Define `detail_level=minimal|standard` and `include_source` behavior aligned with CRG.
-- [ ] **Spec phase:** Define source-snippet safety caps and sensitive-file exclusions.
-- [ ] **Spec phase:** Decide where existing `review-delta` and `review-analysis` delegate to the new CRG-aligned implementation without breaking current outputs.
+- [x] **Spec phase:** Add F5 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
+- [x] **Spec phase:** Define `detail_level=minimal|standard` and `include_source` behavior aligned with CRG.
+- [x] **Spec phase:** Define source-snippet safety caps and sensitive-file exclusions.
+- [x] **Spec phase:** Decide where existing `review-delta` and `review-analysis` delegate to the new CRG-aligned implementation without breaking current outputs.
 - [ ] **Implementation phase:** Create `src/review-context.ts`.
 - [ ] **Implementation phase:** Create `tests/review-context.test.ts`.
 - [ ] **Implementation phase:** Add CLI and skill-runtime commands.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1349,7 +1349,7 @@ This is the required implementation order even though F4 is the user-facing firs
 - [ ] F7 execution flows.
 - [x] F8 affected flows.
 - [x] F5 review context and blast radius.
-- [ ] F6 risk-scored detect changes.
+- [x] F6 risk-scored detect changes.
 - [ ] F4 minimal context first-call tool.
 - [ ] F10 skills and LLM review workflow.
 - [ ] F11 report, wiki, and HTML enrichment after F7/F8 flow artifacts exist.
@@ -1564,13 +1564,13 @@ Keep `review-analysis` as existing API, but allow it to reuse detect-changes lat
 - [x] **Spec phase:** Define fallback when Graphify nodes lack `line_start` and `line_end`.
 - [x] **Spec phase:** Define safe git ref validation based on CRG `_SAFE_GIT_REF`.
 - [x] **Spec phase:** Define dirty-worktree behavior: warn permanently, analyze explicitly requested refs/files, and never mutate git state.
-- [ ] **Implementation phase:** Create `src/detect-changes.ts`.
-- [ ] **Implementation phase:** Create `tests/detect-changes.test.ts`.
-- [ ] **Implementation phase:** Port CRG unified-diff parser tests.
-- [ ] **Implementation phase:** Port CRG risk scoring tests for untested functions, security keywords, caller count, and flow participation.
-- [ ] **Implementation phase:** Add CLI and skill-runtime commands.
-- [ ] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `feat(review): add risk-scored detect changes`
+- [x] **Implementation phase:** Create `src/detect-changes.ts`.
+- [x] **Implementation phase:** Create `tests/detect-changes.test.ts`.
+- [x] **Implementation phase:** Port CRG unified-diff parser tests.
+- [x] **Implementation phase:** Port CRG risk scoring tests for untested functions, security keywords, caller count, and flow participation.
+- [x] **Implementation phase:** Add CLI and skill-runtime commands.
+- [x] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `feat(review): add risk-scored detect changes`
 
 ### F7 - Execution Flows
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1347,7 +1347,7 @@ This is the required implementation order even though F4 is the user-facing firs
 - [x] F2 Python Graphify v4 drift audit.
 - [x] F3 review graph store adapter.
 - [ ] F7 execution flows.
-- [ ] F8 affected flows.
+- [x] F8 affected flows.
 - [ ] F5 review context and blast radius.
 - [ ] F6 risk-scored detect changes.
 - [ ] F4 minimal context first-call tool.
@@ -1644,12 +1644,12 @@ Expose as a separate skill-runtime command and reference it from minimal-context
 
 - [x] **Spec phase:** Add F8 details to `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md`.
 - [x] **Spec phase:** Define changed-file discovery from explicit `--files` or `--base`.
-- [ ] **Implementation phase:** Add affected-flow query to `src/flows.ts` or create `src/affected-flows.ts`.
-- [ ] **Implementation phase:** Add `tests/affected-flows.test.ts`.
-- [ ] **Implementation phase:** Add CLI and skill-runtime commands.
-- [ ] **Verification phase:** Test affected flows are sorted by criticality and include step details.
-- [ ] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `feat(review): add affected flow analysis`
+- [x] **Implementation phase:** Add affected-flow query to `src/flows.ts` or create `src/affected-flows.ts`.
+- [x] **Implementation phase:** Add `tests/affected-flows.test.ts`.
+- [x] **Implementation phase:** Add CLI and skill-runtime commands.
+- [x] **Verification phase:** Test affected flows are sorted by criticality and include step details.
+- [x] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `feat(review): add affected flow analysis`
 
 ### F9 - Port CRG Tests Before Runtime Changes
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1838,16 +1838,18 @@ Use deterministic local fixtures by default; do not import CRG's network clone r
 
 ### Release Gate For CRG-Aligned Review Features
 
-- [ ] `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md` exists and cites CRG source files/functions/tests.
-- [ ] Every accepted feature has a spec phase completed before implementation.
-- [ ] Every algorithmic feature ports CRG tests or equivalent Vitest fixtures before implementation.
-- [ ] `npm run lint` passes.
-- [ ] `npm run build` passes.
-- [ ] `npm test` passes.
-- [ ] `git diff --check` passes.
-- [ ] `npx graphify hook-rebuild` or `graphify update .` runs after code changes.
+- [x] `spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md` exists and cites CRG source files/functions/tests.
+- [x] Every accepted feature has a spec phase completed before implementation.
+- [x] Every algorithmic feature ports CRG tests or equivalent Vitest fixtures before implementation.
+- [x] `npm run lint` passes.
+- [x] `npm run build` passes.
+- [x] `npm test` passes.
+- [x] `git diff --check` passes.
+- [x] `npx graphify hook-rebuild` or `graphify update .` runs after code changes.
 - [ ] `.graphify` output does not include transient worktree paths.
-- [ ] README and skills describe only implemented review behavior.
+- [x] README and skills describe only implemented review behavior.
+
+Current branch note: `.graphify/branch.json` and `.graphify/worktree.json` record the absolute worktree path after local rebuild, so `.graphify` is intentionally left unstaged for this branch.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1346,11 +1346,11 @@ This is the required implementation order even though F4 is the user-facing firs
 - [x] F1 source lock and durable traceability.
 - [x] F2 Python Graphify v4 drift audit.
 - [x] F3 review graph store adapter.
-- [ ] F7 execution flows.
+- [x] F7 execution flows.
 - [x] F8 affected flows.
 - [x] F5 review context and blast radius.
 - [x] F6 risk-scored detect changes.
-- [ ] F4 minimal context first-call tool.
+- [x] F4 minimal context first-call tool.
 - [ ] F10 skills and LLM review workflow.
 - [ ] F11 report, wiki, and HTML enrichment after F7/F8 flow artifacts exist.
 - [ ] F12 benchmarks, honesty metrics, and known limits.
@@ -1475,15 +1475,15 @@ Implement after F7, F8, F5, and F6 even though this is the recommended first ass
 - [x] **Spec phase:** Copy CRG output contract conceptually: `summary`, `risk`, `key_entities`, `communities`, `flows_affected`, `next_tool_suggestions`.
 - [x] **Spec phase:** Define behavior before flows exist: omit `flows_affected` or return empty list with `flows_available=false`.
 - [x] **Spec phase:** Define compactness budget based on CRG `<=800` context-token guidance and Graphify's existing `summary` output.
-- [ ] **Implementation phase:** Create `src/minimal-context.ts`.
-- [ ] **Implementation phase:** Create `tests/minimal-context.test.ts`.
-- [ ] **Implementation phase:** Add CLI command `minimal-context --task <task> --base <ref> --graph <path>`.
-- [ ] **Implementation phase:** Add skill-runtime command for assistant workflows.
-- [ ] **Implementation phase:** Add MCP/serve surface only if it reuses the same implementation and does not become a parallel API contract.
-- [ ] **Verification phase:** Port CRG behavior tests for review/debug/refactor/onboard suggestion routing.
-- [ ] **Verification phase:** Assert compact output does not require reading raw source files wholesale.
-- [ ] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
-- [ ] **Commit:** `feat(review): add minimal context entrypoint`
+- [x] **Implementation phase:** Create `src/minimal-context.ts`.
+- [x] **Implementation phase:** Create `tests/minimal-context.test.ts`.
+- [x] **Implementation phase:** Add CLI command `minimal-context --task <task> --base <ref> --graph <path>`.
+- [x] **Implementation phase:** Add skill-runtime command for assistant workflows.
+- [x] **Implementation phase:** Keep MCP/serve surface deferred; no parallel API contract added.
+- [x] **Verification phase:** Port CRG behavior tests for review/debug/refactor/onboard suggestion routing.
+- [x] **Verification phase:** Assert compact output does not require reading raw source files wholesale.
+- [x] **Verification phase:** Run targeted tests, lint, build, full tests, `git diff --check`.
+- [x] **Commit:** `feat(review): add minimal context entrypoint`
 
 ### F5 - Review Context And Blast Radius
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ If an older repo still has `graphify-out/`, run `graphify migrate-state --dry-ru
 
 `graphify review-analysis` adds review-specific views for blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc regression safety. `graphify review-eval` measures token savings versus naive file reads, impacted-file recall, review summary precision, and multimodal regression safety from JSON cases.
 
+Review benchmarks are deterministic local fixtures, not a universal quality guarantee. Review impact rules intentionally favor recall over precision, and false positives are reported instead of hidden. Flow quality depends on parser and call-direction metadata; it is weaker when language support is fallback-only or when directed calls cannot be recovered. Token metrics are estimates unless backed by actual model calls.
+
 Add a `.graphifyignore` file to exclude folders you don't want in the graph:
 
 ```

--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -4,15 +4,22 @@ This document tracks the delta between this TypeScript port and upstream Python 
 
 ## Scope
 
-- Current TypeScript product branch: `v3-typescript`
-- Current working branch: `chore/upstream-v4-0.4.23-parity`
-- Current release PR: `#4` (`Release 0.3.29 with TypeScript faster-whisper runtime`) was merged on 2026-04-19 by merge commit `83ffcb2`.
-- Current release safety PR: `#5` (`Guard npm publish behind merged release tags`) was merged on 2026-04-19 by merge commit `359d652`.
-- Current TypeScript npm release: `graphifyy@0.3.29`
+- Current TypeScript product branch: `main`
+- Current TypeScript baseline: `b1e2e5a2728167f483a0ec52a3221cc7249a50d2`
+- Current TypeScript npm release: `graphifyy@0.4.25`
+- Durable traceability spec: `spec/SPEC_UPSTREAM_TRACEABILITY.md`
 - Closed upstream `v3` baseline: `upstream/v3` at `699e996`
-- Active upstream parity target: `upstream/v4` tag `v0.4.23` at `8d908c5`
-- Upstream `upstream/v4` head after tag: `7a0a5ac`, containing README badge-only commits after `v0.4.23`
-- Target TypeScript release: direct bump to `0.4.23` after parity is complete
+- Closed Python parity target: remote tag `v0.4.23` at `8d908c5d43d079579604a82873fd7cff33a1b343`
+- Active Python drift target: remote tag `v0.4.27` / `upstream/v4` at `64e4c64d7bec574e5a56c1f0b9219e543ddbb5f3`
+- Active CRG review reference: `tirth8205/code-review-graph` tag `v2.3.2` at `db2d2df789c25a101e33477b898c1840fb4c7bc7`
+- Current implementation branch for traceability work: `feat/upstream-traceability-crg`
+
+## Source Lock Notes
+
+- `git ls-remote` is the authority for Safi Python tags while local tag clobber risk exists.
+- Local `refs/tags/v0.4.23` is not trusted for parity claims because it differs from the remote tag observed by `git ls-remote`.
+- Python `upstream/v4` was fetched on 2026-04-22 and now points to `64e4c64d7bec574e5a56c1f0b9219e543ddbb5f3`.
+- CRG `v2.3.2` remains the stable review-feature source. CRG `main` has advanced and is intentionally deferred until a new spec updates the source lock.
 
 ## Fork Guardrail
 
@@ -35,6 +42,9 @@ These local additions are intentional deltas and must be preserved:
 - `partial`: equivalent behavior exists, but parity is incomplete or not fully tested
 - `missing`: not present in the TypeScript port
 - `needs-audit`: likely covered or intentionally different, but not yet verified carefully
+- `needs-review`: upstream moved or behavior is not yet mapped to local implementation/tests
+- `deferred`: valid upstream concept, but not in the active implementation scope
+- `rejected`: intentionally not adopted
 - `n/a`: upstream fix targeted Python-only behavior that does not map to the TypeScript runtime
 - `intentional-delta`: TypeScript port deliberately differs while preserving the same user-level contract
 
@@ -59,7 +69,7 @@ This table is retained for history. It should stay closed unless upstream rewrit
 
 ## Active v4 Release Gap Table
 
-The target is direct TypeScript release `0.4.23`. Rows must not remain `missing`, `partial`, or `needs-audit` before release.
+The TypeScript port has already shipped the original direct `0.4.23` parity target. Rows below are retained as the closed v4 parity table. New Python drift after `v0.4.23` is tracked in the next section and must not be treated as covered until reviewed.
 
 | Upstream ref | Upstream scope | TS status | Plan lot | Catch-up action |
 | --- | --- | --- | --- | --- |
@@ -89,18 +99,31 @@ The target is direct TypeScript release `0.4.23`. Rows must not remain `missing`
 | `v0.4.23` / `42599a7`, `8d908c5`, `baa4474` | refresh all version stamps, `.html` documents, safe large-graph HTML export, Go import node ID collision, pipx docs | `covered` | Lot 1, Lot 2, Lot 3, Lot 8 | `.html` document detection is covered by Lot 1. Go import prefixing is covered by Lot 2. Safe HTML export is covered by Lot 3. npm/global install docs are covered by Lot 7. Package and MCP server version stamps now read `0.4.23` from `package.json`. |
 | post-`v0.4.23` / `04790e2`, `dc1158b`, `7a0a5ac` | README download badge changes only | `n/a` | Lot 8 | Not part of TypeScript runtime parity; optionally ignore or adapt docs without copying Python download badges. |
 
+## Active Python v4 Drift After TypeScript `0.4.25`
+
+This table starts from the remote Python `v0.4.23` source lock and tracks current `upstream/v4` through remote tag `v0.4.27`.
+
+| Upstream ref | Upstream scope | TS status | Plan lot | Catch-up action |
+| --- | --- | --- | --- | --- |
+| `v0.4.24` / `2b8c08f` | version bump after fixes; later release-line commits include cache hashing, hook handling, watch output, semantic cache directory handling, sensitive directory false-positive fix, label crash guards, and packaging/interpreter docs | `needs-review` | F2 drift audit | Audit against TS cache, hook, watch, security, export, and packaging tests before marking covered. |
+| docs/translations commits / `53d516f`..`5a0c167` | multilingual README expansion and move to `docs/translations/` | `deferred` | separate docs lot | Do not mix translation relocation into runtime parity. Decide separately whether the TS README translation strategy should follow upstream. |
+| `v0.4.25` / `cc917a7` | empty-community report fixes; graph-query CLI rules in installed instructions | `needs-review` | F2 drift audit | Audit TS `report.ts` empty-community behavior and skill/query guidance. |
+| `v0.4.26` / `7891fa8` | wiki encoding and slug collision fixes; hook rebase guard; detect path resolution; README `.gitignore` docs | `needs-review` | F2 drift audit | Audit TS wiki slug/encoding behavior, hook branch safety, detect path resolution, and README guidance. |
+| `v0.4.27` / `64e4c64` | deterministic large-graph `GRAPH_REPORT`, stable edge node IDs, corrected common-root inference | `needs-review` | F2 drift audit | Create parity implementation lots if TS lacks deterministic report ordering, stable extracted edge IDs, or matching common-root inference. |
+
 ## Release Gate
 
-Before publishing TypeScript `0.4.23`:
+Before claiming catch-up through Python `v0.4.27` or publishing a TypeScript parity release:
 
-- all active v4 rows must be `covered`, `n/a`, or `intentional-delta`
+- all active Python drift rows must be `covered`, `n/a`, `deferred`, `rejected`, or `intentional-delta`
+- no row may remain `missing`, `partial`, `needs-audit`, or `needs-review`
 - `PLAN.md` exit criteria must be checked
 - `npm run lint` must pass
 - `npm run build` must pass
 - `npm test` must pass
-- `npm run test:smoke` must pass
-- `npx graphify hook-rebuild` must pass
-- GitHub Actions tag publish and post-publish npm install check must pass
+- `npm run test:smoke` must pass when runtime/package behavior changed
+- `npx graphify hook-rebuild` must pass after code changes
+- GitHub Actions release and post-publish npm install checks must pass for release commits
 
 ## Branching Rule
 

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -1075,6 +1075,63 @@ F11 report/wiki/HTML enrichment must render only grounded flow/review data and m
 
 F12 benchmarks must use deterministic local fixtures and must label token metrics as estimates unless backed by actual model usage.
 
+## F11 Report, Wiki, And HTML Enrichment After Flows
+
+### CRG Source Contract
+
+F11 ports CRG output enrichment patterns:
+
+- `code_review_graph/wiki.py` adds execution-flow context to generated wiki pages.
+- `code_review_graph/visualization.py` supports flow highlighting in graph views.
+- `code_review_graph/tools/build.py` precomputes summaries so agents do not repeatedly traverse the same graph.
+- `tests/test_wiki.py` protects expected sections, links, idempotence, empty graph behavior, and slug collision behavior.
+
+### Graphify Target
+
+Graphify report/wiki output remains unchanged unless flow or review artifacts are explicitly passed to the renderer. No placeholder flow/review section is rendered without grounded data.
+
+Report enrichment may include:
+
+- top critical execution flows from a `ReviewFlowArtifact`.
+- affected flows for a current diff from an `AffectedFlowsResult`.
+- high-risk nodes from the F6 risk analysis result or a normalized caller-provided list.
+- test gaps from the F6 risk analysis result or a normalized caller-provided list.
+
+Wiki enrichment may include:
+
+- execution flows passing through each community.
+- generated flow pages with flow steps, criticality, files, and linked communities.
+- community-to-flow links using wiki links.
+
+### Slug And Link Compatibility
+
+Keep current wiki links unchanged when page titles are unique. If two generated pages normalize to the same filename, keep the first filename and suffix later files with `_2`, `_3`, etc. Links to suffixed pages must use wiki alias syntax:
+
+```text
+[[Core]]
+[[Core_2|Core]]
+```
+
+This matches CRG-style unique slug suffixing while preserving existing Graphify links in the common no-collision case.
+
+### HTML Boundary
+
+Flow highlighting is deferred unless the current HTML exporter can support it without a renderer rewrite. F11 must not block report/wiki flow context on HTML work. If implemented later, HTML flow highlighting must be optional, non-blocking, and disabled for oversized graphs using the existing large-graph safety posture.
+
+### F11 Test Matrix
+
+Port/synthesize:
+
+- report omits flow sections when no flow/review data exists.
+- report includes top critical flows when a flow artifact is passed.
+- report includes affected flows, high-risk nodes, and test gaps only when those grounded lists exist.
+- wiki omits flow sections when no flow artifact exists.
+- wiki community pages list flows through the community when a flow artifact is passed.
+- wiki generates flow pages with steps/files/criticality.
+- wiki index keeps existing community links and adds flow links only when flow pages exist.
+- duplicate normalized titles generate suffixed filenames and alias links.
+- empty graph/wiki behavior stays valid.
+
 ## Compatibility Rules
 
 - No behavior changes without a new command or explicit option unless current behavior is backward-compatible.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -296,6 +296,227 @@ Additional current Graphify test gaps to close in F3:
 - structured line range attrs plus `source_location` parsing.
 - CRG-style `qualified_name`, `kind`, `is_test`, `TESTED_BY`, transitive tests, and future flow fields.
 
+## F7 Execution Flows
+
+### CRG Source Contract
+
+F7 ports `code_review_graph/flows.py` conceptually:
+
+- `detect_entry_points(store, include_tests=False)`
+- `_trace_single_flow(store, ep, max_depth=15)`
+- `trace_flows(store, max_depth=15, include_tests=False)`
+- `compute_criticality(flow, store)`
+- `store_flows(store, flows)`
+- `get_flows(store, sort_by="criticality", limit=50)`
+- `get_flow_by_id(store, flow_id)`
+- `incremental_trace_flows(store, changed_files, max_depth=15)`
+
+The initial Graphify implementation must cover full build/list/get behavior. Incremental retracing may be deferred until F8 if the artifact schema preserves stable flow IDs and node memberships.
+
+### Entrypoint Detection
+
+Graphify must preserve CRG's entrypoint rules with TypeScript constants:
+
+- true root: `Function` or `Test` node whose `qualifiedName` is not in `store.getAllCallTargets()`.
+- framework entrypoint: node `extra.decorators` contains one of CRG's decorator patterns.
+- conventional name: node name matches one of CRG's entry-name patterns.
+- tests excluded by default unless `includeTests` is true.
+- file-level test exclusion applies to `__tests__`, `.spec.ts`, `.spec.tsx`, `.test.ts`, `.test.tsx`, and Python `test_*.py` paths.
+
+Decorator patterns copied conceptually from CRG:
+
+```text
+app.(get|post|put|delete|patch|route|websocket|on_event)
+router.(get|post|put|delete|patch|route)
+blueprint.(route|before_request|after_request)
+(before|after)_(request|response)
+click.(command|group)
+\w+.(command|group)
+(field|model)_(serializer|validator)
+(celery.)?(task|shared_task|periodic_task)
+receiver
+api_view
+\baction\b
+pytest.(fixture|mark)
+(override_settings|modify_settings)
+(event.)?listens_for
+(Get|Post|Put|Delete|Patch|RequestMapping)Mapping
+(Scheduled|EventListener|Bean|Configuration)
+(Component|Injectable|Controller|Module|Guard|Pipe)
+(Subscribe|Mutation|Query|Resolver)
+(app|router).(get|post|put|delete|patch|use|all)
+@(Override|OnLifecycleEvent|Composable)
+(HiltViewModel|AndroidEntryPoint|Inject)
+\w+.(tool|tool_plain|system_prompt|result_validator)
+^tool\b
+\w+.(middleware|exception_handler|on_exception)
+\w+.route\b
+```
+
+Name patterns copied conceptually from CRG:
+
+```text
+^main$
+^__main__$
+^test_
+^Test[A-Z]
+^on_
+^handle_
+^handler$
+^handle$
+^lambda_handler$
+^upgrade$
+^downgrade$
+^lifespan$
+^get_db$
+^on(Create|Start|Resume|Pause|Stop|Destroy|Bind|Receive)
+^do(Get|Post|Put|Delete)$
+^do_(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$
+^log_message$
+^(middleware|errorHandler)$
+^ng(OnInit|OnChanges|OnDestroy|DoCheck|AfterContentInit|AfterContentChecked|AfterViewInit|AfterViewChecked)$
+^(transform|writeValue|registerOnChange|registerOnTouched|setDisabledState)$
+^(canActivate|canDeactivate|canActivateChild|canLoad|canMatch|resolve)$
+^(componentDidMount|componentDidUpdate|componentWillUnmount|shouldComponentUpdate|render)$
+```
+
+### Flow Tracing
+
+Graphify must trace flows with forward BFS over directed `CALLS` edges exposed by `ReviewGraphStoreLike`:
+
+- seed queue with the entrypoint node.
+- follow only `CALLS` edges from `getEdgesBySource()`.
+- never traverse `TESTED_BY`, semantic, conceptual, import-only, or multimodal edges.
+- use a visited qualified-name set for cycle safety.
+- default `maxDepth` is `15`.
+- `depth` is the maximum BFS depth reached.
+- skip trivial single-node flows.
+- sort final flows by descending `criticality`.
+
+On undirected Graphify graphs, only edges with preserved `_src` and `_tgt` from the F3 adapter may participate in forward flows. If skipped edges exist because direction is unavailable, the flow result must include a warning so downstream review features do not overclaim precision.
+
+### Criticality
+
+Graphify must port CRG weights with no product-specific taxonomy:
+
+- file spread: weight `0.30`; one file is `0.0`, five or more files is `1.0`.
+- external calls: weight `0.20`; unresolved `CALLS` targets are external, five or more is `1.0`.
+- security sensitivity: weight `0.25`; count nodes whose name or qualified name contains a CRG security keyword.
+- test coverage gap: weight `0.15`; node is covered if it has an incoming `TESTED_BY` edge.
+- depth: weight `0.10`; depth ten or more is `1.0`.
+
+Security keywords copied from CRG:
+
+```text
+auth, login, password, token, session, crypt, secret, credential,
+permission, sql, query, execute, connect, socket, request, http,
+sanitize, validate, encrypt, decrypt, hash, sign, verify, admin,
+privilege
+```
+
+The final score is rounded to four decimals and clamped to `[0, 1]`.
+
+### Graphify Flow Artifact
+
+Graphify persists derived flows to `.graphify/flows.json` by default. This artifact is generated state, not a new source of truth and not required for ordinary graph build/update commands.
+
+Schema:
+
+```ts
+export interface ReviewFlowArtifact {
+  version: 1;
+  generatedAt: string;
+  graphPath: string | null;
+  maxDepth: number;
+  includeTests: boolean;
+  warnings: string[];
+  flows: ReviewFlow[];
+}
+
+export interface ReviewFlow {
+  id: string;
+  name: string;
+  entryPoint: string;
+  entryPointId: string;
+  path: string[];
+  qualifiedPath: string[];
+  depth: number;
+  nodeCount: number;
+  fileCount: number;
+  files: string[];
+  criticality: number;
+  warnings: string[];
+}
+
+export interface ReviewFlowStep {
+  nodeId: string;
+  name: string;
+  kind: ReviewGraphNodeKind;
+  file: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  qualifiedName: string;
+}
+```
+
+Flow IDs must be deterministic for a graph: `flow:<entryPointId>` sanitized for filesystem and JSON stability. If duplicate entrypoint IDs ever collide after sanitization, suffix with a deterministic counter.
+
+### API Surface
+
+Create `src/flows.ts` with:
+
+- `detectEntryPoints(store, options?)`
+- `traceFlows(store, options?)`
+- `computeFlowCriticality(flow, store)`
+- `flowToSteps(flow, store)`
+- `buildFlowArtifact(store, options?)`
+- `writeFlowArtifact(artifact, path)`
+- `readFlowArtifact(path)`
+- `listFlows(artifact, options?)`
+- `getFlowById(artifact, flowId, store?)`
+
+The functions consume `ReviewGraphStoreLike`; they must not import Graphology directly except optional convenience helpers that wrap `createReviewGraphStore()`.
+
+### CLI And Runtime
+
+Add public CLI commands:
+
+```text
+graphify flows build --graph .graphify/graph.json --out .graphify/flows.json [--max-depth 15] [--include-tests]
+graphify flows list --flows .graphify/flows.json [--sort criticality|depth|node-count|file-count|name] [--limit 50] [--json]
+graphify flows get <flow-id> --flows .graphify/flows.json --graph .graphify/graph.json [--json]
+```
+
+Add skill-runtime equivalents:
+
+```text
+graphify-skill-runtime flows-build --graph <path> --out <path>
+graphify-skill-runtime flows-list --flows <path>
+graphify-skill-runtime flows-get --flows <path> --graph <path> --id <flow-id>
+```
+
+F7 does not change existing `summary`, `review-delta`, `review-analysis`, or `recommend-commits` behavior. Later lots may consume `.graphify/flows.json` only when it exists.
+
+### F7 Test Matrix
+
+Port CRG `tests/test_flows.py` behaviors into Vitest:
+
+- no-incoming `CALLS` functions become entrypoints.
+- framework decorators mark entrypoints even when called.
+- conventional names `main`, `test_*`, `on_*`, `handle_*`, `upgrade`, `downgrade`, `lifespan` become entrypoints.
+- test nodes and test files are excluded by default and included with `includeTests`.
+- linear flow `A -> B -> C` traces all nodes.
+- cycles do not loop forever.
+- `maxDepth` limits traversal.
+- trivial single-node flows are skipped.
+- multi-file flows report all files and `fileCount`.
+- criticality is bounded `[0, 1]`.
+- security-sensitive flow scores at least as high as a comparable non-security flow.
+- file-spread boosts multi-file flows.
+- store/list/get roundtrip works through `.graphify/flows.json`.
+- sort modes match CRG intent.
+- directed-edge degradation warning is emitted for undirected edges that lack preserved direction.
+
 ## F4-F12 Spec Skeleton
 
 F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -607,6 +607,154 @@ JSON output is exactly `AffectedFlowsResult`.
 
 F8 must not trigger a graph rebuild or flow rebuild implicitly. Agents may suggest `graphify flows build` when artifacts are missing or stale, but the command itself stays a read-only query.
 
+## F5 Review Context And Blast Radius
+
+### CRG Source Contract
+
+F5 ports `code_review_graph/tools/review.py:get_review_context()` conceptually:
+
+- auto-detect changed files when omitted.
+- compute impact radius at `max_depth=2`.
+- support `detail_level="minimal" | "standard"`.
+- support `include_source=true` with capped source snippets.
+- return changed files, impacted files, changed nodes, impacted nodes, edges, source snippets, and review guidance.
+
+CRG helper behavior to preserve:
+
+- `_extract_relevant_lines()` includes changed node line ranges with small context and merges overlapping ranges.
+- when no node range matches a long file, fallback returns the first 50 numbered lines.
+- `_generate_review_guidance()` flags test gaps, wide blast radius, inheritance/implementation edges, and cross-file impact.
+- minimal mode returns counts, risk, key entities, test gap count, and next tool suggestions.
+
+### Graphify Target
+
+Create `src/review-context.ts` on top of F3 `ReviewGraphStoreLike`. Do not change existing `review-delta` or `review-analysis` output in this lot.
+
+The new command is additive:
+
+```text
+graphify review-context [files...] --graph .graphify/graph.json
+```
+
+Later lots may let existing `review-delta`/`review-analysis` delegate internally, but their public output must remain backward compatible until a separate compatibility spec changes it.
+
+### API Surface
+
+```ts
+export type ReviewContextDetailLevel = "minimal" | "standard";
+
+export interface BuildReviewContextOptions {
+  maxDepth?: number;
+  detailLevel?: ReviewContextDetailLevel;
+  includeSource?: boolean;
+  maxLinesPerFile?: number;
+  repoRoot?: string;
+}
+
+export interface ReviewContextResult {
+  status: "ok";
+  summary: string;
+  risk?: "low" | "medium" | "high";
+  changedFileCount?: number;
+  impactedFileCount?: number;
+  keyEntities?: string[];
+  testGaps?: number;
+  nextToolSuggestions?: string[];
+  context?: ReviewContextPayload;
+}
+
+export interface ReviewContextPayload {
+  changedFiles: string[];
+  impactedFiles: string[];
+  graph: {
+    changedNodes: ReviewGraphNode[];
+    impactedNodes: ReviewGraphNode[];
+    edges: ReviewGraphEdge[];
+  };
+  sourceSnippets?: Record<string, string>;
+  reviewGuidance: string;
+}
+```
+
+When no changed files are provided or detected, return:
+
+```json
+{
+  "status": "ok",
+  "summary": "No changes detected. Nothing to review.",
+  "context": {}
+}
+```
+
+### Detail Levels
+
+`minimal`:
+
+- risk is `high` when impacted nodes > 20, `medium` when > 5, otherwise `low`.
+- `keyEntities` is the first five changed node names.
+- `testGaps` counts changed non-test functions with no incoming `TESTED_BY` edge.
+- `nextToolSuggestions` is `["detect-changes", "affected-flows", "review-context"]`.
+- no source snippets are emitted.
+
+`standard`:
+
+- includes full impact result from `store.getImpactRadius(changedFiles, { maxDepth })`.
+- includes source snippets only when `includeSource` is true.
+- includes generated guidance.
+
+### Source Snippet Safety
+
+Source snippets are opt-in for runtime callers and default-on for public CLI parity with CRG only when `--include-source` is passed or when the default command chooses it explicitly.
+
+Rules:
+
+- read only files under `repoRoot` after resolving real paths.
+- never read files larger than `maxLinesPerFile` into output wholesale.
+- default `maxLinesPerFile` is `200`.
+- for long files, include changed node ranges with two lines before and one line after, matching CRG intent.
+- fallback for long files with no matching line metadata is first 50 numbered lines.
+- skip binary-looking files and return `(could not read file)` on read errors.
+- exclude obvious secret files by default: `.env`, `.npmrc`, private keys, certificate/key files, and paths containing `secret`, `credential`, or `token`.
+
+### CLI And Runtime
+
+Public CLI:
+
+```text
+graphify review-context [files...] --graph .graphify/graph.json
+graphify review-context --files src/a.ts,src/b.ts
+graphify review-context --base main --head HEAD
+graphify review-context --staged
+graphify review-context --detail-level minimal|standard
+graphify review-context --include-source --max-lines-per-file 200
+graphify review-context --json
+```
+
+File discovery follows F8: explicit files first, then git ref/staged/worktree discovery.
+
+Skill runtime:
+
+```text
+graphify-skill-runtime review-context --graph <path> --files <csv>
+```
+
+Runtime requires explicit files for deterministic assistant orchestration.
+
+### F5 Test Matrix
+
+Port or synthesize CRG behaviors:
+
+- minimal mode returns low/medium/high risk based on impacted node count.
+- standard mode returns changed files, impacted files, changed nodes, impacted nodes and edges.
+- source snippets include numbered relevant lines for changed node ranges.
+- long files use relevant ranges and fallback first 50 lines.
+- sensitive files are not read into snippets.
+- guidance flags untested changed functions.
+- guidance flags wide blast radius.
+- guidance flags inheritance or implementation edges.
+- guidance flags cross-file impact when impacted file count is greater than three.
+- CLI and skill-runtime commands emit text and JSON from the same implementation.
+
 ## F4-F12 Spec Skeleton
 
 F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -994,6 +994,67 @@ Port/synthesize:
 - serialized JSON length stays below 800 words in fixture tests.
 - CLI/runtime emit the same implementation.
 
+## F10 Skills And LLM Review Workflow
+
+### CRG Source Contract
+
+F10 ports the agent workflow guidance from CRG rather than a storage primitive:
+
+- `code-review-graph CLAUDE.md` requires the first tool call to be `get_minimal_context`.
+- `docs/LLM-OPTIMIZED-REFERENCE.md` targets `<=5` graph tool calls and `<=800` graph-context tokens.
+- `skills/review-delta/SKILL.md` and `skills/review-pr/SKILL.md` expand only after the minimal context indicates risk or impact.
+- `code_review_graph/prompts.py` and `code_review_graph/skills.py` separate orientation, detection, expansion, and final review steps.
+
+### Graphify Target
+
+Distributed Graphify skills must keep existing build/update/query behavior intact, but review-oriented workflows start with:
+
+```text
+graphify minimal-context --task "review PR" --graph .graphify/graph.json
+```
+
+Codex-specific skills must spell the user-facing trigger as `$graphify`, not `/graphify`, while shell examples can still use `graphify`.
+
+### Workflow States
+
+The review workflow has five states:
+
+- orient: run `minimal-context` first, confirm graph freshness, and read the compact route.
+- detect: run `detect-changes` when files, refs, or a diff need risk scoring.
+- expand flows: run `flows build` if `.graphify/flows.json` is missing and flow expansion is needed, then `affected-flows`.
+- expand snippets: run `review-context` only for risky or impacted files that need source snippets or radius detail.
+- final review: produce findings from graph evidence plus source diff, explicitly noting gaps when graph data is stale or incomplete.
+
+### CRG Tool Mapping
+
+```text
+get_minimal_context -> graphify minimal-context
+detect_changes      -> graphify detect-changes
+get_affected_flows  -> graphify affected-flows
+get_review_context  -> graphify review-context
+```
+
+### Stale And Dirty State
+
+Skills must warn before relying on review output when `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`.
+
+Dirty worktree handling stays advisory: the skill may warn when the worktree is dirty, but Graphify commands must not mutate git state. Explicit `--files`, `--base`, `--head`, or `--staged` inputs take precedence over unrelated dirty files.
+
+### MCP/Serve Boundary
+
+Do not add MCP prompt/tool parity for F10 until CLI and skill-runtime behavior is stable. If MCP parity is added later, it must call the same implementation and preserve the same workflow states.
+
+### F10 Test Matrix
+
+Port/synthesize:
+
+- every distributed skill mentions `minimal-context`.
+- every distributed skill states it is the first review call.
+- every distributed skill maps the follow-up chain to `detect-changes`, `affected-flows`, and `review-context`.
+- skills preserve existing review-analysis, review-eval, review-delta, recommend-commits, build, update, query, summary, path, and explain workflows.
+- skills keep stale graph warnings and dirty worktree behavior explicit.
+- skills mention the CRG budgets: `<=5 graph tool calls` and `<=800` graph-context tokens.
+
 ## F4-F12 Spec Skeleton
 
 F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -1132,6 +1132,88 @@ Port/synthesize:
 - duplicate normalized titles generate suffixed filenames and alias links.
 - empty graph/wiki behavior stays valid.
 
+## F12 Benchmarks, Honesty Metrics, And Known Limits
+
+### CRG Source Contract
+
+F12 ports CRG evaluation intent, not its network clone runner:
+
+- `code_review_graph/eval/benchmarks/impact_accuracy.py` measures impact accuracy conservatively.
+- `code_review_graph/eval/benchmarks/flow_completeness.py` measures whether expected flows are surfaced.
+- `code_review_graph/eval/benchmarks/token_efficiency.py` estimates context reduction versus naive file reads.
+- `code_review_graph/eval/scorer.py`, `runner.py`, and `reporter.py` separate case schema, scoring, and output formatting.
+- `tests/test_eval.py` keeps benchmark behavior deterministic.
+
+### Graphify Target
+
+Graphify must provide deterministic local benchmark fixtures before claiming CRG-equivalent review quality. The default test path must not clone external repositories, call network services, or require real provider keys.
+
+### Benchmark Case Schema
+
+```ts
+interface ReviewBenchmarkCase {
+  name: string;
+  changedFiles: string[];
+  changedRanges?: ChangedRangesByFile;
+  expectedChangedNodes?: string[];
+  expectedImpactedFiles?: string[];
+  expectedAffectedFlows?: string[];
+  expectedTestGaps?: string[];
+  expectedSummaryFacts?: string[];
+  naiveTokenEstimate?: number;
+  tokenBudget?: number;
+}
+```
+
+Expected node/flow values may use stable IDs, qualified names, or labels where the underlying Graphify graph exposes them.
+
+### Metrics
+
+F12 metrics are intentionally conservative:
+
+- changed-node recall.
+- impacted-file precision.
+- impacted-file recall.
+- impacted-file F1.
+- flow completeness.
+- test-gap recall.
+- summary fact recall.
+- false-positive count.
+- estimated graph-context tokens.
+- token budget pass/fail.
+
+Precision/recall metrics are `null` when no expectation is supplied. False positives count impacted files that were not expected and were not directly changed. Token counts are estimates unless actual model usage is supplied in a future benchmark runner.
+
+### Output Contract
+
+The benchmark API returns machine-readable JSON and a Markdown formatter:
+
+```ts
+evaluateReviewBenchmarks(store, cases, { flows })
+reviewBenchmarkToMarkdown(result)
+```
+
+Markdown output must include an honesty note that tokens are estimated and that flow quality depends on language/parser metadata. JSON output must keep per-case metrics plus aggregate averages.
+
+### README Contract
+
+README must document that review benchmarks are deterministic fixtures, not a universal quality guarantee. It must state:
+
+- review impact favors recall over precision.
+- false positives are reported instead of hidden.
+- flow quality is weaker where parser/call metadata is weak or direction is unavailable.
+- token metrics are estimates unless backed by actual model calls.
+
+### F12 Test Matrix
+
+Port/synthesize:
+
+- benchmark case with expected changed node, impacted files, affected flow, and test gap.
+- benchmark case with a known false-positive impacted file.
+- aggregate averages ignore null metrics.
+- Markdown formatter includes metrics and the estimated-token honesty note.
+- README contains the review benchmark limitations.
+
 ## Compatibility Rules
 
 - No behavior changes without a new command or explicit option unless current behavior is backward-compatible.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -755,6 +755,136 @@ Port or synthesize CRG behaviors:
 - guidance flags cross-file impact when impacted file count is greater than three.
 - CLI and skill-runtime commands emit text and JSON from the same implementation.
 
+## F6 Risk-Scored Detect Changes
+
+### CRG Source Contract
+
+F6 ports `code_review_graph/changes.py` conceptually:
+
+- `parse_git_diff_ranges(repo_root, base="HEAD~1")`
+- `_parse_unified_diff(diff_text)`
+- `map_changes_to_nodes(store, changed_ranges)`
+- `compute_risk_score(store, node)`
+- `analyze_changes(store, changed_files, changed_ranges?, repo_root?, base?)`
+- `tools/review.py:detect_changes_func()`
+
+### Git Diff Parsing
+
+Graphify must parse unified diffs without shell interpretation:
+
+- run `git diff --unified=0 <base> --` through existing safe git helpers or `spawn`/`execFile` style APIs.
+- reject unsafe refs using CRG `_SAFE_GIT_REF`: `^[A-Za-z0-9_.~^/@{}\-]+$`.
+- hunk headers map `@@ ... +start,count @@` to inclusive `[start, end]` ranges.
+- omitted count means one changed line.
+- `count=0` deletion hunks map to `[start, start]`.
+- files are read from `+++ b/<path>` lines.
+- command failure or unsafe ref returns empty ranges and a warning, not a thrown exception from public CLI.
+
+### Changed Range Mapping
+
+`mapChangesToNodes(store, changedRanges)` must:
+
+- use `store.getNodesByFile(file)` first.
+- fall back to `store.getFilesMatching(file)` for suffix/absolute path differences.
+- require node line metadata for line-overlap mapping.
+- dedupe by qualified name.
+- overlap when `node.lineStart <= rangeEnd && node.lineEnd >= rangeStart`.
+- if no ranges are available, `analyzeChanges()` falls back to all nodes in changed files.
+
+### Risk Score
+
+Port CRG weights:
+
+- flow participation: sum flow criticalities for flows containing the node, capped `0.25`; if no criticality data, `0.05` per flow membership capped `0.25`.
+- community crossing: `0.05` per caller from a different community, capped `0.15`.
+- test coverage: `0.30 - min(testCount / 5, 1) * 0.25`; this means untested = `0.30`, 5+ tests = `0.05`.
+- security sensitivity: `0.20` if node name or qualified name contains a CRG security keyword.
+- caller count: caller count / 20 capped `0.10`.
+- clamp and round to four decimals.
+
+Security keywords are the same set as F7.
+
+### Output Contract
+
+```ts
+export interface DetectChangesResult {
+  status: "ok";
+  summary: string;
+  riskScore: number;
+  changedFiles: string[];
+  changedFunctions: DetectChangesNodeRisk[];
+  affectedFlows: ReviewFlowDetail[];
+  testGaps: DetectChangesTestGap[];
+  reviewPriorities: DetectChangesNodeRisk[];
+  warnings: string[];
+}
+```
+
+Minimal output returns:
+
+- `status`
+- `summary`
+- `riskScore`
+- `changedFileCount`
+- `testGapCount`
+- top three `reviewPriorities` names.
+
+### Flow Integration
+
+F6 may accept an optional F7 `ReviewFlowArtifact`:
+
+- CLI option `--flows .graphify/flows.json`.
+- if missing, risk score still works with flow factor `0`.
+- if provided, affected flows are computed with F8 `getAffectedFlows()`.
+- no implicit `flows build`.
+
+### CLI And Runtime
+
+Public CLI:
+
+```text
+graphify detect-changes [files...] --graph .graphify/graph.json
+graphify detect-changes --files src/a.ts,src/b.ts
+graphify detect-changes --base main --head HEAD
+graphify detect-changes --staged
+graphify detect-changes --flows .graphify/flows.json
+graphify detect-changes --detail-level minimal|standard
+graphify detect-changes --json
+```
+
+Skill-runtime requires explicit files and optional precomputed ranges/flows:
+
+```text
+graphify-skill-runtime detect-changes --graph <path> --files <csv> [--flows <path>]
+```
+
+### Dirty Worktree Behavior
+
+Graphify must not mutate git state. If worktree diff is used implicitly, the text output must be framed as current working tree analysis. If explicit files or refs are provided, analyze those and do not warn about unrelated dirty state unless a later skill layer decides to.
+
+### F6 Test Matrix
+
+Port CRG tests:
+
+- parse basic unified diff.
+- parse multiple hunks.
+- parse single-line hunk.
+- parse deletion-only hunk.
+- parse multiple files.
+- reject unsafe git refs.
+- map changed ranges to overlapping nodes.
+- no overlap returns empty.
+- dedupe nodes across ranges.
+- changed ranges across files.
+- risk score is `[0, 1]`.
+- untested function scores higher than tested function.
+- security keyword boosts risk.
+- caller count boosts risk.
+- flow membership/criticality boosts risk when artifact is provided.
+- `analyzeChanges()` returns summary, risk score, changed functions, affected flows, test gaps, priorities.
+- fallback with no ranges maps all nodes in changed files.
+- CLI/runtime minimal and standard outputs use the same implementation.
+
 ## F4-F12 Spec Skeleton
 
 F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -885,6 +885,115 @@ Port CRG tests:
 - fallback with no ranges maps all nodes in changed files.
 - CLI/runtime minimal and standard outputs use the same implementation.
 
+## F4 Minimal Context First-Call Tool
+
+### CRG Source Contract
+
+F4 ports `code_review_graph/tools/context.py:get_minimal_context()` conceptually:
+
+- return the smallest useful orientation for an agent first call.
+- include graph stats, risk if changed files exist, key entities, top communities, top flows, and next tool suggestions.
+- route suggestions by task keywords.
+- target roughly 100 tokens and stay under the LLM reference budget of 800 context tokens.
+
+### Graphify Target
+
+Create `src/minimal-context.ts` after F7/F8/F5/F6 are available.
+
+Graphify input sources:
+
+- F3 `ReviewGraphStoreLike.getGraphStats()`.
+- Graph attributes `community_labels` and node community counts for top communities.
+- F7 `.graphify/flows.json` when provided.
+- F6 `analyzeChanges()` when changed files are explicit or discovered by CLI.
+
+No source snippets, raw file reads, graph rebuilds, or flow rebuilds are allowed in F4.
+
+### Output Contract
+
+```ts
+export interface MinimalContextResult {
+  summary: string;
+  keyEntities?: string[];
+  risk: "unknown" | "low" | "medium" | "high";
+  riskScore: number;
+  communities?: string[];
+  flowsAffected?: string[];
+  flowsAvailable: boolean;
+  nextToolSuggestions: string[];
+}
+```
+
+`summary` format:
+
+```text
+<nodes> nodes, <edges> edges across <files> files. Risk: <risk> (<score>). <n> test gaps.
+```
+
+Risk is:
+
+- `unknown` when no changed files are provided or detected.
+- `high` when F6 risk score > `0.7`.
+- `medium` when > `0.4`.
+- `low` otherwise.
+
+### Suggestion Routing
+
+Port CRG keyword routing but use Graphify command names:
+
+- review/pr/merge/diff -> `detect-changes`, `affected-flows`, `review-context`
+- debug/bug/error/fix -> `summary`, `query`, `flows get`
+- refactor/rename/dead/clean -> `review-context`, `detect-changes`, `recommend-commits`
+- onboard/understand/explore/arch -> `summary`, `flows list`, `path`
+- default -> `detect-changes`, `summary`, `review-context`
+
+### Flows Behavior
+
+When no flow artifact is provided:
+
+- `flowsAvailable` is false.
+- omit `flowsAffected` from text output or return `[]` in JSON.
+- next suggestions may still include `flows list` only for onboarding/architecture tasks, because the assistant can then choose to run `flows build` first if needed.
+
+When flow artifact is provided:
+
+- top flows are the three highest-criticality flow names.
+- if changed files are provided, prefer F8 affected flow names for `flowsAffected`.
+
+### CLI And Runtime
+
+Public CLI:
+
+```text
+graphify minimal-context --task "review PR" --graph .graphify/graph.json
+graphify minimal-context --files src/a.ts --flows .graphify/flows.json
+graphify minimal-context --base main --head HEAD
+graphify minimal-context --json
+```
+
+Skill runtime:
+
+```text
+graphify-skill-runtime minimal-context --graph <path> [--task <text>] [--files <csv>] [--flows <path>]
+```
+
+Runtime does not auto-detect git changes; public CLI may use the same changed-file discovery as F6 when no files are passed.
+
+### F4 Test Matrix
+
+Port/synthesize:
+
+- returns graph stats summary and `risk=unknown` with no changed files.
+- review task suggests `detect-changes`, `affected-flows`, `review-context`.
+- debug task suggests `summary`, `query`, `flows get`.
+- refactor task suggests `review-context`, `detect-changes`, `recommend-commits`.
+- onboard/architecture task suggests `summary`, `flows list`, `path`.
+- changed files invoke F6 risk and key entities.
+- no `flows.json` sets `flowsAvailable=false`.
+- flow artifact exposes top three critical flows.
+- serialized JSON length stays below 800 words in fixture tests.
+- CLI/runtime emit the same implementation.
+
 ## F4-F12 Spec Skeleton
 
 F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -66,6 +66,41 @@ Primary CRG tests to port conceptually:
 - `tests/test_eval.py`
 - `tests/test_integration_v2.py`
 
+## F9 Test-Porting Gate
+
+F9 is not a user-facing command. It is the acceptance gate that keeps every CRG-aligned feature backed by a synthetic Vitest fixture before Graphify claims the behavior.
+
+### Porting Matrix
+
+| Feature | CRG source behavior | Graphify target tests | Notes |
+| --- | --- | --- | --- |
+| F3 store adapter | `graph.py:GraphStore`, `tests/test_tools.py`, `tests/test_changes.py` | `tests/review-store.test.ts` | Uses Graphology fixtures instead of SQLite and preserves `.graphify/graph.json` as source of truth. |
+| F7 execution flows | `flows.py`, `tests/test_flows.py` | `tests/flows.test.ts` | Ports entrypoint heuristics, BFS flow tracing, cycle/depth handling, test exclusion, criticality, list/get persistence, and directed-edge degradation. |
+| F8 affected flows | `flows.py:get_affected_flows`, MCP review wrappers | `tests/affected-flows.test.ts` | Keeps affected-flow expansion separate so agents only pay for it when needed. |
+| F5 review context | `tools/review.py:get_review_context`, `_extract_relevant_lines`, `_generate_review_guidance` | `tests/review-context.test.ts` | Covers minimal/standard output, snippets, sensitive-file caps, test gaps, and blast-radius guidance. |
+| F6 detect changes | `changes.py`, `tools/review.py:detect_changes_func`, `tests/test_changes.py` | `tests/detect-changes.test.ts` | Covers unified diff parsing, safe refs, line overlap mapping, fallback mapping, risk factors, affected flows, and test gaps. |
+| F4 minimal context | `tools/context.py:get_minimal_context`, `docs/LLM-OPTIMIZED-REFERENCE.md` | `tests/minimal-context.test.ts` | Keeps the first-call context compact and verifies task-based next-tool routing. |
+| F10 skills | `CLAUDE.md`, `prompts.py`, `skills.py`, `skills/review-*`, `tests/test_prompts.py`, `tests/test_skills.py` | `tests/skills.test.ts`, `tests/codex-integration.test.ts`, `tests/gemini-integration.test.ts` | Preserves platform-specific syntax while making `minimal-context` the first review call. |
+| F11 report/wiki | `wiki.py`, `visualization.py`, `tests/test_wiki.py` | `tests/report.test.ts`, `tests/wiki.test.ts` | HTML flow highlighting stays deferred; report/wiki flow sections are grounded and optional. |
+| F12 benchmarks | `eval/benchmarks/*.py`, `eval/scorer.py`, `eval/reporter.py`, `tests/test_eval.py` | `tests/review-benchmark.test.ts`, `tests/public-api.test.ts` | Ports deterministic scoring and honesty notes, not CRG's external network clone runner. |
+
+### Fixture Contract
+
+CRG-aligned tests use synthetic fixtures only. Feature-local helpers are acceptable and preferred over one global fixture factory when the fields differ by feature. Every fixture that exercises review algorithms should declare only the fields it needs from this generic set:
+
+- function/class/test nodes with `id`, `label`, `qualified_name`, `kind`, `source_file`, `line_start`, `line_end`, `community`, and optional `is_test`.
+- directed `CALLS` edges with source/target orientation preserved.
+- `TESTED_BY`, `validated_by`, inheritance, or implementation edges when the feature being tested needs coverage or relationship guidance.
+- flow artifacts with stable IDs, names, entry points, ordered steps, files, criticality, and generated timestamp.
+- changed files and optional unified-diff line ranges.
+- compact review expectations: changed nodes, impacted files, affected flows, test gaps, summary facts, and token budgets.
+
+No fixture may include a real customer, partner, proprietary ontology, private repository, or production dataset.
+
+### Acceptance Rule
+
+For each algorithmic feature, the relevant Vitest fixture must exist in the same feature lot before the runtime implementation is accepted. When Graphify intentionally deviates from CRG, the target test must encode the Graphify-specific behavior instead of silently dropping the CRG expectation.
+
 ## F3 ReviewGraphStoreLike Adapter
 
 ### Existing Graphify Graph Shape

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -517,6 +517,96 @@ Port CRG `tests/test_flows.py` behaviors into Vitest:
 - sort modes match CRG intent.
 - directed-edge degradation warning is emitted for undirected edges that lack preserved direction.
 
+## F8 Affected Flows
+
+### CRG Source Contract
+
+F8 ports `code_review_graph/flows.py:get_affected_flows()` and the corresponding review tool wrappers.
+
+CRG behavior:
+
+- accepts `changed_files`.
+- returns empty result when `changed_files` is empty.
+- maps changed files to node IDs.
+- finds flow IDs whose memberships include any of those nodes.
+- returns full flow details with steps.
+- sorts affected flows by descending `criticality`.
+
+### Graphify Target
+
+Graphify must consume the F7 `.graphify/flows.json` artifact and F3 `ReviewGraphStoreLike`:
+
+- `flows.json` supplies derived flow memberships.
+- `graph.json` supplies node metadata and step details.
+- no SQLite table or separate membership store is introduced.
+- if the flow artifact is missing, CLI commands fail clearly and tell the user to run `graphify flows build`.
+
+### API Surface
+
+Add to `src/flows.ts`:
+
+```ts
+export interface AffectedFlowsResult {
+  changedFiles: string[];
+  matchedNodeIds: string[];
+  unmatchedFiles: string[];
+  affectedFlows: ReviewFlowDetail[];
+  total: number;
+}
+
+export function getAffectedFlows(
+  artifact: ReviewFlowArtifact,
+  changedFiles: string[],
+  store: ReviewGraphStoreLike,
+): AffectedFlowsResult;
+```
+
+Mapping rules:
+
+- For each changed file, call `store.getNodesByFile(file)`.
+- A flow is affected when any changed node ID appears in `flow.path`.
+- `matchedNodeIds` is stable sorted unique.
+- `unmatchedFiles` includes changed files with no matched graph nodes.
+- `affectedFlows` includes `steps` from `getFlowById(..., store)`.
+- Sort by descending `criticality`, then name for deterministic ties.
+
+### Changed File Discovery
+
+Public CLI supports the same file discovery convention as existing review commands:
+
+```text
+graphify affected-flows [files...] --flows .graphify/flows.json --graph .graphify/graph.json
+graphify affected-flows --files src/a.ts,src/b.ts
+graphify affected-flows --base main --head HEAD
+graphify affected-flows --staged
+```
+
+Resolution order:
+
+1. positional files and `--files` if present.
+2. `--base/--head` or `--staged`.
+3. working tree diff against `HEAD` plus untracked files, matching existing `review-delta`.
+
+Skill-runtime stays deterministic and requires explicit files:
+
+```text
+graphify-skill-runtime affected-flows --flows <path> --graph <path> --files <csv>
+```
+
+### Output Contract
+
+Text output starts with:
+
+```text
+Affected flows: <total>
+Changed files: <n>
+Matched nodes: <n>
+```
+
+JSON output is exactly `AffectedFlowsResult`.
+
+F8 must not trigger a graph rebuild or flow rebuild implicitly. Agents may suggest `graphify flows build` when artifacts are missing or stale, but the command itself stays a read-only query.
+
 ## F4-F12 Spec Skeleton
 
 F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.

--- a/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
+++ b/spec/SPEC_CODE_REVIEW_GRAPH_ALIGNMENT.md
@@ -1,0 +1,325 @@
+# SPEC_CODE_REVIEW_GRAPH_ALIGNMENT
+
+## Status
+
+This spec defines the TypeScript Graphify alignment plan for selected `code-review-graph` review features.
+
+- Created: 2026-04-22
+- CRG reference: `tirth8205/code-review-graph` tag `v2.3.2`
+- CRG commit: `db2d2df789c25a101e33477b898c1840fb4c7bc7`
+- Local CRG inspection clone: `/tmp/code-review-graph-v2.3.2`
+- Graphify baseline: `graphifyy@0.4.25`
+- Source-lock spec: `spec/SPEC_UPSTREAM_TRACEABILITY.md`
+
+## Product Boundary
+
+Graphify stays a generic multimodal knowledge graph product. CRG is a review-first code graph. This roadmap ports CRG review algorithms conceptually while keeping Graphify's current source of truth as `.graphify/graph.json`.
+
+Graphify must not adopt these CRG defaults in this lot:
+
+- SQLite as required graph storage.
+- Embeddings as a baseline dependency.
+- A review-only product identity.
+- Python runtime dependencies.
+- Network-clone benchmark runners.
+
+## Execution Order
+
+Implementation order is:
+
+1. F3 `ReviewGraphStoreLike` adapter.
+2. F7 execution flows.
+3. F8 affected flows.
+4. F5 review context and blast radius.
+5. F6 risk-scored detect changes.
+6. F4 minimal context first-call tool.
+7. F10 skills and LLM review workflow.
+8. F11 report/wiki/HTML enrichment.
+9. F12 benchmarks and honesty metrics.
+
+F9 is a gate across all algorithmic features: port the relevant CRG test behavior before runtime code is accepted.
+
+## CRG Sources
+
+Primary CRG implementation files:
+
+- `code_review_graph/graph.py`
+- `code_review_graph/changes.py`
+- `code_review_graph/flows.py`
+- `code_review_graph/tools/review.py`
+- `code_review_graph/tools/context.py`
+- `code_review_graph/tools/query.py`
+- `code_review_graph/tools/build.py`
+- `code_review_graph/wiki.py`
+- `code_review_graph/prompts.py`
+- `code_review_graph/skills.py`
+- `code_review_graph/eval/scorer.py`
+
+Primary CRG tests to port conceptually:
+
+- `tests/test_changes.py`
+- `tests/test_flows.py`
+- `tests/test_tools.py`
+- `tests/test_prompts.py`
+- `tests/test_skills.py`
+- `tests/test_wiki.py`
+- `tests/test_eval.py`
+- `tests/test_integration_v2.py`
+
+## F3 ReviewGraphStoreLike Adapter
+
+### Existing Graphify Graph Shape
+
+Graphify serialized graphs currently support:
+
+- top-level `directed`, `multigraph`, `graph`, `nodes`, `links` or `edges`, and `hyperedges`.
+- node attrs `id`, `label`, `file_type`, `source_file`, optional `source_location`, `confidence`, `community`, and arbitrary extra fields.
+- edge attrs `source`, `target`, `relation`, `confidence`, `source_file`, optional `source_location`, `confidence_score`, `weight`, `_src`, `_tgt`, and arbitrary extra fields.
+- `links` are preferred over `edges` when both exist because the current loader uses `raw.links ?? raw.edges`.
+
+### CRG Behavior To Preserve
+
+CRG review features query a SQLite `GraphStore` that provides:
+
+- node lookup by qualified name, file path, kind, ID, community, and search.
+- edge lookup by source, target, relation kind, and edge set among nodes.
+- impact-radius traversal from changed files.
+- line-range mapping from git diffs to nodes.
+- test coverage lookup through direct and transitive `TESTED_BY` edges.
+- flow membership and flow criticality lookup.
+- community lookup for nodes and qualified names.
+- graph stats and all-file enumeration.
+
+The TypeScript adapter is the seam that lets Graphify reuse these review algorithms without adopting SQLite.
+
+### Graphify Target
+
+Create `src/review-store.ts` with a read-only adapter over Graphology graphs loaded from `.graphify/graph.json`.
+
+The initial adapter must not mutate graph artifacts and must not introduce a database. If later performance requires an index, it must be an optional sidecar described by a separate storage spec.
+
+### Normalized Node Contract
+
+```ts
+export type ReviewGraphNodeKind =
+  | "File"
+  | "Class"
+  | "Function"
+  | "Method"
+  | "Type"
+  | "Test"
+  | "Concept"
+  | "Document"
+  | "Image"
+  | "Video"
+  | "Unknown";
+
+export interface ReviewGraphNode {
+  id: string;
+  name: string;
+  qualifiedName: string;
+  kind: ReviewGraphNodeKind;
+  filePath: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  language: string | null;
+  parentName: string | null;
+  isTest: boolean;
+  communityId: number | null;
+  confidence: string | null;
+  extra: Record<string, unknown>;
+}
+```
+
+Mapping rules:
+
+- `id` is the Graphify node ID.
+- `name` is `attrs.label` when present, otherwise the node ID.
+- `qualifiedName` is `attrs.qualified_name`, `attrs.qualifiedName`, or the node ID.
+- `kind` is read from `attrs.kind`, `attrs.node_type`, or `attrs.type`; otherwise infer from `file_type`, path, and label.
+- `filePath` is normalized from `attrs.source_file`.
+- `lineStart` and `lineEnd` are parsed from structured attrs when present, otherwise from `source_location`.
+- `isTest` is true when kind is `Test` or the file path matches test/spec conventions.
+- `communityId` is parsed from `attrs.community`.
+- `extra` preserves original attrs for later feature-specific reads.
+
+### Normalized Edge Contract
+
+```ts
+export interface ReviewGraphEdge {
+  id: string;
+  kind: string;
+  sourceQualified: string;
+  targetQualified: string;
+  sourceId: string;
+  targetId: string;
+  filePath: string | null;
+  line: number | null;
+  confidence: number;
+  confidenceTier: string;
+  extra: Record<string, unknown>;
+}
+```
+
+Mapping rules:
+
+- `kind` canonicalizes Graphify `relation` to CRG-style upper snake case, for example `calls` to `CALLS`, `imports_from` to `IMPORTS_FROM`, and `validated_by` to `TESTED_BY`.
+- On directed Graphology graphs, `source` and `target` define direction.
+- On undirected Graphology graphs, `_src` and `_tgt` define preserved original direction when present.
+- If an undirected edge lacks `_src`/`_tgt`, review traversal may use it for impact radius but not for forward execution-flow tracing.
+- `confidence` uses `confidence_score`, `weight`, or a default of `1.0` for `EXTRACTED`, `0.5` for `INFERRED`, and `0.25` for `AMBIGUOUS`.
+- `confidenceTier` uses Graphify `confidence` or defaults to `EXTRACTED`.
+
+### Adapter Interface
+
+```ts
+export interface ReviewGraphStoreLike {
+  getNode(qualifiedNameOrId: string): ReviewGraphNode | null;
+  getNodeById(id: string): ReviewGraphNode | null;
+  getAllNodes(options?: { excludeFiles?: boolean }): ReviewGraphNode[];
+  getNodesByFile(filePath: string): ReviewGraphNode[];
+  getFilesMatching(pattern: string): string[];
+  getNodesByKind(kinds: ReviewGraphNodeKind[]): ReviewGraphNode[];
+  getAllFiles(): string[];
+
+  getEdgesBySource(qualifiedNameOrId: string, kind?: string): ReviewGraphEdge[];
+  getEdgesByTarget(qualifiedNameOrId: string, kind?: string): ReviewGraphEdge[];
+  getAllEdges(): ReviewGraphEdge[];
+  getEdgesAmong(qualifiedNamesOrIds: Set<string>): ReviewGraphEdge[];
+  getAllCallTargets(): Set<string>;
+
+  getImpactRadius(changedFiles: string[], options?: {
+    maxDepth?: number;
+    maxNodes?: number;
+    direction?: "directed" | "undirected";
+  }): ReviewImpactRadius;
+
+  getTransitiveTests(qualifiedNameOrId: string, maxDepth?: number): ReviewGraphNode[];
+  getNodeCommunityId(qualifiedNameOrId: string): number | null;
+  getCommunityIdsByQualifiedNames(qualifiedNamesOrIds: string[]): Map<string, number | null>;
+  getGraphStats(): ReviewGraphStats;
+}
+```
+
+Supporting result types:
+
+```ts
+export interface ReviewImpactRadius {
+  changedNodes: ReviewGraphNode[];
+  impactedNodes: ReviewGraphNode[];
+  impactedFiles: string[];
+  edges: ReviewGraphEdge[];
+  truncated: boolean;
+  totalImpacted: number;
+}
+
+export interface ReviewGraphStats {
+  totalNodes: number;
+  totalEdges: number;
+  nodesByKind: Record<string, number>;
+  edgesByKind: Record<string, number>;
+  languages: string[];
+  filesCount: number;
+  lastUpdated: string | null;
+}
+```
+
+Flow-aware methods are not required until F7/F8. Their signatures should be reserved in the spec but implemented with empty results only when the flow artifact exists:
+
+```ts
+export interface ReviewFlowLookup {
+  countFlowMemberships(nodeId: string): number;
+  getFlowCriticalitiesForNode(nodeId: string): number[];
+  getNodeIdsByFiles(files: string[]): string[];
+  getFlowIdsByNodeIds(nodeIds: string[]): string[];
+  getFlowQualifiedNames(flowId: string): Set<string>;
+}
+```
+
+### Path Matching
+
+The adapter must preserve existing Graphify path matching:
+
+- normalize backslashes to `/`.
+- remove leading `./`.
+- match exact paths.
+- allow suffix matches in both directions so `src/a.ts` matches `/repo/src/a.ts`.
+- expose `getFilesMatching(pattern)` for CRG-style exact-first then suffix fallback in changed-range mapping.
+- return stable sorted results.
+
+### Line Range Parsing
+
+The adapter must parse these forms when present:
+
+- structured `line_start`, `lineStart`, `line_end`, `lineEnd`.
+- `source_location` values containing `:12`, `:12-20`, `L12`, `L12-L20`, `#L12`, or `lines 12-20`.
+
+If no line range is available, F6 must fall back to file-level mapping rather than dropping the file from review.
+
+### Directed Traversal Policy
+
+Review impact may use undirected traversal to favor recall, matching CRG's conservative blast-radius posture.
+
+Execution flows must use only directed `CALLS` edges. If the graph is undirected and an edge lacks preserved `_src`/`_tgt`, F7 must skip that edge for flow tracing and report a degraded-precision warning.
+
+### F3 Target Files
+
+- Create `src/review-store.ts`.
+- Create `tests/review-store.test.ts`.
+- Export stable public types from `src/index.ts` only after the test contract is stable.
+- Keep existing `src/review.ts` and `src/review-analysis.ts` backward compatible.
+- Later implementation lots may adapt `src/review.ts`, `src/review-analysis.ts`, `src/summary.ts`, `src/cli.ts`, `src/serve.ts`, and `src/skill-runtime.ts` only after the adapter tests pass.
+
+### F3 Test Matrix
+
+Port or synthesize these CRG behaviors:
+
+| Behavior | CRG source | Graphify target test |
+| --- | --- | --- |
+| file path lookup | `GraphStore.get_nodes_by_file`, `changes.map_changes_to_nodes` | exact path and suffix path matching |
+| kind lookup | `GraphStore.get_nodes_by_kind` | function/class/test filtering |
+| source/target edge lookup | `get_edges_by_source`, `get_edges_by_target` | directed Graphology and `_src`/`_tgt` preserved direction |
+| undirected fallback | `get_impact_radius` conservative traversal | impact radius includes neighbors without claiming flow direction |
+| all call targets | `get_all_call_targets` | entry roots exclude functions/tests targeted by canonical `CALLS` edges |
+| line overlap | `changes.map_changes_to_nodes` | changed range maps to overlapping node ranges |
+| missing line fallback | `changes.analyze_changes` fallback | file-level node mapping when line ranges are absent |
+| test lookup | `get_transitive_tests` | direct `TESTED_BY`/`validated_by` and one-hop transitive coverage |
+| community lookup | `get_node_community_id`, `get_community_ids_by_qualified_names` | numeric and string community attrs |
+| stats | `GraphStore.get_stats` | node/edge counts, files count, node kinds |
+
+Additional current Graphify test gaps to close in F3:
+
+- serialized `links` vs `edges` loading in review-store fixtures.
+- directed graph review expectations.
+- Windows paths, absolute paths, and leading `./` paths.
+- missing `source_file` handling.
+- structured line range attrs plus `source_location` parsing.
+- CRG-style `qualified_name`, `kind`, `is_test`, `TESTED_BY`, transitive tests, and future flow fields.
+
+## F4-F12 Spec Skeleton
+
+F4 minimal context must be implemented after F7, F8, F5, and F6. It will combine graph stats, changed-risk summary, top communities, affected flows, and next tool suggestions.
+
+F5 review context must consume `ReviewGraphStoreLike` and preserve existing `review-analysis` outputs while adding CRG-compatible `detail_level=minimal|standard` and source snippet caps.
+
+F6 detect changes must port CRG `_SAFE_GIT_REF`, unified-diff parsing, line-range node mapping, and risk scoring factors: flow participation, cross-community callers, test coverage, security sensitivity, and caller count.
+
+F7 flows must port CRG entry-point detection, forward BFS over `CALLS`, test exclusion, max depth, trivial-flow skip, and criticality weights.
+
+F8 affected flows must map changed files to node IDs, find flows containing those nodes, and sort affected flows by criticality.
+
+F9 test-porting applies before runtime code for every feature.
+
+F10 skills must make minimal context the first review call after the CLI/runtime contract is stable.
+
+F11 report/wiki/HTML enrichment must render only grounded flow/review data and must keep existing Graphify report/wiki sections intact.
+
+F12 benchmarks must use deterministic local fixtures and must label token metrics as estimates unless backed by actual model usage.
+
+## Compatibility Rules
+
+- No behavior changes without a new command or explicit option unless current behavior is backward-compatible.
+- No real client, partner, project, proprietary ontology, or private dataset examples.
+- No MCP prompt/tool parity before CLI/runtime behavior is tested.
+- No generated report/wiki claims about flows unless F7/F8 artifacts exist.
+- Stale `.graphify` state must produce a warning before review conclusions are trusted.

--- a/spec/SPEC_UPSTREAM_TRACEABILITY.md
+++ b/spec/SPEC_UPSTREAM_TRACEABILITY.md
@@ -1,0 +1,92 @@
+# SPEC_UPSTREAM_TRACEABILITY
+
+## Status
+
+This document is the durable upstream traceability contract for the TypeScript Graphify fork.
+
+- Created: 2026-04-22
+- TypeScript baseline: `main` at `b1e2e5a2728167f483a0ec52a3221cc7249a50d2`
+- TypeScript package: `graphifyy@0.4.25`
+- Source orientation: `spec/SPEC_UPSTREAM_DUAL_CATCHUP_2026_04.md`
+- Review inspiration orientation: `spec/SPEC_CODE_REVIEW_GRAPH_OPPORUNITY.md`
+
+## Purpose
+
+Graphify TypeScript has two upstream references:
+
+- Safi Python Graphify is the product lineage.
+- `tirth8205/code-review-graph` is an additive review-workflow reference.
+
+The TypeScript fork must stay generic, npm-first, `.graphify/`-based, and TypeScript-backed. Upstream catch-up must preserve local additions unless a later spec explicitly rejects them.
+
+## Source Locks
+
+| Source | Ref | Remote observed commit | Local tracking commit | Package/version | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| TypeScript Graphify | `main` | `b1e2e5a2728167f483a0ec52a3221cc7249a50d2` | `b1e2e5a2728167f483a0ec52a3221cc7249a50d2` | `graphifyy@0.4.25` | `covered` | Current implementation baseline for this traceability pass. |
+| Safi Python Graphify | remote `v4` branch | `64e4c64d7bec574e5a56c1f0b9219e543ddbb5f3` | `64e4c64d7bec574e5a56c1f0b9219e543ddbb5f3` | `graphifyy@0.4.27` | `needs-review` | Fetched from `https://github.com/safishamsi/graphify` on 2026-04-22. |
+| Safi Python Graphify | remote tag `v0.4.23` | `8d908c5d43d079579604a82873fd7cff33a1b343` | local tag is not trusted | `0.4.23` | `covered` | Verified by `git ls-remote`; local `refs/tags/v0.4.23` is clobber-risk and must not be used as proof. |
+| Safi Python Graphify | remote tag `v0.4.24` | `2b8c08fcb66c288b22a2dfbadfe457fb8fea7c85` | reachable from `upstream/v4` | `0.4.24` | `needs-review` | Version bump plus later commits in the same release line. |
+| Safi Python Graphify | remote tag `v0.4.25` | `cc917a7bc7c9afd67c59823abcfb49cd943844c0` | reachable from `upstream/v4` | `0.4.25` | `needs-review` | Empty-community report fixes and graph-query install rules. |
+| Safi Python Graphify | remote tag `v0.4.26` | `7891fa8854367782425f75b12fee7980580473db` | reachable from `upstream/v4` | `0.4.26` | `needs-review` | Wiki encoding/collisions, hook rebase guard, detect path resolve, gitignore docs. |
+| Safi Python Graphify | remote tag `v0.4.27` | `64e4c64d7bec574e5a56c1f0b9219e543ddbb5f3` | `upstream/v4` | `0.4.27` | `needs-review` | Deterministic large-graph report, stable edge node IDs, common-root inference. |
+| code-review-graph | remote tag `v2.3.2` | `db2d2df789c25a101e33477b898c1840fb4c7bc7` | `/tmp/code-review-graph-v2.3.2` at same commit | `2.3.2` | `covered` | Stable CRG implementation reference for review features. |
+| code-review-graph | remote `main` | `0919071a9ba353e604981059e99ee2ed98768092` | not fetched into reference clone | unknown | `deferred` | Main is intentionally not the implementation target for the current CRG roadmap. |
+
+## Row States
+
+- `covered`: local TypeScript behavior is implemented and backed by tests or explicit verification.
+- `intentional-delta`: local behavior intentionally differs while preserving or improving the user contract.
+- `deferred`: valid upstream concept, but not in the active implementation scope.
+- `rejected`: intentionally not adopted.
+- `needs-review`: upstream moved or behavior is not yet mapped to local implementation/tests.
+
+## Tag Safety Rule
+
+Never trust local tags when `git fetch --tags` or prior fetch notes report clobber risk.
+
+Use primary remote checks instead:
+
+```bash
+git ls-remote --heads --tags https://github.com/safishamsi/graphify \
+  v4 refs/tags/v0.4.23 refs/tags/v0.4.24 refs/tags/v0.4.25 refs/tags/v0.4.26 refs/tags/v0.4.27
+
+git ls-remote --heads --tags https://github.com/tirth8205/code-review-graph \
+  main refs/tags/v2.3.2
+```
+
+If a local tag differs from the remote tag, record the remote commit in this document and avoid using the local tag in parity claims.
+
+## Python v4 Drift Audit
+
+Compared against the previous local Python `v4` baseline `6c8f21272c2343c4c044e3ea8a53459599f2c838`, current `upstream/v4` now includes runtime-relevant changes through `v0.4.27`.
+
+| Ref | Commit | Upstream change | TypeScript status | Required follow-up |
+| --- | --- | --- | --- | --- |
+| `v0.4.24` | `2b8c08fcb66c288b22a2dfbadfe457fb8fea7c85` | Version bump to `0.4.24` after earlier fixes. | `needs-review` | Do not version-bump TS solely for this; map behavior rows below first. |
+| post-`v0.4.24` | `6b3f8a4`, `fbac7e2`, `bba301b`, `bf58d85`, `d34b329` | Cache hashing, hook handling, watch output, sensitive directory false positives, semantic cache directory handling, label crash guards, packaging/interpreter docs. | `needs-review` | Audit against TS cache, hook, watch, security, and packaging tests. |
+| docs/translations | `53d516f`..`5a0c167` | Multilingual README expansion and move to `docs/translations/`. | `deferred` | Separate docs lot only; do not mix into runtime parity. |
+| `v0.4.25` | `cc917a7bc7c9afd67c59823abcfb49cd943844c0` | Empty-community report fixes; graph-query CLI rules in install sections. | `needs-review` | Audit TS report empty-community behavior and installed skill/query guidance. |
+| `v0.4.26` | `7891fa8854367782425f75b12fee7980580473db` | Wiki encoding/collisions, hook rebase guard, detect path resolve, README gitignore docs. | `needs-review` | Audit TS wiki slug/encoding behavior, hook branch safety, path resolution, and docs. |
+| `v0.4.27` | `64e4c64d7bec574e5a56c1f0b9219e543ddbb5f3` | Deterministic large-graph `GRAPH_REPORT`, stable edge node IDs, corrected common-root inference. | `needs-review` | Create parity lots for report determinism, extraction edge IDs, and common-root inference if not already covered. |
+
+## Intentional TypeScript Deltas To Preserve
+
+- `.graphify/` canonical state root and `graphify-out/` migration support.
+- npm package and TypeScript CLI/skill runtime.
+- Graphology/Louvain runtime instead of Python NetworkX/Leiden defaults.
+- TypeScript `faster-whisper-ts` audio/video transcription instead of Python faster-whisper.
+- PDF preflight and optional `mistral-ocr`.
+- Branch/worktree lifecycle metadata.
+- Multi-assistant installer surface and Codex `$graphify` guidance.
+- `summary`, `review-delta`, `review-analysis`, `review-eval`, `recommend-commits`.
+- Ontology/dataprep profile work as a generic opt-in TypeScript product delta.
+- CRG-inspired review roadmap without adopting SQLite as default storage.
+
+## Implementation Rules
+
+- Every upstream catch-up commit must cite the source ref in `UPSTREAM_GAP.md` or the feature spec.
+- Rows may move from `needs-review` to `covered` only after a test, explicit verification command, or documented intentional delta.
+- README changes are required only when upstream changed user-facing behavior that Graphify exposes.
+- Generated docs/translations/logos may be handled separately from runtime parity.
+- CRG `main` must not replace CRG `v2.3.2` as the review implementation baseline without a new spec update.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1775,6 +1775,92 @@ export async function main(): Promise<void> {
       console.log(firstHopSummaryToText(summary));
     });
 
+  const flows = program.command("flows").description("Execution flow analysis derived from graph CALLS edges");
+
+  flows
+    .command("build")
+    .description("Build .graphify/flows.json from graph.json")
+    .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
+    .option("--out <path>", "Path to write flows.json", resolveGraphifyPaths().flows)
+    .option("--max-depth <n>", "Maximum CALLS depth", "15")
+    .option("--include-tests", "Include tests as possible entry points")
+    .option("--json", "Print the generated artifact as JSON")
+    .action(async (opts) => {
+      const gp = resolveGraphInputPath(opts.graph);
+      if (!existsSync(gp)) {
+        console.error(`error: graph file not found: ${gp}`);
+        process.exit(1);
+      }
+      const raw = JSON.parse(readFileSync(gp, "utf-8"));
+      const G = loadGraphFromData(raw);
+      const { createReviewGraphStore } = await import("./review-store.js");
+      const { buildFlowArtifact, writeFlowArtifact } = await import("./flows.js");
+      const artifact = buildFlowArtifact(createReviewGraphStore(G), {
+        graphPath: gp,
+        maxDepth: Number(opts.maxDepth),
+        includeTests: opts.includeTests === true,
+      });
+      writeFlowArtifact(artifact, opts.out);
+      if (opts.json) {
+        console.log(JSON.stringify(artifact, null, 2));
+        return;
+      }
+      console.log(`Execution flows: ${artifact.flows.length} written to ${opts.out}`);
+      for (const warning of artifact.warnings) console.warn(warning);
+    });
+
+  flows
+    .command("list")
+    .description("List execution flows from .graphify/flows.json")
+    .option("--flows <path>", "Path to flows.json", resolveGraphifyPaths().flows)
+    .option("--sort <key>", "criticality|depth|node-count|file-count|name", "criticality")
+    .option("--limit <n>", "Maximum flows to show", "50")
+    .option("--json", "Print JSON")
+    .action(async (opts) => {
+      const { flowListToText, listFlows, readFlowArtifact } = await import("./flows.js");
+      const artifact = readFlowArtifact(opts.flows);
+      const sortBy = ["criticality", "depth", "node-count", "file-count", "name"].includes(String(opts.sort))
+        ? String(opts.sort) as "criticality" | "depth" | "node-count" | "file-count" | "name"
+        : "criticality";
+      const listOptions = {
+        sortBy,
+        limit: Number(opts.limit),
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(listFlows(artifact, listOptions), null, 2));
+        return;
+      }
+      console.log(flowListToText(artifact, listOptions));
+    });
+
+  flows
+    .command("get")
+    .description("Show execution flow details")
+    .argument("<flow-id>")
+    .option("--flows <path>", "Path to flows.json", resolveGraphifyPaths().flows)
+    .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
+    .option("--json", "Print JSON")
+    .action(async (flowId, opts) => {
+      const gp = resolveGraphInputPath(opts.graph);
+      if (!existsSync(gp)) {
+        console.error(`error: graph file not found: ${gp}`);
+        process.exit(1);
+      }
+      const G = loadGraphFromData(JSON.parse(readFileSync(gp, "utf-8")));
+      const { createReviewGraphStore } = await import("./review-store.js");
+      const { flowDetailToText, getFlowById, readFlowArtifact } = await import("./flows.js");
+      const detail = getFlowById(readFlowArtifact(opts.flows), flowId, createReviewGraphStore(G));
+      if (!detail) {
+        console.error(`error: flow not found: ${flowId}`);
+        process.exit(1);
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(detail, null, 2));
+        return;
+      }
+      console.log(flowDetailToText(detail));
+    });
+
   program
     .command("review-delta [files...]")
     .description("Review-oriented graph impact for changed files")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1983,6 +1983,47 @@ export async function main(): Promise<void> {
     });
 
   program
+    .command("minimal-context [files...]")
+    .description("Compact first-call CRG context and next-tool routing")
+    .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
+    .option("--flows <path>", "Optional path to flows.json")
+    .option("--files <csv>", "Comma or newline separated changed files")
+    .option("--base <ref>", "Git base ref; when omitted, compare working tree to HEAD")
+    .option("--head <ref>", "Git head ref to compare with --base", "HEAD")
+    .option("--staged", "Use staged changes only")
+    .option("--task <text>", "Task intent used to route next graph tools", "")
+    .option("--json", "Print JSON")
+    .action(async (files, opts) => {
+      const changedFiles = [
+        ...files,
+        ...splitFiles(opts.files),
+      ];
+      const resolvedChangedFiles = changedFiles.length > 0
+        ? [...new Set(changedFiles)].sort()
+        : changedFilesFromGit({ base: opts.base, head: opts.head, staged: opts.staged });
+      const gp = resolveGraphInputPath(opts.graph);
+      if (!existsSync(gp)) {
+        console.error(`error: graph file not found: ${gp}`);
+        process.exit(1);
+      }
+      const G = loadGraphFromData(JSON.parse(readFileSync(gp, "utf-8")));
+      const { createReviewGraphStore } = await import("./review-store.js");
+      const { readFlowArtifact } = await import("./flows.js");
+      const { buildMinimalContext, minimalContextToText } = await import("./minimal-context.js");
+      const flowsArtifact = opts.flows && existsSync(opts.flows) ? readFlowArtifact(opts.flows) : null;
+      const result = buildMinimalContext(createReviewGraphStore(G), {
+        changedFiles: resolvedChangedFiles,
+        flows: flowsArtifact,
+        task: opts.task,
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(minimalContextToText(result));
+    });
+
+  program
     .command("review-delta [files...]")
     .description("Review-oriented graph impact for changed files")
     .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1862,6 +1862,44 @@ export async function main(): Promise<void> {
     });
 
   program
+    .command("affected-flows [files...]")
+    .description("Find execution flows affected by changed files")
+    .option("--flows <path>", "Path to flows.json", resolveGraphifyPaths().flows)
+    .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
+    .option("--files <csv>", "Comma or newline separated changed files")
+    .option("--base <ref>", "Git base ref; when omitted, compare working tree to HEAD")
+    .option("--head <ref>", "Git head ref to compare with --base", "HEAD")
+    .option("--staged", "Use staged changes only")
+    .option("--json", "Print JSON")
+    .action(async (files, opts) => {
+      const changedFiles = [
+        ...files,
+        ...splitFiles(opts.files),
+      ];
+      const resolvedChangedFiles = changedFiles.length > 0
+        ? [...new Set(changedFiles)].sort()
+        : changedFilesFromGit({ base: opts.base, head: opts.head, staged: opts.staged });
+      const gp = resolveGraphInputPath(opts.graph);
+      if (!existsSync(gp)) {
+        console.error(`error: graph file not found: ${gp}`);
+        process.exit(1);
+      }
+      if (!existsSync(opts.flows)) {
+        console.error(`error: flow artifact not found: ${opts.flows}. Run graphify flows build first.`);
+        process.exit(1);
+      }
+      const G = loadGraphFromData(JSON.parse(readFileSync(gp, "utf-8")));
+      const { createReviewGraphStore } = await import("./review-store.js");
+      const { affectedFlowsToText, getAffectedFlows, readFlowArtifact } = await import("./flows.js");
+      const result = getAffectedFlows(readFlowArtifact(opts.flows), resolvedChangedFiles, createReviewGraphStore(G));
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(affectedFlowsToText(result));
+    });
+
+  program
     .command("review-delta [files...]")
     .description("Review-oriented graph impact for changed files")
     .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1943,6 +1943,46 @@ export async function main(): Promise<void> {
     });
 
   program
+    .command("detect-changes [files...]")
+    .description("CRG-style line-aware risk scoring for changed files")
+    .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
+    .option("--flows <path>", "Optional path to flows.json")
+    .option("--files <csv>", "Comma or newline separated changed files")
+    .option("--base <ref>", "Git base ref; when omitted, compare working tree to HEAD")
+    .option("--head <ref>", "Git head ref to compare with --base", "HEAD")
+    .option("--staged", "Use staged changes only")
+    .option("--detail-level <level>", "minimal|standard", "standard")
+    .option("--json", "Print JSON")
+    .action(async (files, opts) => {
+      const changedFiles = [
+        ...files,
+        ...splitFiles(opts.files),
+      ];
+      const resolvedChangedFiles = changedFiles.length > 0
+        ? [...new Set(changedFiles)].sort()
+        : changedFilesFromGit({ base: opts.base, head: opts.head, staged: opts.staged });
+      const gp = resolveGraphInputPath(opts.graph);
+      if (!existsSync(gp)) {
+        console.error(`error: graph file not found: ${gp}`);
+        process.exit(1);
+      }
+      const G = loadGraphFromData(JSON.parse(readFileSync(gp, "utf-8")));
+      const { createReviewGraphStore } = await import("./review-store.js");
+      const { readFlowArtifact } = await import("./flows.js");
+      const { analyzeChanges, detectChangesToMinimal, detectChangesToText } = await import("./detect-changes.js");
+      const flowsArtifact = opts.flows && existsSync(opts.flows) ? readFlowArtifact(opts.flows) : null;
+      const result = analyzeChanges(createReviewGraphStore(G), resolvedChangedFiles, {
+        flows: flowsArtifact,
+      });
+      const output = opts.detailLevel === "minimal" ? detectChangesToMinimal(result) : result;
+      if (opts.json) {
+        console.log(JSON.stringify(output, null, 2));
+        return;
+      }
+      console.log(detectChangesToText(output));
+    });
+
+  program
     .command("review-delta [files...]")
     .description("Review-oriented graph impact for changed files")
     .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1900,6 +1900,49 @@ export async function main(): Promise<void> {
     });
 
   program
+    .command("review-context [files...]")
+    .description("Focused CRG-style review context for changed files")
+    .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
+    .option("--files <csv>", "Comma or newline separated changed files")
+    .option("--base <ref>", "Git base ref; when omitted, compare working tree to HEAD")
+    .option("--head <ref>", "Git head ref to compare with --base", "HEAD")
+    .option("--staged", "Use staged changes only")
+    .option("--detail-level <level>", "minimal|standard", "standard")
+    .option("--include-source", "Include capped source snippets")
+    .option("--max-depth <n>", "Impact radius depth", "2")
+    .option("--max-lines-per-file <n>", "Maximum full-file snippet lines", "200")
+    .option("--json", "Print JSON")
+    .action(async (files, opts) => {
+      const changedFiles = [
+        ...files,
+        ...splitFiles(opts.files),
+      ];
+      const resolvedChangedFiles = changedFiles.length > 0
+        ? [...new Set(changedFiles)].sort()
+        : changedFilesFromGit({ base: opts.base, head: opts.head, staged: opts.staged });
+      const gp = resolveGraphInputPath(opts.graph);
+      if (!existsSync(gp)) {
+        console.error(`error: graph file not found: ${gp}`);
+        process.exit(1);
+      }
+      const G = loadGraphFromData(JSON.parse(readFileSync(gp, "utf-8")));
+      const { createReviewGraphStore } = await import("./review-store.js");
+      const { buildReviewContext, reviewContextToText } = await import("./review-context.js");
+      const result = buildReviewContext(createReviewGraphStore(G), resolvedChangedFiles, {
+        detailLevel: opts.detailLevel === "minimal" ? "minimal" : "standard",
+        includeSource: opts.includeSource === true,
+        maxDepth: Number(opts.maxDepth),
+        maxLinesPerFile: Number(opts.maxLinesPerFile),
+        repoRoot: ".",
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(reviewContextToText(result));
+    });
+
+  program
     .command("review-delta [files...]")
     .description("Review-oriented graph impact for changed files")
     .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())

--- a/src/detect-changes.ts
+++ b/src/detect-changes.ts
@@ -1,0 +1,316 @@
+import type { ReviewFlowArtifact, ReviewFlowDetail } from "./flows.js";
+import { getAffectedFlows } from "./flows.js";
+import type {
+  ReviewGraphNode,
+  ReviewGraphStoreLike,
+} from "./review-store.js";
+
+export interface ChangedRange {
+  start: number;
+  end: number;
+}
+
+export type ChangedRangesByFile = Record<string, Array<[number, number]> | ChangedRange[]>;
+
+export interface ComputeRiskScoreOptions {
+  flows?: ReviewFlowArtifact | null;
+}
+
+export interface AnalyzeChangesOptions extends ComputeRiskScoreOptions {
+  changedRanges?: ChangedRangesByFile | null;
+}
+
+export interface DetectChangesNodeRisk {
+  id: string;
+  name: string;
+  qualifiedName: string;
+  kind: string;
+  filePath: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  riskScore: number;
+}
+
+export interface DetectChangesTestGap {
+  name: string;
+  qualifiedName: string;
+  file: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+}
+
+export interface DetectChangesResult {
+  status: "ok";
+  summary: string;
+  riskScore: number;
+  changedFiles: string[];
+  changedFunctions: DetectChangesNodeRisk[];
+  affectedFlows: ReviewFlowDetail[];
+  testGaps: DetectChangesTestGap[];
+  reviewPriorities: DetectChangesNodeRisk[];
+  warnings: string[];
+}
+
+export interface DetectChangesMinimalResult {
+  status: "ok";
+  summary: string;
+  riskScore: number;
+  changedFileCount: number;
+  testGapCount: number;
+  reviewPriorities: string[];
+  warnings: string[];
+}
+
+const SAFE_GIT_REF_RE = /^(?!-)(?!.*\.\.)[A-Za-z0-9_.~^/@{}-]+$/u;
+
+const SECURITY_KEYWORDS = [
+  "auth",
+  "login",
+  "password",
+  "token",
+  "session",
+  "crypt",
+  "secret",
+  "credential",
+  "permission",
+  "sql",
+  "query",
+  "execute",
+  "connect",
+  "socket",
+  "request",
+  "http",
+  "sanitize",
+  "validate",
+  "encrypt",
+  "decrypt",
+  "hash",
+  "sign",
+  "verify",
+  "admin",
+  "privilege",
+];
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort(compareStrings);
+}
+
+function rangeStart(range: [number, number] | ChangedRange): number {
+  return Array.isArray(range) ? range[0] : range.start;
+}
+
+function rangeEnd(range: [number, number] | ChangedRange): number {
+  return Array.isArray(range) ? range[1] : range.end;
+}
+
+function sortNodesByLocation(nodes: ReviewGraphNode[]): ReviewGraphNode[] {
+  return [...nodes].sort((a, b) => (
+    compareStrings(a.filePath ?? "", b.filePath ?? "") ||
+    (a.lineStart ?? Number.MAX_SAFE_INTEGER) - (b.lineStart ?? Number.MAX_SAFE_INTEGER) ||
+    compareStrings(a.qualifiedName, b.qualifiedName)
+  ));
+}
+
+function nodeRiskRecord(node: ReviewGraphNode, riskScore: number): DetectChangesNodeRisk {
+  return {
+    id: node.id,
+    name: node.name,
+    qualifiedName: node.qualifiedName,
+    kind: node.kind,
+    filePath: node.filePath,
+    lineStart: node.lineStart,
+    lineEnd: node.lineEnd,
+    riskScore,
+  };
+}
+
+export function isSafeGitRef(ref: string): boolean {
+  return SAFE_GIT_REF_RE.test(ref);
+}
+
+export function parseUnifiedDiff(diffText: string): Record<string, Array<[number, number]>> {
+  const ranges: Record<string, Array<[number, number]>> = {};
+  let currentFile: string | null = null;
+  const filePattern = /^\+\+\+ b\/(.+)$/u;
+  const hunkPattern = /^@@ .+? \+(\d+)(?:,(\d+))? @@/u;
+
+  for (const line of diffText.split(/\r?\n/u)) {
+    const fileMatch = line.match(filePattern);
+    if (fileMatch?.[1]) {
+      currentFile = fileMatch[1];
+      continue;
+    }
+    const hunkMatch = line.match(hunkPattern);
+    if (!hunkMatch?.[1] || currentFile === null) continue;
+    const start = Number.parseInt(hunkMatch[1], 10);
+    const count = hunkMatch[2] ? Number.parseInt(hunkMatch[2], 10) : 1;
+    const end = count === 0 ? start : start + count - 1;
+    ranges[currentFile] ??= [];
+    ranges[currentFile]!.push([start, end]);
+  }
+
+  return ranges;
+}
+
+export function mapChangesToNodes(
+  store: ReviewGraphStoreLike,
+  changedRanges: ChangedRangesByFile,
+): ReviewGraphNode[] {
+  const seen = new Set<string>();
+  const result: ReviewGraphNode[] = [];
+
+  for (const [filePath, ranges] of Object.entries(changedRanges)) {
+    let nodes = store.getNodesByFile(filePath);
+    if (nodes.length === 0) {
+      for (const match of store.getFilesMatching(filePath)) nodes = [...nodes, ...store.getNodesByFile(match)];
+    }
+    for (const node of nodes) {
+      if (seen.has(node.qualifiedName) || node.lineStart === null || node.lineEnd === null) continue;
+      if (ranges.some((range) => node.lineStart! <= rangeEnd(range) && node.lineEnd! >= rangeStart(range))) {
+        seen.add(node.qualifiedName);
+        result.push(node);
+      }
+    }
+  }
+
+  return sortNodesByLocation(result);
+}
+
+export function computeRiskScore(
+  store: ReviewGraphStoreLike,
+  node: ReviewGraphNode,
+  options: ComputeRiskScoreOptions = {},
+): number {
+  let score = 0;
+
+  const flowCriticalities = options.flows?.flows
+    .filter((flow) => flow.path.includes(node.id))
+    .map((flow) => flow.criticality) ?? [];
+  if (flowCriticalities.length > 0) {
+    score += Math.min(flowCriticalities.reduce((sum, value) => sum + value, 0), 0.25);
+  }
+
+  const callers = store.getEdgesByTarget(node.qualifiedName, "CALLS");
+  const nodeCommunity = store.getNodeCommunityId(node.id);
+  if (nodeCommunity !== null && callers.length > 0) {
+    const callerCommunities = store.getCommunityIdsByQualifiedNames(callers.map((edge) => edge.sourceQualified));
+    const crossCommunity = [...callerCommunities.values()].filter((community) => community !== null && community !== nodeCommunity).length;
+    score += Math.min(crossCommunity * 0.05, 0.15);
+  }
+
+  const testCount = store.getTransitiveTests(node.qualifiedName).length;
+  score += 0.30 - Math.min(testCount / 5, 1) * 0.25;
+
+  const name = node.name.toLowerCase();
+  const qualified = node.qualifiedName.toLowerCase();
+  if (SECURITY_KEYWORDS.some((keyword) => name.includes(keyword) || qualified.includes(keyword))) {
+    score += 0.20;
+  }
+
+  score += Math.min(callers.length / 20, 0.10);
+
+  return Math.round(Math.min(Math.max(score, 0), 1) * 10000) / 10000;
+}
+
+function changedNodesFromFiles(store: ReviewGraphStoreLike, changedFiles: string[]): ReviewGraphNode[] {
+  const nodes = new Map<string, ReviewGraphNode>();
+  for (const file of changedFiles) {
+    for (const node of store.getNodesByFile(file)) nodes.set(node.qualifiedName, node);
+  }
+  return sortNodesByLocation([...nodes.values()]);
+}
+
+function isRiskScoredKind(node: ReviewGraphNode): boolean {
+  return node.kind === "Function" || node.kind === "Method" || node.kind === "Test" || node.kind === "Class";
+}
+
+function testGapRecord(node: ReviewGraphNode): DetectChangesTestGap {
+  return {
+    name: node.name,
+    qualifiedName: node.qualifiedName,
+    file: node.filePath,
+    lineStart: node.lineStart,
+    lineEnd: node.lineEnd,
+  };
+}
+
+export function analyzeChanges(
+  store: ReviewGraphStoreLike,
+  changedFilesInput: string[],
+  options: AnalyzeChangesOptions = {},
+): DetectChangesResult {
+  const changedFiles = uniqueSorted(changedFilesInput);
+  const changedNodes = options.changedRanges && Object.keys(options.changedRanges).length > 0
+    ? mapChangesToNodes(store, options.changedRanges)
+    : changedNodesFromFiles(store, changedFiles);
+  const changedFunctions = sortNodesByLocation(changedNodes.filter(isRiskScoredKind));
+  const nodeRisks = changedFunctions.map((node) => nodeRiskRecord(node, computeRiskScore(store, node, options)));
+  const riskScore = Math.max(...nodeRisks.map((node) => node.riskScore), 0);
+  const affectedFlows = options.flows ? getAffectedFlows(options.flows, changedFiles, store).affectedFlows : [];
+  const testGaps = changedFunctions
+    .filter((node) => !node.isTest && store.getEdgesByTarget(node.qualifiedName, "TESTED_BY").length === 0)
+    .map(testGapRecord);
+  const reviewPriorities = [...nodeRisks].sort((a, b) => b.riskScore - a.riskScore || compareStrings(a.qualifiedName, b.qualifiedName)).slice(0, 10);
+  const summaryLines = [
+    `Analyzed ${changedFiles.length} changed file(s):`,
+    `  - ${changedFunctions.length} changed function(s)/class(es)`,
+    `  - ${affectedFlows.length} affected flow(s)`,
+    `  - ${testGaps.length} test gap(s)`,
+    `  - Overall risk score: ${riskScore.toFixed(2)}`,
+  ];
+  if (testGaps.length > 0) summaryLines.push(`  - Untested: ${testGaps.slice(0, 5).map((gap) => gap.name).join(", ")}`);
+
+  return {
+    status: "ok",
+    summary: summaryLines.join("\n"),
+    riskScore,
+    changedFiles,
+    changedFunctions: nodeRisks,
+    affectedFlows,
+    testGaps,
+    reviewPriorities,
+    warnings: [],
+  };
+}
+
+export function detectChangesToMinimal(result: DetectChangesResult): DetectChangesMinimalResult {
+  return {
+    status: "ok",
+    summary: result.summary,
+    riskScore: result.riskScore,
+    changedFileCount: result.changedFiles.length,
+    testGapCount: result.testGaps.length,
+    reviewPriorities: result.reviewPriorities.slice(0, 3).map((priority) => priority.name),
+    warnings: result.warnings,
+  };
+}
+
+export function detectChangesToText(result: DetectChangesResult | DetectChangesMinimalResult): string {
+  const lines = [
+    result.summary,
+    `Risk score: ${result.riskScore.toFixed(4)}`,
+  ];
+  if ("changedFunctions" in result) {
+    lines.push("Review priorities:");
+    for (const priority of result.reviewPriorities) {
+      lines.push(`- ${priority.name} (${priority.qualifiedName}) risk=${priority.riskScore.toFixed(4)}`);
+    }
+    lines.push(`Affected flows: ${result.affectedFlows.length}`);
+    lines.push(`Test gaps: ${result.testGaps.length}`);
+  } else {
+    lines.push(`Changed files: ${result.changedFileCount}`);
+    lines.push(`Test gaps: ${result.testGapCount}`);
+    lines.push(`Review priorities: ${result.reviewPriorities.join(", ") || "none"}`);
+  }
+  if (result.warnings.length > 0) {
+    lines.push("Warnings:");
+    for (const warning of result.warnings) lines.push(`- ${warning}`);
+  }
+  return lines.join("\n");
+}

--- a/src/flows.ts
+++ b/src/flows.ts
@@ -59,6 +59,14 @@ export interface ReviewFlowArtifact {
   flows: ReviewFlow[];
 }
 
+export interface AffectedFlowsResult {
+  changedFiles: string[];
+  matchedNodeIds: string[];
+  unmatchedFiles: string[];
+  affectedFlows: ReviewFlowDetail[];
+  total: number;
+}
+
 export interface ListFlowsOptions {
   sortBy?: "criticality" | "depth" | "node-count" | "file-count" | "name";
   limit?: number;
@@ -415,6 +423,60 @@ export function getFlowById(
   };
 }
 
+export function getAffectedFlows(
+  artifact: ReviewFlowArtifact,
+  changedFiles: string[],
+  store: ReviewGraphStoreLike,
+): AffectedFlowsResult {
+  const normalizedFiles = [...new Set(changedFiles.map((file) => file.trim()).filter(Boolean))].sort(compareStrings);
+  if (normalizedFiles.length === 0) {
+    return {
+      changedFiles: [],
+      matchedNodeIds: [],
+      unmatchedFiles: [],
+      affectedFlows: [],
+      total: 0,
+    };
+  }
+
+  const matchedNodeIds = new Set<string>();
+  const unmatchedFiles: string[] = [];
+  for (const file of normalizedFiles) {
+    const nodes = store.getNodesByFile(file);
+    if (nodes.length === 0) {
+      unmatchedFiles.push(file);
+      continue;
+    }
+    for (const node of nodes) matchedNodeIds.add(node.id);
+  }
+
+  const matched = [...matchedNodeIds].sort(compareStrings);
+  if (matched.length === 0) {
+    return {
+      changedFiles: normalizedFiles,
+      matchedNodeIds: [],
+      unmatchedFiles,
+      affectedFlows: [],
+      total: 0,
+    };
+  }
+
+  const matchedSet = new Set(matched);
+  const affectedFlows = artifact.flows
+    .filter((flow) => flow.path.some((nodeId) => matchedSet.has(nodeId)))
+    .map((flow) => getFlowById(artifact, flow.id, store))
+    .filter((flow): flow is ReviewFlowDetail => !!flow && "steps" in flow)
+    .sort((a, b) => b.criticality - a.criticality || compareStrings(a.name, b.name));
+
+  return {
+    changedFiles: normalizedFiles,
+    matchedNodeIds: matched,
+    unmatchedFiles,
+    affectedFlows,
+    total: affectedFlows.length,
+  };
+}
+
 export function flowListToText(artifact: ReviewFlowArtifact, options: ListFlowsOptions = {}): string {
   const flows = listFlows(artifact, options);
   const lines = [
@@ -429,6 +491,25 @@ export function flowListToText(artifact: ReviewFlowArtifact, options: ListFlowsO
       `- ${flow.id} entry=${flow.entryPoint} criticality=${flow.criticality.toFixed(4)} ` +
       `depth=${flow.depth} nodes=${flow.nodeCount} files=${flow.fileCount}`,
     );
+  }
+  return lines.join("\n");
+}
+
+export function affectedFlowsToText(result: AffectedFlowsResult): string {
+  const lines = [
+    `Affected flows: ${result.total}`,
+    `Changed files: ${result.changedFiles.length}`,
+    `Matched nodes: ${result.matchedNodeIds.length}`,
+  ];
+  if (result.unmatchedFiles.length > 0) {
+    lines.push(`Unmatched files: ${result.unmatchedFiles.join(", ")}`);
+  }
+  for (const flow of result.affectedFlows) {
+    lines.push(
+      `- ${flow.id} entry=${flow.entryPoint} criticality=${flow.criticality.toFixed(4)} ` +
+      `depth=${flow.depth} nodes=${flow.nodeCount} files=${flow.fileCount}`,
+    );
+    for (const step of flow.steps) lines.push(`  - ${step.qualifiedName}`);
   }
   return lines.join("\n");
 }

--- a/src/flows.ts
+++ b/src/flows.ts
@@ -1,0 +1,460 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import type {
+  ReviewGraphNode,
+  ReviewGraphNodeKind,
+  ReviewGraphStoreLike,
+} from "./review-store.js";
+
+export interface DetectEntryPointsOptions {
+  includeTests?: boolean;
+}
+
+export interface TraceFlowsOptions extends DetectEntryPointsOptions {
+  maxDepth?: number;
+}
+
+export interface BuildFlowArtifactOptions extends TraceFlowsOptions {
+  graphPath?: string | null;
+  generatedAt?: string;
+}
+
+export interface ReviewFlow {
+  id: string;
+  name: string;
+  entryPoint: string;
+  entryPointId: string;
+  path: string[];
+  qualifiedPath: string[];
+  depth: number;
+  nodeCount: number;
+  fileCount: number;
+  files: string[];
+  criticality: number;
+  warnings: string[];
+}
+
+export interface ReviewFlowStep {
+  nodeId: string;
+  name: string;
+  kind: ReviewGraphNodeKind;
+  file: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  qualifiedName: string;
+}
+
+export interface ReviewFlowDetail extends ReviewFlow {
+  steps: ReviewFlowStep[];
+}
+
+export interface ReviewFlowArtifact {
+  version: 1;
+  generatedAt: string;
+  graphPath: string | null;
+  maxDepth: number;
+  includeTests: boolean;
+  warnings: string[];
+  flows: ReviewFlow[];
+}
+
+export interface ListFlowsOptions {
+  sortBy?: "criticality" | "depth" | "node-count" | "file-count" | "name";
+  limit?: number;
+}
+
+const FLOW_ARTIFACT_VERSION = 1 as const;
+const DEFAULT_MAX_DEPTH = 15;
+
+const FRAMEWORK_DECORATOR_PATTERNS: RegExp[] = [
+  /app\.(get|post|put|delete|patch|route|websocket|on_event)/iu,
+  /router\.(get|post|put|delete|patch|route)/iu,
+  /blueprint\.(route|before_request|after_request)/iu,
+  /(before|after)_(request|response)/iu,
+  /click\.(command|group)/iu,
+  /\w+\.(command|group)\b/iu,
+  /(field|model)_(serializer|validator)/iu,
+  /(celery\.)?(task|shared_task|periodic_task)/iu,
+  /receiver/iu,
+  /api_view/iu,
+  /\baction\b/iu,
+  /pytest\.(fixture|mark)/u,
+  /(override_settings|modify_settings)/iu,
+  /(event\.)?listens_for/iu,
+  /(Get|Post|Put|Delete|Patch|RequestMapping)Mapping/iu,
+  /(Scheduled|EventListener|Bean|Configuration)/iu,
+  /(Component|Injectable|Controller|Module|Guard|Pipe)/iu,
+  /(Subscribe|Mutation|Query|Resolver)/iu,
+  /(app|router)\.(get|post|put|delete|patch|use|all)\b/u,
+  /@(Override|OnLifecycleEvent|Composable)/iu,
+  /(HiltViewModel|AndroidEntryPoint|Inject)/iu,
+  /\w+\.(tool|tool_plain|system_prompt|result_validator)\b/iu,
+  /^tool\b/iu,
+  /\w+\.(middleware|exception_handler|on_exception)\b/iu,
+  /\w+\.route\b/iu,
+];
+
+const ENTRY_NAME_PATTERNS: RegExp[] = [
+  /^main$/u,
+  /^__main__$/u,
+  /^test_/u,
+  /^Test[A-Z]/u,
+  /^on_/u,
+  /^handle_/u,
+  /^handler$/u,
+  /^handle$/u,
+  /^lambda_handler$/u,
+  /^upgrade$/u,
+  /^downgrade$/u,
+  /^lifespan$/u,
+  /^get_db$/u,
+  /^on(Create|Start|Resume|Pause|Stop|Destroy|Bind|Receive)/u,
+  /^do(Get|Post|Put|Delete)$/u,
+  /^do_(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$/u,
+  /^log_message$/u,
+  /^(middleware|errorHandler)$/u,
+  /^ng(OnInit|OnChanges|OnDestroy|DoCheck|AfterContentInit|AfterContentChecked|AfterViewInit|AfterViewChecked)$/u,
+  /^(transform|writeValue|registerOnChange|registerOnTouched|setDisabledState)$/u,
+  /^(canActivate|canDeactivate|canActivateChild|canLoad|canMatch|resolve)$/u,
+  /^(componentDidMount|componentDidUpdate|componentWillUnmount|shouldComponentUpdate|render)$/u,
+];
+
+const TEST_FILE_RE = /([\\/]__tests__[\\/]|\.spec\.[jt]sx?$|\.test\.[jt]sx?$|[\\/]test_[^/\\]*\.py$)/u;
+
+const SECURITY_KEYWORDS = [
+  "auth",
+  "login",
+  "password",
+  "token",
+  "session",
+  "crypt",
+  "secret",
+  "credential",
+  "permission",
+  "sql",
+  "query",
+  "execute",
+  "connect",
+  "socket",
+  "request",
+  "http",
+  "sanitize",
+  "validate",
+  "encrypt",
+  "decrypt",
+  "hash",
+  "sign",
+  "verify",
+  "admin",
+  "privilege",
+];
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function isTestFile(filePath: string | null): boolean {
+  return !!filePath && TEST_FILE_RE.test(filePath);
+}
+
+function decoratorsOf(node: ReviewGraphNode): string[] {
+  const decorators = node.extra.decorators;
+  if (typeof decorators === "string") return [decorators];
+  if (Array.isArray(decorators)) return decorators.filter((item): item is string => typeof item === "string");
+  return [];
+}
+
+function hasFrameworkDecorator(node: ReviewGraphNode): boolean {
+  return decoratorsOf(node).some((decorator) => FRAMEWORK_DECORATOR_PATTERNS.some((pattern) => pattern.test(decorator)));
+}
+
+function matchesEntryName(node: ReviewGraphNode): boolean {
+  return ENTRY_NAME_PATTERNS.some((pattern) => pattern.test(node.name));
+}
+
+function sanitizeFlowName(name: string): string {
+  return name.replace(/[^\w.:-]+/gu, "_").replace(/^_+|_+$/gu, "") || "flow";
+}
+
+function flowIdFor(entryPointId: string, seen: Set<string>): string {
+  const base = `flow:${sanitizeFlowName(entryPointId)}`;
+  let candidate = base;
+  let suffix = 2;
+  while (seen.has(candidate)) {
+    candidate = `${base}:${suffix}`;
+    suffix += 1;
+  }
+  seen.add(candidate);
+  return candidate;
+}
+
+function stableFiles(nodes: ReviewGraphNode[]): string[] {
+  return [...new Set(nodes.map((node) => node.filePath).filter((file): file is string => !!file))].sort(compareStrings);
+}
+
+export function detectEntryPoints(
+  store: ReviewGraphStoreLike,
+  options: DetectEntryPointsOptions = {},
+): ReviewGraphNode[] {
+  const calledQualifiedNames = store.getAllCallTargets();
+  const candidates = store.getNodesByKind(["Function", "Test"]);
+  const entryPoints: ReviewGraphNode[] = [];
+  const seen = new Set<string>();
+
+  for (const node of candidates) {
+    if (!options.includeTests && (node.isTest || isTestFile(node.filePath))) continue;
+    const isEntry = !calledQualifiedNames.has(node.qualifiedName) || hasFrameworkDecorator(node) || matchesEntryName(node);
+    if (!isEntry || seen.has(node.qualifiedName)) continue;
+    entryPoints.push(node);
+    seen.add(node.qualifiedName);
+  }
+  return entryPoints;
+}
+
+interface TraceResult {
+  flows: ReviewFlow[];
+  warnings: string[];
+}
+
+function traceSingleFlow(
+  store: ReviewGraphStoreLike,
+  entryPoint: ReviewGraphNode,
+  id: string,
+  maxDepth: number,
+  warnings: string[],
+): ReviewFlow | null {
+  const pathIds: string[] = [entryPoint.id];
+  const qualifiedPath: string[] = [entryPoint.qualifiedName];
+  const visited = new Set<string>([entryPoint.qualifiedName]);
+  const queue: Array<{ qualifiedName: string; depth: number }> = [{ qualifiedName: entryPoint.qualifiedName, depth: 0 }];
+  const flowWarnings: string[] = [];
+  let actualDepth = 0;
+  let skippedUndirectedCalls = 0;
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    actualDepth = Math.max(actualDepth, current.depth);
+    if (current.depth >= maxDepth) continue;
+
+    for (const edge of store.getEdgesBySource(current.qualifiedName, "CALLS")) {
+      if (edge.direction === "undirected") {
+        skippedUndirectedCalls += 1;
+        continue;
+      }
+      if (visited.has(edge.targetQualified)) continue;
+      const target = store.getNode(edge.targetQualified);
+      if (!target) continue;
+      visited.add(target.qualifiedName);
+      pathIds.push(target.id);
+      qualifiedPath.push(target.qualifiedName);
+      queue.push({ qualifiedName: target.qualifiedName, depth: current.depth + 1 });
+    }
+  }
+
+  if (skippedUndirectedCalls > 0) {
+    const warning = `Skipped ${skippedUndirectedCalls} CALLS edge(s) without preserved direction while tracing ${entryPoint.qualifiedName}.`;
+    flowWarnings.push(warning);
+    warnings.push(warning);
+  }
+
+  if (pathIds.length < 2) return null;
+
+  const nodes = qualifiedPath.map((qualifiedName) => store.getNode(qualifiedName)).filter((node): node is ReviewGraphNode => !!node);
+  const flow: ReviewFlow = {
+    id,
+    name: sanitizeFlowName(entryPoint.name),
+    entryPoint: entryPoint.qualifiedName,
+    entryPointId: entryPoint.id,
+    path: pathIds,
+    qualifiedPath,
+    depth: actualDepth,
+    nodeCount: pathIds.length,
+    fileCount: stableFiles(nodes).length,
+    files: stableFiles(nodes),
+    criticality: 0,
+    warnings: flowWarnings,
+  };
+  flow.criticality = computeFlowCriticality(flow, store);
+  return flow;
+}
+
+function traceFlowsWithWarnings(
+  store: ReviewGraphStoreLike,
+  options: TraceFlowsOptions = {},
+): TraceResult {
+  const warnings: string[] = [];
+  const maxDepth = Math.max(0, options.maxDepth ?? DEFAULT_MAX_DEPTH);
+  const flowIds = new Set<string>();
+  const flows = detectEntryPoints(store, { includeTests: options.includeTests }).flatMap((entryPoint) => {
+    const flow = traceSingleFlow(store, entryPoint, flowIdFor(entryPoint.id, flowIds), maxDepth, warnings);
+    return flow ? [flow] : [];
+  });
+  return {
+    flows: listFlows({ version: FLOW_ARTIFACT_VERSION, generatedAt: "", graphPath: null, maxDepth, includeTests: options.includeTests === true, warnings, flows }),
+    warnings,
+  };
+}
+
+export function traceFlows(store: ReviewGraphStoreLike, options: TraceFlowsOptions = {}): ReviewFlow[] {
+  return traceFlowsWithWarnings(store, options).flows;
+}
+
+export function computeFlowCriticality(flow: ReviewFlow, store: ReviewGraphStoreLike): number {
+  const nodes = flow.path.map((nodeId) => store.getNodeById(nodeId)).filter((node): node is ReviewGraphNode => !!node);
+  if (nodes.length === 0) return 0;
+
+  const fileSpread = flow.fileCount > 1 ? Math.min((flow.fileCount - 1) / 4, 1) : 0;
+  let externalCount = 0;
+  for (const node of nodes) {
+    for (const edge of store.getEdgesBySource(node.qualifiedName, "CALLS")) {
+      if (!store.getNode(edge.targetQualified)) externalCount += 1;
+    }
+  }
+  const externalScore = Math.min(externalCount / 5, 1);
+  let securityHits = 0;
+  for (const node of nodes) {
+    const name = node.name.toLowerCase();
+    const qualified = node.qualifiedName.toLowerCase();
+    if (SECURITY_KEYWORDS.some((keyword) => name.includes(keyword) || qualified.includes(keyword))) {
+      securityHits += 1;
+    }
+  }
+  const securityScore = Math.min(securityHits / Math.max(nodes.length, 1), 1);
+  const testedCount = nodes.filter((node) => store.getEdgesByTarget(node.qualifiedName, "TESTED_BY").length > 0).length;
+  const testGap = 1 - testedCount / Math.max(nodes.length, 1);
+  const depthScore = Math.min(flow.depth / 10, 1);
+  const criticality = fileSpread * 0.30 + externalScore * 0.20 + securityScore * 0.25 + testGap * 0.15 + depthScore * 0.10;
+  return Math.round(Math.min(Math.max(criticality, 0), 1) * 10000) / 10000;
+}
+
+export function buildFlowArtifact(
+  store: ReviewGraphStoreLike,
+  options: BuildFlowArtifactOptions = {},
+): ReviewFlowArtifact {
+  const maxDepth = Math.max(0, options.maxDepth ?? DEFAULT_MAX_DEPTH);
+  const result = traceFlowsWithWarnings(store, {
+    includeTests: options.includeTests,
+    maxDepth,
+  });
+  return {
+    version: FLOW_ARTIFACT_VERSION,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    graphPath: options.graphPath ?? null,
+    maxDepth,
+    includeTests: options.includeTests === true,
+    warnings: [...new Set(result.warnings)].sort(compareStrings),
+    flows: result.flows,
+  };
+}
+
+export function writeFlowArtifact(artifact: ReviewFlowArtifact, path: string): void {
+  const out = resolve(path);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(artifact, null, 2)}\n`, "utf-8");
+}
+
+export function readFlowArtifact(path: string): ReviewFlowArtifact {
+  const artifact = JSON.parse(readFileSync(resolve(path), "utf-8")) as ReviewFlowArtifact;
+  if (artifact.version !== FLOW_ARTIFACT_VERSION || !Array.isArray(artifact.flows)) {
+    throw new Error(`Invalid graphify flow artifact: ${path}`);
+  }
+  return artifact;
+}
+
+export function listFlows(artifact: ReviewFlowArtifact, options: ListFlowsOptions = {}): ReviewFlow[] {
+  const limit = Math.max(0, options.limit ?? artifact.flows.length);
+  const sortBy = options.sortBy ?? "criticality";
+  return [...artifact.flows]
+    .sort((a, b) => {
+      switch (sortBy) {
+        case "depth":
+          return b.depth - a.depth || compareStrings(a.name, b.name);
+        case "node-count":
+          return b.nodeCount - a.nodeCount || compareStrings(a.name, b.name);
+        case "file-count":
+          return b.fileCount - a.fileCount || compareStrings(a.name, b.name);
+        case "name":
+          return compareStrings(a.name, b.name);
+        case "criticality":
+        default:
+          return b.criticality - a.criticality || compareStrings(a.name, b.name);
+      }
+    })
+    .slice(0, limit);
+}
+
+export function flowToSteps(flow: ReviewFlow, store: ReviewGraphStoreLike): ReviewFlowStep[] {
+  return flow.path
+    .map((nodeId) => store.getNodeById(nodeId))
+    .filter((node): node is ReviewGraphNode => !!node)
+    .map((node) => ({
+      nodeId: node.id,
+      name: node.name,
+      kind: node.kind,
+      file: node.filePath,
+      lineStart: node.lineStart,
+      lineEnd: node.lineEnd,
+      qualifiedName: node.qualifiedName,
+    }));
+}
+
+export function getFlowById(
+  artifact: ReviewFlowArtifact,
+  flowId: string,
+  store?: ReviewGraphStoreLike,
+): ReviewFlowDetail | ReviewFlow | null {
+  const flow = artifact.flows.find((item) => item.id === flowId);
+  if (!flow) return null;
+  if (!store) return flow;
+  return {
+    ...flow,
+    steps: flowToSteps(flow, store),
+  };
+}
+
+export function flowListToText(artifact: ReviewFlowArtifact, options: ListFlowsOptions = {}): string {
+  const flows = listFlows(artifact, options);
+  const lines = [
+    `Execution flows: ${flows.length}/${artifact.flows.length}`,
+  ];
+  if (artifact.warnings.length > 0) {
+    lines.push("Warnings:");
+    for (const warning of artifact.warnings) lines.push(`- ${warning}`);
+  }
+  for (const flow of flows) {
+    lines.push(
+      `- ${flow.id} entry=${flow.entryPoint} criticality=${flow.criticality.toFixed(4)} ` +
+      `depth=${flow.depth} nodes=${flow.nodeCount} files=${flow.fileCount}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+export function flowDetailToText(flow: ReviewFlowDetail | ReviewFlow): string {
+  const lines = [
+    `Flow: ${flow.id}`,
+    `Entry: ${flow.entryPoint}`,
+    `Criticality: ${flow.criticality.toFixed(4)}`,
+    `Depth: ${flow.depth}`,
+    `Nodes: ${flow.nodeCount}`,
+    `Files: ${flow.files.join(", ") || "none"}`,
+  ];
+  if (flow.warnings.length > 0) {
+    lines.push("Warnings:");
+    for (const warning of flow.warnings) lines.push(`- ${warning}`);
+  }
+  if ("steps" in flow) {
+    lines.push("Steps:");
+    for (const step of flow.steps) {
+      const location = step.file ? `${step.file}${step.lineStart ? `:${step.lineStart}` : ""}` : "unknown";
+      lines.push(`- ${step.qualifiedName} (${step.kind}) ${location}`);
+    }
+  } else {
+    lines.push("Path:");
+    for (const qualifiedName of flow.qualifiedPath) lines.push(`- ${qualifiedName}`);
+  }
+  return lines.join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,8 @@ export { buildReviewDelta, reviewDeltaToText } from "./review.js";
 export type { ReviewDelta, ReviewNode, ReviewChain, ReviewDeltaOptions } from "./review.js";
 export { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, reviewEvaluationToText } from "./review-analysis.js";
 export type { ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewImpactedCommunity, ReviewMultimodalSafety, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationResult, ReviewEvaluationOptions, ReviewRiskLevel } from "./review-analysis.js";
+export { createReviewGraphStore } from "./review-store.js";
+export type { ReviewGraphEdge, ReviewGraphNode, ReviewGraphNodeKind, ReviewGraphStats, ReviewGraphStoreLike, ReviewImpactRadius } from "./review-store.js";
 export { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 export type { CommitRecommendation, CommitRecommendationGroup, CommitRecommendationStaleness, CommitRecommendationConfidence, CommitRecommendationOptions } from "./recommend.js";
 export { planGraphifyOutMigration, migrateGraphifyOut, migrationResultToText } from "./migrate-state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,11 @@ export {
 } from "./review-context.js";
 export type { BuildReviewContextOptions, ReviewContextDetailLevel, ReviewContextPayload, ReviewContextResult, ReviewContextRisk } from "./review-context.js";
 export {
+  evaluateReviewBenchmarks,
+  reviewBenchmarkToMarkdown,
+} from "./review-benchmark.js";
+export type { ReviewBenchmarkCase, ReviewBenchmarkCaseResult, ReviewBenchmarkMetrics, ReviewBenchmarkOptions, ReviewBenchmarkResult, ReviewBenchmarkTokenBudgetStatus } from "./review-benchmark.js";
+export {
   analyzeChanges,
   computeRiskScore,
   detectChangesToMinimal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,16 @@ export {
   reviewContextToText,
 } from "./review-context.js";
 export type { BuildReviewContextOptions, ReviewContextDetailLevel, ReviewContextPayload, ReviewContextResult, ReviewContextRisk } from "./review-context.js";
+export {
+  analyzeChanges,
+  computeRiskScore,
+  detectChangesToMinimal,
+  detectChangesToText,
+  isSafeGitRef,
+  mapChangesToNodes,
+  parseUnifiedDiff,
+} from "./detect-changes.js";
+export type { AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap } from "./detect-changes.js";
 export { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 export type { CommitRecommendation, CommitRecommendationGroup, CommitRecommendationStaleness, CommitRecommendationConfidence, CommitRecommendationOptions } from "./recommend.js";
 export { planGraphifyOutMigration, migrateGraphifyOut, migrationResultToText } from "./migrate-state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,6 +213,20 @@ export { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, revi
 export type { ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewImpactedCommunity, ReviewMultimodalSafety, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationResult, ReviewEvaluationOptions, ReviewRiskLevel } from "./review-analysis.js";
 export { createReviewGraphStore } from "./review-store.js";
 export type { ReviewGraphEdge, ReviewGraphNode, ReviewGraphNodeKind, ReviewGraphStats, ReviewGraphStoreLike, ReviewImpactRadius } from "./review-store.js";
+export {
+  buildFlowArtifact,
+  computeFlowCriticality,
+  detectEntryPoints,
+  flowDetailToText,
+  flowListToText,
+  flowToSteps,
+  getFlowById,
+  listFlows,
+  readFlowArtifact,
+  traceFlows,
+  writeFlowArtifact,
+} from "./flows.js";
+export type { BuildFlowArtifactOptions, DetectEntryPointsOptions, ListFlowsOptions, ReviewFlow, ReviewFlowArtifact, ReviewFlowDetail, ReviewFlowStep, TraceFlowsOptions } from "./flows.js";
 export { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 export type { CommitRecommendation, CommitRecommendationGroup, CommitRecommendationStaleness, CommitRecommendationConfidence, CommitRecommendationOptions } from "./recommend.js";
 export { planGraphifyOutMigration, migrateGraphifyOut, migrationResultToText } from "./migrate-state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,11 @@ export {
   parseUnifiedDiff,
 } from "./detect-changes.js";
 export type { AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap } from "./detect-changes.js";
+export {
+  buildMinimalContext,
+  minimalContextToText,
+} from "./minimal-context.js";
+export type { BuildMinimalContextOptions, MinimalContextResult, MinimalContextRisk } from "./minimal-context.js";
 export { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 export type { CommitRecommendation, CommitRecommendationGroup, CommitRecommendationStaleness, CommitRecommendationConfidence, CommitRecommendationOptions } from "./recommend.js";
 export { planGraphifyOutMigration, migrateGraphifyOut, migrationResultToText } from "./migrate-state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,12 @@ export {
   writeFlowArtifact,
 } from "./flows.js";
 export type { AffectedFlowsResult, BuildFlowArtifactOptions, DetectEntryPointsOptions, ListFlowsOptions, ReviewFlow, ReviewFlowArtifact, ReviewFlowDetail, ReviewFlowStep, TraceFlowsOptions } from "./flows.js";
+export {
+  buildReviewContext,
+  extractRelevantLines,
+  reviewContextToText,
+} from "./review-context.js";
+export type { BuildReviewContextOptions, ReviewContextDetailLevel, ReviewContextPayload, ReviewContextResult, ReviewContextRisk } from "./review-context.js";
 export { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 export type { CommitRecommendation, CommitRecommendationGroup, CommitRecommendationStaleness, CommitRecommendationConfidence, CommitRecommendationOptions } from "./recommend.js";
 export { planGraphifyOutMigration, migrateGraphifyOut, migrationResultToText } from "./migrate-state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,19 +214,21 @@ export type { ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewIm
 export { createReviewGraphStore } from "./review-store.js";
 export type { ReviewGraphEdge, ReviewGraphNode, ReviewGraphNodeKind, ReviewGraphStats, ReviewGraphStoreLike, ReviewImpactRadius } from "./review-store.js";
 export {
+  affectedFlowsToText,
   buildFlowArtifact,
   computeFlowCriticality,
   detectEntryPoints,
   flowDetailToText,
   flowListToText,
   flowToSteps,
+  getAffectedFlows,
   getFlowById,
   listFlows,
   readFlowArtifact,
   traceFlows,
   writeFlowArtifact,
 } from "./flows.js";
-export type { BuildFlowArtifactOptions, DetectEntryPointsOptions, ListFlowsOptions, ReviewFlow, ReviewFlowArtifact, ReviewFlowDetail, ReviewFlowStep, TraceFlowsOptions } from "./flows.js";
+export type { AffectedFlowsResult, BuildFlowArtifactOptions, DetectEntryPointsOptions, ListFlowsOptions, ReviewFlow, ReviewFlowArtifact, ReviewFlowDetail, ReviewFlowStep, TraceFlowsOptions } from "./flows.js";
 export { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 export type { CommitRecommendation, CommitRecommendationGroup, CommitRecommendationStaleness, CommitRecommendationConfidence, CommitRecommendationOptions } from "./recommend.js";
 export { planGraphifyOutMigration, migrateGraphifyOut, migrationResultToText } from "./migrate-state.js";

--- a/src/minimal-context.ts
+++ b/src/minimal-context.ts
@@ -1,0 +1,125 @@
+import { analyzeChanges } from "./detect-changes.js";
+import { getAffectedFlows, listFlows, type ReviewFlowArtifact } from "./flows.js";
+import type { ReviewGraphStoreLike } from "./review-store.js";
+
+export type MinimalContextRisk = "unknown" | "low" | "medium" | "high";
+
+export interface BuildMinimalContextOptions {
+  task?: string;
+  changedFiles?: string[];
+  flows?: ReviewFlowArtifact | null;
+  topCommunities?: number;
+  topFlows?: number;
+}
+
+export interface MinimalContextResult {
+  summary: string;
+  keyEntities?: string[];
+  risk: MinimalContextRisk;
+  riskScore: number;
+  communities?: string[];
+  flowsAffected?: string[];
+  flowsAvailable: boolean;
+  nextToolSuggestions: string[];
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort(compareStrings);
+}
+
+function riskFromScore(score: number): Exclude<MinimalContextRisk, "unknown"> {
+  if (score > 0.7) return "high";
+  if (score > 0.4) return "medium";
+  return "low";
+}
+
+function suggestionsForTask(task: string | undefined): string[] {
+  const value = (task ?? "").toLowerCase();
+  if (/(review|pr|merge|diff)/u.test(value)) return ["detect-changes", "affected-flows", "review-context"];
+  if (/(debug|bug|error|fix)/u.test(value)) return ["summary", "query", "flows get"];
+  if (/(refactor|rename|dead|clean)/u.test(value)) return ["review-context", "detect-changes", "recommend-commits"];
+  if (/(onboard|understand|explore|arch)/u.test(value)) return ["summary", "flows list", "path"];
+  return ["detect-changes", "summary", "review-context"];
+}
+
+function topCommunities(store: ReviewGraphStoreLike, limit: number): string[] {
+  const labels = store.getCommunityLabels();
+  const counts = new Map<number, number>();
+  for (const node of store.getAllNodes({ excludeFiles: true })) {
+    if (node.communityId === null) continue;
+    counts.set(node.communityId, (counts.get(node.communityId) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0] - b[0])
+    .slice(0, limit)
+    .map(([id]) => labels.get(id) ?? `Community ${id}`);
+}
+
+function topFlowNames(flows: ReviewFlowArtifact, limit: number): string[] {
+  return listFlows(flows, { limit }).map((flow) => flow.name);
+}
+
+export function buildMinimalContext(
+  store: ReviewGraphStoreLike,
+  options: BuildMinimalContextOptions = {},
+): MinimalContextResult {
+  const stats = store.getGraphStats();
+  const changedFiles = uniqueSorted(options.changedFiles ?? []);
+  let risk: MinimalContextRisk = "unknown";
+  let riskScore = 0;
+  let keyEntities: string[] | undefined;
+  let testGapCount = 0;
+
+  if (changedFiles.length > 0) {
+    const analysis = analyzeChanges(store, changedFiles, { flows: options.flows ?? null });
+    riskScore = analysis.riskScore;
+    risk = riskFromScore(riskScore);
+    keyEntities = analysis.changedFunctions.slice(0, 5).map((node) => node.name);
+    testGapCount = analysis.testGaps.length;
+  }
+
+  const communities = topCommunities(store, Math.max(0, options.topCommunities ?? 3));
+  const flowsAvailable = !!options.flows;
+  let flowsAffected: string[] | undefined;
+  if (options.flows) {
+    flowsAffected = changedFiles.length > 0
+      ? getAffectedFlows(options.flows, changedFiles, store).affectedFlows.slice(0, options.topFlows ?? 3).map((flow) => flow.name)
+      : topFlowNames(options.flows, options.topFlows ?? 3);
+  }
+
+  const summaryParts = [
+    `${stats.totalNodes} nodes, ${stats.totalEdges} edges across ${stats.filesCount} files.`,
+  ];
+  if (risk !== "unknown") summaryParts.push(`Risk: ${risk} (${riskScore.toFixed(2)}).`);
+  if (testGapCount > 0) summaryParts.push(`${testGapCount} test gaps.`);
+
+  return {
+    summary: summaryParts.join(" "),
+    keyEntities: keyEntities && keyEntities.length > 0 ? keyEntities : undefined,
+    risk,
+    riskScore,
+    communities: communities.length > 0 ? communities : undefined,
+    flowsAffected: flowsAffected && flowsAffected.length > 0 ? flowsAffected : [],
+    flowsAvailable,
+    nextToolSuggestions: suggestionsForTask(options.task),
+  };
+}
+
+export function minimalContextToText(result: MinimalContextResult): string {
+  const lines = [
+    result.summary,
+    `Risk: ${result.risk} (${result.riskScore.toFixed(4)})`,
+    `Flows available: ${result.flowsAvailable ? "yes" : "no"}`,
+    `Next tools: ${result.nextToolSuggestions.join(", ")}`,
+  ];
+  if (result.keyEntities) lines.push(`Key entities: ${result.keyEntities.join(", ")}`);
+  if (result.communities) lines.push(`Communities: ${result.communities.join(", ")}`);
+  if (result.flowsAffected && result.flowsAffected.length > 0) lines.push(`Flows affected: ${result.flowsAffected.join(", ")}`);
+  return lines.join("\n");
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -88,6 +88,7 @@ export interface GraphifyPaths {
   graph: string;
   report: string;
   html: string;
+  flows: string;
   manifest: string;
   cost: string;
   cacheDir: string;
@@ -142,6 +143,7 @@ export function resolveGraphifyPaths(options: GraphifyPathOptions = {}): Graphif
     graph: join(stateDir, "graph.json"),
     report: join(stateDir, "GRAPH_REPORT.md"),
     html: join(stateDir, "graph.html"),
+    flows: join(stateDir, "flows.json"),
     manifest: join(stateDir, "manifest.json"),
     cost: join(stateDir, "cost.json"),
     cacheDir: join(stateDir, "cache"),

--- a/src/report.ts
+++ b/src/report.ts
@@ -5,6 +5,96 @@ import Graph from "graphology";
 import type { GodNodeEntry, SurpriseEntry, SuggestedQuestion, DetectionResult } from "./types.js";
 import { type NumericMapLike, toNumericMap } from "./collections.js";
 import { isFileNode, isConceptNode } from "./analyze.js";
+import type { AffectedFlowsResult, ReviewFlow, ReviewFlowArtifact } from "./flows.js";
+
+export interface ReportHighRiskNode {
+  name: string;
+  file?: string | null;
+  riskScore?: number | null;
+  reason?: string | null;
+}
+
+export interface ReportTestGap {
+  name: string;
+  file?: string | null;
+  reason?: string | null;
+}
+
+export interface ReportReviewOptions {
+  flows?: ReviewFlowArtifact | ReviewFlow[] | null;
+  affectedFlows?: AffectedFlowsResult | ReviewFlow[] | null;
+  highRiskNodes?: ReportHighRiskNode[] | null;
+  testGaps?: ReportTestGap[] | null;
+}
+
+export interface GenerateReportOptions {
+  suggestedQuestions?: SuggestedQuestion[] | null;
+  review?: ReportReviewOptions | null;
+}
+
+function compareFlowCriticality(a: ReviewFlow, b: ReviewFlow): number {
+  return b.criticality - a.criticality || a.name.localeCompare(b.name);
+}
+
+function normalizeFlows(input?: ReviewFlowArtifact | ReviewFlow[] | null): ReviewFlow[] {
+  if (!input) return [];
+  return Array.isArray(input) ? input : input.flows;
+}
+
+function normalizeAffectedFlows(input?: AffectedFlowsResult | ReviewFlow[] | null): ReviewFlow[] {
+  if (!input) return [];
+  return Array.isArray(input) ? input : input.affectedFlows;
+}
+
+function formatFlow(flow: ReviewFlow): string {
+  const files = flow.files.length > 0 ? ` · files ${flow.files.join(", ")}` : "";
+  return `- **${flow.name}** entry=\`${flow.entryPoint}\` criticality ${flow.criticality.toFixed(4)} ` +
+    `depth ${flow.depth} · nodes ${flow.nodeCount}${files}`;
+}
+
+function appendReviewSections(lines: string[], review?: ReportReviewOptions | null): void {
+  if (!review) return;
+
+  const topFlows = [...normalizeFlows(review.flows)].sort(compareFlowCriticality).slice(0, 5);
+  if (topFlows.length > 0) {
+    lines.push("## Execution Flows");
+    for (const flow of topFlows) lines.push(formatFlow(flow));
+    lines.push("");
+  }
+
+  const affectedFlows = [...normalizeAffectedFlows(review.affectedFlows)].sort(compareFlowCriticality).slice(0, 8);
+  if (affectedFlows.length > 0) {
+    lines.push("## Affected Flows");
+    if (review.affectedFlows && !Array.isArray(review.affectedFlows)) {
+      lines.push(`Changed files: ${review.affectedFlows.changedFiles.join(", ") || "none"}`);
+    }
+    for (const flow of affectedFlows) lines.push(formatFlow(flow));
+    lines.push("");
+  }
+
+  const highRiskNodes = review.highRiskNodes ?? [];
+  if (highRiskNodes.length > 0) {
+    lines.push("## High-Risk Nodes");
+    for (const node of highRiskNodes.slice(0, 12)) {
+      const file = node.file ? ` · \`${node.file}\`` : "";
+      const score = node.riskScore != null ? ` · risk ${node.riskScore.toFixed(4)}` : "";
+      const reason = node.reason ? ` · ${node.reason}` : "";
+      lines.push(`- **${node.name}**${file}${score}${reason}`);
+    }
+    lines.push("");
+  }
+
+  const testGaps = review.testGaps ?? [];
+  if (testGaps.length > 0) {
+    lines.push("## Test Gaps");
+    for (const gap of testGaps.slice(0, 12)) {
+      const file = gap.file ? ` · \`${gap.file}\`` : "";
+      const reason = gap.reason ? ` · ${gap.reason}` : "";
+      lines.push(`- **${gap.name}**${file}${reason}`);
+    }
+    lines.push("");
+  }
+}
 
 export function generate(
   G: Graph,
@@ -18,7 +108,7 @@ export function generate(
   root: string,
   suggestedQuestions?:
     | SuggestedQuestion[]
-    | { suggestedQuestions?: SuggestedQuestion[] | null }
+    | GenerateReportOptions
     | null,
 ): string {
   const communityMap = toNumericMap(communities);
@@ -27,6 +117,9 @@ export function generate(
   const suggestedQuestionList = Array.isArray(suggestedQuestions)
     ? suggestedQuestions
     : (suggestedQuestions?.suggestedQuestions ?? null);
+  const reviewOptions = Array.isArray(suggestedQuestions)
+    ? null
+    : (suggestedQuestions?.review ?? null);
   const today = new Date().toISOString().slice(0, 10);
 
   const confidences: string[] = [];
@@ -71,8 +164,11 @@ export function generate(
       (infAvg !== null ? ` · INFERRED: ${infEdges.length} edges (avg confidence: ${infAvg})` : ""),
     `- Token cost: ${tokenCost.input.toLocaleString()} input · ${tokenCost.output.toLocaleString()} output`,
     "",
-    "## God Nodes (most connected - your core abstractions)",
   );
+
+  appendReviewSections(lines, reviewOptions);
+
+  lines.push("## God Nodes (most connected - your core abstractions)");
 
   godNodeList.forEach((node, i) => {
     const degree = node.degree ?? node.edges;

--- a/src/review-benchmark.ts
+++ b/src/review-benchmark.ts
@@ -1,0 +1,272 @@
+import { analyzeChanges, type ChangedRangesByFile } from "./detect-changes.js";
+import { buildReviewContext, reviewContextToText } from "./review-context.js";
+import type { ReviewFlowArtifact } from "./flows.js";
+import type { ReviewGraphStoreLike } from "./review-store.js";
+
+export interface ReviewBenchmarkCase {
+  name: string;
+  changedFiles: string[];
+  changedRanges?: ChangedRangesByFile;
+  expectedChangedNodes?: string[];
+  expectedImpactedFiles?: string[];
+  expectedAffectedFlows?: string[];
+  expectedTestGaps?: string[];
+  expectedSummaryFacts?: string[];
+  naiveTokenEstimate?: number;
+  tokenBudget?: number;
+}
+
+export interface ReviewBenchmarkOptions {
+  flows?: ReviewFlowArtifact | null;
+  maxDepth?: number;
+  defaultTokenBudget?: number;
+}
+
+export type ReviewBenchmarkTokenBudgetStatus = "pass" | "fail";
+
+export interface ReviewBenchmarkMetrics {
+  changedNodeRecall: number | null;
+  impactedFilePrecision: number | null;
+  impactedFileRecall: number | null;
+  impactedFileF1: number | null;
+  flowCompleteness: number | null;
+  testGapRecall: number | null;
+  summaryFactRecall: number | null;
+  falsePositiveCount: number;
+  estimatedTokenCount: number;
+  tokenBudget: number;
+  tokenBudgetStatus: ReviewBenchmarkTokenBudgetStatus;
+}
+
+export interface ReviewBenchmarkCaseResult {
+  name: string;
+  changedFiles: string[];
+  metrics: ReviewBenchmarkMetrics;
+  actual: {
+    changedNodes: string[];
+    impactedFiles: string[];
+    affectedFlows: string[];
+    testGaps: string[];
+  };
+  notes: string[];
+}
+
+export interface ReviewBenchmarkResult {
+  cases: ReviewBenchmarkCaseResult[];
+  aggregate: Omit<ReviewBenchmarkMetrics, "tokenBudget" | "tokenBudgetStatus"> & {
+    tokenBudgetPassRate: number | null;
+  };
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function normalize(value: string): string {
+  return value.trim().replace(/\\/g, "/");
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map(normalize).filter(Boolean))].sort(compareStrings);
+}
+
+function identifiers(values: Array<{ id?: string; name?: string; qualifiedName?: string }>): Set<string> {
+  const result = new Set<string>();
+  for (const value of values) {
+    if (value.id) result.add(normalize(value.id));
+    if (value.name) result.add(normalize(value.name));
+    if (value.qualifiedName) result.add(normalize(value.qualifiedName));
+  }
+  return result;
+}
+
+function flowIdentifiers(values: Array<{ id: string; name: string; entryPoint: string }>): Set<string> {
+  const result = new Set<string>();
+  for (const value of values) {
+    result.add(normalize(value.id));
+    result.add(normalize(value.name));
+    result.add(normalize(value.entryPoint));
+  }
+  return result;
+}
+
+function ratio(hits: number, total: number): number | null {
+  return total > 0 ? hits / total : null;
+}
+
+function f1(precision: number | null, recall: number | null): number | null {
+  if (precision === null || recall === null || precision + recall === 0) return null;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+function average(values: Array<number | null>): number | null {
+  const usable = values.filter((value): value is number => value !== null && Number.isFinite(value));
+  if (usable.length === 0) return null;
+  return usable.reduce((sum, value) => sum + value, 0) / usable.length;
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function countHits(expected: string[] | undefined, actual: Set<string>): number {
+  return uniqueSorted(expected ?? []).filter((item) => actual.has(item)).length;
+}
+
+function formatMetric(value: number | null): string {
+  return value === null ? "n/a" : (value * 100).toFixed(1) + "%";
+}
+
+export function evaluateReviewBenchmarks(
+  store: ReviewGraphStoreLike,
+  cases: ReviewBenchmarkCase[],
+  options: ReviewBenchmarkOptions = {},
+): ReviewBenchmarkResult {
+  const results = cases.map((testCase) => {
+    const changes = analyzeChanges(store, testCase.changedFiles, {
+      changedRanges: testCase.changedRanges ?? null,
+      flows: options.flows ?? null,
+    });
+    const context = buildReviewContext(store, testCase.changedFiles, {
+      detailLevel: "standard",
+      maxDepth: options.maxDepth ?? 2,
+    });
+    const contextPayload = context.context;
+    const impactedFiles = contextPayload && "reviewGuidance" in contextPayload
+      ? uniqueSorted(contextPayload.impactedFiles)
+      : [];
+    const changedNodes = identifiers(changes.changedFunctions);
+    const affectedFlows = flowIdentifiers(changes.affectedFlows);
+    const testGaps = identifiers(changes.testGaps.map((gap) => ({
+      name: gap.name,
+      qualifiedName: gap.qualifiedName,
+      id: gap.qualifiedName,
+    })));
+    const expectedChangedNodes = uniqueSorted(testCase.expectedChangedNodes ?? []);
+    const expectedImpactedFiles = uniqueSorted(testCase.expectedImpactedFiles ?? []);
+    const expectedAffectedFlows = uniqueSorted(testCase.expectedAffectedFlows ?? []);
+    const expectedTestGaps = uniqueSorted(testCase.expectedTestGaps ?? []);
+    const expectedSummaryFacts = uniqueSorted(testCase.expectedSummaryFacts ?? []);
+
+    const changedHits = countHits(expectedChangedNodes, changedNodes);
+    const impactedSet = new Set(impactedFiles);
+    const impactedHits = expectedImpactedFiles.filter((file) => impactedSet.has(file)).length;
+    const changedFileSet = new Set(uniqueSorted(testCase.changedFiles));
+    const falsePositiveCount = impactedFiles.filter((file) => (
+      expectedImpactedFiles.length > 0 &&
+      !expectedImpactedFiles.includes(file) &&
+      !changedFileSet.has(file)
+    )).length;
+    const flowHits = countHits(expectedAffectedFlows, affectedFlows);
+    const testGapHits = countHits(expectedTestGaps, testGaps);
+    const summaryText = [
+      changes.summary,
+      reviewContextToText(context),
+      changes.reviewPriorities.map((node) => node.name).join(" "),
+      changes.affectedFlows.map((flow) => flow.name).join(" "),
+    ].join("\n");
+    const lowerSummary = summaryText.toLowerCase();
+    const summaryHits = expectedSummaryFacts.filter((fact) => lowerSummary.includes(fact.toLowerCase())).length;
+    const estimatedTokenCount = estimateTokens(summaryText);
+    const tokenBudget = Math.max(1, testCase.tokenBudget ?? options.defaultTokenBudget ?? testCase.naiveTokenEstimate ?? 800);
+    const impactedFilePrecision = ratio(impactedHits, expectedImpactedFiles.length > 0 ? impactedFiles.length : 0);
+    const impactedFileRecall = ratio(impactedHits, expectedImpactedFiles.length);
+    const metrics: ReviewBenchmarkMetrics = {
+      changedNodeRecall: ratio(changedHits, expectedChangedNodes.length),
+      impactedFilePrecision,
+      impactedFileRecall,
+      impactedFileF1: f1(impactedFilePrecision, impactedFileRecall),
+      flowCompleteness: ratio(flowHits, expectedAffectedFlows.length),
+      testGapRecall: ratio(testGapHits, expectedTestGaps.length),
+      summaryFactRecall: ratio(summaryHits, expectedSummaryFacts.length),
+      falsePositiveCount,
+      estimatedTokenCount,
+      tokenBudget,
+      tokenBudgetStatus: estimatedTokenCount <= tokenBudget ? "pass" : "fail",
+    };
+    const notes: string[] = [];
+    if (falsePositiveCount > 0) notes.push(`${falsePositiveCount} false positives reported, not hidden`);
+    if (metrics.flowCompleteness !== null && metrics.flowCompleteness < 1) notes.push("flow completeness below expectation");
+    if (metrics.tokenBudgetStatus === "fail") notes.push("estimated graph context exceeds token budget");
+
+    return {
+      name: testCase.name,
+      changedFiles: uniqueSorted(testCase.changedFiles),
+      metrics,
+      actual: {
+        changedNodes: uniqueSorted([...changedNodes]),
+        impactedFiles,
+        affectedFlows: uniqueSorted([...affectedFlows]),
+        testGaps: uniqueSorted([...testGaps]),
+      },
+      notes,
+    };
+  });
+
+  return {
+    cases: results,
+    aggregate: {
+      changedNodeRecall: average(results.map((item) => item.metrics.changedNodeRecall)),
+      impactedFilePrecision: average(results.map((item) => item.metrics.impactedFilePrecision)),
+      impactedFileRecall: average(results.map((item) => item.metrics.impactedFileRecall)),
+      impactedFileF1: average(results.map((item) => item.metrics.impactedFileF1)),
+      flowCompleteness: average(results.map((item) => item.metrics.flowCompleteness)),
+      testGapRecall: average(results.map((item) => item.metrics.testGapRecall)),
+      summaryFactRecall: average(results.map((item) => item.metrics.summaryFactRecall)),
+      falsePositiveCount: results.reduce((sum, item) => sum + item.metrics.falsePositiveCount, 0),
+      estimatedTokenCount: results.reduce((sum, item) => sum + item.metrics.estimatedTokenCount, 0),
+      tokenBudgetPassRate: ratio(
+        results.filter((item) => item.metrics.tokenBudgetStatus === "pass").length,
+        results.length,
+      ),
+    },
+  };
+}
+
+export function reviewBenchmarkToMarkdown(result: ReviewBenchmarkResult): string {
+  const lines = [
+    "# Graphify Review Benchmarks",
+    "",
+    "> Token metrics are estimated from graph review text unless backed by actual model usage.",
+    "> Flow quality depends on parser/call metadata; weak or undirected metadata can reduce completeness.",
+    "",
+    "## Aggregate",
+    "",
+    `- Changed-node recall: ${formatMetric(result.aggregate.changedNodeRecall)}`,
+    `- Impacted-file precision: ${formatMetric(result.aggregate.impactedFilePrecision)}`,
+    `- Impacted-file recall: ${formatMetric(result.aggregate.impactedFileRecall)}`,
+    `- Impacted-file F1: ${formatMetric(result.aggregate.impactedFileF1)}`,
+    `- Flow completeness: ${formatMetric(result.aggregate.flowCompleteness)}`,
+    `- Test-gap recall: ${formatMetric(result.aggregate.testGapRecall)}`,
+    `- Summary fact recall: ${formatMetric(result.aggregate.summaryFactRecall)}`,
+    `- False positives: ${result.aggregate.falsePositiveCount}`,
+    `- Estimated graph-context tokens: ${result.aggregate.estimatedTokenCount}`,
+    `- Token budget pass rate: ${formatMetric(result.aggregate.tokenBudgetPassRate)}`,
+    "",
+    "## Cases",
+    "",
+  ];
+
+  for (const testCase of result.cases) {
+    lines.push(
+      `### ${testCase.name}`,
+      "",
+      `- changed files: ${testCase.changedFiles.join(", ") || "none"}`,
+      `- changed-node recall: ${formatMetric(testCase.metrics.changedNodeRecall)}`,
+      `- impacted-file precision: ${formatMetric(testCase.metrics.impactedFilePrecision)}`,
+      `- impacted-file recall: ${formatMetric(testCase.metrics.impactedFileRecall)}`,
+      `- flow completeness: ${formatMetric(testCase.metrics.flowCompleteness)}`,
+      `- test-gap recall: ${formatMetric(testCase.metrics.testGapRecall)}`,
+      `- false positives: ${testCase.metrics.falsePositiveCount}`,
+      `- estimated tokens: ${testCase.metrics.estimatedTokenCount}/${testCase.metrics.tokenBudget} (${testCase.metrics.tokenBudgetStatus})`,
+    );
+    if (testCase.notes.length > 0) {
+      lines.push(`- notes: ${testCase.notes.join("; ")}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/src/review-context.ts
+++ b/src/review-context.ts
@@ -1,0 +1,288 @@
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { basename, relative, resolve } from "node:path";
+
+import type {
+  ReviewGraphEdge,
+  ReviewGraphNode,
+  ReviewGraphStoreLike,
+} from "./review-store.js";
+
+export type ReviewContextDetailLevel = "minimal" | "standard";
+export type ReviewContextRisk = "low" | "medium" | "high";
+
+export interface BuildReviewContextOptions {
+  maxDepth?: number;
+  detailLevel?: ReviewContextDetailLevel;
+  includeSource?: boolean;
+  maxLinesPerFile?: number;
+  repoRoot?: string;
+}
+
+export interface ReviewContextPayload {
+  changedFiles: string[];
+  impactedFiles: string[];
+  graph: {
+    changedNodes: ReviewGraphNode[];
+    impactedNodes: ReviewGraphNode[];
+    edges: ReviewGraphEdge[];
+  };
+  sourceSnippets?: Record<string, string>;
+  reviewGuidance: string;
+}
+
+export interface ReviewContextResult {
+  status: "ok";
+  summary: string;
+  risk?: ReviewContextRisk;
+  changedFileCount?: number;
+  impactedFileCount?: number;
+  keyEntities?: string[];
+  testGaps?: number;
+  nextToolSuggestions?: string[];
+  context?: ReviewContextPayload | Record<string, never>;
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean).map(normalizePath))].sort(compareStrings);
+}
+
+function sourceMatches(sourceFile: string | null, changedFile: string): boolean {
+  if (!sourceFile) return false;
+  const source = normalizePath(sourceFile);
+  const changed = normalizePath(changedFile);
+  return source === changed || source.endsWith(`/${changed}`) || changed.endsWith(`/${source}`);
+}
+
+function riskForImpactedNodes(count: number): ReviewContextRisk {
+  if (count > 20) return "high";
+  if (count > 5) return "medium";
+  return "low";
+}
+
+function changedFunctionsWithoutTests(changedNodes: ReviewGraphNode[], store: ReviewGraphStoreLike): ReviewGraphNode[] {
+  return changedNodes.filter((node) => (
+    node.kind === "Function" &&
+    !node.isTest &&
+    store.getEdgesByTarget(node.qualifiedName, "TESTED_BY").length === 0
+  ));
+}
+
+function isSensitivePath(path: string): boolean {
+  const normalized = normalizePath(path).toLowerCase();
+  const file = basename(normalized);
+  return (
+    file === ".env" ||
+    file === ".npmrc" ||
+    /\.(key|pem|p12|pfx|crt|cer)$/iu.test(file) ||
+    /(secret|credential|token)/iu.test(normalized)
+  );
+}
+
+function isInside(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !resolve(rel).startsWith(".."));
+}
+
+function formatLines(lines: string[], start: number, end: number): string {
+  const out: string[] = [];
+  for (let i = start; i < end; i += 1) out.push(`${i + 1}: ${lines[i] ?? ""}`);
+  return out.join("\n");
+}
+
+export function extractRelevantLines(
+  lines: string[],
+  nodes: ReviewGraphNode[],
+  filePath: string,
+): string {
+  const ranges: Array<[number, number]> = [];
+  for (const node of nodes) {
+    if (!sourceMatches(node.filePath, filePath) || node.lineStart === null || node.lineEnd === null) continue;
+    const start = Math.max(0, node.lineStart - 3);
+    const end = Math.min(lines.length, node.lineEnd + 2);
+    ranges.push([start, end]);
+  }
+
+  if (ranges.length === 0) return formatLines(lines, 0, Math.min(lines.length, 50));
+
+  ranges.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: Array<[number, number]> = [ranges[0]!];
+  for (const [start, end] of ranges.slice(1)) {
+    const last = merged[merged.length - 1]!;
+    if (start <= last[1] + 1) {
+      last[1] = Math.max(last[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
+
+  const parts: string[] = [];
+  for (const [start, end] of merged) {
+    if (parts.length > 0) parts.push("...");
+    parts.push(formatLines(lines, start, end));
+  }
+  return parts.join("\n");
+}
+
+function readSourceSnippet(
+  changedFile: string,
+  changedNodes: ReviewGraphNode[],
+  options: Required<Pick<BuildReviewContextOptions, "maxLinesPerFile" | "repoRoot">>,
+): string {
+  if (isSensitivePath(changedFile)) return "(skipped sensitive file)";
+  try {
+    const root = realpathSync(resolve(options.repoRoot));
+    const fullPath = realpathSync(resolve(root, changedFile));
+    if (!isInside(root, fullPath) || !statSync(fullPath).isFile()) return "(could not read file)";
+    const content = readFileSync(fullPath, "utf-8");
+    if (content.includes("\0")) return "(could not read file)";
+    const lines = content.split(/\r?\n/u);
+    if (lines.length > options.maxLinesPerFile) {
+      return extractRelevantLines(lines, changedNodes, changedFile);
+    }
+    return formatLines(lines, 0, lines.length);
+  } catch {
+    return "(could not read file)";
+  }
+}
+
+function buildSourceSnippets(
+  changedFiles: string[],
+  changedNodes: ReviewGraphNode[],
+  options: Required<Pick<BuildReviewContextOptions, "maxLinesPerFile" | "repoRoot">>,
+): Record<string, string> {
+  const snippets: Record<string, string> = {};
+  for (const file of changedFiles) snippets[file] = readSourceSnippet(file, changedNodes, options);
+  return snippets;
+}
+
+function buildReviewGuidance(
+  changedFiles: string[],
+  changedNodes: ReviewGraphNode[],
+  impactedFiles: string[],
+  impactedNodes: ReviewGraphNode[],
+  edges: ReviewGraphEdge[],
+  store: ReviewGraphStoreLike,
+): string {
+  const guidance: string[] = [];
+  const untested = changedFunctionsWithoutTests(changedNodes, store);
+  if (untested.length > 0) {
+    guidance.push(
+      `- ${untested.length} changed function(s) lack test coverage: ` +
+      untested.slice(0, 5).map((node) => node.name).join(", "),
+    );
+  }
+  if (impactedNodes.length > 20) {
+    guidance.push(`- Wide blast radius: ${impactedNodes.length} nodes impacted. Review callers and dependents carefully.`);
+  }
+  const inheritanceEdges = edges.filter((edge) => edge.kind === "INHERITS" || edge.kind === "IMPLEMENTS");
+  if (inheritanceEdges.length > 0) {
+    guidance.push(`- ${inheritanceEdges.length} inheritance/implementation relationship(s) affected. Check for Liskov substitution violations.`);
+  }
+  if (impactedFiles.length > 3) {
+    guidance.push(`- Changes impact ${impactedFiles.length} other files. Consider splitting into smaller PRs.`);
+  }
+  if (guidance.length === 0) guidance.push("- Changes appear well-contained with minimal blast radius.");
+  return guidance.join("\n");
+}
+
+export function buildReviewContext(
+  store: ReviewGraphStoreLike,
+  changedFilesInput: string[],
+  options: BuildReviewContextOptions = {},
+): ReviewContextResult {
+  const changedFiles = uniqueSorted(changedFilesInput);
+  if (changedFiles.length === 0) {
+    return {
+      status: "ok",
+      summary: "No changes detected. Nothing to review.",
+      context: {},
+    };
+  }
+
+  const maxDepth = Math.max(0, options.maxDepth ?? 2);
+  const impact = store.getImpactRadius(changedFiles, { maxDepth });
+  const changedNodes = impact.changedNodes;
+  const impactedNodes = impact.impactedNodes;
+  const impactedFiles = impact.impactedFiles;
+
+  if (options.detailLevel === "minimal") {
+    const risk = riskForImpactedNodes(impactedNodes.length);
+    const summary = [
+      `Review context for ${changedFiles.length} changed file(s):`,
+      `  - Risk: ${risk}`,
+      `  - ${impactedNodes.length} impacted nodes in ${impactedFiles.length} files`,
+    ].join("\n");
+    return {
+      status: "ok",
+      summary,
+      risk,
+      changedFileCount: changedFiles.length,
+      impactedFileCount: impactedFiles.length,
+      keyEntities: changedNodes.slice(0, 5).map((node) => node.name),
+      testGaps: changedFunctionsWithoutTests(changedNodes, store).length,
+      nextToolSuggestions: ["detect-changes", "affected-flows", "review-context"],
+    };
+  }
+
+  const guidance = buildReviewGuidance(changedFiles, changedNodes, impactedFiles, impactedNodes, impact.edges, store);
+  const payload: ReviewContextPayload = {
+    changedFiles,
+    impactedFiles,
+    graph: {
+      changedNodes,
+      impactedNodes,
+      edges: impact.edges,
+    },
+    reviewGuidance: guidance,
+  };
+  if (options.includeSource) {
+    payload.sourceSnippets = buildSourceSnippets(changedFiles, changedNodes, {
+      repoRoot: options.repoRoot ?? ".",
+      maxLinesPerFile: Math.max(1, options.maxLinesPerFile ?? 200),
+    });
+  }
+  const summary = [
+    `Review context for ${changedFiles.length} changed file(s):`,
+    `  - ${changedNodes.length} directly changed nodes`,
+    `  - ${impactedNodes.length} impacted nodes in ${impactedFiles.length} files`,
+    "",
+    "Review guidance:",
+    guidance,
+  ].join("\n");
+  return {
+    status: "ok",
+    summary,
+    context: payload,
+  };
+}
+
+export function reviewContextToText(result: ReviewContextResult): string {
+  const lines = [result.summary];
+  if (result.risk) lines.push(`Risk: ${result.risk}`);
+  if (result.keyEntities) lines.push(`Key entities: ${result.keyEntities.join(", ") || "none"}`);
+  if (typeof result.testGaps === "number") lines.push(`Test gaps: ${result.testGaps}`);
+  if (result.nextToolSuggestions) lines.push(`Next tools: ${result.nextToolSuggestions.join(", ")}`);
+  if (result.context && "reviewGuidance" in result.context) {
+    lines.push("", "Changed files:");
+    for (const file of result.context.changedFiles) lines.push(`- ${file}`);
+    lines.push("Impacted files:");
+    for (const file of result.context.impactedFiles) lines.push(`- ${file}`);
+    if (result.context.sourceSnippets) {
+      lines.push("Source snippets:");
+      for (const [file, snippet] of Object.entries(result.context.sourceSnippets)) {
+        lines.push(`--- ${file} ---`, snippet);
+      }
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/review-store.ts
+++ b/src/review-store.ts
@@ -83,6 +83,7 @@ export interface ReviewGraphStoreLike {
   getTransitiveTests(qualifiedNameOrId: string, maxDepth?: number): ReviewGraphNode[];
   getNodeCommunityId(qualifiedNameOrId: string): number | null;
   getCommunityIdsByQualifiedNames(qualifiedNamesOrIds: string[]): Map<string, number | null>;
+  getCommunityLabels(): Map<number, string>;
   getGraphStats(): ReviewGraphStats;
 }
 
@@ -432,6 +433,17 @@ export function createReviewGraphStore(G: Graph): ReviewGraphStoreLike {
       const result = new Map<string, number | null>();
       for (const value of qualifiedNamesOrIds) result.set(value, getNode(value)?.communityId ?? null);
       return result;
+    },
+    getCommunityLabels: () => {
+      const rawLabels = G.getAttribute("community_labels") as Record<string, unknown> | undefined;
+      const labels = new Map<number, string>();
+      for (const [key, value] of Object.entries(rawLabels ?? {})) {
+        const id = Number.parseInt(key, 10);
+        if (Number.isFinite(id) && typeof value === "string" && value.trim().length > 0) {
+          labels.set(id, value);
+        }
+      }
+      return labels;
     },
     getGraphStats: () => {
       const nodesByKind: Record<string, number> = {};

--- a/src/review-store.ts
+++ b/src/review-store.ts
@@ -36,6 +36,7 @@ export interface ReviewGraphEdge {
   targetQualified: string;
   sourceId: string;
   targetId: string;
+  direction: "directed" | "preserved" | "undirected";
   filePath: string | null;
   line: number | null;
   confidence: number;
@@ -253,9 +254,13 @@ export function createReviewGraphStore(G: Graph): ReviewGraphStoreLike {
   function normalizeEdge(edgeId: string, attrs: Record<string, unknown>, graphSource: string, graphTarget: string): ReviewGraphEdge | null {
     let sourceId = graphSource;
     let targetId = graphTarget;
+    let direction: ReviewGraphEdge["direction"] = "directed";
     if (G.type !== "directed") {
-      sourceId = asString(attrs._src) ?? graphSource;
-      targetId = asString(attrs._tgt) ?? graphTarget;
+      const preservedSource = asString(attrs._src);
+      const preservedTarget = asString(attrs._tgt);
+      direction = preservedSource && preservedTarget ? "preserved" : "undirected";
+      sourceId = preservedSource ?? graphSource;
+      targetId = preservedTarget ?? graphTarget;
     }
     const source = nodesById.get(sourceId);
     const target = nodesById.get(targetId);
@@ -269,6 +274,7 @@ export function createReviewGraphStore(G: Graph): ReviewGraphStoreLike {
       targetQualified: target.qualifiedName,
       sourceId,
       targetId,
+      direction,
       filePath: asString(attrs.source_file) ?? asString(attrs.sourceFile),
       line: lineStart,
       confidence: confidenceValue(confidenceTier, attrs.confidence_score, attrs.weight),

--- a/src/review-store.ts
+++ b/src/review-store.ts
@@ -1,0 +1,450 @@
+import Graph from "graphology";
+
+export type ReviewGraphNodeKind =
+  | "File"
+  | "Class"
+  | "Function"
+  | "Method"
+  | "Type"
+  | "Test"
+  | "Concept"
+  | "Document"
+  | "Image"
+  | "Video"
+  | "Unknown";
+
+export interface ReviewGraphNode {
+  id: string;
+  name: string;
+  qualifiedName: string;
+  kind: ReviewGraphNodeKind;
+  filePath: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  language: string | null;
+  parentName: string | null;
+  isTest: boolean;
+  communityId: number | null;
+  confidence: string | null;
+  extra: Record<string, unknown>;
+}
+
+export interface ReviewGraphEdge {
+  id: string;
+  kind: string;
+  sourceQualified: string;
+  targetQualified: string;
+  sourceId: string;
+  targetId: string;
+  filePath: string | null;
+  line: number | null;
+  confidence: number;
+  confidenceTier: string;
+  extra: Record<string, unknown>;
+}
+
+export interface ReviewImpactRadius {
+  changedNodes: ReviewGraphNode[];
+  impactedNodes: ReviewGraphNode[];
+  impactedFiles: string[];
+  edges: ReviewGraphEdge[];
+  truncated: boolean;
+  totalImpacted: number;
+}
+
+export interface ReviewGraphStats {
+  totalNodes: number;
+  totalEdges: number;
+  nodesByKind: Record<string, number>;
+  edgesByKind: Record<string, number>;
+  languages: string[];
+  filesCount: number;
+  lastUpdated: string | null;
+}
+
+export interface ReviewGraphStoreLike {
+  getNode(qualifiedNameOrId: string): ReviewGraphNode | null;
+  getNodeById(id: string): ReviewGraphNode | null;
+  getAllNodes(options?: { excludeFiles?: boolean }): ReviewGraphNode[];
+  getNodesByFile(filePath: string): ReviewGraphNode[];
+  getFilesMatching(pattern: string): string[];
+  getNodesByKind(kinds: ReviewGraphNodeKind[]): ReviewGraphNode[];
+  getAllFiles(): string[];
+  getEdgesBySource(qualifiedNameOrId: string, kind?: string): ReviewGraphEdge[];
+  getEdgesByTarget(qualifiedNameOrId: string, kind?: string): ReviewGraphEdge[];
+  getAllEdges(): ReviewGraphEdge[];
+  getEdgesAmong(qualifiedNamesOrIds: Set<string>): ReviewGraphEdge[];
+  getAllCallTargets(): Set<string>;
+  getImpactRadius(
+    changedFiles: string[],
+    options?: { maxDepth?: number; maxNodes?: number; direction?: "directed" | "undirected" },
+  ): ReviewImpactRadius;
+  getTransitiveTests(qualifiedNameOrId: string, maxDepth?: number): ReviewGraphNode[];
+  getNodeCommunityId(qualifiedNameOrId: string): number | null;
+  getCommunityIdsByQualifiedNames(qualifiedNamesOrIds: string[]): Map<string, number | null>;
+  getGraphStats(): ReviewGraphStats;
+}
+
+const KNOWN_KINDS = new Set<ReviewGraphNodeKind>([
+  "File",
+  "Class",
+  "Function",
+  "Method",
+  "Type",
+  "Test",
+  "Concept",
+  "Document",
+  "Image",
+  "Video",
+  "Unknown",
+]);
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function isTestPath(path: string | null): boolean {
+  if (!path) return false;
+  const normalized = normalizePath(path).toLowerCase();
+  return (
+    normalized.includes("/test/") ||
+    normalized.includes("/tests/") ||
+    normalized.includes("/__tests__/") ||
+    /(?:^|[._-])(test|spec)\.[^.]+$/.test(normalized)
+  );
+}
+
+function pathMatches(sourceFile: string | null, changedFile: string): boolean {
+  if (!sourceFile) return false;
+  const source = normalizePath(sourceFile);
+  const changed = normalizePath(changedFile);
+  return source === changed || source.endsWith(`/${changed}`) || changed.endsWith(`/${source}`);
+}
+
+function normalizeKind(attrs: Record<string, unknown>, filePath: string | null): ReviewGraphNodeKind {
+  const raw = asString(attrs.kind) ?? asString(attrs.node_type) ?? asString(attrs.nodeType) ?? asString(attrs.type);
+  if (raw) {
+    const normalized = raw.slice(0, 1).toUpperCase() + raw.slice(1);
+    if (KNOWN_KINDS.has(normalized as ReviewGraphNodeKind)) return normalized as ReviewGraphNodeKind;
+  }
+  if (isTestPath(filePath)) return "Test";
+  switch (attrs.file_type) {
+    case "code":
+      return "Function";
+    case "document":
+    case "paper":
+    case "rationale":
+      return "Document";
+    case "image":
+      return "Image";
+    case "video":
+      return "Video";
+    default:
+      return "Unknown";
+  }
+}
+
+function parseLineRange(attrs: Record<string, unknown>): { lineStart: number | null; lineEnd: number | null } {
+  const directStart = asNumber(attrs.line_start) ?? asNumber(attrs.lineStart) ?? asNumber(attrs.line);
+  const directEnd = asNumber(attrs.line_end) ?? asNumber(attrs.lineEnd) ?? directStart;
+  if (directStart !== null) return { lineStart: directStart, lineEnd: directEnd };
+
+  const sourceLocation = asString(attrs.source_location) ?? asString(attrs.sourceLocation);
+  if (!sourceLocation) return { lineStart: null, lineEnd: null };
+  const match = sourceLocation.match(/(?:lines?\s+|#L|L|:)(\d+)(?:\s*-\s*(?:L)?(\d+))?/i);
+  if (!match?.[1]) return { lineStart: null, lineEnd: null };
+  const start = Number.parseInt(match[1], 10);
+  const end = match[2] ? Number.parseInt(match[2], 10) : start;
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return { lineStart: null, lineEnd: null };
+  return { lineStart: start, lineEnd: end };
+}
+
+function canonicalRelation(value: unknown): string {
+  const raw = typeof value === "string" && value.trim().length > 0 ? value.trim() : "RELATED_TO";
+  const normalized = raw.replace(/([a-z0-9])([A-Z])/g, "$1_$2").replace(/[\s-]+/g, "_").toUpperCase();
+  if (normalized === "VALIDATED_BY" || normalized === "VALIDATES" || normalized === "TESTS") return "TESTED_BY";
+  if (normalized === "IMPORTS") return "IMPORTS_FROM";
+  return normalized;
+}
+
+function confidenceValue(tier: string, score: unknown, weight: unknown): number {
+  const direct = typeof score === "number" && Number.isFinite(score)
+    ? score
+    : typeof weight === "number" && Number.isFinite(weight)
+      ? weight
+      : null;
+  if (direct !== null) return direct;
+  if (tier === "INFERRED") return 0.5;
+  if (tier === "AMBIGUOUS") return 0.25;
+  return 1;
+}
+
+function sortNodes(nodes: ReviewGraphNode[]): ReviewGraphNode[] {
+  return [...nodes].sort((a, b) => (
+    compareStrings(a.name, b.name) ||
+    compareStrings(a.qualifiedName, b.qualifiedName) ||
+    compareStrings(a.filePath ?? "", b.filePath ?? "")
+  ));
+}
+
+function sortEdges(edges: ReviewGraphEdge[]): ReviewGraphEdge[] {
+  return [...edges].sort((a, b) => (
+    compareStrings(a.sourceQualified, b.sourceQualified) ||
+    compareStrings(a.targetQualified, b.targetQualified) ||
+    compareStrings(a.kind, b.kind) ||
+    compareStrings(a.id, b.id)
+  ));
+}
+
+export function createReviewGraphStore(G: Graph): ReviewGraphStoreLike {
+  const nodesById = new Map<string, ReviewGraphNode>();
+  const nodeIdByQualifiedName = new Map<string, string>();
+
+  G.forEachNode((nodeId, attrs) => {
+    const record = attrs as Record<string, unknown>;
+    const filePath = asString(record.source_file) ?? asString(record.sourceFile);
+    const { lineStart, lineEnd } = parseLineRange(record);
+    const kind = normalizeKind(record, filePath);
+    const name = asString(record.label) ?? nodeId;
+    const qualifiedName = asString(record.qualified_name) ?? asString(record.qualifiedName) ?? nodeId;
+    const node: ReviewGraphNode = {
+      id: nodeId,
+      name,
+      qualifiedName,
+      kind,
+      filePath,
+      lineStart,
+      lineEnd,
+      language: asString(record.language),
+      parentName: asString(record.parent_name) ?? asString(record.parentName),
+      isTest: kind === "Test" || isTestPath(filePath),
+      communityId: asNumber(record.community) ?? asNumber(record.community_id) ?? asNumber(record.communityId),
+      confidence: asString(record.confidence),
+      extra: { ...record },
+    };
+    nodesById.set(nodeId, node);
+    if (!nodeIdByQualifiedName.has(qualifiedName)) nodeIdByQualifiedName.set(qualifiedName, nodeId);
+  });
+
+  function resolveNodeId(qualifiedNameOrId: string): string | null {
+    if (nodesById.has(qualifiedNameOrId)) return qualifiedNameOrId;
+    return nodeIdByQualifiedName.get(qualifiedNameOrId) ?? null;
+  }
+
+  function normalizeEdge(edgeId: string, attrs: Record<string, unknown>, graphSource: string, graphTarget: string): ReviewGraphEdge | null {
+    let sourceId = graphSource;
+    let targetId = graphTarget;
+    if (G.type !== "directed") {
+      sourceId = asString(attrs._src) ?? graphSource;
+      targetId = asString(attrs._tgt) ?? graphTarget;
+    }
+    const source = nodesById.get(sourceId);
+    const target = nodesById.get(targetId);
+    if (!source || !target) return null;
+    const confidenceTier = asString(attrs.confidence) ?? "EXTRACTED";
+    const { lineStart } = parseLineRange(attrs);
+    return {
+      id: edgeId,
+      kind: canonicalRelation(attrs.relation),
+      sourceQualified: source.qualifiedName,
+      targetQualified: target.qualifiedName,
+      sourceId,
+      targetId,
+      filePath: asString(attrs.source_file) ?? asString(attrs.sourceFile),
+      line: lineStart,
+      confidence: confidenceValue(confidenceTier, attrs.confidence_score, attrs.weight),
+      confidenceTier,
+      extra: { ...attrs },
+    };
+  }
+
+  const allEdges: ReviewGraphEdge[] = [];
+  G.forEachEdge((edgeId, attrs, source, target) => {
+    const edge = normalizeEdge(edgeId, attrs as Record<string, unknown>, source, target);
+    if (edge) allEdges.push(edge);
+  });
+  const sortedEdges = sortEdges(allEdges);
+
+  function getNode(qualifiedNameOrId: string): ReviewGraphNode | null {
+    const nodeId = resolveNodeId(qualifiedNameOrId);
+    return nodeId ? nodesById.get(nodeId) ?? null : null;
+  }
+
+  function getAllNodes(options: { excludeFiles?: boolean } = {}): ReviewGraphNode[] {
+    const nodes = [...nodesById.values()].filter((node) => !(options.excludeFiles && node.kind === "File"));
+    return sortNodes(nodes);
+  }
+
+  function getNodesByFile(filePath: string): ReviewGraphNode[] {
+    return sortNodes([...nodesById.values()].filter((node) => pathMatches(node.filePath, filePath)));
+  }
+
+  function getFilesMatching(pattern: string): string[] {
+    const files = new Set<string>();
+    for (const node of nodesById.values()) {
+      if (pathMatches(node.filePath, pattern) && node.filePath) files.add(node.filePath);
+    }
+    return [...files].sort(compareStrings);
+  }
+
+  function getEdgesBySource(qualifiedNameOrId: string, kind?: string): ReviewGraphEdge[] {
+    const node = getNode(qualifiedNameOrId);
+    if (!node) return [];
+    const targetKind = kind ? canonicalRelation(kind) : null;
+    return sortedEdges.filter((edge) => edge.sourceQualified === node.qualifiedName && (!targetKind || edge.kind === targetKind));
+  }
+
+  function getEdgesByTarget(qualifiedNameOrId: string, kind?: string): ReviewGraphEdge[] {
+    const node = getNode(qualifiedNameOrId);
+    if (!node) return [];
+    const targetKind = kind ? canonicalRelation(kind) : null;
+    return sortedEdges.filter((edge) => edge.targetQualified === node.qualifiedName && (!targetKind || edge.kind === targetKind));
+  }
+
+  function getTransitiveTests(qualifiedNameOrId: string, maxDepth: number = 1): ReviewGraphNode[] {
+    const start = getNode(qualifiedNameOrId);
+    if (!start) return [];
+    const found = new Map<string, ReviewGraphNode>();
+
+    function addDirectTests(target: ReviewGraphNode): void {
+      for (const edge of getEdgesByTarget(target.qualifiedName, "TESTED_BY")) {
+        const testNode = getNode(edge.sourceQualified);
+        if (testNode?.isTest) found.set(testNode.qualifiedName, testNode);
+      }
+    }
+
+    addDirectTests(start);
+    let frontier = [start];
+    for (let depth = 0; depth < maxDepth; depth += 1) {
+      const next: ReviewGraphNode[] = [];
+      for (const node of frontier) {
+        for (const edge of getEdgesBySource(node.qualifiedName, "CALLS")) {
+          const callee = getNode(edge.targetQualified);
+          if (!callee) continue;
+          addDirectTests(callee);
+          next.push(callee);
+        }
+      }
+      frontier = next;
+    }
+    return sortNodes([...found.values()]);
+  }
+
+  function getImpactRadius(
+    changedFiles: string[],
+    options: { maxDepth?: number; maxNodes?: number; direction?: "directed" | "undirected" } = {},
+  ): ReviewImpactRadius {
+    const maxDepth = Math.max(0, options.maxDepth ?? 2);
+    const maxNodes = Math.max(1, options.maxNodes ?? 200);
+    const changed = new Map<string, ReviewGraphNode>();
+    for (const file of changedFiles) {
+      for (const node of getNodesByFile(file)) changed.set(node.id, node);
+    }
+    const visited = new Map(changed);
+    let truncated = false;
+    let frontier = [...changed.values()];
+
+    for (let depth = 0; depth < maxDepth && frontier.length > 0; depth += 1) {
+      const next: ReviewGraphNode[] = [];
+      for (const node of frontier) {
+        const relatedEdges = options.direction === "directed"
+          ? getEdgesBySource(node.qualifiedName)
+          : [...getEdgesBySource(node.qualifiedName), ...getEdgesByTarget(node.qualifiedName)];
+        for (const edge of relatedEdges) {
+          const otherQualified = edge.sourceQualified === node.qualifiedName ? edge.targetQualified : edge.sourceQualified;
+          const other = getNode(otherQualified);
+          if (!other || visited.has(other.id)) continue;
+          if (visited.size >= maxNodes) {
+            truncated = true;
+            continue;
+          }
+          visited.set(other.id, other);
+          next.push(other);
+        }
+      }
+      frontier = next;
+    }
+
+    const visitedQualified = new Set([...visited.values()].map((node) => node.qualifiedName));
+    const edges = sortedEdges.filter((edge) => visitedQualified.has(edge.sourceQualified) && visitedQualified.has(edge.targetQualified));
+    const impactedNodes = [...visited.values()].filter((node) => !changed.has(node.id));
+    const impactedFiles = [...new Set([...visited.values()].map((node) => node.filePath).filter((file): file is string => !!file))].sort(compareStrings);
+
+    return {
+      changedNodes: sortNodes([...changed.values()]),
+      impactedNodes: sortNodes(impactedNodes),
+      impactedFiles,
+      edges,
+      truncated,
+      totalImpacted: visited.size,
+    };
+  }
+
+  return {
+    getNode,
+    getNodeById: (id) => nodesById.get(id) ?? null,
+    getAllNodes,
+    getNodesByFile,
+    getFilesMatching,
+    getNodesByKind: (kinds) => sortNodes([...nodesById.values()].filter((node) => kinds.includes(node.kind))),
+    getAllFiles: () => [...new Set([...nodesById.values()].map((node) => node.filePath).filter((file): file is string => !!file))].sort(compareStrings),
+    getEdgesBySource,
+    getEdgesByTarget,
+    getAllEdges: () => [...sortedEdges],
+    getEdgesAmong: (qualifiedNamesOrIds) => {
+      const qualified = new Set<string>();
+      for (const value of qualifiedNamesOrIds) {
+        const node = getNode(value);
+        if (node) qualified.add(node.qualifiedName);
+      }
+      return sortedEdges.filter((edge) => qualified.has(edge.sourceQualified) && qualified.has(edge.targetQualified));
+    },
+    getAllCallTargets: () => new Set(sortedEdges.filter((edge) => edge.kind === "CALLS").map((edge) => edge.targetQualified)),
+    getImpactRadius,
+    getTransitiveTests,
+    getNodeCommunityId: (qualifiedNameOrId) => getNode(qualifiedNameOrId)?.communityId ?? null,
+    getCommunityIdsByQualifiedNames: (qualifiedNamesOrIds) => {
+      const result = new Map<string, number | null>();
+      for (const value of qualifiedNamesOrIds) result.set(value, getNode(value)?.communityId ?? null);
+      return result;
+    },
+    getGraphStats: () => {
+      const nodesByKind: Record<string, number> = {};
+      const edgesByKind: Record<string, number> = {};
+      const languages = new Set<string>();
+      for (const node of nodesById.values()) {
+        nodesByKind[node.kind] = (nodesByKind[node.kind] ?? 0) + 1;
+        if (node.language) languages.add(node.language);
+      }
+      for (const edge of sortedEdges) edgesByKind[edge.kind] = (edgesByKind[edge.kind] ?? 0) + 1;
+      return {
+        totalNodes: nodesById.size,
+        totalEdges: sortedEdges.length,
+        nodesByKind,
+        edgesByKind,
+        languages: [...languages].sort(compareStrings),
+        filesCount: new Set([...nodesById.values()].map((node) => node.filePath).filter(Boolean)).size,
+        lastUpdated: null,
+      };
+    },
+  };
+}

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -33,6 +33,7 @@ import { buildFirstHopSummary, firstHopSummaryToText } from "./summary.js";
 import { buildReviewDelta, reviewDeltaToText } from "./review.js";
 import { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, reviewEvaluationToText } from "./review-analysis.js";
 import { buildReviewContext, reviewContextToText } from "./review-context.js";
+import { analyzeChanges, detectChangesToMinimal, detectChangesToText } from "./detect-changes.js";
 import { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 import { createReviewGraphStore } from "./review-store.js";
 import {
@@ -1390,6 +1391,30 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         return;
       }
       console.log(reviewContextToText(result));
+    });
+
+  program
+    .command("detect-changes")
+    .requiredOption("--graph <path>")
+    .requiredOption("--files <csv>", "Comma or newline separated changed files")
+    .option("--flows <path>", "Optional path to flows.json")
+    .option("--detail-level <level>", "minimal|standard", "standard")
+    .option("--json", "Print JSON")
+    .action((opts) => {
+      const files = String(opts.files)
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const flowsArtifact = opts.flows ? readFlowArtifact(opts.flows) : null;
+      const result = analyzeChanges(createReviewGraphStore(loadGraph(opts.graph)), files, {
+        flows: flowsArtifact,
+      });
+      const output = opts.detailLevel === "minimal" ? detectChangesToMinimal(result) : result;
+      if (opts.json) {
+        console.log(JSON.stringify(output, null, 2));
+        return;
+      }
+      console.log(detectChangesToText(output));
     });
 
   program

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -35,9 +35,11 @@ import { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, revi
 import { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 import { createReviewGraphStore } from "./review-store.js";
 import {
+  affectedFlowsToText,
   buildFlowArtifact,
   flowDetailToText,
   flowListToText,
+  getAffectedFlows,
   getFlowById,
   listFlows,
   readFlowArtifact,
@@ -1335,6 +1337,29 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         return;
       }
       console.log(flowDetailToText(detail));
+    });
+
+  program
+    .command("affected-flows")
+    .requiredOption("--flows <path>")
+    .requiredOption("--graph <path>")
+    .requiredOption("--files <csv>", "Comma or newline separated changed files")
+    .option("--json", "Print JSON")
+    .action((opts) => {
+      const files = String(opts.files)
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const result = getAffectedFlows(
+        readFlowArtifact(opts.flows),
+        files,
+        createReviewGraphStore(loadGraph(opts.graph)),
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(affectedFlowsToText(result));
     });
 
   program

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -34,6 +34,7 @@ import { buildReviewDelta, reviewDeltaToText } from "./review.js";
 import { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, reviewEvaluationToText } from "./review-analysis.js";
 import { buildReviewContext, reviewContextToText } from "./review-context.js";
 import { analyzeChanges, detectChangesToMinimal, detectChangesToText } from "./detect-changes.js";
+import { buildMinimalContext, minimalContextToText } from "./minimal-context.js";
 import { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 import { createReviewGraphStore } from "./review-store.js";
 import {
@@ -1415,6 +1416,30 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         return;
       }
       console.log(detectChangesToText(output));
+    });
+
+  program
+    .command("minimal-context")
+    .requiredOption("--graph <path>")
+    .option("--files <csv>", "Comma or newline separated changed files", "")
+    .option("--flows <path>", "Optional path to flows.json")
+    .option("--task <text>", "Task intent used to route next graph tools", "")
+    .option("--json", "Print JSON")
+    .action((opts) => {
+      const files = String(opts.files)
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const result = buildMinimalContext(createReviewGraphStore(loadGraph(opts.graph)), {
+        changedFiles: files,
+        flows: opts.flows ? readFlowArtifact(opts.flows) : null,
+        task: opts.task,
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(minimalContextToText(result));
     });
 
   program

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -33,6 +33,17 @@ import { buildFirstHopSummary, firstHopSummaryToText } from "./summary.js";
 import { buildReviewDelta, reviewDeltaToText } from "./review.js";
 import { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, reviewEvaluationToText } from "./review-analysis.js";
 import { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
+import { createReviewGraphStore } from "./review-store.js";
+import {
+  buildFlowArtifact,
+  flowDetailToText,
+  flowListToText,
+  getFlowById,
+  listFlows,
+  readFlowArtifact,
+  writeFlowArtifact,
+  type ListFlowsOptions,
+} from "./flows.js";
 import { parsePdfOcrMode } from "./pdf-preflight.js";
 import { prepareSemanticDetection } from "./semantic-prepare.js";
 import { discoverProjectConfig, loadProjectConfig } from "./project-config.js";
@@ -1268,6 +1279,62 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         nodesPerCommunity: Number(opts.nodesPerCommunity),
       });
       console.log(firstHopSummaryToText(summary));
+    });
+
+  program
+    .command("flows-build")
+    .requiredOption("--graph <path>")
+    .requiredOption("--out <path>")
+    .option("--max-depth <n>", "Maximum CALLS depth", "15")
+    .option("--include-tests", "Include tests as possible entry points")
+    .action((opts) => {
+      const G = loadGraph(opts.graph);
+      const artifact = buildFlowArtifact(createReviewGraphStore(G), {
+        graphPath: opts.graph,
+        maxDepth: Number(opts.maxDepth),
+        includeTests: opts.includeTests === true,
+      });
+      writeFlowArtifact(artifact, opts.out);
+      console.log(`Execution flows: ${artifact.flows.length} written to ${opts.out}`);
+      for (const warning of artifact.warnings) console.warn(warning);
+    });
+
+  program
+    .command("flows-list")
+    .requiredOption("--flows <path>")
+    .option("--sort <key>", "criticality|depth|node-count|file-count|name", "criticality")
+    .option("--limit <n>", "Maximum flows to show", "50")
+    .option("--json", "Print JSON")
+    .action((opts) => {
+      const artifact = readFlowArtifact(opts.flows);
+      const sortBy = ["criticality", "depth", "node-count", "file-count", "name"].includes(String(opts.sort))
+        ? String(opts.sort) as ListFlowsOptions["sortBy"]
+        : "criticality";
+      const listOptions: ListFlowsOptions = {
+        sortBy,
+        limit: Number(opts.limit),
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(listFlows(artifact, listOptions), null, 2));
+        return;
+      }
+      console.log(flowListToText(artifact, listOptions));
+    });
+
+  program
+    .command("flows-get")
+    .requiredOption("--flows <path>")
+    .requiredOption("--graph <path>")
+    .requiredOption("--id <flow-id>")
+    .option("--json", "Print JSON")
+    .action((opts) => {
+      const detail = getFlowById(readFlowArtifact(opts.flows), opts.id, createReviewGraphStore(loadGraph(opts.graph)));
+      if (!detail) throw new Error(`flow not found: ${opts.id}`);
+      if (opts.json) {
+        console.log(JSON.stringify(detail, null, 2));
+        return;
+      }
+      console.log(flowDetailToText(detail));
     });
 
   program

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -32,6 +32,7 @@ import { defaultManifestPath, resolveGraphifyPaths } from "./paths.js";
 import { buildFirstHopSummary, firstHopSummaryToText } from "./summary.js";
 import { buildReviewDelta, reviewDeltaToText } from "./review.js";
 import { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, reviewEvaluationToText } from "./review-analysis.js";
+import { buildReviewContext, reviewContextToText } from "./review-context.js";
 import { buildCommitRecommendation, commitRecommendationToText } from "./recommend.js";
 import { createReviewGraphStore } from "./review-store.js";
 import {
@@ -1360,6 +1361,35 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         return;
       }
       console.log(affectedFlowsToText(result));
+    });
+
+  program
+    .command("review-context")
+    .requiredOption("--graph <path>")
+    .requiredOption("--files <csv>", "Comma or newline separated changed files")
+    .option("--detail-level <level>", "minimal|standard", "standard")
+    .option("--include-source", "Include capped source snippets")
+    .option("--max-depth <n>", "Impact radius depth", "2")
+    .option("--max-lines-per-file <n>", "Maximum full-file snippet lines", "200")
+    .option("--repo-root <path>", "Repository root for source snippets", ".")
+    .option("--json", "Print JSON")
+    .action((opts) => {
+      const files = String(opts.files)
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const result = buildReviewContext(createReviewGraphStore(loadGraph(opts.graph)), files, {
+        detailLevel: opts.detailLevel === "minimal" ? "minimal" : "standard",
+        includeSource: opts.includeSource === true,
+        maxDepth: Number(opts.maxDepth),
+        maxLinesPerFile: Number(opts.maxLinesPerFile),
+        repoRoot: opts.repoRoot,
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(reviewContextToText(result));
     });
 
   program

--- a/src/skills/skill-claw.md
+++ b/src/skills/skill-claw.md
@@ -33,6 +33,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
 /graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 /graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 /graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 /graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -893,5 +894,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/skills/skill-codex.md
+++ b/src/skills/skill-codex.md
@@ -36,6 +36,7 @@ $graphify query "<question>"                          # BFS traversal - broad co
 $graphify query "<question>" --dfs                    # DFS - trace one chain
 $graphify query "<question>" --budget 1500            # cap answer at N tokens
 $graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+$graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 $graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 $graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 $graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -624,5 +625,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `$graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/skills/skill-droid.md
+++ b/src/skills/skill-droid.md
@@ -33,6 +33,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
 /graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 /graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 /graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 /graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -1258,5 +1259,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/skills/skill-gemini.toml
+++ b/src/skills/skill-gemini.toml
@@ -11,6 +11,7 @@ Use the installed TypeScript runtime only. Do not fall back to Python.
 - `/graphify` with no path means the current directory `.`
 - `/graphify <path> [flags]` means build or update the graph for that path
 - `/graphify summary` means return compact first-hop orientation from `.graphify/graph.json`
+- `/graphify minimal-context [files...]` means return the first review call context and next graph tool route
 - `/graphify review-delta [files...]` means return review-oriented impact for changed files
 - `/graphify review-analysis [files...]` means return blast radius, impacted communities, bridges, test gaps, and multimodal safety
 - `/graphify recommend-commits [files...]` means return advisory-only commit groups; never stage, commit, or mutate branches
@@ -258,3 +259,6 @@ The user's raw `/graphify ...` arguments are appended below this prompt.
 
 # Review analysis workflow
 # `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` measures token savings, impacted-file recall, review summary precision, and multimodal regression safety.
+
+# CRG review workflow
+# `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.

--- a/src/skills/skill-kiro.md
+++ b/src/skills/skill-kiro.md
@@ -18,6 +18,7 @@ Use graphify to build, update, and query the project knowledge graph stored in `
 /graphify . --wiki
 /graphify query "architecture question"
 /graphify summary --graph .graphify/graph.json
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json
 /graphify review-delta --graph .graphify/graph.json
 ```
 
@@ -30,6 +31,10 @@ Use graphify to build, update, and query the project knowledge graph stored in `
 - If `.graphify/graph.json` is missing but `graphify-out/graph.json` exists, run `graphify migrate-state --dry-run` before relying on legacy state.
 - If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn before relying on semantic results and run `/graphify . --update` when appropriate.
 - After modifying code files, run `npx graphify hook-rebuild` to keep the graph current.
+
+## CRG Review Workflow
+
+`graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 ## Configured Project Profiles
 

--- a/src/skills/skill-opencode.md
+++ b/src/skills/skill-opencode.md
@@ -33,6 +33,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
 /graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 /graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 /graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 /graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -1257,5 +1258,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/skills/skill-trae.md
+++ b/src/skills/skill-trae.md
@@ -33,6 +33,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
 /graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 /graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 /graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 /graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -880,5 +881,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/skills/skill-vscode.md
+++ b/src/skills/skill-vscode.md
@@ -18,6 +18,7 @@ Use graphify from VS Code Copilot Chat to build, update, and query the project k
 /graphify . --wiki
 /graphify query "architecture question"
 /graphify summary --graph .graphify/graph.json
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json
 /graphify review-delta --graph .graphify/graph.json
 ```
 
@@ -30,6 +31,10 @@ Use graphify from VS Code Copilot Chat to build, update, and query the project k
 - If `.graphify/graph.json` is missing but `graphify-out/graph.json` exists, run `graphify migrate-state --dry-run` before relying on legacy state.
 - If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn before relying on semantic results and run `/graphify . --update` when appropriate.
 - After modifying code files, run `npx graphify hook-rebuild` to keep the graph current.
+
+## CRG Review Workflow
+
+`graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 ## Configured Project Profiles
 

--- a/src/skills/skill-windows.md
+++ b/src/skills/skill-windows.md
@@ -36,6 +36,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
 /graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 /graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 /graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 /graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -1275,5 +1276,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -36,6 +36,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
 /graphify summary --graph .graphify/graph.json        # compact first-hop orientation before deep traversal
+/graphify minimal-context --task "review PR" --graph .graphify/graph.json  # first review call
 /graphify review-delta --files src/auth.ts --graph .graphify/graph.json  # review impact for changed files
 /graphify review-analysis --files src/auth.ts --graph .graphify/graph.json  # blast radius + review views
 /graphify recommend-commits --files src/auth.ts,src/session.ts --graph .graphify/graph.json  # advisory commit grouping
@@ -1319,5 +1320,7 @@ Do not add MCP, embeddings, databases, direct provider SDKs, a resident LLM back
 - Git hooks may mark stale state after branch switches, merges, and rewrites. Never delete `.graphify/` automatically; use `graphify state prune` only as a non-destructive cleanup preview.
 
 Commit recommendation workflow: `graphify recommend-commits` is advisory-only. It may suggest groups and commit messages, but the user remains the actor; do not auto-stage, auto-commit, or mutate branches.
+
+CRG review workflow: `graphify minimal-context` is the first review call. Keep graph review context within `<=5 graph tool calls` and `<=800` graph-context tokens. If `.graphify/needs_update` exists or `.graphify/branch.json` has `stale=true`, warn and update before trusting semantic review output. Then follow only the compact route: `graphify detect-changes` for risk, `graphify affected-flows` for flow impact, and `graphify review-context` for snippets or radius detail. If `.graphify/flows.json` is missing and flows are needed, run `graphify flows build` first. Explicit `--files`, `--base`, `--head`, or `--staged` inputs override unrelated dirty worktree noise; mention dirty worktrees as a warning and never mutate git state.
 
 Review analysis workflow: `graphify review-analysis` adds blast radius, bridge nodes, test-gap hints, impacted communities, and multimodal/doc safety. `graphify review-eval` is the deterministic evaluation harness for token savings, impacted-file recall, review summary precision, and multimodal regression safety.

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -8,6 +8,14 @@ import Graph from "graphology";
 import type { GodNodeEntry } from "./types.js";
 import { type NumericMapLike, toNumericMap } from "./collections.js";
 import { traversalNeighbors } from "./graph.js";
+import type { ReviewFlow, ReviewFlowArtifact } from "./flows.js";
+
+interface WikiPageRef {
+  key: string;
+  title: string;
+  filename: string;
+  link: string;
+}
 
 function safeFilename(name: string): string {
   return name
@@ -19,20 +27,55 @@ function safeFilename(name: string): string {
     .replace(/:/g, "-");
 }
 
+function uniquePageRefs(pages: Array<{ key: string; title: string }>): Map<string, WikiPageRef> {
+  const used = new Set<string>();
+  const refs = new Map<string, WikiPageRef>();
+  for (const page of pages) {
+    const base = safeFilename(page.title) || "page";
+    let stem = base;
+    let suffix = 2;
+    while (used.has(stem)) {
+      stem = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    used.add(stem);
+    refs.set(page.key, {
+      key: page.key,
+      title: page.title,
+      filename: `${stem}.md`,
+      link: stem === base ? `[[${page.title}]]` : `[[${stem}|${page.title}]]`,
+    });
+  }
+  return refs;
+}
+
+function normalizeFlows(input?: ReviewFlowArtifact | ReviewFlow[] | null): ReviewFlow[] {
+  if (!input) return [];
+  return Array.isArray(input) ? input : input.flows;
+}
+
+function compareFlowCriticality(a: ReviewFlow, b: ReviewFlow): number {
+  return b.criticality - a.criticality || a.name.localeCompare(b.name);
+}
+
+function flowsThroughNodes(flows: ReviewFlow[], nodes: string[]): ReviewFlow[] {
+  const nodeSet = new Set(nodes);
+  return flows
+    .filter((flow) => flow.path.some((nodeId) => nodeSet.has(nodeId)))
+    .sort(compareFlowCriticality);
+}
+
 function crossCommunityLinks(
   G: Graph,
   nodes: string[],
   ownCid: number,
-  labels: NumericMapLike<string>,
-): [string, number][] {
-  const labelMap = toNumericMap(labels);
-  const counts = new Map<string, number>();
+): [number, number][] {
+  const counts = new Map<number, number>();
   for (const nid of nodes) {
     for (const neighbor of traversalNeighbors(G, nid)) {
       const ncid = G.getNodeAttribute(neighbor, "community") as number | undefined;
       if (ncid !== undefined && ncid !== ownCid) {
-        const label = labelMap.get(ncid) ?? `Community ${ncid}`;
-        counts.set(label, (counts.get(label) ?? 0) + 1);
+        counts.set(ncid, (counts.get(ncid) ?? 0) + 1);
       }
     }
   }
@@ -46,9 +89,13 @@ function communityArticle(
   label: string,
   labels: Map<number, string>,
   cohesion: number | undefined,
+  communityLinks: Map<number, string>,
+  flows: ReviewFlow[],
+  flowLinks: Map<string, string>,
 ): string {
   const topNodes = [...nodes].sort((a, b) => G.degree(b) - G.degree(a)).slice(0, 25);
-  const cross = crossCommunityLinks(G, nodes, cid, labels);
+  const cross = crossCommunityLinks(G, nodes, cid);
+  const communityFlows = flowsThroughNodes(flows, nodes);
 
   const confCounts: Record<string, number> = { EXTRACTED: 0, INFERRED: 0, AMBIGUOUS: 0 };
   for (const nid of nodes) {
@@ -83,13 +130,22 @@ function communityArticle(
 
   lines.push("## Relationships", "");
   if (cross.length > 0) {
-    for (const [otherLabel, count] of cross.slice(0, 12)) {
-      lines.push(`- [[${otherLabel}]] (${count} shared connections)`);
+    for (const [otherCid, count] of cross.slice(0, 12)) {
+      lines.push(`- ${communityLinks.get(otherCid) ?? `[[${labels.get(otherCid) ?? `Community ${otherCid}`}]]`} (${count} shared connections)`);
     }
   } else {
     lines.push("- No strong cross-community connections detected");
   }
   lines.push("");
+
+  if (communityFlows.length > 0) {
+    lines.push("## Execution Flows", "");
+    for (const flow of communityFlows.slice(0, 12)) {
+      const link = flowLinks.get(flow.id) ?? `[[Flow ${flow.name}]]`;
+      lines.push(`- ${link} — criticality ${flow.criticality.toFixed(4)} · ${flow.nodeCount} nodes · ${flow.fileCount} files`);
+    }
+    lines.push("");
+  }
 
   if (sources.length > 0) {
     lines.push("## Source Files", "");
@@ -111,7 +167,7 @@ function communityArticle(
   return lines.join("\n");
 }
 
-function godNodeArticle(G: Graph, nid: string, labels: Map<number, string>): string {
+function godNodeArticle(G: Graph, nid: string, labels: Map<number, string>, communityLinks: Map<number, string>): string {
   const d = G.getNodeAttributes(nid);
   const nodeLabel = (d.label as string) ?? nid;
   const src = (d.source_file as string) ?? "";
@@ -123,7 +179,7 @@ function godNodeArticle(G: Graph, nid: string, labels: Map<number, string>): str
   lines.push(`> God node · ${G.degree(nid)} connections · \`${src}\``, "");
 
   if (communityName) {
-    lines.push(`**Community:** [[${communityName}]]`, "");
+    lines.push(`**Community:** ${communityLinks.get(cid!) ?? `[[${communityName}]]`}`, "");
   }
 
   const byRelation = new Map<string, string[]>();
@@ -151,10 +207,50 @@ function godNodeArticle(G: Graph, nid: string, labels: Map<number, string>): str
   return lines.join("\n");
 }
 
+function flowArticle(G: Graph, flow: ReviewFlow, communityLinks: Map<number, string>): string {
+  const lines: string[] = [];
+  lines.push(`# Flow ${flow.name}`, "");
+  lines.push(
+    `> Execution flow · criticality ${flow.criticality.toFixed(4)} · depth ${flow.depth} · ` +
+      `${flow.nodeCount} nodes · ${flow.fileCount} files`,
+    "",
+  );
+  lines.push(`**Entry point:** \`${flow.entryPoint}\``, "");
+
+  if (flow.files.length > 0) {
+    lines.push("## Files", "");
+    for (const file of flow.files) lines.push(`- \`${file}\``);
+    lines.push("");
+  }
+
+  lines.push("## Steps", "");
+  flow.path.forEach((nodeId, index) => {
+    const attrs = G.hasNode(nodeId) ? G.getNodeAttributes(nodeId) : {};
+    const label = (attrs.label as string | undefined) ?? flow.qualifiedPath[index] ?? nodeId;
+    const file = (attrs.source_file as string | undefined) ?? "";
+    const cid = attrs.community as number | undefined;
+    const community = cid !== undefined ? ` · ${communityLinks.get(cid) ?? `[[Community ${cid}]]`}` : "";
+    const filePart = file ? ` · \`${file}\`` : "";
+    lines.push(`- ${index + 1}. **${label}** — \`${flow.qualifiedPath[index] ?? nodeId}\`${filePart}${community}`);
+  });
+  lines.push("");
+
+  if (flow.warnings.length > 0) {
+    lines.push("## Warnings", "");
+    for (const warning of flow.warnings) lines.push(`- ${warning}`);
+    lines.push("");
+  }
+
+  lines.push("---", "", "*Part of the graphify knowledge wiki. See [[index]] to navigate.*");
+  return lines.join("\n");
+}
+
 function indexMd(
   communities: Map<number, string[]>,
   labels: Map<number, string>,
+  communityLinks: Map<number, string>,
   godNodesData: GodNodeEntry[],
+  flowPages: Array<{ flow: ReviewFlow; page: WikiPageRef }>,
   totalNodes: number,
   totalEdges: number,
 ): string {
@@ -175,7 +271,7 @@ function indexMd(
   const sorted = [...communities.entries()].sort((a, b) => b[1].length - a[1].length);
   for (const [cid, nodes] of sorted) {
     const label = labels.get(cid) ?? `Community ${cid}`;
-    lines.push(`- [[${label}]] — ${nodes.length} nodes`);
+    lines.push(`- ${communityLinks.get(cid) ?? `[[${label}]]`} — ${nodes.length} nodes`);
   }
   lines.push("");
 
@@ -183,6 +279,14 @@ function indexMd(
     lines.push("## God Nodes", "(most connected concepts — the load-bearing abstractions)", "");
     for (const node of godNodesData) {
       lines.push(`- [[${node.label}]] — ${node.edges} connections`);
+    }
+    lines.push("");
+  }
+
+  if (flowPages.length > 0) {
+    lines.push("## Execution Flows", "(highest criticality first)", "");
+    for (const { flow, page } of flowPages.sort((a, b) => compareFlowCriticality(a.flow, b.flow))) {
+      lines.push(`- ${page.link} — criticality ${flow.criticality.toFixed(4)} · ${flow.nodeCount} nodes`);
     }
     lines.push("");
   }
@@ -203,6 +307,7 @@ export function toWiki(
     communityLabels?: NumericMapLike<string>;
     cohesion?: NumericMapLike<number>;
     godNodesData?: GodNodeEntry[];
+    flows?: ReviewFlowArtifact | ReviewFlow[] | null;
   },
 ): number {
   const communityMap = toNumericMap(communities);
@@ -213,14 +318,31 @@ export function toWiki(
     : new Map([...communityMap.keys()].map((cid) => [cid, `Community ${cid}`]));
   const cohesion = toNumericMap(options?.cohesion);
   const godNodesData = options?.godNodesData ?? [];
+  const flows = normalizeFlows(options?.flows);
+  const pageRefs = uniquePageRefs([
+    ...[...communityMap.keys()].map((cid) => ({ key: `community:${cid}`, title: labels.get(cid) ?? `Community ${cid}` })),
+    ...godNodesData.map((node) => ({ key: `god:${node.id}`, title: node.label })),
+    ...flows.map((flow) => ({ key: `flow:${flow.id}`, title: `Flow ${flow.name}` })),
+  ]);
+  const communityLinks = new Map<number, string>();
+  for (const cid of communityMap.keys()) {
+    const ref = pageRefs.get(`community:${cid}`);
+    if (ref) communityLinks.set(cid, ref.link);
+  }
+  const flowLinks = new Map<string, string>();
+  for (const flow of flows) {
+    const ref = pageRefs.get(`flow:${flow.id}`);
+    if (ref) flowLinks.set(flow.id, ref.link);
+  }
 
   let count = 0;
 
   // Community articles
   for (const [cid, nodes] of communityMap) {
     const label = labels.get(cid) ?? `Community ${cid}`;
-    const article = communityArticle(G, cid, nodes, label, labels, cohesion.get(cid));
-    writeFileSync(join(outputDir, `${safeFilename(label)}.md`), article);
+    const article = communityArticle(G, cid, nodes, label, labels, cohesion.get(cid), communityLinks, flows, flowLinks);
+    const page = pageRefs.get(`community:${cid}`);
+    writeFileSync(join(outputDir, page?.filename ?? `${safeFilename(label)}.md`), article);
     count++;
   }
 
@@ -228,16 +350,32 @@ export function toWiki(
   for (const nodeData of godNodesData) {
     const nid = nodeData.id;
     if (nid && G.hasNode(nid)) {
-      const article = godNodeArticle(G, nid, labels);
-      writeFileSync(join(outputDir, `${safeFilename(nodeData.label)}.md`), article);
+      const article = godNodeArticle(G, nid, labels, communityLinks);
+      const page = pageRefs.get(`god:${nodeData.id}`);
+      writeFileSync(join(outputDir, page?.filename ?? `${safeFilename(nodeData.label)}.md`), article);
       count++;
     }
+  }
+
+  // Flow articles
+  for (const flow of flows) {
+    const page = pageRefs.get(`flow:${flow.id}`);
+    writeFileSync(join(outputDir, page?.filename ?? `${safeFilename(`Flow ${flow.name}`)}.md`), flowArticle(G, flow, communityLinks));
+    count++;
   }
 
   // Index
   writeFileSync(
     join(outputDir, "index.md"),
-    indexMd(communityMap, labels, godNodesData, G.order, G.size),
+    indexMd(
+      communityMap,
+      labels,
+      communityLinks,
+      godNodesData,
+      flows.map((flow) => ({ flow, page: pageRefs.get(`flow:${flow.id}`)! })).filter((item) => !!item.page),
+      G.order,
+      G.size,
+    ),
   );
 
   return count;

--- a/tests/affected-flows.test.ts
+++ b/tests/affected-flows.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+import { buildFlowArtifact, getAffectedFlows } from "../src/flows.js";
+
+function qn(filePath: string, name: string): string {
+  return `${filePath}::${name}`;
+}
+
+function addFunction(G: Graph, name: string, filePath: string): string {
+  const id = qn(filePath, name);
+  G.addNode(id, {
+    label: name,
+    kind: "Function",
+    qualified_name: id,
+    source_file: filePath,
+    line_start: 1,
+    line_end: 10,
+  });
+  return id;
+}
+
+function addCall(G: Graph, source: string, target: string, filePath: string): void {
+  G.addDirectedEdge(source, target, {
+    relation: "calls",
+    confidence: "EXTRACTED",
+    source_file: filePath,
+  });
+}
+
+function makeFlowStore() {
+  const G = new Graph({ type: "directed" });
+  const route = addFunction(G, "handler", "routes.py");
+  const service = addFunction(G, "service", "services.py");
+  const repo = addFunction(G, "repo", "repo.py");
+  const cli = addFunction(G, "main", "cli.py");
+  const helper = addFunction(G, "helper", "utils.py");
+  addCall(G, route, service, "routes.py");
+  addCall(G, service, repo, "services.py");
+  addCall(G, cli, helper, "cli.py");
+  const store = createReviewGraphStore(G);
+  return {
+    store,
+    artifact: buildFlowArtifact(store, { generatedAt: "2026-04-22T00:00:00.000Z" }),
+    ids: { route, service, repo, cli, helper },
+  };
+}
+
+describe("affected flows", () => {
+  it("maps changed files to flow memberships and returns detailed steps sorted by criticality", () => {
+    const { artifact, store, ids } = makeFlowStore();
+
+    const result = getAffectedFlows(artifact, ["services.py"], store);
+
+    expect(result.total).toBe(1);
+    expect(result.changedFiles).toEqual(["services.py"]);
+    expect(result.matchedNodeIds).toEqual([ids.service]);
+    expect(result.unmatchedFiles).toEqual([]);
+    expect(result.affectedFlows[0]?.entryPoint).toBe(ids.route);
+    expect(result.affectedFlows[0]?.steps.map((step) => step.qualifiedName)).toEqual([
+      ids.route,
+      ids.service,
+      ids.repo,
+    ]);
+  });
+
+  it("returns stable empty results for no files or unmatched files", () => {
+    const { artifact, store } = makeFlowStore();
+
+    expect(getAffectedFlows(artifact, [], store)).toMatchObject({
+      changedFiles: [],
+      matchedNodeIds: [],
+      unmatchedFiles: [],
+      affectedFlows: [],
+      total: 0,
+    });
+    expect(getAffectedFlows(artifact, ["missing.py"], store)).toMatchObject({
+      changedFiles: ["missing.py"],
+      matchedNodeIds: [],
+      unmatchedFiles: ["missing.py"],
+      affectedFlows: [],
+      total: 0,
+    });
+  });
+});

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -235,6 +235,32 @@ describe("public CLI runtime command parity", () => {
     expect(cli.logs.join("\n")).toContain("Review context for 1 changed file(s)");
     expect(runtime.logs.join("\n")).toContain("Next tools: detect-changes, affected-flows, review-context");
   });
+
+  it("supports risk-scored detect changes commands", async () => {
+    const dir = tempProject();
+    const graphPath = writeFlowGraph(dir);
+    const flowsPath = join(dir, ".graphify", "flows.json");
+    await runCli(["flows", "build", "--graph", graphPath, "--out", flowsPath], dir);
+
+    const cli = await runCli([
+      "detect-changes",
+      "--graph", graphPath,
+      "--flows", flowsPath,
+      "--files", "src/service.ts",
+      "--detail-level", "minimal",
+    ], dir);
+    const runtime = await runSkillRuntime([
+      "detect-changes",
+      "--graph", graphPath,
+      "--flows", flowsPath,
+      "--files", "src/service.ts",
+      "--detail-level", "minimal",
+    ], dir);
+
+    expect(cli.exitCode).toBe(0);
+    expect(cli.logs.join("\n")).toContain("Risk score:");
+    expect(runtime.logs.join("\n")).toContain("Review priorities:");
+  });
 });
 
 describe("skill runtime artifact parity", () => {

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -213,6 +213,28 @@ describe("public CLI runtime command parity", () => {
     expect(affected.logs.join("\n")).toContain("Affected flows: 1");
     expect(runtimeAffected.logs.join("\n")).toContain("src/service.ts::run");
   });
+
+  it("supports focused review context commands", async () => {
+    const dir = tempProject();
+    const graphPath = writeFlowGraph(dir);
+
+    const cli = await runCli([
+      "review-context",
+      "--graph", graphPath,
+      "--files", "src/service.ts",
+      "--detail-level", "minimal",
+    ], dir);
+    const runtime = await runSkillRuntime([
+      "review-context",
+      "--graph", graphPath,
+      "--files", "src/service.ts",
+      "--detail-level", "minimal",
+    ], dir);
+
+    expect(cli.exitCode).toBe(0);
+    expect(cli.logs.join("\n")).toContain("Review context for 1 changed file(s)");
+    expect(runtime.logs.join("\n")).toContain("Next tools: detect-changes, affected-flows, review-context");
+  });
 });
 
 describe("skill runtime artifact parity", () => {

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -47,6 +47,28 @@ function writeGraph(dir: string): string {
   return graphPath;
 }
 
+function writeFlowGraph(dir: string): string {
+  const graphDir = join(dir, ".graphify");
+  mkdirSync(graphDir, { recursive: true });
+  const graphPath = join(graphDir, "graph.json");
+  writeFileSync(
+    graphPath,
+    JSON.stringify({
+      directed: true,
+      graph: {},
+      nodes: [
+        { id: "src/app.ts::main", label: "main", kind: "Function", qualified_name: "src/app.ts::main", source_file: "src/app.ts", line_start: 1, line_end: 5 },
+        { id: "src/service.ts::run", label: "run", kind: "Function", qualified_name: "src/service.ts::run", source_file: "src/service.ts", line_start: 7, line_end: 12 },
+      ],
+      links: [
+        { source: "src/app.ts::main", target: "src/service.ts::run", relation: "calls", confidence: "EXTRACTED", source_file: "src/app.ts" },
+      ],
+    }, null, 2),
+    "utf-8",
+  );
+  return graphPath;
+}
+
 async function runCli(args: string[], cwd: string, options: { interceptExit?: boolean } = {}) {
   const { main } = await import("../src/cli.js");
   return runMain(() => main(), ["node", "graphify", ...args], cwd, options);
@@ -168,6 +190,24 @@ describe("public CLI runtime command parity", () => {
     expect(result.logs.join("\n")).toContain("graph.html updated");
     expect(existsSync(join(dir, ".graphify", "GRAPH_REPORT.md"))).toBe(true);
     expect(existsSync(join(dir, ".graphify", "graph.html"))).toBe(true);
+  });
+
+  it("supports execution flow build, list, and get commands", async () => {
+    const dir = tempProject();
+    const graphPath = writeFlowGraph(dir);
+    const flowsPath = join(dir, ".graphify", "flows.json");
+
+    const build = await runCli(["flows", "build", "--graph", graphPath, "--out", flowsPath], dir);
+    const artifact = JSON.parse(readFileSync(flowsPath, "utf-8")) as { flows: Array<{ id: string }> };
+    const list = await runCli(["flows", "list", "--flows", flowsPath], dir);
+    const get = await runCli(["flows", "get", artifact.flows[0]!.id, "--flows", flowsPath, "--graph", graphPath], dir);
+    const runtimeList = await runSkillRuntime(["flows-list", "--flows", flowsPath], dir);
+
+    expect(build.exitCode).toBe(0);
+    expect(build.logs.join("\n")).toContain("Execution flows: 1");
+    expect(list.logs.join("\n")).toContain("src/app.ts::main");
+    expect(get.logs.join("\n")).toContain("src/service.ts::run");
+    expect(runtimeList.logs.join("\n")).toContain("src/app.ts::main");
   });
 });
 

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -202,12 +202,16 @@ describe("public CLI runtime command parity", () => {
     const list = await runCli(["flows", "list", "--flows", flowsPath], dir);
     const get = await runCli(["flows", "get", artifact.flows[0]!.id, "--flows", flowsPath, "--graph", graphPath], dir);
     const runtimeList = await runSkillRuntime(["flows-list", "--flows", flowsPath], dir);
+    const affected = await runCli(["affected-flows", "--flows", flowsPath, "--graph", graphPath, "--files", "src/service.ts"], dir);
+    const runtimeAffected = await runSkillRuntime(["affected-flows", "--flows", flowsPath, "--graph", graphPath, "--files", "src/service.ts"], dir);
 
     expect(build.exitCode).toBe(0);
     expect(build.logs.join("\n")).toContain("Execution flows: 1");
     expect(list.logs.join("\n")).toContain("src/app.ts::main");
     expect(get.logs.join("\n")).toContain("src/service.ts::run");
     expect(runtimeList.logs.join("\n")).toContain("src/app.ts::main");
+    expect(affected.logs.join("\n")).toContain("Affected flows: 1");
+    expect(runtimeAffected.logs.join("\n")).toContain("src/service.ts::run");
   });
 });
 

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -261,6 +261,32 @@ describe("public CLI runtime command parity", () => {
     expect(cli.logs.join("\n")).toContain("Risk score:");
     expect(runtime.logs.join("\n")).toContain("Review priorities:");
   });
+
+  it("supports compact minimal context commands", async () => {
+    const dir = tempProject();
+    const graphPath = writeFlowGraph(dir);
+    const flowsPath = join(dir, ".graphify", "flows.json");
+    await runCli(["flows", "build", "--graph", graphPath, "--out", flowsPath], dir);
+
+    const cli = await runCli([
+      "minimal-context",
+      "--graph", graphPath,
+      "--flows", flowsPath,
+      "--files", "src/service.ts",
+      "--task", "review PR",
+    ], dir);
+    const runtime = await runSkillRuntime([
+      "minimal-context",
+      "--graph", graphPath,
+      "--flows", flowsPath,
+      "--files", "src/service.ts",
+      "--task", "review PR",
+    ], dir);
+
+    expect(cli.exitCode).toBe(0);
+    expect(cli.logs.join("\n")).toContain("Next tools: detect-changes, affected-flows, review-context");
+    expect(runtime.logs.join("\n")).toContain("Flows available: yes");
+  });
 });
 
 describe("skill runtime artifact parity", () => {

--- a/tests/detect-changes.test.ts
+++ b/tests/detect-changes.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+import { buildFlowArtifact } from "../src/flows.js";
+import {
+  analyzeChanges,
+  computeRiskScore,
+  isSafeGitRef,
+  mapChangesToNodes,
+  parseUnifiedDiff,
+} from "../src/detect-changes.js";
+
+function qn(filePath: string, name: string): string {
+  return `${filePath}::${name}`;
+}
+
+function addNode(
+  G: Graph,
+  name: string,
+  filePath: string,
+  options: { start?: number; end?: number; kind?: "Function" | "Class" | "Test"; community?: number } = {},
+): string {
+  const id = qn(filePath, name);
+  G.addNode(id, {
+    label: name,
+    kind: options.kind ?? "Function",
+    qualified_name: id,
+    source_file: filePath,
+    line_start: options.start ?? 1,
+    line_end: options.end ?? 10,
+    community: options.community,
+  });
+  return id;
+}
+
+function addEdge(G: Graph, source: string, target: string, relation: string = "calls"): void {
+  G.addDirectedEdge(source, target, {
+    relation,
+    confidence: "EXTRACTED",
+  });
+}
+
+describe("risk-scored detect changes", () => {
+  it("parses unified diff ranges for basic, single-line, deletion, and multiple-file hunks", () => {
+    const parsed = parseUnifiedDiff([
+      "diff --git a/foo.py b/foo.py",
+      "--- a/foo.py",
+      "+++ b/foo.py",
+      "@@ -10,3 +10,5 @@ def foo():",
+      "+    new line",
+      "@@ -40 +42 @@",
+      "+single",
+      "diff --git a/bar.py b/bar.py",
+      "--- a/bar.py",
+      "+++ b/bar.py",
+      "@@ -8,2 +8,0 @@",
+    ].join("\n"));
+
+    expect(parsed).toEqual({
+      "foo.py": [[10, 14], [42, 42]],
+      "bar.py": [[8, 8]],
+    });
+    expect(isSafeGitRef("main~1")).toBe(true);
+    expect(isSafeGitRef("main;rm -rf .")).toBe(false);
+    expect(isSafeGitRef("--cached")).toBe(false);
+    expect(isSafeGitRef("main..HEAD")).toBe(false);
+  });
+
+  it("maps changed line ranges to overlapping graph nodes with suffix path fallback and dedupe", () => {
+    const G = new Graph({ type: "directed" });
+    const funcA = addNode(G, "funcA", "/repo/src/app.ts", { start: 5, end: 15 });
+    const funcB = addNode(G, "funcB", "/repo/src/app.ts", { start: 20, end: 30 });
+    addNode(G, "funcC", "/repo/src/app.ts", { start: 40, end: 50 });
+    const store = createReviewGraphStore(G);
+
+    const nodes = mapChangesToNodes(store, {
+      "src/app.ts": [[10, 12], [25, 26], [11, 13]],
+    });
+
+    expect(nodes.map((node) => node.qualifiedName)).toEqual([funcA, funcB]);
+  });
+
+  it("scores untested, security-sensitive, called, and flow-participating nodes as higher risk", () => {
+    const G = new Graph({ type: "directed" });
+    const untested = addNode(G, "verify_auth_token", "auth.ts", { community: 1 });
+    const tested = addNode(G, "processData", "data.ts", { community: 1 });
+    const test = addNode(G, "testProcessData", "data.test.ts", { kind: "Test", community: 1 });
+    const caller = addNode(G, "apiHandler", "api.ts", { community: 2 });
+    addEdge(G, test, tested, "tested_by");
+    addEdge(G, caller, untested, "calls");
+    addEdge(G, caller, tested, "calls");
+    const store = createReviewGraphStore(G);
+    const flows = buildFlowArtifact(store, { generatedAt: "2026-04-22T00:00:00.000Z" });
+
+    const untestedScore = computeRiskScore(store, store.getNode(untested)!, { flows });
+    const testedScore = computeRiskScore(store, store.getNode(tested)!, { flows });
+
+    expect(untestedScore).toBeGreaterThan(testedScore);
+    expect(untestedScore).toBeGreaterThanOrEqual(0);
+    expect(untestedScore).toBeLessThanOrEqual(1);
+  });
+
+  it("analyzes changed files with line ranges, affected flows, test gaps, priorities, and fallback mapping", () => {
+    const G = new Graph({ type: "directed" });
+    const handler = addNode(G, "handler", "routes.ts", { start: 1, end: 5 });
+    const service = addNode(G, "service", "services.ts", { start: 10, end: 20 });
+    addNode(G, "other", "services.ts", { start: 40, end: 50 });
+    addEdge(G, handler, service, "calls");
+    const store = createReviewGraphStore(G);
+    const flows = buildFlowArtifact(store, { generatedAt: "2026-04-22T00:00:00.000Z" });
+
+    const ranged = analyzeChanges(store, ["services.ts"], {
+      changedRanges: { "services.ts": [[12, 15]] },
+      flows,
+    });
+    const fallback = analyzeChanges(store, ["services.ts"], { flows });
+
+    expect(ranged.changedFunctions.map((node) => node.qualifiedName)).toEqual([service]);
+    expect(ranged.affectedFlows).toHaveLength(1);
+    expect(ranged.testGaps.map((gap) => gap.qualifiedName)).toEqual([service]);
+    expect(ranged.reviewPriorities[0]?.qualifiedName).toBe(service);
+    expect(ranged.summary).toContain("Analyzed 1 changed file(s)");
+    expect(fallback.changedFunctions.map((node) => node.qualifiedName)).toEqual([
+      service,
+      "services.ts::other",
+    ]);
+  });
+});

--- a/tests/flows.test.ts
+++ b/tests/flows.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+import {
+  buildFlowArtifact,
+  detectEntryPoints,
+  getFlowById,
+  listFlows,
+  readFlowArtifact,
+  traceFlows,
+  writeFlowArtifact,
+} from "../src/flows.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-flows-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function qn(filePath: string, name: string): string {
+  return `${filePath}::${name}`;
+}
+
+function addFunction(
+  G: Graph,
+  name: string,
+  options: {
+    path?: string;
+    kind?: "Function" | "Test";
+    decorators?: string[];
+  } = {},
+): string {
+  const filePath = options.path ?? "app.py";
+  const id = qn(filePath, name);
+  G.addNode(id, {
+    label: name,
+    kind: options.kind ?? "Function",
+    qualified_name: id,
+    source_file: filePath,
+    line_start: 1,
+    line_end: 10,
+    language: filePath.endsWith(".ts") ? "ts" : "python",
+    decorators: options.decorators,
+  });
+  return id;
+}
+
+function addCall(G: Graph, source: string, target: string, filePath: string = "app.py"): void {
+  if (G.type === "directed") {
+    G.addDirectedEdge(source, target, {
+      relation: "calls",
+      confidence: "EXTRACTED",
+      source_file: filePath,
+      source_location: "L5",
+    });
+    return;
+  }
+  G.addUndirectedEdge(source, target, {
+    relation: "calls",
+    confidence: "EXTRACTED",
+    source_file: filePath,
+    source_location: "L5",
+    _src: source,
+    _tgt: target,
+  });
+}
+
+describe("execution flows", () => {
+  it("detects roots, framework decorators, and conventional names while excluding tests by default", () => {
+    const G = new Graph({ type: "directed" });
+    const entry = addFunction(G, "entry_func");
+    const helper = addFunction(G, "helper");
+    const caller = addFunction(G, "caller");
+    const decorated = addFunction(G, "get_users", { decorators: ["app.get('/users')"] });
+    addFunction(G, "main");
+    addFunction(G, "on_message");
+    addFunction(G, "it:should work", { kind: "Test", path: "tests/service.test.ts" });
+    addFunction(G, "describe_block", { path: "src/service.spec.ts" });
+    addCall(G, entry, helper);
+    addCall(G, caller, decorated);
+    const store = createReviewGraphStore(G);
+
+    const defaultNames = detectEntryPoints(store).map((node) => node.name);
+    expect(defaultNames).toContain("entry_func");
+    expect(defaultNames).toContain("get_users");
+    expect(defaultNames).toContain("main");
+    expect(defaultNames).toContain("on_message");
+    expect(defaultNames).not.toContain("helper");
+    expect(defaultNames).not.toContain("it:should work");
+    expect(defaultNames).not.toContain("describe_block");
+
+    const allNames = detectEntryPoints(store, { includeTests: true }).map((node) => node.name);
+    expect(allNames).toContain("it:should work");
+    expect(allNames).toContain("describe_block");
+  });
+
+  it("traces CRG-style BFS flows with cycle protection, max depth, and trivial-flow skipping", () => {
+    const G = new Graph({ type: "directed" });
+    const main = addFunction(G, "main");
+    const first = addFunction(G, "first");
+    const second = addFunction(G, "second");
+    const third = addFunction(G, "third");
+    addFunction(G, "lonely");
+    addCall(G, main, first);
+    addCall(G, first, second);
+    addCall(G, second, first);
+    addCall(G, second, third);
+    const store = createReviewGraphStore(G);
+
+    const flows = traceFlows(store, { maxDepth: 2 });
+    const mainFlow = flows.find((flow) => flow.entryPoint === main);
+
+    expect(mainFlow?.qualifiedPath).toEqual([main, first, second]);
+    expect(mainFlow?.nodeCount).toBe(3);
+    expect(mainFlow?.depth).toBe(2);
+    expect(flows.some((flow) => flow.entryPoint.endsWith("lonely"))).toBe(false);
+  });
+
+  it("reports multi-file flow spread and CRG criticality signals", () => {
+    const G = new Graph({ type: "directed" });
+    const singleA = addFunction(G, "single_a", { path: "one.py" });
+    const singleB = addFunction(G, "single_b", { path: "one.py" });
+    const api = addFunction(G, "login_handler", { path: "routes.py" });
+    const service = addFunction(G, "check_password", { path: "services.py" });
+    const repo = addFunction(G, "persist_session", { path: "repo.py" });
+    addCall(G, singleA, singleB, "one.py");
+    addCall(G, api, service, "routes.py");
+    addCall(G, service, repo, "services.py");
+    const store = createReviewGraphStore(G);
+
+    const flows = traceFlows(store);
+    const single = flows.find((flow) => flow.entryPoint === singleA);
+    const secure = flows.find((flow) => flow.entryPoint === api);
+
+    expect(single?.fileCount).toBe(1);
+    expect(secure?.fileCount).toBe(3);
+    expect(secure?.files).toEqual(["repo.py", "routes.py", "services.py"]);
+    expect(secure?.criticality).toBeGreaterThanOrEqual(single?.criticality ?? 0);
+    for (const flow of flows) {
+      expect(flow.criticality).toBeGreaterThanOrEqual(0);
+      expect(flow.criticality).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("roundtrips .graphify flow artifacts and returns detailed flow steps", () => {
+    const G = new Graph({ type: "directed" });
+    const entry = addFunction(G, "entry");
+    const callee = addFunction(G, "callee");
+    addCall(G, entry, callee);
+    const store = createReviewGraphStore(G);
+    const artifact = buildFlowArtifact(store, {
+      graphPath: ".graphify/graph.json",
+      generatedAt: "2026-04-22T00:00:00.000Z",
+    });
+    const out = join(tempDir(), ".graphify", "flows.json");
+
+    writeFlowArtifact(artifact, out);
+    const restored = readFlowArtifact(out);
+    const listed = listFlows(restored);
+    const detail = getFlowById(restored, listed[0]!.id, store);
+
+    expect(JSON.parse(readFileSync(out, "utf-8")).version).toBe(1);
+    expect(listed).toHaveLength(1);
+    expect(detail?.steps.map((step) => step.name)).toEqual(["entry", "callee"]);
+    expect(detail?.steps[0]).toMatchObject({
+      kind: "Function",
+      file: "app.py",
+      qualifiedName: entry,
+    });
+  });
+
+  it("does not trace undirected CALLS edges without preserved direction and emits a warning", () => {
+    const G = new Graph({ type: "undirected" });
+    const source = addFunction(G, "source");
+    const target = addFunction(G, "target");
+    G.addUndirectedEdge(source, target, {
+      relation: "calls",
+      confidence: "EXTRACTED",
+      source_file: "app.py",
+    });
+    const store = createReviewGraphStore(G);
+
+    const artifact = buildFlowArtifact(store, { generatedAt: "2026-04-22T00:00:00.000Z" });
+
+    expect(artifact.flows).toEqual([]);
+    expect(artifact.warnings.join("\n")).toContain("direction");
+  });
+});

--- a/tests/minimal-context.test.ts
+++ b/tests/minimal-context.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+import { buildFlowArtifact } from "../src/flows.js";
+import { buildMinimalContext } from "../src/minimal-context.js";
+
+function qn(filePath: string, name: string): string {
+  return `${filePath}::${name}`;
+}
+
+function addFunction(G: Graph, name: string, filePath: string, community: number = 1): string {
+  const id = qn(filePath, name);
+  G.addNode(id, {
+    label: name,
+    kind: "Function",
+    qualified_name: id,
+    source_file: filePath,
+    line_start: 1,
+    line_end: 10,
+    community,
+  });
+  return id;
+}
+
+function addCall(G: Graph, source: string, target: string): void {
+  G.addDirectedEdge(source, target, {
+    relation: "calls",
+    confidence: "EXTRACTED",
+  });
+}
+
+function makeStore() {
+  const G = new Graph({ type: "directed" });
+  G.setAttribute("community_labels", {
+    "1": "API",
+    "2": "Services",
+  });
+  const api = addFunction(G, "handler", "routes.ts", 1);
+  const service = addFunction(G, "verifyAuthToken", "services.ts", 2);
+  const repo = addFunction(G, "repo", "repo.ts", 2);
+  addCall(G, api, service);
+  addCall(G, service, repo);
+  const store = createReviewGraphStore(G);
+  return {
+    store,
+    flows: buildFlowArtifact(store, { generatedAt: "2026-04-22T00:00:00.000Z" }),
+  };
+}
+
+describe("minimal context", () => {
+  it("returns compact graph stats with unknown risk when no changed files are supplied", () => {
+    const { store } = makeStore();
+
+    const result = buildMinimalContext(store, { task: "understand architecture" });
+
+    expect(result.summary).toContain("3 nodes, 2 edges across 3 files");
+    expect(result.risk).toBe("unknown");
+    expect(result.flowsAvailable).toBe(false);
+    expect(result.nextToolSuggestions).toEqual(["summary", "flows list", "path"]);
+  });
+
+  it("routes review/debug/refactor tasks to CRG-style next Graphify commands", () => {
+    const { store } = makeStore();
+
+    expect(buildMinimalContext(store, { task: "review PR #42" }).nextToolSuggestions).toEqual([
+      "detect-changes",
+      "affected-flows",
+      "review-context",
+    ]);
+    expect(buildMinimalContext(store, { task: "debug login error" }).nextToolSuggestions).toEqual([
+      "summary",
+      "query",
+      "flows get",
+    ]);
+    expect(buildMinimalContext(store, { task: "refactor dead code" }).nextToolSuggestions).toEqual([
+      "review-context",
+      "detect-changes",
+      "recommend-commits",
+    ]);
+  });
+
+  it("includes risk, key entities, top communities, and affected flows when inputs are available", () => {
+    const { store, flows } = makeStore();
+
+    const result = buildMinimalContext(store, {
+      task: "review diff",
+      changedFiles: ["services.ts"],
+      flows,
+    });
+
+    expect(result.risk).toBe("high");
+    expect(result.riskScore).toBeGreaterThan(0.4);
+    expect(result.keyEntities).toEqual(["verifyAuthToken"]);
+    expect(result.communities).toEqual(["Services", "API"]);
+    expect(result.flowsAvailable).toBe(true);
+    expect(result.flowsAffected).toEqual(["handler"]);
+    expect(JSON.stringify(result).split(/\s+/u).length).toBeLessThan(800);
+  });
+});

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -74,6 +74,8 @@ describe("public API compatibility", () => {
     expect(typeof api.reviewAnalysisToText).toBe("function");
     expect(typeof api.evaluateReviewAnalysis).toBe("function");
     expect(typeof api.reviewEvaluationToText).toBe("function");
+    expect(typeof api.evaluateReviewBenchmarks).toBe("function");
+    expect(typeof api.reviewBenchmarkToMarkdown).toBe("function");
     expect(typeof api.buildCommitRecommendation).toBe("function");
     expect(typeof api.commitRecommendationToText).toBe("function");
     expect(typeof api.planGraphifyOutMigration).toBe("function");

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import Graph from "graphology";
 import { generate } from "../src/report.js";
+import type { AffectedFlowsResult, ReviewFlowArtifact } from "../src/flows.js";
 
 describe("generate report", () => {
   it("generates a valid markdown report", () => {
@@ -79,5 +80,106 @@ describe("generate report", () => {
 
     expect(report).toContain("missing_label");
     expect(report).not.toContain("undefined");
+  });
+
+  it("renders flow-aware review sections only when grounded data is provided", () => {
+    const G = new Graph({ type: "directed" });
+    G.mergeNode("route", { label: "handler", source_file: "routes.ts", file_type: "code" });
+    G.mergeNode("auth", { label: "verifyAuthToken", source_file: "auth.ts", file_type: "code" });
+    G.mergeEdge("route", "auth", { relation: "calls", confidence: "EXTRACTED", source_file: "routes.ts" });
+
+    const flows: ReviewFlowArtifact = {
+      version: 1,
+      generatedAt: "2026-04-22T00:00:00.000Z",
+      graphPath: ".graphify/graph.json",
+      maxDepth: 15,
+      includeTests: false,
+      warnings: [],
+      flows: [
+        {
+          id: "flow:handler",
+          name: "handler",
+          entryPoint: "routes.ts::handler",
+          entryPointId: "route",
+          path: ["route", "auth"],
+          qualifiedPath: ["routes.ts::handler", "auth.ts::verifyAuthToken"],
+          depth: 1,
+          nodeCount: 2,
+          fileCount: 2,
+          files: ["auth.ts", "routes.ts"],
+          criticality: 0.82,
+          warnings: [],
+        },
+      ],
+    };
+    const affectedFlows: AffectedFlowsResult = {
+      changedFiles: ["auth.ts"],
+      matchedNodeIds: ["auth"],
+      unmatchedFiles: [],
+      affectedFlows: [
+        {
+          ...flows.flows[0]!,
+          steps: [
+            {
+              nodeId: "route",
+              name: "handler",
+              kind: "Function",
+              file: "routes.ts",
+              lineStart: 1,
+              lineEnd: 4,
+              qualifiedName: "routes.ts::handler",
+            },
+            {
+              nodeId: "auth",
+              name: "verifyAuthToken",
+              kind: "Function",
+              file: "auth.ts",
+              lineStart: 10,
+              lineEnd: 20,
+              qualifiedName: "auth.ts::verifyAuthToken",
+            },
+          ],
+        },
+      ],
+      total: 1,
+    };
+
+    const report = generate(
+      G,
+      new Map([[0, ["route", "auth"]]]),
+      new Map([[0, 0.9]]),
+      new Map([[0, "Auth"]]),
+      [],
+      [],
+      {
+        files: { code: ["routes.ts", "auth.ts"], document: [], paper: [], image: [] },
+        total_files: 2,
+        total_words: 300,
+        needs_graph: true,
+        warning: null,
+        skipped_sensitive: [],
+        graphifyignore_patterns: 0,
+      },
+      { input: 0, output: 0 },
+      ".",
+      {
+        review: {
+          flows,
+          affectedFlows,
+          highRiskNodes: [{ name: "verifyAuthToken", file: "auth.ts", riskScore: 0.91 }],
+          testGaps: [{ name: "verifyAuthToken", file: "auth.ts", reason: "No TESTED_BY edge" }],
+        },
+      },
+    );
+
+    expect(report).toContain("## Execution Flows");
+    expect(report).toContain("handler");
+    expect(report).toContain("criticality 0.8200");
+    expect(report).toContain("## Affected Flows");
+    expect(report).toContain("auth.ts");
+    expect(report).toContain("## High-Risk Nodes");
+    expect(report).toContain("verifyAuthToken");
+    expect(report).toContain("## Test Gaps");
+    expect(report).toContain("No TESTED_BY edge");
   });
 });

--- a/tests/review-benchmark.test.ts
+++ b/tests/review-benchmark.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+import { buildFlowArtifact } from "../src/flows.js";
+import {
+  evaluateReviewBenchmarks,
+  reviewBenchmarkToMarkdown,
+} from "../src/review-benchmark.js";
+
+function qn(filePath: string, name: string): string {
+  return `${filePath}::${name}`;
+}
+
+function addFunction(
+  G: Graph,
+  name: string,
+  filePath: string,
+  options: { start?: number; end?: number; community?: number } = {},
+): string {
+  const id = qn(filePath, name);
+  G.addNode(id, {
+    label: name,
+    kind: "Function",
+    qualified_name: id,
+    source_file: filePath,
+    line_start: options.start ?? 1,
+    line_end: options.end ?? 10,
+    community: options.community ?? 1,
+  });
+  return id;
+}
+
+function addCall(G: Graph, source: string, target: string): void {
+  G.addDirectedEdge(source, target, {
+    relation: "calls",
+    confidence: "EXTRACTED",
+  });
+}
+
+function makeBenchmarkStore() {
+  const G = new Graph({ type: "directed" });
+  const handler = addFunction(G, "handler", "routes.ts", { community: 1 });
+  const service = addFunction(G, "verifyAuthToken", "services.ts", { start: 10, end: 20, community: 1 });
+  const repo = addFunction(G, "readUser", "repo.ts", { community: 2 });
+  const audit = addFunction(G, "auditLogin", "metrics.ts", { community: 3 });
+  addCall(G, handler, service);
+  addCall(G, service, repo);
+  addCall(G, service, audit);
+  const store = createReviewGraphStore(G);
+  return {
+    store,
+    flows: buildFlowArtifact(store, { generatedAt: "2026-04-22T00:00:00.000Z" }),
+  };
+}
+
+describe("review benchmarks", () => {
+  it("reports conservative recall, precision, flow, test-gap, and false-positive metrics", () => {
+    const { store, flows } = makeBenchmarkStore();
+
+    const result = evaluateReviewBenchmarks(store, [
+      {
+        name: "auth service review",
+        changedFiles: ["services.ts"],
+        changedRanges: { "services.ts": [[12, 15]] },
+        expectedChangedNodes: ["services.ts::verifyAuthToken"],
+        expectedImpactedFiles: ["routes.ts", "services.ts", "repo.ts"],
+        expectedAffectedFlows: ["handler"],
+        expectedTestGaps: ["services.ts::verifyAuthToken"],
+        expectedSummaryFacts: ["verifyAuthToken", "handler"],
+        tokenBudget: 400,
+      },
+    ], { flows });
+
+    const metrics = result.cases[0]!.metrics;
+    expect(metrics.changedNodeRecall).toBe(1);
+    expect(metrics.impactedFileRecall).toBe(1);
+    expect(metrics.impactedFilePrecision).toBeLessThan(1);
+    expect(metrics.falsePositiveCount).toBe(1);
+    expect(metrics.flowCompleteness).toBe(1);
+    expect(metrics.testGapRecall).toBe(1);
+    expect(metrics.summaryFactRecall).toBe(1);
+    expect(metrics.tokenBudgetStatus).toBe("pass");
+    expect(result.aggregate.impactedFileF1).toBeGreaterThan(0.8);
+
+    const markdown = reviewBenchmarkToMarkdown(result);
+    expect(markdown).toContain("Graphify Review Benchmarks");
+    expect(markdown).toContain("false positives");
+    expect(markdown).toContain("estimated");
+  });
+
+  it("ignores null metrics in aggregate averages and documents README limitations", () => {
+    const { store } = makeBenchmarkStore();
+
+    const result = evaluateReviewBenchmarks(store, [
+      { name: "no expectations", changedFiles: ["services.ts"] },
+      {
+        name: "changed node only",
+        changedFiles: ["services.ts"],
+        expectedChangedNodes: ["services.ts::verifyAuthToken"],
+      },
+    ]);
+
+    expect(result.cases[0]!.metrics.changedNodeRecall).toBeNull();
+    expect(result.aggregate.changedNodeRecall).toBe(1);
+
+    const readme = readFileSync(new URL("../README.md", import.meta.url), "utf-8");
+    expect(readme).toContain("Review benchmarks");
+    expect(readme).toContain("favor recall over precision");
+    expect(readme).toContain("false positives");
+    expect(readme).toContain("Token metrics are estimates");
+  });
+});

--- a/tests/review-context.test.ts
+++ b/tests/review-context.test.ts
@@ -1,0 +1,129 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+import { buildReviewContext } from "../src/review-context.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function tempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-review-context-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function qn(filePath: string, name: string): string {
+  return `${filePath}::${name}`;
+}
+
+function addFunction(
+  G: Graph,
+  name: string,
+  filePath: string,
+  options: { start?: number; end?: number; kind?: "Function" | "Test" } = {},
+): string {
+  const id = qn(filePath, name);
+  G.addNode(id, {
+    label: name,
+    kind: options.kind ?? "Function",
+    qualified_name: id,
+    source_file: filePath,
+    line_start: options.start ?? 1,
+    line_end: options.end ?? 5,
+    language: filePath.endsWith(".ts") ? "ts" : "python",
+  });
+  return id;
+}
+
+function addEdge(G: Graph, source: string, target: string, relation: string): void {
+  G.addDirectedEdge(source, target, {
+    relation,
+    confidence: "EXTRACTED",
+  });
+}
+
+function makeReviewGraph(): { G: Graph; changed: string; repo: string } {
+  const G = new Graph({ type: "directed" });
+  const changed = addFunction(G, "processPayment", "src/service.ts", { start: 3, end: 5 });
+  const repo = addFunction(G, "savePayment", "src/repo.ts");
+  addEdge(G, changed, repo, "calls");
+  return { G, changed, repo };
+}
+
+describe("review context", () => {
+  it("returns CRG-style minimal context with risk, key entities, test gaps, and next tools", () => {
+    const { G } = makeReviewGraph();
+    const store = createReviewGraphStore(G);
+
+    const context = buildReviewContext(store, ["src/service.ts"], {
+      detailLevel: "minimal",
+    });
+
+    expect(context).toMatchObject({
+      status: "ok",
+      risk: "low",
+      changedFileCount: 1,
+      impactedFileCount: 2,
+      keyEntities: ["processPayment"],
+      testGaps: 1,
+      nextToolSuggestions: ["detect-changes", "affected-flows", "review-context"],
+    });
+    expect(context.summary).toContain("Review context for 1 changed file(s)");
+  });
+
+  it("returns standard graph context and source snippets with relevant numbered lines", () => {
+    const dir = tempProject();
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "service.ts"),
+      [
+        "const one = 1;",
+        "const two = 2;",
+        "export function processPayment() {",
+        "  return two;",
+        "}",
+        "const six = 6;",
+      ].join("\n"),
+      "utf-8",
+    );
+    const { G, changed, repo } = makeReviewGraph();
+    const store = createReviewGraphStore(G);
+
+    const context = buildReviewContext(store, ["src/service.ts"], {
+      repoRoot: dir,
+      includeSource: true,
+      maxLinesPerFile: 20,
+    });
+
+    expect(context.context?.changedFiles).toEqual(["src/service.ts"]);
+    expect(context.context?.impactedFiles).toEqual(["src/repo.ts", "src/service.ts"]);
+    expect(context.context?.graph.changedNodes.map((node) => node.qualifiedName)).toEqual([changed]);
+    expect(context.context?.graph.impactedNodes.map((node) => node.qualifiedName)).toContain(repo);
+    expect(context.context?.sourceSnippets?.["src/service.ts"]).toContain("3: export function processPayment()");
+    expect(context.context?.reviewGuidance).toContain("lack test coverage");
+  });
+
+  it("does not read sensitive files into source snippets", () => {
+    const dir = tempProject();
+    writeFileSync(join(dir, ".env"), "TOKEN=secret\n", "utf-8");
+    const G = new Graph({ type: "directed" });
+    addFunction(G, "loadSecret", ".env");
+    const store = createReviewGraphStore(G);
+
+    const context = buildReviewContext(store, [".env"], {
+      repoRoot: dir,
+      includeSource: true,
+    });
+
+    expect(context.context?.sourceSnippets?.[".env"]).toBe("(skipped sensitive file)");
+  });
+});

--- a/tests/review-store.test.ts
+++ b/tests/review-store.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { createReviewGraphStore } from "../src/review-store.js";
+
+function makeReviewGraph(): Graph {
+  const G = new Graph({ type: "undirected" });
+  G.setAttribute("community_labels", {
+    "1": "Payments",
+    "2": "Persistence",
+  });
+  G.addNode("src/service.ts::PaymentService", {
+    label: "PaymentService",
+    kind: "Class",
+    source_file: "/repo/src/service.ts",
+    source_location: "L10-L30",
+    language: "ts",
+    community: "1",
+  });
+  G.addNode("src/service.ts::processPayment", {
+    label: "processPayment",
+    kind: "Function",
+    source_file: "/repo/src/service.ts",
+    source_location: "/repo/src/service.ts:12-20",
+    language: "ts",
+    community: 1,
+  });
+  G.addNode("src/service.ts::helper", {
+    label: "helper",
+    file_type: "code",
+    source_file: "src/service.ts",
+    source_location: "#L24",
+  });
+  G.addNode("src/repo.ts::savePayment", {
+    label: "savePayment",
+    kind: "Function",
+    source_file: "/repo/src/repo.ts",
+    line_start: 5,
+    line_end: 8,
+    community: 2,
+  });
+  G.addNode("tests/service.test.ts::testProcessPayment", {
+    label: "testProcessPayment",
+    kind: "Test",
+    source_file: "/repo/tests/service.test.ts",
+    source_location: "lines 4-9",
+    community: 1,
+  });
+  G.addNode("tests/repo.test.ts::testSavePayment", {
+    label: "testSavePayment",
+    kind: "Test",
+    source_file: "/repo/tests/repo.test.ts",
+    source_location: "L4",
+    community: 2,
+  });
+
+  G.addUndirectedEdge("src/service.ts::processPayment", "src/repo.ts::savePayment", {
+    relation: "calls",
+    confidence: "EXTRACTED",
+    source_file: "/repo/src/service.ts",
+    source_location: "L14",
+    _src: "src/service.ts::processPayment",
+    _tgt: "src/repo.ts::savePayment",
+  });
+  G.addUndirectedEdge("tests/service.test.ts::testProcessPayment", "src/service.ts::processPayment", {
+    relation: "validated_by",
+    confidence: "EXTRACTED",
+    source_file: "/repo/tests/service.test.ts",
+    _src: "tests/service.test.ts::testProcessPayment",
+    _tgt: "src/service.ts::processPayment",
+  });
+  G.addUndirectedEdge("tests/repo.test.ts::testSavePayment", "src/repo.ts::savePayment", {
+    relation: "validated_by",
+    confidence: "EXTRACTED",
+    source_file: "/repo/tests/repo.test.ts",
+    _src: "tests/repo.test.ts::testSavePayment",
+    _tgt: "src/repo.ts::savePayment",
+  });
+  return G;
+}
+
+describe("review graph store adapter", () => {
+  it("normalizes Graphify node fields into the CRG review contract", () => {
+    const store = createReviewGraphStore(makeReviewGraph());
+
+    const node = store.getNode("src/service.ts::processPayment");
+
+    expect(node).toMatchObject({
+      id: "src/service.ts::processPayment",
+      name: "processPayment",
+      qualifiedName: "src/service.ts::processPayment",
+      kind: "Function",
+      filePath: "/repo/src/service.ts",
+      lineStart: 12,
+      lineEnd: 20,
+      language: "ts",
+      isTest: false,
+      communityId: 1,
+    });
+    expect(store.getNode("missing")).toBeNull();
+    expect(store.getNodesByKind(["Test"]).map((item) => item.name)).toEqual([
+      "testProcessPayment",
+      "testSavePayment",
+    ]);
+  });
+
+  it("matches changed files by exact and suffix-normalized paths", () => {
+    const store = createReviewGraphStore(makeReviewGraph());
+
+    expect(store.getNodesByFile("src/service.ts").map((item) => item.name)).toEqual([
+      "PaymentService",
+      "helper",
+      "processPayment",
+    ]);
+    expect(store.getNodesByFile("./repo/src/repo.ts").map((item) => item.name)).toEqual([
+      "savePayment",
+    ]);
+    expect(store.getFilesMatching("src/service.ts")).toEqual([
+      "/repo/src/service.ts",
+      "src/service.ts",
+    ]);
+  });
+
+  it("normalizes relation kinds and preserved direction on undirected Graphify edges", () => {
+    const store = createReviewGraphStore(makeReviewGraph());
+
+    expect(store.getAllCallTargets()).toEqual(new Set(["src/repo.ts::savePayment"]));
+    expect(store.getEdgesBySource("src/service.ts::processPayment", "CALLS")).toMatchObject([
+      {
+        kind: "CALLS",
+        sourceQualified: "src/service.ts::processPayment",
+        targetQualified: "src/repo.ts::savePayment",
+        line: 14,
+        confidence: 1,
+        confidenceTier: "EXTRACTED",
+      },
+    ]);
+    expect(store.getEdgesByTarget("src/service.ts::processPayment", "TESTED_BY").map((edge) => edge.sourceQualified)).toEqual([
+      "tests/service.test.ts::testProcessPayment",
+    ]);
+  });
+
+  it("computes CRG-style impact radius with changed seeds, impacted nodes, files, and edges", () => {
+    const store = createReviewGraphStore(makeReviewGraph());
+
+    const impact = store.getImpactRadius(["src/service.ts"], { maxDepth: 1, maxNodes: 10 });
+
+    expect(impact.changedNodes.map((node) => node.qualifiedName)).toEqual([
+      "src/service.ts::PaymentService",
+      "src/service.ts::helper",
+      "src/service.ts::processPayment",
+    ]);
+    expect(impact.impactedNodes.map((node) => node.qualifiedName)).toEqual([
+      "src/repo.ts::savePayment",
+      "tests/service.test.ts::testProcessPayment",
+    ]);
+    expect(impact.impactedFiles).toEqual([
+      "/repo/src/repo.ts",
+      "/repo/src/service.ts",
+      "/repo/tests/service.test.ts",
+      "src/service.ts",
+    ]);
+    expect(impact.edges).toHaveLength(2);
+    expect(impact.truncated).toBe(false);
+    expect(impact.totalImpacted).toBe(5);
+  });
+
+  it("finds direct and one-hop transitive test coverage", () => {
+    const store = createReviewGraphStore(makeReviewGraph());
+
+    expect(store.getTransitiveTests("src/service.ts::processPayment").map((node) => node.qualifiedName)).toEqual([
+      "tests/service.test.ts::testProcessPayment",
+      "tests/repo.test.ts::testSavePayment",
+    ]);
+  });
+
+  it("reports graph stats from normalized nodes and edges", () => {
+    const store = createReviewGraphStore(makeReviewGraph());
+
+    expect(store.getGraphStats()).toMatchObject({
+      totalNodes: 6,
+      totalEdges: 3,
+      nodesByKind: {
+        Class: 1,
+        Function: 3,
+        Test: 2,
+      },
+      edgesByKind: {
+        CALLS: 1,
+        TESTED_BY: 2,
+      },
+      filesCount: 5,
+    });
+  });
+});

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -17,6 +17,12 @@ const ALL_SKILL_DOCS = [
   "../src/skills/skill-trae.md",
 ];
 
+const DISTRIBUTED_SKILL_DOCS = [
+  ...ALL_SKILL_DOCS,
+  "../src/skills/skill-vscode.md",
+  "../src/skills/skill-kiro.md",
+];
+
 describe("skill cache examples", () => {
   it("use tuple destructuring for checkSemanticCache", () => {
     for (const relativePath of SKILLS) {
@@ -88,6 +94,20 @@ describe("skill cache examples", () => {
       expect(content).toContain("blast radius");
       expect(content).toContain("multimodal");
       expect(content).toContain("delegated OCR/vision");
+    }
+  });
+
+  it("documents minimal-context as the first CRG-style review call", () => {
+    for (const relativePath of DISTRIBUTED_SKILL_DOCS) {
+      const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");
+      expect(content).toContain("minimal-context");
+      expect(content).toContain("first review call");
+      expect(content).toContain("detect-changes");
+      expect(content).toContain("affected-flows");
+      expect(content).toContain("review-context");
+      expect(content).toContain("<=5 graph tool calls");
+      expect(content).toContain("<=800");
+      expect(content).toContain("stale=true");
     }
   });
 

--- a/tests/wiki.test.ts
+++ b/tests/wiki.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Graph from "graphology";
 import { toWiki } from "../src/wiki.js";
+import type { ReviewFlowArtifact } from "../src/flows.js";
 
 describe("toWiki", () => {
   let tmpDir: string;
@@ -70,5 +71,74 @@ describe("toWiki", () => {
     toWiki(G, communities, tmpDir, { communityLabels: labels });
 
     expect(existsSync(join(tmpDir, "Core_Module.md"))).toBe(true);
+  });
+
+  it("adds community flow sections and generated flow pages when flows are provided", () => {
+    const G = new Graph({ type: "directed" });
+    G.mergeNode("route", { label: "handler", source_file: "routes.ts", community: 0 });
+    G.mergeNode("auth", { label: "verifyAuthToken", source_file: "auth.ts", community: 1 });
+    G.mergeDirectedEdge("route", "auth", { relation: "calls", confidence: "EXTRACTED" });
+    const communities = new Map([
+      [0, ["route"]],
+      [1, ["auth"]],
+    ]);
+    const labels = new Map([
+      [0, "API"],
+      [1, "Auth"],
+    ]);
+    const flows: ReviewFlowArtifact = {
+      version: 1,
+      generatedAt: "2026-04-22T00:00:00.000Z",
+      graphPath: ".graphify/graph.json",
+      maxDepth: 15,
+      includeTests: false,
+      warnings: [],
+      flows: [
+        {
+          id: "flow:handler",
+          name: "handler",
+          entryPoint: "routes.ts::handler",
+          entryPointId: "route",
+          path: ["route", "auth"],
+          qualifiedPath: ["routes.ts::handler", "auth.ts::verifyAuthToken"],
+          depth: 1,
+          nodeCount: 2,
+          fileCount: 2,
+          files: ["auth.ts", "routes.ts"],
+          criticality: 0.82,
+          warnings: [],
+        },
+      ],
+    };
+
+    const count = toWiki(G, communities, tmpDir, { communityLabels: labels, flows });
+
+    expect(count).toBe(3);
+    expect(readFileSync(join(tmpDir, "API.md"), "utf-8")).toContain("## Execution Flows");
+    expect(readFileSync(join(tmpDir, "API.md"), "utf-8")).toContain("[[Flow handler]]");
+    expect(readFileSync(join(tmpDir, "Flow_handler.md"), "utf-8")).toContain("routes.ts::handler");
+    expect(readFileSync(join(tmpDir, "index.md"), "utf-8")).toContain("## Execution Flows");
+  });
+
+  it("uses suffixed filenames and alias links for duplicate normalized wiki titles", () => {
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("a", { label: "ClassA", source_file: "a.py", community: 0 });
+    G.mergeNode("b", { label: "ClassB", source_file: "b.py", community: 1 });
+    const communities = new Map([
+      [0, ["a"]],
+      [1, ["b"]],
+    ]);
+    const labels = new Map([
+      [0, "Core"],
+      [1, "Core"],
+    ]);
+
+    toWiki(G, communities, tmpDir, { communityLabels: labels });
+
+    expect(existsSync(join(tmpDir, "Core.md"))).toBe(true);
+    expect(existsSync(join(tmpDir, "Core_2.md"))).toBe(true);
+    const index = readFileSync(join(tmpDir, "index.md"), "utf-8");
+    expect(index).toContain("[[Core]]");
+    expect(index).toContain("[[Core_2|Core]]");
   });
 });


### PR DESCRIPTION
## Summary
- add CRG-aligned review store, flow, affected-flow, review-context, detect-changes, minimal-context, report/wiki, skill workflow, and benchmark coverage
- document upstream traceability, test-porting gate, release-gate status, and known benchmark limits
- keep Graphify generic and TypeScript-first without adopting SQLite or network benchmark runners

## Verification
- npm test -- tests/review-benchmark.test.ts tests/public-api.test.ts
- npm run lint
- npm run build
- npm test
- npx graphify hook-rebuild
- git diff --check

## Notes
- .graphify generated files are intentionally not included because branch/worktree metadata records absolute worktree paths in this worktree.