### PR TITLE
Catch up upstream v5 repo workflows and release 0.4.33

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,19 +1,19 @@
 # Graph Report - .  (2026-04-25)
 
 ## Corpus Check
-- Large corpus: 203 files · ~228,581 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder, or use --no-semantic to run AST-only.
+- Large corpus: 208 files · ~230,791 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder, or use --no-semantic to run AST-only.
 
 ## Summary
-- 1338 nodes · 2243 edges · 74 communities detected
-- Extraction: 90% EXTRACTED · 10% INFERRED · 0% AMBIGUOUS · INFERRED: 233 edges (avg confidence: 0.5)
+- 1361 nodes · 2581 edges · 40 communities detected
+- Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS · INFERRED: 233 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 203 · Candidates: 223
-- Excluded: 0 untracked · 179 ignored · 0 sensitive · 0 missing committed
+- Included files: 208 · Candidates: 228
+- Excluded: 0 untracked · 11 ignored · 0 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -28,8 +28,6 @@
 10. `BaseTransport` - 21 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `build()` --calls--> `buildFromJson()`  [EXTRACTED]
-  worked/mixed-corpus/raw/build.py → src/build.ts
 - `Utility functions shared across the library. Small helpers that don't belong in` --uses--> `Cookies`  [INFERRED]
   worked/httpx/raw/utils.py → worked/httpx/raw/models.py
 - `Convert a primitive value to its string representation.` --uses--> `Cookies`  [INFERRED]
@@ -37,6 +35,8 @@
 - `Convert a header key to its canonical Title-Case form.` --uses--> `Cookies`  [INFERRED]
   worked/httpx/raw/utils.py → worked/httpx/raw/models.py
 - `Expand a params dict into a flat list of (key, value) pairs.     List values bec` --uses--> `Cookies`  [INFERRED]
+  worked/httpx/raw/utils.py → worked/httpx/raw/models.py
+- `Parse a Content-Type header value.     Returns (media_type, params_dict).     Ex` --uses--> `Cookies`  [INFERRED]
   worked/httpx/raw/utils.py → worked/httpx/raw/models.py
 
 ## Communities
@@ -46,322 +46,178 @@ Cohesion: 0.03
 Nodes (84): Auth, BasicAuth, BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers. (+76 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.07
-Nodes (46): agentsInstall(), agentsUninstall(), antigravityInstall(), antigravityUninstall(), canonicalPlatformName(), changedFilesFromGit(), checkSkillVersion(), claudeInstall() (+38 more)
+Cohesion: 0.03
+Nodes (69): addCall(), addFunction(), makeFlowStore(), qn(), analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation() (+61 more)
 
 ### Community 2 - "Community 2"
+Cohesion: 0.05
+Nodes (50): build(), build_from_json(), buildFromJson(), buildMerge(), deduplicateByLabel(), normalizedLabel(), Merge multiple extraction results into one graph., buildProfileChunkPrompt() (+42 more)
+
+### Community 3 - "Community 3"
+Cohesion: 0.06
+Nodes (47): agentsInstall(), agentsUninstall(), antigravityInstall(), antigravityUninstall(), canonicalPlatformName(), changedFilesFromGit(), checkSkillVersion(), claudeInstall() (+39 more)
+
+### Community 4 - "Community 4"
+Cohesion: 0.05
+Nodes (43): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData() (+35 more)
+
+### Community 5 - "Community 5"
 Cohesion: 0.09
 Nodes (51): _csharpExtraWalk(), ensureParserInit(), extract(), extractC(), extractCpp(), extractCsharp(), extractElixir(), _extractGeneric() (+43 more)
 
-### Community 3 - "Community 3"
-Cohesion: 0.12
-Nodes (23): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), appendMemoryFiles(), buildGitInventory() (+15 more)
+### Community 6 - "Community 6"
+Cohesion: 0.05
+Nodes (32): average(), buildBlastRadius(), buildReviewAnalysis(), communityRisk(), evaluateReviewAnalysis(), formatMetric(), impactedCommunities(), multimodalSafety() (+24 more)
 
-### Community 4 - "Community 4"
+### Community 7 - "Community 7"
+Cohesion: 0.06
+Nodes (34): runCli(), runMain(), runSkillRuntime(), tempProfileProject(), tempProject(), execGit(), gitRevParse(), resolveFromGitCwd() (+26 more)
+
+### Community 8 - "Community 8"
+Cohesion: 0.07
+Nodes (33): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), artifactId(), artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors() (+25 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.08
+Nodes (35): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+27 more)
+
+### Community 10 - "Community 10"
+Cohesion: 0.1
+Nodes (35): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), normalizeIngestOptions() (+27 more)
+
+### Community 11 - "Community 11"
+Cohesion: 0.08
+Nodes (26): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+18 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.08
+Nodes (26): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+18 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.1
+Nodes (23): classifyFile(), convertOfficeFile(), countWords(), detect(), detectIncremental(), docxToMarkdown(), isIgnored(), isNoiseDir() (+15 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.12
+Nodes (23): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), isSvgOptions(), neo4jLabel(), neo4jRelation() (+15 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.09
+Nodes (18): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), bfs(), communitiesFromGraph(), communityName(), dfs(), findNode() (+10 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.11
+Nodes (17): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), loadProjectConfig(), normalizeProjectConfig() (+9 more)
+
+### Community 17 - "Community 17"
 Cohesion: 0.11
 Nodes (25): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+17 more)
 
-### Community 5 - "Community 5"
-Cohesion: 0.15
-Nodes (24): augmentDetectionWithTranscripts(), buildWhisperPrompt(), cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts(), envBoolean() (+16 more)
-
-### Community 6 - "Community 6"
-Cohesion: 0.12
-Nodes (18): analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), ensureExtractionShape(), getVersion(), loadGraph(), loadProfileRuntimeContext(), main() (+10 more)
-
-### Community 7 - "Community 7"
+### Community 18 - "Community 18"
 Cohesion: 0.13
 Nodes (24): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+16 more)
 
-### Community 8 - "Community 8"
-Cohesion: 0.13
-Nodes (17): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+9 more)
+### Community 19 - "Community 19"
+Cohesion: 0.17
+Nodes (18): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+10 more)
 
-### Community 9 - "Community 9"
-Cohesion: 0.13
-Nodes (14): buildCommitRecommendation(), commitPrefixForArea(), communityLabel(), dominantCommunity(), groupConfidence(), groupDraftForFile(), isGraphifyStatePath(), mergeDrafts() (+6 more)
+### Community 20 - "Community 20"
+Cohesion: 0.19
+Nodes (17): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+9 more)
 
-### Community 10 - "Community 10"
-Cohesion: 0.13
-Nodes (16): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+8 more)
+### Community 21 - "Community 21"
+Cohesion: 0.17
+Nodes (17): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+9 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.14
-Nodes (15): bfs(), communitiesFromGraph(), communityName(), dfs(), findNode(), getVersion(), loadGraph(), scoreNodes() (+7 more)
-
-### Community 12 - "Community 12"
+### Community 22 - "Community 22"
 Cohesion: 0.13
 Nodes (8): Server, Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate()
 
-### Community 13 - "Community 13"
-Cohesion: 0.19
-Nodes (18): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), isSvgOptions(), neo4jLabel(), neo4jRelation() (+10 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.2
-Nodes (18): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+10 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.14
-Nodes (12): average(), buildBlastRadius(), buildReviewAnalysis(), communityRisk(), evaluateReviewAnalysis(), formatMetric(), impactedCommunities(), multimodalSafety() (+4 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.22
-Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.2
-Nodes (16): classifyFile(), convertOfficeFile(), countWords(), detect(), detectIncremental(), docxToMarkdown(), isIgnored(), isNoiseDir() (+8 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.22
-Nodes (17): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), loadProjectConfig(), normalizeProjectConfig() (+9 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.26
-Nodes (17): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+9 more)
-
-### Community 20 - "Community 20"
+### Community 23 - "Community 23"
 Cohesion: 0.12
 Nodes (17): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+9 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.16
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
-
-### Community 22 - "Community 22"
+### Community 24 - "Community 24"
 Cohesion: 0.14
 Nodes (6): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor
 
-### Community 23 - "Community 23"
+### Community 25 - "Community 25"
 Cohesion: 0.21
 Nodes (16): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+8 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.18
-Nodes (14): build_graph(), cluster(), cohesion_score(), cohesionScore(), partition(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed (+6 more)
-
-### Community 25 - "Community 25"
-Cohesion: 0.23
-Nodes (13): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+5 more)
-
 ### Community 26 - "Community 26"
-Cohesion: 0.25
-Nodes (13): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+5 more)
-
-### Community 27 - "Community 27"
-Cohesion: 0.25
-Nodes (13): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+5 more)
-
-### Community 28 - "Community 28"
-Cohesion: 0.26
-Nodes (12): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+4 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.23
+Cohesion: 0.19
 Nodes (9): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+1 more)
 
-### Community 30 - "Community 30"
-Cohesion: 0.34
-Nodes (13): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+5 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.33
-Nodes (9): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+1 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.21
-Nodes (10): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+2 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.22
-Nodes (9): asNumber(), asString(), createReviewGraphStore(), isTestPath(), normalizeKind(), normalizePath(), parseLineRange(), pathMatches() (+1 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.24
-Nodes (11): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), graphDensity(), internalEdgeCounts() (+3 more)
-
-### Community 35 - "Community 35"
+### Community 27 - "Community 27"
 Cohesion: 0.2
 Nodes (13): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+5 more)
 
-### Community 36 - "Community 36"
+### Community 28 - "Community 28"
 Cohesion: 0.2
 Nodes (13): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+5 more)
 
-### Community 37 - "Community 37"
-Cohesion: 0.31
-Nodes (12): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+4 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.33
+### Community 29 - "Community 29"
+Cohesion: 0.29
 Nodes (11): bodyContent(), cachedFiles(), cacheDir(), cacheNamespace(), checkSemanticCache(), clearCache(), fileHash(), loadCached() (+3 more)
 
-### Community 39 - "Community 39"
-Cohesion: 0.33
-Nodes (10): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+2 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.36
-Nodes (11): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), normalizeIngestOptions() (+3 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.32
-Nodes (11): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+3 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.32
+### Community 30 - "Community 30"
+Cohesion: 0.28
 Nodes (10): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), safeFilename() (+2 more)
 
-### Community 43 - "Community 43"
-Cohesion: 0.35
-Nodes (8): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256()
+### Community 31 - "Community 31"
+Cohesion: 0.27
+Nodes (7): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote()
 
-### Community 44 - "Community 44"
+### Community 32 - "Community 32"
 Cohesion: 0.24
 Nodes (8): Base, LinearAlgebra, area(), Circle, describe(), Geometry, Point, Shape
 
-### Community 45 - "Community 45"
+### Community 33 - "Community 33"
 Cohesion: 0.24
 Nodes (1): ApiClient
 
-### Community 46 - "Community 46"
-Cohesion: 0.36
-Nodes (6): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl()
-
-### Community 47 - "Community 47"
+### Community 34 - "Community 34"
 Cohesion: 0.42
-Nodes (7): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote()
+Nodes (5): cloneRepo(), defaultCloneDestination(), execGit(), maybeGithubRepo(), repoNameFromUrl()
 
-### Community 48 - "Community 48"
-Cohesion: 0.36
-Nodes (6): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted()
-
-### Community 49 - "Community 49"
-Cohesion: 0.31
-Nodes (4): isPrivateIp(), safeFetch(), safeFetchText(), validateUrl()
-
-### Community 50 - "Community 50"
-Cohesion: 0.31
-Nodes (5): runCli(), runMain(), runSkillRuntime(), tempProfileProject(), tempProject()
-
-### Community 51 - "Community 51"
+### Community 35 - "Community 35"
 Cohesion: 0.39
 Nodes (5): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis()
 
-### Community 52 - "Community 52"
-Cohesion: 0.36
-Nodes (4): escapeRegExp(), hookBlockRegex(), installHook(), uninstallHook()
-
-### Community 53 - "Community 53"
-Cohesion: 0.5
-Nodes (7): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath()
-
-### Community 54 - "Community 54"
-Cohesion: 0.36
-Nodes (6): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart()
-
-### Community 55 - "Community 55"
-Cohesion: 0.43
-Nodes (6): appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), normalizeAffectedFlows(), normalizeFlows()
-
-### Community 56 - "Community 56"
-Cohesion: 0.52
-Nodes (6): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), toUndirectedGraph(), traversalNeighbors()
-
-### Community 58 - "Community 58"
-Cohesion: 0.53
-Nodes (4): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark()
-
-### Community 59 - "Community 59"
-Cohesion: 0.47
-Nodes (4): build(), build_from_json(), buildFromJson(), Merge multiple extraction results into one graph.
-
-### Community 60 - "Community 60"
-Cohesion: 0.67
-Nodes (5): buildProject(), countNonCodeFiles(), defaultLabels(), fileList(), formatDiagnosticSummary()
-
-### Community 62 - "Community 62"
+### Community 36 - "Community 36"
 Cohesion: 0.33
 Nodes (5): Animal, -initWithName, -speak, Dog, -fetch
 
-### Community 63 - "Community 63"
+### Community 37 - "Community 37"
 Cohesion: 0.47
 Nodes (2): build_graph(), Graph
 
-### Community 64 - "Community 64"
-Cohesion: 0.53
-Nodes (4): addEdge(), addFunction(), makeReviewGraph(), qn()
-
-### Community 65 - "Community 65"
-Cohesion: 0.8
-Nodes (4): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting()
-
-### Community 66 - "Community 66"
-Cohesion: 0.7
-Nodes (4): addCall(), addFunction(), makeFlowStore(), qn()
-
-### Community 67 - "Community 67"
+### Community 38 - "Community 38"
 Cohesion: 0.5
 Nodes (3): MyApp.Accounts.User, create(), validate()
 
-### Community 68 - "Community 68"
-Cohesion: 0.5
-Nodes (2): addFunction(), qn()
-
-### Community 69 - "Community 69"
-Cohesion: 0.7
-Nodes (4): addCall(), addFunction(), makeStore(), qn()
-
-### Community 70 - "Community 70"
-Cohesion: 0.7
-Nodes (4): addCall(), addFunction(), makeBenchmarkStore(), qn()
-
-### Community 72 - "Community 72"
-Cohesion: 0.83
-Nodes (3): normalizeSearchText(), scoreSearchText(), textMatchesQuery()
-
-### Community 74 - "Community 74"
-Cohesion: 0.67
-Nodes (2): addNode(), qn()
-
-### Community 75 - "Community 75"
+### Community 40 - "Community 40"
 Cohesion: 0.5
 Nodes (1): Transformer
-
-### Community 78 - "Community 78"
-Cohesion: 1
-Nodes (2): assertValid(), validateExtraction()
-
-### Community 80 - "Community 80"
-Cohesion: 1
-Nodes (2): git(), hookPath()
 
 ## Knowledge Gaps
 - **72 isolated node(s):** `GraphifyDemo`, `LinearAlgebra`, `Base`, `-initWithName`, `-speak` (+67 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 45`** (1 nodes): `ApiClient`
+- **Thin community `Community 33`** (1 nodes): `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 63`** (2 nodes): `build_graph()`, `Graph`
+- **Thin community `Community 37`** (2 nodes): `build_graph()`, `Graph`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 68`** (2 nodes): `addFunction()`, `qn()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (2 nodes): `addNode()`, `qn()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (1 nodes): `Transformer`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (2 nodes): `assertValid()`, `validateExtraction()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 80`** (2 nodes): `git()`, `hookPath()`
+- **Thin community `Community 40`** (1 nodes): `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `ValidationError` connect `Community 4` to `Community 0`?**
+- **Why does `ValidationError` connect `Community 17` to `Community 0`?**
   _High betweenness centrality (0.006) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 20`?**
-  _High betweenness centrality (0.006) - this node is a cross-community bridge._
+- **Why does `Cookies` connect `Community 0` to `Community 23`?**
+  _High betweenness centrality (0.005) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 39 inferred relationships involving `Request` (e.g. with `Auth` and `BasicAuth`) actually correct?**

--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,10 +1,10 @@
 # Graph Report - .  (2026-04-25)
 
 ## Corpus Check
-- Large corpus: 208 files · ~230,791 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder, or use --no-semantic to run AST-only.
+- Large corpus: 208 files · ~230,121 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder, or use --no-semantic to run AST-only.
 
 ## Summary
-- 1361 nodes · 2581 edges · 40 communities detected
+- 1361 nodes · 2581 edges · 39 communities detected
 - Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS · INFERRED: 233 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,7 +13,7 @@
 - Requested: auto
 - Resolved: committed (source: default-auto)
 - Included files: 208 · Candidates: 228
-- Excluded: 0 untracked · 11 ignored · 0 sensitive · 0 missing committed
+- Excluded: 1 untracked · 174 ignored · 0 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -47,51 +47,51 @@ Nodes (84): Auth, BasicAuth, BearerAuth, DigestAuth, NetRCAuth, Authentication h
 
 ### Community 1 - "Community 1"
 Cohesion: 0.03
-Nodes (69): addCall(), addFunction(), makeFlowStore(), qn(), analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation() (+61 more)
+Nodes (73): addCall(), addFunction(), makeFlowStore(), qn(), analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation() (+65 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.05
-Nodes (50): build(), build_from_json(), buildFromJson(), buildMerge(), deduplicateByLabel(), normalizedLabel(), Merge multiple extraction results into one graph., buildProfileChunkPrompt() (+42 more)
+Nodes (50): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+42 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
-Nodes (47): agentsInstall(), agentsUninstall(), antigravityInstall(), antigravityUninstall(), canonicalPlatformName(), changedFilesFromGit(), checkSkillVersion(), claudeInstall() (+39 more)
+Nodes (44): build(), build_from_json(), buildFromJson(), buildMerge(), deduplicateByLabel(), normalizedLabel(), Merge multiple extraction results into one graph., buildProfileChunkPrompt() (+36 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.05
-Nodes (43): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData() (+35 more)
+Cohesion: 0.06
+Nodes (47): agentsInstall(), agentsUninstall(), antigravityInstall(), antigravityUninstall(), canonicalPlatformName(), changedFilesFromGit(), checkSkillVersion(), claudeInstall() (+39 more)
 
 ### Community 5 - "Community 5"
+Cohesion: 0.05
+Nodes (40): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+32 more)
+
+### Community 6 - "Community 6"
 Cohesion: 0.09
 Nodes (51): _csharpExtraWalk(), ensureParserInit(), extract(), extractC(), extractCpp(), extractCsharp(), extractElixir(), _extractGeneric() (+43 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
 Cohesion: 0.05
 Nodes (32): average(), buildBlastRadius(), buildReviewAnalysis(), communityRisk(), evaluateReviewAnalysis(), formatMetric(), impactedCommunities(), multimodalSafety() (+24 more)
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
 Cohesion: 0.06
 Nodes (34): runCli(), runMain(), runSkillRuntime(), tempProfileProject(), tempProject(), execGit(), gitRevParse(), resolveFromGitCwd() (+26 more)
 
-### Community 8 - "Community 8"
+### Community 9 - "Community 9"
 Cohesion: 0.07
 Nodes (33): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), artifactId(), artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors() (+25 more)
 
-### Community 9 - "Community 9"
+### Community 10 - "Community 10"
 Cohesion: 0.08
 Nodes (35): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+27 more)
 
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.1
 Nodes (35): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), normalizeIngestOptions() (+27 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (26): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+18 more)
-
 ### Community 12 - "Community 12"
 Cohesion: 0.08
-Nodes (26): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+18 more)
+Nodes (26): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+18 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.1
@@ -107,11 +107,11 @@ Nodes (18): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), bfs(),
 
 ### Community 16 - "Community 16"
 Cohesion: 0.11
-Nodes (17): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), loadProjectConfig(), normalizeProjectConfig() (+9 more)
+Nodes (25): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+17 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.11
-Nodes (25): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+17 more)
+Cohesion: 0.12
+Nodes (18): analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), ensureExtractionShape(), getVersion(), loadGraph(), loadProfileRuntimeContext(), main() (+10 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.13
@@ -122,32 +122,32 @@ Cohesion: 0.17
 Nodes (18): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+10 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.19
-Nodes (17): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+9 more)
-
-### Community 21 - "Community 21"
-Cohesion: 0.17
-Nodes (17): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+9 more)
-
-### Community 22 - "Community 22"
 Cohesion: 0.13
 Nodes (8): Server, Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate()
 
-### Community 23 - "Community 23"
+### Community 21 - "Community 21"
 Cohesion: 0.12
 Nodes (17): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+9 more)
 
-### Community 24 - "Community 24"
+### Community 22 - "Community 22"
 Cohesion: 0.14
 Nodes (6): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor
 
-### Community 25 - "Community 25"
+### Community 23 - "Community 23"
 Cohesion: 0.21
 Nodes (16): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+8 more)
 
-### Community 26 - "Community 26"
+### Community 24 - "Community 24"
 Cohesion: 0.19
 Nodes (9): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+1 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.25
+Nodes (13): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+5 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.2
+Nodes (11): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), graphDensity(), internalEdgeCounts() (+3 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.2
@@ -162,61 +162,57 @@ Cohesion: 0.29
 Nodes (11): bodyContent(), cachedFiles(), cacheDir(), cacheNamespace(), checkSemanticCache(), clearCache(), fileHash(), loadCached() (+3 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.28
-Nodes (10): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), safeFilename() (+2 more)
-
-### Community 31 - "Community 31"
 Cohesion: 0.27
 Nodes (7): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote()
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.24
 Nodes (8): Base, LinearAlgebra, area(), Circle, describe(), Geometry, Point, Shape
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.24
 Nodes (1): ApiClient
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.42
 Nodes (5): cloneRepo(), defaultCloneDestination(), execGit(), maybeGithubRepo(), repoNameFromUrl()
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.39
 Nodes (5): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis()
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.33
 Nodes (5): Animal, -initWithName, -speak, Dog, -fetch
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.47
 Nodes (2): build_graph(), Graph
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.5
 Nodes (3): MyApp.Accounts.User, create(), validate()
 
-### Community 40 - "Community 40"
+### Community 39 - "Community 39"
 Cohesion: 0.5
 Nodes (1): Transformer
 
 ## Knowledge Gaps
 - **72 isolated node(s):** `GraphifyDemo`, `LinearAlgebra`, `Base`, `-initWithName`, `-speak` (+67 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 33`** (1 nodes): `ApiClient`
+- **Thin community `Community 32`** (1 nodes): `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 37`** (2 nodes): `build_graph()`, `Graph`
+- **Thin community `Community 36`** (2 nodes): `build_graph()`, `Graph`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (1 nodes): `Transformer`
+- **Thin community `Community 39`** (1 nodes): `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `ValidationError` connect `Community 17` to `Community 0`?**
+- **Why does `ValidationError` connect `Community 16` to `Community 0`?**
   _High betweenness centrality (0.006) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 23`?**
+- **Why does `Cookies` connect `Community 0` to `Community 21`?**
   _High betweenness centrality (0.005) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/.graphify/graph.json
+++ b/.graphify/graph.json
@@ -49,97 +49,7 @@
       "43": "Community 43",
       "44": "Community 44",
       "45": "Community 45",
-      "46": "Community 46",
-      "47": "Community 47",
-      "48": "Community 48",
-      "49": "Community 49",
-      "50": "Community 50",
-      "51": "Community 51",
-      "52": "Community 52",
-      "53": "Community 53",
-      "54": "Community 54",
-      "55": "Community 55",
-      "56": "Community 56",
-      "57": "Community 57",
-      "58": "Community 58",
-      "59": "Community 59",
-      "60": "Community 60",
-      "61": "Community 61",
-      "62": "Community 62",
-      "63": "Community 63",
-      "64": "Community 64",
-      "65": "Community 65",
-      "66": "Community 66",
-      "67": "Community 67",
-      "68": "Community 68",
-      "69": "Community 69",
-      "70": "Community 70",
-      "71": "Community 71",
-      "72": "Community 72",
-      "73": "Community 73",
-      "74": "Community 74",
-      "75": "Community 75",
-      "76": "Community 76",
-      "77": "Community 77",
-      "78": "Community 78",
-      "79": "Community 79",
-      "80": "Community 80",
-      "81": "Community 81",
-      "82": "Community 82",
-      "83": "Community 83",
-      "84": "Community 84",
-      "85": "Community 85",
-      "86": "Community 86",
-      "87": "Community 87",
-      "88": "Community 88",
-      "89": "Community 89",
-      "90": "Community 90",
-      "91": "Community 91",
-      "92": "Community 92",
-      "93": "Community 93",
-      "94": "Community 94",
-      "95": "Community 95",
-      "96": "Community 96",
-      "97": "Community 97",
-      "98": "Community 98",
-      "99": "Community 99",
-      "100": "Community 100",
-      "101": "Community 101",
-      "102": "Community 102",
-      "103": "Community 103",
-      "104": "Community 104",
-      "105": "Community 105",
-      "106": "Community 106",
-      "107": "Community 107",
-      "108": "Community 108",
-      "109": "Community 109",
-      "110": "Community 110",
-      "111": "Community 111",
-      "112": "Community 112",
-      "113": "Community 113",
-      "114": "Community 114",
-      "115": "Community 115",
-      "116": "Community 116",
-      "117": "Community 117",
-      "118": "Community 118",
-      "119": "Community 119",
-      "120": "Community 120",
-      "121": "Community 121",
-      "122": "Community 122",
-      "123": "Community 123",
-      "124": "Community 124",
-      "125": "Community 125",
-      "126": "Community 126",
-      "127": "Community 127",
-      "128": "Community 128",
-      "129": "Community 129",
-      "130": "Community 130",
-      "131": "Community 131",
-      "132": "Community 132",
-      "133": "Community 133",
-      "134": "Community 134",
-      "135": "Community 135",
-      "136": "Community 136"
+      "46": "Community 46"
     }
   },
   "nodes": [
@@ -149,8 +59,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L1",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_nodecommunitymap",
@@ -158,8 +68,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L20",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_isfilenode",
@@ -167,8 +77,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L29",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_isconceptnode",
@@ -176,8 +86,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L45",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_filecategory",
@@ -185,8 +95,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L54",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_topleveldir",
@@ -194,8 +104,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L65",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_surprisescore",
@@ -203,8 +113,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L69",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_godnodes",
@@ -212,8 +122,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L124",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_surprisingconnections",
@@ -221,8 +131,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L143",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_crossfilesurprises",
@@ -230,8 +140,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L162",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_crosscommunitysurprises",
@@ -239,8 +149,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L201",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_edgebetweennesssurprises",
@@ -248,8 +158,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L256",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_suggestquestions",
@@ -257,8 +167,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L281",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_graphdiff",
@@ -266,8 +176,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L404",
-      "community": 28,
-      "community_name": "Community 28"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "src_benchmark_ts",
@@ -275,8 +185,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L1",
-      "community": 58,
-      "community_name": "Community 58"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "benchmark_estimatetokens",
@@ -284,8 +194,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L12",
-      "community": 58,
-      "community_name": "Community 58"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "benchmark_querysubgraphtokens",
@@ -293,8 +203,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L16",
-      "community": 58,
-      "community_name": "Community 58"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "benchmark_loadgraph",
@@ -302,8 +212,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L77",
-      "community": 58,
-      "community_name": "Community 58"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "benchmark_runbenchmark",
@@ -311,8 +221,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L82",
-      "community": 58,
-      "community_name": "Community 58"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "benchmark_printbenchmark",
@@ -320,8 +230,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L138",
-      "community": 58,
-      "community_name": "Community 58"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "src_build_ts",
@@ -329,17 +239,35 @@
       "file_type": "code",
       "source_file": "src/build.ts",
       "source_location": "L1",
-      "community": 59,
-      "community_name": "Community 59"
+      "community": 2,
+      "community_name": "Community 2"
+    },
+    {
+      "id": "build_normalizedlabel",
+      "label": "normalizedLabel()",
+      "file_type": "code",
+      "source_file": "src/build.ts",
+      "source_location": "L24",
+      "community": 2,
+      "community_name": "Community 2"
+    },
+    {
+      "id": "build_deduplicatebylabel",
+      "label": "deduplicateByLabel()",
+      "file_type": "code",
+      "source_file": "src/build.ts",
+      "source_location": "L32",
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "build_buildfromjson",
       "label": "buildFromJson()",
       "file_type": "code",
       "source_file": "src/build.ts",
-      "source_location": "L20",
-      "community": 59,
-      "community_name": "Community 59"
+      "source_location": "L98",
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "build_build",
@@ -347,8 +275,17 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L31",
-      "community": 59,
-      "community_name": "Community 59"
+      "community": 2,
+      "community_name": "Community 2"
+    },
+    {
+      "id": "build_buildmerge",
+      "label": "buildMerge()",
+      "file_type": "code",
+      "source_file": "src/build.ts",
+      "source_location": "L182",
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_cache_ts",
@@ -356,8 +293,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L1",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_bodycontent",
@@ -365,8 +302,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L23",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_filehash",
@@ -374,8 +311,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L41",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_safenamespace",
@@ -383,8 +320,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L61",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_cachenamespace",
@@ -392,8 +329,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L70",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_cachedir",
@@ -401,8 +338,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L77",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_loadcached",
@@ -410,8 +347,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L89",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_savecached",
@@ -419,8 +356,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L110",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_cachedfiles",
@@ -428,8 +365,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L136",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_clearcache",
@@ -437,8 +374,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L150",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_checksemanticcache",
@@ -446,8 +383,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L171",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "cache_savesemanticcache",
@@ -455,8 +392,8 @@
       "file_type": "code",
       "source_file": "src/cache.ts",
       "source_location": "L200",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "src_cli_ts",
@@ -464,8 +401,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_getversion",
@@ -473,8 +410,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L41",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_splitfiles",
@@ -482,8 +419,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L52",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_changedfilesfromgit",
@@ -491,8 +428,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L59",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_loadcligraph",
@@ -500,8 +437,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L71",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_resolveportablecheckdir",
@@ -509,8 +446,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L79",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_readjson",
@@ -518,8 +455,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L91",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_writejson",
@@ -527,8 +464,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L95",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_scopeoptiondescription",
@@ -536,8 +473,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L101",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_resolvecliscopeselection",
@@ -545,8 +482,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L105",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_printscopeinspection",
@@ -554,8 +491,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L112",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_loadcliprofilecontext",
@@ -563,8 +500,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L132",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_findbestmatchingnode",
@@ -572,8 +509,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L146",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_canonicalplatformname",
@@ -581,8 +518,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L256",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_platformnamesforerror",
@@ -590,386 +527,395 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L260",
-      "community": 1,
-      "community_name": "Community 1"
+      "community": 3,
+      "community_name": "Community 3"
+    },
+    {
+      "id": "cli_resolveglobalskilldestination",
+      "label": "resolveGlobalSkillDestination()",
+      "file_type": "code",
+      "source_file": "src/cli.ts",
+      "source_location": "L264",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_opencodeconfigpath",
       "label": "opencodeConfigPath()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L358",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L372",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_legacyopencodeconfigpath",
       "label": "legacyOpencodeConfigPath()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L362",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L376",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_loadopencodeconfig",
       "label": "loadOpenCodeConfig()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L366",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L380",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_previewpath",
       "label": "previewPath()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L386",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L400",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_emptypreview",
       "label": "emptyPreview()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L390",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L404",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_platforminstallpreview",
       "label": "platformInstallPreview()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L394",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L408",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_globalskillinstallpreview",
       "label": "globalSkillInstallPreview()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L447",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L461",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_printmutationpreview",
       "label": "printMutationPreview()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L460",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L474",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_findskillfile",
       "label": "findSkillFile()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L654",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L668",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_renderaiderskill",
       "label": "renderAiderSkill()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L667",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L681",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_loadskillcontent",
       "label": "loadSkillContent()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L674",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L688",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_uninstallskill",
       "label": "uninstallSkill()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L699",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L713",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_getinvocationexample",
       "label": "getInvocationExample()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L727",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L741",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_getagentsmdsection",
       "label": "getAgentsMdSection()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L731",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L745",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_installgeminimcp",
       "label": "installGeminiMcp()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L759",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L773",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_uninstallgeminimcp",
       "label": "uninstallGeminiMcp()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L789",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L803",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_cursorinstall",
       "label": "cursorInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L813",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L827",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_cursoruninstall",
       "label": "cursorUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L828",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L842",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_antigravityinstall",
       "label": "antigravityInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L839",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L853",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_antigravityuninstall",
       "label": "antigravityUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L867",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L881",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_kiroinstall",
       "label": "kiroInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L878",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L892",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_kirouninstall",
       "label": "kiroUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L901",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L915",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_vscodeinstall",
       "label": "vscodeInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L930",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L944",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_vscodeuninstall",
       "label": "vscodeUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L955",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L969",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_installopencodeplugin",
       "label": "installOpenCodePlugin()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L971",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L985",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_uninstallopencodeplugin",
       "label": "uninstallOpenCodePlugin()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1003",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1017",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_writeglobalskill",
       "label": "writeGlobalSkill()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1042",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1056",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_installskill",
       "label": "installSkill()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1076",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1090",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_installclaudehook",
       "label": "installClaudeHook()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1095",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1109",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_uninstallclaudehook",
       "label": "uninstallClaudeHook()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1119",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1133",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_claudeinstall",
       "label": "claudeInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1138",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1152",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_claudeuninstall",
       "label": "claudeUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1163",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1177",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_geminiinstall",
       "label": "geminiInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1186",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1200",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_geminiuninstall",
       "label": "geminiUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1214",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1228",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_installcodexhook",
       "label": "installCodexHook()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1237",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1251",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_uninstallcodexhook",
       "label": "uninstallCodexHook()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1274",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1288",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_agentsinstall",
       "label": "agentsInstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1288",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1302",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_agentsuninstall",
       "label": "agentsUninstall()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1325",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1339",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_checkskillversion",
       "label": "checkSkillVersion()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1356",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1370",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_getplatformstocheck",
       "label": "getPlatformsToCheck()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1367",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1381",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_main",
       "label": "main()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L1408",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L1422",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_isdirectcliexecution",
       "label": "isDirectCliExecution()",
       "file_type": "code",
       "source_file": "src/cli.ts",
-      "source_location": "L2579",
-      "community": 1,
-      "community_name": "Community 1"
+      "source_location": "L2629",
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_cluster_ts",
@@ -977,8 +923,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L1",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_partition",
@@ -986,8 +932,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L14",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_splitcommunity",
@@ -995,8 +941,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L24",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_cluster",
@@ -1004,8 +950,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L27",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_cohesionscore",
@@ -1013,8 +959,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L116",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_scoreall",
@@ -1022,8 +968,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L130",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "src_collections_ts",
@@ -1031,8 +977,8 @@
       "file_type": "code",
       "source_file": "src/collections.ts",
       "source_location": "L1",
-      "community": 77,
-      "community_name": "Community 77"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "collections_tonumericmap",
@@ -1040,8 +986,8 @@
       "file_type": "code",
       "source_file": "src/collections.ts",
       "source_location": "L4",
-      "community": 77,
-      "community_name": "Community 77"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "collections_tostringmap",
@@ -1049,8 +995,8 @@
       "file_type": "code",
       "source_file": "src/collections.ts",
       "source_location": "L22",
-      "community": 77,
-      "community_name": "Community 77"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "src_configured_dataprep_ts",
@@ -1058,8 +1004,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L1",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_uniqueresolved",
@@ -1067,8 +1013,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L79",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_fullpagescreenshotexcludes",
@@ -1076,8 +1022,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L83",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_buildconfigureddetectioninputs",
@@ -1085,8 +1031,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L90",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_emptydetection",
@@ -1094,8 +1040,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L105",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_countwords",
@@ -1103,8 +1049,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L117",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_warningfor",
@@ -1112,8 +1058,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L125",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_recomputedetection",
@@ -1121,8 +1067,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L139",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_mergescopeinspections",
@@ -1130,8 +1076,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L162",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_mergedetections",
@@ -1139,8 +1085,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L181",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_isinside",
@@ -1148,8 +1094,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L203",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_applyconfiguredexcludes",
@@ -1157,8 +1103,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L210",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_writejson",
@@ -1166,8 +1112,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L230",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_writeregistries",
@@ -1175,8 +1121,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L235",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_buildprofilestate",
@@ -1184,8 +1130,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L242",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_writeprofilestate",
@@ -1193,8 +1139,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L265",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_dataprepreport",
@@ -1202,8 +1148,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L269",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_resolveconfigpath",
@@ -1211,8 +1157,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L299",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_runconfigureddataprep",
@@ -1220,8 +1166,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L308",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_detect_changes_ts",
@@ -1229,8 +1175,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L1",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_comparestrings",
@@ -1238,8 +1184,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L94",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_uniquesorted",
@@ -1247,8 +1193,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L100",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_rangestart",
@@ -1256,8 +1202,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L104",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_rangeend",
@@ -1265,8 +1211,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L108",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_sortnodesbylocation",
@@ -1274,8 +1220,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L112",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_noderiskrecord",
@@ -1283,8 +1229,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L120",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_issafegitref",
@@ -1292,8 +1238,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L133",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_parseunifieddiff",
@@ -1301,8 +1247,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L137",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_mapchangestonodes",
@@ -1310,8 +1256,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L161",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_computeriskscore",
@@ -1319,8 +1265,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L185",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_changednodesfromfiles",
@@ -1328,8 +1274,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L221",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_isriskscoredkind",
@@ -1337,8 +1283,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L229",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_testgaprecord",
@@ -1346,8 +1292,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L233",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_analyzechanges",
@@ -1355,8 +1301,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L243",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_detectchangestominimal",
@@ -1364,8 +1310,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L282",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_detectchangestotext",
@@ -1373,8 +1319,8 @@
       "file_type": "code",
       "source_file": "src/detect-changes.ts",
       "source_location": "L294",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "src_detect_ts",
@@ -1382,8 +1328,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L1",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_issensitive",
@@ -1391,8 +1337,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L55",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_lookslikepaper",
@@ -1400,8 +1346,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L60",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_classifyfile",
@@ -1409,8 +1355,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L72",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_extractpdftext",
@@ -1418,8 +1364,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L92",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_docxtomarkdown",
@@ -1427,8 +1373,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L104",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_xlsxtomarkdown",
@@ -1436,8 +1382,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L116",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_convertofficefile",
@@ -1445,8 +1391,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L144",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_countwords",
@@ -1454,8 +1400,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L165",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_isnoisedir",
@@ -1463,8 +1409,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L182",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_loadgraphifyignore",
@@ -1472,8 +1418,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L189",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_matchglob",
@@ -1481,8 +1427,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L217",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_isignored",
@@ -1490,8 +1436,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L226",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_walkdir",
@@ -1499,8 +1445,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L248",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_resolvecandidatefiles",
@@ -1508,8 +1454,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L294",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_detect",
@@ -1517,8 +1463,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L321",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_loadmanifest",
@@ -1526,8 +1472,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L418",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_savemanifest",
@@ -1535,8 +1481,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L426",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "detect_detectincremental",
@@ -1544,8 +1490,8 @@
       "file_type": "code",
       "source_file": "src/detect.ts",
       "source_location": "L440",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "src_export_ts",
@@ -1553,8 +1499,8 @@
       "file_type": "code",
       "source_file": "src/export.ts",
       "source_location": "L1",
-      "community": 13,
-      "community_name": "Community 13"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_nodecommunitymap",
@@ -1562,8 +1508,8 @@
       "file_type": "code",
       "source_file": "src/export.ts",
       "source_location": "L50",
-      "community": 13,
-      "community_name": "Community 13"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_cypherescape",
@@ -1571,8 +1517,8 @@
       "file_type": "code",
       "source_file": "src/export.ts",
       "source_location": "L59",
-      "community": 13,
-      "community_name": "Community 13"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_iscommunitylabeloptions",
@@ -1580,161 +1526,161 @@
       "file_type": "code",
       "source_file": "src/export.ts",
       "source_location": "L63",
-      "community": 13,
-      "community_name": "Community 13"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_iscanvasoptions",
       "label": "isCanvasOptions()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L72",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L73",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_issvgoptions",
       "label": "isSvgOptions()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L81",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L82",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_normalizecommunitylabels",
       "label": "normalizeCommunityLabels()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L90",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L91",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_normalizemembercounts",
       "label": "normalizeMemberCounts()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L100",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L101",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_tojson",
       "label": "toJson()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L112",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L113",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_tocypher",
       "label": "toCypher()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L176",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L199",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_neo4jlabel",
       "label": "neo4jLabel()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L207",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L230",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_neo4jrelation",
       "label": "neo4jRelation()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L212",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L235",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_scalarprops",
       "label": "scalarProps()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L220",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L243",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_pushtoneo4j",
       "label": "pushToNeo4j()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L234",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L257",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_htmlstyles",
       "label": "htmlStyles()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L317",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L340",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_hyperedgescript",
       "label": "hyperedgeScript()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L350",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L373",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_htmlscript",
       "label": "htmlScript()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L404",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L427",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_tohtml",
       "label": "toHtml()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L560",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L583",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_tographml",
       "label": "toGraphml()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L717",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L740",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_tosvg",
       "label": "toSvg()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L777",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L800",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "export_tocanvas",
       "label": "toCanvas()",
       "file_type": "code",
       "source_file": "src/export.ts",
-      "source_location": "L885",
-      "community": 13,
-      "community_name": "Community 13"
+      "source_location": "L908",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "src_extract_ts",
@@ -1742,8 +1688,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_getmodulerequire",
@@ -1751,8 +1697,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L33",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_ensureparserinit",
@@ -1760,8 +1706,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L43",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_parsetext",
@@ -1769,8 +1715,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L50",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_resolvegrammarwasm",
@@ -1778,8 +1724,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L59",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_loadlanguage",
@@ -1787,8 +1733,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L95",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_makeid",
@@ -1796,8 +1742,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L109",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_toportablepath",
@@ -1805,8 +1751,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L118",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_infercommonroot",
@@ -1814,8 +1760,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L122",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_projectrelativefilepath",
@@ -1823,8 +1769,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L149",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_remapfilenodeids",
@@ -1832,8 +1778,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L158",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_readtext",
@@ -1841,8 +1787,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L207",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_defaultconfig",
@@ -1850,8 +1796,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L271",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_resolvename",
@@ -1859,8 +1805,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L297",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_findbody",
@@ -1868,8 +1814,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L311",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importpython",
@@ -1877,8 +1823,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L326",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importjs",
@@ -1886,8 +1832,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L358",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importjava",
@@ -1895,8 +1841,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L393",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importc",
@@ -1904,8 +1850,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L438",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importcsharp",
@@ -1913,8 +1859,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L459",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importkotlin",
@@ -1922,8 +1868,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L480",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importscala",
@@ -1931,8 +1877,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L513",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importphp",
@@ -1940,8 +1886,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L534",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importlua",
@@ -1949,8 +1895,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L555",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_importswift",
@@ -1958,8 +1904,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L573",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_getcfuncname",
@@ -1967,8 +1913,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L595",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_getcppfuncname",
@@ -1976,8 +1922,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L605",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_jsextrawalk",
@@ -1985,8 +1931,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L623",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_csharpextrawalk",
@@ -1994,8 +1940,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L660",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_swiftextrawalk",
@@ -2003,8 +1949,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L693",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractgeneric",
@@ -2012,8 +1958,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L924",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractpythonrationale",
@@ -2021,8 +1967,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1398",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractpython",
@@ -2030,8 +1976,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1510",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractjs",
@@ -2039,8 +1985,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1518",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractjava",
@@ -2048,8 +1994,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1524",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractc",
@@ -2057,8 +2003,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1528",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractcpp",
@@ -2066,8 +2012,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1532",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractruby",
@@ -2075,8 +2021,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1536",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractcsharp",
@@ -2084,8 +2030,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1540",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractkotlin",
@@ -2093,8 +2039,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1544",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractscala",
@@ -2102,8 +2048,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1548",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractphp",
@@ -2111,8 +2057,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1552",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractlua",
@@ -2120,8 +2066,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1556",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractswift",
@@ -2129,8 +2075,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1560",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractjulia",
@@ -2138,8 +2084,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1568",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_lineforindex",
@@ -2147,8 +2093,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1792",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractregexbackedcode",
@@ -2156,8 +2102,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1796",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractgo",
@@ -2165,8 +2111,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1866",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractrust",
@@ -2174,8 +2120,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2073",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractzig",
@@ -2183,8 +2129,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2251",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractpowershell",
@@ -2192,8 +2138,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2437",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractobjc",
@@ -2201,8 +2147,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2632",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractelixir",
@@ -2210,8 +2156,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2856",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_resolvecrossfileimports",
@@ -2219,8 +2165,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3064",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extractwithdiagnostics",
@@ -2228,8 +2174,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3253",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_extract",
@@ -2237,8 +2183,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3324",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "extract_collectfiles",
@@ -2246,8 +2192,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3347",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "src_flows_ts",
@@ -2255,8 +2201,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_comparestrings",
@@ -2264,8 +2210,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L161",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_istestfile",
@@ -2273,8 +2219,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L167",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_decoratorsof",
@@ -2282,8 +2228,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L171",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_hasframeworkdecorator",
@@ -2291,8 +2237,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L178",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_matchesentryname",
@@ -2300,8 +2246,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L182",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_sanitizeflowname",
@@ -2309,8 +2255,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L186",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_flowidfor",
@@ -2318,8 +2264,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L190",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_stablefiles",
@@ -2327,8 +2273,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L202",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_detectentrypoints",
@@ -2336,8 +2282,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L206",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_tracesingleflow",
@@ -2345,8 +2291,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L230",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_traceflowswithwarnings",
@@ -2354,8 +2300,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L292",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_traceflows",
@@ -2363,8 +2309,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L309",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_computeflowcriticality",
@@ -2372,8 +2318,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L313",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_buildflowartifact",
@@ -2381,8 +2327,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L341",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_writeflowartifact",
@@ -2390,8 +2336,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L361",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_readflowartifact",
@@ -2399,8 +2345,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L367",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_listflows",
@@ -2408,8 +2354,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L375",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_flowtosteps",
@@ -2417,8 +2363,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L397",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_getflowbyid",
@@ -2426,8 +2372,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L412",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_getaffectedflows",
@@ -2435,8 +2381,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L426",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_flowlisttotext",
@@ -2444,8 +2390,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L480",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_affectedflowstotext",
@@ -2453,8 +2399,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L498",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_flowdetailtotext",
@@ -2462,8 +2408,8 @@
       "file_type": "code",
       "source_file": "src/flows.ts",
       "source_location": "L517",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "src_git_ts",
@@ -2471,8 +2417,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "git_execgit",
@@ -2480,8 +2426,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L12",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "git_safeexecgit",
@@ -2489,8 +2435,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L30",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "git_resolvefromgitcwd",
@@ -2498,8 +2444,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L39",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "git_gitrevparse",
@@ -2507,8 +2453,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L43",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "git_safegitrevparse",
@@ -2516,8 +2462,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L47",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "git_resolvegitcontext",
@@ -2525,8 +2471,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L51",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "src_graph_ts",
@@ -2534,8 +2480,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L1",
-      "community": 56,
-      "community_name": "Community 56"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "graph_creategraph",
@@ -2543,8 +2489,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L13",
-      "community": 56,
-      "community_name": "Community 56"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "graph_isdirectedgraph",
@@ -2552,8 +2498,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L17",
-      "community": 56,
-      "community_name": "Community 56"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "graph_loadgraphfromdata",
@@ -2561,35 +2507,44 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L21",
-      "community": 56,
-      "community_name": "Community 56"
+      "community": 4,
+      "community_name": "Community 4"
+    },
+    {
+      "id": "graph_serializegraph",
+      "label": "serializeGraph()",
+      "file_type": "code",
+      "source_file": "src/graph.ts",
+      "source_location": "L50",
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "graph_toundirectedgraph",
       "label": "toUndirectedGraph()",
       "file_type": "code",
       "source_file": "src/graph.ts",
-      "source_location": "L50",
-      "community": 56,
-      "community_name": "Community 56"
+      "source_location": "L74",
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "graph_foreachtraversalneighbor",
       "label": "forEachTraversalNeighbor()",
       "file_type": "code",
       "source_file": "src/graph.ts",
-      "source_location": "L75",
-      "community": 56,
-      "community_name": "Community 56"
+      "source_location": "L99",
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "graph_traversalneighbors",
       "label": "traversalNeighbors()",
       "file_type": "code",
       "source_file": "src/graph.ts",
-      "source_location": "L87",
-      "community": 56,
-      "community_name": "Community 56"
+      "source_location": "L111",
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "src_hooks_ts",
@@ -2597,8 +2552,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L1",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_installhook",
@@ -2606,8 +2561,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L168",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_uninstallhook",
@@ -2615,8 +2570,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L192",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_hookblockregex",
@@ -2624,8 +2579,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L212",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_escaperegexp",
@@ -2633,8 +2588,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L216",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_install",
@@ -2642,8 +2597,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L220",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_uninstall",
@@ -2651,8 +2606,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L232",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_status",
@@ -2660,8 +2615,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L243",
-      "community": 52,
-      "community_name": "Community 52"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "src_html_export_ts",
@@ -2669,8 +2624,8 @@
       "file_type": "code",
       "source_file": "src/html-export.ts",
       "source_location": "L1",
-      "community": 89,
-      "community_name": "Community 89"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "html_export_safetohtml",
@@ -2678,8 +2633,8 @@
       "file_type": "code",
       "source_file": "src/html-export.ts",
       "source_location": "L13",
-      "community": 89,
-      "community_name": "Community 89"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "src_image_caption_schema_ts",
@@ -2687,8 +2642,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L1",
-      "community": 65,
-      "community_name": "Community 65"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_caption_schema_isrecord",
@@ -2696,8 +2651,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L4",
-      "community": 65,
-      "community_name": "Community 65"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_caption_schema_isstringarray",
@@ -2705,8 +2660,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L8",
-      "community": 65,
-      "community_name": "Community 65"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_caption_schema_validateimagecaption",
@@ -2714,8 +2669,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L12",
-      "community": 65,
-      "community_name": "Community 65"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_caption_schema_validateimagerouting",
@@ -2723,8 +2678,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L45",
-      "community": 65,
-      "community_name": "Community 65"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_image_dataprep_batch_ts",
@@ -2732,8 +2687,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L1",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_jsonlline",
@@ -2741,8 +2696,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L40",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_readjsonl",
@@ -2750,8 +2705,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L44",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_asrecord",
@@ -2759,8 +2714,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L52",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_readcaption",
@@ -2768,8 +2723,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L56",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_artifacthasdeeproute",
@@ -2777,8 +2732,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L60",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_exportimagedataprepbatchrequests",
@@ -2786,8 +2741,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L75",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_existingvalidsidecarerrors",
@@ -2795,8 +2750,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L96",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_importimagedataprepbatchresults",
@@ -2804,8 +2759,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L107",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_image_dataprep_ts",
@@ -2813,8 +2768,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L1",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_sha256",
@@ -2822,8 +2777,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L51",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_filehash",
@@ -2831,8 +2786,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L55",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_mimetype",
@@ -2840,8 +2795,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L59",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_fullpagescreenshot",
@@ -2849,8 +2804,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L68",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_sourcepage",
@@ -2858,8 +2813,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L72",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_artifactid",
@@ -2867,8 +2822,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L77",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_pdfartifactbyimage",
@@ -2876,8 +2831,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L81",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_existingimages",
@@ -2885,8 +2840,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L91",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_buildimagedataprepmanifest",
@@ -2894,8 +2849,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L105",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_writeassistantinstructions",
@@ -2903,8 +2858,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L145",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_runimagedataprep",
@@ -2912,8 +2867,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L167",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_image_routing_calibration_ts",
@@ -2921,8 +2876,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L1",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_asrecord",
@@ -2930,8 +2885,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L107",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_parsefile",
@@ -2939,8 +2894,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L111",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_stringarray",
@@ -2948,8 +2903,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L116",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_numbervalue",
@@ -2957,8 +2912,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L120",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_countarray",
@@ -2966,8 +2921,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L124",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_imageroutingsamplefromcaption",
@@ -2975,8 +2930,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L128",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_normalizebucket",
@@ -2984,8 +2939,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L141",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_loadimageroutinglabels",
@@ -2993,8 +2948,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L153",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_loadimageroutingrules",
@@ -3002,8 +2957,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L173",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_assertacceptedimageroutingrules",
@@ -3011,8 +2966,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L190",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_writeimageroutingcalibrationsamples",
@@ -3020,8 +2975,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L196",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_bucketmatches",
@@ -3029,8 +2984,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L235",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_routeimagewithrules",
@@ -3038,8 +2993,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L246",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_requiresdeep",
@@ -3047,8 +3002,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L263",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_calibrateimagerouting",
@@ -3056,8 +3011,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L267",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_index_ts",
@@ -3065,8 +3020,8 @@
       "file_type": "code",
       "source_file": "src/index.ts",
       "source_location": "L1",
-      "community": 107,
-      "community_name": "Community 107"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "src_ingest_ts",
@@ -3074,8 +3029,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L1",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_yamlstr",
@@ -3083,8 +3038,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L16",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_safefilename",
@@ -3092,8 +3047,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L24",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_detecturltype",
@@ -3101,8 +3056,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L37",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_htmltomarkdown",
@@ -3110,8 +3065,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L60",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_fetchtweet",
@@ -3119,8 +3074,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L82",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_fetchwebpage",
@@ -3128,8 +3083,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L125",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_fetcharxiv",
@@ -3137,8 +3092,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L159",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_downloadbinary",
@@ -3146,8 +3101,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L225",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_normalizeingestoptions",
@@ -3155,8 +3110,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L242",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_ingest",
@@ -3164,8 +3119,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L263",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "ingest_savequeryresult",
@@ -3173,8 +3128,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L331",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "src_input_scope_ts",
@@ -3182,8 +3137,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_splitgitlines",
@@ -3191,8 +3146,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L38",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_toposixpath",
@@ -3200,8 +3155,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L43",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_toreporelative",
@@ -3209,8 +3164,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L47",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_pathspecforprefix",
@@ -3218,8 +3173,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L51",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_isgraphifymemorypath",
@@ -3227,8 +3182,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L56",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_walkfiles",
@@ -3236,8 +3191,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L60",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_resolvegitscopecontext",
@@ -3245,8 +3200,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L80",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_makescope",
@@ -3254,8 +3209,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L101",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_countgitpaths",
@@ -3263,8 +3218,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L133",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_gitinventory",
@@ -3272,8 +3227,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L137",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_appendmemoryfiles",
@@ -3281,8 +3236,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L145",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_buildgitinventory",
@@ -3290,8 +3245,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L157",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_fallbackallscope",
@@ -3299,8 +3254,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L200",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_inspectinputscope",
@@ -3308,8 +3263,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L227",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_isinputscopemode",
@@ -3317,8 +3272,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L271",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_parseinputscopemode",
@@ -3326,8 +3281,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L275",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_resolvecliinputscopeselection",
@@ -3335,8 +3290,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L282",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_resolveconfiguredinputscopeselection",
@@ -3344,8 +3299,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L296",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "src_lifecycle_ts",
@@ -3353,8 +3308,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L1",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_readjson",
@@ -3362,8 +3317,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L60",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_writejson",
@@ -3371,8 +3326,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L68",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_currenthead",
@@ -3380,8 +3335,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L72",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_currentbranch",
@@ -3389,8 +3344,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L76",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_upstreamref",
@@ -3398,8 +3353,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L81",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_mergebase",
@@ -3407,8 +3362,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L85",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_lifecyclepaths",
@@ -3416,8 +3371,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L89",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_readlifecyclemetadata",
@@ -3425,8 +3380,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L97",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_refreshlifecyclemetadata",
@@ -3434,8 +3389,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L104",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_marklifecyclestale",
@@ -3443,8 +3398,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L174",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_marklifecycleanalyzed",
@@ -3452,8 +3407,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L182",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "lifecycle_planlifecycleprune",
@@ -3461,8 +3416,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L186",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "src_llm_execution_ts",
@@ -3470,8 +3425,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L1",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_safename",
@@ -3479,8 +3434,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L92",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_writeinstruction",
@@ -3488,8 +3443,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L96",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_preflightllmexecution",
@@ -3497,8 +3452,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L101",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_createassistanttextjsonclient",
@@ -3506,8 +3461,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L126",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_createassistantvisionjsonclient",
@@ -3515,8 +3470,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L157",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_redactsecrets",
@@ -3524,8 +3479,53 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L192",
-      "community": 57,
-      "community_name": "Community 57"
+      "community": 16,
+      "community_name": "Community 16"
+    },
+    {
+      "id": "src_merge_graphs_ts",
+      "label": "merge-graphs.ts",
+      "file_type": "code",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L1",
+      "community": 4,
+      "community_name": "Community 4"
+    },
+    {
+      "id": "merge_graphs_repotagfromgraphpath",
+      "label": "repoTagFromGraphPath()",
+      "file_type": "code",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L19",
+      "community": 4,
+      "community_name": "Community 4"
+    },
+    {
+      "id": "merge_graphs_mergedgraphtype",
+      "label": "mergedGraphType()",
+      "file_type": "code",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L27",
+      "community": 4,
+      "community_name": "Community 4"
+    },
+    {
+      "id": "merge_graphs_mergehyperedges",
+      "label": "mergeHyperedges()",
+      "file_type": "code",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L31",
+      "community": 4,
+      "community_name": "Community 4"
+    },
+    {
+      "id": "merge_graphs_mergegraphsfromfiles",
+      "label": "mergeGraphsFromFiles()",
+      "file_type": "code",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L46",
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "src_migrate_state_ts",
@@ -3533,8 +3533,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L1",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_shellquote",
@@ -3542,8 +3542,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L55",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_normalizegitpath",
@@ -3551,8 +3551,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L60",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_collectentries",
@@ -3560,8 +3560,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L64",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_gitadvice",
@@ -3569,8 +3569,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L94",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_plangraphifyoutmigration",
@@ -3578,8 +3578,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L144",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_applyentry",
@@ -3587,8 +3587,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L165",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_migrategraphifyout",
@@ -3596,8 +3596,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L176",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_migrationresulttotext",
@@ -3605,8 +3605,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L194",
-      "community": 47,
-      "community_name": "Community 47"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "src_minimal_context_ts",
@@ -3614,8 +3614,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L1",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_comparestrings",
@@ -3623,8 +3623,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L26",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_uniquesorted",
@@ -3632,8 +3632,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L32",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_riskfromscore",
@@ -3641,8 +3641,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L36",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_suggestionsfortask",
@@ -3650,8 +3650,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L42",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_topcommunities",
@@ -3659,8 +3659,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L51",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_topflownames",
@@ -3668,8 +3668,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L64",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_buildminimalcontext",
@@ -3677,8 +3677,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L68",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_minimalcontexttotext",
@@ -3686,8 +3686,8 @@
       "file_type": "code",
       "source_file": "src/minimal-context.ts",
       "source_location": "L114",
-      "community": 48,
-      "community_name": "Community 48"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "src_ontology_output_ts",
@@ -3695,8 +3695,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L1",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_sha256",
@@ -3704,8 +3704,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L55",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_normalizedterm",
@@ -3713,8 +3713,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L59",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_stringarray",
@@ -3722,8 +3722,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L63",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_stringvalue",
@@ -3731,8 +3731,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L67",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_ontologynodetype",
@@ -3740,8 +3740,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L73",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_confidencescore",
@@ -3749,8 +3749,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L77",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_sourceref",
@@ -3758,8 +3758,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L81",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_writejson",
@@ -3767,8 +3767,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L86",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_safefilename",
@@ -3776,8 +3776,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L91",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_compilenodes",
@@ -3785,8 +3785,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L95",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_compilerelations",
@@ -3794,8 +3794,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L147",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_writewiki",
@@ -3803,8 +3803,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L163",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_compileontologyoutputs",
@@ -3812,8 +3812,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L198",
-      "community": 29,
-      "community_name": "Community 29"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "src_ontology_profile_ts",
@@ -3821,8 +3821,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L1",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_asrecord",
@@ -3830,8 +3830,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L24",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_asstringarray",
@@ -3839,8 +3839,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L30",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizestringmap",
@@ -3848,8 +3848,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L38",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_stableforhash",
@@ -3857,8 +3857,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L45",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_relationendpoints",
@@ -3866,8 +3866,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L58",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizerelation",
@@ -3875,8 +3875,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L65",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizeregistry",
@@ -3884,8 +3884,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L72",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizecitationpolicy",
@@ -3893,8 +3893,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L83",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizehardeningpolicy",
@@ -3902,8 +3902,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L94",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_relationexports",
@@ -3911,8 +3911,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L103",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizeoutputs",
@@ -3920,8 +3920,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L114",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_parseontologyprofile",
@@ -3929,8 +3929,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L139",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_validateontologyprofile",
@@ -3938,8 +3938,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L148",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_hashontologyprofile",
@@ -3947,8 +3947,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L234",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_normalizeontologyprofile",
@@ -3956,8 +3956,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L240",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_bindontologyprofile",
@@ -3965,8 +3965,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L272",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_loadontologyprofile",
@@ -3974,8 +3974,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L296",
-      "community": 19,
-      "community_name": "Community 19"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "src_paths_ts",
@@ -3983,8 +3983,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L1",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_statepath",
@@ -3992,8 +3992,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L109",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_resolvegraphifypaths",
@@ -4001,8 +4001,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L113",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_defaultgraphpath",
@@ -4010,8 +4010,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L201",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_legacygraphpath",
@@ -4019,8 +4019,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L205",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_resolvegraphinputpath",
@@ -4028,8 +4028,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L215",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_defaultmanifestpath",
@@ -4037,8 +4037,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L224",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "paths_defaulttranscriptsdir",
@@ -4046,8 +4046,8 @@
       "file_type": "code",
       "source_file": "src/paths.ts",
       "source_location": "L228",
-      "community": 53,
-      "community_name": "Community 53"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "src_pdf_ocr_ts",
@@ -4055,8 +4055,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L1",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_clonedetection",
@@ -4064,8 +4064,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L43",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_countwords",
@@ -4073,8 +4073,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L47",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_metadatapath",
@@ -4082,8 +4082,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L51",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_listimageartifacts",
@@ -4091,8 +4091,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L55",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_textmarkdown",
@@ -4100,8 +4100,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L70",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_loadmistralocrmodule",
@@ -4109,8 +4109,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L84",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_writemetadata",
@@ -4118,8 +4118,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L106",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_shouldfail",
@@ -4127,8 +4127,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L119",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_preparepdf",
@@ -4136,8 +4136,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L123",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_dedupe",
@@ -4145,8 +4145,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L251",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_ocr_augmentdetectionwithpdfpreflight",
@@ -4154,8 +4154,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L255",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_pdf_preflight_ts",
@@ -4163,8 +4163,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L1",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_parsepdfocrmode",
@@ -4172,8 +4172,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L41",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_normalizetext",
@@ -4181,8 +4181,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L53",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_countwords",
@@ -4190,8 +4190,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L57",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_countimagemarkers",
@@ -4199,8 +4199,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L61",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_sha256",
@@ -4208,8 +4208,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L65",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_extractwithpdfparse",
@@ -4217,8 +4217,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L69",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_extractwithpdftotext",
@@ -4226,8 +4226,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L83",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_extractpdftextlayer",
@@ -4235,8 +4235,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L113",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_preflightpdf",
@@ -4244,8 +4244,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L134",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "pdf_preflight_pdfocrsidecarstem",
@@ -4253,8 +4253,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L194",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_pipeline_ts",
@@ -4262,8 +4262,8 @@
       "file_type": "code",
       "source_file": "src/pipeline.ts",
       "source_location": "L1",
-      "community": 60,
-      "community_name": "Community 60"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "pipeline_defaultlabels",
@@ -4271,8 +4271,8 @@
       "file_type": "code",
       "source_file": "src/pipeline.ts",
       "source_location": "L79",
-      "community": 60,
-      "community_name": "Community 60"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "pipeline_countnoncodefiles",
@@ -4280,8 +4280,8 @@
       "file_type": "code",
       "source_file": "src/pipeline.ts",
       "source_location": "L87",
-      "community": 60,
-      "community_name": "Community 60"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "pipeline_formatdiagnosticsummary",
@@ -4289,8 +4289,8 @@
       "file_type": "code",
       "source_file": "src/pipeline.ts",
       "source_location": "L96",
-      "community": 60,
-      "community_name": "Community 60"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "pipeline_filelist",
@@ -4298,8 +4298,8 @@
       "file_type": "code",
       "source_file": "src/pipeline.ts",
       "source_location": "L103",
-      "community": 60,
-      "community_name": "Community 60"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "pipeline_buildproject",
@@ -4307,8 +4307,8 @@
       "file_type": "code",
       "source_file": "src/pipeline.ts",
       "source_location": "L107",
-      "community": 60,
-      "community_name": "Community 60"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "src_portable_artifacts_ts",
@@ -4316,8 +4316,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L1",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_iswindowsabsolutepath",
@@ -4325,8 +4325,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L53",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_hasschemeprefix",
@@ -4334,8 +4334,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L57",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_portablepath",
@@ -4343,8 +4343,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L62",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_stripleadingdotslash",
@@ -4352,8 +4352,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L66",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_toprojectrelativepath",
@@ -4361,8 +4361,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L70",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_projectrootlabel",
@@ -4370,8 +4370,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L82",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_normalizemaybepath",
@@ -4379,8 +4379,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L89",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_normalizescopepath",
@@ -4388,8 +4388,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L94",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_makeextractionportable",
@@ -4397,8 +4397,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L100",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_normalizefilemap",
@@ -4406,8 +4406,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L118",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_makedetectionportable",
@@ -4415,8 +4415,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L126",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_makegraphportable",
@@ -4424,8 +4424,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L148",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_isignoredlocalartifact",
@@ -4433,8 +4433,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L177",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_shouldscanfile",
@@ -4442,8 +4442,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L184",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_pathissuekind",
@@ -4451,8 +4451,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L191",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_collectstringissues",
@@ -4460,8 +4460,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L197",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_collectjsonissues",
@@ -4469,8 +4469,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L219",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_collecttextissues",
@@ -4478,8 +4478,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L240",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_walkfiles",
@@ -4487,8 +4487,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L247",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_scanportablegraphifyartifacts",
@@ -4496,8 +4496,8 @@
       "file_type": "code",
       "source_file": "src/portable-artifacts.ts",
       "source_location": "L259",
-      "community": 14,
-      "community_name": "Community 14"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "src_profile_prompts_ts",
@@ -4505,8 +4505,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L1",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_samplelimit",
@@ -4514,8 +4514,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L26",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_rel",
@@ -4523,8 +4523,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L30",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_nodetypesection",
@@ -4532,8 +4532,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L35",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_relationtypesection",
@@ -4541,8 +4541,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L47",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_registrysection",
@@ -4550,8 +4550,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L54",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_citationsection",
@@ -4559,8 +4559,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L70",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_hardeningsection",
@@ -4568,8 +4568,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L79",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_inputhintssection",
@@ -4577,8 +4577,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L88",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_schemasection",
@@ -4586,8 +4586,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L99",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_genericsafetysection",
@@ -4595,8 +4595,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L110",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_chunkguidance",
@@ -4604,8 +4604,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L119",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_buildprofileextractionprompt",
@@ -4613,8 +4613,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L141",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_buildprofilechunkprompt",
@@ -4622,8 +4622,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L169",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_buildprofilevalidationprompt",
@@ -4631,8 +4631,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L188",
-      "community": 27,
-      "community_name": "Community 27"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_profile_registry_ts",
@@ -4640,8 +4640,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L1",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_readregistryrows",
@@ -4649,8 +4649,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L13",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_field",
@@ -4658,8 +4658,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L40",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_normalizeregistryrecord",
@@ -4667,8 +4667,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L45",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_loadprofileregistry",
@@ -4676,8 +4676,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L72",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_loadprofileregistries",
@@ -4685,8 +4685,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L93",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_safeidpart",
@@ -4694,8 +4694,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L104",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_registryrecordstoextraction",
@@ -4703,8 +4703,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L111",
-      "community": 54,
-      "community_name": "Community 54"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_profile_report_ts",
@@ -4712,8 +4712,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L1",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_rel",
@@ -4721,8 +4721,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L29",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_stringvalue",
@@ -4730,8 +4730,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L35",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_graphnodes",
@@ -4739,8 +4739,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L39",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_graphlinks",
@@ -4748,8 +4748,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L46",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_projectconfigsection",
@@ -4757,8 +4757,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L53",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_registrycoveragesection",
@@ -4766,8 +4766,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L68",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_unattachedentitiessection",
@@ -4775,8 +4775,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L97",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_invalidrelationssection",
@@ -4784,8 +4784,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L112",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_highdegreesection",
@@ -4793,8 +4793,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L126",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_lowevidencesection",
@@ -4802,8 +4802,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L143",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_humanreviewsection",
@@ -4811,8 +4811,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L159",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_pdfocrsection",
@@ -4820,8 +4820,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L167",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_buildprofilereport",
@@ -4829,8 +4829,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L179",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_profile_validate_ts",
@@ -4838,8 +4838,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L1",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_stringvalue",
@@ -4847,8 +4847,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L29",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_citations",
@@ -4856,8 +4856,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L33",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_haspagecitation",
@@ -4865,8 +4865,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L40",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_addissue",
@@ -4874,8 +4874,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L45",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_validatecitations",
@@ -4883,8 +4883,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L52",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_validatestatus",
@@ -4892,8 +4892,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L82",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_isregistryseed",
@@ -4901,8 +4901,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L100",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_validatenode",
@@ -4910,8 +4910,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L104",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_isprofileedge",
@@ -4919,8 +4919,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L142",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_validateedge",
@@ -4928,8 +4928,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L158",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_validateprofileextraction",
@@ -4937,8 +4937,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L209",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_profilevalidationresulttojson",
@@ -4946,8 +4946,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L243",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_profilevalidationresulttomarkdown",
@@ -4955,8 +4955,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L247",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_project_config_ts",
@@ -4964,8 +4964,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L1",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_asrecord",
@@ -4973,8 +4973,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L31",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_asstringarray",
@@ -4982,8 +4982,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L37",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_asboolean",
@@ -4991,8 +4991,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L43",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_asstring",
@@ -5000,8 +5000,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L47",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_asnumber",
@@ -5009,8 +5009,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L51",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_resolvepath",
@@ -5018,8 +5018,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L55",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_registrysourcename",
@@ -5027,8 +5027,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L59",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_buildregistrysources",
@@ -5036,8 +5036,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L64",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_parsepdfocrmode",
@@ -5045,8 +5045,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L73",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_parsecitationminimum",
@@ -5054,8 +5054,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L80",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_parsellmexecutionmode",
@@ -5063,8 +5063,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L87",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_parseimageartifactsource",
@@ -5072,8 +5072,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L94",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_parseinputscopemode",
@@ -5081,8 +5081,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L101",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_discoverprojectconfig",
@@ -5090,8 +5090,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L108",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_parseprojectconfig",
@@ -5099,8 +5099,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L119",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_validateprojectconfig",
@@ -5108,8 +5108,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L127",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_normalizeprojectconfig",
@@ -5117,8 +5117,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L191",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_loadprojectconfig",
@@ -5126,8 +5126,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L291",
-      "community": 18,
-      "community_name": "Community 18"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "src_recommend_ts",
@@ -5135,8 +5135,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_comparestrings",
@@ -5144,8 +5144,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L68",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_normalizepath",
@@ -5153,8 +5153,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L74",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_uniquesorted",
@@ -5162,8 +5162,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L78",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_isgraphifystatepath",
@@ -5171,8 +5171,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L82",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_maybecommunity",
@@ -5180,8 +5180,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L87",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_sourcematches",
@@ -5189,8 +5189,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L96",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_communitylabel",
@@ -5198,8 +5198,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L103",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_toplevelarea",
@@ -5207,8 +5207,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L112",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_commitprefixforarea",
@@ -5216,8 +5216,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L119",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_fileinfo",
@@ -5225,8 +5225,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L124",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_dominantcommunity",
@@ -5234,8 +5234,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L142",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_groupdraftforfile",
@@ -5243,8 +5243,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L153",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_mergedrafts",
@@ -5252,8 +5252,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L176",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_stalenessfrom",
@@ -5261,8 +5261,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L206",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_confidencerank",
@@ -5270,8 +5270,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L238",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_minconfidence",
@@ -5279,8 +5279,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L242",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_groupconfidence",
@@ -5288,8 +5288,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L249",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_communitiesfromdelta",
@@ -5297,8 +5297,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L274",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_suggestedmessage",
@@ -5306,8 +5306,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L285",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_rationalefor",
@@ -5315,8 +5315,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L291",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_buildcommitrecommendation",
@@ -5324,8 +5324,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L301",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_formatlist",
@@ -5333,8 +5333,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L366",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_commitrecommendationtotext",
@@ -5342,8 +5342,62 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L370",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 11,
+      "community_name": "Community 11"
+    },
+    {
+      "id": "src_repo_clone_ts",
+      "label": "repo-clone.ts",
+      "file_type": "code",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L1",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_execgit",
+      "label": "execGit()",
+      "file_type": "code",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L28",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_maybegithubrepo",
+      "label": "maybeGithubRepo()",
+      "file_type": "code",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L36",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_reponamefromurl",
+      "label": "repoNameFromUrl()",
+      "file_type": "code",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L49",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_defaultclonedestination",
+      "label": "defaultCloneDestination()",
+      "file_type": "code",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L68",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_clonerepo",
+      "label": "cloneRepo()",
+      "file_type": "code",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L76",
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "src_report_ts",
@@ -5351,8 +5405,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L1",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_compareflowcriticality",
@@ -5360,8 +5414,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L35",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_normalizeflows",
@@ -5369,8 +5423,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L39",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_normalizeaffectedflows",
@@ -5378,8 +5432,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L44",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_formatflow",
@@ -5387,8 +5441,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L49",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_appendreviewsections",
@@ -5396,8 +5450,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L55",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_appendinputscopesection",
@@ -5405,8 +5459,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L99",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "report_generate",
@@ -5414,8 +5468,8 @@
       "file_type": "code",
       "source_file": "src/report.ts",
       "source_location": "L121",
-      "community": 55,
-      "community_name": "Community 55"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "src_review_analysis_ts",
@@ -5423,8 +5477,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L1",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_comparestrings",
@@ -5432,8 +5486,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L113",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_uniquesorted",
@@ -5441,8 +5495,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L119",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_maybecommunity",
@@ -5450,8 +5504,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L123",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_communitylabel",
@@ -5459,8 +5513,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L132",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_risklevel",
@@ -5468,8 +5522,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L140",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_communityrisk",
@@ -5477,8 +5531,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L146",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_nodecommunities",
@@ -5486,8 +5540,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L151",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_buildblastradius",
@@ -5495,8 +5549,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L159",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_impactedcommunities",
@@ -5504,8 +5558,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L190",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_ismultimodalpath",
@@ -5513,8 +5567,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L240",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_multimodalsafety",
@@ -5522,8 +5576,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L244",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_buildreviewanalysis",
@@ -5531,8 +5585,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L264",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_nodeline",
@@ -5540,8 +5594,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L292",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_reviewanalysistotext",
@@ -5549,8 +5603,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L298",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_estimatetokens",
@@ -5558,8 +5612,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L340",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_ratio",
@@ -5567,8 +5621,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L344",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_average",
@@ -5576,8 +5630,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L348",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_evaluatereviewanalysis",
@@ -5585,8 +5639,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L354",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_formatmetric",
@@ -5594,8 +5648,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L406",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_reviewevaluationtotext",
@@ -5603,8 +5657,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L410",
-      "community": 15,
-      "community_name": "Community 15"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "src_review_benchmark_ts",
@@ -5612,8 +5666,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L1",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_comparestrings",
@@ -5621,8 +5675,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L61",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_normalize",
@@ -5630,8 +5684,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L67",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_uniquesorted",
@@ -5639,8 +5693,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L71",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_identifiers",
@@ -5648,8 +5702,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L75",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_flowidentifiers",
@@ -5657,8 +5711,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L85",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_ratio",
@@ -5666,8 +5720,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L95",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_f1",
@@ -5675,8 +5729,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L99",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_average",
@@ -5684,8 +5738,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L104",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_estimatetokens",
@@ -5693,8 +5747,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L110",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_counthits",
@@ -5702,8 +5756,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L114",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_formatmetric",
@@ -5711,8 +5765,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L118",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_evaluatereviewbenchmarks",
@@ -5720,8 +5774,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L122",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_reviewbenchmarktomarkdown",
@@ -5729,8 +5783,8 @@
       "file_type": "code",
       "source_file": "src/review-benchmark.ts",
       "source_location": "L228",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "src_review_context_ts",
@@ -5738,8 +5792,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L1",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_comparestrings",
@@ -5747,8 +5801,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L45",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_normalizepath",
@@ -5756,8 +5810,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L51",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_uniquesorted",
@@ -5765,8 +5819,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L55",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_sourcematches",
@@ -5774,8 +5828,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L59",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_riskforimpactednodes",
@@ -5783,8 +5837,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L66",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_changedfunctionswithouttests",
@@ -5792,8 +5846,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L72",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_issensitivepath",
@@ -5801,8 +5855,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L80",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_isinside",
@@ -5810,8 +5864,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L91",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_formatlines",
@@ -5819,8 +5873,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L96",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_extractrelevantlines",
@@ -5828,8 +5882,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L102",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_readsourcesnippet",
@@ -5837,8 +5891,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L136",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_buildsourcesnippets",
@@ -5846,8 +5900,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L158",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_buildreviewguidance",
@@ -5855,8 +5909,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L168",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_buildreviewcontext",
@@ -5864,8 +5918,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L198",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_reviewcontexttotext",
@@ -5873,8 +5927,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L269",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "src_review_store_ts",
@@ -5882,8 +5936,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L1",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_comparestrings",
@@ -5891,8 +5945,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L104",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_normalizepath",
@@ -5900,8 +5954,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L110",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_asstring",
@@ -5909,8 +5963,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L114",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_asnumber",
@@ -5918,8 +5972,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L118",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_istestpath",
@@ -5927,8 +5981,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L127",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_pathmatches",
@@ -5936,8 +5990,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L138",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_normalizekind",
@@ -5945,8 +5999,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L145",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_parselinerange",
@@ -5954,8 +6008,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L168",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_canonicalrelation",
@@ -5963,8 +6017,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L183",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_confidencevalue",
@@ -5972,8 +6026,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L191",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_sortnodes",
@@ -5981,8 +6035,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L203",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_sortedges",
@@ -5990,8 +6044,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L211",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_createreviewgraphstore",
@@ -5999,8 +6053,8 @@
       "file_type": "code",
       "source_file": "src/review-store.ts",
       "source_location": "L220",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "src_review_ts",
@@ -6008,8 +6062,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L1",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_comparestrings",
@@ -6017,8 +6071,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L42",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_normalizepath",
@@ -6026,8 +6080,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L48",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_uniquesorted",
@@ -6035,8 +6089,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L52",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_maybecommunity",
@@ -6044,8 +6098,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L56",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_nodeinfo",
@@ -6053,8 +6107,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L65",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_comparenodes",
@@ -6062,8 +6116,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L78",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_sourcematches",
@@ -6071,8 +6125,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L82",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_changednodeids",
@@ -6080,8 +6134,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L89",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_impactednodeids",
@@ -6089,8 +6143,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L100",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_neighborcommunities",
@@ -6098,8 +6152,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L110",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_iscodepath",
@@ -6107,8 +6161,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L119",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_istestpath",
@@ -6116,8 +6170,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L123",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_stem",
@@ -6125,8 +6179,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L133",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_likelytestgaps",
@@ -6134,8 +6188,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L140",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_edgetext",
@@ -6143,8 +6197,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L151",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_riskfor",
@@ -6152,8 +6206,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L160",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_highriskchains",
@@ -6161,8 +6215,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L169",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_chainlabel",
@@ -6170,8 +6224,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L219",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_buildreviewdelta",
@@ -6179,8 +6233,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L223",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_nodeline",
@@ -6188,8 +6242,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L266",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_chainline",
@@ -6197,8 +6251,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L272",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_reviewdeltatotext",
@@ -6206,8 +6260,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L286",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "src_search_ts",
@@ -6215,8 +6269,8 @@
       "file_type": "code",
       "source_file": "src/search.ts",
       "source_location": "L1",
-      "community": 72,
-      "community_name": "Community 72"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "search_normalizesearchtext",
@@ -6224,8 +6278,8 @@
       "file_type": "code",
       "source_file": "src/search.ts",
       "source_location": "L1",
-      "community": 72,
-      "community_name": "Community 72"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "search_textmatchesquery",
@@ -6233,8 +6287,8 @@
       "file_type": "code",
       "source_file": "src/search.ts",
       "source_location": "L8",
-      "community": 72,
-      "community_name": "Community 72"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "search_scoresearchtext",
@@ -6242,8 +6296,8 @@
       "file_type": "code",
       "source_file": "src/search.ts",
       "source_location": "L14",
-      "community": 72,
-      "community_name": "Community 72"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "src_security_ts",
@@ -6251,8 +6305,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L1",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_validateurl",
@@ -6260,8 +6314,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L24",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_validateurlsync",
@@ -6269,8 +6323,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L65",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_isprivateip",
@@ -6278,8 +6332,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L86",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_safefetch",
@@ -6287,8 +6341,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L116",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_safefetchtext",
@@ -6296,8 +6350,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L168",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_validategraphpath",
@@ -6305,8 +6359,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L185",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_sanitizelabel",
@@ -6314,8 +6368,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L217",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "security_escapehtml",
@@ -6323,8 +6377,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L229",
-      "community": 49,
-      "community_name": "Community 49"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "src_semantic_prepare_ts",
@@ -6332,8 +6386,8 @@
       "file_type": "code",
       "source_file": "src/semantic-prepare.ts",
       "source_location": "L1",
-      "community": 90,
-      "community_name": "Community 90"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "semantic_prepare_preparesemanticdetection",
@@ -6341,8 +6395,8 @@
       "file_type": "code",
       "source_file": "src/semantic-prepare.ts",
       "source_location": "L25",
-      "community": 90,
-      "community_name": "Community 90"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_serve_ts",
@@ -6350,8 +6404,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L1",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_loadgraph",
@@ -6359,8 +6413,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L30",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_getversion",
@@ -6368,8 +6422,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L52",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_communitiesfromgraph",
@@ -6377,8 +6431,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L60",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_communityname",
@@ -6386,8 +6440,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L72",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_scorenodes",
@@ -6395,8 +6449,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L82",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_bfs",
@@ -6404,8 +6458,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L94",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_dfs",
@@ -6413,8 +6467,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L118",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_subgraphtotext",
@@ -6422,8 +6476,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L140",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_findnode",
@@ -6431,8 +6485,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L173",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolquerygraph",
@@ -6440,8 +6494,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L191",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolgetnode",
@@ -6449,8 +6503,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L215",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolgetneighbors",
@@ -6458,8 +6512,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L242",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolgetcommunity",
@@ -6467,8 +6521,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L262",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolgodnodes",
@@ -6476,8 +6530,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L281",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolgraphstats",
@@ -6485,8 +6539,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L291",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolfirsthopsummary",
@@ -6494,8 +6548,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L310",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolreviewdelta",
@@ -6503,8 +6557,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L314",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolrecommendcommits",
@@ -6512,8 +6566,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L328",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolreviewanalysis",
@@ -6521,8 +6575,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L344",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_toolshortestpath",
@@ -6530,8 +6584,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L359",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_serve",
@@ -6539,8 +6593,8 @@
       "file_type": "code",
       "source_file": "src/serve.ts",
       "source_location": "L409",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "src_skill_runtime_ts",
@@ -6548,8 +6602,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_readjson",
@@ -6557,8 +6611,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L111",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_writejson",
@@ -6566,8 +6620,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L115",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_scopeoptiondescription",
@@ -6575,8 +6629,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L121",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_resolvecliscopeselection",
@@ -6584,8 +6638,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L125",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_cacheoptionsfromruntime",
@@ -6593,8 +6647,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L132",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_loadprofileruntimecontext",
@@ -6602,8 +6656,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L150",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_getversion",
@@ -6611,8 +6665,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L175",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_defaultlabels",
@@ -6620,8 +6674,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L184",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_maptoobject",
@@ -6629,8 +6683,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L192",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_objecttostringmap",
@@ -6638,8 +6692,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L196",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_ensureextractionshape",
@@ -6647,8 +6701,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L206",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_loadgraph",
@@ -6656,8 +6710,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L216",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_shouldbuilddirected",
@@ -6665,8 +6719,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L221",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_mergehyperedges",
@@ -6674,8 +6728,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L228",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_mergegraphs",
@@ -6683,8 +6737,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L244",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_analyzegraph",
@@ -6692,8 +6746,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L265",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_placeholderdetection",
@@ -6701,8 +6755,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L320",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_mergesemanticartifacts",
@@ -6710,8 +6764,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L332",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_mergeastandsemantic",
@@ -6719,8 +6773,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L356",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_updatecostfile",
@@ -6728,8 +6782,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L380",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_findbestmatchingnode",
@@ -6737,8 +6791,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L414",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_runtimeinfo",
@@ -6746,8 +6800,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L429",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_main",
@@ -6755,8 +6809,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L441",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "skill_runtime_isdirectruntimeexecution",
@@ -6764,8 +6818,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L1700",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "src_summary_ts",
@@ -6773,8 +6827,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L1",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_comparestrings",
@@ -6782,8 +6836,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L45",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_round",
@@ -6791,8 +6845,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L51",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_maybecommunity",
@@ -6800,8 +6854,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L55",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_communitylabels",
@@ -6809,8 +6863,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L64",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_graphdensity",
@@ -6818,8 +6872,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L84",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_nodesummary",
@@ -6827,8 +6881,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L92",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_comparehubs",
@@ -6836,8 +6890,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L107",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_communitymembership",
@@ -6845,8 +6899,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L115",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_internaledgecounts",
@@ -6854,8 +6908,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L129",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_buildnextbestaction",
@@ -6863,8 +6917,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L142",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_buildfirsthopsummary",
@@ -6872,8 +6926,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L154",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_hubline",
@@ -6881,8 +6935,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L220",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_firsthopsummarytotext",
@@ -6890,8 +6944,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L229",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "src_transcribe_ts",
@@ -6899,8 +6953,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L1",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_runcommand",
@@ -6908,8 +6962,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L91",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_defaultwhispercachedir",
@@ -6917,8 +6971,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L109",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_resolverequestedmodel",
@@ -6926,8 +6980,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L123",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_sanitizecachesegment",
@@ -6935,8 +6989,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L135",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_missingmodelfiles",
@@ -6944,8 +6998,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L139",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_validatewhispermodeldir",
@@ -6953,8 +7007,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L143",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_whispermodelrepoid",
@@ -6962,8 +7016,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L153",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_whispermodelrevision",
@@ -6971,8 +7025,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L157",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_modeldownloadurl",
@@ -6980,8 +7034,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L161",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_normalizemodelerror",
@@ -6989,8 +7043,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L165",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_downloadfile",
@@ -6998,8 +7052,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L173",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_ensurewhisperartifacts",
@@ -7007,8 +7061,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L181",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_loadfasterwhispermodule",
@@ -7016,8 +7070,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L230",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_envnumber",
@@ -7025,8 +7079,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L255",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_envboolean",
@@ -7034,8 +7088,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L262",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_getwhispermodel",
@@ -7043,8 +7097,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L268",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_strippromptecho",
@@ -7052,8 +7106,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L295",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_extracttranscripttext",
@@ -7061,8 +7115,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L312",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_isurl",
@@ -7070,8 +7124,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L320",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_downloadaudio",
@@ -7079,8 +7133,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L324",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_buildwhisperprompt",
@@ -7088,8 +7142,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L365",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_transcribe",
@@ -7097,8 +7151,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L381",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_transcribeall",
@@ -7106,8 +7160,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L443",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_clonedetection",
@@ -7115,8 +7169,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L465",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_augmentdetectionwithtranscripts",
@@ -7124,8 +7178,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L469",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "src_types_ts",
@@ -7133,8 +7187,8 @@
       "file_type": "code",
       "source_file": "src/types.ts",
       "source_location": "L1",
-      "community": 108,
-      "community_name": "Community 108"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_validate_ts",
@@ -7142,8 +7196,8 @@
       "file_type": "code",
       "source_file": "src/validate.ts",
       "source_location": "L1",
-      "community": 78,
-      "community_name": "Community 78"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "validate_validateextraction",
@@ -7151,8 +7205,8 @@
       "file_type": "code",
       "source_file": "src/validate.ts",
       "source_location": "L14",
-      "community": 78,
-      "community_name": "Community 78"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "validate_assertvalid",
@@ -7160,8 +7214,8 @@
       "file_type": "code",
       "source_file": "src/validate.ts",
       "source_location": "L95",
-      "community": 78,
-      "community_name": "Community 78"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_watch_ts",
@@ -7169,8 +7223,8 @@
       "file_type": "code",
       "source_file": "src/watch.ts",
       "source_location": "L1",
-      "community": 61,
-      "community_name": "Community 61"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "watch_rebuildcode",
@@ -7178,8 +7232,8 @@
       "file_type": "code",
       "source_file": "src/watch.ts",
       "source_location": "L44",
-      "community": 61,
-      "community_name": "Community 61"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "watch_checkupdate",
@@ -7187,8 +7241,8 @@
       "file_type": "code",
       "source_file": "src/watch.ts",
       "source_location": "L176",
-      "community": 61,
-      "community_name": "Community 61"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "watch_notifyonly",
@@ -7196,8 +7250,8 @@
       "file_type": "code",
       "source_file": "src/watch.ts",
       "source_location": "L200",
-      "community": 61,
-      "community_name": "Community 61"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "watch_hasnoncode",
@@ -7205,8 +7259,8 @@
       "file_type": "code",
       "source_file": "src/watch.ts",
       "source_location": "L217",
-      "community": 61,
-      "community_name": "Community 61"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "watch_watch",
@@ -7214,8 +7268,8 @@
       "file_type": "code",
       "source_file": "src/watch.ts",
       "source_location": "L225",
-      "community": 61,
-      "community_name": "Community 61"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "src_wiki_ts",
@@ -7223,8 +7277,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L1",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_safefilename",
@@ -7232,8 +7286,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L20",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_uniquepagerefs",
@@ -7241,8 +7295,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L30",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_normalizeflows",
@@ -7250,8 +7304,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L52",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_compareflowcriticality",
@@ -7259,8 +7313,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L57",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_flowsthroughnodes",
@@ -7268,8 +7322,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L61",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_crosscommunitylinks",
@@ -7277,8 +7331,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L68",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_communityarticle",
@@ -7286,8 +7340,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L85",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_godnodearticle",
@@ -7295,8 +7349,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L170",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_flowarticle",
@@ -7304,8 +7358,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L210",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_indexmd",
@@ -7313,8 +7367,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L248",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "wiki_towiki",
@@ -7322,8 +7376,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L302",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "tests_affected_flows_test_ts",
@@ -7331,8 +7385,8 @@
       "file_type": "code",
       "source_file": "tests/affected-flows.test.ts",
       "source_location": "L1",
-      "community": 66,
-      "community_name": "Community 66"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "affected_flows_test_qn",
@@ -7340,8 +7394,8 @@
       "file_type": "code",
       "source_file": "tests/affected-flows.test.ts",
       "source_location": "L7",
-      "community": 66,
-      "community_name": "Community 66"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "affected_flows_test_addfunction",
@@ -7349,8 +7403,8 @@
       "file_type": "code",
       "source_file": "tests/affected-flows.test.ts",
       "source_location": "L11",
-      "community": 66,
-      "community_name": "Community 66"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "affected_flows_test_addcall",
@@ -7358,8 +7412,8 @@
       "file_type": "code",
       "source_file": "tests/affected-flows.test.ts",
       "source_location": "L24",
-      "community": 66,
-      "community_name": "Community 66"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "affected_flows_test_makeflowstore",
@@ -7367,8 +7421,8 @@
       "file_type": "code",
       "source_file": "tests/affected-flows.test.ts",
       "source_location": "L32",
-      "community": 66,
-      "community_name": "Community 66"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_aider_integration_test_ts",
@@ -7376,8 +7430,8 @@
       "file_type": "code",
       "source_file": "tests/aider-integration.test.ts",
       "source_location": "L1",
-      "community": 109,
-      "community_name": "Community 109"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_analyze_test_ts",
@@ -7385,8 +7439,8 @@
       "file_type": "code",
       "source_file": "tests/analyze.test.ts",
       "source_location": "L1",
-      "community": 91,
-      "community_name": "Community 91"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "analyze_test_buildtestgraph",
@@ -7394,8 +7448,26 @@
       "file_type": "code",
       "source_file": "tests/analyze.test.ts",
       "source_location": "L5",
-      "community": 91,
-      "community_name": "Community 91"
+      "community": 12,
+      "community_name": "Community 12"
+    },
+    {
+      "id": "tests_build_merge_test_ts",
+      "label": "build-merge.test.ts",
+      "file_type": "code",
+      "source_file": "tests/build-merge.test.ts",
+      "source_location": "L1",
+      "community": 2,
+      "community_name": "Community 2"
+    },
+    {
+      "id": "build_merge_test_tempdir",
+      "label": "tempDir()",
+      "file_type": "code",
+      "source_file": "tests/build-merge.test.ts",
+      "source_location": "L9",
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_build_project_test_ts",
@@ -7403,8 +7475,8 @@
       "file_type": "code",
       "source_file": "tests/build-project.test.ts",
       "source_location": "L1",
-      "community": 92,
-      "community_name": "Community 92"
+      "community": 41,
+      "community_name": "Community 41"
     },
     {
       "id": "build_project_test_makeprojectdir",
@@ -7412,8 +7484,8 @@
       "file_type": "code",
       "source_file": "tests/build-project.test.ts",
       "source_location": "L8",
-      "community": 92,
-      "community_name": "Community 92"
+      "community": 41,
+      "community_name": "Community 41"
     },
     {
       "id": "tests_build_test_ts",
@@ -7421,8 +7493,8 @@
       "file_type": "code",
       "source_file": "tests/build.test.ts",
       "source_location": "L1",
-      "community": 110,
-      "community_name": "Community 110"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_cache_test_ts",
@@ -7430,8 +7502,8 @@
       "file_type": "code",
       "source_file": "tests/cache.test.ts",
       "source_location": "L1",
-      "community": 111,
-      "community_name": "Community 111"
+      "community": 29,
+      "community_name": "Community 29"
     },
     {
       "id": "tests_claude_integration_test_ts",
@@ -7439,8 +7511,8 @@
       "file_type": "code",
       "source_file": "tests/claude-integration.test.ts",
       "source_location": "L1",
-      "community": 112,
-      "community_name": "Community 112"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_cli_runtime_test_ts",
@@ -7448,8 +7520,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L1",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_tempproject",
@@ -7457,8 +7529,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L15",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_tempprofileproject",
@@ -7466,8 +7538,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L21",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_writegraph",
@@ -7475,8 +7547,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L27",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_writeflowgraph",
@@ -7484,8 +7556,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L51",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_initgitrepo",
@@ -7493,8 +7565,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L73",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_runcli",
@@ -7502,8 +7574,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L79",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_runskillruntime",
@@ -7511,8 +7583,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L84",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "cli_runtime_test_runmain",
@@ -7520,8 +7592,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L89",
-      "community": 50,
-      "community_name": "Community 50"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_cli_test_ts",
@@ -7529,8 +7601,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L1",
-      "community": 73,
-      "community_name": "Community 73"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_test_tempprofileproject",
@@ -7538,8 +7610,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L16",
-      "community": 73,
-      "community_name": "Community 73"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_test_writegraph",
@@ -7547,8 +7619,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L23",
-      "community": 73,
-      "community_name": "Community 73"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "cli_test_runcli",
@@ -7556,8 +7628,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L40",
-      "community": 73,
-      "community_name": "Community 73"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_cluster_test_ts",
@@ -7565,8 +7637,8 @@
       "file_type": "code",
       "source_file": "tests/cluster.test.ts",
       "source_location": "L1",
-      "community": 93,
-      "community_name": "Community 93"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_test_makegraph",
@@ -7574,8 +7646,8 @@
       "file_type": "code",
       "source_file": "tests/cluster.test.ts",
       "source_location": "L5",
-      "community": 93,
-      "community_name": "Community 93"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "tests_codex_integration_test_ts",
@@ -7583,8 +7655,8 @@
       "file_type": "code",
       "source_file": "tests/codex-integration.test.ts",
       "source_location": "L1",
-      "community": 113,
-      "community_name": "Community 113"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_configured_dataprep_test_ts",
@@ -7592,8 +7664,8 @@
       "file_type": "code",
       "source_file": "tests/configured-dataprep.test.ts",
       "source_location": "L1",
-      "community": 79,
-      "community_name": "Community 79"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_test_makeproject",
@@ -7601,8 +7673,8 @@
       "file_type": "code",
       "source_file": "tests/configured-dataprep.test.ts",
       "source_location": "L19",
-      "community": 79,
-      "community_name": "Community 79"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "configured_dataprep_test_allfiles",
@@ -7610,8 +7682,8 @@
       "file_type": "code",
       "source_file": "tests/configured-dataprep.test.ts",
       "source_location": "L30",
-      "community": 79,
-      "community_name": "Community 79"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "tests_copilot_integration_test_ts",
@@ -7619,8 +7691,8 @@
       "file_type": "code",
       "source_file": "tests/copilot-integration.test.ts",
       "source_location": "L1",
-      "community": 114,
-      "community_name": "Community 114"
+      "community": 43,
+      "community_name": "Community 43"
     },
     {
       "id": "tests_cursor_integration_test_ts",
@@ -7628,8 +7700,8 @@
       "file_type": "code",
       "source_file": "tests/cursor-integration.test.ts",
       "source_location": "L1",
-      "community": 115,
-      "community_name": "Community 115"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_detect_changes_test_ts",
@@ -7637,8 +7709,8 @@
       "file_type": "code",
       "source_file": "tests/detect-changes.test.ts",
       "source_location": "L1",
-      "community": 74,
-      "community_name": "Community 74"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_test_qn",
@@ -7646,8 +7718,8 @@
       "file_type": "code",
       "source_file": "tests/detect-changes.test.ts",
       "source_location": "L14",
-      "community": 74,
-      "community_name": "Community 74"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_test_addnode",
@@ -7655,8 +7727,8 @@
       "file_type": "code",
       "source_file": "tests/detect-changes.test.ts",
       "source_location": "L18",
-      "community": 74,
-      "community_name": "Community 74"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "detect_changes_test_addedge",
@@ -7664,8 +7736,8 @@
       "file_type": "code",
       "source_file": "tests/detect-changes.test.ts",
       "source_location": "L37",
-      "community": 74,
-      "community_name": "Community 74"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_detect_test_ts",
@@ -7673,8 +7745,26 @@
       "file_type": "code",
       "source_file": "tests/detect.test.ts",
       "source_location": "L1",
-      "community": 116,
-      "community_name": "Community 116"
+      "community": 7,
+      "community_name": "Community 7"
+    },
+    {
+      "id": "tests_export_json_test_ts",
+      "label": "export-json.test.ts",
+      "file_type": "code",
+      "source_file": "tests/export-json.test.ts",
+      "source_location": "L1",
+      "community": 14,
+      "community_name": "Community 14"
+    },
+    {
+      "id": "export_json_test_tempdir",
+      "label": "tempDir()",
+      "file_type": "code",
+      "source_file": "tests/export-json.test.ts",
+      "source_location": "L10",
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "tests_extract_call_confidence_test_ts",
@@ -7682,8 +7772,8 @@
       "file_type": "code",
       "source_file": "tests/extract-call-confidence.test.ts",
       "source_location": "L1",
-      "community": 117,
-      "community_name": "Community 117"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_fixtures_sample_c",
@@ -7691,8 +7781,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.c",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_validate",
@@ -7700,8 +7790,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.c",
       "source_location": "L7",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_process",
@@ -7709,8 +7799,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.c",
       "source_location": "L11",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_main",
@@ -7718,8 +7808,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L24",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_cpp",
@@ -7727,8 +7817,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cpp",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclient",
@@ -7736,8 +7826,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L3",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclient_httpclient",
@@ -7745,8 +7835,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cpp",
       "source_location": "L7",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_cs",
@@ -7754,8 +7844,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_graphifydemo",
@@ -7763,8 +7853,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L5",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_iprocessor",
@@ -7772,8 +7862,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L7",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_iprocessor_process",
@@ -7781,8 +7871,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L9",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor",
@@ -7790,8 +7880,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L18",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor_process",
@@ -7799,8 +7889,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L15",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor_validate",
@@ -7808,8 +7898,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L19",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "tests_fixtures_sample_ex",
@@ -7817,8 +7907,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L1",
-      "community": 67,
-      "community_name": "Community 67"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "sample_myapp_accounts_user",
@@ -7826,8 +7916,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L1",
-      "community": 67,
-      "community_name": "Community 67"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "sample_myapp_accounts_user_create",
@@ -7835,8 +7925,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L11",
-      "community": 67,
-      "community_name": "Community 67"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "sample_myapp_accounts_user_find",
@@ -7844,8 +7934,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L17",
-      "community": 67,
-      "community_name": "Community 67"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "sample_myapp_accounts_user_validate",
@@ -7853,8 +7943,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L21",
-      "community": 67,
-      "community_name": "Community 67"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "tests_fixtures_sample_go",
@@ -7862,8 +7952,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "fixtures_server",
@@ -7871,8 +7961,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L8",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_newserver",
@@ -7880,8 +7970,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L12",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "fixtures_server_start",
@@ -7889,8 +7979,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L16",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "fixtures_server_stop",
@@ -7898,8 +7988,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L20",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_java",
@@ -7907,8 +7997,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor_dataprocessor",
@@ -7916,8 +8006,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L21",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor_additem",
@@ -7925,8 +8015,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L11",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_processor",
@@ -7934,8 +8024,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L30",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_processor_process",
@@ -7943,8 +8033,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L31",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "tests_fixtures_sample_jl",
@@ -7952,8 +8042,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L1",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_geometry",
@@ -7961,8 +8051,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L1",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "linearalgebra",
@@ -7970,8 +8060,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L3",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "base",
@@ -7979,8 +8069,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L4",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_shape",
@@ -7988,8 +8078,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L6",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_point",
@@ -7997,8 +8087,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L8",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_circle",
@@ -8006,8 +8096,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L13",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_area",
@@ -8015,8 +8105,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L18",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_distance",
@@ -8024,8 +8114,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L22",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_perimeter",
@@ -8033,8 +8123,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L26",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_describe",
@@ -8042,8 +8132,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L28",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "tests_fixtures_sample_m",
@@ -8051,8 +8141,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L1",
-      "community": 62,
-      "community_name": "Community 62"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_animal",
@@ -8060,8 +8150,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L4",
-      "community": 62,
-      "community_name": "Community 62"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_animal_initwithname",
@@ -8069,8 +8159,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L8",
-      "community": 62,
-      "community_name": "Community 62"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_animal_speak",
@@ -8078,8 +8168,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L9",
-      "community": 62,
-      "community_name": "Community 62"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_dog",
@@ -8087,8 +8177,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L29",
-      "community": 62,
-      "community_name": "Community 62"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_dog_fetch",
@@ -8096,8 +8186,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L31",
-      "community": 62,
-      "community_name": "Community 62"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "tests_fixtures_sample_php",
@@ -8105,8 +8195,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.php",
       "source_location": "L1",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_apiclient",
@@ -8114,8 +8204,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L4",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_apiclient_construct",
@@ -8123,8 +8213,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.php",
       "source_location": "L13",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_apiclient_get",
@@ -8132,8 +8222,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L9",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_apiclient_post",
@@ -8141,8 +8231,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L13",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_apiclient_fetch",
@@ -8150,8 +8240,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L19",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_parseresponse",
@@ -8159,8 +8249,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.php",
       "source_location": "L36",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "tests_fixtures_sample_ps1",
@@ -8168,8 +8258,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_get_data",
@@ -8177,8 +8267,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L4",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_process_items",
@@ -8186,8 +8276,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L13",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor_transform",
@@ -8195,8 +8285,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L25",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "sample_dataprocessor_save",
@@ -8204,8 +8294,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L29",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "tests_fixtures_sample_py",
@@ -8213,8 +8303,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L1",
-      "community": 75,
-      "community_name": "Community 75"
+      "community": 40,
+      "community_name": "Community 40"
     },
     {
       "id": "sample_transformer",
@@ -8222,8 +8312,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L1",
-      "community": 75,
-      "community_name": "Community 75"
+      "community": 40,
+      "community_name": "Community 40"
     },
     {
       "id": "sample_transformer_init",
@@ -8231,8 +8321,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L2",
-      "community": 75,
-      "community_name": "Community 75"
+      "community": 40,
+      "community_name": "Community 40"
     },
     {
       "id": "sample_transformer_forward",
@@ -8240,8 +8330,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L5",
-      "community": 75,
-      "community_name": "Community 75"
+      "community": 40,
+      "community_name": "Community 40"
     },
     {
       "id": "tests_fixtures_sample_rb",
@@ -8249,8 +8339,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L1",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_apiclient_initialize",
@@ -8258,8 +8348,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L5",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "sample_parse_response",
@@ -8267,8 +8357,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L25",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "tests_fixtures_sample_rs",
@@ -8276,8 +8366,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L1",
-      "community": 63,
-      "community_name": "Community 63"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_graph",
@@ -8285,8 +8375,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L3",
-      "community": 63,
-      "community_name": "Community 63"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_graph_new",
@@ -8294,8 +8384,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L8",
-      "community": 63,
-      "community_name": "Community 63"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_graph_add_node",
@@ -8303,8 +8393,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L12",
-      "community": 63,
-      "community_name": "Community 63"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_graph_add_edge",
@@ -8312,8 +8402,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L16",
-      "community": 63,
-      "community_name": "Community 63"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_build_graph",
@@ -8321,8 +8411,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L21",
-      "community": 63,
-      "community_name": "Community 63"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "tests_fixtures_sample_scala",
@@ -8330,8 +8420,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_config",
@@ -8339,8 +8429,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L3",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclient_get",
@@ -8348,8 +8438,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L10",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclient_post",
@@ -8357,8 +8447,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L14",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclient_buildrequest",
@@ -8366,8 +8456,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L14",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclientfactory",
@@ -8375,8 +8465,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L19",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclientfactory_create",
@@ -8384,8 +8474,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L20",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_ts",
@@ -8393,8 +8483,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_httpclient_constructor",
@@ -8402,8 +8492,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L6",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_buildheaders",
@@ -8411,8 +8501,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L19",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_calls_py",
@@ -8420,8 +8510,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L1",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_compute_score",
@@ -8429,8 +8519,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L4",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_normalize",
@@ -8438,8 +8528,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L8",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_run_analysis",
@@ -8447,8 +8537,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L12",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_analyzer",
@@ -8456,8 +8546,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L17",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_analyzer_process",
@@ -8465,8 +8555,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L18",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_analyzer_score",
@@ -8474,8 +8564,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L21",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_analyzer_full_pipeline",
@@ -8483,8 +8573,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L24",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_calls_rationale_1",
@@ -8492,8 +8582,8 @@
       "file_type": "rationale",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L1",
-      "community": 51,
-      "community_name": "Community 51"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "tests_flows_test_ts",
@@ -8501,8 +8591,8 @@
       "file_type": "code",
       "source_file": "tests/flows.test.ts",
       "source_location": "L1",
-      "community": 68,
-      "community_name": "Community 68"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_test_tempdir",
@@ -8510,8 +8600,8 @@
       "file_type": "code",
       "source_file": "tests/flows.test.ts",
       "source_location": "L26",
-      "community": 68,
-      "community_name": "Community 68"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_test_qn",
@@ -8519,8 +8609,8 @@
       "file_type": "code",
       "source_file": "tests/flows.test.ts",
       "source_location": "L32",
-      "community": 68,
-      "community_name": "Community 68"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_test_addfunction",
@@ -8528,8 +8618,8 @@
       "file_type": "code",
       "source_file": "tests/flows.test.ts",
       "source_location": "L36",
-      "community": 68,
-      "community_name": "Community 68"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "flows_test_addcall",
@@ -8537,8 +8627,8 @@
       "file_type": "code",
       "source_file": "tests/flows.test.ts",
       "source_location": "L60",
-      "community": 68,
-      "community_name": "Community 68"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_gemini_integration_test_ts",
@@ -8546,8 +8636,8 @@
       "file_type": "code",
       "source_file": "tests/gemini-integration.test.ts",
       "source_location": "L1",
-      "community": 118,
-      "community_name": "Community 118"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_hooks_test_ts",
@@ -8555,8 +8645,8 @@
       "file_type": "code",
       "source_file": "tests/hooks.test.ts",
       "source_location": "L1",
-      "community": 80,
-      "community_name": "Community 80"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_test_git",
@@ -8564,8 +8654,8 @@
       "file_type": "code",
       "source_file": "tests/hooks.test.ts",
       "source_location": "L20",
-      "community": 80,
-      "community_name": "Community 80"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "hooks_test_hookpath",
@@ -8573,8 +8663,8 @@
       "file_type": "code",
       "source_file": "tests/hooks.test.ts",
       "source_location": "L30",
-      "community": 80,
-      "community_name": "Community 80"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_html_export_test_ts",
@@ -8582,8 +8672,8 @@
       "file_type": "code",
       "source_file": "tests/html-export.test.ts",
       "source_location": "L1",
-      "community": 119,
-      "community_name": "Community 119"
+      "community": 14,
+      "community_name": "Community 14"
     },
     {
       "id": "tests_image_dataprep_batch_test_ts",
@@ -8591,8 +8681,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep-batch.test.ts",
       "source_location": "L1",
-      "community": 81,
-      "community_name": "Community 81"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_test_maketempdir",
@@ -8600,8 +8690,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep-batch.test.ts",
       "source_location": "L15",
-      "community": 81,
-      "community_name": "Community 81"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_batch_test_manifest",
@@ -8609,8 +8699,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep-batch.test.ts",
       "source_location": "L27",
-      "community": 81,
-      "community_name": "Community 81"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_image_dataprep_test_ts",
@@ -8618,8 +8708,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep.test.ts",
       "source_location": "L1",
-      "community": 82,
-      "community_name": "Community 82"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_test_maketempdir",
@@ -8627,8 +8717,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep.test.ts",
       "source_location": "L13",
-      "community": 82,
-      "community_name": "Community 82"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_dataprep_test_detection",
@@ -8636,8 +8726,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep.test.ts",
       "source_location": "L19",
-      "community": 82,
-      "community_name": "Community 82"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_image_routing_calibration_test_ts",
@@ -8645,8 +8735,8 @@
       "file_type": "code",
       "source_file": "tests/image-routing-calibration.test.ts",
       "source_location": "L1",
-      "community": 94,
-      "community_name": "Community 94"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "image_routing_calibration_test_maketempdir",
@@ -8654,8 +8744,8 @@
       "file_type": "code",
       "source_file": "tests/image-routing-calibration.test.ts",
       "source_location": "L18",
-      "community": 94,
-      "community_name": "Community 94"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_ingest_test_ts",
@@ -8663,8 +8753,8 @@
       "file_type": "code",
       "source_file": "tests/ingest.test.ts",
       "source_location": "L1",
-      "community": 120,
-      "community_name": "Community 120"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "tests_input_scope_test_ts",
@@ -8672,8 +8762,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_test_initrepo",
@@ -8681,8 +8771,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L20",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_test_write",
@@ -8690,8 +8780,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L26",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "input_scope_test_commit",
@@ -8699,8 +8789,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L32",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_install_preview_test_ts",
@@ -8708,8 +8798,8 @@
       "file_type": "code",
       "source_file": "tests/install-preview.test.ts",
       "source_location": "L1",
-      "community": 121,
-      "community_name": "Community 121"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_language_surface_test_ts",
@@ -8717,8 +8807,8 @@
       "file_type": "code",
       "source_file": "tests/language-surface.test.ts",
       "source_location": "L1",
-      "community": 122,
-      "community_name": "Community 122"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_lifecycle_test_ts",
@@ -8726,8 +8816,8 @@
       "file_type": "code",
       "source_file": "tests/lifecycle.test.ts",
       "source_location": "L1",
-      "community": 123,
-      "community_name": "Community 123"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_llm_execution_test_ts",
@@ -8735,8 +8825,8 @@
       "file_type": "code",
       "source_file": "tests/llm-execution.test.ts",
       "source_location": "L1",
-      "community": 95,
-      "community_name": "Community 95"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "llm_execution_test_maketempdir",
@@ -8744,8 +8834,8 @@
       "file_type": "code",
       "source_file": "tests/llm-execution.test.ts",
       "source_location": "L16",
-      "community": 95,
-      "community_name": "Community 95"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "tests_migrate_state_test_ts",
@@ -8753,8 +8843,8 @@
       "file_type": "code",
       "source_file": "tests/migrate-state.test.ts",
       "source_location": "L1",
-      "community": 83,
-      "community_name": "Community 83"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_test_maketempdir",
@@ -8762,8 +8852,8 @@
       "file_type": "code",
       "source_file": "tests/migrate-state.test.ts",
       "source_location": "L11",
-      "community": 83,
-      "community_name": "Community 83"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "migrate_state_test_git",
@@ -8771,8 +8861,8 @@
       "file_type": "code",
       "source_file": "tests/migrate-state.test.ts",
       "source_location": "L17",
-      "community": 83,
-      "community_name": "Community 83"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "tests_minimal_context_test_ts",
@@ -8780,8 +8870,8 @@
       "file_type": "code",
       "source_file": "tests/minimal-context.test.ts",
       "source_location": "L1",
-      "community": 69,
-      "community_name": "Community 69"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_test_qn",
@@ -8789,8 +8879,8 @@
       "file_type": "code",
       "source_file": "tests/minimal-context.test.ts",
       "source_location": "L8",
-      "community": 69,
-      "community_name": "Community 69"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_test_addfunction",
@@ -8798,8 +8888,8 @@
       "file_type": "code",
       "source_file": "tests/minimal-context.test.ts",
       "source_location": "L12",
-      "community": 69,
-      "community_name": "Community 69"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_test_addcall",
@@ -8807,8 +8897,8 @@
       "file_type": "code",
       "source_file": "tests/minimal-context.test.ts",
       "source_location": "L26",
-      "community": 69,
-      "community_name": "Community 69"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "minimal_context_test_makestore",
@@ -8816,8 +8906,8 @@
       "file_type": "code",
       "source_file": "tests/minimal-context.test.ts",
       "source_location": "L33",
-      "community": 69,
-      "community_name": "Community 69"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_mistral_ocr_integration_test_ts",
@@ -8825,8 +8915,8 @@
       "file_type": "code",
       "source_file": "tests/mistral-ocr.integration.test.ts",
       "source_location": "L1",
-      "community": 124,
-      "community_name": "Community 124"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "tests_ontology_output_test_ts",
@@ -8834,8 +8924,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-output.test.ts",
       "source_location": "L1",
-      "community": 96,
-      "community_name": "Community 96"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "ontology_output_test_maketempdir",
@@ -8843,8 +8933,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-output.test.ts",
       "source_location": "L12",
-      "community": 96,
-      "community_name": "Community 96"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "tests_ontology_profile_test_ts",
@@ -8852,8 +8942,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L1",
-      "community": 76,
-      "community_name": "Community 76"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_test_maketempdir",
@@ -8861,8 +8951,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L18",
-      "community": 76,
-      "community_name": "Community 76"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_test_write",
@@ -8870,8 +8960,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L24",
-      "community": 76,
-      "community_name": "Community 76"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "ontology_profile_test_validprofileyaml",
@@ -8879,8 +8969,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L29",
-      "community": 76,
-      "community_name": "Community 76"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "tests_opencode_integration_test_ts",
@@ -8888,8 +8978,8 @@
       "file_type": "code",
       "source_file": "tests/opencode-integration.test.ts",
       "source_location": "L1",
-      "community": 125,
-      "community_name": "Community 125"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_paths_test_ts",
@@ -8897,8 +8987,8 @@
       "file_type": "code",
       "source_file": "tests/paths.test.ts",
       "source_location": "L1",
-      "community": 126,
-      "community_name": "Community 126"
+      "community": 13,
+      "community_name": "Community 13"
     },
     {
       "id": "tests_pdf_preflight_test_ts",
@@ -8906,8 +8996,8 @@
       "file_type": "code",
       "source_file": "tests/pdf-preflight.test.ts",
       "source_location": "L1",
-      "community": 127,
-      "community_name": "Community 127"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "tests_pipeline_test_ts",
@@ -8915,8 +9005,8 @@
       "file_type": "code",
       "source_file": "tests/pipeline.test.ts",
       "source_location": "L1",
-      "community": 128,
-      "community_name": "Community 128"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_platform_v4_integration_test_ts",
@@ -8924,8 +9014,8 @@
       "file_type": "code",
       "source_file": "tests/platform-v4-integration.test.ts",
       "source_location": "L1",
-      "community": 97,
-      "community_name": "Community 97"
+      "community": 42,
+      "community_name": "Community 42"
     },
     {
       "id": "platform_v4_integration_test_runcliintemp",
@@ -8933,8 +9023,8 @@
       "file_type": "code",
       "source_file": "tests/platform-v4-integration.test.ts",
       "source_location": "L14",
-      "community": 97,
-      "community_name": "Community 97"
+      "community": 42,
+      "community_name": "Community 42"
     },
     {
       "id": "tests_portable_artifacts_test_ts",
@@ -8942,8 +9032,8 @@
       "file_type": "code",
       "source_file": "tests/portable-artifacts.test.ts",
       "source_location": "L1",
-      "community": 98,
-      "community_name": "Community 98"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "portable_artifacts_test_tempproject",
@@ -8951,8 +9041,8 @@
       "file_type": "code",
       "source_file": "tests/portable-artifacts.test.ts",
       "source_location": "L22",
-      "community": 98,
-      "community_name": "Community 98"
+      "community": 19,
+      "community_name": "Community 19"
     },
     {
       "id": "tests_profile_pipeline_test_ts",
@@ -8960,8 +9050,8 @@
       "file_type": "code",
       "source_file": "tests/profile-pipeline.test.ts",
       "source_location": "L1",
-      "community": 99,
-      "community_name": "Community 99"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_pipeline_test_makeproject",
@@ -8969,8 +9059,8 @@
       "file_type": "code",
       "source_file": "tests/profile-pipeline.test.ts",
       "source_location": "L19",
-      "community": 99,
-      "community_name": "Community 99"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_profile_prompts_test_ts",
@@ -8978,8 +9068,8 @@
       "file_type": "code",
       "source_file": "tests/profile-prompts.test.ts",
       "source_location": "L1",
-      "community": 100,
-      "community_name": "Community 100"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_prompts_test_promptstate",
@@ -8987,8 +9077,8 @@
       "file_type": "code",
       "source_file": "tests/profile-prompts.test.ts",
       "source_location": "L16",
-      "community": 100,
-      "community_name": "Community 100"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_profile_registry_test_ts",
@@ -8996,8 +9086,8 @@
       "file_type": "code",
       "source_file": "tests/profile-registry.test.ts",
       "source_location": "L1",
-      "community": 101,
-      "community_name": "Community 101"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_registry_test_maketempdir",
@@ -9005,8 +9095,8 @@
       "file_type": "code",
       "source_file": "tests/profile-registry.test.ts",
       "source_location": "L18",
-      "community": 101,
-      "community_name": "Community 101"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_profile_report_test_ts",
@@ -9014,8 +9104,8 @@
       "file_type": "code",
       "source_file": "tests/profile-report.test.ts",
       "source_location": "L1",
-      "community": 84,
-      "community_name": "Community 84"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_test_basestate",
@@ -9023,8 +9113,8 @@
       "file_type": "code",
       "source_file": "tests/profile-report.test.ts",
       "source_location": "L13",
-      "community": 84,
-      "community_name": "Community 84"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_report_test_validationresult",
@@ -9032,8 +9122,8 @@
       "file_type": "code",
       "source_file": "tests/profile-report.test.ts",
       "source_location": "L31",
-      "community": 84,
-      "community_name": "Community 84"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_profile_validate_test_ts",
@@ -9041,8 +9131,8 @@
       "file_type": "code",
       "source_file": "tests/profile-validate.test.ts",
       "source_location": "L1",
-      "community": 85,
-      "community_name": "Community 85"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_test_profile",
@@ -9050,8 +9140,8 @@
       "file_type": "code",
       "source_file": "tests/profile-validate.test.ts",
       "source_location": "L14",
-      "community": 85,
-      "community_name": "Community 85"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "profile_validate_test_baseextraction",
@@ -9059,8 +9149,8 @@
       "file_type": "code",
       "source_file": "tests/profile-validate.test.ts",
       "source_location": "L18",
-      "community": 85,
-      "community_name": "Community 85"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_project_config_test_ts",
@@ -9068,8 +9158,8 @@
       "file_type": "code",
       "source_file": "tests/project-config.test.ts",
       "source_location": "L1",
-      "community": 86,
-      "community_name": "Community 86"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_test_maketempdir",
@@ -9077,8 +9167,8 @@
       "file_type": "code",
       "source_file": "tests/project-config.test.ts",
       "source_location": "L16",
-      "community": 86,
-      "community_name": "Community 86"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "project_config_test_write",
@@ -9086,8 +9176,8 @@
       "file_type": "code",
       "source_file": "tests/project-config.test.ts",
       "source_location": "L22",
-      "community": 86,
-      "community_name": "Community 86"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "tests_public_api_test_ts",
@@ -9095,8 +9185,8 @@
       "file_type": "code",
       "source_file": "tests/public-api.test.ts",
       "source_location": "L1",
-      "community": 87,
-      "community_name": "Community 87"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "public_api_test_maketempdir",
@@ -9104,8 +9194,8 @@
       "file_type": "code",
       "source_file": "tests/public-api.test.ts",
       "source_location": "L11",
-      "community": 87,
-      "community_name": "Community 87"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "public_api_test_makegraph",
@@ -9113,8 +9203,8 @@
       "file_type": "code",
       "source_file": "tests/public-api.test.ts",
       "source_location": "L17",
-      "community": 87,
-      "community_name": "Community 87"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "tests_recommend_test_ts",
@@ -9122,8 +9212,8 @@
       "file_type": "code",
       "source_file": "tests/recommend.test.ts",
       "source_location": "L1",
-      "community": 88,
-      "community_name": "Community 88"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_test_makegraph",
@@ -9131,8 +9221,8 @@
       "file_type": "code",
       "source_file": "tests/recommend.test.ts",
       "source_location": "L7",
-      "community": 88,
-      "community_name": "Community 88"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "recommend_test_lifecycle",
@@ -9140,8 +9230,35 @@
       "file_type": "code",
       "source_file": "tests/recommend.test.ts",
       "source_location": "L33",
-      "community": 88,
-      "community_name": "Community 88"
+      "community": 11,
+      "community_name": "Community 11"
+    },
+    {
+      "id": "tests_repo_clone_test_ts",
+      "label": "repo-clone.test.ts",
+      "file_type": "code",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L1",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_test_tempdir",
+      "label": "tempDir()",
+      "file_type": "code",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L10",
+      "community": 34,
+      "community_name": "Community 34"
+    },
+    {
+      "id": "repo_clone_test_initrepo",
+      "label": "initRepo()",
+      "file_type": "code",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L22",
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "tests_report_test_ts",
@@ -9149,8 +9266,8 @@
       "file_type": "code",
       "source_file": "tests/report.test.ts",
       "source_location": "L1",
-      "community": 129,
-      "community_name": "Community 129"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_review_analysis_test_ts",
@@ -9158,8 +9275,8 @@
       "file_type": "code",
       "source_file": "tests/review-analysis.test.ts",
       "source_location": "L1",
-      "community": 102,
-      "community_name": "Community 102"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_analysis_test_makegraph",
@@ -9167,8 +9284,8 @@
       "file_type": "code",
       "source_file": "tests/review-analysis.test.ts",
       "source_location": "L11",
-      "community": 102,
-      "community_name": "Community 102"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "tests_review_benchmark_test_ts",
@@ -9176,8 +9293,8 @@
       "file_type": "code",
       "source_file": "tests/review-benchmark.test.ts",
       "source_location": "L1",
-      "community": 70,
-      "community_name": "Community 70"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_test_qn",
@@ -9185,8 +9302,8 @@
       "file_type": "code",
       "source_file": "tests/review-benchmark.test.ts",
       "source_location": "L12",
-      "community": 70,
-      "community_name": "Community 70"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_test_addfunction",
@@ -9194,8 +9311,8 @@
       "file_type": "code",
       "source_file": "tests/review-benchmark.test.ts",
       "source_location": "L16",
-      "community": 70,
-      "community_name": "Community 70"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_test_addcall",
@@ -9203,8 +9320,8 @@
       "file_type": "code",
       "source_file": "tests/review-benchmark.test.ts",
       "source_location": "L35",
-      "community": 70,
-      "community_name": "Community 70"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_benchmark_test_makebenchmarkstore",
@@ -9212,8 +9329,8 @@
       "file_type": "code",
       "source_file": "tests/review-benchmark.test.ts",
       "source_location": "L42",
-      "community": 70,
-      "community_name": "Community 70"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_review_context_test_ts",
@@ -9221,8 +9338,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L1",
-      "community": 64,
-      "community_name": "Community 64"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_test_tempproject",
@@ -9230,8 +9347,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L18",
-      "community": 64,
-      "community_name": "Community 64"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_test_qn",
@@ -9239,8 +9356,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L24",
-      "community": 64,
-      "community_name": "Community 64"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_test_addfunction",
@@ -9248,8 +9365,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L28",
-      "community": 64,
-      "community_name": "Community 64"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_test_addedge",
@@ -9257,8 +9374,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L47",
-      "community": 64,
-      "community_name": "Community 64"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "review_context_test_makereviewgraph",
@@ -9266,8 +9383,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L54",
-      "community": 64,
-      "community_name": "Community 64"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "tests_review_store_test_ts",
@@ -9275,8 +9392,8 @@
       "file_type": "code",
       "source_file": "tests/review-store.test.ts",
       "source_location": "L1",
-      "community": 103,
-      "community_name": "Community 103"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_store_test_makereviewgraph",
@@ -9284,8 +9401,8 @@
       "file_type": "code",
       "source_file": "tests/review-store.test.ts",
       "source_location": "L6",
-      "community": 103,
-      "community_name": "Community 103"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_review_test_ts",
@@ -9293,8 +9410,8 @@
       "file_type": "code",
       "source_file": "tests/review.test.ts",
       "source_location": "L1",
-      "community": 104,
-      "community_name": "Community 104"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "review_test_makegraph",
@@ -9302,8 +9419,8 @@
       "file_type": "code",
       "source_file": "tests/review.test.ts",
       "source_location": "L6",
-      "community": 104,
-      "community_name": "Community 104"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "tests_search_test_ts",
@@ -9311,8 +9428,8 @@
       "file_type": "code",
       "source_file": "tests/search.test.ts",
       "source_location": "L1",
-      "community": 130,
-      "community_name": "Community 130"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "tests_security_test_ts",
@@ -9320,8 +9437,8 @@
       "file_type": "code",
       "source_file": "tests/security.test.ts",
       "source_location": "L1",
-      "community": 131,
-      "community_name": "Community 131"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "tests_serve_test_ts",
@@ -9329,8 +9446,8 @@
       "file_type": "code",
       "source_file": "tests/serve.test.ts",
       "source_location": "L1",
-      "community": 71,
-      "community_name": "Community 71"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_test_maketempdir",
@@ -9338,8 +9455,8 @@
       "file_type": "code",
       "source_file": "tests/serve.test.ts",
       "source_location": "L19",
-      "community": 71,
-      "community_name": "Community 71"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_test_makeexternaltempdir",
@@ -9347,8 +9464,8 @@
       "file_type": "code",
       "source_file": "tests/serve.test.ts",
       "source_location": "L26",
-      "community": 71,
-      "community_name": "Community 71"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_test_writefixturegraph",
@@ -9356,8 +9473,8 @@
       "file_type": "code",
       "source_file": "tests/serve.test.ts",
       "source_location": "L32",
-      "community": 71,
-      "community_name": "Community 71"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "serve_test_tooltext",
@@ -9365,8 +9482,8 @@
       "file_type": "code",
       "source_file": "tests/serve.test.ts",
       "source_location": "L96",
-      "community": 71,
-      "community_name": "Community 71"
+      "community": 15,
+      "community_name": "Community 15"
     },
     {
       "id": "tests_skills_test_ts",
@@ -9374,8 +9491,8 @@
       "file_type": "code",
       "source_file": "tests/skills.test.ts",
       "source_location": "L1",
-      "community": 132,
-      "community_name": "Community 132"
+      "community": 44,
+      "community_name": "Community 44"
     },
     {
       "id": "tests_summary_test_ts",
@@ -9383,8 +9500,8 @@
       "file_type": "code",
       "source_file": "tests/summary.test.ts",
       "source_location": "L1",
-      "community": 105,
-      "community_name": "Community 105"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "summary_test_makegraph",
@@ -9392,8 +9509,8 @@
       "file_type": "code",
       "source_file": "tests/summary.test.ts",
       "source_location": "L6",
-      "community": 105,
-      "community_name": "Community 105"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_transcribe_test_ts",
@@ -9401,8 +9518,8 @@
       "file_type": "code",
       "source_file": "tests/transcribe.test.ts",
       "source_location": "L1",
-      "community": 106,
-      "community_name": "Community 106"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "transcribe_test_mockytdlpdownload",
@@ -9410,8 +9527,8 @@
       "file_type": "code",
       "source_file": "tests/transcribe.test.ts",
       "source_location": "L77",
-      "community": 106,
-      "community_name": "Community 106"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "tests_validate_test_ts",
@@ -9419,8 +9536,8 @@
       "file_type": "code",
       "source_file": "tests/validate.test.ts",
       "source_location": "L1",
-      "community": 133,
-      "community_name": "Community 133"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_wiki_test_ts",
@@ -9428,8 +9545,8 @@
       "file_type": "code",
       "source_file": "tests/wiki.test.ts",
       "source_location": "L1",
-      "community": 134,
-      "community_name": "Community 134"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "tsup_config_ts",
@@ -9437,8 +9554,8 @@
       "file_type": "code",
       "source_file": "tsup.config.ts",
       "source_location": "L1",
-      "community": 135,
-      "community_name": "Community 135"
+      "community": 45,
+      "community_name": "Community 45"
     },
     {
       "id": "vitest_config_ts",
@@ -9446,8 +9563,8 @@
       "file_type": "code",
       "source_file": "vitest.config.ts",
       "source_location": "L1",
-      "community": 136,
-      "community_name": "Community 136"
+      "community": 46,
+      "community_name": "Community 46"
     },
     {
       "id": "worked_example_raw_api_py",
@@ -9455,8 +9572,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_handle_upload",
@@ -9464,8 +9581,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L11",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_handle_get",
@@ -9473,8 +9590,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L27",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_handle_delete",
@@ -9482,8 +9599,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L35",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_handle_list",
@@ -9491,8 +9608,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L43",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_handle_search",
@@ -9500,8 +9617,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L48",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_handle_enrich",
@@ -9509,8 +9626,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L67",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_1",
@@ -9518,8 +9635,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_12",
@@ -9527,8 +9644,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L12",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_28",
@@ -9536,8 +9653,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L28",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_36",
@@ -9545,8 +9662,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L36",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_44",
@@ -9554,8 +9671,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L44",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_49",
@@ -9563,8 +9680,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L49",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "api_rationale_68",
@@ -9572,8 +9689,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L68",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "worked_example_raw_parser_py",
@@ -9581,8 +9698,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L1",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_parse_file",
@@ -9590,8 +9707,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L12",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_parse_markdown",
@@ -9599,8 +9716,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L29",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_parse_json",
@@ -9608,8 +9725,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L49",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_parse_plaintext",
@@ -9617,8 +9734,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L56",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_parse_and_save",
@@ -9626,8 +9743,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L62",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_batch_parse",
@@ -9635,8 +9752,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L70",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_1",
@@ -9644,8 +9761,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L1",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_13",
@@ -9653,8 +9770,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L13",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_30",
@@ -9662,8 +9779,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L30",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_50",
@@ -9671,8 +9788,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L50",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_57",
@@ -9680,8 +9797,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L57",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_63",
@@ -9689,8 +9806,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L63",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "parser_rationale_71",
@@ -9698,8 +9815,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/parser.py",
       "source_location": "L71",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 27,
+      "community_name": "Community 27"
     },
     {
       "id": "worked_example_raw_processor_py",
@@ -9707,8 +9824,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L1",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_normalize_text",
@@ -9716,8 +9833,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L12",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_extract_keywords",
@@ -9725,8 +9842,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L20",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_enrich_document",
@@ -9734,8 +9851,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L32",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_find_cross_references",
@@ -9743,8 +9860,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L44",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_process_and_save",
@@ -9752,8 +9869,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L57",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_reprocess_all",
@@ -9761,8 +9878,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L64",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_1",
@@ -9770,8 +9887,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L1",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_13",
@@ -9779,8 +9896,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L13",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_21",
@@ -9788,8 +9905,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L21",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_33",
@@ -9797,8 +9914,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L33",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_45",
@@ -9806,8 +9923,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L45",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_58",
@@ -9815,8 +9932,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L58",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "processor_rationale_65",
@@ -9824,8 +9941,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/processor.py",
       "source_location": "L65",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 28,
+      "community_name": "Community 28"
     },
     {
       "id": "worked_example_raw_storage_py",
@@ -9833,8 +9950,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L1",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_ensure_storage",
@@ -9842,8 +9959,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L14",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_load_index",
@@ -9851,8 +9968,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L20",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_save_index",
@@ -9860,8 +9977,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L26",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_save_parsed",
@@ -9869,8 +9986,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L32",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_save_processed",
@@ -9878,8 +9995,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L49",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_load_record",
@@ -9887,8 +10004,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L65",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_delete_record",
@@ -9896,8 +10013,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L74",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_list_records",
@@ -9905,8 +10022,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L87",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_1",
@@ -9914,8 +10031,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L1",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_21",
@@ -9923,8 +10040,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L21",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_27",
@@ -9932,8 +10049,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L27",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_33",
@@ -9941,8 +10058,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L33",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_50",
@@ -9950,8 +10067,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L50",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_66",
@@ -9959,8 +10076,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L66",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_75",
@@ -9968,8 +10085,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L75",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "storage_rationale_88",
@@ -9977,8 +10094,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L88",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "worked_example_raw_validator_py",
@@ -9986,8 +10103,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_validationerror",
@@ -9995,8 +10112,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L13",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "exception",
@@ -10013,8 +10130,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L17",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_check_required_fields",
@@ -10022,8 +10139,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L25",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_check_format",
@@ -10031,8 +10148,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L32",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_normalize_fields",
@@ -10040,8 +10157,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L39",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_validate_batch",
@@ -10049,8 +10166,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L52",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_rationale_1",
@@ -10058,8 +10175,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_rationale_18",
@@ -10067,8 +10184,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L18",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_rationale_26",
@@ -10076,8 +10193,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L26",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_rationale_33",
@@ -10085,8 +10202,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L33",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_rationale_40",
@@ -10094,8 +10211,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L40",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "validator_rationale_53",
@@ -10103,8 +10220,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L53",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "worked_httpx_raw_auth_py",
@@ -11687,8 +11804,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L1",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_primitive_value_to_str",
@@ -11696,8 +11813,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L12",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_normalize_header_key",
@@ -11705,8 +11822,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L19",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_flatten_queryparams",
@@ -11714,8 +11831,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L24",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_parse_content_type",
@@ -11723,8 +11840,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L39",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_obfuscate_sensitive_headers",
@@ -11732,8 +11849,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L55",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_unset_all_cookies",
@@ -11741,8 +11858,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L63",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_is_known_encoding",
@@ -11750,8 +11867,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L68",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_build_url_with_params",
@@ -11759,8 +11876,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L78",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_1",
@@ -11768,8 +11885,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L1",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_13",
@@ -11777,8 +11894,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L13",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_20",
@@ -11786,8 +11903,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L20",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_25",
@@ -11795,8 +11912,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L25",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_40",
@@ -11804,8 +11921,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L40",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_56",
@@ -11813,8 +11930,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L56",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_64",
@@ -11822,8 +11939,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L64",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_69",
@@ -11831,8 +11948,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L69",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "utils_rationale_79",
@@ -11840,8 +11957,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L79",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "worked_mixed_corpus_raw_analyze_py",
@@ -11849,8 +11966,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_node_community_map",
@@ -11858,8 +11975,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L6",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_is_file_node",
@@ -11867,8 +11984,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L11",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_god_nodes",
@@ -11876,8 +11993,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L35",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_surprising_connections",
@@ -11885,8 +12002,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L57",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_is_concept_node",
@@ -11894,8 +12011,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L89",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_file_category",
@@ -11903,8 +12020,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L114",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_top_level_dir",
@@ -11912,8 +12029,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L125",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_surprise_score",
@@ -11921,8 +12038,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L130",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_cross_file_surprises",
@@ -11930,8 +12047,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L181",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_cross_community_surprises",
@@ -11939,8 +12056,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L239",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_suggest_questions",
@@ -11948,8 +12065,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L321",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_graph_diff",
@@ -11957,8 +12074,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L438",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_1",
@@ -11966,8 +12083,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_7",
@@ -11975,8 +12092,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L7",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_12",
@@ -11984,8 +12101,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L12",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_36",
@@ -11993,8 +12110,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L36",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_62",
@@ -12002,8 +12119,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L62",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_90",
@@ -12011,8 +12128,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L90",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_126",
@@ -12020,8 +12137,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L126",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_139",
@@ -12029,8 +12146,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L139",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_182",
@@ -12038,8 +12155,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L182",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_244",
@@ -12047,8 +12164,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L244",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_327",
@@ -12056,8 +12173,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L327",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "analyze_rationale_439",
@@ -12065,8 +12182,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/analyze.py",
       "source_location": "L439",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 18,
+      "community_name": "Community 18"
     },
     {
       "id": "worked_mixed_corpus_raw_build_py",
@@ -12074,8 +12191,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L1",
-      "community": 59,
-      "community_name": "Community 59"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "build_build_from_json",
@@ -12083,8 +12200,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L8",
-      "community": 59,
-      "community_name": "Community 59"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "build_rationale_32",
@@ -12092,8 +12209,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L32",
-      "community": 59,
-      "community_name": "Community 59"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "worked_mixed_corpus_raw_cluster_py",
@@ -12101,8 +12218,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L1",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_build_graph",
@@ -12110,8 +12227,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L6",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_split_community",
@@ -12119,8 +12236,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L72",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_cohesion_score",
@@ -12128,8 +12245,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L92",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_score_all",
@@ -12137,8 +12254,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L103",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_rationale_1",
@@ -12146,8 +12263,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L1",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_rationale_7",
@@ -12155,8 +12272,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L7",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_rationale_28",
@@ -12164,8 +12281,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L28",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_rationale_73",
@@ -12173,8 +12290,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L73",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "cluster_rationale_93",
@@ -12182,11 +12299,71 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L93",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 12,
+      "community_name": "Community 12"
     }
   ],
   "links": [
+    {
+      "source": "src_analyze_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/analyze.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "src_analyze_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_analyze_ts",
+      "target": "src_collections_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/analyze.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_analyze_ts",
+      "_tgt": "src_collections_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_analyze_ts",
+      "target": "src_cluster_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/analyze.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_analyze_ts",
+      "_tgt": "src_cluster_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_analyze_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/analyze.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "src_analyze_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_analyze_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/analyze.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "src_analyze_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
     {
       "source": "src_analyze_ts",
       "target": "analyze_nodecommunitymap",
@@ -12477,6 +12654,42 @@
     },
     {
       "source": "src_benchmark_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/benchmark.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_benchmark_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_benchmark_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/benchmark.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "src_benchmark_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_benchmark_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/benchmark.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_benchmark_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_benchmark_ts",
       "target": "benchmark_estimatetokens",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -12573,11 +12786,71 @@
     },
     {
       "source": "src_build_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "src_build_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_build_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L15",
+      "weight": 1,
+      "_src": "src_build_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_build_ts",
+      "target": "src_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "src_build_ts",
+      "_tgt": "src_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_build_ts",
+      "target": "build_normalizedlabel",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L24",
+      "weight": 1,
+      "_src": "src_build_ts",
+      "_tgt": "build_normalizedlabel",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_build_ts",
+      "target": "build_deduplicatebylabel",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L32",
+      "weight": 1,
+      "_src": "src_build_ts",
+      "_tgt": "build_deduplicatebylabel",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_build_ts",
       "target": "build_buildfromjson",
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/build.ts",
-      "source_location": "L20",
+      "source_location": "L98",
       "weight": 1,
       "_src": "src_build_ts",
       "_tgt": "build_buildfromjson",
@@ -12589,10 +12862,34 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/build.ts",
-      "source_location": "L65",
+      "source_location": "L159",
       "weight": 1,
       "_src": "src_build_ts",
       "_tgt": "build_build",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_build_ts",
+      "target": "build_buildmerge",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L182",
+      "weight": 1,
+      "_src": "src_build_ts",
+      "_tgt": "build_buildmerge",
+      "confidence_score": 1
+    },
+    {
+      "source": "build_deduplicatebylabel",
+      "target": "build_normalizedlabel",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L37",
+      "weight": 1,
+      "_src": "build_deduplicatebylabel",
+      "_tgt": "build_normalizedlabel",
       "confidence_score": 1
     },
     {
@@ -12601,10 +12898,46 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/build.ts",
-      "source_location": "L80",
+      "source_location": "L174",
       "weight": 1,
       "_src": "build_build",
       "_tgt": "build_buildfromjson",
+      "confidence_score": 1
+    },
+    {
+      "source": "build_buildmerge",
+      "target": "build_deduplicatebylabel",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L235",
+      "weight": 1,
+      "_src": "build_buildmerge",
+      "_tgt": "build_deduplicatebylabel",
+      "confidence_score": 1
+    },
+    {
+      "source": "build_buildmerge",
+      "target": "build_buildfromjson",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/build.ts",
+      "source_location": "L236",
+      "weight": 1,
+      "_src": "build_buildmerge",
+      "_tgt": "build_buildfromjson",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cache_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cache.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "src_cache_ts",
+      "_tgt": "src_paths_ts",
       "confidence_score": 1
     },
     {
@@ -12873,6 +13206,114 @@
     },
     {
       "source": "src_cli_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L19",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_configured_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L25",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_configured_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_input_scope_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L26",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_input_scope_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L31",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L32",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L33",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L34",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_search_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L35",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_search_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
+      "target": "src_portable_artifacts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L36",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "src_portable_artifacts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
       "target": "cli_getversion",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -13041,11 +13482,23 @@
     },
     {
       "source": "src_cli_ts",
+      "target": "cli_resolveglobalskilldestination",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L264",
+      "weight": 1,
+      "_src": "src_cli_ts",
+      "_tgt": "cli_resolveglobalskilldestination",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cli_ts",
       "target": "cli_opencodeconfigpath",
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L358",
+      "source_location": "L372",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_opencodeconfigpath",
@@ -13057,7 +13510,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L362",
+      "source_location": "L376",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_legacyopencodeconfigpath",
@@ -13069,7 +13522,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L366",
+      "source_location": "L380",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_loadopencodeconfig",
@@ -13081,7 +13534,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L386",
+      "source_location": "L400",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_previewpath",
@@ -13093,7 +13546,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L390",
+      "source_location": "L404",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_emptypreview",
@@ -13105,7 +13558,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L394",
+      "source_location": "L408",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_platforminstallpreview",
@@ -13117,7 +13570,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L447",
+      "source_location": "L461",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_globalskillinstallpreview",
@@ -13129,7 +13582,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L460",
+      "source_location": "L474",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_printmutationpreview",
@@ -13141,7 +13594,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L654",
+      "source_location": "L668",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_findskillfile",
@@ -13153,7 +13606,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L667",
+      "source_location": "L681",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_renderaiderskill",
@@ -13165,7 +13618,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L674",
+      "source_location": "L688",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_loadskillcontent",
@@ -13177,7 +13630,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L699",
+      "source_location": "L713",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_uninstallskill",
@@ -13189,7 +13642,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L727",
+      "source_location": "L741",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_getinvocationexample",
@@ -13201,7 +13654,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L731",
+      "source_location": "L745",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_getagentsmdsection",
@@ -13213,7 +13666,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L759",
+      "source_location": "L773",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_installgeminimcp",
@@ -13225,7 +13678,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L789",
+      "source_location": "L803",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_uninstallgeminimcp",
@@ -13237,7 +13690,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L813",
+      "source_location": "L827",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_cursorinstall",
@@ -13249,7 +13702,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L828",
+      "source_location": "L842",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_cursoruninstall",
@@ -13261,7 +13714,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L839",
+      "source_location": "L853",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_antigravityinstall",
@@ -13273,7 +13726,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L867",
+      "source_location": "L881",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_antigravityuninstall",
@@ -13285,7 +13738,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L878",
+      "source_location": "L892",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_kiroinstall",
@@ -13297,7 +13750,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L901",
+      "source_location": "L915",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_kirouninstall",
@@ -13309,7 +13762,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L930",
+      "source_location": "L944",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_vscodeinstall",
@@ -13321,7 +13774,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L955",
+      "source_location": "L969",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_vscodeuninstall",
@@ -13333,7 +13786,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L971",
+      "source_location": "L985",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_installopencodeplugin",
@@ -13345,7 +13798,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1003",
+      "source_location": "L1017",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_uninstallopencodeplugin",
@@ -13357,7 +13810,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1042",
+      "source_location": "L1056",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_writeglobalskill",
@@ -13369,7 +13822,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1076",
+      "source_location": "L1090",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_installskill",
@@ -13381,7 +13834,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1095",
+      "source_location": "L1109",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_installclaudehook",
@@ -13393,7 +13846,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1119",
+      "source_location": "L1133",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_uninstallclaudehook",
@@ -13405,7 +13858,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1138",
+      "source_location": "L1152",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_claudeinstall",
@@ -13417,7 +13870,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1163",
+      "source_location": "L1177",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_claudeuninstall",
@@ -13429,7 +13882,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1186",
+      "source_location": "L1200",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_geminiinstall",
@@ -13441,7 +13894,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1214",
+      "source_location": "L1228",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_geminiuninstall",
@@ -13453,7 +13906,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1237",
+      "source_location": "L1251",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_installcodexhook",
@@ -13465,7 +13918,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1274",
+      "source_location": "L1288",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_uninstallcodexhook",
@@ -13477,7 +13930,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1288",
+      "source_location": "L1302",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_agentsinstall",
@@ -13489,7 +13942,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1325",
+      "source_location": "L1339",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_agentsuninstall",
@@ -13501,7 +13954,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1356",
+      "source_location": "L1370",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_checkskillversion",
@@ -13513,7 +13966,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1367",
+      "source_location": "L1381",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_getplatformstocheck",
@@ -13525,7 +13978,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1408",
+      "source_location": "L1422",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_main",
@@ -13537,7 +13990,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L2579",
+      "source_location": "L2629",
       "weight": 1,
       "_src": "src_cli_ts",
       "_tgt": "cli_isdirectcliexecution",
@@ -13568,12 +14021,36 @@
       "confidence_score": 1
     },
     {
+      "source": "cli_resolveglobalskilldestination",
+      "target": "cli_canonicalplatformname",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L265",
+      "weight": 1,
+      "_src": "cli_resolveglobalskilldestination",
+      "_tgt": "cli_canonicalplatformname",
+      "confidence_score": 1
+    },
+    {
+      "source": "cli_resolveglobalskilldestination",
+      "target": "cli_platformnamesforerror",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L268",
+      "weight": 1,
+      "_src": "cli_resolveglobalskilldestination",
+      "_tgt": "cli_platformnamesforerror",
+      "confidence_score": 1
+    },
+    {
       "source": "cli_loadopencodeconfig",
       "target": "cli_opencodeconfigpath",
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L370",
+      "source_location": "L384",
       "weight": 1,
       "_src": "cli_loadopencodeconfig",
       "_tgt": "cli_opencodeconfigpath",
@@ -13585,7 +14062,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L371",
+      "source_location": "L385",
       "weight": 1,
       "_src": "cli_loadopencodeconfig",
       "_tgt": "cli_legacyopencodeconfigpath",
@@ -13597,7 +14074,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L395",
+      "source_location": "L409",
       "weight": 1,
       "_src": "cli_platforminstallpreview",
       "_tgt": "cli_canonicalplatformname",
@@ -13609,7 +14086,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L396",
+      "source_location": "L410",
       "weight": 1,
       "_src": "cli_platforminstallpreview",
       "_tgt": "cli_emptypreview",
@@ -13621,7 +14098,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L398",
+      "source_location": "L412",
       "weight": 1,
       "_src": "cli_platforminstallpreview",
       "_tgt": "cli_previewpath",
@@ -13633,7 +14110,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L448",
+      "source_location": "L462",
       "weight": 1,
       "_src": "cli_globalskillinstallpreview",
       "_tgt": "cli_canonicalplatformname",
@@ -13645,10 +14122,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L450",
+      "source_location": "L464",
       "weight": 1,
       "_src": "cli_globalskillinstallpreview",
       "_tgt": "cli_emptypreview",
+      "confidence_score": 1
+    },
+    {
+      "source": "cli_globalskillinstallpreview",
+      "target": "cli_resolveglobalskilldestination",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L466",
+      "weight": 1,
+      "_src": "cli_globalskillinstallpreview",
+      "_tgt": "cli_resolveglobalskilldestination",
       "confidence_score": 1
     },
     {
@@ -13657,7 +14146,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L675",
+      "source_location": "L689",
       "weight": 1,
       "_src": "cli_loadskillcontent",
       "_tgt": "cli_canonicalplatformname",
@@ -13669,7 +14158,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L678",
+      "source_location": "L692",
       "weight": 1,
       "_src": "cli_loadskillcontent",
       "_tgt": "cli_platformnamesforerror",
@@ -13681,7 +14170,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L682",
+      "source_location": "L696",
       "weight": 1,
       "_src": "cli_loadskillcontent",
       "_tgt": "cli_findskillfile",
@@ -13693,7 +14182,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L690",
+      "source_location": "L704",
       "weight": 1,
       "_src": "cli_loadskillcontent",
       "_tgt": "cli_renderaiderskill",
@@ -13705,7 +14194,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L700",
+      "source_location": "L714",
       "weight": 1,
       "_src": "cli_uninstallskill",
       "_tgt": "cli_canonicalplatformname",
@@ -13717,7 +14206,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L703",
+      "source_location": "L717",
       "weight": 1,
       "_src": "cli_uninstallskill",
       "_tgt": "cli_platformnamesforerror",
@@ -13729,7 +14218,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L814",
+      "source_location": "L828",
       "weight": 1,
       "_src": "cli_cursorinstall",
       "_tgt": "cli_printmutationpreview",
@@ -13741,7 +14230,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L814",
+      "source_location": "L828",
       "weight": 1,
       "_src": "cli_cursorinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -13753,7 +14242,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L840",
+      "source_location": "L854",
       "weight": 1,
       "_src": "cli_antigravityinstall",
       "_tgt": "cli_printmutationpreview",
@@ -13765,7 +14254,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L840",
+      "source_location": "L854",
       "weight": 1,
       "_src": "cli_antigravityinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -13777,7 +14266,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L841",
+      "source_location": "L855",
       "weight": 1,
       "_src": "cli_antigravityinstall",
       "_tgt": "cli_globalskillinstallpreview",
@@ -13789,7 +14278,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L842",
+      "source_location": "L856",
       "weight": 1,
       "_src": "cli_antigravityinstall",
       "_tgt": "cli_writeglobalskill",
@@ -13801,7 +14290,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L875",
+      "source_location": "L889",
       "weight": 1,
       "_src": "cli_antigravityuninstall",
       "_tgt": "cli_uninstallskill",
@@ -13813,7 +14302,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L879",
+      "source_location": "L893",
       "weight": 1,
       "_src": "cli_kiroinstall",
       "_tgt": "cli_printmutationpreview",
@@ -13825,7 +14314,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L879",
+      "source_location": "L893",
       "weight": 1,
       "_src": "cli_kiroinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -13837,7 +14326,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L883",
+      "source_location": "L897",
       "weight": 1,
       "_src": "cli_kiroinstall",
       "_tgt": "cli_loadskillcontent",
@@ -13849,7 +14338,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L931",
+      "source_location": "L945",
       "weight": 1,
       "_src": "cli_vscodeinstall",
       "_tgt": "cli_printmutationpreview",
@@ -13861,7 +14350,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L931",
+      "source_location": "L945",
       "weight": 1,
       "_src": "cli_vscodeinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -13873,7 +14362,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L932",
+      "source_location": "L946",
       "weight": 1,
       "_src": "cli_vscodeinstall",
       "_tgt": "cli_globalskillinstallpreview",
@@ -13885,7 +14374,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L933",
+      "source_location": "L947",
       "weight": 1,
       "_src": "cli_vscodeinstall",
       "_tgt": "cli_writeglobalskill",
@@ -13897,7 +14386,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L956",
+      "source_location": "L970",
       "weight": 1,
       "_src": "cli_vscodeuninstall",
       "_tgt": "cli_uninstallskill",
@@ -13909,7 +14398,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L983",
+      "source_location": "L997",
       "weight": 1,
       "_src": "cli_installopencodeplugin",
       "_tgt": "cli_loadopencodeconfig",
@@ -13921,7 +14410,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L990",
+      "source_location": "L1004",
       "weight": 1,
       "_src": "cli_installopencodeplugin",
       "_tgt": "cli_opencodeconfigpath",
@@ -13933,7 +14422,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1010",
+      "source_location": "L1024",
       "weight": 1,
       "_src": "cli_uninstallopencodeplugin",
       "_tgt": "cli_opencodeconfigpath",
@@ -13945,7 +14434,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1012",
+      "source_location": "L1026",
       "weight": 1,
       "_src": "cli_uninstallopencodeplugin",
       "_tgt": "cli_legacyopencodeconfigpath",
@@ -13957,7 +14446,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1043",
+      "source_location": "L1057",
       "weight": 1,
       "_src": "cli_writeglobalskill",
       "_tgt": "cli_canonicalplatformname",
@@ -13969,10 +14458,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1046",
+      "source_location": "L1060",
       "weight": 1,
       "_src": "cli_writeglobalskill",
       "_tgt": "cli_platformnamesforerror",
+      "confidence_score": 1
+    },
+    {
+      "source": "cli_writeglobalskill",
+      "target": "cli_resolveglobalskilldestination",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L1064",
+      "weight": 1,
+      "_src": "cli_writeglobalskill",
+      "_tgt": "cli_resolveglobalskilldestination",
       "confidence_score": 1
     },
     {
@@ -13981,7 +14482,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1052",
+      "source_location": "L1066",
       "weight": 1,
       "_src": "cli_writeglobalskill",
       "_tgt": "cli_loadskillcontent",
@@ -13993,7 +14494,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1077",
+      "source_location": "L1091",
       "weight": 1,
       "_src": "cli_installskill",
       "_tgt": "cli_canonicalplatformname",
@@ -14005,7 +14506,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1078",
+      "source_location": "L1092",
       "weight": 1,
       "_src": "cli_installskill",
       "_tgt": "cli_printmutationpreview",
@@ -14017,7 +14518,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1078",
+      "source_location": "L1092",
       "weight": 1,
       "_src": "cli_installskill",
       "_tgt": "cli_globalskillinstallpreview",
@@ -14029,7 +14530,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1079",
+      "source_location": "L1093",
       "weight": 1,
       "_src": "cli_installskill",
       "_tgt": "cli_writeglobalskill",
@@ -14041,7 +14542,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1084",
+      "source_location": "L1098",
       "weight": 1,
       "_src": "cli_installskill",
       "_tgt": "cli_getinvocationexample",
@@ -14053,7 +14554,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1139",
+      "source_location": "L1153",
       "weight": 1,
       "_src": "cli_claudeinstall",
       "_tgt": "cli_printmutationpreview",
@@ -14065,7 +14566,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1139",
+      "source_location": "L1153",
       "weight": 1,
       "_src": "cli_claudeinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -14077,7 +14578,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1157",
+      "source_location": "L1171",
       "weight": 1,
       "_src": "cli_claudeinstall",
       "_tgt": "cli_installclaudehook",
@@ -14089,7 +14590,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1183",
+      "source_location": "L1197",
       "weight": 1,
       "_src": "cli_claudeuninstall",
       "_tgt": "cli_uninstallclaudehook",
@@ -14101,7 +14602,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1187",
+      "source_location": "L1201",
       "weight": 1,
       "_src": "cli_geminiinstall",
       "_tgt": "cli_printmutationpreview",
@@ -14113,7 +14614,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1187",
+      "source_location": "L1201",
       "weight": 1,
       "_src": "cli_geminiinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -14125,7 +14626,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1205",
+      "source_location": "L1219",
       "weight": 1,
       "_src": "cli_geminiinstall",
       "_tgt": "cli_installgeminimcp",
@@ -14137,7 +14638,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1234",
+      "source_location": "L1248",
       "weight": 1,
       "_src": "cli_geminiuninstall",
       "_tgt": "cli_uninstallgeminimcp",
@@ -14149,7 +14650,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1289",
+      "source_location": "L1303",
       "weight": 1,
       "_src": "cli_agentsinstall",
       "_tgt": "cli_printmutationpreview",
@@ -14161,7 +14662,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1289",
+      "source_location": "L1303",
       "weight": 1,
       "_src": "cli_agentsinstall",
       "_tgt": "cli_platforminstallpreview",
@@ -14173,7 +14674,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1292",
+      "source_location": "L1306",
       "weight": 1,
       "_src": "cli_agentsinstall",
       "_tgt": "cli_getagentsmdsection",
@@ -14185,7 +14686,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1310",
+      "source_location": "L1324",
       "weight": 1,
       "_src": "cli_agentsinstall",
       "_tgt": "cli_installcodexhook",
@@ -14197,7 +14698,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1312",
+      "source_location": "L1326",
       "weight": 1,
       "_src": "cli_agentsinstall",
       "_tgt": "cli_installopencodeplugin",
@@ -14209,7 +14710,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1346",
+      "source_location": "L1360",
       "weight": 1,
       "_src": "cli_agentsuninstall",
       "_tgt": "cli_uninstallcodexhook",
@@ -14221,7 +14722,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1348",
+      "source_location": "L1362",
       "weight": 1,
       "_src": "cli_agentsuninstall",
       "_tgt": "cli_uninstallopencodeplugin",
@@ -14233,7 +14734,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1410",
+      "source_location": "L1424",
       "weight": 1,
       "_src": "cli_main",
       "_tgt": "cli_getplatformstocheck",
@@ -14245,10 +14746,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1413",
+      "source_location": "L1427",
       "weight": 1,
       "_src": "cli_main",
       "_tgt": "cli_checkskillversion",
+      "confidence_score": 1
+    },
+    {
+      "source": "cli_main",
+      "target": "cli_resolveglobalskilldestination",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cli.ts",
+      "source_location": "L1427",
+      "weight": 1,
+      "_src": "cli_main",
+      "_tgt": "cli_resolveglobalskilldestination",
       "confidence_score": 1
     },
     {
@@ -14257,10 +14770,34 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/cli.ts",
-      "source_location": "L1569",
+      "source_location": "L1583",
       "weight": 1,
       "_src": "cli_main",
       "_tgt": "cli_scopeoptiondescription",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cluster_ts",
+      "target": "src_collections_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cluster.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_cluster_ts",
+      "_tgt": "src_collections_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_cluster_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/cluster.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_cluster_ts",
+      "_tgt": "src_graph_ts",
       "confidence_score": 1
     },
     {
@@ -14393,6 +14930,114 @@
       "weight": 1,
       "_src": "src_collections_ts",
       "_tgt": "collections_tostringmap",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_input_scope_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_input_scope_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_ontology_profile_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_profile_registry_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_profile_registry_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_semantic_prepare_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L22",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_semantic_prepare_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_configured_dataprep_ts",
+      "target": "src_pdf_preflight_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/configured-dataprep.ts",
+      "source_location": "L21",
+      "weight": 1,
+      "_src": "src_configured_dataprep_ts",
+      "_tgt": "src_pdf_preflight_ts",
       "confidence_score": 1
     },
     {
@@ -14841,6 +15486,30 @@
     },
     {
       "source": "src_detect_changes_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/detect-changes.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "src_detect_changes_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_detect_changes_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/detect-changes.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_detect_changes_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_detect_changes_ts",
       "target": "detect_changes_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -15101,6 +15770,30 @@
       "weight": 1,
       "_src": "detect_changes_analyzechanges",
       "_tgt": "detect_changes_sortnodesbylocation",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_detect_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/detect.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_detect_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_detect_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/detect.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "src_detect_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -15513,6 +16206,54 @@
     },
     {
       "source": "src_export_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/export.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_export_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_export_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/export.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "src_export_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_export_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/export.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_export_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_export_ts",
+      "target": "src_collections_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/export.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_export_ts",
+      "_tgt": "src_collections_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_export_ts",
       "target": "export_nodecommunitymap",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -15553,7 +16294,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L72",
+      "source_location": "L73",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_iscanvasoptions",
@@ -15565,7 +16306,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L81",
+      "source_location": "L82",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_issvgoptions",
@@ -15577,7 +16318,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L90",
+      "source_location": "L91",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_normalizecommunitylabels",
@@ -15589,7 +16330,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L100",
+      "source_location": "L101",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_normalizemembercounts",
@@ -15601,7 +16342,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L112",
+      "source_location": "L113",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_tojson",
@@ -15613,7 +16354,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L176",
+      "source_location": "L199",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_tocypher",
@@ -15625,7 +16366,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L207",
+      "source_location": "L230",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_neo4jlabel",
@@ -15637,7 +16378,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L212",
+      "source_location": "L235",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_neo4jrelation",
@@ -15649,7 +16390,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L220",
+      "source_location": "L243",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_scalarprops",
@@ -15661,7 +16402,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L234",
+      "source_location": "L257",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_pushtoneo4j",
@@ -15673,7 +16414,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L317",
+      "source_location": "L340",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_htmlstyles",
@@ -15685,7 +16426,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L350",
+      "source_location": "L373",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_hyperedgescript",
@@ -15697,7 +16438,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L404",
+      "source_location": "L427",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_htmlscript",
@@ -15709,7 +16450,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L560",
+      "source_location": "L583",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_tohtml",
@@ -15721,7 +16462,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L717",
+      "source_location": "L740",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_tographml",
@@ -15733,7 +16474,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L777",
+      "source_location": "L800",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_tosvg",
@@ -15745,7 +16486,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L885",
+      "source_location": "L908",
       "weight": 1,
       "_src": "src_export_ts",
       "_tgt": "export_tocanvas",
@@ -15757,7 +16498,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L94",
+      "source_location": "L95",
       "weight": 1,
       "_src": "export_normalizecommunitylabels",
       "_tgt": "export_iscommunitylabeloptions",
@@ -15769,7 +16510,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L103",
+      "source_location": "L104",
       "weight": 1,
       "_src": "export_normalizemembercounts",
       "_tgt": "export_iscommunitylabeloptions",
@@ -15781,7 +16522,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L118",
+      "source_location": "L119",
       "weight": 1,
       "_src": "export_tojson",
       "_tgt": "export_nodecommunitymap",
@@ -15793,7 +16534,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L119",
+      "source_location": "L120",
       "weight": 1,
       "_src": "export_tojson",
       "_tgt": "export_normalizecommunitylabels",
@@ -15805,7 +16546,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L262",
+      "source_location": "L285",
       "weight": 1,
       "_src": "export_pushtoneo4j",
       "_tgt": "export_nodecommunitymap",
@@ -15817,7 +16558,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L271",
+      "source_location": "L294",
       "weight": 1,
       "_src": "export_pushtoneo4j",
       "_tgt": "export_scalarprops",
@@ -15829,7 +16570,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L279",
+      "source_location": "L302",
       "weight": 1,
       "_src": "export_pushtoneo4j",
       "_tgt": "export_neo4jlabel",
@@ -15841,7 +16582,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L295",
+      "source_location": "L318",
       "weight": 1,
       "_src": "export_pushtoneo4j",
       "_tgt": "export_neo4jrelation",
@@ -15853,7 +16594,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L567",
+      "source_location": "L590",
       "weight": 1,
       "_src": "export_tohtml",
       "_tgt": "export_normalizecommunitylabels",
@@ -15865,7 +16606,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L568",
+      "source_location": "L591",
       "weight": 1,
       "_src": "export_tohtml",
       "_tgt": "export_normalizemembercounts",
@@ -15877,7 +16618,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L576",
+      "source_location": "L599",
       "weight": 1,
       "_src": "export_tohtml",
       "_tgt": "export_nodecommunitymap",
@@ -15889,7 +16630,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L686",
+      "source_location": "L709",
       "weight": 1,
       "_src": "export_tohtml",
       "_tgt": "export_htmlstyles",
@@ -15901,7 +16642,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L705",
+      "source_location": "L728",
       "weight": 1,
       "_src": "export_tohtml",
       "_tgt": "export_htmlscript",
@@ -15913,7 +16654,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L706",
+      "source_location": "L729",
       "weight": 1,
       "_src": "export_tohtml",
       "_tgt": "export_hyperedgescript",
@@ -15925,7 +16666,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L722",
+      "source_location": "L745",
       "weight": 1,
       "_src": "export_tographml",
       "_tgt": "export_nodecommunitymap",
@@ -15937,7 +16678,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L785",
+      "source_location": "L808",
       "weight": 1,
       "_src": "export_tosvg",
       "_tgt": "export_issvgoptions",
@@ -15949,7 +16690,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L788",
+      "source_location": "L811",
       "weight": 1,
       "_src": "export_tosvg",
       "_tgt": "export_normalizecommunitylabels",
@@ -15961,7 +16702,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L789",
+      "source_location": "L812",
       "weight": 1,
       "_src": "export_tosvg",
       "_tgt": "export_nodecommunitymap",
@@ -15973,7 +16714,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L893",
+      "source_location": "L916",
       "weight": 1,
       "_src": "export_tocanvas",
       "_tgt": "export_iscanvasoptions",
@@ -15985,10 +16726,34 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/export.ts",
-      "source_location": "L896",
+      "source_location": "L919",
       "weight": 1,
       "_src": "export_tocanvas",
       "_tgt": "export_normalizecommunitylabels",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_extract_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/extract.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "src_extract_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_extract_ts",
+      "target": "src_cache_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/extract.ts",
+      "source_location": "L13",
+      "weight": 1,
+      "_src": "src_extract_ts",
+      "_tgt": "src_cache_ts",
       "confidence_score": 1
     },
     {
@@ -17745,6 +18510,18 @@
     },
     {
       "source": "src_flows_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/flows.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_flows_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_flows_ts",
       "target": "flows_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -18357,11 +19134,23 @@
     },
     {
       "source": "src_graph_ts",
-      "target": "graph_toundirectedgraph",
+      "target": "graph_serializegraph",
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
       "source_location": "L50",
+      "weight": 1,
+      "_src": "src_graph_ts",
+      "_tgt": "graph_serializegraph",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_graph_ts",
+      "target": "graph_toundirectedgraph",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/graph.ts",
+      "source_location": "L74",
       "weight": 1,
       "_src": "src_graph_ts",
       "_tgt": "graph_toundirectedgraph",
@@ -18373,7 +19162,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
-      "source_location": "L75",
+      "source_location": "L99",
       "weight": 1,
       "_src": "src_graph_ts",
       "_tgt": "graph_foreachtraversalneighbor",
@@ -18385,7 +19174,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
-      "source_location": "L87",
+      "source_location": "L111",
       "weight": 1,
       "_src": "src_graph_ts",
       "_tgt": "graph_traversalneighbors",
@@ -18404,12 +19193,24 @@
       "confidence_score": 1
     },
     {
+      "source": "graph_serializegraph",
+      "target": "graph_isdirectedgraph",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/graph.ts",
+      "source_location": "L65",
+      "weight": 1,
+      "_src": "graph_serializegraph",
+      "_tgt": "graph_isdirectedgraph",
+      "confidence_score": 1
+    },
+    {
       "source": "graph_toundirectedgraph",
       "target": "graph_isdirectedgraph",
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
-      "source_location": "L51",
+      "source_location": "L75",
       "weight": 1,
       "_src": "graph_toundirectedgraph",
       "_tgt": "graph_isdirectedgraph",
@@ -18421,7 +19222,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
-      "source_location": "L53",
+      "source_location": "L77",
       "weight": 1,
       "_src": "graph_toundirectedgraph",
       "_tgt": "graph_creategraph",
@@ -18433,7 +19234,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
-      "source_location": "L80",
+      "source_location": "L104",
       "weight": 1,
       "_src": "graph_foreachtraversalneighbor",
       "_tgt": "graph_isdirectedgraph",
@@ -18445,10 +19246,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "src/graph.ts",
-      "source_location": "L89",
+      "source_location": "L113",
       "weight": 1,
       "_src": "graph_traversalneighbors",
       "_tgt": "graph_foreachtraversalneighbor",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_hooks_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/hooks.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_hooks_ts",
+      "_tgt": "src_git_ts",
       "confidence_score": 1
     },
     {
@@ -18573,6 +19386,18 @@
     },
     {
       "source": "src_html_export_ts",
+      "target": "src_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/html-export.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_html_export_ts",
+      "_tgt": "src_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_html_export_ts",
       "target": "html_export_safetohtml",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -18677,6 +19502,42 @@
       "weight": 1,
       "_src": "image_caption_schema_validateimagerouting",
       "_tgt": "image_caption_schema_isstringarray",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_image_dataprep_batch_ts",
+      "target": "src_image_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/image-dataprep-batch.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_image_dataprep_batch_ts",
+      "_tgt": "src_image_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_image_dataprep_batch_ts",
+      "target": "src_image_caption_schema_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/image-dataprep-batch.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_image_dataprep_batch_ts",
+      "_tgt": "src_image_caption_schema_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_image_dataprep_batch_ts",
+      "target": "src_image_routing_calibration_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/image-dataprep-batch.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_image_dataprep_batch_ts",
+      "_tgt": "src_image_routing_calibration_ts",
       "confidence_score": 1
     },
     {
@@ -18833,6 +19694,30 @@
       "weight": 1,
       "_src": "image_dataprep_batch_importimagedataprepbatchresults",
       "_tgt": "image_dataprep_batch_existingvalidsidecarerrors",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_image_dataprep_ts",
+      "target": "src_pdf_ocr_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/image-dataprep.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_image_dataprep_ts",
+      "_tgt": "src_pdf_ocr_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_image_dataprep_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/image-dataprep.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_image_dataprep_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -19097,6 +19982,18 @@
       "weight": 1,
       "_src": "image_dataprep_runimagedataprep",
       "_tgt": "image_dataprep_writeassistantinstructions",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_image_routing_calibration_ts",
+      "target": "src_image_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/image-routing-calibration.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_image_routing_calibration_ts",
+      "_tgt": "src_image_dataprep_ts",
       "confidence_score": 1
     },
     {
@@ -19437,6 +20334,30 @@
     },
     {
       "source": "src_ingest_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ingest.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_ingest_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_ingest_ts",
+      "target": "src_transcribe_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ingest.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "src_ingest_ts",
+      "_tgt": "src_transcribe_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_ingest_ts",
       "target": "ingest_yamlstr",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -19721,6 +20642,42 @@
       "weight": 1,
       "_src": "ingest_savequeryresult",
       "_tgt": "ingest_yamlstr",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_input_scope_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/input-scope.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_input_scope_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_input_scope_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/input-scope.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_input_scope_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_input_scope_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/input-scope.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_input_scope_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -20157,6 +21114,30 @@
     },
     {
       "source": "src_lifecycle_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lifecycle.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_lifecycle_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_lifecycle_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lifecycle.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_lifecycle_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_lifecycle_ts",
       "target": "lifecycle_readjson",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -20445,6 +21426,18 @@
     },
     {
       "source": "src_llm_execution_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/llm-execution.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_llm_execution_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_llm_execution_ts",
       "target": "llm_execution_safename",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -20513,6 +21506,114 @@
       "weight": 1,
       "_src": "src_llm_execution_ts",
       "_tgt": "llm_execution_redactsecrets",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_merge_graphs_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_merge_graphs_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_merge_graphs_ts",
+      "target": "merge_graphs_repotagfromgraphpath",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L19",
+      "weight": 1,
+      "_src": "src_merge_graphs_ts",
+      "_tgt": "merge_graphs_repotagfromgraphpath",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_merge_graphs_ts",
+      "target": "merge_graphs_mergedgraphtype",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L27",
+      "weight": 1,
+      "_src": "src_merge_graphs_ts",
+      "_tgt": "merge_graphs_mergedgraphtype",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_merge_graphs_ts",
+      "target": "merge_graphs_mergehyperedges",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L31",
+      "weight": 1,
+      "_src": "src_merge_graphs_ts",
+      "_tgt": "merge_graphs_mergehyperedges",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_merge_graphs_ts",
+      "target": "merge_graphs_mergegraphsfromfiles",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L46",
+      "weight": 1,
+      "_src": "src_merge_graphs_ts",
+      "_tgt": "merge_graphs_mergegraphsfromfiles",
+      "confidence_score": 1
+    },
+    {
+      "source": "merge_graphs_mergegraphsfromfiles",
+      "target": "merge_graphs_mergedgraphtype",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L67",
+      "weight": 1,
+      "_src": "merge_graphs_mergegraphsfromfiles",
+      "_tgt": "merge_graphs_mergedgraphtype",
+      "confidence_score": 1
+    },
+    {
+      "source": "merge_graphs_mergegraphsfromfiles",
+      "target": "merge_graphs_mergehyperedges",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/merge-graphs.ts",
+      "source_location": "L87",
+      "weight": 1,
+      "_src": "merge_graphs_mergegraphsfromfiles",
+      "_tgt": "merge_graphs_mergehyperedges",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_migrate_state_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/migrate-state.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_migrate_state_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_migrate_state_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/migrate-state.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_migrate_state_ts",
+      "_tgt": "src_paths_ts",
       "confidence_score": 1
     },
     {
@@ -20697,6 +21798,42 @@
     },
     {
       "source": "src_minimal_context_ts",
+      "target": "src_detect_changes_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/minimal-context.ts",
+      "source_location": "L1",
+      "weight": 1,
+      "_src": "src_minimal_context_ts",
+      "_tgt": "src_detect_changes_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_minimal_context_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/minimal-context.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "src_minimal_context_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_minimal_context_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/minimal-context.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_minimal_context_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_minimal_context_ts",
       "target": "minimal_context_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -20849,6 +21986,18 @@
       "weight": 1,
       "_src": "minimal_context_buildminimalcontext",
       "_tgt": "minimal_context_suggestionsfortask",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_ontology_output_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ontology-output.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_ontology_output_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -21101,6 +22250,18 @@
       "weight": 1,
       "_src": "ontology_output_compileontologyoutputs",
       "_tgt": "ontology_output_writejson",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_ontology_profile_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ontology-profile.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_ontology_profile_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -21753,6 +22914,30 @@
     },
     {
       "source": "src_pdf_ocr_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pdf-ocr.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_pdf_ocr_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pdf_ocr_ts",
+      "target": "src_pdf_preflight_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pdf-ocr.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_pdf_ocr_ts",
+      "_tgt": "src_pdf_preflight_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pdf_ocr_ts",
       "target": "pdf_ocr_clonedetection",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -22233,6 +23418,174 @@
     },
     {
       "source": "src_pipeline_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_input_scope_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_input_scope_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_build_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L13",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_build_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_cluster_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_cluster_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L15",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L17",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_html_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L18",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_html_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_extract_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L19",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_extract_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L20",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_lifecycle_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L21",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_lifecycle_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_wiki_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L22",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_wiki_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_portable_artifacts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L23",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_portable_artifacts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pipeline.ts",
+      "source_location": "L28",
+      "weight": 1,
+      "_src": "src_pipeline_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_pipeline_ts",
       "target": "pipeline_defaultlabels",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -22349,6 +23702,18 @@
       "weight": 1,
       "_src": "pipeline_buildproject",
       "_tgt": "pipeline_defaultlabels",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_portable_artifacts_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/portable-artifacts.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_portable_artifacts_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -22845,6 +24210,18 @@
     },
     {
       "source": "src_profile_prompts_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-prompts.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_profile_prompts_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_prompts_ts",
       "target": "profile_prompts_samplelimit",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -23157,6 +24534,18 @@
     },
     {
       "source": "src_profile_registry_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-registry.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_profile_registry_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_registry_ts",
       "target": "profile_registry_readregistryrows",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -23273,6 +24662,42 @@
       "weight": 1,
       "_src": "profile_registry_registryrecordstoextraction",
       "_tgt": "profile_registry_safeidpart",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_report_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-report.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_profile_report_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_report_ts",
+      "target": "src_profile_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-report.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "src_profile_report_ts",
+      "_tgt": "src_profile_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_report_ts",
+      "target": "src_configured_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-report.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_profile_report_ts",
+      "_tgt": "src_configured_dataprep_ts",
       "confidence_score": 1
     },
     {
@@ -23649,6 +25074,30 @@
     },
     {
       "source": "src_profile_validate_ts",
+      "target": "src_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-validate.ts",
+      "source_location": "L1",
+      "weight": 1,
+      "_src": "src_profile_validate_ts",
+      "_tgt": "src_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_validate_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/profile-validate.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "src_profile_validate_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_profile_validate_ts",
       "target": "profile_validate_stringvalue",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -24005,6 +25454,18 @@
       "weight": 1,
       "_src": "profile_validate_validateedge",
       "_tgt": "profile_validate_addissue",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_project_config_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/project-config.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_project_config_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -24453,6 +25914,42 @@
     },
     {
       "source": "src_recommend_ts",
+      "target": "src_review_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/recommend.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_recommend_ts",
+      "_tgt": "src_review_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_recommend_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/recommend.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_recommend_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_recommend_ts",
+      "target": "src_lifecycle_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/recommend.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_recommend_ts",
+      "_tgt": "src_lifecycle_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_recommend_ts",
       "target": "recommend_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -24896,6 +26393,198 @@
       "confidence_score": 1
     },
     {
+      "source": "src_repo_clone_ts",
+      "target": "repo_clone_execgit",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L28",
+      "weight": 1,
+      "_src": "src_repo_clone_ts",
+      "_tgt": "repo_clone_execgit",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_repo_clone_ts",
+      "target": "repo_clone_maybegithubrepo",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L36",
+      "weight": 1,
+      "_src": "src_repo_clone_ts",
+      "_tgt": "repo_clone_maybegithubrepo",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_repo_clone_ts",
+      "target": "repo_clone_reponamefromurl",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L49",
+      "weight": 1,
+      "_src": "src_repo_clone_ts",
+      "_tgt": "repo_clone_reponamefromurl",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_repo_clone_ts",
+      "target": "repo_clone_defaultclonedestination",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L68",
+      "weight": 1,
+      "_src": "src_repo_clone_ts",
+      "_tgt": "repo_clone_defaultclonedestination",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_repo_clone_ts",
+      "target": "repo_clone_clonerepo",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L76",
+      "weight": 1,
+      "_src": "src_repo_clone_ts",
+      "_tgt": "repo_clone_clonerepo",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_reponamefromurl",
+      "target": "repo_clone_maybegithubrepo",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L50",
+      "weight": 1,
+      "_src": "repo_clone_reponamefromurl",
+      "_tgt": "repo_clone_maybegithubrepo",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_defaultclonedestination",
+      "target": "repo_clone_maybegithubrepo",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L69",
+      "weight": 1,
+      "_src": "repo_clone_defaultclonedestination",
+      "_tgt": "repo_clone_maybegithubrepo",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_defaultclonedestination",
+      "target": "repo_clone_reponamefromurl",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L73",
+      "weight": 1,
+      "_src": "repo_clone_defaultclonedestination",
+      "_tgt": "repo_clone_reponamefromurl",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_clonerepo",
+      "target": "repo_clone_maybegithubrepo",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L77",
+      "weight": 1,
+      "_src": "repo_clone_clonerepo",
+      "_tgt": "repo_clone_maybegithubrepo",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_clonerepo",
+      "target": "repo_clone_reponamefromurl",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L79",
+      "weight": 1,
+      "_src": "repo_clone_clonerepo",
+      "_tgt": "repo_clone_reponamefromurl",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_clonerepo",
+      "target": "repo_clone_defaultclonedestination",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L80",
+      "weight": 1,
+      "_src": "repo_clone_clonerepo",
+      "_tgt": "repo_clone_defaultclonedestination",
+      "confidence_score": 1
+    },
+    {
+      "source": "repo_clone_clonerepo",
+      "target": "repo_clone_execgit",
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "src/repo-clone.ts",
+      "source_location": "L91",
+      "weight": 1,
+      "_src": "repo_clone_clonerepo",
+      "_tgt": "repo_clone_execgit",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_report_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/report.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_report_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_report_ts",
+      "target": "src_collections_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/report.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_report_ts",
+      "_tgt": "src_collections_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_report_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/report.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "src_report_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_report_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/report.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_report_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "src_report_ts",
       "target": "report_compareflowcriticality",
       "relation": "contains",
@@ -25037,6 +26726,30 @@
       "weight": 1,
       "_src": "report_generate",
       "_tgt": "report_appendreviewsections",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_analysis_ts",
+      "target": "src_review_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-analysis.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_review_analysis_ts",
+      "_tgt": "src_review_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_analysis_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-analysis.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_review_analysis_ts",
+      "_tgt": "src_security_ts",
       "confidence_score": 1
     },
     {
@@ -25389,6 +27102,54 @@
     },
     {
       "source": "src_review_benchmark_ts",
+      "target": "src_detect_changes_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-benchmark.ts",
+      "source_location": "L1",
+      "weight": 1,
+      "_src": "src_review_benchmark_ts",
+      "_tgt": "src_detect_changes_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_benchmark_ts",
+      "target": "src_review_context_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-benchmark.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "src_review_benchmark_ts",
+      "_tgt": "src_review_context_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_benchmark_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-benchmark.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_review_benchmark_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_benchmark_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-benchmark.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_review_benchmark_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_benchmark_ts",
       "target": "review_benchmark_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -25613,6 +27374,18 @@
       "weight": 1,
       "_src": "review_benchmark_reviewbenchmarktomarkdown",
       "_tgt": "review_benchmark_formatmetric",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_context_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review-context.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_review_context_ts",
+      "_tgt": "src_review_store_ts",
       "confidence_score": 1
     },
     {
@@ -26217,6 +27990,54 @@
     },
     {
       "source": "src_review_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_review_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_review_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "src_review_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/review.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "src_review_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_review_ts",
       "target": "review_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -26685,6 +28506,18 @@
     },
     {
       "source": "src_security_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/security.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_security_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_security_ts",
       "target": "security_validateurl",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -26817,6 +28650,54 @@
     },
     {
       "source": "src_semantic_prepare_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/semantic-prepare.ts",
+      "source_location": "L1",
+      "weight": 1,
+      "_src": "src_semantic_prepare_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_semantic_prepare_ts",
+      "target": "src_pdf_ocr_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/semantic-prepare.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "src_semantic_prepare_ts",
+      "_tgt": "src_pdf_ocr_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_semantic_prepare_ts",
+      "target": "src_pdf_preflight_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/semantic-prepare.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_semantic_prepare_ts",
+      "_tgt": "src_pdf_preflight_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_semantic_prepare_ts",
+      "target": "src_transcribe_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/semantic-prepare.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_semantic_prepare_ts",
+      "_tgt": "src_transcribe_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_semantic_prepare_ts",
       "target": "semantic_prepare_preparesemanticdetection",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -26825,6 +28706,114 @@
       "weight": 1,
       "_src": "src_semantic_prepare_ts",
       "_tgt": "semantic_prepare_preparesemanticdetection",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L17",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_search_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L18",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_search_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L19",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_summary_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L20",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_summary_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_review_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L21",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_review_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_review_analysis_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L22",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_review_analysis_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_serve_ts",
+      "target": "src_recommend_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/serve.ts",
+      "source_location": "L23",
+      "weight": 1,
+      "_src": "src_serve_ts",
+      "_tgt": "src_recommend_ts",
       "confidence_score": 1
     },
     {
@@ -27209,6 +29198,450 @@
       "weight": 1,
       "_src": "serve_serve",
       "_tgt": "serve_getversion",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_benchmark_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L15",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_benchmark_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_cache_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_cache_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_build_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L17",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_build_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_cluster_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L18",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_cluster_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L19",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_input_scope_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L20",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_input_scope_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L25",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_html_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L26",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_html_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_extract_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L27",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_extract_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L28",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_ingest_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L34",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_ingest_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L35",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L36",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_summary_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L37",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_summary_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_review_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L38",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_review_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_review_analysis_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L39",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_review_analysis_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_review_context_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L40",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_review_context_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_detect_changes_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L41",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_detect_changes_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_minimal_context_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L42",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_minimal_context_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_recommend_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L43",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_recommend_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L44",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_portable_artifacts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L45",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_portable_artifacts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L51",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_pdf_preflight_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L63",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_pdf_preflight_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_semantic_prepare_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L64",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_semantic_prepare_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L65",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L66",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_ontology_profile_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_configured_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L67",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_configured_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_profile_prompts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L68",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_profile_prompts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_profile_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L69",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_profile_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_profile_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L70",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_profile_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_ontology_output_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L71",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_ontology_output_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_image_routing_calibration_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L72",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_image_routing_calibration_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_image_dataprep_batch_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L79",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_image_dataprep_batch_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_search_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L83",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_search_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_skill_runtime_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/skill-runtime.ts",
+      "source_location": "L84",
+      "weight": 1,
+      "_src": "src_skill_runtime_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -27657,6 +30090,42 @@
     },
     {
       "source": "src_summary_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/summary.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "src_summary_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_summary_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/summary.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "src_summary_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_summary_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/summary.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "src_summary_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_summary_ts",
       "target": "summary_comparestrings",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -27917,6 +30386,30 @@
       "weight": 1,
       "_src": "summary_buildfirsthopsummary",
       "_tgt": "summary_buildnextbestaction",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_transcribe_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/transcribe.ts",
+      "source_location": "L17",
+      "weight": 1,
+      "_src": "src_transcribe_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_transcribe_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/transcribe.ts",
+      "source_location": "L18",
+      "weight": 1,
+      "_src": "src_transcribe_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -28557,6 +31050,78 @@
     },
     {
       "source": "src_watch_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/watch.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "src_watch_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_watch_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/watch.ts",
+      "source_location": "L15",
+      "weight": 1,
+      "_src": "src_watch_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_watch_ts",
+      "target": "src_input_scope_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/watch.ts",
+      "source_location": "L23",
+      "weight": 1,
+      "_src": "src_watch_ts",
+      "_tgt": "src_input_scope_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_watch_ts",
+      "target": "src_lifecycle_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/watch.ts",
+      "source_location": "L24",
+      "weight": 1,
+      "_src": "src_watch_ts",
+      "_tgt": "src_lifecycle_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_watch_ts",
+      "target": "src_portable_artifacts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/watch.ts",
+      "source_location": "L25",
+      "weight": 1,
+      "_src": "src_watch_ts",
+      "_tgt": "src_portable_artifacts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_watch_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/watch.ts",
+      "source_location": "L31",
+      "weight": 1,
+      "_src": "src_watch_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_watch_ts",
       "target": "watch_rebuildcode",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -28613,6 +31178,54 @@
       "weight": 1,
       "_src": "src_watch_ts",
       "_tgt": "watch_watch",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_wiki_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/wiki.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "src_wiki_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_wiki_ts",
+      "target": "src_collections_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/wiki.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "src_wiki_ts",
+      "_tgt": "src_collections_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_wiki_ts",
+      "target": "src_graph_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/wiki.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "src_wiki_ts",
+      "_tgt": "src_graph_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "src_wiki_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "src/wiki.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "src_wiki_ts",
+      "_tgt": "src_flows_ts",
       "confidence_score": 1
     },
     {
@@ -28869,6 +31482,30 @@
     },
     {
       "source": "tests_affected_flows_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/affected-flows.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_affected_flows_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_affected_flows_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/affected-flows.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_affected_flows_test_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_affected_flows_test_ts",
       "target": "affected_flows_test_qn",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -28952,6 +31589,30 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_aider_integration_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/aider-integration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_aider_integration_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_analyze_test_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/analyze.test.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "tests_analyze_test_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_analyze_test_ts",
       "target": "analyze_test_buildtestgraph",
       "relation": "contains",
@@ -28964,6 +31625,30 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_build_merge_test_ts",
+      "target": "src_build_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/build-merge.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_build_merge_test_ts",
+      "_tgt": "src_build_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_build_merge_test_ts",
+      "target": "build_merge_test_tempdir",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/build-merge.test.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "tests_build_merge_test_ts",
+      "_tgt": "build_merge_test_tempdir",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_build_project_test_ts",
       "target": "build_project_test_makeprojectdir",
       "relation": "contains",
@@ -28973,6 +31658,66 @@
       "weight": 1,
       "_src": "tests_build_project_test_ts",
       "_tgt": "build_project_test_makeprojectdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_build_test_ts",
+      "target": "src_build_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/build.test.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "tests_build_test_ts",
+      "_tgt": "src_build_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_build_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/build.test.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "tests_build_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_cache_test_ts",
+      "target": "src_cache_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/cache.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_cache_test_ts",
+      "_tgt": "src_cache_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_claude_integration_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/claude-integration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_claude_integration_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_cli_runtime_test_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/cli-runtime.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_cli_runtime_test_ts",
+      "_tgt": "src_git_ts",
       "confidence_score": 1
     },
     {
@@ -29109,6 +31854,18 @@
     },
     {
       "source": "tests_cli_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/cli.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_cli_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_cli_test_ts",
       "target": "cli_test_tempprofileproject",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -29145,6 +31902,18 @@
     },
     {
       "source": "tests_cluster_test_ts",
+      "target": "src_cluster_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/cluster.test.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "tests_cluster_test_ts",
+      "_tgt": "src_cluster_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_cluster_test_ts",
       "target": "cluster_test_makegraph",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -29153,6 +31922,78 @@
       "weight": 1,
       "_src": "tests_cluster_test_ts",
       "_tgt": "cluster_test_makegraph",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_codex_integration_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/codex-integration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_codex_integration_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_configured_dataprep_test_ts",
+      "target": "src_configured_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/configured-dataprep.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_configured_dataprep_test_ts",
+      "_tgt": "src_configured_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_configured_dataprep_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/configured-dataprep.test.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "tests_configured_dataprep_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_configured_dataprep_test_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/configured-dataprep.test.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "tests_configured_dataprep_test_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_configured_dataprep_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/configured-dataprep.test.ts",
+      "source_location": "L13",
+      "weight": 1,
+      "_src": "tests_configured_dataprep_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_configured_dataprep_test_ts",
+      "target": "src_semantic_prepare_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/configured-dataprep.test.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "tests_configured_dataprep_test_ts",
+      "_tgt": "src_semantic_prepare_ts",
       "confidence_score": 1
     },
     {
@@ -29177,6 +32018,54 @@
       "weight": 1,
       "_src": "tests_configured_dataprep_test_ts",
       "_tgt": "configured_dataprep_test_allfiles",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_cursor_integration_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/cursor-integration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_cursor_integration_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_changes_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect-changes.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_detect_changes_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_changes_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect-changes.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_detect_changes_test_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_changes_test_ts",
+      "target": "src_detect_changes_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect-changes.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_detect_changes_test_ts",
+      "_tgt": "src_detect_changes_ts",
       "confidence_score": 1
     },
     {
@@ -29225,6 +32114,90 @@
       "weight": 1,
       "_src": "detect_changes_test_addnode",
       "_tgt": "detect_changes_test_qn",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_test_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_detect_test_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_test_ts",
+      "target": "src_input_scope_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_detect_test_ts",
+      "_tgt": "src_input_scope_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_test_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_detect_test_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_detect_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/detect.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_detect_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_export_json_test_ts",
+      "target": "src_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/export-json.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_export_json_test_ts",
+      "_tgt": "src_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_export_json_test_ts",
+      "target": "export_json_test_tempdir",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/export-json.test.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "tests_export_json_test_ts",
+      "_tgt": "export_json_test_tempdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_extract_call_confidence_test_ts",
+      "target": "src_extract_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/extract-call-confidence.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_extract_call_confidence_test_ts",
+      "_tgt": "src_extract_ts",
       "confidence_score": 1
     },
     {
@@ -30501,6 +33474,30 @@
     },
     {
       "source": "tests_flows_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/flows.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_flows_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_flows_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/flows.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_flows_test_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_flows_test_ts",
       "target": "flows_test_tempdir",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -30560,6 +33557,30 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_gemini_integration_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/gemini-integration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_gemini_integration_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_hooks_test_ts",
+      "target": "src_hooks_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/hooks.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_hooks_test_ts",
+      "_tgt": "src_hooks_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_hooks_test_ts",
       "target": "hooks_test_git",
       "relation": "contains",
@@ -30596,6 +33617,66 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_html_export_test_ts",
+      "target": "src_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/html-export.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_html_export_test_ts",
+      "_tgt": "src_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_html_export_test_ts",
+      "target": "src_html_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/html-export.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_html_export_test_ts",
+      "_tgt": "src_html_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_batch_test_ts",
+      "target": "src_image_dataprep_batch_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep-batch.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_image_dataprep_batch_test_ts",
+      "_tgt": "src_image_dataprep_batch_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_batch_test_ts",
+      "target": "src_image_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep-batch.test.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "tests_image_dataprep_batch_test_ts",
+      "_tgt": "src_image_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_batch_test_ts",
+      "target": "src_image_routing_calibration_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep-batch.test.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "tests_image_dataprep_batch_test_ts",
+      "_tgt": "src_image_routing_calibration_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_image_dataprep_batch_test_ts",
       "target": "image_dataprep_batch_test_maketempdir",
       "relation": "contains",
@@ -30617,6 +33698,54 @@
       "weight": 1,
       "_src": "tests_image_dataprep_batch_test_ts",
       "_tgt": "image_dataprep_batch_test_manifest",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_test_ts",
+      "target": "src_image_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_image_dataprep_test_ts",
+      "_tgt": "src_image_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_test_ts",
+      "target": "src_image_caption_schema_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_image_dataprep_test_ts",
+      "_tgt": "src_image_caption_schema_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_image_dataprep_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_dataprep_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-dataprep.test.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "tests_image_dataprep_test_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -30645,6 +33774,30 @@
     },
     {
       "source": "tests_image_routing_calibration_test_ts",
+      "target": "src_image_routing_calibration_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-routing-calibration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_image_routing_calibration_test_ts",
+      "_tgt": "src_image_routing_calibration_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_routing_calibration_test_ts",
+      "target": "src_image_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/image-routing-calibration.test.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "tests_image_routing_calibration_test_ts",
+      "_tgt": "src_image_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_image_routing_calibration_test_ts",
       "target": "image_routing_calibration_test_maketempdir",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -30653,6 +33806,30 @@
       "weight": 1,
       "_src": "tests_image_routing_calibration_test_ts",
       "_tgt": "image_routing_calibration_test_maketempdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ingest_test_ts",
+      "target": "src_ingest_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ingest.test.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "tests_ingest_test_ts",
+      "_tgt": "src_ingest_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ingest_test_ts",
+      "target": "src_transcribe_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ingest.test.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "tests_ingest_test_ts",
+      "_tgt": "src_transcribe_ts",
       "confidence_score": 1
     },
     {
@@ -30716,6 +33893,78 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_install_preview_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/install-preview.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_install_preview_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_language_surface_test_ts",
+      "target": "src_extract_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/language-surface.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_language_surface_test_ts",
+      "_tgt": "src_extract_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_lifecycle_test_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/lifecycle.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_lifecycle_test_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_lifecycle_test_ts",
+      "target": "src_lifecycle_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/lifecycle.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_lifecycle_test_ts",
+      "_tgt": "src_lifecycle_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_llm_execution_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/llm-execution.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_llm_execution_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_llm_execution_test_ts",
+      "target": "src_llm_execution_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/llm-execution.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_llm_execution_test_ts",
+      "_tgt": "src_llm_execution_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_llm_execution_test_ts",
       "target": "llm_execution_test_maketempdir",
       "relation": "contains",
@@ -30725,6 +33974,18 @@
       "weight": 1,
       "_src": "tests_llm_execution_test_ts",
       "_tgt": "llm_execution_test_maketempdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_migrate_state_test_ts",
+      "target": "src_migrate_state_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/migrate-state.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_migrate_state_test_ts",
+      "_tgt": "src_migrate_state_ts",
       "confidence_score": 1
     },
     {
@@ -30749,6 +34010,42 @@
       "weight": 1,
       "_src": "tests_migrate_state_test_ts",
       "_tgt": "migrate_state_test_git",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_minimal_context_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/minimal-context.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_minimal_context_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_minimal_context_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/minimal-context.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_minimal_context_test_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_minimal_context_test_ts",
+      "target": "src_minimal_context_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/minimal-context.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_minimal_context_test_ts",
+      "_tgt": "src_minimal_context_ts",
       "confidence_score": 1
     },
     {
@@ -30836,6 +34133,54 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_mistral_ocr_integration_test_ts",
+      "target": "src_pdf_ocr_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/mistral-ocr.integration.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_mistral_ocr_integration_test_ts",
+      "_tgt": "src_pdf_ocr_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ontology_output_test_ts",
+      "target": "src_ontology_output_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ontology-output.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_ontology_output_test_ts",
+      "_tgt": "src_ontology_output_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ontology_output_test_ts",
+      "target": "src_profile_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ontology-output.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_ontology_output_test_ts",
+      "_tgt": "src_profile_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ontology_output_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ontology-output.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_ontology_output_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_ontology_output_test_ts",
       "target": "ontology_output_test_maketempdir",
       "relation": "contains",
@@ -30845,6 +34190,30 @@
       "weight": 1,
       "_src": "tests_ontology_output_test_ts",
       "_tgt": "ontology_output_test_maketempdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ontology_profile_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ontology-profile.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_ontology_profile_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_ontology_profile_test_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/ontology-profile.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_ontology_profile_test_ts",
+      "_tgt": "src_ontology_profile_ts",
       "confidence_score": 1
     },
     {
@@ -30884,6 +34253,150 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_opencode_integration_test_ts",
+      "target": "src_cli_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/opencode-integration.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_opencode_integration_test_ts",
+      "_tgt": "src_cli_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_paths_test_ts",
+      "target": "src_paths_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/paths.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_paths_test_ts",
+      "_tgt": "src_paths_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pdf_preflight_test_ts",
+      "target": "src_pdf_ocr_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pdf-preflight.test.ts",
+      "source_location": "L24",
+      "weight": 1,
+      "_src": "tests_pdf_preflight_test_ts",
+      "_tgt": "src_pdf_ocr_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pdf_preflight_test_ts",
+      "target": "src_pdf_preflight_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pdf-preflight.test.ts",
+      "source_location": "L25",
+      "weight": 1,
+      "_src": "tests_pdf_preflight_test_ts",
+      "_tgt": "src_pdf_preflight_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pdf_preflight_test_ts",
+      "target": "src_semantic_prepare_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pdf-preflight.test.ts",
+      "source_location": "L26",
+      "weight": 1,
+      "_src": "tests_pdf_preflight_test_ts",
+      "_tgt": "src_semantic_prepare_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_detect_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_detect_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_build_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_build_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_cluster_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L13",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_cluster_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_analyze_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_analyze_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L15",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L16",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_pipeline_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/pipeline.test.ts",
+      "source_location": "L17",
+      "weight": 1,
+      "_src": "tests_pipeline_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_platform_v4_integration_test_ts",
       "target": "platform_v4_integration_test_runcliintemp",
       "relation": "contains",
@@ -30893,6 +34406,30 @@
       "weight": 1,
       "_src": "tests_platform_v4_integration_test_ts",
       "_tgt": "platform_v4_integration_test_runcliintemp",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_portable_artifacts_test_ts",
+      "target": "src_portable_artifacts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/portable-artifacts.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_portable_artifacts_test_ts",
+      "_tgt": "src_portable_artifacts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_portable_artifacts_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/portable-artifacts.test.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "tests_portable_artifacts_test_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -30909,6 +34446,114 @@
     },
     {
       "source": "tests_profile_pipeline_test_ts",
+      "target": "src_build_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_build_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_cluster_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_cluster_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_configured_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_configured_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_export_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_export_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_profile_prompts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_profile_prompts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_profile_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_profile_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_profile_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_profile_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L13",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-pipeline.test.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "tests_profile_pipeline_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_pipeline_test_ts",
       "target": "profile_pipeline_test_makeproject",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -30917,6 +34562,66 @@
       "weight": 1,
       "_src": "tests_profile_pipeline_test_ts",
       "_tgt": "profile_pipeline_test_makeproject",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_prompts_test_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-prompts.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_profile_prompts_test_ts",
+      "_tgt": "src_ontology_profile_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_prompts_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-prompts.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_profile_prompts_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_prompts_test_ts",
+      "target": "src_profile_registry_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-prompts.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_profile_prompts_test_ts",
+      "_tgt": "src_profile_registry_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_prompts_test_ts",
+      "target": "src_profile_prompts_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-prompts.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_profile_prompts_test_ts",
+      "_tgt": "src_profile_prompts_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_prompts_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-prompts.test.ts",
+      "source_location": "L12",
+      "weight": 1,
+      "_src": "tests_profile_prompts_test_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -30933,6 +34638,54 @@
     },
     {
       "source": "tests_profile_registry_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-registry.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_profile_registry_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_registry_test_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-registry.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_profile_registry_test_ts",
+      "_tgt": "src_ontology_profile_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_registry_test_ts",
+      "target": "src_profile_registry_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-registry.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_profile_registry_test_ts",
+      "_tgt": "src_profile_registry_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_registry_test_ts",
+      "target": "src_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-registry.test.ts",
+      "source_location": "L14",
+      "weight": 1,
+      "_src": "tests_profile_registry_test_ts",
+      "_tgt": "src_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_registry_test_ts",
       "target": "profile_registry_test_maketempdir",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -30941,6 +34694,78 @@
       "weight": 1,
       "_src": "tests_profile_registry_test_ts",
       "_tgt": "profile_registry_test_maketempdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_report_test_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-report.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_profile_report_test_ts",
+      "_tgt": "src_ontology_profile_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_report_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-report.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_profile_report_test_ts",
+      "_tgt": "src_project_config_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_report_test_ts",
+      "target": "src_profile_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-report.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_profile_report_test_ts",
+      "_tgt": "src_profile_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_report_test_ts",
+      "target": "src_configured_dataprep_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-report.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_profile_report_test_ts",
+      "_tgt": "src_configured_dataprep_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_report_test_ts",
+      "target": "src_profile_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-report.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_profile_report_test_ts",
+      "_tgt": "src_profile_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_report_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-report.test.ts",
+      "source_location": "L9",
+      "weight": 1,
+      "_src": "tests_profile_report_test_ts",
+      "_tgt": "src_types_ts",
       "confidence_score": 1
     },
     {
@@ -30969,6 +34794,42 @@
     },
     {
       "source": "tests_profile_validate_test_ts",
+      "target": "src_ontology_profile_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-validate.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_profile_validate_test_ts",
+      "_tgt": "src_ontology_profile_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_validate_test_ts",
+      "target": "src_profile_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-validate.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_profile_validate_test_ts",
+      "_tgt": "src_profile_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_validate_test_ts",
+      "target": "src_types_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/profile-validate.test.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "tests_profile_validate_test_ts",
+      "_tgt": "src_types_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_profile_validate_test_ts",
       "target": "profile_validate_test_profile",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -30989,6 +34850,18 @@
       "weight": 1,
       "_src": "tests_profile_validate_test_ts",
       "_tgt": "profile_validate_test_baseextraction",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_project_config_test_ts",
+      "target": "src_project_config_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/project-config.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_project_config_test_ts",
+      "_tgt": "src_project_config_ts",
       "confidence_score": 1
     },
     {
@@ -31017,6 +34890,18 @@
     },
     {
       "source": "tests_public_api_test_ts",
+      "target": "src_index_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/public-api.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_public_api_test_ts",
+      "_tgt": "src_index_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_public_api_test_ts",
       "target": "public_api_test_maketempdir",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -31037,6 +34922,30 @@
       "weight": 1,
       "_src": "tests_public_api_test_ts",
       "_tgt": "public_api_test_makegraph",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_recommend_test_ts",
+      "target": "src_recommend_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/recommend.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_recommend_test_ts",
+      "_tgt": "src_recommend_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_recommend_test_ts",
+      "target": "src_lifecycle_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/recommend.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_recommend_test_ts",
+      "_tgt": "src_lifecycle_ts",
       "confidence_score": 1
     },
     {
@@ -31064,6 +34973,90 @@
       "confidence_score": 1
     },
     {
+      "source": "tests_repo_clone_test_ts",
+      "target": "src_repo_clone_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_repo_clone_test_ts",
+      "_tgt": "src_repo_clone_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_repo_clone_test_ts",
+      "target": "src_git_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_repo_clone_test_ts",
+      "_tgt": "src_git_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_repo_clone_test_ts",
+      "target": "repo_clone_test_tempdir",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L10",
+      "weight": 1,
+      "_src": "tests_repo_clone_test_ts",
+      "_tgt": "repo_clone_test_tempdir",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_repo_clone_test_ts",
+      "target": "repo_clone_test_initrepo",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/repo-clone.test.ts",
+      "source_location": "L22",
+      "weight": 1,
+      "_src": "tests_repo_clone_test_ts",
+      "_tgt": "repo_clone_test_initrepo",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_report_test_ts",
+      "target": "src_report_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/report.test.ts",
+      "source_location": "L3",
+      "weight": 1,
+      "_src": "tests_report_test_ts",
+      "_tgt": "src_report_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_report_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/report.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_report_test_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_analysis_test_ts",
+      "target": "src_review_analysis_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-analysis.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_review_analysis_test_ts",
+      "_tgt": "src_review_analysis_ts",
+      "confidence_score": 1
+    },
+    {
       "source": "tests_review_analysis_test_ts",
       "target": "review_analysis_test_makegraph",
       "relation": "contains",
@@ -31073,6 +35066,42 @@
       "weight": 1,
       "_src": "tests_review_analysis_test_ts",
       "_tgt": "review_analysis_test_makegraph",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_benchmark_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-benchmark.test.ts",
+      "source_location": "L5",
+      "weight": 1,
+      "_src": "tests_review_benchmark_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_benchmark_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-benchmark.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_review_benchmark_test_ts",
+      "_tgt": "src_flows_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_benchmark_test_ts",
+      "target": "src_review_benchmark_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-benchmark.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_review_benchmark_test_ts",
+      "_tgt": "src_review_benchmark_ts",
       "confidence_score": 1
     },
     {
@@ -31157,6 +35186,30 @@
       "weight": 1,
       "_src": "review_benchmark_test_makebenchmarkstore",
       "_tgt": "review_benchmark_test_addcall",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_context_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-context.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_review_context_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_context_test_ts",
+      "target": "src_review_context_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-context.test.ts",
+      "source_location": "L8",
+      "weight": 1,
+      "_src": "tests_review_context_test_ts",
+      "_tgt": "src_review_context_ts",
       "confidence_score": 1
     },
     {
@@ -31257,6 +35310,18 @@
     },
     {
       "source": "tests_review_store_test_ts",
+      "target": "src_review_store_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review-store.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_review_store_test_ts",
+      "_tgt": "src_review_store_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_store_test_ts",
       "target": "review_store_test_makereviewgraph",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -31269,6 +35334,18 @@
     },
     {
       "source": "tests_review_test_ts",
+      "target": "src_review_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/review.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_review_test_ts",
+      "_tgt": "src_review_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_review_test_ts",
       "target": "review_test_makegraph",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -31277,6 +35354,42 @@
       "weight": 1,
       "_src": "tests_review_test_ts",
       "_tgt": "review_test_makegraph",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_search_test_ts",
+      "target": "src_search_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/search.test.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "tests_search_test_ts",
+      "_tgt": "src_search_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_security_test_ts",
+      "target": "src_security_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/security.test.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "tests_security_test_ts",
+      "_tgt": "src_security_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_serve_test_ts",
+      "target": "src_serve_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/serve.test.ts",
+      "source_location": "L11",
+      "weight": 1,
+      "_src": "tests_serve_test_ts",
+      "_tgt": "src_serve_ts",
       "confidence_score": 1
     },
     {
@@ -31329,6 +35442,18 @@
     },
     {
       "source": "tests_summary_test_ts",
+      "target": "src_summary_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/summary.test.ts",
+      "source_location": "L4",
+      "weight": 1,
+      "_src": "tests_summary_test_ts",
+      "_tgt": "src_summary_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_summary_test_ts",
       "target": "summary_test_makegraph",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -31341,6 +35466,18 @@
     },
     {
       "source": "tests_transcribe_test_ts",
+      "target": "src_transcribe_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/transcribe.test.ts",
+      "source_location": "L22",
+      "weight": 1,
+      "_src": "tests_transcribe_test_ts",
+      "_tgt": "src_transcribe_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_transcribe_test_ts",
       "target": "transcribe_test_mockytdlpdownload",
       "relation": "contains",
       "confidence": "EXTRACTED",
@@ -31349,6 +35486,42 @@
       "weight": 1,
       "_src": "tests_transcribe_test_ts",
       "_tgt": "transcribe_test_mockytdlpdownload",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_validate_test_ts",
+      "target": "src_validate_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/validate.test.ts",
+      "source_location": "L2",
+      "weight": 1,
+      "_src": "tests_validate_test_ts",
+      "_tgt": "src_validate_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_wiki_test_ts",
+      "target": "src_wiki_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/wiki.test.ts",
+      "source_location": "L6",
+      "weight": 1,
+      "_src": "tests_wiki_test_ts",
+      "_tgt": "src_wiki_ts",
+      "confidence_score": 1
+    },
+    {
+      "source": "tests_wiki_test_ts",
+      "target": "src_flows_ts",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "tests/wiki.test.ts",
+      "source_location": "L7",
+      "weight": 1,
+      "_src": "tests_wiki_test_ts",
+      "_tgt": "src_flows_ts",
       "confidence_score": 1
     },
     {

--- a/.graphify/graph.json
+++ b/.graphify/graph.json
@@ -48,8 +48,7 @@
       "42": "Community 42",
       "43": "Community 43",
       "44": "Community 44",
-      "45": "Community 45",
-      "46": "Community 46"
+      "45": "Community 45"
     }
   },
   "nodes": [
@@ -59,8 +58,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_nodecommunitymap",
@@ -68,8 +67,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L20",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_isfilenode",
@@ -77,8 +76,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L29",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_isconceptnode",
@@ -86,8 +85,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L45",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_filecategory",
@@ -95,8 +94,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L54",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_topleveldir",
@@ -104,8 +103,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L65",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_surprisescore",
@@ -113,8 +112,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L69",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_godnodes",
@@ -122,8 +121,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L124",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_surprisingconnections",
@@ -131,8 +130,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L143",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_crossfilesurprises",
@@ -140,8 +139,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L162",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_crosscommunitysurprises",
@@ -149,8 +148,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L201",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_edgebetweennesssurprises",
@@ -158,8 +157,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L256",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_suggestquestions",
@@ -167,8 +166,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L281",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_graphdiff",
@@ -176,8 +175,8 @@
       "file_type": "code",
       "source_file": "src/analyze.ts",
       "source_location": "L404",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_benchmark_ts",
@@ -185,8 +184,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "benchmark_estimatetokens",
@@ -194,8 +193,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L12",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "benchmark_querysubgraphtokens",
@@ -203,8 +202,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L16",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "benchmark_loadgraph",
@@ -212,8 +211,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L77",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "benchmark_runbenchmark",
@@ -221,8 +220,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L82",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "benchmark_printbenchmark",
@@ -230,8 +229,8 @@
       "file_type": "code",
       "source_file": "src/benchmark.ts",
       "source_location": "L138",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_build_ts",
@@ -239,8 +238,8 @@
       "file_type": "code",
       "source_file": "src/build.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_normalizedlabel",
@@ -248,8 +247,8 @@
       "file_type": "code",
       "source_file": "src/build.ts",
       "source_location": "L24",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_deduplicatebylabel",
@@ -257,8 +256,8 @@
       "file_type": "code",
       "source_file": "src/build.ts",
       "source_location": "L32",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_buildfromjson",
@@ -266,8 +265,8 @@
       "file_type": "code",
       "source_file": "src/build.ts",
       "source_location": "L98",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_build",
@@ -275,8 +274,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L31",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_buildmerge",
@@ -284,8 +283,8 @@
       "file_type": "code",
       "source_file": "src/build.ts",
       "source_location": "L182",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_cache_ts",
@@ -401,8 +400,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_getversion",
@@ -410,8 +409,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L41",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_splitfiles",
@@ -419,8 +418,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L52",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_changedfilesfromgit",
@@ -428,8 +427,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L59",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_loadcligraph",
@@ -437,8 +436,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L71",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_resolveportablecheckdir",
@@ -446,8 +445,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L79",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_readjson",
@@ -455,8 +454,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L91",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_writejson",
@@ -464,8 +463,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L95",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_scopeoptiondescription",
@@ -473,8 +472,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L101",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_resolvecliscopeselection",
@@ -482,8 +481,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L105",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_printscopeinspection",
@@ -491,8 +490,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L112",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_loadcliprofilecontext",
@@ -500,8 +499,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L132",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_findbestmatchingnode",
@@ -509,8 +508,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L146",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_canonicalplatformname",
@@ -518,8 +517,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L256",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_platformnamesforerror",
@@ -527,8 +526,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L260",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_resolveglobalskilldestination",
@@ -536,8 +535,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L264",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_opencodeconfigpath",
@@ -545,8 +544,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L372",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_legacyopencodeconfigpath",
@@ -554,8 +553,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L376",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_loadopencodeconfig",
@@ -563,8 +562,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L380",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_previewpath",
@@ -572,8 +571,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L400",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_emptypreview",
@@ -581,8 +580,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L404",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_platforminstallpreview",
@@ -590,8 +589,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L408",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_globalskillinstallpreview",
@@ -599,8 +598,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L461",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_printmutationpreview",
@@ -608,8 +607,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L474",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_findskillfile",
@@ -617,8 +616,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L668",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_renderaiderskill",
@@ -626,8 +625,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L681",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_loadskillcontent",
@@ -635,8 +634,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L688",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_uninstallskill",
@@ -644,8 +643,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L713",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_getinvocationexample",
@@ -653,8 +652,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L741",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_getagentsmdsection",
@@ -662,8 +661,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L745",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_installgeminimcp",
@@ -671,8 +670,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L773",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_uninstallgeminimcp",
@@ -680,8 +679,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L803",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_cursorinstall",
@@ -689,8 +688,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L827",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_cursoruninstall",
@@ -698,8 +697,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L842",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_antigravityinstall",
@@ -707,8 +706,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L853",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_antigravityuninstall",
@@ -716,8 +715,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L881",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_kiroinstall",
@@ -725,8 +724,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L892",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_kirouninstall",
@@ -734,8 +733,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L915",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_vscodeinstall",
@@ -743,8 +742,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L944",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_vscodeuninstall",
@@ -752,8 +751,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L969",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_installopencodeplugin",
@@ -761,8 +760,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L985",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_uninstallopencodeplugin",
@@ -770,8 +769,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1017",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_writeglobalskill",
@@ -779,8 +778,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1056",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_installskill",
@@ -788,8 +787,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1090",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_installclaudehook",
@@ -797,8 +796,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1109",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_uninstallclaudehook",
@@ -806,8 +805,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1133",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_claudeinstall",
@@ -815,8 +814,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1152",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_claudeuninstall",
@@ -824,8 +823,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1177",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_geminiinstall",
@@ -833,8 +832,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1200",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_geminiuninstall",
@@ -842,8 +841,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1228",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_installcodexhook",
@@ -851,8 +850,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1251",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_uninstallcodexhook",
@@ -860,8 +859,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1288",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_agentsinstall",
@@ -869,8 +868,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1302",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_agentsuninstall",
@@ -878,8 +877,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1339",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_checkskillversion",
@@ -887,8 +886,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1370",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_getplatformstocheck",
@@ -896,8 +895,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1381",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_main",
@@ -905,8 +904,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L1422",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_isdirectcliexecution",
@@ -914,8 +913,8 @@
       "file_type": "code",
       "source_file": "src/cli.ts",
       "source_location": "L2629",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "src_cluster_ts",
@@ -923,8 +922,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_partition",
@@ -932,8 +931,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L14",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_splitcommunity",
@@ -941,8 +940,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L24",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_cluster",
@@ -950,8 +949,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L27",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_cohesionscore",
@@ -959,8 +958,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L116",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_scoreall",
@@ -968,8 +967,8 @@
       "file_type": "code",
       "source_file": "src/cluster.ts",
       "source_location": "L130",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_collections_ts",
@@ -977,8 +976,8 @@
       "file_type": "code",
       "source_file": "src/collections.ts",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "collections_tonumericmap",
@@ -986,8 +985,8 @@
       "file_type": "code",
       "source_file": "src/collections.ts",
       "source_location": "L4",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "collections_tostringmap",
@@ -995,8 +994,8 @@
       "file_type": "code",
       "source_file": "src/collections.ts",
       "source_location": "L22",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_configured_dataprep_ts",
@@ -1004,8 +1003,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_uniqueresolved",
@@ -1013,8 +1012,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L79",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_fullpagescreenshotexcludes",
@@ -1022,8 +1021,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L83",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_buildconfigureddetectioninputs",
@@ -1031,8 +1030,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L90",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_emptydetection",
@@ -1040,8 +1039,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L105",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_countwords",
@@ -1049,8 +1048,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L117",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_warningfor",
@@ -1058,8 +1057,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L125",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_recomputedetection",
@@ -1067,8 +1066,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L139",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_mergescopeinspections",
@@ -1076,8 +1075,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L162",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_mergedetections",
@@ -1085,8 +1084,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L181",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_isinside",
@@ -1094,8 +1093,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L203",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_applyconfiguredexcludes",
@@ -1103,8 +1102,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L210",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_writejson",
@@ -1112,8 +1111,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L230",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_writeregistries",
@@ -1121,8 +1120,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L235",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_buildprofilestate",
@@ -1130,8 +1129,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L242",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_writeprofilestate",
@@ -1139,8 +1138,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L265",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_dataprepreport",
@@ -1148,8 +1147,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L269",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_resolveconfigpath",
@@ -1157,8 +1156,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L299",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_runconfigureddataprep",
@@ -1166,8 +1165,8 @@
       "file_type": "code",
       "source_file": "src/configured-dataprep.ts",
       "source_location": "L308",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "src_detect_changes_ts",
@@ -1688,8 +1687,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_getmodulerequire",
@@ -1697,8 +1696,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L33",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_ensureparserinit",
@@ -1706,8 +1705,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L43",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_parsetext",
@@ -1715,8 +1714,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L50",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_resolvegrammarwasm",
@@ -1724,8 +1723,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L59",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_loadlanguage",
@@ -1733,8 +1732,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L95",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_makeid",
@@ -1742,8 +1741,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L109",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_toportablepath",
@@ -1751,8 +1750,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L118",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_infercommonroot",
@@ -1760,8 +1759,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L122",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_projectrelativefilepath",
@@ -1769,8 +1768,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L149",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_remapfilenodeids",
@@ -1778,8 +1777,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L158",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_readtext",
@@ -1787,8 +1786,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L207",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_defaultconfig",
@@ -1796,8 +1795,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L271",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_resolvename",
@@ -1805,8 +1804,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L297",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_findbody",
@@ -1814,8 +1813,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L311",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importpython",
@@ -1823,8 +1822,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L326",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importjs",
@@ -1832,8 +1831,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L358",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importjava",
@@ -1841,8 +1840,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L393",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importc",
@@ -1850,8 +1849,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L438",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importcsharp",
@@ -1859,8 +1858,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L459",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importkotlin",
@@ -1868,8 +1867,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L480",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importscala",
@@ -1877,8 +1876,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L513",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importphp",
@@ -1886,8 +1885,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L534",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importlua",
@@ -1895,8 +1894,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L555",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_importswift",
@@ -1904,8 +1903,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L573",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_getcfuncname",
@@ -1913,8 +1912,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L595",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_getcppfuncname",
@@ -1922,8 +1921,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L605",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_jsextrawalk",
@@ -1931,8 +1930,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L623",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_csharpextrawalk",
@@ -1940,8 +1939,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L660",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_swiftextrawalk",
@@ -1949,8 +1948,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L693",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractgeneric",
@@ -1958,8 +1957,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L924",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractpythonrationale",
@@ -1967,8 +1966,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1398",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractpython",
@@ -1976,8 +1975,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1510",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractjs",
@@ -1985,8 +1984,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1518",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractjava",
@@ -1994,8 +1993,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1524",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractc",
@@ -2003,8 +2002,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1528",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractcpp",
@@ -2012,8 +2011,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1532",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractruby",
@@ -2021,8 +2020,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1536",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractcsharp",
@@ -2030,8 +2029,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1540",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractkotlin",
@@ -2039,8 +2038,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1544",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractscala",
@@ -2048,8 +2047,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1548",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractphp",
@@ -2057,8 +2056,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1552",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractlua",
@@ -2066,8 +2065,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1556",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractswift",
@@ -2075,8 +2074,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1560",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractjulia",
@@ -2084,8 +2083,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1568",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_lineforindex",
@@ -2093,8 +2092,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1792",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractregexbackedcode",
@@ -2102,8 +2101,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1796",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractgo",
@@ -2111,8 +2110,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L1866",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractrust",
@@ -2120,8 +2119,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2073",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractzig",
@@ -2129,8 +2128,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2251",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractpowershell",
@@ -2138,8 +2137,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2437",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractobjc",
@@ -2147,8 +2146,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2632",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractelixir",
@@ -2156,8 +2155,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L2856",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_resolvecrossfileimports",
@@ -2165,8 +2164,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3064",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extractwithdiagnostics",
@@ -2174,8 +2173,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3253",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_extract",
@@ -2183,8 +2182,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3324",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "extract_collectfiles",
@@ -2192,8 +2191,8 @@
       "file_type": "code",
       "source_file": "src/extract.ts",
       "source_location": "L3347",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "src_flows_ts",
@@ -2417,8 +2416,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "git_execgit",
@@ -2426,8 +2425,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L12",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "git_safeexecgit",
@@ -2435,8 +2434,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L30",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "git_resolvefromgitcwd",
@@ -2444,8 +2443,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L39",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "git_gitrevparse",
@@ -2453,8 +2452,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L43",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "git_safegitrevparse",
@@ -2462,8 +2461,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L47",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "git_resolvegitcontext",
@@ -2471,8 +2470,8 @@
       "file_type": "code",
       "source_file": "src/git.ts",
       "source_location": "L51",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_graph_ts",
@@ -2480,8 +2479,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_creategraph",
@@ -2489,8 +2488,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L13",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_isdirectedgraph",
@@ -2498,8 +2497,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L17",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_loadgraphfromdata",
@@ -2507,8 +2506,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L21",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_serializegraph",
@@ -2516,8 +2515,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L50",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_toundirectedgraph",
@@ -2525,8 +2524,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L74",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_foreachtraversalneighbor",
@@ -2534,8 +2533,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L99",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "graph_traversalneighbors",
@@ -2543,8 +2542,8 @@
       "file_type": "code",
       "source_file": "src/graph.ts",
       "source_location": "L111",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_hooks_ts",
@@ -2552,8 +2551,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_installhook",
@@ -2561,8 +2560,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L168",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_uninstallhook",
@@ -2570,8 +2569,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L192",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_hookblockregex",
@@ -2579,8 +2578,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L212",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_escaperegexp",
@@ -2588,8 +2587,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L216",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_install",
@@ -2597,8 +2596,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L220",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_uninstall",
@@ -2606,8 +2605,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L232",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_status",
@@ -2615,8 +2614,8 @@
       "file_type": "code",
       "source_file": "src/hooks.ts",
       "source_location": "L243",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_html_export_ts",
@@ -2642,8 +2641,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_caption_schema_isrecord",
@@ -2651,8 +2650,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L4",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_caption_schema_isstringarray",
@@ -2660,8 +2659,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L8",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_caption_schema_validateimagecaption",
@@ -2669,8 +2668,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L12",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_caption_schema_validateimagerouting",
@@ -2678,8 +2677,8 @@
       "file_type": "code",
       "source_file": "src/image-caption-schema.ts",
       "source_location": "L45",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_image_dataprep_batch_ts",
@@ -2687,8 +2686,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_jsonlline",
@@ -2696,8 +2695,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L40",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_readjsonl",
@@ -2705,8 +2704,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L44",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_asrecord",
@@ -2714,8 +2713,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L52",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_readcaption",
@@ -2723,8 +2722,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L56",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_artifacthasdeeproute",
@@ -2732,8 +2731,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L60",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_exportimagedataprepbatchrequests",
@@ -2741,8 +2740,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L75",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_existingvalidsidecarerrors",
@@ -2750,8 +2749,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L96",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_importimagedataprepbatchresults",
@@ -2759,8 +2758,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep-batch.ts",
       "source_location": "L107",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_image_dataprep_ts",
@@ -2768,8 +2767,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_sha256",
@@ -2777,8 +2776,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L51",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_filehash",
@@ -2786,8 +2785,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L55",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_mimetype",
@@ -2795,8 +2794,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L59",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_fullpagescreenshot",
@@ -2804,8 +2803,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L68",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_sourcepage",
@@ -2813,8 +2812,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L72",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_artifactid",
@@ -2822,8 +2821,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L77",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_pdfartifactbyimage",
@@ -2831,8 +2830,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L81",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_existingimages",
@@ -2840,8 +2839,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L91",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_buildimagedataprepmanifest",
@@ -2849,8 +2848,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L105",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_writeassistantinstructions",
@@ -2858,8 +2857,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L145",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_runimagedataprep",
@@ -2867,8 +2866,8 @@
       "file_type": "code",
       "source_file": "src/image-dataprep.ts",
       "source_location": "L167",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_image_routing_calibration_ts",
@@ -2876,8 +2875,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_asrecord",
@@ -2885,8 +2884,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L107",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_parsefile",
@@ -2894,8 +2893,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L111",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_stringarray",
@@ -2903,8 +2902,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L116",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_numbervalue",
@@ -2912,8 +2911,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L120",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_countarray",
@@ -2921,8 +2920,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L124",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_imageroutingsamplefromcaption",
@@ -2930,8 +2929,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L128",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_normalizebucket",
@@ -2939,8 +2938,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L141",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_loadimageroutinglabels",
@@ -2948,8 +2947,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L153",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_loadimageroutingrules",
@@ -2957,8 +2956,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L173",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_assertacceptedimageroutingrules",
@@ -2966,8 +2965,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L190",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_writeimageroutingcalibrationsamples",
@@ -2975,8 +2974,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L196",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_bucketmatches",
@@ -2984,8 +2983,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L235",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_routeimagewithrules",
@@ -2993,8 +2992,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L246",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_requiresdeep",
@@ -3002,8 +3001,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L263",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_calibrateimagerouting",
@@ -3011,8 +3010,8 @@
       "file_type": "code",
       "source_file": "src/image-routing-calibration.ts",
       "source_location": "L267",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "src_index_ts",
@@ -3020,8 +3019,8 @@
       "file_type": "code",
       "source_file": "src/index.ts",
       "source_location": "L1",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "src_ingest_ts",
@@ -3029,8 +3028,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L1",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_yamlstr",
@@ -3038,8 +3037,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L16",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_safefilename",
@@ -3047,8 +3046,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L24",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_detecturltype",
@@ -3056,8 +3055,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L37",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_htmltomarkdown",
@@ -3065,8 +3064,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L60",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_fetchtweet",
@@ -3074,8 +3073,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L82",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_fetchwebpage",
@@ -3083,8 +3082,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L125",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_fetcharxiv",
@@ -3092,8 +3091,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L159",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_downloadbinary",
@@ -3101,8 +3100,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L225",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_normalizeingestoptions",
@@ -3110,8 +3109,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L242",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_ingest",
@@ -3119,8 +3118,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L263",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "ingest_savequeryresult",
@@ -3128,8 +3127,8 @@
       "file_type": "code",
       "source_file": "src/ingest.ts",
       "source_location": "L331",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "src_input_scope_ts",
@@ -3137,8 +3136,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_splitgitlines",
@@ -3146,8 +3145,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L38",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_toposixpath",
@@ -3155,8 +3154,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L43",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_toreporelative",
@@ -3164,8 +3163,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L47",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_pathspecforprefix",
@@ -3173,8 +3172,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L51",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_isgraphifymemorypath",
@@ -3182,8 +3181,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L56",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_walkfiles",
@@ -3191,8 +3190,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L60",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_resolvegitscopecontext",
@@ -3200,8 +3199,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L80",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_makescope",
@@ -3209,8 +3208,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L101",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_countgitpaths",
@@ -3218,8 +3217,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L133",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_gitinventory",
@@ -3227,8 +3226,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L137",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_appendmemoryfiles",
@@ -3236,8 +3235,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L145",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_buildgitinventory",
@@ -3245,8 +3244,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L157",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_fallbackallscope",
@@ -3254,8 +3253,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L200",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_inspectinputscope",
@@ -3263,8 +3262,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L227",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_isinputscopemode",
@@ -3272,8 +3271,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L271",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_parseinputscopemode",
@@ -3281,8 +3280,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L275",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_resolvecliinputscopeselection",
@@ -3290,8 +3289,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L282",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_resolveconfiguredinputscopeselection",
@@ -3299,8 +3298,8 @@
       "file_type": "code",
       "source_file": "src/input-scope.ts",
       "source_location": "L296",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "src_lifecycle_ts",
@@ -3308,8 +3307,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L1",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_readjson",
@@ -3317,8 +3316,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L60",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_writejson",
@@ -3326,8 +3325,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L68",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_currenthead",
@@ -3335,8 +3334,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L72",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_currentbranch",
@@ -3344,8 +3343,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L76",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_upstreamref",
@@ -3353,8 +3352,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L81",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_mergebase",
@@ -3362,8 +3361,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L85",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_lifecyclepaths",
@@ -3371,8 +3370,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L89",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_readlifecyclemetadata",
@@ -3380,8 +3379,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L97",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_refreshlifecyclemetadata",
@@ -3389,8 +3388,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L104",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_marklifecyclestale",
@@ -3398,8 +3397,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L174",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_marklifecycleanalyzed",
@@ -3407,8 +3406,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L182",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "lifecycle_planlifecycleprune",
@@ -3416,8 +3415,8 @@
       "file_type": "code",
       "source_file": "src/lifecycle.ts",
       "source_location": "L186",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "src_llm_execution_ts",
@@ -3425,8 +3424,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L1",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_safename",
@@ -3434,8 +3433,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L92",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_writeinstruction",
@@ -3443,8 +3442,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L96",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_preflightllmexecution",
@@ -3452,8 +3451,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L101",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_createassistanttextjsonclient",
@@ -3461,8 +3460,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L126",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_createassistantvisionjsonclient",
@@ -3470,8 +3469,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L157",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_redactsecrets",
@@ -3479,8 +3478,8 @@
       "file_type": "code",
       "source_file": "src/llm-execution.ts",
       "source_location": "L192",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "src_merge_graphs_ts",
@@ -3488,8 +3487,8 @@
       "file_type": "code",
       "source_file": "src/merge-graphs.ts",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "merge_graphs_repotagfromgraphpath",
@@ -3497,8 +3496,8 @@
       "file_type": "code",
       "source_file": "src/merge-graphs.ts",
       "source_location": "L19",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "merge_graphs_mergedgraphtype",
@@ -3506,8 +3505,8 @@
       "file_type": "code",
       "source_file": "src/merge-graphs.ts",
       "source_location": "L27",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "merge_graphs_mergehyperedges",
@@ -3515,8 +3514,8 @@
       "file_type": "code",
       "source_file": "src/merge-graphs.ts",
       "source_location": "L31",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "merge_graphs_mergegraphsfromfiles",
@@ -3524,8 +3523,8 @@
       "file_type": "code",
       "source_file": "src/merge-graphs.ts",
       "source_location": "L46",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "src_migrate_state_ts",
@@ -3533,8 +3532,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L1",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_shellquote",
@@ -3542,8 +3541,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L55",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_normalizegitpath",
@@ -3551,8 +3550,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L60",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_collectentries",
@@ -3560,8 +3559,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L64",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_gitadvice",
@@ -3569,8 +3568,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L94",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_plangraphifyoutmigration",
@@ -3578,8 +3577,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L144",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_applyentry",
@@ -3587,8 +3586,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L165",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_migrategraphifyout",
@@ -3596,8 +3595,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L176",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_migrationresulttotext",
@@ -3605,8 +3604,8 @@
       "file_type": "code",
       "source_file": "src/migrate-state.ts",
       "source_location": "L194",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "src_minimal_context_ts",
@@ -3695,8 +3694,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L1",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_sha256",
@@ -3704,8 +3703,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L55",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_normalizedterm",
@@ -3713,8 +3712,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L59",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_stringarray",
@@ -3722,8 +3721,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L63",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_stringvalue",
@@ -3731,8 +3730,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L67",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_ontologynodetype",
@@ -3740,8 +3739,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L73",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_confidencescore",
@@ -3749,8 +3748,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L77",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_sourceref",
@@ -3758,8 +3757,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L81",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_writejson",
@@ -3767,8 +3766,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L86",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_safefilename",
@@ -3776,8 +3775,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L91",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_compilenodes",
@@ -3785,8 +3784,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L95",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_compilerelations",
@@ -3794,8 +3793,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L147",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_writewiki",
@@ -3803,8 +3802,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L163",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_compileontologyoutputs",
@@ -3812,8 +3811,8 @@
       "file_type": "code",
       "source_file": "src/ontology-output.ts",
       "source_location": "L198",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "src_ontology_profile_ts",
@@ -3821,8 +3820,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L1",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_asrecord",
@@ -3830,8 +3829,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L24",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_asstringarray",
@@ -3839,8 +3838,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L30",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizestringmap",
@@ -3848,8 +3847,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L38",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_stableforhash",
@@ -3857,8 +3856,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L45",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_relationendpoints",
@@ -3866,8 +3865,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L58",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizerelation",
@@ -3875,8 +3874,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L65",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizeregistry",
@@ -3884,8 +3883,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L72",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizecitationpolicy",
@@ -3893,8 +3892,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L83",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizehardeningpolicy",
@@ -3902,8 +3901,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L94",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_relationexports",
@@ -3911,8 +3910,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L103",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizeoutputs",
@@ -3920,8 +3919,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L114",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_parseontologyprofile",
@@ -3929,8 +3928,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L139",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_validateontologyprofile",
@@ -3938,8 +3937,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L148",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_hashontologyprofile",
@@ -3947,8 +3946,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L234",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_normalizeontologyprofile",
@@ -3956,8 +3955,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L240",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_bindontologyprofile",
@@ -3965,8 +3964,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L272",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_loadontologyprofile",
@@ -3974,8 +3973,8 @@
       "file_type": "code",
       "source_file": "src/ontology-profile.ts",
       "source_location": "L296",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "src_paths_ts",
@@ -4055,8 +4054,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_clonedetection",
@@ -4064,8 +4063,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L43",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_countwords",
@@ -4073,8 +4072,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L47",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_metadatapath",
@@ -4082,8 +4081,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L51",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_listimageartifacts",
@@ -4091,8 +4090,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L55",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_textmarkdown",
@@ -4100,8 +4099,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L70",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_loadmistralocrmodule",
@@ -4109,8 +4108,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L84",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_writemetadata",
@@ -4118,8 +4117,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L106",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_shouldfail",
@@ -4127,8 +4126,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L119",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_preparepdf",
@@ -4136,8 +4135,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L123",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_dedupe",
@@ -4145,8 +4144,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L251",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_ocr_augmentdetectionwithpdfpreflight",
@@ -4154,8 +4153,8 @@
       "file_type": "code",
       "source_file": "src/pdf-ocr.ts",
       "source_location": "L255",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "src_pdf_preflight_ts",
@@ -4163,8 +4162,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_parsepdfocrmode",
@@ -4172,8 +4171,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L41",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_normalizetext",
@@ -4181,8 +4180,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L53",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_countwords",
@@ -4190,8 +4189,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L57",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_countimagemarkers",
@@ -4199,8 +4198,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L61",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_sha256",
@@ -4208,8 +4207,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L65",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_extractwithpdfparse",
@@ -4217,8 +4216,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L69",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_extractwithpdftotext",
@@ -4226,8 +4225,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L83",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_extractpdftextlayer",
@@ -4235,8 +4234,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L113",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_preflightpdf",
@@ -4244,8 +4243,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L134",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "pdf_preflight_pdfocrsidecarstem",
@@ -4253,8 +4252,8 @@
       "file_type": "code",
       "source_file": "src/pdf-preflight.ts",
       "source_location": "L194",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "src_pipeline_ts",
@@ -4505,8 +4504,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_samplelimit",
@@ -4514,8 +4513,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L26",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_rel",
@@ -4523,8 +4522,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L30",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_nodetypesection",
@@ -4532,8 +4531,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L35",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_relationtypesection",
@@ -4541,8 +4540,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L47",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_registrysection",
@@ -4550,8 +4549,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L54",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_citationsection",
@@ -4559,8 +4558,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L70",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_hardeningsection",
@@ -4568,8 +4567,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L79",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_inputhintssection",
@@ -4577,8 +4576,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L88",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_schemasection",
@@ -4586,8 +4585,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L99",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_genericsafetysection",
@@ -4595,8 +4594,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L110",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_chunkguidance",
@@ -4604,8 +4603,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L119",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_buildprofileextractionprompt",
@@ -4613,8 +4612,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L141",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_buildprofilechunkprompt",
@@ -4622,8 +4621,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L169",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_prompts_buildprofilevalidationprompt",
@@ -4631,8 +4630,8 @@
       "file_type": "code",
       "source_file": "src/profile-prompts.ts",
       "source_location": "L188",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_profile_registry_ts",
@@ -4640,8 +4639,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_readregistryrows",
@@ -4649,8 +4648,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L13",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_field",
@@ -4658,8 +4657,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L40",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_normalizeregistryrecord",
@@ -4667,8 +4666,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L45",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_loadprofileregistry",
@@ -4676,8 +4675,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L72",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_loadprofileregistries",
@@ -4685,8 +4684,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L93",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_safeidpart",
@@ -4694,8 +4693,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L104",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_registryrecordstoextraction",
@@ -4703,8 +4702,8 @@
       "file_type": "code",
       "source_file": "src/profile-registry.ts",
       "source_location": "L111",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "src_profile_report_ts",
@@ -4712,8 +4711,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_rel",
@@ -4721,8 +4720,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L29",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_stringvalue",
@@ -4730,8 +4729,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L35",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_graphnodes",
@@ -4739,8 +4738,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L39",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_graphlinks",
@@ -4748,8 +4747,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L46",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_projectconfigsection",
@@ -4757,8 +4756,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L53",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_registrycoveragesection",
@@ -4766,8 +4765,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L68",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_unattachedentitiessection",
@@ -4775,8 +4774,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L97",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_invalidrelationssection",
@@ -4784,8 +4783,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L112",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_highdegreesection",
@@ -4793,8 +4792,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L126",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_lowevidencesection",
@@ -4802,8 +4801,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L143",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_humanreviewsection",
@@ -4811,8 +4810,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L159",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_pdfocrsection",
@@ -4820,8 +4819,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L167",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_buildprofilereport",
@@ -4829,8 +4828,8 @@
       "file_type": "code",
       "source_file": "src/profile-report.ts",
       "source_location": "L179",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_profile_validate_ts",
@@ -4838,8 +4837,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_stringvalue",
@@ -4847,8 +4846,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L29",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_citations",
@@ -4856,8 +4855,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L33",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_haspagecitation",
@@ -4865,8 +4864,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L40",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_addissue",
@@ -4874,8 +4873,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L45",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_validatecitations",
@@ -4883,8 +4882,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L52",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_validatestatus",
@@ -4892,8 +4891,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L82",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_isregistryseed",
@@ -4901,8 +4900,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L100",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_validatenode",
@@ -4910,8 +4909,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L104",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_isprofileedge",
@@ -4919,8 +4918,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L142",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_validateedge",
@@ -4928,8 +4927,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L158",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_validateprofileextraction",
@@ -4937,8 +4936,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L209",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_profilevalidationresulttojson",
@@ -4946,8 +4945,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L243",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_profilevalidationresulttomarkdown",
@@ -4955,8 +4954,8 @@
       "file_type": "code",
       "source_file": "src/profile-validate.ts",
       "source_location": "L247",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_project_config_ts",
@@ -4964,8 +4963,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L1",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_asrecord",
@@ -4973,8 +4972,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L31",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_asstringarray",
@@ -4982,8 +4981,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L37",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_asboolean",
@@ -4991,8 +4990,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L43",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_asstring",
@@ -5000,8 +4999,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L47",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_asnumber",
@@ -5009,8 +5008,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L51",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_resolvepath",
@@ -5018,8 +5017,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L55",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_registrysourcename",
@@ -5027,8 +5026,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L59",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_buildregistrysources",
@@ -5036,8 +5035,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L64",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_parsepdfocrmode",
@@ -5045,8 +5044,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L73",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_parsecitationminimum",
@@ -5054,8 +5053,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L80",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_parsellmexecutionmode",
@@ -5063,8 +5062,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L87",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_parseimageartifactsource",
@@ -5072,8 +5071,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L94",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_parseinputscopemode",
@@ -5081,8 +5080,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L101",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_discoverprojectconfig",
@@ -5090,8 +5089,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L108",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_parseprojectconfig",
@@ -5099,8 +5098,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L119",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_validateprojectconfig",
@@ -5108,8 +5107,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L127",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_normalizeprojectconfig",
@@ -5117,8 +5116,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L191",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_loadprojectconfig",
@@ -5126,8 +5125,8 @@
       "file_type": "code",
       "source_file": "src/project-config.ts",
       "source_location": "L291",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "src_recommend_ts",
@@ -5135,8 +5134,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L1",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_comparestrings",
@@ -5144,8 +5143,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L68",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_normalizepath",
@@ -5153,8 +5152,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L74",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_uniquesorted",
@@ -5162,8 +5161,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L78",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_isgraphifystatepath",
@@ -5171,8 +5170,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L82",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_maybecommunity",
@@ -5180,8 +5179,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L87",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_sourcematches",
@@ -5189,8 +5188,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L96",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_communitylabel",
@@ -5198,8 +5197,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L103",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_toplevelarea",
@@ -5207,8 +5206,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L112",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_commitprefixforarea",
@@ -5216,8 +5215,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L119",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_fileinfo",
@@ -5225,8 +5224,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L124",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_dominantcommunity",
@@ -5234,8 +5233,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L142",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_groupdraftforfile",
@@ -5243,8 +5242,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L153",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_mergedrafts",
@@ -5252,8 +5251,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L176",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_stalenessfrom",
@@ -5261,8 +5260,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L206",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_confidencerank",
@@ -5270,8 +5269,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L238",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_minconfidence",
@@ -5279,8 +5278,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L242",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_groupconfidence",
@@ -5288,8 +5287,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L249",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_communitiesfromdelta",
@@ -5297,8 +5296,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L274",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_suggestedmessage",
@@ -5306,8 +5305,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L285",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_rationalefor",
@@ -5315,8 +5314,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L291",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_buildcommitrecommendation",
@@ -5324,8 +5323,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L301",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_formatlist",
@@ -5333,8 +5332,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L366",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_commitrecommendationtotext",
@@ -5342,8 +5341,8 @@
       "file_type": "code",
       "source_file": "src/recommend.ts",
       "source_location": "L370",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "src_repo_clone_ts",
@@ -5351,8 +5350,8 @@
       "file_type": "code",
       "source_file": "src/repo-clone.ts",
       "source_location": "L1",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_execgit",
@@ -5360,8 +5359,8 @@
       "file_type": "code",
       "source_file": "src/repo-clone.ts",
       "source_location": "L28",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_maybegithubrepo",
@@ -5369,8 +5368,8 @@
       "file_type": "code",
       "source_file": "src/repo-clone.ts",
       "source_location": "L36",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_reponamefromurl",
@@ -5378,8 +5377,8 @@
       "file_type": "code",
       "source_file": "src/repo-clone.ts",
       "source_location": "L49",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_defaultclonedestination",
@@ -5387,8 +5386,8 @@
       "file_type": "code",
       "source_file": "src/repo-clone.ts",
       "source_location": "L68",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_clonerepo",
@@ -5396,8 +5395,8 @@
       "file_type": "code",
       "source_file": "src/repo-clone.ts",
       "source_location": "L76",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "src_report_ts",
@@ -5477,8 +5476,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_comparestrings",
@@ -5486,8 +5485,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L113",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_uniquesorted",
@@ -5495,8 +5494,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L119",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_maybecommunity",
@@ -5504,8 +5503,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L123",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_communitylabel",
@@ -5513,8 +5512,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L132",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_risklevel",
@@ -5522,8 +5521,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L140",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_communityrisk",
@@ -5531,8 +5530,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L146",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_nodecommunities",
@@ -5540,8 +5539,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L151",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_buildblastradius",
@@ -5549,8 +5548,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L159",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_impactedcommunities",
@@ -5558,8 +5557,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L190",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_ismultimodalpath",
@@ -5567,8 +5566,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L240",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_multimodalsafety",
@@ -5576,8 +5575,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L244",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_buildreviewanalysis",
@@ -5585,8 +5584,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L264",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_nodeline",
@@ -5594,8 +5593,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L292",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_reviewanalysistotext",
@@ -5603,8 +5602,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L298",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_estimatetokens",
@@ -5612,8 +5611,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L340",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_ratio",
@@ -5621,8 +5620,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L344",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_average",
@@ -5630,8 +5629,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L348",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_evaluatereviewanalysis",
@@ -5639,8 +5638,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L354",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_formatmetric",
@@ -5648,8 +5647,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L406",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_reviewevaluationtotext",
@@ -5657,8 +5656,8 @@
       "file_type": "code",
       "source_file": "src/review-analysis.ts",
       "source_location": "L410",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "src_review_benchmark_ts",
@@ -5792,8 +5791,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L1",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_comparestrings",
@@ -5801,8 +5800,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L45",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_normalizepath",
@@ -5810,8 +5809,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L51",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_uniquesorted",
@@ -5819,8 +5818,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L55",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_sourcematches",
@@ -5828,8 +5827,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L59",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_riskforimpactednodes",
@@ -5837,8 +5836,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L66",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_changedfunctionswithouttests",
@@ -5846,8 +5845,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L72",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_issensitivepath",
@@ -5855,8 +5854,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L80",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_isinside",
@@ -5864,8 +5863,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L91",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_formatlines",
@@ -5873,8 +5872,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L96",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_extractrelevantlines",
@@ -5882,8 +5881,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L102",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_readsourcesnippet",
@@ -5891,8 +5890,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L136",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_buildsourcesnippets",
@@ -5900,8 +5899,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L158",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_buildreviewguidance",
@@ -5909,8 +5908,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L168",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_buildreviewcontext",
@@ -5918,8 +5917,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L198",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "review_context_reviewcontexttotext",
@@ -5927,8 +5926,8 @@
       "file_type": "code",
       "source_file": "src/review-context.ts",
       "source_location": "L269",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 25,
+      "community_name": "Community 25"
     },
     {
       "id": "src_review_store_ts",
@@ -6062,8 +6061,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_comparestrings",
@@ -6071,8 +6070,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L42",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_normalizepath",
@@ -6080,8 +6079,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L48",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_uniquesorted",
@@ -6089,8 +6088,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L52",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_maybecommunity",
@@ -6098,8 +6097,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L56",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_nodeinfo",
@@ -6107,8 +6106,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L65",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_comparenodes",
@@ -6116,8 +6115,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L78",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_sourcematches",
@@ -6125,8 +6124,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L82",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_changednodeids",
@@ -6134,8 +6133,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L89",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_impactednodeids",
@@ -6143,8 +6142,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L100",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_neighborcommunities",
@@ -6152,8 +6151,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L110",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_iscodepath",
@@ -6161,8 +6160,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L119",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_istestpath",
@@ -6170,8 +6169,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L123",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_stem",
@@ -6179,8 +6178,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L133",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_likelytestgaps",
@@ -6188,8 +6187,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L140",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_edgetext",
@@ -6197,8 +6196,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L151",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_riskfor",
@@ -6206,8 +6205,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L160",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_highriskchains",
@@ -6215,8 +6214,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L169",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_chainlabel",
@@ -6224,8 +6223,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L219",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_buildreviewdelta",
@@ -6233,8 +6232,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L223",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_nodeline",
@@ -6242,8 +6241,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L266",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_chainline",
@@ -6251,8 +6250,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L272",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_reviewdeltatotext",
@@ -6260,8 +6259,8 @@
       "file_type": "code",
       "source_file": "src/review.ts",
       "source_location": "L286",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "src_search_ts",
@@ -6305,8 +6304,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_validateurl",
@@ -6314,8 +6313,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L24",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_validateurlsync",
@@ -6323,8 +6322,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L65",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_isprivateip",
@@ -6332,8 +6331,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L86",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_safefetch",
@@ -6341,8 +6340,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L116",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_safefetchtext",
@@ -6350,8 +6349,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L168",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_validategraphpath",
@@ -6359,8 +6358,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L185",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_sanitizelabel",
@@ -6368,8 +6367,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L217",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "security_escapehtml",
@@ -6377,8 +6376,8 @@
       "file_type": "code",
       "source_file": "src/security.ts",
       "source_location": "L229",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "src_semantic_prepare_ts",
@@ -6386,8 +6385,8 @@
       "file_type": "code",
       "source_file": "src/semantic-prepare.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "semantic_prepare_preparesemanticdetection",
@@ -6395,8 +6394,8 @@
       "file_type": "code",
       "source_file": "src/semantic-prepare.ts",
       "source_location": "L25",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "src_serve_ts",
@@ -6602,8 +6601,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_readjson",
@@ -6611,8 +6610,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L111",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_writejson",
@@ -6620,8 +6619,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L115",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_scopeoptiondescription",
@@ -6629,8 +6628,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L121",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_resolvecliscopeselection",
@@ -6638,8 +6637,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L125",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_cacheoptionsfromruntime",
@@ -6647,8 +6646,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L132",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_loadprofileruntimecontext",
@@ -6656,8 +6655,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L150",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_getversion",
@@ -6665,8 +6664,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L175",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_defaultlabels",
@@ -6674,8 +6673,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L184",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_maptoobject",
@@ -6683,8 +6682,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L192",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_objecttostringmap",
@@ -6692,8 +6691,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L196",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_ensureextractionshape",
@@ -6701,8 +6700,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L206",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_loadgraph",
@@ -6710,8 +6709,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L216",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_shouldbuilddirected",
@@ -6719,8 +6718,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L221",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_mergehyperedges",
@@ -6728,8 +6727,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L228",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_mergegraphs",
@@ -6737,8 +6736,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L244",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_analyzegraph",
@@ -6746,8 +6745,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L265",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_placeholderdetection",
@@ -6755,8 +6754,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L320",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_mergesemanticartifacts",
@@ -6764,8 +6763,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L332",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_mergeastandsemantic",
@@ -6773,8 +6772,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L356",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_updatecostfile",
@@ -6782,8 +6781,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L380",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_findbestmatchingnode",
@@ -6791,8 +6790,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L414",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_runtimeinfo",
@@ -6800,8 +6799,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L429",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_main",
@@ -6809,8 +6808,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L441",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "skill_runtime_isdirectruntimeexecution",
@@ -6818,8 +6817,8 @@
       "file_type": "code",
       "source_file": "src/skill-runtime.ts",
       "source_location": "L1700",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 17,
+      "community_name": "Community 17"
     },
     {
       "id": "src_summary_ts",
@@ -6827,8 +6826,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_comparestrings",
@@ -6836,8 +6835,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L45",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_round",
@@ -6845,8 +6844,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L51",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_maybecommunity",
@@ -6854,8 +6853,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L55",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_communitylabels",
@@ -6863,8 +6862,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L64",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_graphdensity",
@@ -6872,8 +6871,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L84",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_nodesummary",
@@ -6881,8 +6880,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L92",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_comparehubs",
@@ -6890,8 +6889,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L107",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_communitymembership",
@@ -6899,8 +6898,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L115",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_internaledgecounts",
@@ -6908,8 +6907,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L129",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_buildnextbestaction",
@@ -6917,8 +6916,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L142",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_buildfirsthopsummary",
@@ -6926,8 +6925,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L154",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_hubline",
@@ -6935,8 +6934,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L220",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_firsthopsummarytotext",
@@ -6944,8 +6943,8 @@
       "file_type": "code",
       "source_file": "src/summary.ts",
       "source_location": "L229",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "src_transcribe_ts",
@@ -6953,8 +6952,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L1",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_runcommand",
@@ -6962,8 +6961,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L91",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_defaultwhispercachedir",
@@ -6971,8 +6970,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L109",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_resolverequestedmodel",
@@ -6980,8 +6979,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L123",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_sanitizecachesegment",
@@ -6989,8 +6988,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L135",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_missingmodelfiles",
@@ -6998,8 +6997,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L139",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_validatewhispermodeldir",
@@ -7007,8 +7006,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L143",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_whispermodelrepoid",
@@ -7016,8 +7015,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L153",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_whispermodelrevision",
@@ -7025,8 +7024,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L157",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_modeldownloadurl",
@@ -7034,8 +7033,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L161",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_normalizemodelerror",
@@ -7043,8 +7042,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L165",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_downloadfile",
@@ -7052,8 +7051,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L173",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_ensurewhisperartifacts",
@@ -7061,8 +7060,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L181",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_loadfasterwhispermodule",
@@ -7070,8 +7069,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L230",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_envnumber",
@@ -7079,8 +7078,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L255",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_envboolean",
@@ -7088,8 +7087,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L262",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_getwhispermodel",
@@ -7097,8 +7096,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L268",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_strippromptecho",
@@ -7106,8 +7105,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L295",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_extracttranscripttext",
@@ -7115,8 +7114,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L312",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_isurl",
@@ -7124,8 +7123,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L320",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_downloadaudio",
@@ -7133,8 +7132,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L324",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_buildwhisperprompt",
@@ -7142,8 +7141,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L365",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_transcribe",
@@ -7151,8 +7150,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L381",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_transcribeall",
@@ -7160,8 +7159,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L443",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_clonedetection",
@@ -7169,8 +7168,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L465",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_augmentdetectionwithtranscripts",
@@ -7178,8 +7177,8 @@
       "file_type": "code",
       "source_file": "src/transcribe.ts",
       "source_location": "L469",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "src_types_ts",
@@ -7187,8 +7186,8 @@
       "file_type": "code",
       "source_file": "src/types.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_validate_ts",
@@ -7196,8 +7195,8 @@
       "file_type": "code",
       "source_file": "src/validate.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "validate_validateextraction",
@@ -7205,8 +7204,8 @@
       "file_type": "code",
       "source_file": "src/validate.ts",
       "source_location": "L14",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "validate_assertvalid",
@@ -7214,8 +7213,8 @@
       "file_type": "code",
       "source_file": "src/validate.ts",
       "source_location": "L95",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "src_watch_ts",
@@ -7277,8 +7276,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L1",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_safefilename",
@@ -7286,8 +7285,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L20",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_uniquepagerefs",
@@ -7295,8 +7294,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L30",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_normalizeflows",
@@ -7304,8 +7303,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L52",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_compareflowcriticality",
@@ -7313,8 +7312,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L57",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_flowsthroughnodes",
@@ -7322,8 +7321,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L61",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_crosscommunitylinks",
@@ -7331,8 +7330,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L68",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_communityarticle",
@@ -7340,8 +7339,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L85",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_godnodearticle",
@@ -7349,8 +7348,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L170",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_flowarticle",
@@ -7358,8 +7357,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L210",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_indexmd",
@@ -7367,8 +7366,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L248",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "wiki_towiki",
@@ -7376,8 +7375,8 @@
       "file_type": "code",
       "source_file": "src/wiki.ts",
       "source_location": "L302",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_affected_flows_test_ts",
@@ -7430,8 +7429,8 @@
       "file_type": "code",
       "source_file": "tests/aider-integration.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_analyze_test_ts",
@@ -7439,8 +7438,8 @@
       "file_type": "code",
       "source_file": "tests/analyze.test.ts",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "analyze_test_buildtestgraph",
@@ -7448,8 +7447,8 @@
       "file_type": "code",
       "source_file": "tests/analyze.test.ts",
       "source_location": "L5",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_build_merge_test_ts",
@@ -7457,8 +7456,8 @@
       "file_type": "code",
       "source_file": "tests/build-merge.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_merge_test_tempdir",
@@ -7466,8 +7465,8 @@
       "file_type": "code",
       "source_file": "tests/build-merge.test.ts",
       "source_location": "L9",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_build_project_test_ts",
@@ -7475,8 +7474,8 @@
       "file_type": "code",
       "source_file": "tests/build-project.test.ts",
       "source_location": "L1",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 40,
+      "community_name": "Community 40"
     },
     {
       "id": "build_project_test_makeprojectdir",
@@ -7484,8 +7483,8 @@
       "file_type": "code",
       "source_file": "tests/build-project.test.ts",
       "source_location": "L8",
-      "community": 41,
-      "community_name": "Community 41"
+      "community": 40,
+      "community_name": "Community 40"
     },
     {
       "id": "tests_build_test_ts",
@@ -7493,8 +7492,8 @@
       "file_type": "code",
       "source_file": "tests/build.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_cache_test_ts",
@@ -7511,8 +7510,8 @@
       "file_type": "code",
       "source_file": "tests/claude-integration.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_cli_runtime_test_ts",
@@ -7520,8 +7519,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_tempproject",
@@ -7529,8 +7528,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L15",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_tempprofileproject",
@@ -7538,8 +7537,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L21",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_writegraph",
@@ -7547,8 +7546,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L27",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_writeflowgraph",
@@ -7556,8 +7555,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L51",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_initgitrepo",
@@ -7565,8 +7564,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L73",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_runcli",
@@ -7574,8 +7573,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L79",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_runskillruntime",
@@ -7583,8 +7582,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L84",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "cli_runtime_test_runmain",
@@ -7592,8 +7591,8 @@
       "file_type": "code",
       "source_file": "tests/cli-runtime.test.ts",
       "source_location": "L89",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_cli_test_ts",
@@ -7601,8 +7600,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_test_tempprofileproject",
@@ -7610,8 +7609,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L16",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_test_writegraph",
@@ -7619,8 +7618,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L23",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "cli_test_runcli",
@@ -7628,8 +7627,8 @@
       "file_type": "code",
       "source_file": "tests/cli.test.ts",
       "source_location": "L40",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_cluster_test_ts",
@@ -7637,8 +7636,8 @@
       "file_type": "code",
       "source_file": "tests/cluster.test.ts",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_test_makegraph",
@@ -7646,8 +7645,8 @@
       "file_type": "code",
       "source_file": "tests/cluster.test.ts",
       "source_location": "L5",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tests_codex_integration_test_ts",
@@ -7655,8 +7654,8 @@
       "file_type": "code",
       "source_file": "tests/codex-integration.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_configured_dataprep_test_ts",
@@ -7664,8 +7663,8 @@
       "file_type": "code",
       "source_file": "tests/configured-dataprep.test.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_test_makeproject",
@@ -7673,8 +7672,8 @@
       "file_type": "code",
       "source_file": "tests/configured-dataprep.test.ts",
       "source_location": "L19",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "configured_dataprep_test_allfiles",
@@ -7682,8 +7681,8 @@
       "file_type": "code",
       "source_file": "tests/configured-dataprep.test.ts",
       "source_location": "L30",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "tests_copilot_integration_test_ts",
@@ -7691,8 +7690,8 @@
       "file_type": "code",
       "source_file": "tests/copilot-integration.test.ts",
       "source_location": "L1",
-      "community": 43,
-      "community_name": "Community 43"
+      "community": 42,
+      "community_name": "Community 42"
     },
     {
       "id": "tests_cursor_integration_test_ts",
@@ -7700,8 +7699,8 @@
       "file_type": "code",
       "source_file": "tests/cursor-integration.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_detect_changes_test_ts",
@@ -7745,8 +7744,8 @@
       "file_type": "code",
       "source_file": "tests/detect.test.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_export_json_test_ts",
@@ -7772,8 +7771,8 @@
       "file_type": "code",
       "source_file": "tests/extract-call-confidence.test.ts",
       "source_location": "L1",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "tests_fixtures_sample_c",
@@ -7781,8 +7780,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.c",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_validate",
@@ -7790,8 +7789,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.c",
       "source_location": "L7",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_process",
@@ -7799,8 +7798,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.c",
       "source_location": "L11",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_main",
@@ -7808,8 +7807,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L24",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "tests_fixtures_sample_cpp",
@@ -7817,8 +7816,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cpp",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclient",
@@ -7826,8 +7825,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L3",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclient_httpclient",
@@ -7835,8 +7834,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cpp",
       "source_location": "L7",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "tests_fixtures_sample_cs",
@@ -7844,8 +7843,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L1",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_graphifydemo",
@@ -7853,8 +7852,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L5",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_iprocessor",
@@ -7862,8 +7861,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L7",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_iprocessor_process",
@@ -7871,8 +7870,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.cs",
       "source_location": "L9",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor",
@@ -7880,8 +7879,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L18",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor_process",
@@ -7889,8 +7888,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L15",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor_validate",
@@ -7898,8 +7897,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L19",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_ex",
@@ -7907,8 +7906,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L1",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_myapp_accounts_user",
@@ -7916,8 +7915,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L1",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_myapp_accounts_user_create",
@@ -7925,8 +7924,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L11",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_myapp_accounts_user_find",
@@ -7934,8 +7933,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L17",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "sample_myapp_accounts_user_validate",
@@ -7943,8 +7942,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ex",
       "source_location": "L21",
-      "community": 38,
-      "community_name": "Community 38"
+      "community": 37,
+      "community_name": "Community 37"
     },
     {
       "id": "tests_fixtures_sample_go",
@@ -7952,8 +7951,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "fixtures_server",
@@ -7961,8 +7960,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L8",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_newserver",
@@ -7970,8 +7969,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L12",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "fixtures_server_start",
@@ -7979,8 +7978,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L16",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "fixtures_server_stop",
@@ -7988,8 +7987,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.go",
       "source_location": "L20",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "tests_fixtures_sample_java",
@@ -7997,8 +7996,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L1",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor_dataprocessor",
@@ -8006,8 +8005,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L21",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor_additem",
@@ -8015,8 +8014,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L11",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_processor",
@@ -8024,8 +8023,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L30",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_processor_process",
@@ -8033,8 +8032,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.java",
       "source_location": "L31",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_jl",
@@ -8042,8 +8041,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L1",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_geometry",
@@ -8051,8 +8050,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L1",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "linearalgebra",
@@ -8060,8 +8059,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L3",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "base",
@@ -8069,8 +8068,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L4",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_shape",
@@ -8078,8 +8077,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L6",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_point",
@@ -8087,8 +8086,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L8",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_circle",
@@ -8096,8 +8095,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L13",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_area",
@@ -8105,8 +8104,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L18",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_distance",
@@ -8114,8 +8113,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L22",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_perimeter",
@@ -8123,8 +8122,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L26",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "sample_describe",
@@ -8132,8 +8131,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.jl",
       "source_location": "L28",
-      "community": 32,
-      "community_name": "Community 32"
+      "community": 31,
+      "community_name": "Community 31"
     },
     {
       "id": "tests_fixtures_sample_m",
@@ -8141,8 +8140,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L1",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_animal",
@@ -8150,8 +8149,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L4",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_animal_initwithname",
@@ -8159,8 +8158,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L8",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_animal_speak",
@@ -8168,8 +8167,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L9",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_dog",
@@ -8177,8 +8176,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L29",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "sample_dog_fetch",
@@ -8186,8 +8185,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.m",
       "source_location": "L31",
-      "community": 36,
-      "community_name": "Community 36"
+      "community": 35,
+      "community_name": "Community 35"
     },
     {
       "id": "tests_fixtures_sample_php",
@@ -8195,8 +8194,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.php",
       "source_location": "L1",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_apiclient",
@@ -8204,8 +8203,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L4",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_apiclient_construct",
@@ -8213,8 +8212,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.php",
       "source_location": "L13",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_apiclient_get",
@@ -8222,8 +8221,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L9",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_apiclient_post",
@@ -8231,8 +8230,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L13",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_apiclient_fetch",
@@ -8240,8 +8239,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L19",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_parseresponse",
@@ -8249,8 +8248,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.php",
       "source_location": "L36",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "tests_fixtures_sample_ps1",
@@ -8258,8 +8257,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L1",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_get_data",
@@ -8267,8 +8266,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L4",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_process_items",
@@ -8276,8 +8275,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L13",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor_transform",
@@ -8285,8 +8284,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L25",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "sample_dataprocessor_save",
@@ -8294,8 +8293,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ps1",
       "source_location": "L29",
-      "community": 24,
-      "community_name": "Community 24"
+      "community": 22,
+      "community_name": "Community 22"
     },
     {
       "id": "tests_fixtures_sample_py",
@@ -8303,8 +8302,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L1",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "sample_transformer",
@@ -8312,8 +8311,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L1",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "sample_transformer_init",
@@ -8321,8 +8320,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L2",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "sample_transformer_forward",
@@ -8330,8 +8329,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.py",
       "source_location": "L5",
-      "community": 40,
-      "community_name": "Community 40"
+      "community": 39,
+      "community_name": "Community 39"
     },
     {
       "id": "tests_fixtures_sample_rb",
@@ -8339,8 +8338,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L1",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_apiclient_initialize",
@@ -8348,8 +8347,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L5",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "sample_parse_response",
@@ -8357,8 +8356,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rb",
       "source_location": "L25",
-      "community": 33,
-      "community_name": "Community 33"
+      "community": 32,
+      "community_name": "Community 32"
     },
     {
       "id": "tests_fixtures_sample_rs",
@@ -8366,8 +8365,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L1",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_graph",
@@ -8375,8 +8374,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L3",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_graph_new",
@@ -8384,8 +8383,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L8",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_graph_add_node",
@@ -8393,8 +8392,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L12",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_graph_add_edge",
@@ -8402,8 +8401,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L16",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "sample_build_graph",
@@ -8411,8 +8410,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.rs",
       "source_location": "L21",
-      "community": 37,
-      "community_name": "Community 37"
+      "community": 36,
+      "community_name": "Community 36"
     },
     {
       "id": "tests_fixtures_sample_scala",
@@ -8420,8 +8419,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_config",
@@ -8429,8 +8428,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L3",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclient_get",
@@ -8438,8 +8437,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L10",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclient_post",
@@ -8447,8 +8446,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L14",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclient_buildrequest",
@@ -8456,8 +8455,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L14",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclientfactory",
@@ -8465,8 +8464,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L19",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclientfactory_create",
@@ -8474,8 +8473,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.scala",
       "source_location": "L20",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "tests_fixtures_sample_ts",
@@ -8483,8 +8482,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L1",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_httpclient_constructor",
@@ -8492,8 +8491,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L6",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "sample_buildheaders",
@@ -8501,8 +8500,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample.ts",
       "source_location": "L19",
-      "community": 22,
-      "community_name": "Community 22"
+      "community": 20,
+      "community_name": "Community 20"
     },
     {
       "id": "tests_fixtures_sample_calls_py",
@@ -8510,8 +8509,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L1",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_compute_score",
@@ -8519,8 +8518,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L4",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_normalize",
@@ -8528,8 +8527,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L8",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_run_analysis",
@@ -8537,8 +8536,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L12",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_analyzer",
@@ -8546,8 +8545,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L17",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_analyzer_process",
@@ -8555,8 +8554,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L18",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_analyzer_score",
@@ -8564,8 +8563,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L21",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_analyzer_full_pipeline",
@@ -8573,8 +8572,8 @@
       "file_type": "code",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L24",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "sample_calls_rationale_1",
@@ -8582,8 +8581,8 @@
       "file_type": "rationale",
       "source_file": "tests/fixtures/sample_calls.py",
       "source_location": "L1",
-      "community": 35,
-      "community_name": "Community 35"
+      "community": 34,
+      "community_name": "Community 34"
     },
     {
       "id": "tests_flows_test_ts",
@@ -8636,8 +8635,8 @@
       "file_type": "code",
       "source_file": "tests/gemini-integration.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_hooks_test_ts",
@@ -8645,8 +8644,8 @@
       "file_type": "code",
       "source_file": "tests/hooks.test.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_test_git",
@@ -8654,8 +8653,8 @@
       "file_type": "code",
       "source_file": "tests/hooks.test.ts",
       "source_location": "L20",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "hooks_test_hookpath",
@@ -8663,8 +8662,8 @@
       "file_type": "code",
       "source_file": "tests/hooks.test.ts",
       "source_location": "L30",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_html_export_test_ts",
@@ -8681,8 +8680,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep-batch.test.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_test_maketempdir",
@@ -8690,8 +8689,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep-batch.test.ts",
       "source_location": "L15",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_batch_test_manifest",
@@ -8699,8 +8698,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep-batch.test.ts",
       "source_location": "L27",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "tests_image_dataprep_test_ts",
@@ -8708,8 +8707,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep.test.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_test_maketempdir",
@@ -8717,8 +8716,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep.test.ts",
       "source_location": "L13",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_dataprep_test_detection",
@@ -8726,8 +8725,8 @@
       "file_type": "code",
       "source_file": "tests/image-dataprep.test.ts",
       "source_location": "L19",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "tests_image_routing_calibration_test_ts",
@@ -8735,8 +8734,8 @@
       "file_type": "code",
       "source_file": "tests/image-routing-calibration.test.ts",
       "source_location": "L1",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "image_routing_calibration_test_maketempdir",
@@ -8744,8 +8743,8 @@
       "file_type": "code",
       "source_file": "tests/image-routing-calibration.test.ts",
       "source_location": "L18",
-      "community": 8,
-      "community_name": "Community 8"
+      "community": 9,
+      "community_name": "Community 9"
     },
     {
       "id": "tests_ingest_test_ts",
@@ -8753,8 +8752,8 @@
       "file_type": "code",
       "source_file": "tests/ingest.test.ts",
       "source_location": "L1",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "tests_input_scope_test_ts",
@@ -8762,8 +8761,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_test_initrepo",
@@ -8771,8 +8770,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L20",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_test_write",
@@ -8780,8 +8779,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L26",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "input_scope_test_commit",
@@ -8789,8 +8788,8 @@
       "file_type": "code",
       "source_file": "tests/input-scope.test.ts",
       "source_location": "L32",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_install_preview_test_ts",
@@ -8798,8 +8797,8 @@
       "file_type": "code",
       "source_file": "tests/install-preview.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_language_surface_test_ts",
@@ -8807,8 +8806,8 @@
       "file_type": "code",
       "source_file": "tests/language-surface.test.ts",
       "source_location": "L1",
-      "community": 5,
-      "community_name": "Community 5"
+      "community": 6,
+      "community_name": "Community 6"
     },
     {
       "id": "tests_lifecycle_test_ts",
@@ -8816,8 +8815,8 @@
       "file_type": "code",
       "source_file": "tests/lifecycle.test.ts",
       "source_location": "L1",
-      "community": 7,
-      "community_name": "Community 7"
+      "community": 8,
+      "community_name": "Community 8"
     },
     {
       "id": "tests_llm_execution_test_ts",
@@ -8825,8 +8824,8 @@
       "file_type": "code",
       "source_file": "tests/llm-execution.test.ts",
       "source_location": "L1",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "llm_execution_test_maketempdir",
@@ -8834,8 +8833,8 @@
       "file_type": "code",
       "source_file": "tests/llm-execution.test.ts",
       "source_location": "L16",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_migrate_state_test_ts",
@@ -8843,8 +8842,8 @@
       "file_type": "code",
       "source_file": "tests/migrate-state.test.ts",
       "source_location": "L1",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_test_maketempdir",
@@ -8852,8 +8851,8 @@
       "file_type": "code",
       "source_file": "tests/migrate-state.test.ts",
       "source_location": "L11",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "migrate_state_test_git",
@@ -8861,8 +8860,8 @@
       "file_type": "code",
       "source_file": "tests/migrate-state.test.ts",
       "source_location": "L17",
-      "community": 31,
-      "community_name": "Community 31"
+      "community": 30,
+      "community_name": "Community 30"
     },
     {
       "id": "tests_minimal_context_test_ts",
@@ -8915,8 +8914,8 @@
       "file_type": "code",
       "source_file": "tests/mistral-ocr.integration.test.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "tests_ontology_output_test_ts",
@@ -8924,8 +8923,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-output.test.ts",
       "source_location": "L1",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "ontology_output_test_maketempdir",
@@ -8933,8 +8932,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-output.test.ts",
       "source_location": "L12",
-      "community": 26,
-      "community_name": "Community 26"
+      "community": 24,
+      "community_name": "Community 24"
     },
     {
       "id": "tests_ontology_profile_test_ts",
@@ -8942,8 +8941,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L1",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_test_maketempdir",
@@ -8951,8 +8950,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L18",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_test_write",
@@ -8960,8 +8959,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L24",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "ontology_profile_test_validprofileyaml",
@@ -8969,8 +8968,8 @@
       "file_type": "code",
       "source_file": "tests/ontology-profile.test.ts",
       "source_location": "L29",
-      "community": 20,
-      "community_name": "Community 20"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_opencode_integration_test_ts",
@@ -8978,8 +8977,8 @@
       "file_type": "code",
       "source_file": "tests/opencode-integration.test.ts",
       "source_location": "L1",
-      "community": 3,
-      "community_name": "Community 3"
+      "community": 4,
+      "community_name": "Community 4"
     },
     {
       "id": "tests_paths_test_ts",
@@ -8996,8 +8995,8 @@
       "file_type": "code",
       "source_file": "tests/pdf-preflight.test.ts",
       "source_location": "L1",
-      "community": 9,
-      "community_name": "Community 9"
+      "community": 10,
+      "community_name": "Community 10"
     },
     {
       "id": "tests_pipeline_test_ts",
@@ -9005,8 +9004,8 @@
       "file_type": "code",
       "source_file": "tests/pipeline.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_platform_v4_integration_test_ts",
@@ -9014,8 +9013,8 @@
       "file_type": "code",
       "source_file": "tests/platform-v4-integration.test.ts",
       "source_location": "L1",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 41,
+      "community_name": "Community 41"
     },
     {
       "id": "platform_v4_integration_test_runcliintemp",
@@ -9023,8 +9022,8 @@
       "file_type": "code",
       "source_file": "tests/platform-v4-integration.test.ts",
       "source_location": "L14",
-      "community": 42,
-      "community_name": "Community 42"
+      "community": 41,
+      "community_name": "Community 41"
     },
     {
       "id": "tests_portable_artifacts_test_ts",
@@ -9050,8 +9049,8 @@
       "file_type": "code",
       "source_file": "tests/profile-pipeline.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_pipeline_test_makeproject",
@@ -9059,8 +9058,8 @@
       "file_type": "code",
       "source_file": "tests/profile-pipeline.test.ts",
       "source_location": "L19",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_profile_prompts_test_ts",
@@ -9068,8 +9067,8 @@
       "file_type": "code",
       "source_file": "tests/profile-prompts.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_prompts_test_promptstate",
@@ -9077,8 +9076,8 @@
       "file_type": "code",
       "source_file": "tests/profile-prompts.test.ts",
       "source_location": "L16",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_profile_registry_test_ts",
@@ -9086,8 +9085,8 @@
       "file_type": "code",
       "source_file": "tests/profile-registry.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "profile_registry_test_maketempdir",
@@ -9095,8 +9094,8 @@
       "file_type": "code",
       "source_file": "tests/profile-registry.test.ts",
       "source_location": "L18",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_profile_report_test_ts",
@@ -9104,8 +9103,8 @@
       "file_type": "code",
       "source_file": "tests/profile-report.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_test_basestate",
@@ -9113,8 +9112,8 @@
       "file_type": "code",
       "source_file": "tests/profile-report.test.ts",
       "source_location": "L13",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_report_test_validationresult",
@@ -9122,8 +9121,8 @@
       "file_type": "code",
       "source_file": "tests/profile-report.test.ts",
       "source_location": "L31",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_profile_validate_test_ts",
@@ -9131,8 +9130,8 @@
       "file_type": "code",
       "source_file": "tests/profile-validate.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_test_profile",
@@ -9140,8 +9139,8 @@
       "file_type": "code",
       "source_file": "tests/profile-validate.test.ts",
       "source_location": "L14",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "profile_validate_test_baseextraction",
@@ -9149,8 +9148,8 @@
       "file_type": "code",
       "source_file": "tests/profile-validate.test.ts",
       "source_location": "L18",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_project_config_test_ts",
@@ -9158,8 +9157,8 @@
       "file_type": "code",
       "source_file": "tests/project-config.test.ts",
       "source_location": "L1",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_test_maketempdir",
@@ -9167,8 +9166,8 @@
       "file_type": "code",
       "source_file": "tests/project-config.test.ts",
       "source_location": "L16",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "project_config_test_write",
@@ -9176,8 +9175,8 @@
       "file_type": "code",
       "source_file": "tests/project-config.test.ts",
       "source_location": "L22",
-      "community": 16,
-      "community_name": "Community 16"
+      "community": 5,
+      "community_name": "Community 5"
     },
     {
       "id": "tests_public_api_test_ts",
@@ -9185,8 +9184,8 @@
       "file_type": "code",
       "source_file": "tests/public-api.test.ts",
       "source_location": "L1",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "public_api_test_maketempdir",
@@ -9194,8 +9193,8 @@
       "file_type": "code",
       "source_file": "tests/public-api.test.ts",
       "source_location": "L11",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "public_api_test_makegraph",
@@ -9203,8 +9202,8 @@
       "file_type": "code",
       "source_file": "tests/public-api.test.ts",
       "source_location": "L17",
-      "community": 39,
-      "community_name": "Community 39"
+      "community": 38,
+      "community_name": "Community 38"
     },
     {
       "id": "tests_recommend_test_ts",
@@ -9212,8 +9211,8 @@
       "file_type": "code",
       "source_file": "tests/recommend.test.ts",
       "source_location": "L1",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_test_makegraph",
@@ -9221,8 +9220,8 @@
       "file_type": "code",
       "source_file": "tests/recommend.test.ts",
       "source_location": "L7",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "recommend_test_lifecycle",
@@ -9230,8 +9229,8 @@
       "file_type": "code",
       "source_file": "tests/recommend.test.ts",
       "source_location": "L33",
-      "community": 11,
-      "community_name": "Community 11"
+      "community": 12,
+      "community_name": "Community 12"
     },
     {
       "id": "tests_repo_clone_test_ts",
@@ -9239,8 +9238,8 @@
       "file_type": "code",
       "source_file": "tests/repo-clone.test.ts",
       "source_location": "L1",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_test_tempdir",
@@ -9248,8 +9247,8 @@
       "file_type": "code",
       "source_file": "tests/repo-clone.test.ts",
       "source_location": "L10",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "repo_clone_test_initrepo",
@@ -9257,8 +9256,8 @@
       "file_type": "code",
       "source_file": "tests/repo-clone.test.ts",
       "source_location": "L22",
-      "community": 34,
-      "community_name": "Community 34"
+      "community": 33,
+      "community_name": "Community 33"
     },
     {
       "id": "tests_report_test_ts",
@@ -9275,8 +9274,8 @@
       "file_type": "code",
       "source_file": "tests/review-analysis.test.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_analysis_test_makegraph",
@@ -9284,8 +9283,8 @@
       "file_type": "code",
       "source_file": "tests/review-analysis.test.ts",
       "source_location": "L11",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_review_benchmark_test_ts",
@@ -9338,8 +9337,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L1",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_context_test_tempproject",
@@ -9347,8 +9346,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L18",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_context_test_qn",
@@ -9356,8 +9355,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L24",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_context_test_addfunction",
@@ -9365,8 +9364,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L28",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_context_test_addedge",
@@ -9374,8 +9373,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L47",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "review_context_test_makereviewgraph",
@@ -9383,8 +9382,8 @@
       "file_type": "code",
       "source_file": "tests/review-context.test.ts",
       "source_location": "L54",
-      "community": 21,
-      "community_name": "Community 21"
+      "community": 1,
+      "community_name": "Community 1"
     },
     {
       "id": "tests_review_store_test_ts",
@@ -9410,8 +9409,8 @@
       "file_type": "code",
       "source_file": "tests/review.test.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "review_test_makegraph",
@@ -9419,8 +9418,8 @@
       "file_type": "code",
       "source_file": "tests/review.test.ts",
       "source_location": "L6",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_search_test_ts",
@@ -9437,8 +9436,8 @@
       "file_type": "code",
       "source_file": "tests/security.test.ts",
       "source_location": "L1",
-      "community": 6,
-      "community_name": "Community 6"
+      "community": 7,
+      "community_name": "Community 7"
     },
     {
       "id": "tests_serve_test_ts",
@@ -9491,8 +9490,8 @@
       "file_type": "code",
       "source_file": "tests/skills.test.ts",
       "source_location": "L1",
-      "community": 44,
-      "community_name": "Community 44"
+      "community": 43,
+      "community_name": "Community 43"
     },
     {
       "id": "tests_summary_test_ts",
@@ -9500,8 +9499,8 @@
       "file_type": "code",
       "source_file": "tests/summary.test.ts",
       "source_location": "L1",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "summary_test_makegraph",
@@ -9509,8 +9508,8 @@
       "file_type": "code",
       "source_file": "tests/summary.test.ts",
       "source_location": "L6",
-      "community": 4,
-      "community_name": "Community 4"
+      "community": 26,
+      "community_name": "Community 26"
     },
     {
       "id": "tests_transcribe_test_ts",
@@ -9518,8 +9517,8 @@
       "file_type": "code",
       "source_file": "tests/transcribe.test.ts",
       "source_location": "L1",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "transcribe_test_mockytdlpdownload",
@@ -9527,8 +9526,8 @@
       "file_type": "code",
       "source_file": "tests/transcribe.test.ts",
       "source_location": "L77",
-      "community": 10,
-      "community_name": "Community 10"
+      "community": 11,
+      "community_name": "Community 11"
     },
     {
       "id": "tests_validate_test_ts",
@@ -9536,8 +9535,8 @@
       "file_type": "code",
       "source_file": "tests/validate.test.ts",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "tests_wiki_test_ts",
@@ -9545,8 +9544,8 @@
       "file_type": "code",
       "source_file": "tests/wiki.test.ts",
       "source_location": "L1",
-      "community": 30,
-      "community_name": "Community 30"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "tsup_config_ts",
@@ -9554,8 +9553,8 @@
       "file_type": "code",
       "source_file": "tsup.config.ts",
       "source_location": "L1",
-      "community": 45,
-      "community_name": "Community 45"
+      "community": 44,
+      "community_name": "Community 44"
     },
     {
       "id": "vitest_config_ts",
@@ -9563,8 +9562,8 @@
       "file_type": "code",
       "source_file": "vitest.config.ts",
       "source_location": "L1",
-      "community": 46,
-      "community_name": "Community 46"
+      "community": 45,
+      "community_name": "Community 45"
     },
     {
       "id": "worked_example_raw_api_py",
@@ -9572,8 +9571,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L1",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_handle_upload",
@@ -9581,8 +9580,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L11",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_handle_get",
@@ -9590,8 +9589,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L27",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_handle_delete",
@@ -9599,8 +9598,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L35",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_handle_list",
@@ -9608,8 +9607,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L43",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_handle_search",
@@ -9617,8 +9616,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L48",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_handle_enrich",
@@ -9626,8 +9625,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L67",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_1",
@@ -9635,8 +9634,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L1",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_12",
@@ -9644,8 +9643,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L12",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_28",
@@ -9653,8 +9652,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L28",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_36",
@@ -9662,8 +9661,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L36",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_44",
@@ -9671,8 +9670,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L44",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_49",
@@ -9680,8 +9679,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L49",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "api_rationale_68",
@@ -9689,8 +9688,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/api.py",
       "source_location": "L68",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "worked_example_raw_parser_py",
@@ -9950,8 +9949,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L1",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_ensure_storage",
@@ -9959,8 +9958,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L14",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_load_index",
@@ -9968,8 +9967,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L20",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_save_index",
@@ -9977,8 +9976,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L26",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_save_parsed",
@@ -9986,8 +9985,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L32",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_save_processed",
@@ -9995,8 +9994,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L49",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_load_record",
@@ -10004,8 +10003,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L65",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_delete_record",
@@ -10013,8 +10012,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L74",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_list_records",
@@ -10022,8 +10021,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L87",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_1",
@@ -10031,8 +10030,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L1",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_21",
@@ -10040,8 +10039,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L21",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_27",
@@ -10049,8 +10048,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L27",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_33",
@@ -10058,8 +10057,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L33",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_50",
@@ -10067,8 +10066,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L50",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_66",
@@ -10076,8 +10075,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L66",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_75",
@@ -10085,8 +10084,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L75",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "storage_rationale_88",
@@ -10094,8 +10093,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/storage.py",
       "source_location": "L88",
-      "community": 25,
-      "community_name": "Community 25"
+      "community": 23,
+      "community_name": "Community 23"
     },
     {
       "id": "worked_example_raw_validator_py",
@@ -10103,8 +10102,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L1",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_validationerror",
@@ -10112,8 +10111,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L13",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "exception",
@@ -10130,8 +10129,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L17",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_check_required_fields",
@@ -10139,8 +10138,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L25",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_check_format",
@@ -10148,8 +10147,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L32",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_normalize_fields",
@@ -10157,8 +10156,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L39",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_validate_batch",
@@ -10166,8 +10165,8 @@
       "file_type": "code",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L52",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_rationale_1",
@@ -10175,8 +10174,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L1",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_rationale_18",
@@ -10184,8 +10183,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L18",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_rationale_26",
@@ -10193,8 +10192,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L26",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_rationale_33",
@@ -10202,8 +10201,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L33",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_rationale_40",
@@ -10211,8 +10210,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L40",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "validator_rationale_53",
@@ -10220,8 +10219,8 @@
       "file_type": "rationale",
       "source_file": "worked/example/raw/validator.py",
       "source_location": "L53",
-      "community": 17,
-      "community_name": "Community 17"
+      "community": 16,
+      "community_name": "Community 16"
     },
     {
       "id": "worked_httpx_raw_auth_py",
@@ -11804,8 +11803,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L1",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_primitive_value_to_str",
@@ -11813,8 +11812,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L12",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_normalize_header_key",
@@ -11822,8 +11821,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L19",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_flatten_queryparams",
@@ -11831,8 +11830,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L24",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_parse_content_type",
@@ -11840,8 +11839,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L39",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_obfuscate_sensitive_headers",
@@ -11849,8 +11848,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L55",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_unset_all_cookies",
@@ -11858,8 +11857,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L63",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_is_known_encoding",
@@ -11867,8 +11866,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L68",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_build_url_with_params",
@@ -11876,8 +11875,8 @@
       "file_type": "code",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L78",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_1",
@@ -11885,8 +11884,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L1",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_13",
@@ -11894,8 +11893,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L13",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_20",
@@ -11903,8 +11902,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L20",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_25",
@@ -11912,8 +11911,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L25",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_40",
@@ -11921,8 +11920,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L40",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_56",
@@ -11930,8 +11929,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L56",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_64",
@@ -11939,8 +11938,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L64",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_69",
@@ -11948,8 +11947,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L69",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "utils_rationale_79",
@@ -11957,8 +11956,8 @@
       "file_type": "rationale",
       "source_file": "worked/httpx/raw/utils.py",
       "source_location": "L79",
-      "community": 23,
-      "community_name": "Community 23"
+      "community": 21,
+      "community_name": "Community 21"
     },
     {
       "id": "worked_mixed_corpus_raw_analyze_py",
@@ -12191,8 +12190,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L1",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_build_from_json",
@@ -12200,8 +12199,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L8",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "build_rationale_32",
@@ -12209,8 +12208,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/build.py",
       "source_location": "L32",
-      "community": 2,
-      "community_name": "Community 2"
+      "community": 3,
+      "community_name": "Community 3"
     },
     {
       "id": "worked_mixed_corpus_raw_cluster_py",
@@ -12218,8 +12217,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_build_graph",
@@ -12227,8 +12226,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L6",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_split_community",
@@ -12236,8 +12235,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L72",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_cohesion_score",
@@ -12245,8 +12244,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L92",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_score_all",
@@ -12254,8 +12253,8 @@
       "file_type": "code",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L103",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_rationale_1",
@@ -12263,8 +12262,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L1",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_rationale_7",
@@ -12272,8 +12271,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L7",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_rationale_28",
@@ -12281,8 +12280,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L28",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_rationale_73",
@@ -12290,8 +12289,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L73",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     },
     {
       "id": "cluster_rationale_93",
@@ -12299,8 +12298,8 @@
       "file_type": "rationale",
       "source_file": "worked/mixed-corpus/raw/cluster.py",
       "source_location": "L93",
-      "community": 12,
-      "community_name": "Community 12"
+      "community": 2,
+      "community_name": "Community 2"
     }
   ],
   "links": [

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -8,13 +8,13 @@
 
 このリポジトリは元の Graphify プロジェクトの保守中 TypeScript ポートです。製品の方向性、ワークフロー、初期実装は [Safi Shamsi](https://github.com/safishamsi/graphify) による原典プロジェクトに依拠しています。
 
-graphify はマルチモーダルであり、この TypeScript ポートは upstream Python Graphify `v4` 系を `graphifyy@0.4.32` まで閉じたうえで、小さめの `v5` リポジトリ指向ワークフローも差分を明示しながら追随しています。現在の TS ランタイムはコード、Markdown、MDX、HTML、PDF、Office 文書、スクリーンショット、図表、その他の画像を処理できます。PDF はまずローカル preflight を通り、テキスト層が読める場合は `pdf-parse` で Markdown 化し、利用可能なら `pdftotext` にフォールバックします。スキャン/低テキスト PDF は `mistral-ocr` で Markdown + 画像に変換できます。ローカル音声/動画検出は `yt-dlp` + `ffmpeg` + `faster-whisper-ts` を使い、生成された transcript と PDF sidecar も同じ意味抽出パスに流し込まれます。tree-sitter AST により 20 言語をサポートし（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia）、Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS、EJS には upstream に合わせた fallback 対応があります。
+graphify はマルチモーダルであり、この TypeScript ポートは upstream Python Graphify `v4` 系を `graphifyy@0.4.33` まで閉じたうえで、小さめの `v5` リポジトリ指向ワークフローも差分を明示しながら追随しています。現在の TS ランタイムはコード、Markdown、MDX、HTML、PDF、Office 文書、スクリーンショット、図表、その他の画像を処理できます。PDF はまずローカル preflight を通り、テキスト層が読める場合は `pdf-parse` で Markdown 化し、利用可能なら `pdftotext` にフォールバックします。スキャン/低テキスト PDF は `mistral-ocr` で Markdown + 画像に変換できます。ローカル音声/動画検出は `yt-dlp` + `ffmpeg` + `faster-whisper-ts` を使い、生成された transcript と PDF sidecar も同じ意味抽出パスに流し込まれます。tree-sitter AST により 20 言語をサポートし（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia）、Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS、EJS には upstream に合わせた fallback 対応があります。
 
 ## ブランチモデル
 
 - `main` は現在のデフォルトで、保守対象の TypeScript 製品ブランチです。
 - `v3` は元の Python Graphify 系譜を追跡する upstream mirror / alignment ブランチです。
-- TypeScript 製品としての `v4` parity は `graphifyy@0.4.32` で閉じており、以後の upstream 作業や `v5` 差分は `UPSTREAM_GAP.md` に明示します。
+- TypeScript 製品としての `v4` parity は `graphifyy@0.4.33` で閉じており、以後の upstream 作業や `v5` 差分は `UPSTREAM_GAP.md` に明示します。
 - npm 公開は GitHub Actions trusted publishing で保護されます。release tag は、タグ対象コミットが既にデフォルトブランチに含まれ、タグのバージョンが `package.json` と一致する場合のみ有効です。
 
 ## 系譜とアラインメント

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -8,20 +8,20 @@
 
 このリポジトリは元の Graphify プロジェクトの保守中 TypeScript ポートです。製品の方向性、ワークフロー、初期実装は [Safi Shamsi](https://github.com/safishamsi/graphify) による原典プロジェクトに依拠しています。
 
-graphify はマルチモーダルであり、この TypeScript ポートは upstream Python Graphify `v4` に対してリリース単位でキャッチアップしており、現在の目標は `v0.4.23` parity です。現在の TS ランタイムはコード、Markdown、MDX、HTML、PDF、Office 文書、スクリーンショット、図表、その他の画像を処理できます。PDF はまずローカル preflight を通り、テキスト層が読める場合は `pdf-parse` で Markdown 化し、利用可能なら `pdftotext` にフォールバックします。スキャン/低テキスト PDF は `mistral-ocr` で Markdown + 画像に変換できます。ローカル音声/動画検出は `yt-dlp` + `ffmpeg` + `faster-whisper-ts` を使い、生成された transcript と PDF sidecar も同じ意味抽出パスに流し込まれます。tree-sitter AST により 20 言語をサポートし（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia）、Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS、EJS には upstream v4 に合わせた fallback 対応があります。
+graphify はマルチモーダルであり、この TypeScript ポートは upstream Python Graphify `v4` 系を `graphifyy@0.4.32` まで閉じたうえで、小さめの `v5` リポジトリ指向ワークフローも差分を明示しながら追随しています。現在の TS ランタイムはコード、Markdown、MDX、HTML、PDF、Office 文書、スクリーンショット、図表、その他の画像を処理できます。PDF はまずローカル preflight を通り、テキスト層が読める場合は `pdf-parse` で Markdown 化し、利用可能なら `pdftotext` にフォールバックします。スキャン/低テキスト PDF は `mistral-ocr` で Markdown + 画像に変換できます。ローカル音声/動画検出は `yt-dlp` + `ffmpeg` + `faster-whisper-ts` を使い、生成された transcript と PDF sidecar も同じ意味抽出パスに流し込まれます。tree-sitter AST により 20 言語をサポートし（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia）、Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS、EJS には upstream に合わせた fallback 対応があります。
 
 ## ブランチモデル
 
 - `main` は現在のデフォルトで、保守対象の TypeScript 製品ブランチです。
 - `v3` は元の Python Graphify 系譜を追跡する upstream mirror / alignment ブランチです。
-- 現在のキャッチアップ作業は upstream Python Graphify `v4` の `v0.4.23` までを対象とし、差分は `UPSTREAM_GAP.md` に明示します。
+- TypeScript 製品としての `v4` parity は `graphifyy@0.4.32` で閉じており、以後の upstream 作業や `v5` 差分は `UPSTREAM_GAP.md` に明示します。
 - npm 公開は GitHub Actions trusted publishing で保護されます。release tag は、タグ対象コミットが既にデフォルトブランチに含まれ、タグのバージョンが `package.json` と一致する場合のみ有効です。
 
 ## 系譜とアラインメント
 
 | 出典 | このリポジトリで維持または適応するもの | アラインメント契約 |
 |---|---|---|
-| [Safi Shamsi](https://github.com/safishamsi/graphify) による元の Graphify | 中核となる製品アイデア：フォルダ -> ナレッジグラフ、assistant-skill ワークフロー、graph/report/html 出力、provenance ラベル、コミュニティ検出、マルチモーダルなコーパス運用。 | `v3` は upstream Python Graphify をミラーし、`UPSTREAM_GAP.md` が `v0.4.23` までの v4 parity を追跡します。 |
+| [Safi Shamsi](https://github.com/safishamsi/graphify) による元の Graphify | 中核となる製品アイデア：フォルダ -> ナレッジグラフ、assistant-skill ワークフロー、graph/report/html 出力、provenance ラベル、コミュニティ検出、マルチモーダルなコーパス運用。 | `v3` は upstream Python Graphify の履歴ミラーであり、`UPSTREAM_GAP.md` が閉じた `v4` 系と進行中の `v5` キャッチアップを追跡します。 |
 | この TypeScript ポート | npm パッケージ、リポジトリルートの TypeScript runtime、`.graphify/` state、複数アシスタント向け installer、MCP surface、git/worktree lifecycle、TS ツールチェーンによるローカル音声/動画文字起こし。 | `main` が保守対象のデフォルトブランチです。TS 固有の挙動は upstream parity ではなく、意図的な分岐として文書化します。 |
 | `code-review-graph` 参照プロジェクト | review 向けのグラフ投影：first-hop summary、review delta、review analysis、review evaluation、install preview、advisory commit grouping の語彙。 | Graphify のグラフ上に追加される review surface として採用します。Graphify は review-only にはならず、SQLite/embeddings をデフォルト採用せず、マルチモーダル対応を維持します。 |
 
@@ -305,7 +305,7 @@ graphify profile report \
 
 | タイプ | 拡張子 | 抽出方法 |
 |------|-----------|------------|
-| コード | `.py .ts .js .jsx .tsx .mjs .vue .svelte .ejs .go .rs .java .c .cpp .rb .cs .kt .scala .php .blade.php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .dart .v .sv` | tree-sitter AST（利用可能な場合）+ upstream v4 surface language fallback + コールグラフ + docstring / コメントの根拠 |
+| コード | `.py .ts .js .jsx .tsx .mjs .vue .svelte .ejs .go .rs .java .c .cpp .rb .cs .kt .scala .php .blade.php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .dart .v .sv` | tree-sitter AST（利用可能な場合）+ upstream Python surface language fallback + コールグラフ + docstring / コメントの根拠 |
 | ドキュメント | `.md .mdx .txt .rst .html` | 現在のプラットフォームモデルによる概念 + 関係性 + 設計根拠 |
 | Office | `.docx .xlsx` | Markdown に変換した後、現在のプラットフォームモデルで抽出 |
 | 論文 | `.pdf` | ローカル PDF preflight。テキスト層 PDF は `pdf-parse`/`pdftotext` で Markdown 化し、スキャン/低テキスト PDF は `mistral-ocr` で Markdown + 画像にしてから意味抽出 |

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 
 This repository is the maintained TypeScript port of the original Graphify project. Thanks to the original work by [Safi Shamsi](https://github.com/safishamsi/graphify) for the product direction, workflow, and initial implementation.
 
-Multimodal, with the TypeScript port tracked release-by-release against upstream Python Graphify `v4` and targeted at `v0.4.23` parity. Code, Markdown, MDX, HTML, PDFs, Office docs, screenshots, diagrams, and other images flow through the current TS runtime. PDFs go through a local preflight: text-layer PDFs are converted with `pdf-parse` and a `pdftotext` fallback when available, while scanned/low-text PDFs can be converted to Markdown + images through `mistral-ocr`. Local audio/video detection uses `yt-dlp` + `ffmpeg` + `faster-whisper-ts`, and generated transcripts/PDF sidecars feed the same assistant-driven semantic pass as docs and papers. 20 languages are supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia), with upstream-aligned fallback support for Vue, Svelte, Blade, Dart, Verilog/SystemVerilog, MJS, and EJS.
+Multimodal, with the TypeScript port now closed through the upstream Python Graphify `v4` line and published as `graphifyy@0.4.32`, while smaller `v5` repo-oriented workflows are tracked explicitly in this fork instead of being hidden. Code, Markdown, MDX, HTML, PDFs, Office docs, screenshots, diagrams, and other images flow through the current TS runtime. PDFs go through a local preflight: text-layer PDFs are converted with `pdf-parse` and a `pdftotext` fallback when available, while scanned/low-text PDFs can be converted to Markdown + images through `mistral-ocr`. Local audio/video detection uses `yt-dlp` + `ffmpeg` + `faster-whisper-ts`, and generated transcripts/PDF sidecars feed the same assistant-driven semantic pass as docs and papers. 20 languages are supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia), with upstream-aligned fallback support for Vue, Svelte, Blade, Dart, Verilog/SystemVerilog, MJS, and EJS.
 
 ## Branch Model
 
 - `main` is the maintained TypeScript product branch and the default branch for this repository.
 - `v3` is kept as an upstream mirror / alignment branch for the original Python Graphify lineage.
-- Current catch-up work tracks upstream Python Graphify `v4` through `v0.4.23`; parity gaps stay explicit instead of being hidden in the fork.
+- The `v4` parity line is closed in the TypeScript product through `graphifyy@0.4.32`; ongoing upstream work, including the smaller `v5` repo-oriented additions, stays explicit in `UPSTREAM_GAP.md`.
 - npm publication is guarded by GitHub Actions trusted publishing. Release tags are only valid when the tagged commit is already contained in the default branch and the tag version matches `package.json`.
 
 ## Lineage And Alignment
 
 | Source | What this repo keeps or adapts | Alignment contract |
 |---|---|---|
-| Original Graphify by [Safi Shamsi](https://github.com/safishamsi/graphify) | Core product idea: folder -> knowledge graph, assistant skill workflow, graph/report/html outputs, provenance labels, community detection, and multimodal corpus workflow. | `v3` mirrors upstream Python Graphify; `UPSTREAM_GAP.md` tracks `v4` parity through `v0.4.23`. |
+| Original Graphify by [Safi Shamsi](https://github.com/safishamsi/graphify) | Core product idea: folder -> knowledge graph, assistant skill workflow, graph/report/html outputs, provenance labels, community detection, and multimodal corpus workflow. | `v3` mirrors upstream Python Graphify history; `UPSTREAM_GAP.md` tracks the closed `v4` line and the active `v5` catch-up work. |
 | This TypeScript port | npm package, TypeScript runtime at repo root, `.graphify/` state, multi-assistant installers, MCP surfaces, git/worktree lifecycle, and local audio/video transcription through the TS toolchain. | `main` is the maintained default branch; TS-specific behavior is documented as deliberate divergence, not upstream parity. |
 | `code-review-graph` reference | Review-oriented graph projections: first-hop summary, review delta, review analysis, review evaluation, install previews, and advisory commit grouping vocabulary. | Adopted as additive review surfaces over Graphify's graph; Graphify does not become review-only, does not adopt SQLite/embeddings as default, and keeps multimodal support. |
 
@@ -30,6 +30,8 @@ Multimodal, with the TypeScript port tracked release-by-release against upstream
 ```bash
 $graphify .                        # Codex
 /graphify .                        # Claude Code / Gemini CLI / Copilot / Aider / OpenCode / OpenClaw / Droid / Trae / Kiro / Antigravity
+graphify clone https://github.com/<owner>/<repo>
+graphify merge-graphs repo-a/.graphify/graph.json repo-b/.graphify/graph.json --out .graphify/cross-repo-graph.json
 ```
 
 In Codex, `$graphify` is a skill trigger, not a Bash subcommand like `graphify .`. A successful TypeScript-backed Codex run should leave `.graphify/.graphify_runtime.json` with `runtime: "typescript"`.
@@ -250,6 +252,8 @@ curl -fsSL https://raw.githubusercontent.com/rhanka/graphify/main/src/skills/ski
   > ~/.claude/skills/graphify/SKILL.md
 ```
 
+If `CLAUDE_CONFIG_DIR` is set in your environment, substitute that directory for `~/.claude` when placing the global Claude skill.
+
 Add to `~/.claude/CLAUDE.md`:
 
 ```
@@ -266,6 +270,7 @@ In Codex, replace the leading `/` in the examples below with `$`. Gemini CLI, Gi
 ```
 /graphify                          # run on current directory
 /graphify ./raw                    # run on a specific folder
+/graphify https://github.com/<owner>/<repo>   # clone a repo locally, then graph it
 /graphify ./raw --directed         # build directed graph (preserves source->target)
 /graphify ./raw --mode deep        # more aggressive INFERRED edge extraction
 /graphify ./raw --pdf-ocr auto     # preflight PDFs; OCR scanned/low-text PDFs with mistral-ocr when needed
@@ -300,6 +305,9 @@ In Codex, replace the leading `/` in the examples below with `$`. Gemini CLI, Gi
 /graphify ./raw --mcp              # start MCP stdio server
 
 # git hooks - platform-agnostic, mark stale and rebuild code graph on git lifecycle events
+graphify clone https://github.com/<owner>/<repo>
+graphify clone https://github.com/<owner>/<repo> --branch main
+graphify merge-graphs repo-a/.graphify/graph.json repo-b/.graphify/graph.json --out .graphify/cross-repo-graph.json
 graphify hook install
 graphify hook uninstall
 graphify hook status
@@ -373,7 +381,7 @@ Works with any mix of file types:
 
 | Type | Extensions | Extraction |
 |------|-----------|------------|
-| Code | `.py .ts .js .jsx .tsx .mjs .vue .svelte .ejs .go .rs .java .c .cpp .rb .cs .kt .scala .php .blade.php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .dart .v .sv` | AST via tree-sitter when available, plus fallback extraction for upstream v4 surface languages, call-graph, and docstring/comment rationale |
+| Code | `.py .ts .js .jsx .tsx .mjs .vue .svelte .ejs .go .rs .java .c .cpp .rb .cs .kt .scala .php .blade.php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .dart .v .sv` | AST via tree-sitter when available, plus fallback extraction for upstream Python surface languages, call-graph, and docstring/comment rationale |
 | Docs | `.md .mdx .txt .rst .html` | Concepts + relationships + design rationale via the platform model |
 | Office | `.docx .xlsx` | Converted to markdown then extracted via the platform model |
 | Papers | `.pdf` | Local PDF preflight; text-layer PDFs become Markdown via `pdf-parse`/`pdftotext`; scanned/low-text PDFs can use `mistral-ocr` for Markdown + images before semantic extraction |

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 This repository is the maintained TypeScript port of the original Graphify project. Thanks to the original work by [Safi Shamsi](https://github.com/safishamsi/graphify) for the product direction, workflow, and initial implementation.
 
-Multimodal, with the TypeScript port now closed through the upstream Python Graphify `v4` line and published as `graphifyy@0.4.32`, while smaller `v5` repo-oriented workflows are tracked explicitly in this fork instead of being hidden. Code, Markdown, MDX, HTML, PDFs, Office docs, screenshots, diagrams, and other images flow through the current TS runtime. PDFs go through a local preflight: text-layer PDFs are converted with `pdf-parse` and a `pdftotext` fallback when available, while scanned/low-text PDFs can be converted to Markdown + images through `mistral-ocr`. Local audio/video detection uses `yt-dlp` + `ffmpeg` + `faster-whisper-ts`, and generated transcripts/PDF sidecars feed the same assistant-driven semantic pass as docs and papers. 20 languages are supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia), with upstream-aligned fallback support for Vue, Svelte, Blade, Dart, Verilog/SystemVerilog, MJS, and EJS.
+Multimodal, with the TypeScript port now closed through the upstream Python Graphify `v4` line and prepared as `graphifyy@0.4.33`, while smaller `v5` repo-oriented workflows are tracked explicitly in this fork instead of being hidden. Code, Markdown, MDX, HTML, PDFs, Office docs, screenshots, diagrams, and other images flow through the current TS runtime. PDFs go through a local preflight: text-layer PDFs are converted with `pdf-parse` and a `pdftotext` fallback when available, while scanned/low-text PDFs can be converted to Markdown + images through `mistral-ocr`. Local audio/video detection uses `yt-dlp` + `ffmpeg` + `faster-whisper-ts`, and generated transcripts/PDF sidecars feed the same assistant-driven semantic pass as docs and papers. 20 languages are supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia), with upstream-aligned fallback support for Vue, Svelte, Blade, Dart, Verilog/SystemVerilog, MJS, and EJS.
 
 ## Branch Model
 
 - `main` is the maintained TypeScript product branch and the default branch for this repository.
 - `v3` is kept as an upstream mirror / alignment branch for the original Python Graphify lineage.
-- The `v4` parity line is closed in the TypeScript product through `graphifyy@0.4.32`; ongoing upstream work, including the smaller `v5` repo-oriented additions, stays explicit in `UPSTREAM_GAP.md`.
+- The `v4` parity line is closed in the TypeScript product through `graphifyy@0.4.33`; ongoing upstream work, including the smaller `v5` repo-oriented additions, stays explicit in `UPSTREAM_GAP.md`.
 - npm publication is guarded by GitHub Actions trusted publishing. Release tags are only valid when the tagged commit is already contained in the default branch and the tag version matches `package.json`.
 
 ## Lineage And Alignment

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,20 +8,20 @@
 
 这个仓库是原始 Graphify 项目的受维护 TypeScript 版本。产品方向、工作流和最初实现来自 [Safi Shamsi](https://github.com/safishamsi/graphify) 的原始项目，这里保留了同样的知识图谱与 assistant-skill 交互模型。
 
-graphify 是多模态的，而且这个 TypeScript 端口正按 upstream Python Graphify `v4` 的发布节奏逐版追平，当前目标是 `v0.4.23` parity。当前 TS runtime 覆盖代码、Markdown、MDX、HTML、PDF、Office 文档、截图、图表和其他图片。PDF 会先走本地 preflight：有可读文本层时用 `pdf-parse` 转成 Markdown，并在可用时回退到 `pdftotext`；扫描件或低文本 PDF 可通过 `mistral-ocr` 转成 Markdown + 图片。本地音频/视频检测使用 `yt-dlp` + `ffmpeg` + `faster-whisper-ts`；这些 transcript 和 PDF sidecar 都会并入同一条语义抽取流水线。代码 AST 侧通过 tree-sitter 支持 20 种语言（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia），并为 Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS 和 EJS 提供 upstream v4 对齐的 fallback 支持。
+graphify 是多模态的，而且这个 TypeScript 端口已经把 upstream Python Graphify `v4` 线闭合到了 `graphifyy@0.4.32`，同时也在以显式差异跟踪的方式继续吸收较小的 `v5` 仓库工作流能力。当前 TS runtime 覆盖代码、Markdown、MDX、HTML、PDF、Office 文档、截图、图表和其他图片。PDF 会先走本地 preflight：有可读文本层时用 `pdf-parse` 转成 Markdown，并在可用时回退到 `pdftotext`；扫描件或低文本 PDF 可通过 `mistral-ocr` 转成 Markdown + 图片。本地音频/视频检测使用 `yt-dlp` + `ffmpeg` + `faster-whisper-ts`；这些 transcript 和 PDF sidecar 都会并入同一条语义抽取流水线。代码 AST 侧通过 tree-sitter 支持 20 种语言（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia），并为 Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS 和 EJS 提供与 upstream 对齐的 fallback 支持。
 
 ## 分支模型
 
 - `main` 是当前默认分支和受维护的 TypeScript 产品分支。
 - `v3` 保留为原始 Python Graphify 的 upstream mirror / 对齐分支。
-- 当前追平工作覆盖 upstream Python Graphify `v4` 到 `v0.4.23`；差异通过 `UPSTREAM_GAP.md` 显式记录。
+- TypeScript 产品线里的 `v4` parity 已在 `graphifyy@0.4.32` 收口；后续 upstream 变化以及 `v5` 差异通过 `UPSTREAM_GAP.md` 显式记录。
 - npm 发布使用 GitHub Actions trusted publishing 保护。release tag 只有在 tag commit 已经进入默认分支且 tag 版本匹配 `package.json` 时才允许发布。
 
 ## 血统与对齐
 
 | 来源 | 本仓库保留或改造的内容 | 对齐约定 |
 |---|---|---|
-| [Safi Shamsi](https://github.com/safishamsi/graphify) 的原始 Graphify | 核心产品思路：文件夹 -> 知识图谱、assistant-skill 工作流、graph/report/html 输出、provenance 标签、社区发现、多模态语料工作流。 | `v3` 镜像 upstream Python Graphify；`UPSTREAM_GAP.md` 跟踪到 `v0.4.23` 的 v4 parity。 |
+| [Safi Shamsi](https://github.com/safishamsi/graphify) 的原始 Graphify | 核心产品思路：文件夹 -> 知识图谱、assistant-skill 工作流、graph/report/html 输出、provenance 标签、社区发现、多模态语料工作流。 | `v3` 保留 upstream Python Graphify 的历史镜像；`UPSTREAM_GAP.md` 跟踪已经闭合的 `v4` 线和正在进行的 `v5` 追平。 |
 | 当前 TypeScript 端口 | npm 包、仓库根目录的 TypeScript runtime、`.graphify/` 状态、多助手安装器、MCP surface、git/worktree 生命周期，以及通过 TS 工具链完成的本地音频/视频转录。 | `main` 是受维护的默认分支；TS 特有行为会作为有意分叉记录，而不是伪装成 upstream parity。 |
 | `code-review-graph` 参考项目 | 面向 review 的图投影：first-hop summary、review delta、review analysis、review evaluation、install preview，以及 advisory commit grouping 术语。 | 作为 Graphify 图上的增量 review surface 采用；Graphify 不转向 review-only，不默认采用 SQLite/embeddings，并继续保留多模态支持。 |
 
@@ -283,7 +283,7 @@ graphify profile report \
 
 | 类型 | 扩展名 | 提取方式 |
 |------|--------|----------|
-| 代码 | `.py .ts .js .jsx .tsx .mjs .vue .svelte .ejs .go .rs .java .c .cpp .rb .cs .kt .scala .php .blade.php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .dart .v .sv` | tree-sitter AST（可用时）+ upstream v4 surface 语言 fallback + 调用图 + docstring / 注释中的 rationale |
+| 代码 | `.py .ts .js .jsx .tsx .mjs .vue .svelte .ejs .go .rs .java .c .cpp .rb .cs .kt .scala .php .blade.php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .dart .v .sv` | tree-sitter AST（可用时）+ upstream Python surface 语言 fallback + 调用图 + docstring / 注释中的 rationale |
 | 文档 | `.md .mdx .txt .rst .html` | 通过当前平台模型提取概念、关系和设计动机 |
 | Office | `.docx .xlsx` | 先转换成 markdown，再交给当前平台模型做抽取 |
 | 论文 | `.pdf` | 本地 PDF preflight；文本层 PDF 用 `pdf-parse`/`pdftotext` 转 Markdown；扫描件/低文本 PDF 可用 `mistral-ocr` 生成 Markdown + 图片后再抽取 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,13 +8,13 @@
 
 这个仓库是原始 Graphify 项目的受维护 TypeScript 版本。产品方向、工作流和最初实现来自 [Safi Shamsi](https://github.com/safishamsi/graphify) 的原始项目，这里保留了同样的知识图谱与 assistant-skill 交互模型。
 
-graphify 是多模态的，而且这个 TypeScript 端口已经把 upstream Python Graphify `v4` 线闭合到了 `graphifyy@0.4.32`，同时也在以显式差异跟踪的方式继续吸收较小的 `v5` 仓库工作流能力。当前 TS runtime 覆盖代码、Markdown、MDX、HTML、PDF、Office 文档、截图、图表和其他图片。PDF 会先走本地 preflight：有可读文本层时用 `pdf-parse` 转成 Markdown，并在可用时回退到 `pdftotext`；扫描件或低文本 PDF 可通过 `mistral-ocr` 转成 Markdown + 图片。本地音频/视频检测使用 `yt-dlp` + `ffmpeg` + `faster-whisper-ts`；这些 transcript 和 PDF sidecar 都会并入同一条语义抽取流水线。代码 AST 侧通过 tree-sitter 支持 20 种语言（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia），并为 Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS 和 EJS 提供与 upstream 对齐的 fallback 支持。
+graphify 是多模态的，而且这个 TypeScript 端口已经把 upstream Python Graphify `v4` 线闭合到了 `graphifyy@0.4.33`，同时也在以显式差异跟踪的方式继续吸收较小的 `v5` 仓库工作流能力。当前 TS runtime 覆盖代码、Markdown、MDX、HTML、PDF、Office 文档、截图、图表和其他图片。PDF 会先走本地 preflight：有可读文本层时用 `pdf-parse` 转成 Markdown，并在可用时回退到 `pdftotext`；扫描件或低文本 PDF 可通过 `mistral-ocr` 转成 Markdown + 图片。本地音频/视频检测使用 `yt-dlp` + `ffmpeg` + `faster-whisper-ts`；这些 transcript 和 PDF sidecar 都会并入同一条语义抽取流水线。代码 AST 侧通过 tree-sitter 支持 20 种语言（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia），并为 Vue、Svelte、Blade、Dart、Verilog/SystemVerilog、MJS 和 EJS 提供与 upstream 对齐的 fallback 支持。
 
 ## 分支模型
 
 - `main` 是当前默认分支和受维护的 TypeScript 产品分支。
 - `v3` 保留为原始 Python Graphify 的 upstream mirror / 对齐分支。
-- TypeScript 产品线里的 `v4` parity 已在 `graphifyy@0.4.32` 收口；后续 upstream 变化以及 `v5` 差异通过 `UPSTREAM_GAP.md` 显式记录。
+- TypeScript 产品线里的 `v4` parity 已在 `graphifyy@0.4.33` 收口；后续 upstream 变化以及 `v5` 差异通过 `UPSTREAM_GAP.md` 显式记录。
 - npm 发布使用 GitHub Actions trusted publishing 保护。release tag 只有在 tag commit 已经进入默认分支且 tag 版本匹配 `package.json` 时才允许发布。
 
 ## 血统与对齐

--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -6,7 +6,7 @@ This document tracks the delta between this TypeScript port and upstream Python 
 
 - Current TypeScript product branch: `main`
 - Current TypeScript baseline: `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc`
-- Current TypeScript npm release: `graphifyy@0.4.32`
+- Current TypeScript npm release: `graphifyy@0.4.33`
 - Durable traceability spec: `spec/SPEC_UPSTREAM_TRACEABILITY.md`
 - Closed upstream `v3` baseline: `upstream/v3` at `699e996`
 - Closed Python parity target: remote tag `v0.4.23` at `8d908c5d43d079579604a82873fd7cff33a1b343`
@@ -102,7 +102,7 @@ The TypeScript port has already shipped the original direct `0.4.23` parity targ
 | `v0.4.23` / `42599a7`, `8d908c5`, `baa4474` | refresh all version stamps, `.html` documents, safe large-graph HTML export, Go import node ID collision, pipx docs | `covered` | Lot 1, Lot 2, Lot 3, Lot 8 | `.html` document detection is covered by Lot 1. Go import prefixing is covered by Lot 2. Safe HTML export is covered by Lot 3. npm/global install docs are covered by Lot 7. Package and MCP server version stamps now read `0.4.23` from `package.json`. |
 | post-`v0.4.23` / `04790e2`, `dc1158b`, `7a0a5ac` | README download badge changes only | `n/a` | Lot 8 | Not part of TypeScript runtime parity; optionally ignore or adapt docs without copying Python download badges. |
 
-## Closed Python v4 Drift After TypeScript `0.4.32`
+## Closed Python v4 Drift After TypeScript `0.4.33`
 
 This table is retained as closed history. The TypeScript product line has already absorbed the runtime-relevant `upstream/v4` drift through commit `5843ffc`.
 

--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -5,22 +5,22 @@ This document tracks the delta between this TypeScript port and upstream Python 
 ## Scope
 
 - Current TypeScript product branch: `main`
-- Current TypeScript baseline: `660e3836a165f815e3f31c925784ff4db97e7762`
-- Current TypeScript npm release: `graphifyy@0.4.25`
+- Current TypeScript baseline: `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc`
+- Current TypeScript npm release: `graphifyy@0.4.32`
 - Durable traceability spec: `spec/SPEC_UPSTREAM_TRACEABILITY.md`
 - Closed upstream `v3` baseline: `upstream/v3` at `699e996`
 - Closed Python parity target: remote tag `v0.4.23` at `8d908c5d43d079579604a82873fd7cff33a1b343`
-- Active Python drift target: `upstream/v4` at `5843ffc277c54766854f9201286c9647da095390`
-- Deferred major-version source lock: `upstream/v5` at `770d7f54c40d7301a0166a6b7782cb03827897e5`
+- Closed Python drift target: `upstream/v4` at `5843ffc277c54766854f9201286c9647da095390`
+- Active major-version source lock: `upstream/v5` at `770d7f54c40d7301a0166a6b7782cb03827897e5`
 - Active CRG review reference: `tirth8205/code-review-graph` tag `v2.3.2` at `db2d2df789c25a101e33477b898c1840fb4c7bc7`
-- Current implementation branch for traceability work: `chore/upstream-v4-0.4.32-catchup`
+- Current implementation branch for traceability work: `chore/upstream-v5-0.5.0-catchup`
 
 ## Source Lock Notes
 
 - `git ls-remote` is the authority for Safi Python tags while local tag clobber risk exists.
 - Local `refs/tags/v0.4.23` is not trusted for parity claims because it differs from the remote tag observed by `git ls-remote`.
-- Python `upstream/v4` was fetched on 2026-04-25 and now points to `5843ffc277c54766854f9201286c9647da095390`.
-- Python `upstream/v5` now exists and is locked separately as deferred major-version work.
+- Python `upstream/v4` was fetched on 2026-04-25 and remains locked as a closed parity line at `5843ffc277c54766854f9201286c9647da095390`.
+- Python `upstream/v5` was fetched on 2026-04-25 and is the active upstream source lock for this branch at `770d7f54c40d7301a0166a6b7782cb03827897e5`.
 - Local `v0.4.28`..`v0.4.32` tags are not trusted for parity claims while tag clobber risk exists; use branch commits and `git ls-remote` instead.
 - CRG `v2.3.2` remains the stable review-feature source. CRG `main` has advanced and is intentionally deferred until a new spec updates the source lock.
 
@@ -102,9 +102,9 @@ The TypeScript port has already shipped the original direct `0.4.23` parity targ
 | `v0.4.23` / `42599a7`, `8d908c5`, `baa4474` | refresh all version stamps, `.html` documents, safe large-graph HTML export, Go import node ID collision, pipx docs | `covered` | Lot 1, Lot 2, Lot 3, Lot 8 | `.html` document detection is covered by Lot 1. Go import prefixing is covered by Lot 2. Safe HTML export is covered by Lot 3. npm/global install docs are covered by Lot 7. Package and MCP server version stamps now read `0.4.23` from `package.json`. |
 | post-`v0.4.23` / `04790e2`, `dc1158b`, `7a0a5ac` | README download badge changes only | `n/a` | Lot 8 | Not part of TypeScript runtime parity; optionally ignore or adapt docs without copying Python download badges. |
 
-## Active Python v4 Drift After TypeScript `0.4.25`
+## Closed Python v4 Drift After TypeScript `0.4.32`
 
-This table starts from the remote Python `v0.4.23` source lock and tracks current `upstream/v4` through commit `5843ffc`.
+This table is retained as closed history. The TypeScript product line has already absorbed the runtime-relevant `upstream/v4` drift through commit `5843ffc`.
 
 | Upstream ref | Upstream scope | TS status | Plan lot | Catch-up action |
 | --- | --- | --- | --- | --- |
@@ -114,11 +114,21 @@ This table starts from the remote Python `v0.4.23` source lock and tracks curren
 | `v0.4.26` / `f8fd8f8` | wiki encoding and slug collision fixes; hook rebase guard; detect path resolution; README `.gitignore` docs | `covered` | F2 drift audit | Hook guard now has regression coverage in `tests/hooks.test.ts`; wiki collision coverage already exists in `tests/wiki.test.ts`; detect resolves root up front; README and `.gitignore` are updated in this branch. |
 | post-`v0.4.27` / `86d6d93`, `52ad45b`, `4bc2052`, `e4bdcc2`, `64f38ac`, `e915a87`, `b326aa8`, `5843ffc` | OpenCode config relocation, `check-update`, Java inheritance, Windows Python docs, canvas/docs polish, aggregated HTML viz, local benchmark-script ignores | `covered` / `n/a` | F2 drift audit | `.opencode/opencode.json`, `check-update`, Java inheritance, aggregated HTML member counts, canvas-relative exports, and benchmark-script ignores are covered by runtime/tests. Remaining Windows Python packaging/docs polish is `n/a` for the TypeScript runtime. |
 | `v0.4.27` / `d9b2928` | deterministic large-graph `GRAPH_REPORT`, stable edge node IDs, corrected common-root inference | `covered` | F2 drift audit | Covered by project-relative file-node remap plus stable relative-import targets in `tests/language-surface.test.ts`, and deterministic large-graph analysis coverage in `tests/analyze.test.ts`. |
-| `v0.5.0` / `upstream/v5` | major-version line and enterprise-oriented design work | `deferred` | separate major-version spec | Track separately from the current v4 catch-up branch. |
+## Active Python v5 Catch-up
+
+This table tracks the repo-oriented upstream `v5` line at `770d7f5`. The TypeScript fork keeps its own runtime and `.graphify/` state model while adopting the user-facing workflow changes that map cleanly.
+
+| Upstream ref | Upstream scope | TS status | Plan lot | Catch-up action |
+| --- | --- | --- | --- | --- |
+| `2c49da2` | repo clone command and GitHub URL workflow | `covered` | V5 lot 1 | Covered by `src/repo-clone.ts`, `src/cli.ts`, `src/index.ts`, and `tests/repo-clone.test.ts`. |
+| `2faeed9` | `merge-graphs`, `CLAUDE_CONFIG_DIR` skill install destination, legacy `graphify-out` skip during detection | `covered` | V5 lot 1 | `merge-graphs` is covered by `src/merge-graphs.ts`, CLI wiring, and `tests/cli-runtime.test.ts`; `CLAUDE_CONFIG_DIR` install preview/write path is covered by `tests/install-preview.test.ts`; legacy `graphify-out` skipping was already covered in `src/detect.ts`. |
+| `df9b7ec` | `build_merge`, pre-write shrink guard, label dedup, chunk-suffix prompt hardening | `covered` / `intentional-delta` | V5 lot 2 | `buildMerge`, conservative label dedup, and JSON shrink guard are covered by `tests/build-merge.test.ts` and `tests/export-json.test.ts`. Dedup is intentionally conservative in TS to avoid collapsing same-label entities across distinct files. Skill prompts now forbid chunk-suffix node IDs. |
+| `8bed332` | upstream version bump to `0.5.0` | `n/a` | release lot | Do not mirror Python version bumps mechanically; TypeScript versioning remains release-driven. |
+| `770d7f5` | README badge refresh | `n/a` | docs lot | Python download badges do not map to npm-first TypeScript distribution. |
 
 ## Release Gate
 
-Before claiming catch-up through Python `upstream/v4` at `5843ffc` or publishing a TypeScript parity release:
+Before claiming catch-up through Python `upstream/v5` at `770d7f5` or publishing the next TypeScript release from this branch:
 
 - all active Python drift rows must be `covered`, `n/a`, `deferred`, `rejected`, or `intentional-delta`
 - no row may remain `missing`, `partial`, `needs-audit`, or `needs-review`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphifyy",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphifyy",
-      "version": "0.4.32",
+      "version": "0.4.33",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphifyy",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "description": "AI coding assistant skill (Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Aider, OpenCode, OpenClaw) - turn any folder of code, docs, papers, images, or audio/video transcripts into a queryable knowledge graph",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/spec/SPEC_UPSTREAM_TRACEABILITY.md
+++ b/spec/SPEC_UPSTREAM_TRACEABILITY.md
@@ -6,7 +6,7 @@ This document is the durable upstream traceability contract for the TypeScript G
 
 - Created: 2026-04-22
 - TypeScript baseline: `main` at `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc`
-- TypeScript package: `graphifyy@0.4.32`
+- TypeScript package: `graphifyy@0.4.33`
 - Source orientation: `spec/SPEC_UPSTREAM_DUAL_CATCHUP_2026_04.md`
 - Review inspiration orientation: `spec/SPEC_CODE_REVIEW_GRAPH_OPPORUNITY.md`
 
@@ -23,7 +23,7 @@ The TypeScript fork must stay generic, npm-first, `.graphify/`-based, and TypeSc
 
 | Source | Ref | Remote observed commit | Local tracking commit | Package/version | Status | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| TypeScript Graphify | `main` | `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc` | `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc` | `graphifyy@0.4.32` | `covered` | Current implementation baseline for this traceability pass. |
+| TypeScript Graphify | `main` | `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc` | `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc` | `graphifyy@0.4.33` | `covered` | Current implementation baseline for this traceability pass. |
 | Safi Python Graphify | remote `v4` branch | `5843ffc277c54766854f9201286c9647da095390` | `5843ffc277c54766854f9201286c9647da095390` | `0.4.31` line | `covered` / `deferred` / `n/a` | Current runtime drift is covered in this branch; translation relocation is deferred and Python packaging/interpreter notes are `n/a` for the TypeScript runtime. |
 | Safi Python Graphify | remote tag `v0.4.23` | `8d908c5d43d079579604a82873fd7cff33a1b343` | local tag is not trusted | `0.4.23` | `covered` | Verified by `git ls-remote`; local `refs/tags/v0.4.23` is clobber-risk and must not be used as proof. |
 | Safi Python Graphify | remote tag `v0.4.24` | `2b8c08fcb66c288b22a2dfbadfe457fb8fea7c85` | reachable from `upstream/v4` | `0.4.24` | `covered` / `n/a` | Release-line runtime fixes are covered locally; Python packaging/interpreter notes are `n/a` for the TypeScript runtime. |

--- a/spec/SPEC_UPSTREAM_TRACEABILITY.md
+++ b/spec/SPEC_UPSTREAM_TRACEABILITY.md
@@ -5,8 +5,8 @@
 This document is the durable upstream traceability contract for the TypeScript Graphify fork.
 
 - Created: 2026-04-22
-- TypeScript baseline: `main` at `660e3836a165f815e3f31c925784ff4db97e7762`
-- TypeScript package: `graphifyy@0.4.25`
+- TypeScript baseline: `main` at `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc`
+- TypeScript package: `graphifyy@0.4.32`
 - Source orientation: `spec/SPEC_UPSTREAM_DUAL_CATCHUP_2026_04.md`
 - Review inspiration orientation: `spec/SPEC_CODE_REVIEW_GRAPH_OPPORUNITY.md`
 
@@ -23,14 +23,14 @@ The TypeScript fork must stay generic, npm-first, `.graphify/`-based, and TypeSc
 
 | Source | Ref | Remote observed commit | Local tracking commit | Package/version | Status | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| TypeScript Graphify | `main` | `660e3836a165f815e3f31c925784ff4db97e7762` | `660e3836a165f815e3f31c925784ff4db97e7762` | `graphifyy@0.4.25` | `covered` | Current implementation baseline for this traceability pass. |
+| TypeScript Graphify | `main` | `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc` | `703b0aed69e3cbc3c0b5acddfeee23f7a931b8fc` | `graphifyy@0.4.32` | `covered` | Current implementation baseline for this traceability pass. |
 | Safi Python Graphify | remote `v4` branch | `5843ffc277c54766854f9201286c9647da095390` | `5843ffc277c54766854f9201286c9647da095390` | `0.4.31` line | `covered` / `deferred` / `n/a` | Current runtime drift is covered in this branch; translation relocation is deferred and Python packaging/interpreter notes are `n/a` for the TypeScript runtime. |
 | Safi Python Graphify | remote tag `v0.4.23` | `8d908c5d43d079579604a82873fd7cff33a1b343` | local tag is not trusted | `0.4.23` | `covered` | Verified by `git ls-remote`; local `refs/tags/v0.4.23` is clobber-risk and must not be used as proof. |
 | Safi Python Graphify | remote tag `v0.4.24` | `2b8c08fcb66c288b22a2dfbadfe457fb8fea7c85` | reachable from `upstream/v4` | `0.4.24` | `covered` / `n/a` | Release-line runtime fixes are covered locally; Python packaging/interpreter notes are `n/a` for the TypeScript runtime. |
 | Safi Python Graphify | remote tag `v0.4.25` | `cc917a7bc7c9afd67c59823abcfb49cd943844c0` | reachable from `upstream/v4` | `0.4.25` | `covered` | Empty-community report fixes and graph-query install guidance are covered. |
 | Safi Python Graphify | remote tag `v0.4.26` | `7891fa8854367782425f75b12fee7980580473db` | reachable from `upstream/v4` | `0.4.26` | `covered` | Wiki encoding/collisions, hook rebase guard, detect path resolve, and gitignore docs are covered. |
 | Safi Python Graphify | post-`v0.4.27` `upstream/v4` | `5843ffc277c54766854f9201286c9647da095390` | `upstream/v4` | `0.4.28`..`0.4.31` line | `covered` / `n/a` | Runtime drift for this line is covered in this branch; only Python-specific packaging/docs polish remains `n/a` for the TypeScript runtime. |
-| Safi Python Graphify | remote `v5` branch | `770d7f54c40d7301a0166a6b7782cb03827897e5` | `770d7f54c40d7301a0166a6b7782cb03827897e5` | `0.5.0` | `deferred` | Major-version line; track separately from the current v4 parity branch. |
+| Safi Python Graphify | remote `v5` branch | `770d7f54c40d7301a0166a6b7782cb03827897e5` | `770d7f54c40d7301a0166a6b7782cb03827897e5` | `0.5.0` | `covered` / `n/a` | Repo-oriented `v5` workflow changes that map cleanly to the TS fork are implemented on this branch; Python-specific version/badge deltas remain `n/a`. |
 | code-review-graph | remote tag `v2.3.2` | `db2d2df789c25a101e33477b898c1840fb4c7bc7` | `/tmp/code-review-graph-v2.3.2` at same commit | `2.3.2` | `covered` | Stable CRG implementation reference for review features. |
 | code-review-graph | remote `main` | `0919071a9ba353e604981059e99ee2ed98768092` | not fetched into reference clone | unknown | `deferred` | Main is intentionally not the implementation target for the current CRG roadmap. |
 
@@ -71,6 +71,18 @@ Compared against the previous local Python `v4` baseline `6c8f21272c2343c4c044e3
 | `v0.4.26` | `f8fd8f8479240337a449030a632cc76c20203844` | Wiki encoding/collisions, hook rebase guard, detect path resolve, README gitignore docs. | `covered` | Hook guard has explicit regression coverage; wiki collision coverage already exists; detect resolves root up front; README/gitignore updated here. |
 | post-`v0.4.27` | `86d6d93`, `52ad45b`, `4bc2052`, `e4bdcc2`, `64f38ac`, `e915a87`, `b326aa8`, `5843ffc` | OpenCode config relocation, `check-update`, Java inheritance, docs/gitignore drift, aggregated HTML viz, Windows Python docs. | `covered` / `n/a` | `.opencode/opencode.json`, `check-update`, Java inheritance, aggregated HTML member counts, canvas-relative exports, and benchmark-script ignores are covered here. Remaining Windows Python packaging/docs polish is `n/a` for the TypeScript runtime. |
 | `v0.4.27` core structural diff | `d9b2928da151e690ac299bdfef1c78d3d9e32815` | Deterministic large-graph `GRAPH_REPORT`, stable edge node IDs, corrected common-root inference. | `covered` | Project-relative file-node remap plus stable relative-import targets are now covered by `tests/language-surface.test.ts`, and deterministic large-graph analysis behavior is covered by `tests/analyze.test.ts`. |
+
+## Python v5 Catch-up Audit
+
+Compared against the locked `upstream/v5` branch at `770d7f54c40d7301a0166a6b7782cb03827897e5`, the TypeScript fork adopts the workflow-level changes that map cleanly while keeping `.graphify/`, the TypeScript runtime, and npm-first distribution intact.
+
+| Ref | Commit | Upstream change | TypeScript status | Required follow-up |
+| --- | --- | --- | --- | --- |
+| `v5` repo workflow | `2c49da2` | GitHub repo clone command and URL-driven build flow. | `covered` | Covered by `src/repo-clone.ts`, public CLI wiring, and `tests/repo-clone.test.ts`. |
+| `v5` merge/install delta | `2faeed9` | `merge-graphs`, `CLAUDE_CONFIG_DIR` install support, explicit legacy output skip. | `covered` | Covered by `src/merge-graphs.ts`, CLI wiring, `tests/cli-runtime.test.ts`, and `tests/install-preview.test.ts`. Legacy `graphify-out` skipping already existed in `src/detect.ts`. |
+| `v5` safer merge/export | `df9b7ec` | `build_merge`, shrink guard before overwrite, label dedup, chunk-suffix prompt hardening. | `covered` / `intentional-delta` | `buildMerge`, conservative dedup, and JSON shrink guard are covered by `tests/build-merge.test.ts` and `tests/export-json.test.ts`. Dedup remains conservative to avoid collapsing distinct same-label entities across files. |
+| `v5` version bump | `8bed332` | Upstream Python version bump to `0.5.0`. | `n/a` | TS release version stays independent and release-driven. |
+| `v5` README badge | `770d7f5` | Python README badge refresh. | `n/a` | npm-first TypeScript distribution does not reuse Python download badges. |
 
 ## Intentional TypeScript Deltas To Preserve
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -8,16 +8,110 @@
  * 3. Semantic merge (skill): before calling build(), the skill merges results
  *    using an explicit `seen` set keyed on node.id.
  */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import Graph from "graphology";
 import type { Extraction } from "./types.js";
-import { createGraph } from "./graph.js";
+import { createGraph, loadGraphFromData } from "./graph.js";
 import { validateExtraction } from "./validate.js";
 
 export interface BuildOptions {
   directed?: boolean;
 }
 
+const CHUNK_SUFFIX = /_c\d+$/;
+
+function normalizedLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function deduplicateByLabel(extraction: Extraction): Extraction {
+  const canonicalByLabel = new Map<string, Extraction["nodes"][number]>();
+  const remap = new Map<string, string>();
+
+  for (const node of extraction.nodes ?? []) {
+    const label = normalizedLabel(String(node.label ?? node.id ?? ""));
+    if (!label) continue;
+
+    const existing = canonicalByLabel.get(label);
+    if (!existing) {
+      canonicalByLabel.set(label, node);
+      continue;
+    }
+
+    const sameSource = existing.source_file === node.source_file;
+    const chunkCandidate = CHUNK_SUFFIX.test(existing.id) || CHUNK_SUFFIX.test(node.id);
+    if (!sameSource && !chunkCandidate) {
+      continue;
+    }
+
+    const existingChunk = CHUNK_SUFFIX.test(existing.id);
+    const currentChunk = CHUNK_SUFFIX.test(node.id);
+    const preferCurrent =
+      (existingChunk && !currentChunk) ||
+      (existingChunk === currentChunk && node.id.length < existing.id.length);
+
+    if (preferCurrent) {
+      remap.set(existing.id, node.id);
+      canonicalByLabel.set(label, node);
+    } else {
+      remap.set(node.id, existing.id);
+    }
+  }
+
+  if (remap.size === 0) {
+    return extraction;
+  }
+
+  console.error(`[graphify] Deduplicated ${remap.size} duplicate node(s) by label.`);
+
+  const nodes = Array.from(
+    new Map(
+      [...canonicalByLabel.values(), ...(extraction.nodes ?? []).filter((node) => !remap.has(node.id))]
+        .map((node) => [node.id, node]),
+    ).values(),
+  );
+  const edges = (extraction.edges ?? [])
+    .map((edge) => ({
+      ...edge,
+      source: remap.get(edge.source) ?? edge.source,
+      target: remap.get(edge.target) ?? edge.target,
+    }))
+    .filter((edge) => edge.source !== edge.target);
+  const hyperedges = (extraction.hyperedges ?? []).map((hyperedge) => ({
+    ...hyperedge,
+    nodes: hyperedge.nodes.map((nodeId) => remap.get(nodeId) ?? nodeId),
+  }));
+
+  return {
+    ...extraction,
+    nodes,
+    edges,
+    hyperedges,
+  };
+}
+
 export function buildFromJson(extraction: Extraction, options?: BuildOptions): Graph {
+  for (const node of extraction.nodes ?? []) {
+    const legacySource = node.source as unknown;
+    if (legacySource !== undefined && node.source_file === undefined) {
+      const affectedEdges = (extraction.edges ?? []).filter(
+        (edge) => edge.source === node.id || edge.target === node.id,
+      ).length;
+      console.error(
+        `[graphify] WARNING: node '${node.id}' uses field 'source' instead of ` +
+        `'source_file' - ${affectedEdges} edge(s) may be misrouted. Rename the field to ` +
+        "'source_file' to silence this warning.",
+      );
+      node.source_file = String(legacySource);
+      delete node.source;
+    }
+  }
+
   const errors = validateExtraction(extraction);
   // Dangling edges (stdlib/external imports) are expected - only warn about real schema errors.
   const realErrors = errors.filter((e) => !e.includes("does not match any node id"));
@@ -78,4 +172,84 @@ export function build(extractions: Extraction[], options?: BuildOptions): Graph 
     combined.output_tokens += ext.output_tokens ?? 0;
   }
   return buildFromJson(combined, options);
+}
+
+export interface BuildMergeOptions extends BuildOptions {
+  graphPath?: string;
+  pruneSources?: string[];
+}
+
+export function buildMerge(newChunks: Extraction[], options?: BuildMergeOptions): Graph {
+  const graphPath = resolve(options?.graphPath ?? ".graphify/graph.json");
+  const base: Extraction[] = [];
+  let existingNodeCount = 0;
+
+  if (existsSync(graphPath)) {
+    const existingGraph = loadGraphFromData(JSON.parse(readFileSync(graphPath, "utf-8")) as Record<string, unknown>);
+    const existingNodes: Extraction["nodes"] = [];
+    existingGraph.forEachNode((nodeId, attrs) => {
+      existingNodes.push({
+        id: nodeId,
+        label: String(attrs.label ?? nodeId),
+        file_type: String(attrs.file_type ?? "code") as Extraction["nodes"][number]["file_type"],
+        source_file: String(attrs.source_file ?? ""),
+        ...attrs,
+      });
+    });
+    const existingEdges: Extraction["edges"] = [];
+    existingGraph.forEachEdge((_edge, attrs, source, target) => {
+      existingEdges.push({
+        source,
+        target,
+        relation: String(attrs.relation ?? "related_to"),
+        confidence: String(attrs.confidence ?? "EXTRACTED") as Extraction["edges"][number]["confidence"],
+        source_file: String(attrs.source_file ?? ""),
+        ...attrs,
+      });
+    });
+    base.push({
+      nodes: existingNodes,
+      edges: existingEdges,
+      hyperedges: (existingGraph.getAttribute("hyperedges") as Extraction["hyperedges"]) ?? [],
+      input_tokens: 0,
+      output_tokens: 0,
+    });
+    existingNodeCount = existingGraph.order;
+  }
+
+  const mergedExtraction: Extraction = {
+    nodes: [],
+    edges: [],
+    hyperedges: [],
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+  for (const chunk of [...base, ...newChunks]) {
+    mergedExtraction.nodes.push(...(chunk.nodes ?? []));
+    mergedExtraction.edges.push(...(chunk.edges ?? []));
+    (mergedExtraction.hyperedges ??= []).push(...(chunk.hyperedges ?? []));
+    mergedExtraction.input_tokens += chunk.input_tokens ?? 0;
+    mergedExtraction.output_tokens += chunk.output_tokens ?? 0;
+  }
+
+  const deduplicated = deduplicateByLabel(mergedExtraction);
+  const graph = buildFromJson(deduplicated, options);
+
+  if ((options?.pruneSources?.length ?? 0) > 0) {
+    const pruneSet = new Set(options?.pruneSources);
+    graph.forEachNode((nodeId, attrs) => {
+      if (pruneSet.has(String(attrs.source_file ?? ""))) {
+        graph.dropNode(nodeId);
+      }
+    });
+  }
+
+  if (existingNodeCount > 0 && graph.order < existingNodeCount && (options?.pruneSources?.length ?? 0) === 0) {
+    throw new Error(
+      `graphify: buildMerge would shrink graph from ${existingNodeCount} to ${graph.order} nodes. ` +
+      "Pass pruneSources explicitly if you intend to remove nodes.",
+    );
+  }
+
+  return graph;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -261,6 +261,20 @@ function platformNamesForError(): string {
   return [...Object.keys(PLATFORM_CONFIG), ...Object.keys(PLATFORM_ALIASES)].join(", ");
 }
 
+function resolveGlobalSkillDestination(platformName: string): string {
+  const canonical = canonicalPlatformName(platformName);
+  const cfg = PLATFORM_CONFIG[canonical];
+  if (!cfg) {
+    console.error(`error: unknown platform '${platformName}'. Choose from: ${platformNamesForError()}`);
+    process.exit(1);
+  }
+  const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  if ((canonical === "claude" || canonical === "windows") && claudeConfigDir) {
+    return resolve(claudeConfigDir, "skills", "graphify", "SKILL.md");
+  }
+  return join(homedir(), cfg.skill_dst);
+}
+
 const SETTINGS_HOOK = {
   matcher: "Glob|Grep",
   hooks: [
@@ -449,7 +463,7 @@ export function globalSkillInstallPreview(platformName: string): InstallMutation
   const cfg = PLATFORM_CONFIG[platformName];
   const preview = emptyPreview(platformName, "install");
   if (!cfg) return preview;
-  const skillDst = join(homedir(), cfg.skill_dst);
+  const skillDst = resolveGlobalSkillDestination(platformName);
   preview.writes.push(skillDst, join(dirname(skillDst), ".graphify_version"));
   if (cfg.claude_md) {
     preview.writes.push(join(homedir(), ".claude", "CLAUDE.md"));
@@ -1047,7 +1061,7 @@ function writeGlobalSkill(platformName: string): string {
     process.exit(1);
   }
 
-  const skillDst = join(homedir(), cfg.skill_dst);
+  const skillDst = resolveGlobalSkillDestination(platformName);
   mkdirSync(dirname(skillDst), { recursive: true });
   writeFileSync(skillDst, loadSkillContent(platformName), "utf-8");
   writeFileSync(join(dirname(skillDst), ".graphify_version"), VERSION, "utf-8");
@@ -1410,7 +1424,7 @@ export async function main(): Promise<void> {
   for (const platformName of getPlatformsToCheck(process.argv.slice(2))) {
     const cfg = PLATFORM_CONFIG[platformName];
     if (!cfg) continue;
-    checkSkillVersion(join(homedir(), cfg.skill_dst));
+    checkSkillVersion(resolveGlobalSkillDestination(platformName));
   }
 
   const program = new Command();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1657,6 +1657,42 @@ export async function main(): Promise<void> {
     });
 
   program
+    .command("clone <url>")
+    .description("Clone a repository locally and print its resolved path")
+    .option("--branch <branch>", "Checkout a specific branch")
+    .option("--out <dir>", "Clone into a custom directory")
+    .action(async (url, opts) => {
+      try {
+        const { cloneRepo } = await import("./repo-clone.js");
+        const result = cloneRepo({
+          url,
+          ...(opts.branch ? { branch: opts.branch } : {}),
+          ...(opts.out ? { outDir: opts.out } : {}),
+        });
+        console.log(result.path);
+      } catch (err) {
+        console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command("merge-graphs <graphs...>")
+    .description("Merge two or more graph.json files into one cross-repo graph")
+    .option("--out <path>", "Merged graph output path", ".graphify/merged-graph.json")
+    .action(async (graphs: string[], opts) => {
+      try {
+        const { mergeGraphsFromFiles } = await import("./merge-graphs.js");
+        const result = mergeGraphsFromFiles({ inputs: graphs, out: opts.out });
+        console.log(`Merged ${result.graphCount} graphs -> ${result.nodeCount} nodes, ${result.edgeCount} edges`);
+        console.log(`Written to: ${result.out}`);
+      } catch (err) {
+        console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+
+  program
     .command("detect")
     .argument("<inputPath>")
     .option("--out <path>")

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,7 +1,7 @@
 /**
  * Export graph to HTML, JSON, SVG, GraphML, Obsidian Canvas, and Neo4j Cypher.
  */
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import Graph from "graphology";
 import { sanitizeLabel, escapeHtml } from "./security.js";
 import { isDirectedGraph } from "./graph.js";
@@ -37,7 +37,7 @@ const CONFIDENCE_SCORE_DEFAULTS: Record<string, number> = {
 type CommunityLabelsInput = NumericMapLike<string>;
 type CommunityLabelOptions = { communityLabels?: CommunityLabelsInput };
 type HtmlOptions = CommunityLabelOptions & { memberCounts?: NumericMapLike<number> };
-type JsonOptions = CommunityLabelOptions;
+type JsonOptions = CommunityLabelOptions & { force?: boolean };
 type SvgOptions = CommunityLabelOptions & { figsize?: [number, number] };
 type CanvasOptions = CommunityLabelOptions & { nodeFilenames?: StringMapLike<string> };
 type Neo4jPushOptions = {
@@ -65,7 +65,8 @@ function isCommunityLabelOptions(
 ): value is CommunityLabelOptions {
   return !(value instanceof Map) && (
     Object.prototype.hasOwnProperty.call(value, "communityLabels") ||
-    Object.prototype.hasOwnProperty.call(value, "memberCounts")
+    Object.prototype.hasOwnProperty.call(value, "memberCounts") ||
+    Object.prototype.hasOwnProperty.call(value, "force")
   );
 }
 
@@ -117,6 +118,12 @@ export function toJson(
 ): void {
   const nodeComm = nodeCommunityMap(communities);
   const communityLabels = normalizeCommunityLabels(communityLabelsOrOptions);
+  const forceWrite = Boolean(
+    communityLabelsOrOptions &&
+    !(communityLabelsOrOptions instanceof Map) &&
+    Object.prototype.hasOwnProperty.call(communityLabelsOrOptions, "force") &&
+    (communityLabelsOrOptions as { force?: boolean }).force,
+  );
 
   const nodes: Record<string, unknown>[] = [];
   G.forEachNode((nodeId, attrs) => {
@@ -165,6 +172,22 @@ export function toJson(
     links,
     hyperedges,
   };
+
+  if (!forceWrite) {
+    try {
+      const existing = JSON.parse(readFileSync(outputPath, "utf-8")) as { nodes?: unknown[] };
+      const existingNodeCount = existing.nodes?.length ?? 0;
+      if (existingNodeCount > nodes.length) {
+        console.warn(
+          `[graphify] WARNING: new graph has ${nodes.length} nodes but existing graph.json has ` +
+          `${existingNodeCount}. Refusing to overwrite; pass force=true to override.`,
+        );
+        return;
+      }
+    } catch {
+      // No previous graph or unreadable payload - continue with the write.
+    }
+  }
 
   writeFileSync(outputPath, JSON.stringify(output, null, 2), "utf-8");
 }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -47,6 +47,30 @@ export function loadGraphFromData(raw: SerializedGraphData): Graph {
   return G;
 }
 
+export function serializeGraph(G: Graph): SerializedGraphData {
+  const nodes: Array<Record<string, unknown> & { id: string }> = [];
+  G.forEachNode((nodeId, attrs) => {
+    nodes.push({ id: nodeId, ...attrs });
+  });
+
+  const links: Array<Record<string, unknown> & { source: string; target: string }> = [];
+  G.forEachEdge((_edge, attrs, source, target) => {
+    links.push({ source, target, ...attrs });
+  });
+
+  const graph = G.getAttributes();
+  const hyperedges = G.getAttribute("hyperedges") as Array<Record<string, unknown>> | undefined;
+
+  return {
+    directed: isDirectedGraph(G),
+    multigraph: false,
+    graph,
+    nodes,
+    links,
+    ...(hyperedges && hyperedges.length > 0 ? { hyperedges } : {}),
+  };
+}
+
 export function toUndirectedGraph(G: Graph): Graph {
   if (!isDirectedGraph(G)) return G.copy();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ export type {
   ProfileReportPdfArtifact,
 } from "./profile-report.js";
 export { validateExtraction, assertValid } from "./validate.js";
-export { buildFromJson, build } from "./build.js";
+export { buildFromJson, build, buildMerge, deduplicateByLabel } from "./build.js";
 export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";
 export type { CloneRepoOptions, CloneRepoResult } from "./repo-clone.js";
 export { mergeGraphsFromFiles } from "./merge-graphs.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,10 @@ export type {
 } from "./profile-report.js";
 export { validateExtraction, assertValid } from "./validate.js";
 export { buildFromJson, build } from "./build.js";
+export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";
+export type { CloneRepoOptions, CloneRepoResult } from "./repo-clone.js";
+export { mergeGraphsFromFiles } from "./merge-graphs.js";
+export type { MergeGraphsOptions, MergeGraphsResult } from "./merge-graphs.js";
 export { cluster, cohesionScore, scoreAll } from "./cluster.js";
 export { godNodes, surprisingConnections, suggestQuestions, graphDiff } from "./analyze.js";
 export { generate as generateReport } from "./report.js";
@@ -198,6 +202,7 @@ export { extract, collectFiles } from "./extract.js";
 export { fileHash, loadCached, saveCached, checkSemanticCache, saveSemanticCache } from "./cache.js";
 export { validateUrl, safeFetch, safeFetchText, validateGraphPath, sanitizeLabel } from "./security.js";
 export { DEFAULT_GRAPHIFY_STATE_DIR, LEGACY_GRAPHIFY_STATE_DIR, NEXT_GRAPHIFY_STATE_DIR, resolveGraphifyPaths, defaultGraphPath, legacyGraphPath, resolveGraphInputPath, defaultManifestPath, defaultTranscriptsDir } from "./paths.js";
+export { createGraph, isDirectedGraph, loadGraphFromData, serializeGraph } from "./graph.js";
 export { resolveGitContext, safeExecGit, safeGitRevParse } from "./git.js";
 export { lifecyclePaths, readLifecycleMetadata, refreshLifecycleMetadata, markLifecycleStale, markLifecycleAnalyzed, planLifecyclePrune } from "./lifecycle.js";
 export type { GitContext } from "./git.js";

--- a/src/merge-graphs.ts
+++ b/src/merge-graphs.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import type Graph from "graphology";
+import { createGraph, isDirectedGraph, loadGraphFromData, serializeGraph } from "./graph.js";
+
+export interface MergeGraphsOptions {
+  inputs: string[];
+  out: string;
+}
+
+export interface MergeGraphsResult {
+  graph: Graph;
+  out: string;
+  graphCount: number;
+  nodeCount: number;
+  edgeCount: number;
+}
+
+function repoTagFromGraphPath(graphPath: string): string {
+  const parentName = basename(dirname(graphPath));
+  if (parentName === ".graphify" || parentName === "graphify-out") {
+    return basename(dirname(dirname(graphPath))) || "unknown";
+  }
+  return parentName || "unknown";
+}
+
+function mergedGraphType(graphs: Graph[]): boolean {
+  return graphs.some((graph) => isDirectedGraph(graph));
+}
+
+function mergeHyperedges(graphs: Graph[]): Array<Record<string, unknown>> {
+  const merged: Array<Record<string, unknown>> = [];
+  const seen = new Set<string>();
+  for (const graph of graphs) {
+    const hyperedges = (graph.getAttribute("hyperedges") as Array<Record<string, unknown>> | undefined) ?? [];
+    for (const hyperedge of hyperedges) {
+      const id = typeof hyperedge.id === "string" ? hyperedge.id : JSON.stringify(hyperedge);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      merged.push(hyperedge);
+    }
+  }
+  return merged;
+}
+
+export function mergeGraphsFromFiles(options: MergeGraphsOptions): MergeGraphsResult {
+  if (options.inputs.length < 2) {
+    throw new Error("merge-graphs requires at least two graph.json inputs");
+  }
+
+  const graphs = options.inputs.map((inputPath) => {
+    const resolved = resolve(inputPath);
+    if (!existsSync(resolved)) {
+      throw new Error(`graph file not found: ${resolved}`);
+    }
+    const raw = JSON.parse(readFileSync(resolved, "utf-8")) as Record<string, unknown>;
+    const graph = loadGraphFromData(raw);
+    const repo = repoTagFromGraphPath(resolved);
+    graph.forEachNode((nodeId, attrs) => {
+      if (attrs.repo === undefined) {
+        graph.setNodeAttribute(nodeId, "repo", repo);
+      }
+    });
+    return graph;
+  });
+
+  const merged = createGraph(mergedGraphType(graphs));
+  for (const graph of graphs) {
+    for (const [key, value] of Object.entries(graph.getAttributes())) {
+      if (!merged.hasAttribute(key)) {
+        merged.setAttribute(key, value);
+      }
+    }
+    graph.forEachNode((nodeId, attrs) => {
+      merged.mergeNode(nodeId, attrs);
+    });
+    graph.forEachEdge((_edge, attrs, source, target) => {
+      if (!merged.hasNode(source) || !merged.hasNode(target)) return;
+      try {
+        merged.mergeEdge(source, target, attrs);
+      } catch {
+        // Keep the first compatible edge if a duplicate merge collides.
+      }
+    });
+  }
+
+  const hyperedges = mergeHyperedges(graphs);
+  if (hyperedges.length > 0) {
+    merged.setAttribute("hyperedges", hyperedges);
+  }
+
+  const outPath = resolve(options.out);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(serializeGraph(merged), null, 2), "utf-8");
+
+  return {
+    graph: merged,
+    out: outPath,
+    graphCount: graphs.length,
+    nodeCount: merged.order,
+    edgeCount: merged.size,
+  };
+}

--- a/src/repo-clone.ts
+++ b/src/repo-clone.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CloneRepoOptions {
+  url: string;
+  branch?: string;
+  outDir?: string;
+  cacheRoot?: string;
+}
+
+export interface CloneRepoResult {
+  path: string;
+  remote: string;
+  reused: boolean;
+  owner?: string;
+  repo: string;
+}
+
+interface GithubRepoRef {
+  owner: string;
+  repo: string;
+  cloneUrl: string;
+}
+
+function execGit(args: string[]): string {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function maybeGithubRepo(url: string): GithubRepoRef | null {
+  const normalized = url.trim().replace(/\/+$/, "");
+  const match = normalized.match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  if (!match) return null;
+  const owner = match[1]!;
+  const repo = match[2]!;
+  return {
+    owner,
+    repo,
+    cloneUrl: normalized.endsWith(".git") ? normalized : `${normalized}.git`,
+  };
+}
+
+function repoNameFromUrl(url: string): string {
+  const github = maybeGithubRepo(url);
+  if (github) return github.repo;
+
+  try {
+    if (url.startsWith("file://")) {
+      return basename(fileURLToPath(url)).replace(/\.git$/i, "") || "repo";
+    }
+    if (/^[a-z]+:\/\//i.test(url)) {
+      const parsed = new URL(url);
+      return basename(parsed.pathname).replace(/\.git$/i, "") || "repo";
+    }
+  } catch {
+    // Fall through to path-like handling below.
+  }
+
+  return basename(url).replace(/\.git$/i, "") || "repo";
+}
+
+export function defaultCloneDestination(url: string, cacheRoot: string = join(homedir(), ".graphify", "repos")): string {
+  const github = maybeGithubRepo(url);
+  if (github) {
+    return resolve(cacheRoot, github.owner, github.repo);
+  }
+  return resolve(cacheRoot, "external", repoNameFromUrl(url));
+}
+
+export function cloneRepo(options: CloneRepoOptions): CloneRepoResult {
+  const github = maybeGithubRepo(options.url);
+  const remote = github?.cloneUrl ?? options.url.trim();
+  const repo = github?.repo ?? repoNameFromUrl(options.url);
+  const destination = resolve(options.outDir ?? defaultCloneDestination(options.url, options.cacheRoot));
+
+  if (existsSync(destination)) {
+    if (!statSync(destination).isDirectory()) {
+      throw new Error(`clone destination exists and is not a directory: ${destination}`);
+    }
+    if (!existsSync(join(destination, ".git"))) {
+      throw new Error(`clone destination exists but is not a git repository: ${destination}`);
+    }
+
+    console.error(`Repo already cloned at ${destination} - pulling latest...`);
+    execGit(["-C", destination, "remote", "set-url", "origin", remote]);
+    if (options.branch) {
+      execGit(["-C", destination, "fetch", "--depth", "1", "origin", options.branch]);
+      try {
+        execGit(["-C", destination, "checkout", options.branch]);
+      } catch {
+        execGit(["-C", destination, "checkout", "-B", options.branch, "FETCH_HEAD"]);
+      }
+      execGit(["-C", destination, "pull", "--ff-only", "origin", options.branch]);
+    } else {
+      execGit(["-C", destination, "pull", "--ff-only"]);
+    }
+    return {
+      path: destination,
+      remote,
+      reused: true,
+      ...(github ? { owner: github.owner } : {}),
+      repo,
+    };
+  }
+
+  mkdirSync(join(destination, ".."), { recursive: true });
+  console.error(`Cloning ${options.url} -> ${destination} ...`);
+  const args = ["clone", "--depth", "1"];
+  if (options.branch) {
+    args.push("--branch", options.branch);
+  }
+  args.push(remote, destination);
+  execGit(args);
+
+  return {
+    path: destination,
+    remote,
+    reused: false,
+    ...(github ? { owner: github.owner } : {}),
+    repo,
+  };
+}

--- a/src/skills/skill-codex.md
+++ b/src/skills/skill-codex.md
@@ -15,6 +15,8 @@ This Codex skill is **TypeScript-backed**. Before calling the run successful, co
 ```bash
 $graphify                                             # full pipeline on current directory
 $graphify <path>                                      # full pipeline on specific path
+$graphify https://github.com/<owner>/<repo>           # clone repo locally, then run the full pipeline
+$graphify https://github.com/<owner>/<repo> --branch <branch>  # clone a specific branch before graphing
 $graphify <path> --scope auto                         # safe default for code/review repos
 $graphify <path> --scope tracked                      # include newly staged files too
 $graphify <path> --all                                # full recursive folder walk for knowledge bases
@@ -69,7 +71,20 @@ graphify codex install
 
 If no path was given, use `.`. Do not ask the user for a path.
 
+If the path argument starts with `https://github.com/` or `http://github.com/`, treat it as a GitHub URL and run Step 0 before anything else. Use the resolved local clone path for all later steps.
+
 Follow these steps in order. Do not skip the runtime proof step.
+
+### Step 0 - Clone GitHub repos when the input is a GitHub URL
+
+```bash
+GRAPHIFY_BRANCH_FLAG=""
+if the original invocation included --branch <name>, set GRAPHIFY_BRANCH_FLAG="--branch <name>"
+
+LOCAL_PATH=$(graphify clone "INPUT_GITHUB_URL" $GRAPHIFY_BRANCH_FLAG)
+```
+
+Replace `INPUT_PATH` with `LOCAL_PATH` for all subsequent commands.
 
 ### Step 1 - Resolve the installed TypeScript runtime
 
@@ -252,6 +267,7 @@ Rules:
 - EXTRACTED: relationship explicit in source
 - INFERRED: reasonable inference
 - AMBIGUOUS: uncertain - flag it, do not omit it
+- Node IDs must stay stable across chunks and reruns. Base them on the entity label or file-relative identity only. Never append chunk counters like `_c1`, `_c2`, `_chunk3`, or similar suffixes.
 
 Code files: focus on semantic edges AST cannot find. Do not re-extract imports.
 Doc/paper files: extract named concepts, entities, citations, and rationale.

--- a/src/skills/skill-gemini.toml
+++ b/src/skills/skill-gemini.toml
@@ -10,6 +10,8 @@ Use the installed TypeScript runtime only. Do not fall back to Python.
 
 - `/graphify` with no path means the current directory `.`
 - `/graphify <path> [flags]` means build or update the graph for that path
+- `/graphify https://github.com/<owner>/<repo> [--branch <branch>]` means clone the repo first, then run the graph flow on the local clone
+- `/graphify <url1> <url2> ...` with GitHub URLs means clone each repo, build each graph, then merge them with `graphify merge-graphs`
 - `/graphify summary` means return compact first-hop orientation from `.graphify/graph.json`
 - `/graphify minimal-context [files...]` means return the first review call context and next graph tool route
 - `/graphify review-delta [files...]` means return review-oriented impact for changed files
@@ -73,6 +75,17 @@ $(cat .graphify/.graphify_node) "$(cat .graphify/.graphify_runtime_script)" ...
 ## Build and update flow
 
 For a build or update request:
+
+0. If the target path is a GitHub URL, clone first:
+
+```bash
+GRAPHIFY_BRANCH_FLAG=""
+if the original invocation included --branch <name>, set GRAPHIFY_BRANCH_FLAG="--branch <name>"
+
+LOCAL_PATH=$(graphify clone "INPUT_GITHUB_URL" $GRAPHIFY_BRANCH_FLAG)
+```
+
+Use `LOCAL_PATH` as `INPUT_PATH` in the rest of the flow. If the user passed multiple GitHub URLs, clone each one, run the same build flow per local clone, then merge the resulting `.graphify/graph.json` files with `graphify merge-graphs`.
 
 1. Detect files:
 
@@ -145,6 +158,7 @@ Rules:
 - `EXTRACTED`: explicit in source
 - `INFERRED`: reasonable inference
 - `AMBIGUOUS`: uncertain, flag it rather than omitting it
+- Node IDs must stay stable across chunks and reruns. Base them on the entity label or file-relative identity only. Never append chunk counters like `_c1`, `_c2`, `_chunk3`, or similar suffixes.
 - for code files, only add semantic edges AST would miss
 - for image files, use vision if available; for images extracted from PDFs, decode figures, tables, diagrams, captions, and embedded text when they carry meaning, or use a delegated OCR/vision model when configured, while preserving provenance to the source PDF and sidecar
 - if a file has YAML frontmatter, copy `source_url`, `captured_at`, `author`, `contributor` onto every node from that file

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -13,6 +13,8 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 ```
 /graphify                                             # full pipeline on current directory → Obsidian vault
 /graphify <path>                                      # full pipeline on specific path
+/graphify https://github.com/<owner>/<repo>           # clone repo locally, then run the full pipeline
+/graphify https://github.com/<owner>/<repo> --branch <branch>  # clone a specific branch before graphing
 /graphify <path> --scope auto                         # safe default for code/review repos
 /graphify <path> --scope tracked                      # include newly staged files too
 /graphify <path> --all                                # full recursive folder walk for knowledge bases
@@ -74,7 +76,20 @@ Use it for:
 
 If no path was given, use `.` (current directory). Do not ask the user for a path.
 
+If the path argument starts with `https://github.com/` or `http://github.com/`, treat it as a GitHub URL and run Step 0 before anything else. Replace the target path for all later steps with the resolved local clone path.
+
 Follow these steps in order. Do not skip steps.
+
+### Step 0 - Clone GitHub repos when the input is a GitHub URL
+
+```bash
+GRAPHIFY_BRANCH_FLAG=""
+if the original invocation included --branch <name>, set GRAPHIFY_BRANCH_FLAG="--branch <name>"
+
+LOCAL_PATH=$(graphify clone "INPUT_GITHUB_URL" $GRAPHIFY_BRANCH_FLAG)
+```
+
+Use `LOCAL_PATH` as the input path for all subsequent commands.
 
 ### Step 1 - Ensure graphify is installed
 
@@ -251,6 +266,7 @@ Rules:
 - EXTRACTED: relationship explicit in source (import, call, citation, "see §3.2")
 - INFERRED: reasonable inference (shared data structure, implied dependency)
 - AMBIGUOUS: uncertain - flag for review, do not omit
+- Node IDs must stay stable across chunks and reruns. Base them on the entity label or file-relative identity only. Never append chunk counters like `_c1`, `_c2`, `_chunk3`, or similar suffixes.
 
 Code files: focus on semantic edges AST cannot find (call relationships, shared data, arch patterns).
   Do not re-extract imports - AST already has those.

--- a/tests/build-merge.test.ts
+++ b/tests/build-merge.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildMerge } from "../src/build.js";
+
+const cleanupDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-build-merge-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("buildMerge", () => {
+  it("merges new chunks with an existing graph snapshot", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [{ id: "alpha", label: "Alpha", source_file: "src/a.ts", file_type: "code" }],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const graph = buildMerge([
+      {
+        nodes: [{ id: "beta", label: "Beta", source_file: "src/b.ts", file_type: "code" }],
+        edges: [{ source: "alpha", target: "beta", relation: "uses", confidence: "EXTRACTED", source_file: "src/b.ts" }],
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    ], { graphPath });
+
+    expect(graph.order).toBe(2);
+    expect(graph.size).toBe(1);
+    expect(graph.hasNode("alpha")).toBe(true);
+    expect(graph.hasNode("beta")).toBe(true);
+  });
+
+  it("refuses to silently shrink an existing graph without pruneSources", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "auth_session_c1", label: "Auth Session", source_file: "docs/chunk-a.md", file_type: "document" },
+          { id: "auth_session", label: "Auth Session", source_file: "docs/chunk-b.md", file_type: "document" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    expect(() => buildMerge([], { graphPath })).toThrow("buildMerge would shrink graph");
+  });
+
+  it("deduplicates chunk-suffixed labels during explicit merge flows", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    const graph = buildMerge([
+      {
+        nodes: [
+          { id: "auth_session_c1", label: "Auth Session", source_file: "docs/chunk-a.md", file_type: "document" },
+          { id: "auth_session", label: "Auth Session", source_file: "docs/chunk-b.md", file_type: "document" },
+        ],
+        edges: [
+          { source: "auth_session_c1", target: "auth_session", relation: "relates_to", confidence: "INFERRED", source_file: "docs/chunk-a.md" },
+        ],
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    ], { graphPath });
+
+    expect(graph.hasNode("auth_session")).toBe(true);
+    expect(graph.hasNode("auth_session_c1")).toBe(false);
+    expect(graph.size).toBe(0);
+  });
+});

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -157,6 +157,69 @@ describe("public CLI runtime command parity", () => {
     expect(result.errors.join("\n")).not.toContain("unknown command");
   });
 
+  it("supports clone with an explicit output directory", async () => {
+    const source = tempProject();
+    initGitRepo(source);
+    writeFileSync(join(source, "README.md"), "# source\n", "utf-8");
+    execGit(source, ["add", "README.md"]);
+    execGit(source, ["commit", "-q", "-m", "init"]);
+
+    const destRoot = tempProject();
+    const dest = join(destRoot, "cloned");
+    const result = await runCli(["clone", source, "--out", dest], tempProject());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.logs.join("\n")).toContain(dest);
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+    expect(readFileSync(join(dest, "README.md"), "utf-8")).toContain("source");
+  });
+
+  it("supports merge-graphs and annotates nodes with their repo of origin", async () => {
+    const root = tempProject();
+    const repoA = join(root, "repo-a");
+    const repoB = join(root, "repo-b");
+    mkdirSync(join(repoA, ".graphify"), { recursive: true });
+    mkdirSync(join(repoB, ".graphify"), { recursive: true });
+
+    const graphA = join(repoA, ".graphify", "graph.json");
+    writeFileSync(
+      graphA,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [{ id: "alpha", label: "Alpha", source_file: "src/a.ts", file_type: "code" }],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+    const graphB = join(repoB, ".graphify", "graph.json");
+    writeFileSync(
+      graphB,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [{ id: "beta", label: "Beta", source_file: "src/b.ts", file_type: "code" }],
+        links: [{ source: "beta", target: "beta", relation: "self", confidence: "EXTRACTED" }],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const mergedPath = join(root, ".graphify", "merged-graph.json");
+    const result = await runCli(["merge-graphs", graphA, graphB, "--out", mergedPath], root);
+    const merged = JSON.parse(readFileSync(mergedPath, "utf-8")) as {
+      nodes: Array<{ id: string; repo?: string }>;
+    };
+
+    expect(result.exitCode).toBe(0);
+    expect(result.logs.join("\n")).toContain("Merged 2 graphs");
+    expect(merged.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "alpha", repo: "repo-a" }),
+        expect.objectContaining({ id: "beta", repo: "repo-b" }),
+      ]),
+    );
+  });
+
   it("supports one-shot update rebuilds for code-only projects", async () => {
     const dir = tempProject();
     mkdirSync(join(dir, "src"), { recursive: true });

--- a/tests/export-json.test.ts
+++ b/tests/export-json.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import { toJson } from "../src/export.js";
+
+const cleanupDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-export-json-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("toJson shrink guard", () => {
+  it("refuses to overwrite an existing larger graph unless forced", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "alpha", label: "Alpha", source_file: "src/a.ts", file_type: "code" },
+          { id: "beta", label: "Beta", source_file: "src/b.ts", file_type: "code" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+    try {
+      const graph = new Graph();
+      graph.addNode("alpha", { label: "Alpha", source_file: "src/a.ts", file_type: "code" });
+      toJson(graph, new Map([[0, ["alpha"]]]), graphPath);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const persisted = JSON.parse(readFileSync(graphPath, "utf-8")) as { nodes: Array<{ id: string }> };
+    expect(persisted.nodes).toHaveLength(2);
+    expect(warnings.join("\n")).toContain("Refusing to overwrite");
+  });
+
+  it("overwrites when force=true is supplied", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "alpha", label: "Alpha", source_file: "src/a.ts", file_type: "code" },
+          { id: "beta", label: "Beta", source_file: "src/b.ts", file_type: "code" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const graph = new Graph();
+    graph.addNode("alpha", { label: "Alpha", source_file: "src/a.ts", file_type: "code" });
+    toJson(graph, new Map([[0, ["alpha"]]]), graphPath, { force: true });
+
+    const persisted = JSON.parse(readFileSync(graphPath, "utf-8")) as { nodes: Array<{ id: string }> };
+    expect(persisted.nodes).toHaveLength(1);
+    expect(persisted.nodes[0]?.id).toBe("alpha");
+  });
+});

--- a/tests/install-preview.test.ts
+++ b/tests/install-preview.test.ts
@@ -46,6 +46,26 @@ describe("install mutation previews", () => {
     expect(preview.writes.some((path) => path.endsWith(".agents/skills/graphify/.graphify_version"))).toBe(true);
   });
 
+  it("uses CLAUDE_CONFIG_DIR for the Claude global skill destination when set", () => {
+    const previous = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/claude-config";
+    try {
+      const preview = globalSkillInstallPreview("claude");
+      expect(preview.writes).toEqual(
+        expect.arrayContaining([
+          resolve("/tmp/claude-config/skills/graphify/SKILL.md"),
+          resolve("/tmp/claude-config/skills/graphify/.graphify_version"),
+        ]),
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = previous;
+      }
+    }
+  });
+
   it("lists upstream v4 platform project files", () => {
     expect(platformInstallPreview("/repo", "antigravity").writes).toEqual([
       resolve("/repo/.agent/rules/graphify.md"),

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -92,6 +92,10 @@ describe("public API compatibility", () => {
     expect(typeof api.writeImageRoutingCalibrationSamples).toBe("function");
     expect(typeof api.imageRoutingSampleFromCaption).toBe("function");
     expect(typeof api.compileOntologyOutputs).toBe("function");
+    expect(typeof api.cloneRepo).toBe("function");
+    expect(typeof api.defaultCloneDestination).toBe("function");
+    expect(typeof api.mergeGraphsFromFiles).toBe("function");
+    expect(typeof api.serializeGraph).toBe("function");
   });
 
   it("accepts object-style map inputs and option objects", () => {

--- a/tests/repo-clone.test.ts
+++ b/tests/repo-clone.test.ts
@@ -1,0 +1,70 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { defaultCloneDestination, cloneRepo } from "../src/repo-clone.js";
+import { execGit } from "../src/git.js";
+
+const cleanupDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function initRepo(dir: string): void {
+  execGit(dir, ["init", "-q"]);
+  execGit(dir, ["config", "user.email", "graphify@example.test"]);
+  execGit(dir, ["config", "user.name", "Graphify Test"]);
+}
+
+describe("repo clone helpers", () => {
+  it("computes the default GitHub clone destination under ~/.graphify/repos", () => {
+    const cacheRoot = tempDir("graphify-clone-cache-");
+    const destination = defaultCloneDestination("https://github.com/acme/alpha", cacheRoot);
+    expect(destination).toBe(join(cacheRoot, "acme", "alpha"));
+  });
+
+  it("clones a local repository into an explicit destination", () => {
+    const source = tempDir("graphify-clone-source-");
+    initRepo(source);
+    writeFileSync(join(source, "README.md"), "# hello\n", "utf-8");
+    execGit(source, ["add", "README.md"]);
+    execGit(source, ["commit", "-q", "-m", "init"]);
+
+    const destination = join(tempDir("graphify-clone-dest-"), "cloned");
+    const result = cloneRepo({ url: source, outDir: destination });
+
+    expect(result.path).toBe(destination);
+    expect(result.repo).toBe(basename(source));
+    expect(existsSync(join(destination, ".git"))).toBe(true);
+    expect(readFileSync(join(destination, "README.md"), "utf-8")).toContain("hello");
+  });
+
+  it("reuses an existing clone and pulls the latest commit", () => {
+    const source = tempDir("graphify-clone-reuse-source-");
+    initRepo(source);
+    writeFileSync(join(source, "README.md"), "# hello\n", "utf-8");
+    execGit(source, ["add", "README.md"]);
+    execGit(source, ["commit", "-q", "-m", "init"]);
+
+    const destination = join(tempDir("graphify-clone-reuse-dest-"), "cloned");
+    cloneRepo({ url: source, outDir: destination });
+
+    writeFileSync(join(source, "CHANGELOG.md"), "v2\n", "utf-8");
+    execGit(source, ["add", "CHANGELOG.md"]);
+    execGit(source, ["commit", "-q", "-m", "update"]);
+
+    const result = cloneRepo({ url: source, outDir: destination });
+
+    expect(result.reused).toBe(true);
+    expect(readFileSync(join(destination, "CHANGELOG.md"), "utf-8")).toContain("v2");
+  });
+});


### PR DESCRIPTION
## Summary
- catch up the upstream v5 repo-oriented workflow additions in the TypeScript port
- add clone, merge-graphs, buildMerge/shrink guards, and Claude skill install parity
- refresh README, skills, traceability, and .graphify artifacts for release 0.4.33

## Verification
- npm run lint
- npm run build
- npm test
- npm pack
- install tarball in a temp prefix
- smoke test graphify --version, clone, merge-graphs, CLAUDE_CONFIG_DIR install
- node dist/cli.js update .
- node dist/cli.js check-update .
- node dist/cli.js portable-check .graphify