### PR TITLE
Track C-final-1: box (outline) vs square (solid) visual distinction

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -893,11 +893,18 @@ export function toHtml(
     const fontSize = memberCounts ? 12 : (deg >= maxDeg * 0.15 ? 12 : 0);
     const sourceFile = (data.source_file as string) ?? "";
     const fileType = (data.file_type as string) ?? "";
+    const shape = inferNodeShape(fileType, sourceFile);
+    // C-final-1: shape "box" (document/paper/concept) renders as outline-only
+    // so it is visually distinct from "square" (test) which stays solid-filled.
+    // vis.js draws a filled rectangle when color.background is a color; setting
+    // background to a transparent value keeps the border (color) and shows the
+    // label cleanly without the fill blob.
+    const isOutlinedShape = shape === "box";
     visNodes.push({
       id: nodeId,
       label,
       color: {
-        background: color,
+        background: isOutlinedShape ? "rgba(0,0,0,0)" : color,
         border: color,
         highlight: { background: "#ffffff", border: color },
       },
@@ -908,7 +915,7 @@ export function toHtml(
       community_name: sanitizeLabel(communityLabels?.get(cid) ?? `Community ${cid}`),
       source_file: sanitizeLabel(sourceFile),
       file_type: fileType,
-      shape: inferNodeShape(fileType, sourceFile),
+      shape,
       degree: deg,
     });
   });
@@ -1001,10 +1008,10 @@ ${htmlStyles()}
     <h3 id="shapes-heading" style="margin-top:14px">Shapes</h3>
     <ul id="shape-legend" aria-labelledby="shapes-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:#bbb">
       <li>● dot &mdash; code</li>
-      <li>■ square &mdash; test</li>
+      <li><span style="display:inline-block;width:10px;height:10px;background:#bbb;vertical-align:middle"></span> square (filled) &mdash; test</li>
       <li>▲ triangle &mdash; config (yaml/toml/...)</li>
       <li>◆ diamond &mdash; type definition (.d.ts)</li>
-      <li>▢ box &mdash; document / paper / concept</li>
+      <li><span style="display:inline-block;width:10px;height:10px;border:1px solid #bbb;background:transparent;vertical-align:middle"></span> box (outline) &mdash; document / paper / concept</li>
       <li>★ star &mdash; image</li>
       <li>⬢ hexagon &mdash; video</li>
     </ul>

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -196,10 +196,33 @@ describe("toHtml visual encoding (Track C3)", () => {
     // Static shape and edge legends are present in the sidebar.
     expect(html).toContain('id="shape-legend"');
     expect(html).toContain("triangle &mdash; config");
+    expect(html).toContain("box (outline) &mdash; document");
+    expect(html).toContain("square (filled) &mdash; test");
     expect(html).toContain('id="relation-legend"');
     expect(html).toContain("dotted &mdash; tested_by");
     // The vis.js options no longer force shape: 'dot' globally.
     expect(html).toContain("/* shape comes from per-node n.shape */");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("C-final-1: shape 'box' (document/paper/concept) is outlined (transparent background)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-c-final-1-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    G.addNode("code_a", { label: "AlphaService", source_file: "src/alpha.ts", file_type: "code" });
+    G.addNode("doc_a", { label: "DesignNote", source_file: "docs/design.md", file_type: "document" });
+    G.addUndirectedEdge("code_a", "doc_a", { relation: "documented_by", confidence: "EXTRACTED" });
+    const communities = new Map([[0, ["code_a", "doc_a"]]]);
+    toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
+    const html = readFileSync(htmlPath, "utf-8");
+
+    // Box (document) carries the transparent background so the border-only
+    // rendering is visually distinct from the solid square (test).
+    expect(html).toMatch(/"id":"doc_a"[^{]*\{[^}]*"background":"rgba\(0,0,0,0\)"/);
+    expect(html).toMatch(/"id":"doc_a"[\s\S]*?"shape":"box"/);
+    // Sanity: a code node keeps a coloured (non-transparent) background.
+    expect(html).toMatch(/"id":"code_a"[^{]*\{[^}]*"background":"#[0-9A-Fa-f]{6}"/);
 
     rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

C-UAT 2026-05-16 feedback : *"les box sans label ressemblent à des carrés. dans la légende, les box sont en contour sans fond vs les carrés en plein, faudrait peut-être faire ça dans le graph"*.

vis.js draws a filled rectangle when `color.background` is a colour string. Setting it to `rgba(0,0,0,0)` keeps the border (community colour) and shows the label cleanly without the fill blob. The `square`/`dot`/`triangle`/`diamond`/`star`/`hexagon` shapes remain solid-filled, so the box/square ambiguity is gone.

## Changes

- `src/export.ts` — per-node `color.background` switched to `rgba(0,0,0,0)` when `shape === 'box'` (file_type ∈ {document, paper, concept, rationale}). All other shapes unchanged.
- `src/export.ts` — shape-legend HTML updated: box now shows an outlined swatch, square shows a filled swatch, both as inline span swatches so the legend matches the actual rendering.
- `tests/html-export.test.ts` — extended existing visual-encoding test with new legend assertions, plus new dedicated case asserting the doc node carries the transparent background while a code node keeps its coloured fill.

## Test plan

- [x] `npm run build` — OK
- [x] `npm test` — **602 passed** (was 601) / 7 skipped / 0 failed
- [x] No source-API change, no schema change, no version bump (cosmetic-only).

## Visual

Doc/paper/concept/rationale nodes now render as outlined rectangles (community colour as border, transparent fill) — clearly distinct from solid squares (tests).