### PR TITLE
Track E Lot 4-safe: bump graphology + @types/node + commander to current majors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "@ai-sdk/openai": "^3.0.61",
         "@sentropic/llm-mesh": "^0.1.0",
         "ai": "^6.0.175",
-        "commander": "^12.1.0",
+        "commander": "^14.0.3",
         "csv-parse": "^6.2.1",
-        "graphology": "^0.25.4",
+        "graphology": "^0.26.0",
         "graphology-communities-louvain": "^2.0.1",
         "graphology-metrics": "^2.1.0",
         "graphology-shortest-path": "^2.1.0",
@@ -32,7 +32,7 @@
         "graphify": "dist/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^22.10.0",
+        "@types/node": "^25.8.0",
         "tsup": "^8.3.0",
         "typescript": "^5.7.0",
         "vitest": "^2.1.0"
@@ -1242,13 +1242,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@vercel/oidc": {
@@ -1692,12 +1691,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -1896,21 +1895,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/docx/node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
-    "node_modules/docx/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2422,13 +2406,12 @@
       }
     },
     "node_modules/graphology": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
-      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
       "license": "MIT",
       "dependencies": {
-        "events": "^3.3.0",
-        "obliterator": "^2.0.2"
+        "events": "^3.3.0"
       },
       "peerDependencies": {
         "graphology-types": ">=0.24.0"
@@ -4785,10 +4768,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unpdf": {

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "@ai-sdk/openai": "^3.0.61",
     "@sentropic/llm-mesh": "^0.1.0",
     "ai": "^6.0.175",
-    "commander": "^12.1.0",
+    "commander": "^14.0.3",
     "csv-parse": "^6.2.1",
-    "graphology": "^0.25.4",
+    "graphology": "^0.26.0",
     "graphology-communities-louvain": "^2.0.1",
     "graphology-metrics": "^2.1.0",
     "graphology-shortest-path": "^2.1.0",
@@ -97,7 +97,6 @@
     "faster-whisper-ts": "^1.2.1",
     "neo4j-driver": "^5.27.0",
     "officeparser": "^7.0.2",
-    "unpdf": "^1.6.2",
     "tree-sitter-c": "^0.24.1",
     "tree-sitter-c-sharp": "^0.23.1",
     "tree-sitter-cpp": "^0.23.4",
@@ -118,7 +117,8 @@
     "tree-sitter-swift": "^0.7.1",
     "tree-sitter-typescript": "^0.23.2",
     "tree-sitter-zig": "^0.2.0",
-    "turndown": "^7.2.0"
+    "turndown": "^7.2.0",
+    "unpdf": "^1.6.2"
   },
   "overrides": {
     "officeparser": {
@@ -128,7 +128,7 @@
     "tree-sitter": "^0.26.8"
   },
   "devDependencies": {
-    "@types/node": "^22.10.0",
+    "@types/node": "^25.8.0",
     "tsup": "^8.3.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"


### PR DESCRIPTION
## Summary

Track E Lot 4 split into **safe** (this PR) and **risky** (separate, later) sub-lots. Ships only the three majors with low breaking-change blast radius:

| Dep | From | To | Risk |
|---|---|---|---|
| `graphology` | `^0.25.4` | `^0.26.0` | Minor in 0.x; small Set/Map iteration tightening, no API removal |
| `@types/node` | `^22.10.0` | `^25.8.0` | Pure dev dep; tracks current Node LTS type ergonomics |
| `commander` | `^12.1.0` | `^14.0.3` | Action handler signature stable; we already use the parser builder pattern |

**Left for a separate Lot 4-risky** (each isolated):

- `chokidar 4 → 5` (watch event semantics edge cases)
- `neo4j-driver 5 → 6` (session API breaking)
- `typescript 5 → 6` (strict mode tightenings, tsup may need bump)
- `vitest 2 → 4` (mocks API + env API breaking, full mock-fixture re-walk)

## Test plan

- [x] `npm install --legacy-peer-deps` — clean
- [x] `npm run build` — OK
- [x] `npm test` — 600 passed, 7 skipped, 0 failed