### PR TITLE
Add ontology reconciliation candidate queue

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -285,15 +285,21 @@ Progress note:
 - [x] Define Svelte package boundaries and fallback token adapter for open-source development before the design system exists.
 - [x] Confirm static export fallback: read-only viewer can export patch JSON without running a write server.
 
-## Task G: Local Reconciliation Studio Implementation
+## Task G: Reconciliation Candidate Queue And Local Studio Implementation
 
 **Files:**
-- Add: Svelte studio package or module after Task F approval
+- Add: `src/ontology-reconciliation.ts`
+- Add: reconciliation candidate tests
+- Add later: Svelte studio package or module after candidate queue/API approval
 - Modify/Add: CLI server command
 - Modify/Add: tests and UAT docs
 
-**Status:** Deferred to the next UI lot. This branch intentionally merges the ontology patch/MCP infrastructure and UAT framing first, then uses the public-domain mystery corpus to mock and validate the studio before implementation.
+**Status:** Candidate queue first. The studio must consume a deterministic reconciliation queue and emit patch JSON or patch API calls; it must not infer write behavior directly from graph visualization state.
 
+- [x] Define stable `graphify_ontology_reconciliation_candidates_v1` queue schema.
+- [x] Generate deterministic entity-match candidates from ontology output nodes and evidence refs.
+- [x] Expose candidate generation through CLI and skill runtime.
+- [ ] Expose read-only candidate APIs before any browser write UI.
 - [ ] Implement read-only studio served by `graphify ontology studio --config graphify.yaml`.
 - [ ] Implement write-enabled studio only with `--write`, localhost binding and local token.
 - [ ] Route every write through patch validate/dry-run/apply APIs.
@@ -427,7 +433,7 @@ graphify extract ./tmp/direct-uat-corpus --backend openai --model gpt-5.5 --no-c
 - [x] Decide evidence policy: no rendered description without source evidence refs.
 - [x] Decide insufficient-evidence behavior: record `insufficient_evidence` in sidecar, omit Markdown paragraph.
 - [x] Create the initial feature spec.
-- [ ] Add description sidecar schema and validation.
+- [x] Add description sidecar schema and validation.
 - [ ] Add wiki description generation command or runtime path for assistant/direct/batch/mesh.
 - [ ] Add `--wiki-descriptions` and `--wiki-community-descriptions` or equivalent config options.
 - [ ] Render validated descriptions in community wiki pages and ontology entity pages.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1914,6 +1914,27 @@ export async function main(): Promise<void> {
     });
 
   const ontology = program.command("ontology").description("Ontology lifecycle and reconciliation commands");
+  ontology
+    .command("candidates")
+    .description("Generate a deterministic ontology reconciliation candidate queue")
+    .requiredOption("--profile-state <path>", "Path to .graphify/profile/profile-state.json")
+    .requiredOption("--out <path>", "Candidate queue JSON output path")
+    .option("--json", "Print JSON result")
+    .action(async (opts) => {
+      const {
+        generateOntologyReconciliationCandidates,
+        writeOntologyReconciliationCandidates,
+      } = await import("./ontology-reconciliation.js");
+      const context = loadOntologyPatchContext(opts.profileState);
+      const queue = generateOntologyReconciliationCandidates(context);
+      writeOntologyReconciliationCandidates(opts.out, queue);
+      if (opts.json) {
+        console.log(JSON.stringify(queue, null, 2));
+      } else {
+        console.log(`Ontology reconciliation candidates: ${queue.candidate_count} written to ${resolve(opts.out)}`);
+      }
+    });
+
   const ontologyPatch = ontology.command("patch").description("Validate and apply ontology reconciliation patches");
   ontologyPatch
     .command("validate")

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,11 @@ export {
 export {
   compileOntologyOutputs,
 } from "./ontology-output.js";
+export {
+  generateOntologyReconciliationCandidates,
+  ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA,
+  writeOntologyReconciliationCandidates,
+} from "./ontology-reconciliation.js";
 export type {
   AssistantLlmClientOptions,
   BatchVisionExportInput,
@@ -151,6 +156,11 @@ export type {
   CompileOntologyOutputsResult,
   OntologyOutputConfig,
 } from "./ontology-output.js";
+export type {
+  GenerateOntologyReconciliationCandidatesOptions,
+  OntologyReconciliationCandidate,
+  OntologyReconciliationCandidateQueue,
+} from "./ontology-reconciliation.js";
 export {
   bindOntologyProfile,
   hashOntologyProfile,

--- a/src/ontology-patch-context.ts
+++ b/src/ontology-patch-context.ts
@@ -82,9 +82,13 @@ export function loadOntologyPatchContext(profileStatePath: string): OntologyPatc
     nodes: optionalJson<Array<Record<string, unknown>>>(join(ontologyDir, "nodes.json"), [])
       .map((node) => ({
         id: stringValue(node.id) ?? "",
+        label: stringValue(node.label) ?? undefined,
         type: stringValue(node.type) ?? undefined,
         status: stringValue(node.status) ?? undefined,
+        aliases: stringArray(node.aliases),
+        normalized_terms: stringArray(node.normalized_terms),
         source_refs: stringArray(node.source_refs),
+        registry_refs: stringArray(node.registry_refs),
       }))
       .filter((node) => node.id.length > 0),
     relations: optionalJson<Array<Record<string, unknown>>>(join(ontologyDir, "relations.json"), [])

--- a/src/ontology-patch.ts
+++ b/src/ontology-patch.ts
@@ -36,9 +36,13 @@ export interface OntologyPatch {
 
 export interface OntologyPatchNode {
   id: string;
+  label?: string;
   type?: string;
   status?: OntologyStatus;
+  aliases?: string[];
+  normalized_terms?: string[];
   source_refs?: string[];
+  registry_refs?: string[];
 }
 
 export interface OntologyPatchRelation {

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -1,0 +1,162 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import type { OntologyPatchContext, OntologyPatchNode } from "./ontology-patch.js";
+
+export const ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA = "graphify_ontology_reconciliation_candidates_v1" as const;
+
+export type OntologyReconciliationCandidateKind = "entity_match";
+export type OntologyReconciliationCandidateStatus = "candidate";
+
+export interface OntologyReconciliationCandidate {
+  id: string;
+  kind: OntologyReconciliationCandidateKind;
+  status: OntologyReconciliationCandidateStatus;
+  score: number;
+  candidate_id: string;
+  canonical_id: string;
+  shared_terms: string[];
+  evidence_refs: string[];
+  reasons: string[];
+  proposed_patch_operation: "accept_match";
+}
+
+export interface OntologyReconciliationCandidateQueue {
+  schema: typeof ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA;
+  graph_hash: string;
+  profile_hash: string;
+  generated_at: string;
+  candidate_count: number;
+  candidates: OntologyReconciliationCandidate[];
+}
+
+export interface GenerateOntologyReconciliationCandidatesOptions {
+  generatedAt?: string;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeTerm(value: string): string {
+  return value.trim().replace(/\s+/gu, " ").toLowerCase();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort((a, b) => a.localeCompare(b));
+}
+
+function nodeTerms(node: OntologyPatchNode): string[] {
+  return uniqueSorted([
+    ...(node.label ? [normalizeTerm(node.label)] : []),
+    ...(node.aliases ?? []).map(normalizeTerm),
+    ...(node.normalized_terms ?? []).map(normalizeTerm),
+  ]);
+}
+
+function statusRank(status: string | undefined): number {
+  switch (status) {
+    case "validated":
+      return 4;
+    case "needs_review":
+      return 3;
+    case "candidate":
+      return 2;
+    case "rejected":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function chooseCanonicalPair(a: OntologyPatchNode, b: OntologyPatchNode): {
+  canonical: OntologyPatchNode;
+  candidate: OntologyPatchNode;
+} {
+  const rankA = statusRank(a.status);
+  const rankB = statusRank(b.status);
+  if (rankA !== rankB) {
+    return rankA > rankB ? { canonical: a, candidate: b } : { canonical: b, candidate: a };
+  }
+  return a.id.localeCompare(b.id) <= 0 ? { canonical: a, candidate: b } : { canonical: b, candidate: a };
+}
+
+function candidateScore(sharedTerms: string[], canonical: OntologyPatchNode, candidate: OntologyPatchNode): number {
+  const canonicalLabel = canonical.label ? normalizeTerm(canonical.label) : null;
+  const candidateLabel = candidate.label ? normalizeTerm(candidate.label) : null;
+  const exactLabelMatch = canonicalLabel !== null && canonicalLabel === candidateLabel && sharedTerms.includes(canonicalLabel);
+  const statusBoost = statusRank(canonical.status) > statusRank(candidate.status) ? 0.05 : 0;
+  return Math.min(exactLabelMatch ? 0.95 + statusBoost : 0.8 + statusBoost, 1);
+}
+
+function candidateId(canonical: OntologyPatchNode, candidate: OntologyPatchNode, sharedTerms: string[]): string {
+  return `reconcile:${sha256([
+    "entity_match",
+    canonical.id,
+    candidate.id,
+    ...sharedTerms,
+  ].join("|")).slice(0, 24)}`;
+}
+
+export function generateOntologyReconciliationCandidates(
+  context: OntologyPatchContext,
+  options: GenerateOntologyReconciliationCandidatesOptions = {},
+): OntologyReconciliationCandidateQueue {
+  const candidates: OntologyReconciliationCandidate[] = [];
+  const comparableNodes = context.nodes
+    .filter((node) => node.type && nodeTerms(node).length > 0)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  for (let i = 0; i < comparableNodes.length; i += 1) {
+    for (let j = i + 1; j < comparableNodes.length; j += 1) {
+      const left = comparableNodes[i]!;
+      const right = comparableNodes[j]!;
+      if (left.type !== right.type) continue;
+
+      const leftTerms = new Set(nodeTerms(left));
+      const sharedTerms = nodeTerms(right).filter((term) => leftTerms.has(term));
+      if (sharedTerms.length === 0) continue;
+
+      const { canonical, candidate } = chooseCanonicalPair(left, right);
+      const evidenceRefs = uniqueSorted([
+        ...(canonical.source_refs ?? []),
+        ...(candidate.source_refs ?? []),
+      ]);
+      candidates.push({
+        id: candidateId(canonical, candidate, sharedTerms),
+        kind: "entity_match",
+        status: "candidate",
+        score: candidateScore(sharedTerms, canonical, candidate),
+        candidate_id: candidate.id,
+        canonical_id: canonical.id,
+        shared_terms: sharedTerms,
+        evidence_refs: evidenceRefs,
+        reasons: [
+          `same node type: ${canonical.type}`,
+          `shared normalized term(s): ${sharedTerms.join(", ")}`,
+        ],
+        proposed_patch_operation: "accept_match",
+      });
+    }
+  }
+
+  candidates.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  return {
+    schema: ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA,
+    graph_hash: context.graphHash,
+    profile_hash: context.profile.profile_hash,
+    generated_at: options.generatedAt ?? new Date().toISOString(),
+    candidate_count: candidates.length,
+    candidates,
+  };
+}
+
+export function writeOntologyReconciliationCandidates(
+  outPath: string,
+  queue: OntologyReconciliationCandidateQueue,
+): void {
+  const resolved = resolve(outPath);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, JSON.stringify(queue, null, 2) + "\n", "utf-8");
+}

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -652,6 +652,22 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     });
 
   program
+    .command("ontology-candidates")
+    .description("Generate a deterministic ontology reconciliation candidate queue")
+    .requiredOption("--profile-state <path>", "Path to .graphify/profile/profile-state.json")
+    .requiredOption("--out <path>", "Candidate queue JSON output path")
+    .action(async (opts) => {
+      const {
+        generateOntologyReconciliationCandidates,
+        writeOntologyReconciliationCandidates,
+      } = await import("./ontology-reconciliation.js");
+      const context = loadOntologyPatchContext(opts.profileState);
+      const queue = generateOntologyReconciliationCandidates(context);
+      writeOntologyReconciliationCandidates(resolve(opts.out), queue);
+      console.log(`Ontology reconciliation candidates: ${queue.candidate_count} written to ${resolve(opts.out)}`);
+    });
+
+  program
     .command("ontology-patch-validate")
     .description("Validate a graphify_ontology_patch_v1 JSON file without mutation")
     .requiredOption("--profile-state <path>", "Path to .graphify/profile/profile-state.json")

--- a/tests/ontology-patch-cli.test.ts
+++ b/tests/ontology-patch-cli.test.ts
@@ -101,8 +101,23 @@ async function prepareProject(): Promise<{ root: string; profileStatePath: strin
   writeFileSync(
     join(ontologyDir, "nodes.json"),
     JSON.stringify([
-      { id: "candidate-component", type: "Component", status: "candidate", source_refs: ["manual.md#p1"] },
-      { id: "component-a", type: "Component", status: "validated", source_refs: ["manual.md#p1"] },
+      {
+        id: "candidate-component",
+        label: "Component A",
+        type: "Component",
+        status: "candidate",
+        normalized_terms: ["component a"],
+        source_refs: ["manual.md#p1"],
+      },
+      {
+        id: "component-a",
+        label: "Component A",
+        type: "Component",
+        status: "validated",
+        aliases: ["A Component"],
+        normalized_terms: ["component a", "a component"],
+        source_refs: ["manual.md#p1"],
+      },
     ], null, 2),
     "utf-8",
   );
@@ -132,6 +147,45 @@ async function prepareProject(): Promise<{ root: string; profileStatePath: strin
 }
 
 describe("ontology patch CLI", () => {
+  it("generates reconciliation candidates through CLI and skill runtime", async () => {
+    const { root, profileStatePath } = await prepareProject();
+    const cliOut = join(root, ".graphify", "ontology", "reconciliation", "candidates.json");
+    const runtimeOut = join(root, ".graphify", "ontology", "reconciliation", "runtime-candidates.json");
+
+    const cli = await runCli([
+      "ontology",
+      "candidates",
+      "--profile-state",
+      profileStatePath,
+      "--out",
+      cliOut,
+      "--json",
+    ], root);
+    const runtime = await runSkillRuntime([
+      "ontology-candidates",
+      "--profile-state",
+      profileStatePath,
+      "--out",
+      runtimeOut,
+    ], root);
+
+    expect(cli.exitCode, JSON.stringify(cli, null, 2)).toBe(0);
+    expect(runtime.exitCode, JSON.stringify(runtime, null, 2)).toBe(0);
+    const queue = JSON.parse(readFileSync(cliOut, "utf-8")) as {
+      schema: string;
+      candidate_count: number;
+      candidates: Array<{ candidate_id: string; canonical_id: string; proposed_patch_operation: string }>;
+    };
+    expect(queue.schema).toBe("graphify_ontology_reconciliation_candidates_v1");
+    expect(queue.candidate_count).toBe(1);
+    expect(queue.candidates[0]).toMatchObject({
+      candidate_id: "candidate-component",
+      canonical_id: "component-a",
+      proposed_patch_operation: "accept_match",
+    });
+    expect(existsSync(runtimeOut)).toBe(true);
+  });
+
   it("validates, dry-runs and writes ontology patches through configured authoritative paths", async () => {
     const { root, profileStatePath, patchPath, decisionsPath } = await prepareProject();
 

--- a/tests/ontology-reconciliation.test.ts
+++ b/tests/ontology-reconciliation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  generateOntologyReconciliationCandidates,
+  ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA,
+} from "../src/ontology-reconciliation.js";
+import type { OntologyPatchContext } from "../src/ontology-patch.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+
+const profile = {
+  id: "synthetic-profile",
+  version: "1",
+  default_language: "en",
+  profile_hash: "profile-hash",
+  node_types: {
+    Component: {
+      description: "Synthetic component",
+      required_fields: [],
+      optional_fields: [],
+    },
+  },
+  relation_types: {},
+  registries: {},
+  citation_policy: {},
+  hardening: {
+    statuses: ["candidate", "needs_review", "validated", "rejected", "deprecated"],
+    default_status: "candidate",
+    status_transitions: [],
+  },
+  inference_policy: {},
+  evidence_policy: {},
+  hierarchies: {},
+  outputs: {
+    ontology: {
+      enabled: true,
+      artifact_schema: "graphify_ontology_outputs_v1",
+      canonical_node_types: ["Component"],
+      source_node_types: [],
+      occurrence_node_types: [],
+      alias_fields: [],
+      relation_exports: [],
+      wiki: {
+        enabled: false,
+        page_node_types: [],
+      },
+    },
+  },
+} as unknown as NormalizedOntologyProfile;
+
+function context(): OntologyPatchContext {
+  return {
+    rootDir: "/repo",
+    stateDir: "/repo/.graphify",
+    graphHash: "graph-hash",
+    profile,
+    profileState: {
+      profile_id: "synthetic-profile",
+      profile_version: "1",
+      profile_hash: "profile-hash",
+      project_config_path: "/repo/graphify.yaml",
+      ontology_profile_path: "/repo/profile.yaml",
+      state_dir: "/repo/.graphify",
+      detect_roots: [],
+      exclude_roots: [],
+      registry_counts: {},
+      registry_node_count: 0,
+      semantic_file_count: 0,
+      transcript_count: 0,
+      pdf_artifact_count: 0,
+    },
+    nodes: [
+      {
+        id: "component-payment",
+        label: "Payment Service",
+        type: "Component",
+        status: "validated",
+        aliases: ["Payments"],
+        normalized_terms: ["payment service", "payments"],
+        source_refs: ["manual.md#p1"],
+      },
+      {
+        id: "candidate-payments",
+        label: "Payments",
+        type: "Component",
+        status: "candidate",
+        aliases: [],
+        normalized_terms: ["payments"],
+        source_refs: ["manual.md#p2"],
+      },
+    ],
+    relations: [],
+    evidenceRefs: new Set(["manual.md#p1", "manual.md#p2"]),
+  };
+}
+
+describe("ontology reconciliation candidates", () => {
+  it("generates deterministic entity-match candidates from shared normalized terms", () => {
+    const first = generateOntologyReconciliationCandidates(context(), {
+      generatedAt: "2026-05-09T00:00:00.000Z",
+    });
+    const second = generateOntologyReconciliationCandidates(context(), {
+      generatedAt: "2026-05-09T00:00:00.000Z",
+    });
+
+    expect(first).toEqual(second);
+    expect(first.schema).toBe(ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA);
+    expect(first.candidate_count).toBe(1);
+    expect(first.candidates[0]).toMatchObject({
+      kind: "entity_match",
+      status: "candidate",
+      canonical_id: "component-payment",
+      candidate_id: "candidate-payments",
+      shared_terms: ["payments"],
+      evidence_refs: ["manual.md#p1", "manual.md#p2"],
+      proposed_patch_operation: "accept_match",
+    });
+    expect(first.candidates[0]!.score).toBeGreaterThan(0.8);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic ontology reconciliation candidate generation
- expose ontology candidates in CLI and skill runtime
- extend ontology patch sidecar metadata for labels, aliases, normalized terms, and registry refs

## Tests
- npm test -- tests/ontology-reconciliation.test.ts tests/ontology-patch-cli.test.ts tests/wiki-descriptions.test.ts tests/serve.test.ts tests/ontology-patch.test.ts
- npm run lint
- npm run build