### PR TITLE
feat: add ontology reconciliation studio shell

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,10 @@
 # Graph Report - .  (2026-05-21)
 
 ## Corpus Check
-- 266 files · ~334,885 words
-- Verdict: corpus is large enough that graph structure adds value.
+- Large corpus: 267 files · ~343,867 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder, or use --no-semantic to run AST-only.
 
 ## Summary
-- 4205 nodes · 6731 edges · 220 communities detected
+- 4242 nodes · 6779 edges · 211 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +12,12 @@
 ## Input Scope
 - Requested: tracked
 - Resolved: tracked (source: cli)
-- Included files: 266 · Candidates: 286
-- Excluded: 0 untracked · 15716 ignored · 4 sensitive · 0 missing committed
+- Included files: 267 · Candidates: 288
+- Excluded: 0 untracked · 15710 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `a6269ff`
+- Built from Git commit: `d216c3d`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -55,248 +54,248 @@ Cohesion: 0.02
 Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
 
 ### Community 2 - "Community 2"
+Cohesion: 0.05
+Nodes (65): bfs(), communitiesFromGraph(), communityName(), dfs(), findNode(), getVersion(), loadGraph(), scoreNodes() (+57 more)
+
+### Community 3 - "Community 3"
 Cohesion: 0.03
 Nodes (58): alphaNeighbors, audit, beforeAudit, beforeDecisions, betaNeighbors, candidate, candidateResponse, candidates (+50 more)
 
-### Community 3 - "Community 3"
+### Community 4 - "Community 4"
 Cohesion: 0.05
 Nodes (48): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+40 more)
 
-### Community 4 - "Community 4"
+### Community 5 - "Community 5"
 Cohesion: 0.05
 Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+44 more)
 
-### Community 5 - "Community 5"
-Cohesion: 0.06
-Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
-
 ### Community 6 - "Community 6"
 Cohesion: 0.05
-Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
+Nodes (38): average(), buildBlastRadius(), buildReviewAnalysis(), communityRisk(), evaluateReviewAnalysis(), formatMetric(), impactedCommunities(), multimodalSafety() (+30 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.06
-Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
+Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
 
 ### Community 8 - "Community 8"
+Cohesion: 0.05
+Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.06
+Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.04
 Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
 
-### Community 9 - "Community 9"
+### Community 11 - "Community 11"
 Cohesion: 0.07
 Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
 
-### Community 10 - "Community 10"
+### Community 12 - "Community 12"
 Cohesion: 0.06
 Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
 
-### Community 11 - "Community 11"
+### Community 13 - "Community 13"
 Cohesion: 0.05
 Nodes (34): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+26 more)
 
-### Community 12 - "Community 12"
+### Community 14 - "Community 14"
 Cohesion: 0.09
 Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
 
-### Community 13 - "Community 13"
+### Community 15 - "Community 15"
 Cohesion: 0.07
 Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
 
-### Community 14 - "Community 14"
+### Community 16 - "Community 16"
 Cohesion: 0.07
 Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
 Cohesion: 0.06
 Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.10
+### Community 18 - "Community 18"
+Cohesion: 0.1
 Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
 
-### Community 17 - "Community 17"
+### Community 19 - "Community 19"
 Cohesion: 0.05
 Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
 
-### Community 18 - "Community 18"
+### Community 20 - "Community 20"
 Cohesion: 0.08
 Nodes (38): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderMetricsCard(), renderViewerSurface() (+30 more)
 
-### Community 19 - "Community 19"
-Cohesion: 0.10
-Nodes (30): ConnectError, ConnectTimeout, PoolTimeout, ProtocolError, ProxyError, An error occurred at the transport layer., Timed out while connecting to the host., Timed out while receiving data from the host. (+22 more)
-
-### Community 20 - "Community 20"
-Cohesion: 0.06
-Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
-
 ### Community 21 - "Community 21"
-Cohesion: 0.11
-Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+18 more)
+Cohesion: 0.1
+Nodes (30): ConnectError, ConnectTimeout, PoolTimeout, ProtocolError, ProxyError, An error occurred at the transport layer., Timed out while connecting to the host., Timed out while receiving data from the host. (+22 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.06
-Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
+Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
 ### Community 23 - "Community 23"
+Cohesion: 0.11
+Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+18 more)
+
+### Community 24 - "Community 24"
+Cohesion: 0.06
+Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
+
+### Community 25 - "Community 25"
 Cohesion: 0.07
 Nodes (35): Cookies, build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str() (+27 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.10
+### Community 26 - "Community 26"
+Cohesion: 0.1
 Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
 
-### Community 25 - "Community 25"
+### Community 27 - "Community 27"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
 
-### Community 26 - "Community 26"
+### Community 28 - "Community 28"
 Cohesion: 0.05
 Nodes (33): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+25 more)
 
-### Community 27 - "Community 27"
+### Community 29 - "Community 29"
 Cohesion: 0.07
 Nodes (35): Exception, CloseError, ConnectTimeout, CookieConflict, DecodingError, HTTPError, HTTPStatusError, NetworkError (+27 more)
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.08
 Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.09
 Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
-### Community 31 - "Community 31"
+### Community 33 - "Community 33"
 Cohesion: 0.09
 Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
-### Community 32 - "Community 32"
+### Community 34 - "Community 34"
 Cohesion: 0.09
 Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
 
-### Community 33 - "Community 33"
-Cohesion: 0.10
+### Community 35 - "Community 35"
+Cohesion: 0.1
 Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
 
-### Community 34 - "Community 34"
+### Community 36 - "Community 36"
+Cohesion: 0.06
+Nodes (28): apply, audit, auditLine, authoritative, { body, headers }, { bootstrapScript, clientScript }, candidateDetails, context (+20 more)
+
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
-### Community 35 - "Community 35"
+### Community 38 - "Community 38"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
 
-### Community 36 - "Community 36"
-Cohesion: 0.08
-Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.06
-Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.09
-Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
-
 ### Community 39 - "Community 39"
-Cohesion: 0.16
-Nodes (16): Auth, BasicAuth, BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
+Cohesion: 0.1
+Nodes (27): candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), handleOntologyStudioRequest(), htmlResult(), isLoopbackHost(), jsonResult() (+19 more)
 
 ### Community 40 - "Community 40"
 Cohesion: 0.08
-Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
+Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
 ### Community 41 - "Community 41"
+Cohesion: 0.06
+Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
+
+### Community 42 - "Community 42"
+Cohesion: 0.09
+Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.16
+Nodes (16): Auth, BasicAuth, BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.08
+Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
+
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
-### Community 42 - "Community 42"
-Cohesion: 0.10
+### Community 46 - "Community 46"
+Cohesion: 0.1
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 43 - "Community 43"
-Cohesion: 0.10
+### Community 47 - "Community 47"
+Cohesion: 0.1
 Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
-### Community 44 - "Community 44"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
-### Community 45 - "Community 45"
+### Community 49 - "Community 49"
 Cohesion: 0.16
 Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
 
-### Community 46 - "Community 46"
+### Community 50 - "Community 50"
 Cohesion: 0.09
 Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
 
-### Community 47 - "Community 47"
+### Community 51 - "Community 51"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 48 - "Community 48"
-Cohesion: 0.07
-Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
-
-### Community 49 - "Community 49"
-Cohesion: 0.09
-Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
-
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.07
 Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
-### Community 51 - "Community 51"
+### Community 53 - "Community 53"
 Cohesion: 0.13
 Nodes (2): AsyncClient, Client
 
-### Community 52 - "Community 52"
-Cohesion: 0.10
+### Community 54 - "Community 54"
+Cohesion: 0.1
 Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.13
 Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
 
-### Community 54 - "Community 54"
-Cohesion: 0.10
+### Community 56 - "Community 56"
+Cohesion: 0.1
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
-### Community 55 - "Community 55"
+### Community 57 - "Community 57"
 Cohesion: 0.14
 Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
 
-### Community 56 - "Community 56"
-Cohesion: 0.08
-Nodes (21): OntologyWriteFixture, apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine (+13 more)
-
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.09
 Nodes (6): Core data models: URL, Headers, Cookies, Request, Response. These are the centra, HTTPStatusError, A 4xx or 5xx response was received., Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, URL
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.16
 Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.11
 Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+4 more)
 
-### Community 61 - "Community 61"
-Cohesion: 0.10
-Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
-
 ### Community 62 - "Community 62"
-Cohesion: 0.13
-Nodes (19): candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), handleOntologyStudioRequest(), htmlResult(), isLoopbackHost(), jsonResult() (+11 more)
+Cohesion: 0.1
+Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
 
 ### Community 63 - "Community 63"
 Cohesion: 0.09
@@ -311,7 +310,7 @@ Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.10
+Cohesion: 0.1
 Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
 
 ### Community 67 - "Community 67"
@@ -355,7 +354,7 @@ Cohesion: 0.14
 Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.10
+Cohesion: 0.1
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
 ### Community 78 - "Community 78"
@@ -395,7 +394,7 @@ Cohesion: 0.12
 Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.20
+Cohesion: 0.2
 Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
 
 ### Community 88 - "Community 88"
@@ -500,155 +499,155 @@ Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), sa
 
 ### Community 113 - "Community 113"
 Cohesion: 0.21
-Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.21
 Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.18
 Nodes (1): Headers
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.18
 Nodes (1): Client
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.24
 Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 129 - "Community 129"
+### Community 128 - "Community 128"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.27
 Nodes (2): ConnectionPool, HTTPTransport
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.22
 Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 140 - "Community 140"
-Cohesion: 0.20
+### Community 139 - "Community 139"
+Cohesion: 0.2
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 142 - "Community 142"
-Cohesion: 0.20
+### Community 141 - "Community 141"
+Cohesion: 0.2
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.24
 Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 145 - "Community 145"
-Cohesion: 0.20
+### Community 144 - "Community 144"
+Cohesion: 0.2
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.24
 Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
 
-### Community 148 - "Community 148"
-Cohesion: 0.20
+### Community 147 - "Community 147"
+Cohesion: 0.2
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 149 - "Community 149"
-Cohesion: 0.20
+### Community 148 - "Community 148"
+Cohesion: 0.2
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
+
+### Community 149 - "Community 149"
+Cohesion: 0.22
+Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
 ### Community 150 - "Community 150"
 Cohesion: 0.22
-Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
+Nodes (2): handler, MockElement
 
 ### Community 151 - "Community 151"
 Cohesion: 0.28
@@ -688,296 +687,260 @@ Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePat
 
 ### Community 160 - "Community 160"
 Cohesion: 0.25
-Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
-
-### Community 161 - "Community 161"
-Cohesion: 0.25
 Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.22
 Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.32
 Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
 
-### Community 165 - "Community 165"
+### Community 164 - "Community 164"
 Cohesion: 0.25
 Nodes (8): CloseError, NetworkError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection., ReadError, WriteError
 
-### Community 166 - "Community 166"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 167 - "Community 167"
+### Community 165 - "Community 165"
 Cohesion: 0.25
 Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
 
-### Community 168 - "Community 168"
+### Community 166 - "Community 166"
 Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
-### Community 169 - "Community 169"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 170 - "Community 170"
+### Community 167 - "Community 167"
 Cohesion: 0.32
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 171 - "Community 171"
+### Community 168 - "Community 168"
 Cohesion: 0.25
 Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
-### Community 172 - "Community 172"
+### Community 169 - "Community 169"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 173 - "Community 173"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
-### Community 174 - "Community 174"
+### Community 171 - "Community 171"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 175 - "Community 175"
+### Community 172 - "Community 172"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 176 - "Community 176"
+### Community 173 - "Community 173"
 Cohesion: 0.29
 Nodes (6): DecodingError, HTTPError, An error occurred while issuing a request., Decoding of the response failed., Base class for all httpx exceptions., RequestError
 
-### Community 177 - "Community 177"
+### Community 174 - "Community 174"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 178 - "Community 178"
-Cohesion: 0.29
-Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
-
-### Community 179 - "Community 179"
-Cohesion: 0.43
-Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
-
-### Community 180 - "Community 180"
-Cohesion: 0.33
-Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
-
-### Community 181 - "Community 181"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 182 - "Community 182"
+### Community 176 - "Community 176"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 183 - "Community 183"
+### Community 177 - "Community 177"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 184 - "Community 184"
+### Community 178 - "Community 178"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 185 - "Community 185"
+### Community 179 - "Community 179"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 186 - "Community 186"
+### Community 180 - "Community 180"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 187 - "Community 187"
+### Community 181 - "Community 181"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 188 - "Community 188"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (1): recommendation
 
-### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
-
-### Community 190 - "Community 190"
-Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
-
-### Community 191 - "Community 191"
+### Community 183 - "Community 183"
 Cohesion: 0.33
 Nodes (1): CONFIDENCE_VALUES
 
-### Community 192 - "Community 192"
+### Community 184 - "Community 184"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 193 - "Community 193"
+### Community 185 - "Community 185"
 Cohesion: 0.47
 Nodes (5): escapeHtml(), HTML_ESCAPE_MAP, renderWorkspaceShell(), RenderWorkspaceShellOptions, shellStyles()
 
-### Community 194 - "Community 194"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (5): commands, dir, matchers, settings, tempDirs
 
-### Community 195 - "Community 195"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (5): dir, original, rule, rulePath, tempDirs
 
-### Community 196 - "Community 196"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
-### Community 197 - "Community 197"
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (4): dir, logs, preview, tempDirs
 
-### Community 198 - "Community 198"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
-### Community 199 - "Community 199"
+### Community 191 - "Community 191"
 Cohesion: 0.33
 Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
-### Community 200 - "Community 200"
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (4): contents, dir, lockPath, tempDirs
 
-### Community 201 - "Community 201"
-Cohesion: 0.60
+### Community 193 - "Community 193"
+Cohesion: 0.6
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 202 - "Community 202"
-Cohesion: 0.60
+### Community 194 - "Community 194"
+Cohesion: 0.6
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 203 - "Community 203"
-Cohesion: 0.50
+### Community 195 - "Community 195"
+Cohesion: 0.5
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 204 - "Community 204"
-Cohesion: 0.40
+### Community 196 - "Community 196"
+Cohesion: 0.4
 Nodes (4): chunks, client, files, root
 
-### Community 205 - "Community 205"
-Cohesion: 0.40
+### Community 197 - "Community 197"
+Cohesion: 0.4
+Nodes (2): MockDocument, registerStudioShellDom()
+
+### Community 198 - "Community 198"
+Cohesion: 0.4
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 206 - "Community 206"
-Cohesion: 0.40
+### Community 199 - "Community 199"
+Cohesion: 0.4
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 207 - "Community 207"
+### Community 200 - "Community 200"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 208 - "Community 208"
-Cohesion: 0.50
+### Community 201 - "Community 201"
+Cohesion: 0.5
 Nodes (3): b1, b2, backup
 
-### Community 209 - "Community 209"
+### Community 202 - "Community 202"
+Cohesion: 0.67
+Nodes (1): OntologyWriteFixture
+
+### Community 203 - "Community 203"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 210 - "Community 210"
+### Community 204 - "Community 204"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 211 - "Community 211"
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 212 - "Community 212"
-Cohesion: 1.00
+### Community 206 - "Community 206"
+Cohesion: 1
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 213 - "Community 213"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 214 - "Community 214"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 215 - "Community 215"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 216 - "Community 216"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 217 - "Community 217"
-Cohesion: 1.00
+### Community 207 - "Community 207"
+Cohesion: 1
 Nodes (1): UnpdfTextResult
 
-### Community 218 - "Community 218"
-Cohesion: 1.00
+### Community 208 - "Community 208"
+Cohesion: 1
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 219 - "Community 219"
-Cohesion: 1.00
+### Community 209 - "Community 209"
+Cohesion: 1
+Nodes (1): MockNode
+
+### Community 210 - "Community 210"
+Cohesion: 1
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1633 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1628 more)
+- **1643 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1638 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 51`** (2 nodes): `AsyncClient`, `Client`
+- **Thin community `Community 53`** (2 nodes): `AsyncClient`, `Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 104`** (1 nodes): `AsyncClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (1 nodes): `Headers`
+- **Thin community `Community 119`** (1 nodes): `Headers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (1 nodes): `Client`
+- **Thin community `Community 120`** (1 nodes): `Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (2 nodes): `ConnectionPool`, `HTTPTransport`
+- **Thin community `Community 132`** (2 nodes): `ConnectionPool`, `HTTPTransport`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 150`** (2 nodes): `handler`, `MockElement`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 153`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 162`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 172`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (1 nodes): `recommendation`
+- **Thin community `Community 182`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 183`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (2 nodes): `paths`, `root`
+- **Thin community `Community 197`** (2 nodes): `MockDocument`, `registerStudioShellDom()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 202`** (1 nodes): `OntologyWriteFixture`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 204`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 206`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 207`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 208`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 209`** (1 nodes): `MockNode`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `tempProfileProject()`, `tempProject()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 210`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 23` to `Community 57`, `Community 120`, `Community 39`, `Community 51`, `Community 27`?**
+- **Why does `MockElement` connect `Community 150` to `Community 36`, `Community 197`?**
+  _High betweenness centrality (0.003) - this node is a cross-community bridge._
+- **Why does `Cookies` connect `Community 25` to `Community 58`, `Community 119`, `Community 43`, `Community 53`, `Community 29`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 45` to `Community 57`, `Community 121`, `Community 104`, `Community 23`?**
-  _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `InvalidURL` connect `Community 45` to `Community 27`, `Community 121`, `Community 104`?**
+- **Why does `Cookies` connect `Community 49` to `Community 58`, `Community 120`, `Community 104`, `Community 25`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/scripts/preuat-reconciliation.sh
+++ b/scripts/preuat-reconciliation.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 /path/to/graphify.yaml" >&2
+  exit 1
+fi
+
+CONFIG_PATH="$1"
+
+node --input-type=module - "$CONFIG_PATH" <<'EOF'
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import YAML from "yaml";
+
+const configPath = resolve(process.argv[2]);
+const configDir = dirname(configPath);
+const config = YAML.parse(readFileSync(configPath, "utf-8")) ?? {};
+const stateDir = resolve(configDir, config.outputs?.state_dir ?? ".graphify");
+const profileStatePath = resolve(stateDir, "profile", "profile-state.json");
+const manifestPath = resolve(stateDir, "ontology", "manifest.json");
+const nodesPath = resolve(stateDir, "ontology", "nodes.json");
+const queuePath = resolve(stateDir, "ontology", "reconciliation", "candidates.json");
+
+for (const requiredPath of [profileStatePath, manifestPath, nodesPath]) {
+  if (!existsSync(requiredPath)) {
+    throw new Error(`missing required ontology artifact: ${requiredPath}`);
+  }
+}
+
+const profileState = JSON.parse(readFileSync(profileStatePath, "utf-8"));
+const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+const nodes = JSON.parse(readFileSync(nodesPath, "utf-8"));
+
+if (existsSync(queuePath)) {
+  const currentQueue = JSON.parse(readFileSync(queuePath, "utf-8"));
+  if (typeof currentQueue.candidate_count === "number" && currentQueue.candidate_count > 0) {
+    console.log(`Queue already populated: ${queuePath} (${currentQueue.candidate_count} candidate(s))`);
+    process.exit(0);
+  }
+}
+
+function normalize(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function nodeTerms(node) {
+  const normalizedTerms = Array.isArray(node?.normalized_terms) ? node.normalized_terms : [];
+  return new Set(normalizedTerms.map((value) => normalize(value)).filter(Boolean));
+}
+
+function nodeTokens(node) {
+  const values = [
+    node?.label,
+    ...(Array.isArray(node?.aliases) ? node.aliases : []),
+    ...(Array.isArray(node?.normalized_terms) ? node.normalized_terms : []),
+  ];
+  return new Set(
+    values
+      .flatMap((value) => normalize(value).split(/\s+/))
+      .filter((token) => token.length >= 4),
+  );
+}
+
+function chooseSeedPair(allNodes) {
+  const sherlock = allNodes.find((node) => node?.id === "character_sherlock_holmes");
+  const herlock = allNodes.find((node) => node?.id === "character_herlock_sholmes");
+  if (sherlock && herlock) {
+    return {
+      canonical: sherlock,
+      candidate: herlock,
+      score: 0.97,
+      sharedTerms: ["sherlock holmes"],
+      reasons: [
+        "same node type: Character",
+        "cross-work detective alias review: Sherlock Holmes vs Herlock Sholmes",
+      ],
+    };
+  }
+
+  const candidates = allNodes.filter((node) => node?.status === "candidate");
+  const canonicals = allNodes.filter((node) => node?.status === "validated");
+  for (const candidate of candidates) {
+    const candidateTerms = nodeTerms(candidate);
+    const candidateTokens = nodeTokens(candidate);
+    for (const canonical of canonicals) {
+      if (!candidate?.type || candidate.type !== canonical?.type) continue;
+      const sharedTerms = Array.from(nodeTerms(canonical)).filter((term) => candidateTerms.has(term));
+      if (sharedTerms.length > 0) {
+        return {
+          canonical,
+          candidate,
+          score: 0.95,
+          sharedTerms,
+          reasons: [
+            `same node type: ${candidate.type}`,
+            `shared normalized term(s): ${sharedTerms.join(", ")}`,
+          ],
+        };
+      }
+
+      const sharedTokens = Array.from(nodeTokens(canonical)).filter((token) => candidateTokens.has(token));
+      if (sharedTokens.length > 0) {
+        return {
+          canonical,
+          candidate,
+          score: 0.84,
+          sharedTerms: sharedTokens.slice(0, 3),
+          reasons: [
+            `same node type: ${candidate.type}`,
+            `shared token(s): ${sharedTokens.slice(0, 3).join(", ")}`,
+          ],
+        };
+      }
+    }
+  }
+  return null;
+}
+
+const seed = chooseSeedPair(nodes);
+if (!seed) {
+  throw new Error(`could not derive a demo reconciliation candidate from ${nodesPath}`);
+}
+
+const evidenceRefs = Array.from(new Set([
+  ...(Array.isArray(seed.candidate?.source_refs) ? seed.candidate.source_refs : []),
+  ...(Array.isArray(seed.canonical?.source_refs) ? seed.canonical.source_refs : []),
+]));
+const candidateId = "uat:" + createHash("sha256")
+  .update([
+    "entity_match",
+    seed.canonical.id,
+    seed.candidate.id,
+    ...seed.sharedTerms,
+  ].join("|"))
+  .digest("hex")
+  .slice(0, 24);
+
+const queue = {
+  schema: "graphify_ontology_reconciliation_candidates_v1",
+  graph_hash: manifest.graph_hash ?? "unknown-graph-hash",
+  profile_hash: profileState.profile_hash ?? "unknown-profile-hash",
+  generated_at: new Date().toISOString(),
+  candidate_count: 1,
+  candidates: [
+    {
+      id: candidateId,
+      kind: "entity_match",
+      status: "candidate",
+      score: seed.score,
+      candidate_id: seed.candidate.id,
+      canonical_id: seed.canonical.id,
+      shared_terms: seed.sharedTerms,
+      evidence_refs: evidenceRefs,
+      reasons: seed.reasons,
+      proposed_patch_operation: "accept_match",
+    },
+  ],
+};
+
+mkdirSync(dirname(queuePath), { recursive: true });
+writeFileSync(queuePath, JSON.stringify(queue, null, 2) + "\n", "utf-8");
+
+console.log(`Wrote 1 UAT reconciliation candidate to ${queuePath}`);
+console.log(`Seed pair: ${seed.candidate.id} -> ${seed.canonical.id}`);
+console.log(`Suggested studio command: node dist/cli.js ontology studio --config ${configPath} --port 4180`);
+EOF

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -124,10 +124,914 @@ function jsonResult(status: number, value: unknown): OntologyStudioRouteResult {
   };
 }
 
+interface OntologyStudioBootstrap {
+  writeEnabled: boolean;
+  routes: {
+    candidates: string;
+    candidateBase: string;
+    decisionLog: string;
+    rebuildStatus: string;
+    patchValidate: string;
+    patchDryRun: string;
+    patchApply: string;
+  };
+}
+
+function scriptSafeJson(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+}
+
+function studioBootstrap(writeEnabled: boolean): OntologyStudioBootstrap {
+  return {
+    writeEnabled,
+    routes: {
+      candidates: "/api/ontology/reconciliation/candidates",
+      candidateBase: "/api/ontology/reconciliation/candidates/",
+      decisionLog: "/api/ontology/reconciliation/decision-log",
+      rebuildStatus: "/api/ontology/rebuild-status",
+      patchValidate: "/api/ontology/patch/validate",
+      patchDryRun: "/api/ontology/patch/dry-run",
+      patchApply: "/api/ontology/patch/apply",
+    },
+  };
+}
+
+function studioStyles(): string {
+  return `
+    :root {
+      color-scheme: light;
+      --surface: #f5f6f7;
+      --surface-muted: #eceff1;
+      --surface-raised: #ffffff;
+      --surface-accent: #effcf7;
+      --surface-warning: #fff7ed;
+      --text: #16191d;
+      --text-muted: #5d6670;
+      --border: #d6dde3;
+      --border-strong: #b8c2cc;
+      --accent: #0f766e;
+      --accent-strong: #115e59;
+      --warning: #b45309;
+      --danger: #b91c1c;
+      --success: #166534;
+      --info: #1d4ed8;
+      --shadow: 0 14px 30px rgba(22, 25, 29, 0.08);
+      font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(180deg, #fbfcfc 0%, var(--surface) 100%);
+      color: var(--text);
+    }
+
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+
+    button {
+      border: 1px solid var(--border-strong);
+      border-radius: 8px;
+      background: var(--surface-raised);
+      color: var(--text);
+      cursor: pointer;
+      padding: 0.6rem 0.9rem;
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      color: var(--text-muted);
+      background: var(--surface-muted);
+      border-color: var(--border);
+    }
+
+    input,
+    select {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface-raised);
+      color: var(--text);
+      padding: 0.6rem 0.75rem;
+    }
+
+    code,
+    pre {
+      font-family: "SFMono-Regular", ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+    }
+
+    .studio {
+      max-width: 1600px;
+      margin: 0 auto;
+      padding: 1.5rem;
+    }
+
+    .studio__header {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: minmax(0, 1.7fr) minmax(320px, 1fr);
+      align-items: start;
+      margin-bottom: 1rem;
+    }
+
+    .studio__intro,
+    .studio__mode,
+    .panel {
+      background: var(--surface-raised);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+
+    .studio__intro,
+    .studio__mode {
+      padding: 1.2rem 1.25rem;
+    }
+
+    .eyebrow {
+      margin: 0 0 0.55rem;
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.95rem;
+      line-height: 1.08;
+    }
+
+    .lead {
+      margin: 0.65rem 0 0;
+      max-width: 70ch;
+      color: var(--text-muted);
+    }
+
+    .chip-row,
+    .meta-row,
+    .action-row,
+    .route-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      min-height: 2rem;
+      padding: 0.35rem 0.65rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface-muted);
+      color: var(--text);
+      font-size: 0.82rem;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .chip--accent {
+      border-color: color-mix(in srgb, var(--accent) 28%, white);
+      background: var(--surface-accent);
+      color: var(--accent-strong);
+    }
+
+    .chip--warning {
+      border-color: color-mix(in srgb, var(--warning) 32%, white);
+      background: var(--surface-warning);
+      color: var(--warning);
+    }
+
+    .chip--success {
+      border-color: color-mix(in srgb, var(--success) 28%, white);
+      background: #f0fdf4;
+      color: var(--success);
+    }
+
+    .chip--danger {
+      border-color: color-mix(in srgb, var(--danger) 28%, white);
+      background: #fef2f2;
+      color: var(--danger);
+    }
+
+    .studio__workspace {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: minmax(320px, 390px) minmax(0, 1fr);
+      align-items: start;
+    }
+
+    .panel {
+      overflow: hidden;
+    }
+
+    .panel__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 1rem 1.1rem 0.85rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .panel__title {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.25;
+    }
+
+    .panel__subhead {
+      margin: 0.3rem 0 0;
+      color: var(--text-muted);
+      font-size: 0.88rem;
+    }
+
+    .panel__body {
+      padding: 1rem 1.1rem 1.1rem;
+    }
+
+    .queue-toolbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 140px auto;
+      gap: 0.75rem;
+      align-items: end;
+      padding: 0.95rem 1.1rem 0.85rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .field {
+      display: grid;
+      gap: 0.38rem;
+    }
+
+    .field > span {
+      color: var(--text-muted);
+      font-size: 0.77rem;
+      font-weight: 600;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    .status-line {
+      padding: 0.8rem 1.1rem 0;
+      color: var(--text-muted);
+      font-size: 0.88rem;
+    }
+
+    .queue-list {
+      display: grid;
+      gap: 0.7rem;
+      padding: 0.8rem 1.1rem 1.1rem;
+      max-height: calc(100vh - 18rem);
+      overflow: auto;
+    }
+
+    .queue-item {
+      width: 100%;
+      text-align: left;
+      padding: 0.9rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface-raised);
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .queue-item[aria-selected="true"] {
+      border-color: color-mix(in srgb, var(--accent) 40%, white);
+      background: var(--surface-accent);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, white);
+    }
+
+    .queue-item__top,
+    .queue-item__meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.6rem;
+    }
+
+    .queue-item__title {
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+    }
+
+    .queue-item__score {
+      flex: 0 0 auto;
+      min-width: 3.7rem;
+      text-align: center;
+      padding: 0.28rem 0.5rem;
+      border-radius: 999px;
+      background: var(--surface-muted);
+      color: var(--text);
+      font-size: 0.78rem;
+      font-weight: 700;
+    }
+
+    .queue-item__meta,
+    .caption,
+    .hint {
+      color: var(--text-muted);
+      font-size: 0.82rem;
+    }
+
+    .details-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+    }
+
+    .details-grid > .panel--span-12 { grid-column: span 12; }
+    .details-grid > .panel--span-8 { grid-column: span 8; }
+    .details-grid > .panel--span-6 { grid-column: span 6; }
+    .details-grid > .panel--span-4 { grid-column: span 4; }
+
+    .key-value {
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .key-value__row {
+      display: grid;
+      grid-template-columns: minmax(110px, 150px) minmax(0, 1fr);
+      gap: 0.8rem;
+      align-items: start;
+      padding-top: 0.6rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .key-value__row:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    .key-value__label {
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    .key-value__value {
+      overflow-wrap: anywhere;
+    }
+
+    .stack {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .list {
+      display: grid;
+      gap: 0.5rem;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    .list__item {
+      padding: 0.8rem 0.9rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+
+    .mono-block {
+      min-height: 18rem;
+      margin: 0;
+      padding: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: #f7f8f9;
+      color: #111827;
+      font-size: 0.84rem;
+      line-height: 1.5;
+      overflow: auto;
+    }
+
+    .route-list code {
+      padding: 0.2rem 0.35rem;
+      border-radius: 6px;
+      background: #f4f6f8;
+    }
+
+    .empty {
+      padding: 1rem;
+      border: 1px dashed var(--border);
+      border-radius: 8px;
+      color: var(--text-muted);
+      background: var(--surface);
+    }
+
+    @media (max-width: 1180px) {
+      .studio__header,
+      .studio__workspace {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .queue-list {
+        max-height: 32rem;
+      }
+    }
+
+    @media (max-width: 900px) {
+      .details-grid > .panel--span-12,
+      .details-grid > .panel--span-8,
+      .details-grid > .panel--span-6,
+      .details-grid > .panel--span-4 {
+        grid-column: span 12;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .studio {
+        padding: 1rem;
+      }
+
+      .queue-toolbar {
+        grid-template-columns: 1fr;
+      }
+
+      .queue-list {
+        max-height: none;
+      }
+
+      .key-value__row {
+        grid-template-columns: 1fr;
+        gap: 0.35rem;
+      }
+    }
+  `;
+}
+
+function studioClientScript(): string {
+  return `
+    (function () {
+      const bootstrap = window.__ONTOLOGY_STUDIO_BOOTSTRAP__;
+      const state = {
+        queue: null,
+        selectedId: null,
+        selectedCandidate: null,
+        rebuild: null,
+        log: null,
+        queueError: null,
+      };
+
+      const elements = {
+        queue: document.getElementById("candidate-queue"),
+        queueStatus: document.getElementById("queue-status"),
+        queueCount: document.getElementById("queue-count"),
+        queueQuery: document.getElementById("queue-query"),
+        queueMinScore: document.getElementById("queue-min-score"),
+        refresh: document.getElementById("refresh-button"),
+        selectedTitle: document.getElementById("selected-title"),
+        selectedMeta: document.getElementById("selected-meta"),
+        selectedSummary: document.getElementById("selected-summary"),
+        evidenceBody: document.getElementById("evidence-panel-body"),
+        canonicalBody: document.getElementById("canonical-panel-body"),
+        graphBody: document.getElementById("graph-panel-body"),
+        rebuildBody: document.getElementById("rebuild-panel-body"),
+        auditBody: document.getElementById("audit-panel-body"),
+        patchPreview: document.getElementById("patch-preview"),
+        patchHint: document.getElementById("patch-mode-copy"),
+      };
+
+      function fetchJson(path) {
+        return fetch(path, { headers: { accept: "application/json" } }).then(async function (response) {
+          if (response.ok) return response.json();
+          let message = response.status + " " + response.statusText;
+          try {
+            const json = await response.json();
+            if (json && typeof json.error === "string" && json.error.trim()) {
+              message = json.error;
+            }
+          } catch (_error) {
+            // ignore parse failures and fall back to HTTP status text
+          }
+          throw new Error(message);
+        });
+      }
+
+      function create(tagName, className, text) {
+        const node = document.createElement(tagName);
+        if (className) node.className = className;
+        if (text !== undefined) node.textContent = text;
+        return node;
+      }
+
+      function replaceBody(target, body) {
+        if (!target) return;
+        target.replaceChildren(body);
+      }
+
+      function emptyState(message) {
+        return create("div", "empty", message);
+      }
+
+      function valueText(value, fallback) {
+        if (value === null || value === undefined || value === "") return fallback || "Unavailable";
+        return String(value);
+      }
+
+      function formatScore(value) {
+        return typeof value === "number" && Number.isFinite(value) ? value.toFixed(2) : "--";
+      }
+
+      function formatDate(value) {
+        if (typeof value !== "string" || value.trim() === "") return "Unavailable";
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) return value;
+        return parsed.toLocaleString();
+      }
+
+      function keyValue(rows) {
+        const wrapper = create("div", "key-value");
+        rows.forEach(function (row) {
+          const item = create("div", "key-value__row");
+          item.appendChild(create("div", "key-value__label", row.label));
+          if (Array.isArray(row.values)) {
+            const stack = create("div", "stack");
+            if (row.values.length === 0) {
+              stack.appendChild(create("div", "caption", row.empty || "None"));
+            } else {
+              row.values.forEach(function (value) {
+                if (typeof value === "string") {
+                  stack.appendChild(create("div", "key-value__value", value));
+                } else {
+                  stack.appendChild(value);
+                }
+              });
+            }
+            item.appendChild(stack);
+          } else if (row.value instanceof Node) {
+            item.appendChild(row.value);
+          } else {
+            item.appendChild(create("div", "key-value__value", row.value));
+          }
+          wrapper.appendChild(item);
+        });
+        return wrapper;
+      }
+
+      function chip(text, tone) {
+        const toneSuffix = tone ? " chip--" + tone : "";
+        return create("span", "chip" + toneSuffix, text);
+      }
+
+      function renderQueue() {
+        if (!elements.queue || !elements.queueStatus || !elements.queueCount) return;
+        const queue = state.queue;
+        if (state.queueError) {
+          elements.queueStatus.textContent = state.queueError;
+          elements.queueCount.textContent = "0";
+          elements.queue.replaceChildren(emptyState("Candidates are unavailable until the reconciliation queue exists."));
+          return;
+        }
+        if (!queue) {
+          elements.queueStatus.textContent = "Loading reconciliation candidates...";
+          elements.queueCount.textContent = "0";
+          elements.queue.replaceChildren(emptyState("Fetching candidate queue..."));
+          return;
+        }
+
+        elements.queueCount.textContent = String(queue.total);
+        elements.queueStatus.textContent = queue.stale
+          ? "Queue is stale against the current graph/profile context."
+          : "Queue is aligned with the active graph/profile context.";
+
+        if (!Array.isArray(queue.items) || queue.items.length === 0) {
+          elements.queue.replaceChildren(emptyState("No reconciliation candidates matched the current filters."));
+          return;
+        }
+
+        const buttons = queue.items.map(function (candidate) {
+          const button = create("button", "queue-item");
+          button.type = "button";
+          button.setAttribute("aria-selected", String(candidate.id === state.selectedId));
+
+          const top = create("div", "queue-item__top");
+          const title = create("h3", "queue-item__title", candidate.candidate_id + " -> " + candidate.canonical_id);
+          const score = create("span", "queue-item__score", formatScore(candidate.score));
+          top.appendChild(title);
+          top.appendChild(score);
+
+          const meta = create("div", "queue-item__meta");
+          meta.appendChild(create("span", "", candidate.proposed_patch_operation));
+          meta.appendChild(create("span", "", (candidate.evidence_refs || []).length + " evidence"));
+
+          const caption = create("div", "caption", (candidate.shared_terms || []).join(", "));
+
+          button.appendChild(top);
+          button.appendChild(meta);
+          button.appendChild(caption);
+          button.addEventListener("click", function () {
+            selectCandidate(candidate.id);
+          });
+          return button;
+        });
+
+        elements.queue.replaceChildren.apply(elements.queue, buttons);
+      }
+
+      function renderSelectedCandidate() {
+        const candidate = state.selectedCandidate;
+        if (!elements.selectedTitle || !elements.selectedMeta || !elements.selectedSummary) return;
+        if (!candidate) {
+          elements.selectedTitle.textContent = "No candidate selected";
+          elements.selectedMeta.replaceChildren();
+          elements.selectedSummary.replaceChildren(emptyState("Choose a candidate from the queue to inspect evidence, canonical context, and preview data."));
+          return;
+        }
+
+        elements.selectedTitle.textContent = candidate.candidate_id + " -> " + candidate.canonical_id;
+        elements.selectedMeta.replaceChildren(
+          chip(candidate.kind, "accent"),
+          chip(candidate.status, candidate.status === "candidate" ? "warning" : "success"),
+          chip(candidate.proposed_patch_operation, "accent"),
+          chip("Score " + formatScore(candidate.score), "success")
+        );
+
+        elements.selectedSummary.replaceChildren(
+          keyValue([
+            { label: "Candidate ID", value: valueText(candidate.candidate_id) },
+            { label: "Canonical ID", value: valueText(candidate.canonical_id) },
+            { label: "Operation", value: valueText(candidate.proposed_patch_operation) },
+            { label: "Shared terms", values: (candidate.shared_terms || []).map(function (term) { return term; }), empty: "No shared terms recorded" },
+          ])
+        );
+      }
+
+      function renderEvidence() {
+        const candidate = state.selectedCandidate;
+        if (!elements.evidenceBody) return;
+        if (!candidate) {
+          replaceBody(elements.evidenceBody, emptyState("Evidence references and reconciliation reasons appear here after you select a queue item."));
+          return;
+        }
+
+        replaceBody(
+          elements.evidenceBody,
+          keyValue([
+            { label: "Evidence refs", values: (candidate.evidence_refs || []).map(function (ref) { return ref; }), empty: "No evidence refs supplied" },
+            { label: "Review reasons", values: (candidate.reasons || []).map(function (reason) { return reason; }), empty: "No reasons supplied" },
+            { label: "Coverage", value: (candidate.evidence_refs || []).length + " referenced source(s)" },
+          ])
+        );
+      }
+
+      function renderCanonical() {
+        const candidate = state.selectedCandidate;
+        if (!elements.canonicalBody) return;
+        if (!candidate) {
+          replaceBody(elements.canonicalBody, emptyState("Canonical entity context will appear here for the active candidate."));
+          return;
+        }
+
+        replaceBody(
+          elements.canonicalBody,
+          keyValue([
+            { label: "Canonical node", value: valueText(candidate.canonical_id) },
+            { label: "Candidate node", value: valueText(candidate.candidate_id) },
+            { label: "Status", value: valueText(candidate.status) },
+            { label: "Suggested patch", value: valueText(candidate.proposed_patch_operation) },
+          ])
+        );
+      }
+
+      function renderGraphContext() {
+        const candidate = state.selectedCandidate;
+        if (!elements.graphBody) return;
+        if (!candidate) {
+          replaceBody(elements.graphBody, emptyState("Select a candidate to anchor graph context and patch preview metadata."));
+          return;
+        }
+
+        const wrapper = create("div", "stack");
+        const chips = create("div", "chip-row");
+        chips.appendChild(chip("Candidate " + valueText(candidate.candidate_id, "?"), "accent"));
+        chips.appendChild(chip("Canonical " + valueText(candidate.canonical_id, "?"), "accent"));
+        chips.appendChild(chip((candidate.shared_terms || []).length + " shared terms", "success"));
+        if (state.rebuild && state.rebuild.needs_update) {
+          chips.appendChild(chip("Rebuild pending", "warning"));
+        }
+        wrapper.appendChild(chips);
+        wrapper.appendChild(create("p", "hint", "This read-only shell uses the current candidate IDs, evidence refs, and rebuild metadata as graph context. A dedicated neighborhood API can plug into this panel later without changing the shell structure."));
+        replaceBody(elements.graphBody, wrapper);
+      }
+
+      function renderRebuild() {
+        if (!elements.rebuildBody) return;
+        if (!state.rebuild) {
+          replaceBody(elements.rebuildBody, emptyState("Loading rebuild status..."));
+          return;
+        }
+        const status = state.rebuild;
+        const issueValues = Array.isArray(status.candidates && status.candidates.issues)
+          ? status.candidates.issues.map(function (issue) { return issue; })
+          : [];
+
+        replaceBody(
+          elements.rebuildBody,
+          keyValue([
+            { label: "Needs update", value: status.needs_update ? "Yes" : "No" },
+            { label: "Candidates match", value: status.candidates_match ? "Yes" : "No" },
+            { label: "Decision log", value: status.decision_log_available ? "Available" : "Unavailable" },
+            { label: "Candidate file", value: status.candidates ? valueText(status.candidates.path) : "Unavailable" },
+            { label: "Generated at", value: status.candidates ? valueText(status.candidates.generated_at, "Unavailable") : "Unavailable" },
+            { label: "Issues", values: issueValues, empty: "No candidate consistency issues reported" },
+          ])
+        );
+      }
+
+      function patchPreviewValue() {
+        const candidate = state.selectedCandidate;
+        if (!candidate) return "{\\n  \\"select_candidate\\": true\\n}";
+        return JSON.stringify({
+          schema: "graphify_ontology_patch_v1",
+          id: "preview:" + candidate.id,
+          operation: candidate.proposed_patch_operation,
+          status: "proposed",
+          profile_hash: state.queue ? state.queue.profile_hash : null,
+          graph_hash: state.queue ? state.queue.graph_hash : null,
+          target: {
+            candidate_id: candidate.candidate_id,
+            canonical_id: candidate.canonical_id,
+          },
+          evidence_refs: candidate.evidence_refs || [],
+          reason: (candidate.reasons || [])[0] || "Review in ontology studio before apply",
+          author: "ontology-studio",
+          created_at: "__preview_only__",
+        }, null, 2);
+      }
+
+      function renderPatchPreview() {
+        if (!elements.patchPreview || !elements.patchHint) return;
+        elements.patchPreview.textContent = patchPreviewValue();
+        elements.patchHint.textContent = bootstrap.writeEnabled
+          ? "Write API available. Patch actions stay disabled in this shell until a tokenized submit flow is added."
+          : "Read-only studio. Start the server with --write to expose token-protected patch routes.";
+      }
+
+      function renderAuditTrail() {
+        if (!elements.auditBody) return;
+        if (!state.log) {
+          replaceBody(elements.auditBody, emptyState("Loading decision log..."));
+          return;
+        }
+        if (!Array.isArray(state.log.items) || state.log.items.length === 0) {
+          replaceBody(elements.auditBody, emptyState("No applied or rejected patches have been recorded yet."));
+          return;
+        }
+
+        const list = create("ul", "list");
+        state.log.items.slice(0, 12).forEach(function (item) {
+          const patch = item && item.patch ? item.patch : {};
+          const patchId = valueText(patch.id, "unknown-patch");
+          const operation = valueText(patch.operation, "unknown-operation");
+          const status = valueText(patch.status, item.source === "audit" ? "applied" : "recorded");
+          const when = formatDate(item.recorded_at);
+          const row = create("li", "list__item");
+          row.appendChild(create("div", "", patchId));
+          row.appendChild(create("div", "caption", item.source + " · " + operation + " · " + status));
+          row.appendChild(create("div", "hint", when + " · " + valueText(item.path)));
+          list.appendChild(row);
+        });
+        replaceBody(elements.auditBody, list);
+      }
+
+      function renderEverything() {
+        renderQueue();
+        renderSelectedCandidate();
+        renderEvidence();
+        renderCanonical();
+        renderGraphContext();
+        renderRebuild();
+        renderPatchPreview();
+        renderAuditTrail();
+      }
+
+      async function selectCandidate(id) {
+        state.selectedId = id;
+        renderQueue();
+        try {
+          state.selectedCandidate = await fetchJson(bootstrap.routes.candidateBase + encodeURIComponent(id));
+        } catch (error) {
+          state.selectedCandidate = null;
+          if (elements.selectedSummary) {
+            elements.selectedSummary.replaceChildren(emptyState(error instanceof Error ? error.message : String(error)));
+          }
+        }
+        renderEverything();
+      }
+
+      async function loadQueue() {
+        const params = new URLSearchParams();
+        params.set("limit", "50");
+        const query = elements.queueQuery && elements.queueQuery.value ? elements.queueQuery.value.trim() : "";
+        const minScore = elements.queueMinScore && elements.queueMinScore.value ? elements.queueMinScore.value : "";
+        if (query) params.set("query", query);
+        if (minScore) params.set("min_score", minScore);
+        state.queueError = null;
+        try {
+          state.queue = await fetchJson(bootstrap.routes.candidates + "?" + params.toString());
+          const items = Array.isArray(state.queue && state.queue.items) ? state.queue.items : [];
+          if (!items.some(function (item) { return item.id === state.selectedId; })) {
+            state.selectedId = items.length > 0 ? items[0].id : null;
+          }
+          if (state.selectedId) {
+            await selectCandidate(state.selectedId);
+            return;
+          }
+          state.selectedCandidate = null;
+        } catch (error) {
+          state.queue = null;
+          state.selectedId = null;
+          state.selectedCandidate = null;
+          state.queueError = error instanceof Error ? error.message : String(error);
+        }
+        renderEverything();
+      }
+
+      async function loadRebuild() {
+        try {
+          state.rebuild = await fetchJson(bootstrap.routes.rebuildStatus);
+        } catch (error) {
+          state.rebuild = {
+            needs_update: false,
+            candidates_match: false,
+            decision_log_available: false,
+            candidates: {
+              path: "unavailable",
+              generated_at: null,
+              issues: [error instanceof Error ? error.message : String(error)],
+            },
+          };
+        }
+        renderRebuild();
+      }
+
+      async function loadAuditTrail() {
+        try {
+          state.log = await fetchJson(bootstrap.routes.decisionLog + "?source=both&status=all&limit=12");
+        } catch (error) {
+          state.log = {
+            items: [],
+            issues: [{ message: error instanceof Error ? error.message : String(error) }],
+          };
+        }
+        renderAuditTrail();
+      }
+
+      let queueTimer = null;
+      function scheduleQueueRefresh() {
+        if (queueTimer) window.clearTimeout(queueTimer);
+        queueTimer = window.setTimeout(function () {
+          void loadQueue();
+        }, 150);
+      }
+
+      if (elements.queueQuery) elements.queueQuery.addEventListener("input", scheduleQueueRefresh);
+      if (elements.queueMinScore) elements.queueMinScore.addEventListener("change", function () { void loadQueue(); });
+      if (elements.refresh) elements.refresh.addEventListener("click", function () {
+        void Promise.all([loadQueue(), loadRebuild(), loadAuditTrail()]);
+      });
+
+      renderEverything();
+      void Promise.all([loadQueue(), loadRebuild(), loadAuditTrail()]);
+    })();
+  `;
+}
+
 function htmlResult(writeEnabled: boolean): OntologyStudioRouteResult {
-  const writeBlock = writeEnabled
-    ? `<p><strong>Write mode is enabled.</strong> Mutation routes under <code>/api/ontology/patch/*</code> require an <code>Authorization: Bearer &lt;token&gt;</code> header.</p>`
-    : `<p>This server is read-only. Start with <code>--write</code> to enable patch mutation routes.</p>`;
+  const bootstrap = studioBootstrap(writeEnabled);
+  const writeBadge = writeEnabled
+    ? `<span class="chip chip--success">Write API available</span>`
+    : `<span class="chip chip--warning">Read-only studio</span>`;
+  const writeCopy = writeEnabled
+    ? `<p class="panel__subhead">The server exposes protected patch routes. This page advertises them without embedding the bearer token.</p>`
+    : `<p class="panel__subhead">Start with <code>--write</code> to expose token-protected patch routes while keeping the default browser experience read-only.</p>`;
+  const patchRoutes = writeEnabled
+    ? `<div class="route-list">
+        <code>${bootstrap.routes.patchValidate}</code>
+        <code>${bootstrap.routes.patchDryRun}</code>
+        <code>${bootstrap.routes.patchApply}</code>
+      </div>`
+    : `<div class="route-list">
+        <code>${bootstrap.routes.candidates}</code>
+        <code>${bootstrap.routes.decisionLog}</code>
+        <code>${bootstrap.routes.rebuildStatus}</code>
+      </div>`;
   return {
     status: 200,
     contentType: "text/html; charset=utf-8",
@@ -138,14 +1042,142 @@ function htmlResult(writeEnabled: boolean): OntologyStudioRouteResult {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Graphify Ontology Studio</title>
   <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.45; }
-    code { background: #f2f4f7; padding: 0.1rem 0.25rem; border-radius: 4px; }
+${studioStyles()}
   </style>
 </head>
 <body>
-  <h1>Graphify Ontology Studio</h1>
-  <p>Read-only reconciliation APIs are available under <code>/api/ontology</code>.</p>
-  ${writeBlock}
+  <div class="studio">
+    <header class="studio__header">
+      <section class="studio__intro" aria-labelledby="studio-title">
+        <p class="eyebrow">Ontology Reconciliation Studio</p>
+        <h1 id="studio-title">Graphify Ontology Studio</h1>
+        <p class="lead">Review reconciliation candidates, inspect evidence and canonical targets, watch rebuild state, and stage patch previews over the existing local ontology endpoints.</p>
+      </section>
+      <aside class="studio__mode" aria-labelledby="studio-mode-title">
+        <div class="chip-row">${writeBadge}<span class="chip chip--accent">Existing API-backed shell</span></div>
+        <h2 id="studio-mode-title" class="panel__title" style="margin-top: 0.9rem;">Server mode</h2>
+        ${writeCopy}
+        ${patchRoutes}
+      </aside>
+    </header>
+
+    <main class="studio__workspace">
+      <section class="panel" aria-labelledby="candidate-queue-title">
+        <div class="panel__header">
+          <div>
+            <h2 id="candidate-queue-title" class="panel__title">Candidate Queue</h2>
+            <p class="panel__subhead">Filter unresolved candidates and keep selection pinned while the shell refreshes against the local queue.</p>
+          </div>
+          <span class="chip chip--accent"><span id="queue-count">0</span>&nbsp;items</span>
+        </div>
+        <div class="queue-toolbar">
+          <label class="field">
+            <span>Search</span>
+            <input id="queue-query" type="search" placeholder="Candidate, canonical, evidence, reason">
+          </label>
+          <label class="field">
+            <span>Min score</span>
+            <select id="queue-min-score">
+              <option value="">Any</option>
+              <option value="0.5">0.50+</option>
+              <option value="0.75">0.75+</option>
+              <option value="0.9">0.90+</option>
+            </select>
+          </label>
+          <button id="refresh-button" type="button">Refresh</button>
+        </div>
+        <div id="queue-status" class="status-line" aria-live="polite">Loading reconciliation candidates...</div>
+        <div id="candidate-queue" class="queue-list" role="listbox" aria-label="Reconciliation candidates"></div>
+      </section>
+
+      <div class="details-grid">
+        <section class="panel panel--span-8" aria-labelledby="selected-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="selected-title" class="panel__title">No candidate selected</h2>
+              <p class="panel__subhead">Selection drives the evidence, canonical entity, graph context, patch preview, and audit readbacks.</p>
+            </div>
+            <div id="selected-meta" class="meta-row" aria-live="polite"></div>
+          </div>
+          <div id="selected-summary" class="panel__body"></div>
+        </section>
+
+        <section class="panel panel--span-4" aria-labelledby="rebuild-status-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="rebuild-status-title" class="panel__title">Rebuild Status</h2>
+              <p class="panel__subhead">Track graph/profile drift and whether the queued candidates still match the active context.</p>
+            </div>
+          </div>
+          <div id="rebuild-panel-body" class="panel__body"></div>
+        </section>
+
+        <section class="panel panel--span-4" aria-labelledby="evidence-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="evidence-title" class="panel__title">Evidence</h2>
+              <p class="panel__subhead">Source references and rationale for the selected reconciliation decision.</p>
+            </div>
+          </div>
+          <div id="evidence-panel-body" class="panel__body"></div>
+        </section>
+
+        <section class="panel panel--span-4" aria-labelledby="canonical-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="canonical-title" class="panel__title">Canonical Entity</h2>
+              <p class="panel__subhead">Current candidate-to-canonical mapping from the read-only queue.</p>
+            </div>
+          </div>
+          <div id="canonical-panel-body" class="panel__body"></div>
+        </section>
+
+        <section class="panel panel--span-4" aria-labelledby="graph-context-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="graph-context-title" class="panel__title">Graph Context</h2>
+              <p class="panel__subhead">Selection-scoped context until a dedicated neighborhood endpoint lands.</p>
+            </div>
+          </div>
+          <div id="graph-panel-body" class="panel__body"></div>
+        </section>
+
+        <section class="panel panel--span-6" aria-labelledby="patch-preview-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="patch-preview-title" class="panel__title">Patch Preview</h2>
+              <p class="panel__subhead" id="patch-mode-copy">Read-only studio. Start the server with --write to expose token-protected patch routes.</p>
+            </div>
+          </div>
+          <div class="panel__body stack">
+            <pre id="patch-preview" class="mono-block" aria-live="polite"></pre>
+            <div class="action-row">
+              <button type="button" disabled>Validate</button>
+              <button type="button" disabled>Dry Run</button>
+              <button type="button" disabled>Apply</button>
+            </div>
+            <p class="hint">Mutation stays behind the existing HTTP API. This shell stages the candidate-derived patch shape without embedding secrets.</p>
+          </div>
+        </section>
+
+        <section class="panel panel--span-6" aria-labelledby="audit-trail-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="audit-trail-title" class="panel__title">Audit Trail</h2>
+              <p class="panel__subhead">Authoritative and applied patch records read through the decision-log endpoint.</p>
+            </div>
+          </div>
+          <div id="audit-panel-body" class="panel__body"></div>
+        </section>
+      </div>
+    </main>
+  </div>
+  <script>
+    window.__ONTOLOGY_STUDIO_BOOTSTRAP__ = ${scriptSafeJson(bootstrap)};
+  </script>
+  <script>
+${studioClientScript()}
+  </script>
 </body>
 </html>`,
   };

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -197,22 +197,23 @@ function studioStyles(): string {
   return `
     :root {
       color-scheme: light;
-      --surface: #f5f6f7;
-      --surface-muted: #eceff1;
+      --surface: #f4f7fb;
+      --surface-muted: #e8edf4;
       --surface-raised: #ffffff;
-      --surface-accent: #effcf7;
+      --surface-accent: #ecfdf5;
       --surface-warning: #fff7ed;
-      --text: #16191d;
-      --text-muted: #5d6670;
-      --border: #d6dde3;
-      --border-strong: #b8c2cc;
+      --surface-info: #eff6ff;
+      --text: #111827;
+      --text-muted: #5b6574;
+      --border: #d7e0ea;
+      --border-strong: #b5c0cd;
       --accent: #0f766e;
       --accent-strong: #115e59;
       --warning: #b45309;
       --danger: #b91c1c;
       --success: #166534;
       --info: #1d4ed8;
-      --shadow: 0 14px 30px rgba(22, 25, 29, 0.08);
+      --shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
       font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
 
@@ -221,7 +222,7 @@ function studioStyles(): string {
     body {
       margin: 0;
       min-height: 100vh;
-      background: linear-gradient(180deg, #fbfcfc 0%, var(--surface) 100%);
+      background: var(--surface);
       color: var(--text);
     }
 
@@ -263,16 +264,16 @@ function studioStyles(): string {
     }
 
     .studio {
-      max-width: 1600px;
+      max-width: 1760px;
       margin: 0 auto;
-      padding: 1.5rem;
+      padding: 1.25rem;
     }
 
     .studio__header {
       display: grid;
       gap: 1rem;
-      grid-template-columns: minmax(0, 1.7fr) minmax(320px, 1fr);
-      align-items: start;
+      grid-template-columns: minmax(0, 1.35fr) minmax(320px, 420px);
+      align-items: stretch;
       margin-bottom: 1rem;
     }
 
@@ -288,7 +289,12 @@ function studioStyles(): string {
 
     .studio__intro,
     .studio__mode {
-      padding: 1.2rem 1.25rem;
+      padding: 1.2rem 1.25rem 1.25rem;
+    }
+
+    .studio__intro {
+      display: grid;
+      gap: 1rem;
     }
 
     .eyebrow {
@@ -302,14 +308,15 @@ function studioStyles(): string {
 
     h1 {
       margin: 0;
-      font-size: 1.95rem;
-      line-height: 1.08;
+      font-size: 2rem;
+      line-height: 1.05;
     }
 
     .lead {
       margin: 0.65rem 0 0;
-      max-width: 70ch;
+      max-width: 72ch;
       color: var(--text-muted);
+      font-size: 0.97rem;
     }
 
     .chip-row,
@@ -325,13 +332,13 @@ function studioStyles(): string {
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
-      min-height: 2rem;
-      padding: 0.35rem 0.65rem;
+      min-height: 1.9rem;
+      padding: 0.3rem 0.6rem;
       border-radius: 999px;
       border: 1px solid var(--border);
       background: var(--surface-muted);
       color: var(--text);
-      font-size: 0.82rem;
+      font-size: 0.8rem;
       font-weight: 600;
       white-space: nowrap;
     }
@@ -360,11 +367,85 @@ function studioStyles(): string {
       color: var(--danger);
     }
 
+    .hero-metrics,
+    .insight-grid,
+    .decision-grid {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .hero-metrics,
+    .insight-grid,
+    .decision-grid {
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+
+    .hero-metric,
+    .signal-card,
+    .info-card {
+      padding: 0.9rem 0.95rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      min-width: 0;
+    }
+
+    .hero-metric__label,
+    .signal-card__label,
+    .info-card__label {
+      color: var(--text-muted);
+      font-size: 0.76rem;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .hero-metric__value,
+    .signal-card__value,
+    .info-card__value {
+      margin-top: 0.35rem;
+      font-size: 1rem;
+      font-weight: 700;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+    }
+
+    .hero-metric__detail,
+    .signal-card__detail,
+    .info-card__detail {
+      margin-top: 0.35rem;
+      color: var(--text-muted);
+      font-size: 0.82rem;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+
     .studio__workspace {
       display: grid;
       gap: 1rem;
-      grid-template-columns: minmax(320px, 390px) minmax(0, 1fr);
+      grid-template-columns: minmax(300px, 360px) minmax(0, 1fr) minmax(310px, 390px);
       align-items: start;
+    }
+
+    .studio__rail,
+    .studio__main,
+    .studio__side {
+      min-width: 0;
+    }
+
+    .studio__main,
+    .studio__side {
+      display: grid;
+      gap: 1rem;
+      align-content: start;
+    }
+
+    .panel--sticky {
+      position: sticky;
+      top: 1rem;
+    }
+
+    .studio__workspace {
+      min-width: 0;
     }
 
     .panel {
@@ -398,7 +479,7 @@ function studioStyles(): string {
 
     .queue-toolbar {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.75rem;
       align-items: end;
       padding: 0.95rem 1.1rem 0.85rem;
@@ -432,23 +513,26 @@ function studioStyles(): string {
       display: grid;
       gap: 0.7rem;
       padding: 0.8rem 1.1rem 1.1rem;
-      max-height: calc(100vh - 18rem);
+      max-height: calc(100vh - 16rem);
       overflow: auto;
     }
 
     .queue-item {
       width: 100%;
       text-align: left;
-      padding: 0.9rem;
+      padding: 0.9rem 0.95rem;
       border: 1px solid var(--border);
+      border-left: 4px solid transparent;
       border-radius: 8px;
       background: var(--surface-raised);
       display: grid;
-      gap: 0.45rem;
+      gap: 0.55rem;
+      transition: border-color 140ms ease, background-color 140ms ease, box-shadow 140ms ease;
     }
 
     .queue-item[aria-selected="true"] {
-      border-color: color-mix(in srgb, var(--accent) 40%, white);
+      border-color: color-mix(in srgb, var(--accent) 38%, white);
+      border-left-color: var(--accent);
       background: var(--surface-accent);
       box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, white);
     }
@@ -463,8 +547,8 @@ function studioStyles(): string {
 
     .queue-item__title {
       margin: 0;
-      font-size: 0.95rem;
-      line-height: 1.3;
+      font-size: 0.96rem;
+      line-height: 1.28;
       overflow-wrap: anywhere;
     }
 
@@ -480,6 +564,19 @@ function studioStyles(): string {
       font-weight: 700;
     }
 
+    .queue-item__route {
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+
+    .queue-item__signals {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+
     .queue-item__meta,
     .caption,
     .hint {
@@ -491,10 +588,6 @@ function studioStyles(): string {
     .metric-grid {
       display: grid;
       gap: 0.75rem;
-    }
-
-    .compare-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .metric-grid {
@@ -512,6 +605,10 @@ function studioStyles(): string {
       padding: 0.9rem;
       display: grid;
       gap: 0.75rem;
+    }
+
+    .compare-card--soft {
+      background: var(--surface);
     }
 
     .compare-card__title {
@@ -545,16 +642,240 @@ function studioStyles(): string {
       overflow-wrap: anywhere;
     }
 
-    .details-grid {
+    .decision-summary {
       display: grid;
-      gap: 1rem;
-      grid-template-columns: repeat(12, minmax(0, 1fr));
+      gap: 0.75rem;
+      grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
     }
 
-    .details-grid > .panel--span-12 { grid-column: span 12; }
-    .details-grid > .panel--span-8 { grid-column: span 8; }
-    .details-grid > .panel--span-6 { grid-column: span 6; }
-    .details-grid > .panel--span-4 { grid-column: span 4; }
+    .comparison-board {
+      display: grid;
+      gap: 0.7rem;
+    }
+
+    .comparison-row {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: minmax(110px, 132px) minmax(0, 1fr) minmax(84px, auto) minmax(0, 1fr);
+      align-items: start;
+      padding: 0.75rem 0.8rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      min-width: 0;
+    }
+
+    .comparison-row--match {
+      border-color: color-mix(in srgb, var(--success) 22%, white);
+      background: #f6fdf8;
+    }
+
+    .comparison-row--partial {
+      border-color: color-mix(in srgb, var(--warning) 26%, white);
+      background: #fffaf2;
+    }
+
+    .comparison-row__label {
+      color: var(--text-muted);
+      font-size: 0.76rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .comparison-row__cell {
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .comparison-row__marker {
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      min-width: 0;
+    }
+
+    .value-stack {
+      display: grid;
+      gap: 0.35rem;
+      min-width: 0;
+    }
+
+    .value-pill {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      max-width: 100%;
+      padding: 0.22rem 0.45rem;
+      border-radius: 999px;
+      background: var(--surface-muted);
+      color: var(--text);
+      font-size: 0.76rem;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+      white-space: normal;
+    }
+
+    .map-stage {
+      display: grid;
+      gap: 0.9rem;
+    }
+
+    .graph-map {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: minmax(0, 1fr) minmax(48px, auto) minmax(160px, 220px) minmax(48px, auto) minmax(0, 1fr);
+      align-items: center;
+    }
+
+    .graph-node {
+      padding: 0.9rem;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      min-width: 0;
+    }
+
+    .graph-node--candidate {
+      border-color: color-mix(in srgb, var(--accent) 24%, white);
+      background: var(--surface-accent);
+    }
+
+    .graph-node--shared {
+      border-color: color-mix(in srgb, var(--info) 18%, white);
+      background: var(--surface-info);
+    }
+
+    .graph-node__eyebrow {
+      color: var(--text-muted);
+      font-size: 0.74rem;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .graph-node__title {
+      margin-top: 0.25rem;
+      font-size: 0.94rem;
+      font-weight: 700;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+    }
+
+    .graph-node__detail {
+      margin-top: 0.32rem;
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+
+    .graph-link {
+      color: var(--text-muted);
+      font-size: 0.76rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      text-align: center;
+    }
+
+    .timeline {
+      display: grid;
+      gap: 0.7rem;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    .timeline__item {
+      display: grid;
+      gap: 0.45rem;
+      padding: 0.85rem 0.9rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+
+    .timeline__top {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.65rem;
+    }
+
+    .timeline__title {
+      margin: 0;
+      font-size: 0.9rem;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+    }
+
+    .timeline__meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+      align-items: center;
+    }
+
+    .section-copy {
+      margin: 0 0 0.8rem;
+      color: var(--text-muted);
+      font-size: 0.88rem;
+      line-height: 1.45;
+    }
+
+    .action-form {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .field--wide {
+      grid-column: span 2;
+    }
+
+    .action-status {
+      padding: 0.8rem 0.9rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      color: var(--text);
+      font-size: 0.84rem;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+
+    .action-status--success {
+      border-color: color-mix(in srgb, var(--success) 24%, white);
+      background: #f0fdf4;
+    }
+
+    .action-status--danger {
+      border-color: color-mix(in srgb, var(--danger) 24%, white);
+      background: #fef2f2;
+    }
+
+    .action-status--warning {
+      border-color: color-mix(in srgb, var(--warning) 24%, white);
+      background: #fffaf2;
+    }
+
+    .list {
+      display: grid;
+      gap: 0.5rem;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    .list__item {
+      padding: 0.8rem 0.9rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+
+    .list--compact .list__item {
+      padding: 0.55rem 0.7rem;
+    }
 
     .key-value {
       display: grid;
@@ -592,43 +913,27 @@ function studioStyles(): string {
       gap: 0.5rem;
     }
 
-    .list {
-      display: grid;
-      gap: 0.5rem;
-      padding: 0;
-      margin: 0;
-      list-style: none;
-    }
-
-    .list__item {
-      padding: 0.8rem 0.9rem;
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      background: var(--surface);
-    }
-
-    .list--compact .list__item {
-      padding: 0.55rem 0.7rem;
-    }
-
     .mono-block {
-      min-height: 18rem;
+      min-height: 14rem;
       margin: 0;
       padding: 1rem;
       border: 1px solid var(--border);
       border-radius: 8px;
-      background: #f7f8f9;
-      color: #111827;
+      background: #f8fafc;
+      color: #0f172a;
       font-size: 0.84rem;
       line-height: 1.5;
       overflow: auto;
     }
 
     .route-list code {
+      display: block;
       max-width: 100%;
+      width: 100%;
       padding: 0.2rem 0.35rem;
       border-radius: 6px;
-      background: #f4f6f8;
+      border: 1px solid var(--border);
+      background: #f8fafc;
       overflow-wrap: anywhere;
       white-space: normal;
     }
@@ -650,18 +955,41 @@ function studioStyles(): string {
       .queue-list {
         max-height: 32rem;
       }
+
+      .studio__workspace {
+        grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+      }
+
+      .studio__side {
+        grid-column: span 2;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .panel--sticky {
+        position: static;
+      }
     }
 
     @media (max-width: 900px) {
-      .details-grid > .panel--span-12,
-      .details-grid > .panel--span-8,
-      .details-grid > .panel--span-6,
-      .details-grid > .panel--span-4 {
-        grid-column: span 12;
+      .studio__workspace {
+        grid-template-columns: 1fr;
       }
 
-      .compare-grid {
+      .studio__side {
+        grid-column: auto;
+      }
+
+      .decision-summary,
+      .queue-toolbar,
+      .action-form,
+      .studio__side,
+      .graph-map,
+      .comparison-row {
         grid-template-columns: 1fr;
+      }
+
+      .comparison-row__marker {
+        justify-content: flex-start;
       }
     }
 
@@ -670,16 +998,18 @@ function studioStyles(): string {
         padding: 1rem;
       }
 
-      .queue-toolbar {
-        grid-template-columns: 1fr;
-      }
-
       .field--search {
         grid-column: span 1;
       }
 
       .queue-list {
         max-height: none;
+      }
+
+      .hero-metrics,
+      .insight-grid,
+      .decision-grid {
+        grid-template-columns: 1fr;
       }
 
       .key-value__row {
@@ -701,6 +1031,8 @@ function studioClientScript(): string {
         rebuild: null,
         log: null,
         queueError: null,
+        patchPending: false,
+        patchResult: null,
       };
 
       const elements = {
@@ -725,10 +1057,41 @@ function studioClientScript(): string {
         auditBody: document.getElementById("audit-panel-body"),
         patchPreview: document.getElementById("patch-preview"),
         patchHint: document.getElementById("patch-mode-copy"),
+        patchToken: document.getElementById("patch-token"),
+        patchOperation: document.getElementById("patch-operation"),
+        patchNote: document.getElementById("patch-note"),
+        patchValidate: document.getElementById("patch-validate"),
+        patchDryRun: document.getElementById("patch-dry-run"),
+        patchApply: document.getElementById("patch-apply"),
+        patchResult: document.getElementById("patch-result"),
       };
 
       function fetchJson(path) {
         return fetch(path, { headers: { accept: "application/json" } }).then(async function (response) {
+          if (response.ok) return response.json();
+          let message = response.status + " " + response.statusText;
+          try {
+            const json = await response.json();
+            if (json && typeof json.error === "string" && json.error.trim()) {
+              message = json.error;
+            }
+          } catch (_error) {
+            // ignore parse failures and fall back to HTTP status text
+          }
+          throw new Error(message);
+        });
+      }
+
+      function postJson(path, payload, token) {
+        return fetch(path, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            authorization: "Bearer " + token,
+          },
+          body: JSON.stringify(payload),
+        }).then(async function (response) {
           if (response.ok) return response.json();
           let message = response.status + " " + response.statusText;
           try {
@@ -855,6 +1218,139 @@ function studioClientScript(): string {
         block.appendChild(create("div", "metric__label", label));
         block.appendChild(create("div", "metric__value", value));
         return block;
+      }
+
+      function stringValues(value) {
+        if (Array.isArray(value)) return uniqueValues(value);
+        const single = recordString(value);
+        return single ? [single] : [];
+      }
+
+      function overlapValues(left, right) {
+        const rightMap = new Map();
+        stringValues(right).forEach(function (value) {
+          rightMap.set(value.toLowerCase(), value);
+        });
+        return stringValues(left).filter(function (value) {
+          return rightMap.has(value.toLowerCase());
+        });
+      }
+
+      function exclusiveValues(left, right) {
+        const rightSet = new Set(stringValues(right).map(function (value) {
+          return value.toLowerCase();
+        }));
+        return stringValues(left).filter(function (value) {
+          return !rightSet.has(value.toLowerCase());
+        });
+      }
+
+      function titleFromId(value) {
+        const text = recordString(value);
+        if (!text) return "Unavailable";
+        const segments = text.split("_").filter(Boolean);
+        const label = segments.length > 1 ? segments.slice(1).join(" ") : text;
+        return label
+          .replace(/[:\-]+/g, " ")
+          .replace(/\s+/g, " ")
+          .trim()
+          .replace(/\b\w/g, function (letter) { return letter.toUpperCase(); });
+      }
+
+      function signalCard(label, value, detail) {
+        const card = create("section", "signal-card");
+        card.appendChild(create("div", "signal-card__label", label));
+        card.appendChild(create("div", "signal-card__value", value));
+        if (detail) card.appendChild(create("div", "signal-card__detail", detail));
+        return card;
+      }
+
+      function valueStackNode(values, emptyMessage) {
+        const stack = create("div", "value-stack");
+        const entries = stringValues(values);
+        if (entries.length === 0) {
+          stack.appendChild(create("div", "caption", emptyMessage || "None"));
+          return stack;
+        }
+        entries.forEach(function (value) {
+          stack.appendChild(create("div", "value-pill", value));
+        });
+        return stack;
+      }
+
+      function comparisonState(left, right) {
+        const leftValues = stringValues(left);
+        const rightValues = stringValues(right);
+        if (leftValues.length === 0 && rightValues.length === 0) {
+          return { label: "Empty", tone: "accent", rowClass: "" };
+        }
+        if (leftValues.length === rightValues.length && leftValues.every(function (value, index) {
+          return value.toLowerCase() === rightValues[index].toLowerCase();
+        })) {
+          return { label: "Aligned", tone: "success", rowClass: "comparison-row--match" };
+        }
+        if (overlapValues(leftValues, rightValues).length > 0) {
+          return { label: "Overlap", tone: "warning", rowClass: "comparison-row--partial" };
+        }
+        return { label: "Distinct", tone: "accent", rowClass: "" };
+      }
+
+      function comparisonRow(label, left, right, stateOverride) {
+        const stateValue = stateOverride || comparisonState(left, right);
+        const row = create("div", "comparison-row" + (stateValue.rowClass ? " " + stateValue.rowClass : ""));
+        row.appendChild(create("div", "comparison-row__label", label));
+        const leftCell = create("div", "comparison-row__cell");
+        const rightCell = create("div", "comparison-row__cell");
+        leftCell.appendChild(left instanceof Node ? left : valueStackNode(left));
+        rightCell.appendChild(right instanceof Node ? right : valueStackNode(right));
+        row.appendChild(leftCell);
+        const marker = create("div", "comparison-row__marker");
+        marker.appendChild(chip(stateValue.label, stateValue.tone));
+        row.appendChild(marker);
+        row.appendChild(rightCell);
+        return row;
+      }
+
+      function graphNode(className, eyebrow, title, detail, badges) {
+        const node = create("section", "graph-node " + className);
+        node.appendChild(create("div", "graph-node__eyebrow", eyebrow));
+        node.appendChild(create("div", "graph-node__title", title));
+        if (detail) node.appendChild(create("div", "graph-node__detail", detail));
+        if (Array.isArray(badges) && badges.length > 0) {
+          const row = create("div", "chip-row");
+          badges.forEach(function (badge) {
+            if (badge) row.appendChild(badge);
+          });
+          node.appendChild(row);
+        }
+        return node;
+      }
+
+      function decisionGroupsList(groups, emptyMessage) {
+        const list = create("ul", "timeline");
+        if (!Array.isArray(groups) || groups.length === 0) {
+          list.appendChild(create("li", "timeline__item", emptyMessage || "No decisions recorded"));
+          return list;
+        }
+        groups.forEach(function (group) {
+          const row = create("li", "timeline__item");
+          const top = create("div", "timeline__top");
+          const heading = create("div", "stack");
+          heading.appendChild(create("h3", "timeline__title", group.id));
+          heading.appendChild(create("div", "caption", group.targets.length > 0 ? group.targets.join(" ; ") : "No candidate pair recorded"));
+          top.appendChild(heading);
+          const meta = create("div", "timeline__meta");
+          meta.appendChild(chip(group.operation, "accent"));
+          meta.appendChild(chip(group.status, statusTone(group.status)));
+          meta.appendChild(chip(group.sources.join(" + "), "accent"));
+          top.appendChild(meta);
+          row.appendChild(top);
+          const segments = [formatDate(group.recorded_at)];
+          if (group.paths.length > 0) segments.push(group.paths.join(", "));
+          row.appendChild(create("div", "hint", segments.join(" · ")));
+          list.appendChild(row);
+        });
+        return list;
       }
 
       function nodeSummary(candidate, key) {
@@ -996,14 +1492,22 @@ function studioClientScript(): string {
           button.setAttribute("aria-selected", String(candidate.id === state.selectedId));
 
           const top = create("div", "queue-item__top");
-          const title = create("h3", "queue-item__title", candidate.candidate_id + " -> " + candidate.canonical_id);
+          const title = create("h3", "queue-item__title", titleFromId(candidate.candidate_id) + " -> " + titleFromId(candidate.canonical_id));
           const score = create("span", "queue-item__score", formatScore(candidate.score));
           top.appendChild(title);
           top.appendChild(score);
 
+          const route = create("div", "queue-item__route", candidate.candidate_id + " -> " + candidate.canonical_id);
           const meta = create("div", "queue-item__meta");
           meta.appendChild(create("span", "", [candidate.kind, candidate.status].join(" · ")));
-          meta.appendChild(create("span", "", [candidate.proposed_patch_operation, (candidate.evidence_refs || []).length + " refs"].join(" · ")));
+          meta.appendChild(create("span", "", (candidate.evidence_refs || []).length + " refs"));
+
+          const signals = create("div", "chip-row queue-item__signals");
+          signals.appendChild(chip(candidate.status, statusTone(candidate.status)));
+          signals.appendChild(chip(candidate.proposed_patch_operation, "accent"));
+          if ((candidate.shared_terms || []).length > 0) {
+            signals.appendChild(chip((candidate.shared_terms || []).length + " shared terms", "success"));
+          }
 
           const caption = create(
             "div",
@@ -1012,7 +1516,9 @@ function studioClientScript(): string {
           );
 
           button.appendChild(top);
+          button.appendChild(route);
           button.appendChild(meta);
+          button.appendChild(signals);
           button.appendChild(caption);
           button.addEventListener("click", function () {
             selectCandidate(candidate.id);
@@ -1035,6 +1541,8 @@ function studioClientScript(): string {
 
         const candidateNode = nodeSummary(candidate, "candidate_node");
         const canonicalNode = nodeSummary(candidate, "canonical_node");
+        const evidenceRefs = combinedEvidenceRefs(candidate);
+        const relatedDecisions = relatedDecisionGroups(candidate);
         elements.selectedTitle.textContent = nodeLabel(candidateNode, candidate.candidate_id) + " -> " + nodeLabel(canonicalNode, candidate.canonical_id);
         elements.selectedMeta.replaceChildren(
           chip(candidate.kind, "accent"),
@@ -1043,18 +1551,46 @@ function studioClientScript(): string {
           chip("Score " + formatScore(candidate.score), "success")
         );
 
-        elements.selectedSummary.replaceChildren(
+        const wrapper = create("div", "stack");
+        const metrics = create("div", "metric-grid");
+        metrics.appendChild(metric("Confidence", formatScore(candidate.score)));
+        metrics.appendChild(metric("Evidence refs", String(evidenceRefs.length)));
+        metrics.appendChild(metric("Related decisions", String(relatedDecisions.length)));
+        metrics.appendChild(metric("Shared terms", String(uniqueValues(candidate.shared_terms || []).length)));
+        wrapper.appendChild(metrics);
+
+        const summaryGrid = create("div", "decision-summary");
+        const overview = create("section", "compare-card compare-card--soft");
+        overview.appendChild(create("h3", "compare-card__heading", "Decision brief"));
+        overview.appendChild(
           keyValue([
-            { label: "Candidate label", value: nodeLabel(candidateNode, candidate.candidate_id) },
-            { label: "Canonical label", value: nodeLabel(canonicalNode, candidate.canonical_id) },
+            { label: "Candidate", value: nodeLabel(candidateNode, candidate.candidate_id) },
+            { label: "Canonical", value: nodeLabel(canonicalNode, candidate.canonical_id) },
             { label: "Candidate ID", value: valueText(candidate.candidate_id) },
             { label: "Canonical ID", value: valueText(candidate.canonical_id) },
             { label: "Entity type", value: nodeType(candidateNode, candidate.kind) },
-            { label: "Operation", value: valueText(candidate.proposed_patch_operation) },
-            { label: "Shared terms", value: listNode(candidate.shared_terms || [], "No shared terms recorded") },
-            { label: "Reasons", value: listNode(candidate.reasons || [], "No reasons supplied") },
+            { label: "Suggested patch", value: valueText(candidate.proposed_patch_operation) },
           ])
         );
+
+        const reasons = create("section", "compare-card compare-card--soft");
+        reasons.appendChild(create("h3", "compare-card__heading", "Why it is queued"));
+        reasons.appendChild(listNode(candidate.reasons || [], "No reasons supplied"));
+        if ((candidate.shared_terms || []).length > 0) {
+          reasons.appendChild(create("div", "section-copy", "Shared terms reinforce the proposed merge and should match canonical vocabulary."));
+        }
+        summaryGrid.appendChild(overview);
+        summaryGrid.appendChild(reasons);
+        wrapper.appendChild(summaryGrid);
+
+        const signals = create("div", "decision-grid");
+        signals.appendChild(signalCard("Candidate status", nodeStatus(candidateNode, candidate.status), "Current lifecycle state carried by the source node."));
+        signals.appendChild(signalCard("Canonical status", nodeStatus(canonicalNode, canonicalNode && canonicalNode.status), "Canonical target state from the active ontology graph."));
+        signals.appendChild(signalCard("Top shared term", uniqueValues(candidate.shared_terms || [])[0] || "None", uniqueValues(candidate.shared_terms || []).length > 1 ? uniqueValues(candidate.shared_terms || []).slice(1).join(", ") : "No additional shared terms"));
+        signals.appendChild(signalCard("Primary reason", uniqueValues(candidate.reasons || [])[0] || "None", uniqueValues(candidate.reasons || []).slice(1).join(" · ") || "No secondary reasons"));
+        wrapper.appendChild(signals);
+
+        elements.selectedSummary.replaceChildren(wrapper);
       }
 
       function renderEvidence() {
@@ -1067,11 +1603,11 @@ function studioClientScript(): string {
 
         const evidenceRefs = combinedEvidenceRefs(candidate);
         const wrapper = create("div", "stack");
-        const metrics = create("div", "metric-grid");
-        metrics.appendChild(metric("Score", formatScore(candidate.score)));
-        metrics.appendChild(metric("Evidence refs", String(evidenceRefs.length)));
-        metrics.appendChild(metric("Reasons", String(uniqueValues(candidate.reasons || []).length)));
-        wrapper.appendChild(metrics);
+        const insights = create("div", "insight-grid");
+        insights.appendChild(signalCard("Evidence footprint", String(evidenceRefs.length), "Combined candidate and canonical source references."));
+        insights.appendChild(signalCard("Reasons", String(uniqueValues(candidate.reasons || []).length), "Distinct reconciliation reasons surfaced for this pair."));
+        insights.appendChild(signalCard("Shared terms", String(uniqueValues(candidate.shared_terms || []).length), "Normalized terms already seen on both sides."));
+        wrapper.appendChild(insights);
         wrapper.appendChild(
           keyValue([
             { label: "Evidence refs", value: listNode(evidenceRefs, "No evidence refs supplied") },
@@ -1095,15 +1631,69 @@ function studioClientScript(): string {
         const candidateNode = nodeSummary(candidate, "candidate_node");
         const canonicalNode = nodeSummary(candidate, "canonical_node");
         const wrapper = create("div", "stack");
-        const metrics = create("div", "metric-grid");
-        metrics.appendChild(metric("Score", formatScore(candidate.score)));
-        metrics.appendChild(metric("Operation", valueText(candidate.proposed_patch_operation)));
-        metrics.appendChild(metric("Shared terms", String(uniqueValues(candidate.shared_terms || []).length)));
+        const metrics = create("div", "insight-grid");
+        metrics.appendChild(signalCard("Score", formatScore(candidate.score), "Current reconciliation confidence."));
+        metrics.appendChild(signalCard("Suggested patch", valueText(candidate.proposed_patch_operation), "Operation proposed by the candidate queue."));
+        metrics.appendChild(signalCard("Term overlap", String(overlapValues(candidateNode && candidateNode.normalized_terms, canonicalNode && canonicalNode.normalized_terms).length), "Normalized terms shared by both entities."));
+        metrics.appendChild(signalCard("Ref overlap", String(overlapValues(candidateNode && candidateNode.source_refs, canonicalNode && canonicalNode.source_refs).length), "Source references already present on both sides."));
         wrapper.appendChild(metrics);
-        const compare = create("div", "compare-grid");
-        compare.appendChild(nodeCard("Candidate node", candidateNode, candidate.candidate_id, candidate.status, candidate.kind));
-        compare.appendChild(nodeCard("Canonical node", canonicalNode, candidate.canonical_id, canonicalNode && canonicalNode.status, candidate.kind));
-        wrapper.appendChild(compare);
+
+        const board = create("div", "comparison-board");
+        board.appendChild(comparisonRow(
+          "Label",
+          [nodeLabel(candidateNode, candidate.candidate_id)],
+          [nodeLabel(canonicalNode, candidate.canonical_id)],
+        ));
+        board.appendChild(comparisonRow(
+          "ID",
+          [valueText(candidate.candidate_id)],
+          [valueText(candidate.canonical_id)],
+          { label: "Distinct", tone: "accent", rowClass: "" },
+        ));
+        board.appendChild(comparisonRow(
+          "Status",
+          [nodeStatus(candidateNode, candidate.status)],
+          [nodeStatus(canonicalNode, canonicalNode && canonicalNode.status)],
+        ));
+        board.appendChild(comparisonRow(
+          "Type",
+          [nodeType(candidateNode, candidate.kind)],
+          [nodeType(canonicalNode, candidate.kind)],
+        ));
+        board.appendChild(comparisonRow(
+          "Aliases",
+          candidateNode && candidateNode.aliases,
+          canonicalNode && canonicalNode.aliases,
+        ));
+        board.appendChild(comparisonRow(
+          "Terms",
+          candidateNode && candidateNode.normalized_terms,
+          canonicalNode && canonicalNode.normalized_terms,
+        ));
+        board.appendChild(comparisonRow(
+          "Evidence refs",
+          candidateNode && candidateNode.source_refs,
+          canonicalNode && canonicalNode.source_refs,
+        ));
+        wrapper.appendChild(board);
+
+        const deltas = create("div", "decision-grid");
+        deltas.appendChild(signalCard(
+          "Shared terms",
+          uniqueValues(candidate.shared_terms || []).join(", ") || "None",
+          "Terms already seen on both nodes.",
+        ));
+        deltas.appendChild(signalCard(
+          "Candidate only",
+          exclusiveValues(candidateNode && candidateNode.normalized_terms, canonicalNode && canonicalNode.normalized_terms).join(", ") || "None",
+          "Terms that still need explicit judgment before merge.",
+        ));
+        deltas.appendChild(signalCard(
+          "Canonical only",
+          exclusiveValues(canonicalNode && canonicalNode.normalized_terms, candidateNode && candidateNode.normalized_terms).join(", ") || "None",
+          "Canonical vocabulary not currently present on the candidate.",
+        ));
+        wrapper.appendChild(deltas);
         replaceBody(
           elements.canonicalBody,
           wrapper
@@ -1126,38 +1716,47 @@ function studioClientScript(): string {
           ? state.rebuild.candidates.issues
           : [];
         const wrapper = create("div", "stack");
-        const metrics = create("div", "metric-grid");
-        metrics.appendChild(metric("Related decisions", String(relatedDecisions.length)));
-        metrics.appendChild(metric("Evidence footprint", String(evidenceRefs.length)));
-        metrics.appendChild(metric("Shared terms", String(uniqueValues(candidate.shared_terms || []).length)));
-        metrics.appendChild(metric("Rebuild drift", state.rebuild && state.rebuild.needs_update ? "Pending" : "Clear"));
-        wrapper.appendChild(metrics);
-        wrapper.appendChild(
-          keyValue([
-            {
-              label: "Anchor nodes",
-              value: listNode([
-                nodeLabel(candidateNode, candidate.candidate_id) + " (" + valueText(candidate.candidate_id) + ")",
-                nodeLabel(canonicalNode, candidate.canonical_id) + " (" + valueText(candidate.canonical_id) + ")",
-              ], "No anchor nodes available"),
-            },
-            { label: "Shared terms", value: listNode(candidate.shared_terms || [], "No shared terms recorded") },
-            { label: "Evidence refs", value: listNode(evidenceRefs, "No evidence refs supplied") },
-            {
-              label: "Related decisions",
-              value: listNode(relatedDecisions.map(function (group) {
-                const segments = [
-                  group.id,
-                  "[" + group.sources.join(", ") + "]",
-                  group.operation,
-                ];
-                if (group.targets.length > 0) segments.push(group.targets.join(" ; "));
-                return segments.join(" ");
-              }), "No related decisions in the loaded audit window"),
-            },
-            { label: "Rebuild issues", value: listNode(rebuildIssues, "No candidate consistency issues reported") },
-          ])
-        );
+        const mapStage = create("div", "map-stage");
+        const map = create("div", "graph-map");
+        map.appendChild(graphNode(
+          "graph-node--candidate",
+          "Candidate",
+          nodeLabel(candidateNode, candidate.candidate_id),
+          valueText(candidate.candidate_id),
+          [chip(nodeStatus(candidateNode, candidate.status), statusTone(nodeStatus(candidateNode, candidate.status)))]
+        ));
+        map.appendChild(create("div", "graph-link", "signals"));
+        map.appendChild(graphNode(
+          "graph-node--shared",
+          "Decision context",
+          uniqueValues(candidate.shared_terms || []).length + " shared terms",
+          evidenceRefs.length + " evidence refs · " + relatedDecisions.length + " related decisions",
+          [chip(candidate.proposed_patch_operation, "accent"), chip("Score " + formatScore(candidate.score), "success")]
+        ));
+        map.appendChild(create("div", "graph-link", "targets"));
+        map.appendChild(graphNode(
+          "",
+          "Canonical",
+          nodeLabel(canonicalNode, candidate.canonical_id),
+          valueText(candidate.canonical_id),
+          [chip(nodeStatus(canonicalNode, canonicalNode && canonicalNode.status), statusTone(nodeStatus(canonicalNode, canonicalNode && canonicalNode.status)))]
+        ));
+        mapStage.appendChild(map);
+        wrapper.appendChild(mapStage);
+
+        const insights = create("div", "insight-grid");
+        insights.appendChild(signalCard("Shared terms", uniqueValues(candidate.shared_terms || []).join(", ") || "None", "Direct lexical overlap already found."));
+        insights.appendChild(signalCard("Candidate-only refs", exclusiveValues(candidateNode && candidateNode.source_refs, canonicalNode && canonicalNode.source_refs).join(", ") || "None", "Sources currently carried only by the candidate."));
+        insights.appendChild(signalCard("Canonical-only refs", exclusiveValues(canonicalNode && canonicalNode.source_refs, candidateNode && candidateNode.source_refs).join(", ") || "None", "Sources already attached to the canonical node."));
+        insights.appendChild(signalCard("Rebuild drift", state.rebuild && state.rebuild.needs_update ? "Pending" : "Clear", rebuildIssues[0] || "No rebuild consistency issue reported."));
+        wrapper.appendChild(insights);
+
+        if (relatedDecisions.length > 0) {
+          wrapper.appendChild(create("p", "section-copy", "Recent related decisions touching this candidate or its canonical target."));
+          wrapper.appendChild(decisionGroupsList(relatedDecisions.slice(0, 4), "No related decisions in the loaded audit window"));
+        } else {
+          wrapper.appendChild(emptyState("No related decisions in the loaded audit window."));
+        }
         replaceBody(elements.graphBody, wrapper);
       }
 
@@ -1185,13 +1784,27 @@ function studioClientScript(): string {
         );
       }
 
-      function patchPreviewValue() {
+      function patchOperationValue() {
         const candidate = state.selectedCandidate;
-        if (!candidate) return "{\\n  \\"select_candidate\\": true\\n}";
-        return JSON.stringify({
+        const override = elements.patchOperation && elements.patchOperation.value ? elements.patchOperation.value : "";
+        if (override) return override;
+        return candidate ? valueText(candidate.proposed_patch_operation, "accept_match") : "accept_match";
+      }
+
+      function patchReasonValue() {
+        const candidate = state.selectedCandidate;
+        const note = elements.patchNote && elements.patchNote.value ? elements.patchNote.value.trim() : "";
+        if (note) return note;
+        return (candidate && Array.isArray(candidate.reasons) && candidate.reasons[0]) || "Review in ontology studio before apply";
+      }
+
+      function patchPreviewObject() {
+        const candidate = state.selectedCandidate;
+        if (!candidate) return null;
+        return {
           schema: "graphify_ontology_patch_v1",
           id: "preview:" + candidate.id,
-          operation: candidate.proposed_patch_operation,
+          operation: patchOperationValue(),
           status: "proposed",
           profile_hash: state.queue ? state.queue.profile_hash : null,
           graph_hash: state.queue ? state.queue.graph_hash : null,
@@ -1200,18 +1813,118 @@ function studioClientScript(): string {
             canonical_id: candidate.canonical_id,
           },
           evidence_refs: candidate.evidence_refs || [],
-          reason: (candidate.reasons || [])[0] || "Review in ontology studio before apply",
+          reason: patchReasonValue(),
           author: "ontology-studio",
           created_at: "__preview_only__",
-        }, null, 2);
+        };
+      }
+
+      function patchPreviewValue() {
+        const preview = patchPreviewObject();
+        if (!preview) return "{\\n  \\"select_candidate\\": true\\n}";
+        return JSON.stringify(preview, null, 2);
+      }
+
+      function patchResultNode() {
+        if (state.patchPending) {
+          return create("div", "action-status action-status--warning", "Submitting patch request...");
+        }
+        if (!state.patchResult) {
+          const defaultMessage = bootstrap.writeEnabled
+            ? "Paste the bearer token to validate, dry-run, or apply the active patch."
+            : "Write actions appear only when the server is started with --write.";
+          return create("div", "action-status", defaultMessage);
+        }
+        const result = state.patchResult;
+        const tone = result.ok ? "success" : "danger";
+        const box = create("div", "action-status action-status--" + tone);
+        const lines = [];
+        lines.push((result.action || "request") + (result.ok ? " succeeded" : " failed"));
+        if (result.result && typeof result.result === "object") {
+          const payload = result.result;
+          if (typeof payload.patch_id === "string" && payload.patch_id.trim().length > 0) {
+            lines.push("Patch: " + payload.patch_id);
+          }
+          if (payload.valid === false) {
+            lines.push("Patch is invalid");
+          }
+          if (payload.dry_run === true) {
+            lines.push("Dry run only; no files were changed");
+          }
+          if (Array.isArray(payload.changed_files) && payload.changed_files.length > 0) {
+            lines.push("Files: " + payload.changed_files.map(function (file) {
+              return file.path;
+            }).join(", "));
+          }
+          if (Array.isArray(payload.issues) && payload.issues.length > 0) {
+            lines.push(payload.issues.map(function (issue) {
+              return issue.message || String(issue);
+            }).join(" | "));
+          }
+        }
+        if (result.message) lines.push(result.message);
+        box.textContent = lines.join(" · ");
+        return box;
+      }
+
+      async function submitPatch(action) {
+        if (!bootstrap.writeEnabled) return;
+        const preview = patchPreviewObject();
+        const token = elements.patchToken && elements.patchToken.value ? elements.patchToken.value.trim() : "";
+        if (!preview) {
+          state.patchResult = { action, ok: false, message: "Select a candidate before submitting a patch." };
+          renderPatchPreview();
+          return;
+        }
+        if (!token) {
+          state.patchResult = { action, ok: false, message: "Bearer token required." };
+          renderPatchPreview();
+          return;
+        }
+        state.patchPending = true;
+        state.patchResult = null;
+        renderPatchPreview();
+        try {
+          const route = action === "validate"
+            ? bootstrap.routes.patchValidate
+            : action === "dry-run"
+              ? bootstrap.routes.patchDryRun
+              : bootstrap.routes.patchApply;
+          const result = await postJson(route, preview, token);
+          state.patchResult = { action, ok: result && result.valid !== false, result };
+          state.patchPending = false;
+          renderPatchPreview();
+          if (action === "apply" && result && result.valid) {
+            await Promise.all([loadQueue(), loadRebuild(), loadAuditTrail()]);
+            return;
+          }
+        } catch (error) {
+          state.patchPending = false;
+          state.patchResult = { action, ok: false, message: error instanceof Error ? error.message : String(error) };
+          renderPatchPreview();
+        }
       }
 
       function renderPatchPreview() {
         if (!elements.patchPreview || !elements.patchHint) return;
         elements.patchPreview.textContent = patchPreviewValue();
         elements.patchHint.textContent = bootstrap.writeEnabled
-          ? "Write API available. Patch actions stay disabled in this shell until a tokenized submit flow is added."
-          : "Read-only studio. Start the server with --write to expose token-protected patch routes.";
+          ? "Protected write routes are available. Use a tokenized client to validate, dry-run, or apply this preview."
+          : "Browser session is read-only. Start the server with --write to expose token-protected validation and apply routes.";
+        if (elements.patchValidate && elements.patchDryRun && elements.patchApply) {
+          const ready = Boolean(
+            bootstrap.writeEnabled
+            && state.selectedCandidate
+            && elements.patchToken
+            && elements.patchToken.value.trim().length > 0,
+          );
+          elements.patchValidate.disabled = !ready || state.patchPending;
+          elements.patchDryRun.disabled = !ready || state.patchPending;
+          elements.patchApply.disabled = !ready || state.patchPending;
+        }
+        if (elements.patchResult) {
+          elements.patchResult.replaceChildren(patchResultNode());
+        }
       }
 
       function renderAuditTrail() {
@@ -1226,18 +1939,19 @@ function studioClientScript(): string {
           return;
         }
 
-        const list = create("ul", "list");
-        groups.slice(0, 12).forEach(function (group) {
-          const row = create("li", "list__item");
-          row.appendChild(create("div", "", group.id));
-          row.appendChild(create("div", "caption", group.sources.join(", ") + " · " + group.operation + " · " + group.status));
-          const segments = [formatDate(group.recorded_at)];
-          if (group.targets.length > 0) segments.push(group.targets.join(" ; "));
-          if (group.paths.length > 0) segments.push(group.paths.join(", "));
-          row.appendChild(create("div", "hint", segments.join(" · ")));
-          list.appendChild(row);
-        });
-        replaceBody(elements.auditBody, list);
+        const wrapper = create("div", "stack");
+        const related = state.selectedCandidate ? relatedDecisionGroups(state.selectedCandidate) : [];
+        const relatedIds = new Set(related.map(function (group) { return group.id; }));
+        if (related.length > 0) {
+          wrapper.appendChild(create("p", "section-copy", "Records tied to the active candidate appear first so the analyst can anchor the decision against prior work."));
+          wrapper.appendChild(decisionGroupsList(related.slice(0, 4), "No related decision records"));
+        }
+        const remaining = groups.filter(function (group) { return !relatedIds.has(group.id); });
+        if (remaining.length > 0) {
+          wrapper.appendChild(create("p", "section-copy", related.length > 0 ? "Recent decisions outside the active selection." : "Recent decisions across the loaded audit window."));
+          wrapper.appendChild(decisionGroupsList(remaining.slice(0, 8), "No additional decision records"));
+        }
+        replaceBody(elements.auditBody, wrapper);
       }
 
       function renderEverything() {
@@ -1256,6 +1970,10 @@ function studioClientScript(): string {
         renderQueue();
         try {
           state.selectedCandidate = await fetchJson(bootstrap.routes.candidateBase + encodeURIComponent(id));
+          if (elements.patchOperation && state.selectedCandidate) {
+            elements.patchOperation.value = valueText(state.selectedCandidate.proposed_patch_operation, "accept_match");
+          }
+          if (elements.patchNote) elements.patchNote.value = "";
         } catch (error) {
           state.selectedCandidate = null;
           if (elements.selectedSummary) {
@@ -1294,11 +2012,13 @@ function studioClientScript(): string {
             return;
           }
           state.selectedCandidate = null;
+          state.patchResult = null;
         } catch (error) {
           state.queue = null;
           state.selectedId = null;
           state.selectedCandidate = null;
           state.queueError = error instanceof Error ? error.message : String(error);
+          state.patchResult = null;
         }
         renderEverything();
       }
@@ -1341,6 +2061,11 @@ function studioClientScript(): string {
         }, 150);
       }
 
+      function resetPatchResultAndRender() {
+        state.patchResult = null;
+        renderPatchPreview();
+      }
+
       if (elements.queueQuery) elements.queueQuery.addEventListener("input", scheduleQueueRefresh);
       if (elements.queueMinScore) elements.queueMinScore.addEventListener("change", function () { void loadQueue(); });
       if (elements.queueStatusFilter) elements.queueStatusFilter.addEventListener("change", function () { void loadQueue(); });
@@ -1348,6 +2073,12 @@ function studioClientScript(): string {
       if (elements.queueOperationFilter) elements.queueOperationFilter.addEventListener("change", function () { void loadQueue(); });
       if (elements.queueSort) elements.queueSort.addEventListener("change", function () { void loadQueue(); });
       if (elements.queueOrder) elements.queueOrder.addEventListener("change", function () { void loadQueue(); });
+      if (elements.patchOperation) elements.patchOperation.addEventListener("change", resetPatchResultAndRender);
+      if (elements.patchNote) elements.patchNote.addEventListener("input", resetPatchResultAndRender);
+      if (elements.patchToken) elements.patchToken.addEventListener("input", resetPatchResultAndRender);
+      if (elements.patchValidate) elements.patchValidate.addEventListener("click", function () { void submitPatch("validate"); });
+      if (elements.patchDryRun) elements.patchDryRun.addEventListener("click", function () { void submitPatch("dry-run"); });
+      if (elements.patchApply) elements.patchApply.addEventListener("click", function () { void submitPatch("apply"); });
       if (elements.refresh) elements.refresh.addEventListener("click", function () {
         void Promise.all([loadQueue(), loadRebuild(), loadAuditTrail()]);
       });
@@ -1363,10 +2094,10 @@ function htmlResult(writeEnabled: boolean): OntologyStudioRouteResult {
   const writeBadge = writeEnabled
     ? `<span class="chip chip--success">Write API available</span>`
     : `<span class="chip chip--warning">Read-only studio</span>`;
-  const writeCopy = writeEnabled
-    ? `<p class="panel__subhead">The server exposes protected patch routes. This page advertises them without embedding the bearer token.</p>`
-    : `<p class="panel__subhead">Start with <code>--write</code> to expose token-protected patch routes while keeping the default browser experience read-only.</p>`;
-  const patchRoutes = writeEnabled
+  const reviewCopy = writeEnabled
+    ? `<p class="panel__subhead">Protected write routes are exposed on this server. The browser shell stays inspection-first and never embeds the bearer token.</p>`
+    : `<p class="panel__subhead">This browser session stays read-only. Start with <code>--write</code> when you need token-protected validation or apply routes.</p>`;
+  const actionRoutes = writeEnabled
     ? `<div class="route-list">
         <code>${bootstrap.routes.patchValidate}</code>
         <code>${bootstrap.routes.patchDryRun}</code>
@@ -1377,6 +2108,33 @@ function htmlResult(writeEnabled: boolean): OntologyStudioRouteResult {
         <code>${bootstrap.routes.decisionLog}</code>
         <code>${bootstrap.routes.rebuildStatus}</code>
       </div>`;
+  const actionControls = writeEnabled
+    ? `<div class="stack">
+        <div class="action-form">
+          <label class="field field--wide">
+            <span>Bearer token</span>
+            <input id="patch-token" type="password" placeholder="Paste the write token for this server">
+          </label>
+          <label class="field">
+            <span>Decision</span>
+            <select id="patch-operation">
+              <option value="accept_match">Accept match</option>
+              <option value="reject_match">Reject match</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Analyst note</span>
+            <input id="patch-note" type="text" placeholder="Optional note carried into patch reason">
+          </label>
+        </div>
+        <div class="action-row">
+          <button id="patch-validate" type="button">Validate</button>
+          <button id="patch-dry-run" type="button">Dry Run</button>
+          <button id="patch-apply" type="button">Apply</button>
+        </div>
+        <div id="patch-result"></div>
+      </div>`
+    : "";
   return {
     status: 200,
     contentType: "text/html; charset=utf-8",
@@ -1394,24 +2152,60 @@ ${studioStyles()}
   <div class="studio">
     <header class="studio__header">
       <section class="studio__intro" aria-labelledby="studio-title">
-        <p class="eyebrow">Ontology Reconciliation Studio</p>
-        <h1 id="studio-title">Graphify Ontology Studio</h1>
-        <p class="lead">Review reconciliation candidates, inspect evidence and canonical targets, watch rebuild state, and stage patch previews over the existing local ontology endpoints.</p>
+        <div>
+          <p class="eyebrow">Ontology Reconciliation Workspace</p>
+          <h1 id="studio-title">Reconcile candidates against canonical entities</h1>
+          <p class="lead">Work the queue, compare both sides in one place, and anchor each decision with evidence, prior patches, and rebuild drift before anything is applied.</p>
+        </div>
+        <div class="hero-metrics">
+          <div class="hero-metric">
+            <div class="hero-metric__label">Queue</div>
+            <div class="hero-metric__value">Search, sort, review</div>
+            <div class="hero-metric__detail">Keep backlog triage compact and selection-driven.</div>
+          </div>
+          <div class="hero-metric">
+            <div class="hero-metric__label">Comparison</div>
+            <div class="hero-metric__value">Candidate vs canonical</div>
+            <div class="hero-metric__detail">Line up labels, ids, status, terms, aliases, and evidence.</div>
+          </div>
+          <div class="hero-metric">
+            <div class="hero-metric__label">Context</div>
+            <div class="hero-metric__value">Evidence and audit</div>
+            <div class="hero-metric__detail">Recent related patches and graph drift stay visible during review.</div>
+          </div>
+        </div>
       </section>
       <aside class="studio__mode" aria-labelledby="studio-mode-title">
-        <div class="chip-row">${writeBadge}<span class="chip chip--accent">Existing API-backed shell</span></div>
-        <h2 id="studio-mode-title" class="panel__title" style="margin-top: 0.9rem;">Server mode</h2>
-        ${writeCopy}
-        ${patchRoutes}
+        <p class="eyebrow">Review posture</p>
+        <h2 id="studio-mode-title" class="panel__title">Inspection-first browser session</h2>
+        ${reviewCopy}
+        <div class="chip-row">
+          ${writeBadge}
+          <span class="chip chip--accent">Selection-led workflow</span>
+          <span class="chip chip--warning">Protected mutations</span>
+        </div>
+        <div class="hero-metrics">
+          <div class="hero-metric">
+            <div class="hero-metric__label">Active focus</div>
+            <div class="hero-metric__value">One pair at a time</div>
+            <div class="hero-metric__detail">Center the analyst on the current candidate and its canonical target.</div>
+          </div>
+          <div class="hero-metric">
+            <div class="hero-metric__label">Write safety</div>
+            <div class="hero-metric__value">No token in browser</div>
+            <div class="hero-metric__detail">Validation and apply stay behind the protected HTTP routes.</div>
+          </div>
+        </div>
       </aside>
     </header>
 
     <main class="studio__workspace">
-      <section class="panel" aria-labelledby="candidate-queue-title">
+      <aside class="studio__rail">
+      <section class="panel panel--sticky" aria-labelledby="candidate-queue-title">
         <div class="panel__header">
           <div>
             <h2 id="candidate-queue-title" class="panel__title">Candidate Queue</h2>
-            <p class="panel__subhead">Filter unresolved candidates and keep selection pinned while the shell refreshes against the local queue.</p>
+            <p class="panel__subhead">Triage the backlog without losing the current review target while the queue refreshes.</p>
           </div>
           <span class="chip chip--accent"><span id="queue-count">0</span>&nbsp;items</span>
         </div>
@@ -1469,87 +2263,87 @@ ${studioStyles()}
         <div id="queue-status" class="status-line" aria-live="polite">Loading reconciliation candidates...</div>
         <div id="candidate-queue" class="queue-list" role="listbox" aria-label="Reconciliation candidates"></div>
       </section>
+      </aside>
 
-      <div class="details-grid">
-        <section class="panel panel--span-8" aria-labelledby="selected-title">
+      <section class="studio__main">
+        <section class="panel" aria-labelledby="selected-title">
           <div class="panel__header">
             <div>
               <h2 id="selected-title" class="panel__title">No candidate selected</h2>
-              <p class="panel__subhead">Selection drives the evidence, canonical entity, graph context, patch preview, and audit readbacks.</p>
+              <p class="panel__subhead">Decision brief for the active pair: confirm the rationale, judge the overlap, then move to action.</p>
             </div>
             <div id="selected-meta" class="meta-row" aria-live="polite"></div>
           </div>
           <div id="selected-summary" class="panel__body"></div>
         </section>
 
-        <section class="panel panel--span-4" aria-labelledby="rebuild-status-title">
+        <section class="panel" aria-labelledby="canonical-title">
           <div class="panel__header">
             <div>
-              <h2 id="rebuild-status-title" class="panel__title">Rebuild Status</h2>
-              <p class="panel__subhead">Track graph/profile drift and whether the queued candidates still match the active context.</p>
-            </div>
-          </div>
-          <div id="rebuild-panel-body" class="panel__body"></div>
-        </section>
-
-        <section class="panel panel--span-4" aria-labelledby="evidence-title">
-          <div class="panel__header">
-            <div>
-              <h2 id="evidence-title" class="panel__title">Evidence</h2>
-              <p class="panel__subhead">Source references and rationale for the selected reconciliation decision.</p>
-            </div>
-          </div>
-          <div id="evidence-panel-body" class="panel__body"></div>
-        </section>
-
-        <section class="panel panel--span-4" aria-labelledby="canonical-title">
-          <div class="panel__header">
-            <div>
-              <h2 id="canonical-title" class="panel__title">Canonical Entity</h2>
-              <p class="panel__subhead">Side-by-side candidate and canonical details from the selected reconciliation pair.</p>
+              <h2 id="canonical-title" class="panel__title">Candidate vs Canonical</h2>
+              <p class="panel__subhead">Aligned rows surface what matches, what overlaps, and where the merge still needs judgment.</p>
             </div>
           </div>
           <div id="canonical-panel-body" class="panel__body"></div>
         </section>
 
-        <section class="panel panel--span-4" aria-labelledby="graph-context-title">
+        <section class="panel" aria-labelledby="graph-context-title">
           <div class="panel__header">
             <div>
-              <h2 id="graph-context-title" class="panel__title">Graph Context</h2>
-              <p class="panel__subhead">Selection anchors, evidence footprint, rebuild drift, and recent related decisions.</p>
+              <h2 id="graph-context-title" class="panel__title">Decision Context</h2>
+              <p class="panel__subhead">Anchor nodes, shared signals, recent related decisions, and rebuild drift around the active pair.</p>
             </div>
           </div>
           <div id="graph-panel-body" class="panel__body"></div>
         </section>
+      </section>
 
-        <section class="panel panel--span-6" aria-labelledby="patch-preview-title">
+      <aside class="studio__side">
+        <section class="panel" aria-labelledby="evidence-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="evidence-title" class="panel__title">Evidence</h2>
+              <p class="panel__subhead">Source references and reasons that justify or weaken the proposed reconciliation.</p>
+            </div>
+          </div>
+          <div id="evidence-panel-body" class="panel__body"></div>
+        </section>
+
+        <section class="panel" aria-labelledby="patch-preview-title">
           <div class="panel__header">
             <div>
               <h2 id="patch-preview-title" class="panel__title">Patch Preview</h2>
-              <p class="panel__subhead" id="patch-mode-copy">Read-only studio. Start the server with --write to expose token-protected patch routes.</p>
+              <p class="panel__subhead" id="patch-mode-copy">Browser session is read-only. Start the server with --write to expose token-protected validation and apply routes.</p>
             </div>
           </div>
           <div class="panel__body stack">
+            <p class="section-copy">Preview the candidate-derived patch here. Route exposure stays visible, but write operations remain tokenized outside the browser session.</p>
+            ${actionRoutes}
+            ${actionControls}
             <pre id="patch-preview" class="mono-block" aria-live="polite"></pre>
-            <div class="action-row">
-              <button type="button" disabled>Validate</button>
-              <button type="button" disabled>Dry Run</button>
-              <button type="button" disabled>Apply</button>
-            </div>
-            <p class="hint">Mutation stays behind the existing HTTP API. This shell stages the candidate-derived patch shape without embedding secrets.</p>
           </div>
         </section>
 
-        <section class="panel panel--span-6" aria-labelledby="audit-trail-title">
+        <section class="panel" aria-labelledby="audit-trail-title">
           <div class="panel__header">
             <div>
               <h2 id="audit-trail-title" class="panel__title">Audit Trail</h2>
-              <p class="panel__subhead">Authoritative and audit records grouped by patch so duplicate source=both rows stay readable.</p>
+              <p class="panel__subhead">Grouped by patch id so authoritative and audit sources stay readable without duplicate rows.</p>
             </div>
           </div>
           <div id="audit-panel-body" class="panel__body"></div>
         </section>
-      </div>
+
+        <section class="panel" aria-labelledby="rebuild-status-title">
+          <div class="panel__header">
+            <div>
+              <h2 id="rebuild-status-title" class="panel__title">Rebuild Status</h2>
+              <p class="panel__subhead">Track graph/profile drift and whether the queued candidates still match the active ontology context.</p>
+            </div>
+          </div>
+          <div id="rebuild-panel-body" class="panel__body"></div>
+        </section>
+      </aside>
     </main>
   </div>
   <script>

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -11,8 +11,8 @@ import {
   listOntologyReconciliationCandidates,
   previewOntologyDecisionLog,
 } from "./ontology-reconciliation-api.js";
-import type { OntologyReconciliationCandidateFilter } from "./ontology-reconciliation.js";
-import type { OntologyReconciliationDecisionLogOptions } from "./ontology-patch.js";
+import type { OntologyPatchNode, OntologyReconciliationDecisionLogOptions } from "./ontology-patch.js";
+import type { OntologyReconciliationCandidate, OntologyReconciliationCandidateFilter } from "./ontology-reconciliation.js";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost", "ip6-loopback"]);
 const POST_BODY_MAX_BYTES = 256 * 1024;
@@ -121,6 +121,43 @@ function jsonResult(status: number, value: unknown): OntologyStudioRouteResult {
     status,
     contentType: "application/json; charset=utf-8",
     body: `${JSON.stringify(value, null, 2)}\n`,
+  };
+}
+
+interface OntologyStudioNodeSummary {
+  id: string;
+  label?: string;
+  type?: string;
+  status?: string;
+  aliases?: string[];
+  normalized_terms?: string[];
+  source_refs?: string[];
+  registry_refs?: string[];
+}
+
+function studioNodeSummary(node: OntologyPatchNode | undefined): OntologyStudioNodeSummary | null {
+  if (!node) return null;
+  return {
+    id: node.id,
+    ...(node.label ? { label: node.label } : {}),
+    ...(node.type ? { type: node.type } : {}),
+    ...(node.status ? { status: node.status } : {}),
+    ...(node.aliases?.length ? { aliases: node.aliases } : {}),
+    ...(node.normalized_terms?.length ? { normalized_terms: node.normalized_terms } : {}),
+    ...(node.source_refs?.length ? { source_refs: node.source_refs } : {}),
+    ...(node.registry_refs?.length ? { registry_refs: node.registry_refs } : {}),
+  };
+}
+
+function studioCandidateDetail(
+  candidate: OntologyReconciliationCandidate,
+  candidateNode: OntologyPatchNode | undefined,
+  canonicalNode: OntologyPatchNode | undefined,
+): Record<string, unknown> {
+  return {
+    ...candidate,
+    candidate_node: studioNodeSummary(candidateNode),
+    canonical_node: studioNodeSummary(canonicalNode),
   };
 }
 
@@ -361,11 +398,15 @@ function studioStyles(): string {
 
     .queue-toolbar {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 140px auto;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       gap: 0.75rem;
       align-items: end;
       padding: 0.95rem 1.1rem 0.85rem;
       border-bottom: 1px solid var(--border);
+    }
+
+    .field--search {
+      grid-column: span 2;
     }
 
     .field {
@@ -446,6 +487,64 @@ function studioStyles(): string {
       font-size: 0.82rem;
     }
 
+    .compare-grid,
+    .metric-grid {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .compare-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .metric-grid {
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+
+    .compare-card,
+    .metric {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+
+    .compare-card {
+      padding: 0.9rem;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .compare-card__title {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
+    .compare-card__heading {
+      margin: 0;
+      font-size: 0.93rem;
+      line-height: 1.3;
+    }
+
+    .metric {
+      padding: 0.75rem 0.85rem;
+    }
+
+    .metric__label {
+      color: var(--text-muted);
+      font-size: 0.76rem;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .metric__value {
+      margin-top: 0.25rem;
+      font-size: 1rem;
+      font-weight: 700;
+      overflow-wrap: anywhere;
+    }
+
     .details-grid {
       display: grid;
       gap: 1rem;
@@ -508,6 +607,10 @@ function studioStyles(): string {
       background: var(--surface);
     }
 
+    .list--compact .list__item {
+      padding: 0.55rem 0.7rem;
+    }
+
     .mono-block {
       min-height: 18rem;
       margin: 0;
@@ -556,6 +659,10 @@ function studioStyles(): string {
       .details-grid > .panel--span-4 {
         grid-column: span 12;
       }
+
+      .compare-grid {
+        grid-template-columns: 1fr;
+      }
     }
 
     @media (max-width: 640px) {
@@ -565,6 +672,10 @@ function studioStyles(): string {
 
       .queue-toolbar {
         grid-template-columns: 1fr;
+      }
+
+      .field--search {
+        grid-column: span 1;
       }
 
       .queue-list {
@@ -598,6 +709,11 @@ function studioClientScript(): string {
         queueCount: document.getElementById("queue-count"),
         queueQuery: document.getElementById("queue-query"),
         queueMinScore: document.getElementById("queue-min-score"),
+        queueStatusFilter: document.getElementById("queue-status-filter"),
+        queueKindFilter: document.getElementById("queue-kind-filter"),
+        queueOperationFilter: document.getElementById("queue-operation-filter"),
+        queueSort: document.getElementById("queue-sort"),
+        queueOrder: document.getElementById("queue-order"),
         refresh: document.getElementById("refresh-button"),
         selectedTitle: document.getElementById("selected-title"),
         selectedMeta: document.getElementById("selected-meta"),
@@ -659,6 +775,32 @@ function studioClientScript(): string {
         return parsed.toLocaleString();
       }
 
+      function uniqueValues(values) {
+        return Array.from(new Set((Array.isArray(values) ? values : []).filter(function (value) {
+          return typeof value === "string" && value.trim().length > 0;
+        })));
+      }
+
+      function recordString(value) {
+        return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+      }
+
+      function statusTone(value) {
+        switch (value) {
+          case "validated":
+          case "applied":
+            return "success";
+          case "candidate":
+          case "needs_review":
+          case "proposed":
+            return "warning";
+          case "rejected":
+            return "danger";
+          default:
+            return "accent";
+        }
+      }
+
       function keyValue(rows) {
         const wrapper = create("div", "key-value");
         rows.forEach(function (row) {
@@ -691,6 +833,135 @@ function studioClientScript(): string {
       function chip(text, tone) {
         const toneSuffix = tone ? " chip--" + tone : "";
         return create("span", "chip" + toneSuffix, text);
+      }
+
+      function listNode(values, emptyMessage) {
+        const items = uniqueValues(values);
+        const list = create("ul", "list list--compact");
+        if (items.length === 0) {
+          list.appendChild(create("li", "list__item", emptyMessage || "None"));
+          return list;
+        }
+        items.forEach(function (value) {
+          const row = create("li", "list__item");
+          row.appendChild(create("div", "key-value__value", value));
+          list.appendChild(row);
+        });
+        return list;
+      }
+
+      function metric(label, value) {
+        const block = create("div", "metric");
+        block.appendChild(create("div", "metric__label", label));
+        block.appendChild(create("div", "metric__value", value));
+        return block;
+      }
+
+      function nodeSummary(candidate, key) {
+        const value = candidate && typeof candidate === "object" ? candidate[key] : null;
+        return value && typeof value === "object" ? value : null;
+      }
+
+      function nodeLabel(node, fallbackId) {
+        return node && typeof node.label === "string" && node.label.trim().length > 0
+          ? node.label.trim()
+          : valueText(fallbackId);
+      }
+
+      function nodeStatus(node, fallbackStatus) {
+        return node && typeof node.status === "string" && node.status.trim().length > 0
+          ? node.status.trim()
+          : valueText(fallbackStatus, "Unknown");
+      }
+
+      function nodeType(node, fallbackType) {
+        return node && typeof node.type === "string" && node.type.trim().length > 0
+          ? node.type.trim()
+          : valueText(fallbackType, "Unavailable");
+      }
+
+      function combinedEvidenceRefs(candidate) {
+        const candidateNode = nodeSummary(candidate, "candidate_node");
+        const canonicalNode = nodeSummary(candidate, "canonical_node");
+        return uniqueValues([
+          ...(candidate && Array.isArray(candidate.evidence_refs) ? candidate.evidence_refs : []),
+          ...(candidateNode && Array.isArray(candidateNode.source_refs) ? candidateNode.source_refs : []),
+          ...(canonicalNode && Array.isArray(canonicalNode.source_refs) ? canonicalNode.source_refs : []),
+        ]);
+      }
+
+      function patchRecord(item) {
+        return item && item.patch && typeof item.patch === "object" ? item.patch : {};
+      }
+
+      function patchTarget(patch) {
+        return patch && patch.target && typeof patch.target === "object" ? patch.target : {};
+      }
+
+      function groupedDecisionLogItems(items) {
+        const groups = new Map();
+        (Array.isArray(items) ? items : []).forEach(function (item) {
+          const patch = patchRecord(item);
+          const key = [valueText(patch.id, "unknown-patch"), valueText(patch.operation, "unknown-operation")].join("::");
+          let group = groups.get(key);
+          if (!group) {
+            group = {
+              id: valueText(patch.id, "unknown-patch"),
+              operation: valueText(patch.operation, "unknown-operation"),
+              status: valueText(patch.status, item && item.source === "audit" ? "applied" : "recorded"),
+              recorded_at: item ? item.recorded_at : null,
+              patch: patch,
+              sources: [],
+              paths: [],
+              targets: [],
+            };
+            groups.set(key, group);
+          }
+          if (item && group.sources.indexOf(item.source) === -1) group.sources.push(item.source);
+          if (item && item.path && group.paths.indexOf(item.path) === -1) group.paths.push(item.path);
+          if (item && typeof item.recorded_at === "string" && item.recorded_at.trim().length > 0) {
+            if (!group.recorded_at || item.recorded_at > group.recorded_at) group.recorded_at = item.recorded_at;
+          }
+          const target = patchTarget(patch);
+          const candidateId = recordString(target.candidate_id);
+          const canonicalId = recordString(target.canonical_id);
+          const pair = candidateId && canonicalId ? candidateId + " -> " + canonicalId : null;
+          if (pair && group.targets.indexOf(pair) === -1) group.targets.push(pair);
+        });
+        return Array.from(groups.values());
+      }
+
+      function relatedDecisionGroups(candidate) {
+        if (!candidate || !state.log || !Array.isArray(state.log.items)) return [];
+        return groupedDecisionLogItems(state.log.items).filter(function (group) {
+          const target = patchTarget(group.patch);
+          return [target.candidate_id, target.canonical_id].some(function (value) {
+            return typeof value === "string"
+              && (value === candidate.candidate_id || value === candidate.canonical_id);
+          });
+        });
+      }
+
+      function nodeCard(title, node, fallbackId, fallbackStatus, fallbackType) {
+        const card = create("section", "compare-card");
+        const heading = create("div", "compare-card__title");
+        const headingText = create("div", "stack");
+        headingText.appendChild(create("h3", "compare-card__heading", title));
+        headingText.appendChild(create("div", "caption", nodeLabel(node, fallbackId)));
+        heading.appendChild(headingText);
+        heading.appendChild(chip(nodeStatus(node, fallbackStatus), statusTone(nodeStatus(node, fallbackStatus))));
+        card.appendChild(heading);
+        card.appendChild(
+          keyValue([
+            { label: "Label", value: nodeLabel(node, fallbackId) },
+            { label: "ID", value: valueText(fallbackId) },
+            { label: "Type", value: nodeType(node, fallbackType) },
+            { label: "Aliases", value: listNode(node && node.aliases, "No aliases recorded") },
+            { label: "Terms", value: listNode(node && node.normalized_terms, "No normalized terms recorded") },
+            { label: "Evidence refs", value: listNode(node && node.source_refs, "No source refs recorded") },
+          ])
+        );
+        return card;
       }
 
       function renderQueue() {
@@ -731,10 +1002,14 @@ function studioClientScript(): string {
           top.appendChild(score);
 
           const meta = create("div", "queue-item__meta");
-          meta.appendChild(create("span", "", candidate.proposed_patch_operation));
-          meta.appendChild(create("span", "", (candidate.evidence_refs || []).length + " evidence"));
+          meta.appendChild(create("span", "", [candidate.kind, candidate.status].join(" · ")));
+          meta.appendChild(create("span", "", [candidate.proposed_patch_operation, (candidate.evidence_refs || []).length + " refs"].join(" · ")));
 
-          const caption = create("div", "caption", (candidate.shared_terms || []).join(", "));
+          const caption = create(
+            "div",
+            "caption",
+            (candidate.shared_terms || []).length > 0 ? (candidate.shared_terms || []).join(", ") : "No shared terms recorded",
+          );
 
           button.appendChild(top);
           button.appendChild(meta);
@@ -758,20 +1033,26 @@ function studioClientScript(): string {
           return;
         }
 
-        elements.selectedTitle.textContent = candidate.candidate_id + " -> " + candidate.canonical_id;
+        const candidateNode = nodeSummary(candidate, "candidate_node");
+        const canonicalNode = nodeSummary(candidate, "canonical_node");
+        elements.selectedTitle.textContent = nodeLabel(candidateNode, candidate.candidate_id) + " -> " + nodeLabel(canonicalNode, candidate.canonical_id);
         elements.selectedMeta.replaceChildren(
           chip(candidate.kind, "accent"),
-          chip(candidate.status, candidate.status === "candidate" ? "warning" : "success"),
+          chip(nodeStatus(candidateNode, candidate.status), statusTone(nodeStatus(candidateNode, candidate.status))),
           chip(candidate.proposed_patch_operation, "accent"),
           chip("Score " + formatScore(candidate.score), "success")
         );
 
         elements.selectedSummary.replaceChildren(
           keyValue([
+            { label: "Candidate label", value: nodeLabel(candidateNode, candidate.candidate_id) },
+            { label: "Canonical label", value: nodeLabel(canonicalNode, candidate.canonical_id) },
             { label: "Candidate ID", value: valueText(candidate.candidate_id) },
             { label: "Canonical ID", value: valueText(candidate.canonical_id) },
+            { label: "Entity type", value: nodeType(candidateNode, candidate.kind) },
             { label: "Operation", value: valueText(candidate.proposed_patch_operation) },
-            { label: "Shared terms", values: (candidate.shared_terms || []).map(function (term) { return term; }), empty: "No shared terms recorded" },
+            { label: "Shared terms", value: listNode(candidate.shared_terms || [], "No shared terms recorded") },
+            { label: "Reasons", value: listNode(candidate.reasons || [], "No reasons supplied") },
           ])
         );
       }
@@ -784,13 +1065,22 @@ function studioClientScript(): string {
           return;
         }
 
+        const evidenceRefs = combinedEvidenceRefs(candidate);
+        const wrapper = create("div", "stack");
+        const metrics = create("div", "metric-grid");
+        metrics.appendChild(metric("Score", formatScore(candidate.score)));
+        metrics.appendChild(metric("Evidence refs", String(evidenceRefs.length)));
+        metrics.appendChild(metric("Reasons", String(uniqueValues(candidate.reasons || []).length)));
+        wrapper.appendChild(metrics);
+        wrapper.appendChild(
+          keyValue([
+            { label: "Evidence refs", value: listNode(evidenceRefs, "No evidence refs supplied") },
+            { label: "Reasons", value: listNode(candidate.reasons || [], "No reasons supplied") },
+          ])
+        );
         replaceBody(
           elements.evidenceBody,
-          keyValue([
-            { label: "Evidence refs", values: (candidate.evidence_refs || []).map(function (ref) { return ref; }), empty: "No evidence refs supplied" },
-            { label: "Review reasons", values: (candidate.reasons || []).map(function (reason) { return reason; }), empty: "No reasons supplied" },
-            { label: "Coverage", value: (candidate.evidence_refs || []).length + " referenced source(s)" },
-          ])
+          wrapper
         );
       }
 
@@ -802,14 +1092,21 @@ function studioClientScript(): string {
           return;
         }
 
+        const candidateNode = nodeSummary(candidate, "candidate_node");
+        const canonicalNode = nodeSummary(candidate, "canonical_node");
+        const wrapper = create("div", "stack");
+        const metrics = create("div", "metric-grid");
+        metrics.appendChild(metric("Score", formatScore(candidate.score)));
+        metrics.appendChild(metric("Operation", valueText(candidate.proposed_patch_operation)));
+        metrics.appendChild(metric("Shared terms", String(uniqueValues(candidate.shared_terms || []).length)));
+        wrapper.appendChild(metrics);
+        const compare = create("div", "compare-grid");
+        compare.appendChild(nodeCard("Candidate node", candidateNode, candidate.candidate_id, candidate.status, candidate.kind));
+        compare.appendChild(nodeCard("Canonical node", canonicalNode, candidate.canonical_id, canonicalNode && canonicalNode.status, candidate.kind));
+        wrapper.appendChild(compare);
         replaceBody(
           elements.canonicalBody,
-          keyValue([
-            { label: "Canonical node", value: valueText(candidate.canonical_id) },
-            { label: "Candidate node", value: valueText(candidate.candidate_id) },
-            { label: "Status", value: valueText(candidate.status) },
-            { label: "Suggested patch", value: valueText(candidate.proposed_patch_operation) },
-          ])
+          wrapper
         );
       }
 
@@ -821,16 +1118,46 @@ function studioClientScript(): string {
           return;
         }
 
+        const candidateNode = nodeSummary(candidate, "candidate_node");
+        const canonicalNode = nodeSummary(candidate, "canonical_node");
+        const evidenceRefs = combinedEvidenceRefs(candidate);
+        const relatedDecisions = relatedDecisionGroups(candidate);
+        const rebuildIssues = state.rebuild && state.rebuild.candidates && Array.isArray(state.rebuild.candidates.issues)
+          ? state.rebuild.candidates.issues
+          : [];
         const wrapper = create("div", "stack");
-        const chips = create("div", "chip-row");
-        chips.appendChild(chip("Candidate " + valueText(candidate.candidate_id, "?"), "accent"));
-        chips.appendChild(chip("Canonical " + valueText(candidate.canonical_id, "?"), "accent"));
-        chips.appendChild(chip((candidate.shared_terms || []).length + " shared terms", "success"));
-        if (state.rebuild && state.rebuild.needs_update) {
-          chips.appendChild(chip("Rebuild pending", "warning"));
-        }
-        wrapper.appendChild(chips);
-        wrapper.appendChild(create("p", "hint", "This read-only shell uses the current candidate IDs, evidence refs, and rebuild metadata as graph context. A dedicated neighborhood API can plug into this panel later without changing the shell structure."));
+        const metrics = create("div", "metric-grid");
+        metrics.appendChild(metric("Related decisions", String(relatedDecisions.length)));
+        metrics.appendChild(metric("Evidence footprint", String(evidenceRefs.length)));
+        metrics.appendChild(metric("Shared terms", String(uniqueValues(candidate.shared_terms || []).length)));
+        metrics.appendChild(metric("Rebuild drift", state.rebuild && state.rebuild.needs_update ? "Pending" : "Clear"));
+        wrapper.appendChild(metrics);
+        wrapper.appendChild(
+          keyValue([
+            {
+              label: "Anchor nodes",
+              value: listNode([
+                nodeLabel(candidateNode, candidate.candidate_id) + " (" + valueText(candidate.candidate_id) + ")",
+                nodeLabel(canonicalNode, candidate.canonical_id) + " (" + valueText(candidate.canonical_id) + ")",
+              ], "No anchor nodes available"),
+            },
+            { label: "Shared terms", value: listNode(candidate.shared_terms || [], "No shared terms recorded") },
+            { label: "Evidence refs", value: listNode(evidenceRefs, "No evidence refs supplied") },
+            {
+              label: "Related decisions",
+              value: listNode(relatedDecisions.map(function (group) {
+                const segments = [
+                  group.id,
+                  "[" + group.sources.join(", ") + "]",
+                  group.operation,
+                ];
+                if (group.targets.length > 0) segments.push(group.targets.join(" ; "));
+                return segments.join(" ");
+              }), "No related decisions in the loaded audit window"),
+            },
+            { label: "Rebuild issues", value: listNode(rebuildIssues, "No candidate consistency issues reported") },
+          ])
+        );
         replaceBody(elements.graphBody, wrapper);
       }
 
@@ -893,22 +1220,21 @@ function studioClientScript(): string {
           replaceBody(elements.auditBody, emptyState("Loading decision log..."));
           return;
         }
-        if (!Array.isArray(state.log.items) || state.log.items.length === 0) {
+        const groups = groupedDecisionLogItems(state.log.items);
+        if (groups.length === 0) {
           replaceBody(elements.auditBody, emptyState("No applied or rejected patches have been recorded yet."));
           return;
         }
 
         const list = create("ul", "list");
-        state.log.items.slice(0, 12).forEach(function (item) {
-          const patch = item && item.patch ? item.patch : {};
-          const patchId = valueText(patch.id, "unknown-patch");
-          const operation = valueText(patch.operation, "unknown-operation");
-          const status = valueText(patch.status, item.source === "audit" ? "applied" : "recorded");
-          const when = formatDate(item.recorded_at);
+        groups.slice(0, 12).forEach(function (group) {
           const row = create("li", "list__item");
-          row.appendChild(create("div", "", patchId));
-          row.appendChild(create("div", "caption", item.source + " · " + operation + " · " + status));
-          row.appendChild(create("div", "hint", when + " · " + valueText(item.path)));
+          row.appendChild(create("div", "", group.id));
+          row.appendChild(create("div", "caption", group.sources.join(", ") + " · " + group.operation + " · " + group.status));
+          const segments = [formatDate(group.recorded_at)];
+          if (group.targets.length > 0) segments.push(group.targets.join(" ; "));
+          if (group.paths.length > 0) segments.push(group.paths.join(", "));
+          row.appendChild(create("div", "hint", segments.join(" · ")));
           list.appendChild(row);
         });
         replaceBody(elements.auditBody, list);
@@ -944,8 +1270,18 @@ function studioClientScript(): string {
         params.set("limit", "50");
         const query = elements.queueQuery && elements.queueQuery.value ? elements.queueQuery.value.trim() : "";
         const minScore = elements.queueMinScore && elements.queueMinScore.value ? elements.queueMinScore.value : "";
+        const status = elements.queueStatusFilter && elements.queueStatusFilter.value ? elements.queueStatusFilter.value : "";
+        const kind = elements.queueKindFilter && elements.queueKindFilter.value ? elements.queueKindFilter.value : "";
+        const operation = elements.queueOperationFilter && elements.queueOperationFilter.value ? elements.queueOperationFilter.value : "";
+        const sort = elements.queueSort && elements.queueSort.value ? elements.queueSort.value : "";
+        const order = elements.queueOrder && elements.queueOrder.value ? elements.queueOrder.value : "";
         if (query) params.set("query", query);
         if (minScore) params.set("min_score", minScore);
+        if (status) params.set("status", status);
+        if (kind) params.set("kind", kind);
+        if (operation) params.set("operation", operation);
+        if (sort) params.set("sort", sort);
+        if (order) params.set("order", order);
         state.queueError = null;
         try {
           state.queue = await fetchJson(bootstrap.routes.candidates + "?" + params.toString());
@@ -987,7 +1323,7 @@ function studioClientScript(): string {
 
       async function loadAuditTrail() {
         try {
-          state.log = await fetchJson(bootstrap.routes.decisionLog + "?source=both&status=all&limit=12");
+          state.log = await fetchJson(bootstrap.routes.decisionLog + "?source=both&status=all&limit=24");
         } catch (error) {
           state.log = {
             items: [],
@@ -1007,6 +1343,11 @@ function studioClientScript(): string {
 
       if (elements.queueQuery) elements.queueQuery.addEventListener("input", scheduleQueueRefresh);
       if (elements.queueMinScore) elements.queueMinScore.addEventListener("change", function () { void loadQueue(); });
+      if (elements.queueStatusFilter) elements.queueStatusFilter.addEventListener("change", function () { void loadQueue(); });
+      if (elements.queueKindFilter) elements.queueKindFilter.addEventListener("change", function () { void loadQueue(); });
+      if (elements.queueOperationFilter) elements.queueOperationFilter.addEventListener("change", function () { void loadQueue(); });
+      if (elements.queueSort) elements.queueSort.addEventListener("change", function () { void loadQueue(); });
+      if (elements.queueOrder) elements.queueOrder.addEventListener("change", function () { void loadQueue(); });
       if (elements.refresh) elements.refresh.addEventListener("click", function () {
         void Promise.all([loadQueue(), loadRebuild(), loadAuditTrail()]);
       });
@@ -1075,7 +1416,7 @@ ${studioStyles()}
           <span class="chip chip--accent"><span id="queue-count">0</span>&nbsp;items</span>
         </div>
         <div class="queue-toolbar">
-          <label class="field">
+          <label class="field field--search">
             <span>Search</span>
             <input id="queue-query" type="search" placeholder="Candidate, canonical, evidence, reason">
           </label>
@@ -1086,6 +1427,41 @@ ${studioStyles()}
               <option value="0.5">0.50+</option>
               <option value="0.75">0.75+</option>
               <option value="0.9">0.90+</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Status</span>
+            <select id="queue-status-filter">
+              <option value="">Any</option>
+              <option value="candidate">Candidate</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Kind</span>
+            <select id="queue-kind-filter">
+              <option value="">Any</option>
+              <option value="entity_match">Entity Match</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Operation</span>
+            <select id="queue-operation-filter">
+              <option value="">Any</option>
+              <option value="accept_match">Accept Match</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Sort</span>
+            <select id="queue-sort">
+              <option value="score">Score</option>
+              <option value="id">ID</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Order</span>
+            <select id="queue-order">
+              <option value="desc">Desc</option>
+              <option value="asc">Asc</option>
             </select>
           </label>
           <button id="refresh-button" type="button">Refresh</button>
@@ -1130,7 +1506,7 @@ ${studioStyles()}
           <div class="panel__header">
             <div>
               <h2 id="canonical-title" class="panel__title">Canonical Entity</h2>
-              <p class="panel__subhead">Current candidate-to-canonical mapping from the read-only queue.</p>
+              <p class="panel__subhead">Side-by-side candidate and canonical details from the selected reconciliation pair.</p>
             </div>
           </div>
           <div id="canonical-panel-body" class="panel__body"></div>
@@ -1140,7 +1516,7 @@ ${studioStyles()}
           <div class="panel__header">
             <div>
               <h2 id="graph-context-title" class="panel__title">Graph Context</h2>
-              <p class="panel__subhead">Selection-scoped context until a dedicated neighborhood endpoint lands.</p>
+              <p class="panel__subhead">Selection anchors, evidence footprint, rebuild drift, and recent related decisions.</p>
             </div>
           </div>
           <div id="graph-panel-body" class="panel__body"></div>
@@ -1168,7 +1544,7 @@ ${studioStyles()}
           <div class="panel__header">
             <div>
               <h2 id="audit-trail-title" class="panel__title">Audit Trail</h2>
-              <p class="panel__subhead">Authoritative and applied patch records read through the decision-log endpoint.</p>
+              <p class="panel__subhead">Authoritative and audit records grouped by patch so duplicate source=both rows stay readable.</p>
             </div>
           </div>
           <div id="audit-panel-body" class="panel__body"></div>
@@ -1318,7 +1694,15 @@ export function handleOntologyStudioRequest(
     const candidatePrefix = "/api/ontology/reconciliation/candidates/";
     if (url.pathname.startsWith(candidatePrefix)) {
       const id = decodeURIComponent(url.pathname.slice(candidatePrefix.length));
-      return jsonResult(200, getOntologyReconciliationCandidate(context, id));
+      const candidate = getOntologyReconciliationCandidate(context, id);
+      return jsonResult(
+        200,
+        studioCandidateDetail(
+          candidate,
+          context.nodes.find((node) => node.id === candidate.candidate_id),
+          context.nodes.find((node) => node.id === candidate.canonical_id),
+        ),
+      );
     }
     if (url.pathname === "/api/ontology/reconciliation/decision-log") {
       return jsonResult(200, previewOntologyDecisionLog(context, decisionLogOptions(url.searchParams)));

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -242,6 +242,7 @@ function studioStyles(): string {
     .studio__intro,
     .studio__mode,
     .panel {
+      min-width: 0;
       background: var(--surface-raised);
       border: 1px solid var(--border);
       border-radius: 8px;
@@ -521,9 +522,12 @@ function studioStyles(): string {
     }
 
     .route-list code {
+      max-width: 100%;
       padding: 0.2rem 0.35rem;
       border-radius: 6px;
       background: #f4f6f8;
+      overflow-wrap: anywhere;
+      white-space: normal;
     }
 
     .empty {

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   createOntologyStudioRequestHandler,
   generateOntologyStudioToken,
+  handleOntologyStudioRequest,
   startOntologyStudioServer,
 } from "../src/ontology-studio.js";
 
@@ -76,6 +77,48 @@ describe("graphify ontology studio --write", () => {
     } finally {
       started.server.close();
     }
+  });
+
+  it("serves a reconciliation studio shell that bootstraps the existing read-only APIs", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+
+    const response = handleOntologyStudioRequest({ profileStatePath: fixture.profileStatePath }, "GET", "/");
+
+    expect(response.status).toBe(200);
+    expect(response.contentType).toBe("text/html; charset=utf-8");
+    expect(response.body).toContain("Graphify Ontology Studio");
+    expect(response.body).toContain("Candidate Queue");
+    expect(response.body).toContain("Evidence");
+    expect(response.body).toContain("Canonical Entity");
+    expect(response.body).toContain("Graph Context");
+    expect(response.body).toContain("Patch Preview");
+    expect(response.body).toContain("Audit Trail");
+    expect(response.body).toContain("window.__ONTOLOGY_STUDIO_BOOTSTRAP__");
+    expect(response.body).toContain("/api/ontology/reconciliation/candidates");
+    expect(response.body).toContain("/api/ontology/reconciliation/decision-log");
+    expect(response.body).toContain("/api/ontology/rebuild-status");
+    expect(response.body).toContain("Read-only studio");
+    expect(response.body).toContain("disabled");
+  });
+
+  it("write-enabled shell advertises protected patch routes without leaking the bearer token", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    const token = "super-secret-token";
+
+    const response = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token } },
+      "GET",
+      "/",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toContain("/api/ontology/patch/validate");
+    expect(response.body).toContain("/api/ontology/patch/dry-run");
+    expect(response.body).toContain("/api/ontology/patch/apply");
+    expect(response.body).toContain("Write API available");
+    expect(response.body).not.toContain(token);
   });
 
   it("requires a bearer token for write routes and never mutates without it", async () => {

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createContext, Script } from "node:vm";
 
 import {
   createOntologyStudioRequestHandler,
@@ -29,6 +30,141 @@ function postBody(payload: unknown): { body: string; headers: Record<string, str
       "content-length": String(Buffer.byteLength(body)),
     },
   };
+}
+
+class MockNode {
+  protected _textContent = "";
+
+  get textContent(): string {
+    return this._textContent;
+  }
+
+  set textContent(value: string) {
+    this._textContent = value;
+  }
+}
+
+class MockElement extends MockNode {
+  id = "";
+  className = "";
+  type = "";
+  value = "";
+  children: MockNode[] = [];
+  attributes = new Map<string, string>();
+  listeners = new Map<string, Array<(event: { type: string; target: MockElement; currentTarget: MockElement }) => void>>();
+
+  constructor(readonly tagName: string) {
+    super();
+  }
+
+  override get textContent(): string {
+    return this._textContent + this.children.map((child) => child.textContent).join("");
+  }
+
+  override set textContent(value: string) {
+    this._textContent = value;
+    this.children = [];
+  }
+
+  appendChild<T extends MockNode>(child: T): T {
+    this.children.push(child);
+    return child;
+  }
+
+  replaceChildren(...nodes: MockNode[]): void {
+    this._textContent = "";
+    this.children = [...nodes];
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+    if (name === "id") this.id = value;
+  }
+
+  addEventListener(
+    type: string,
+    handler: (event: { type: string; target: MockElement; currentTarget: MockElement }) => void,
+  ): void {
+    const handlers = this.listeners.get(type) ?? [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  dispatch(type: string): void {
+    for (const handler of this.listeners.get(type) ?? []) {
+      handler({ type, target: this, currentTarget: this });
+    }
+  }
+
+  click(): void {
+    this.dispatch("click");
+  }
+}
+
+class MockDocument {
+  private readonly elements = new Map<string, MockElement>();
+
+  register(id: string, tagName = "div"): MockElement {
+    const element = new MockElement(tagName);
+    element.id = id;
+    this.elements.set(id, element);
+    return element;
+  }
+
+  getElementById(id: string): MockElement | null {
+    return this.elements.get(id) ?? null;
+  }
+
+  createElement(tagName: string): MockElement {
+    return new MockElement(tagName);
+  }
+}
+
+function extractInlineScripts(html: string): { bootstrapScript: string; clientScript: string } {
+  const scripts = Array.from(html.matchAll(/<script>\s*([\s\S]*?)\s*<\/script>/g), (match) => match[1] ?? "");
+  const bootstrapScript = scripts.find((script) => script.includes("window.__ONTOLOGY_STUDIO_BOOTSTRAP__"));
+  const clientScript = scripts.find((script) => script.includes("const bootstrap = window.__ONTOLOGY_STUDIO_BOOTSTRAP__"));
+  if (!bootstrapScript || !clientScript) {
+    throw new Error("expected bootstrap and client inline scripts in ontology studio shell");
+  }
+  return { bootstrapScript, clientScript };
+}
+
+function registerStudioShellDom(document: MockDocument): Record<string, MockElement> {
+  return {
+    queue: document.register("candidate-queue"),
+    queueStatus: document.register("queue-status"),
+    queueCount: document.register("queue-count", "span"),
+    queueQuery: document.register("queue-query", "input"),
+    queueMinScore: document.register("queue-min-score", "select"),
+    queueStatusFilter: document.register("queue-status-filter", "select"),
+    queueKindFilter: document.register("queue-kind-filter", "select"),
+    queueOperationFilter: document.register("queue-operation-filter", "select"),
+    queueSort: document.register("queue-sort", "select"),
+    queueOrder: document.register("queue-order", "select"),
+    refresh: document.register("refresh-button", "button"),
+    selectedTitle: document.register("selected-title"),
+    selectedMeta: document.register("selected-meta"),
+    selectedSummary: document.register("selected-summary"),
+    evidenceBody: document.register("evidence-panel-body"),
+    canonicalBody: document.register("canonical-panel-body"),
+    graphBody: document.register("graph-panel-body"),
+    rebuildBody: document.register("rebuild-panel-body"),
+    auditBody: document.register("audit-panel-body"),
+    patchPreview: document.register("patch-preview", "pre"),
+    patchHint: document.register("patch-mode-copy"),
+  };
+}
+
+function occurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  return haystack.split(needle).length - 1;
+}
+
+async function flushMicrotasks(rounds = 20): Promise<void> {
+  for (let index = 0; index < rounds; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 afterEach(() => {
@@ -98,10 +234,302 @@ describe("graphify ontology studio --write", () => {
     expect(response.body).toContain("/api/ontology/reconciliation/candidates");
     expect(response.body).toContain("/api/ontology/reconciliation/decision-log");
     expect(response.body).toContain("/api/ontology/rebuild-status");
+    expect(response.body).toContain("queue-status-filter");
+    expect(response.body).toContain("queue-kind-filter");
+    expect(response.body).toContain("queue-operation-filter");
+    expect(response.body).toContain("queue-sort");
+    expect(response.body).toContain("queue-order");
     expect(response.body).toContain("Read-only studio");
     expect(response.body).toContain("disabled");
     expect(response.body).toContain("min-width: 0;");
     expect(response.body).toContain("overflow-wrap: anywhere;");
+  });
+
+  it("executes the inline bootstrap script with a minimal DOM and renders reconciliation details", async () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    const html = handleOntologyStudioRequest({ profileStatePath: fixture.profileStatePath }, "GET", "/").body;
+    const { bootstrapScript, clientScript } = extractInlineScripts(html);
+    const document = new MockDocument();
+    const elements = registerStudioShellDom(document);
+    const timers = new Map<number, () => void>();
+    let nextTimerId = 1;
+    const fetchCalls: string[] = [];
+    const candidateDetails = {
+      "candidate-high": {
+        id: "candidate-high",
+        kind: "entity_match",
+        status: "candidate",
+        score: 0.97,
+        candidate_id: "character_herlock_sholmes",
+        canonical_id: "character_sherlock_holmes",
+        shared_terms: ["sherlock holmes"],
+        evidence_refs: [
+          "corpus/arsene-lupin/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/text.txt#Sherlock Holmes Arrives Too Late",
+          "corpus/sherlock-holmes/a-study-in-scarlet/text.txt#part 1",
+        ],
+        reasons: [
+          "same node type: Character",
+          "shared normalized term(s): sherlock holmes",
+        ],
+        proposed_patch_operation: "accept_match",
+        candidate_node: {
+          id: "character_herlock_sholmes",
+          label: "Herlock Sholmes",
+          type: "Character",
+          status: "candidate",
+          aliases: ["Sherlock Holmes parody figure"],
+          normalized_terms: ["herlock sholmes", "sherlock holmes parody figure"],
+          source_refs: [
+            "corpus/arsene-lupin/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/text.txt#Sherlock Holmes Arrives Too Late",
+          ],
+        },
+        canonical_node: {
+          id: "character_sherlock_holmes",
+          label: "Sherlock Holmes",
+          type: "Character",
+          status: "validated",
+          aliases: ["Mr. Holmes"],
+          normalized_terms: ["sherlock holmes", "mr. holmes"],
+          source_refs: ["corpus/sherlock-holmes/a-study-in-scarlet/text.txt#part 1"],
+        },
+      },
+      "candidate-low": {
+        id: "candidate-low",
+        kind: "entity_match",
+        status: "candidate",
+        score: 0.64,
+        candidate_id: "story_sherlock_holmes_too_late",
+        canonical_id: "story_scandal_bohemia",
+        shared_terms: ["story"],
+        evidence_refs: ["corpus/arsene-lupin/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/text.txt#story"],
+        reasons: ["story-level review sample"],
+        proposed_patch_operation: "accept_match",
+        candidate_node: {
+          id: "story_sherlock_holmes_too_late",
+          label: "Sherlock Holmes Arrives Too Late",
+          type: "ChapterOrStory",
+          status: "candidate",
+          aliases: [],
+          normalized_terms: ["sherlock holmes arrives too late"],
+          source_refs: ["corpus/arsene-lupin/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/text.txt#story"],
+        },
+        canonical_node: {
+          id: "story_scandal_bohemia",
+          label: "A Scandal in Bohemia",
+          type: "ChapterOrStory",
+          status: "validated",
+          aliases: [],
+          normalized_terms: ["a scandal in bohemia"],
+          source_refs: ["corpus/sherlock-holmes/the-adventures-of-sherlock-holmes/text.txt#story"],
+        },
+      },
+    } as const;
+
+    const fetchStub = async (path: string) => {
+      fetchCalls.push(path);
+      if (path.startsWith("/api/ontology/reconciliation/candidates?")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return {
+              schema: "graphify_ontology_reconciliation_candidates_response_v1",
+              generated_at: "2026-05-18T13:00:00.000Z",
+              graph_hash: "graph-hash",
+              profile_hash: "profile-hash",
+              stale: false,
+              total: 2,
+              limit: 50,
+              offset: 0,
+              items: [
+                {
+                  id: "candidate-high",
+                  kind: "entity_match",
+                  status: "candidate",
+                  score: 0.97,
+                  candidate_id: "character_herlock_sholmes",
+                  canonical_id: "character_sherlock_holmes",
+                  shared_terms: ["sherlock holmes"],
+                  evidence_refs: [
+                    "corpus/arsene-lupin/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/text.txt#Sherlock Holmes Arrives Too Late",
+                  ],
+                  reasons: ["same node type: Character"],
+                  proposed_patch_operation: "accept_match",
+                },
+                {
+                  id: "candidate-low",
+                  kind: "entity_match",
+                  status: "candidate",
+                  score: 0.64,
+                  candidate_id: "story_sherlock_holmes_too_late",
+                  canonical_id: "story_scandal_bohemia",
+                  shared_terms: ["story"],
+                  evidence_refs: ["corpus/arsene-lupin/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/text.txt#story"],
+                  reasons: ["story-level review sample"],
+                  proposed_patch_operation: "accept_match",
+                },
+              ],
+            };
+          },
+        };
+      }
+
+      if (path === "/api/ontology/rebuild-status") {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return {
+              schema: "graphify_ontology_rebuild_status_v1",
+              needs_update: true,
+              candidates_match: false,
+              decision_log_available: true,
+              graph_hash: "graph-hash",
+              profile_hash: "profile-hash",
+              candidates: {
+                path: "ontology/reconciliation/candidates.json",
+                generated_at: "2026-05-18T13:00:00.000Z",
+                issues: ["candidates graph_hash does not match active graph"],
+              },
+            };
+          },
+        };
+      }
+
+      if (path.startsWith("/api/ontology/reconciliation/decision-log")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return {
+              schema: "graphify_ontology_reconciliation_decision_log_v1",
+              total: 2,
+              limit: 12,
+              offset: 0,
+              items: [
+                {
+                  source: "authoritative",
+                  path: "graphify/reconciliation/decisions.jsonl",
+                  recorded_at: "2026-05-18T13:05:00.000Z",
+                  patch: {
+                    id: "patch-001",
+                    operation: "accept_match",
+                    status: "applied",
+                    target: {
+                      candidate_id: "character_herlock_sholmes",
+                      canonical_id: "character_sherlock_holmes",
+                    },
+                  },
+                },
+                {
+                  source: "audit",
+                  path: ".graphify/ontology/reconciliation/applied-patches.jsonl",
+                  recorded_at: "2026-05-18T13:06:00.000Z",
+                  patch: {
+                    id: "patch-001",
+                    operation: "accept_match",
+                    status: "applied",
+                    target: {
+                      candidate_id: "character_herlock_sholmes",
+                      canonical_id: "character_sherlock_holmes",
+                    },
+                  },
+                },
+              ],
+              issues: [],
+            };
+          },
+        };
+      }
+
+      const detailId = decodeURIComponent(path.slice(path.lastIndexOf("/") + 1));
+      if (path.startsWith("/api/ontology/reconciliation/candidates/") && detailId in candidateDetails) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return candidateDetails[detailId as keyof typeof candidateDetails];
+          },
+        };
+      }
+
+      throw new Error(`unexpected fetch path: ${path}`);
+    };
+
+    const context = createContext({
+      console,
+      Node: MockNode,
+      URLSearchParams,
+      encodeURIComponent,
+      fetch: fetchStub,
+      document,
+      window: {
+        document,
+        fetch: fetchStub,
+        setTimeout(callback: () => void) {
+          const timerId = nextTimerId++;
+          timers.set(timerId, callback);
+          return timerId;
+        },
+        clearTimeout(timerId: number) {
+          timers.delete(timerId);
+        },
+      },
+    });
+
+    new Script(bootstrapScript).runInContext(context);
+    new Script(clientScript).runInContext(context);
+    await flushMicrotasks();
+
+    expect(elements.queue.children).toHaveLength(2);
+    expect(elements.selectedTitle.textContent).toContain("Herlock Sholmes -> Sherlock Holmes");
+    expect(elements.selectedSummary.textContent).toContain("character_herlock_sholmes");
+    expect(elements.selectedSummary.textContent).toContain("character_sherlock_holmes");
+    expect(elements.canonicalBody.textContent).toContain("Herlock Sholmes");
+    expect(elements.canonicalBody.textContent).toContain("Sherlock Holmes");
+    expect(elements.canonicalBody.textContent).toContain("validated");
+    expect(elements.graphBody.textContent).toContain("Related decisions");
+    expect(elements.graphBody.textContent).toContain("candidates graph_hash does not match active graph");
+    expect(occurrences(elements.auditBody.textContent, "patch-001")).toBe(1);
+    expect(elements.auditBody.textContent).toContain("authoritative");
+    expect(elements.auditBody.textContent).toContain("audit");
+
+    (elements.queue.children[1] as MockElement).click();
+    await flushMicrotasks();
+    expect(elements.selectedTitle.textContent).toContain("Sherlock Holmes Arrives Too Late -> A Scandal in Bohemia");
+    expect(elements.patchPreview.textContent).toContain("\"candidate_id\": \"story_sherlock_holmes_too_late\"");
+
+    elements.queueQuery.value = "sherlock";
+    elements.queueMinScore.value = "0.75";
+    elements.queueStatusFilter.value = "candidate";
+    elements.queueKindFilter.value = "entity_match";
+    elements.queueOperationFilter.value = "accept_match";
+    elements.queueSort.value = "id";
+    elements.queueOrder.value = "asc";
+    elements.queueStatusFilter.dispatch("change");
+    elements.queueKindFilter.dispatch("change");
+    elements.queueOperationFilter.dispatch("change");
+    elements.queueSort.dispatch("change");
+    elements.queueOrder.dispatch("change");
+    elements.queueQuery.dispatch("input");
+    for (const callback of timers.values()) callback();
+    timers.clear();
+    await flushMicrotasks();
+
+    expect(fetchCalls.some((path) =>
+      path.includes("query=sherlock")
+      && path.includes("min_score=0.75")
+      && path.includes("status=candidate")
+      && path.includes("kind=entity_match")
+      && path.includes("operation=accept_match")
+      && path.includes("sort=id")
+      && path.includes("order=asc"),
+    )).toBe(true);
   });
 
   it("write-enabled shell advertises protected patch routes without leaking the bearer token", () => {

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -153,6 +153,13 @@ function registerStudioShellDom(document: MockDocument): Record<string, MockElem
     auditBody: document.register("audit-panel-body"),
     patchPreview: document.register("patch-preview", "pre"),
     patchHint: document.register("patch-mode-copy"),
+    patchToken: document.register("patch-token", "input"),
+    patchOperation: document.register("patch-operation", "select"),
+    patchNote: document.register("patch-note", "input"),
+    patchValidate: document.register("patch-validate", "button"),
+    patchDryRun: document.register("patch-dry-run", "button"),
+    patchApply: document.register("patch-apply", "button"),
+    patchResult: document.register("patch-result"),
   };
 }
 
@@ -226,8 +233,8 @@ describe("graphify ontology studio --write", () => {
     expect(response.body).toContain("Graphify Ontology Studio");
     expect(response.body).toContain("Candidate Queue");
     expect(response.body).toContain("Evidence");
-    expect(response.body).toContain("Canonical Entity");
-    expect(response.body).toContain("Graph Context");
+    expect(response.body).toContain("Candidate vs Canonical");
+    expect(response.body).toContain("Decision Context");
     expect(response.body).toContain("Patch Preview");
     expect(response.body).toContain("Audit Trail");
     expect(response.body).toContain("window.__ONTOLOGY_STUDIO_BOOTSTRAP__");
@@ -240,7 +247,7 @@ describe("graphify ontology studio --write", () => {
     expect(response.body).toContain("queue-sort");
     expect(response.body).toContain("queue-order");
     expect(response.body).toContain("Read-only studio");
-    expect(response.body).toContain("disabled");
+    expect(response.body).toContain("Inspection-first browser session");
     expect(response.body).toContain("min-width: 0;");
     expect(response.body).toContain("overflow-wrap: anywhere;");
   });
@@ -493,7 +500,7 @@ describe("graphify ontology studio --write", () => {
     expect(elements.canonicalBody.textContent).toContain("Herlock Sholmes");
     expect(elements.canonicalBody.textContent).toContain("Sherlock Holmes");
     expect(elements.canonicalBody.textContent).toContain("validated");
-    expect(elements.graphBody.textContent).toContain("Related decisions");
+    expect(elements.graphBody.textContent).toContain("Recent related decisions");
     expect(elements.graphBody.textContent).toContain("candidates graph_hash does not match active graph");
     expect(occurrences(elements.auditBody.textContent, "patch-001")).toBe(1);
     expect(elements.auditBody.textContent).toContain("authoritative");
@@ -530,6 +537,246 @@ describe("graphify ontology studio --write", () => {
       && path.includes("sort=id")
       && path.includes("order=asc"),
     )).toBe(true);
+  });
+
+  it("supports validate, dry-run, and apply from the write-enabled browser shell with a pasted token", async () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    const token = "deadbeef".repeat(6);
+    const html = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token } },
+      "GET",
+      "/",
+    ).body;
+    const { bootstrapScript, clientScript } = extractInlineScripts(html);
+    const document = new MockDocument();
+    const elements = registerStudioShellDom(document);
+    const postRequests: Array<{ path: string; authorization?: string; body: Record<string, unknown> }> = [];
+
+    const fetchStub = async (path: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => {
+      if (!options || !options.method || options.method === "GET") {
+        if (path.startsWith("/api/ontology/reconciliation/candidates?")) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            async json() {
+              return {
+                schema: "graphify_ontology_reconciliation_candidates_response_v1",
+                generated_at: "2026-05-18T13:00:00.000Z",
+                graph_hash: "graph-hash",
+                profile_hash: "profile-hash",
+                stale: false,
+                total: 1,
+                limit: 50,
+                offset: 0,
+                items: [
+                  {
+                    id: "candidate-high",
+                    kind: "entity_match",
+                    status: "candidate",
+                    score: 0.97,
+                    candidate_id: "character_herlock_sholmes",
+                    canonical_id: "character_sherlock_holmes",
+                    shared_terms: ["sherlock holmes"],
+                    evidence_refs: ["corpus/arsene-lupin/story#1"],
+                    reasons: ["same normalized term"],
+                    proposed_patch_operation: "accept_match",
+                  },
+                ],
+              };
+            },
+          };
+        }
+        if (path === "/api/ontology/rebuild-status") {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            async json() {
+              return {
+                schema: "graphify_ontology_rebuild_status_v1",
+                needs_update: false,
+                candidates_match: true,
+                decision_log_available: true,
+                candidates: {
+                  path: "ontology/reconciliation/candidates.json",
+                  generated_at: "2026-05-18T13:00:00.000Z",
+                  issues: [],
+                },
+              };
+            },
+          };
+        }
+        if (path.startsWith("/api/ontology/reconciliation/decision-log")) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            async json() {
+              return {
+                schema: "graphify_ontology_reconciliation_decision_log_v1",
+                total: 0,
+                limit: 24,
+                offset: 0,
+                items: [],
+                issues: [],
+              };
+            },
+          };
+        }
+        if (path === "/api/ontology/reconciliation/candidates/candidate-high") {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            async json() {
+              return {
+                id: "candidate-high",
+                kind: "entity_match",
+                status: "candidate",
+                score: 0.97,
+                candidate_id: "character_herlock_sholmes",
+                canonical_id: "character_sherlock_holmes",
+                shared_terms: ["sherlock holmes"],
+                evidence_refs: ["corpus/arsene-lupin/story#1"],
+                reasons: ["same normalized term"],
+                proposed_patch_operation: "accept_match",
+                candidate_node: {
+                  id: "character_herlock_sholmes",
+                  label: "Herlock Sholmes",
+                  type: "Character",
+                  status: "candidate",
+                  aliases: [],
+                  normalized_terms: ["herlock sholmes", "sherlock holmes"],
+                  source_refs: ["corpus/arsene-lupin/story#1"],
+                },
+                canonical_node: {
+                  id: "character_sherlock_holmes",
+                  label: "Sherlock Holmes",
+                  type: "Character",
+                  status: "validated",
+                  aliases: [],
+                  normalized_terms: ["sherlock holmes"],
+                  source_refs: ["corpus/sherlock/story#1"],
+                },
+              };
+            },
+          };
+        }
+        throw new Error(`unexpected GET path: ${path}`);
+      }
+
+      const body = JSON.parse(options.body ?? "{}") as Record<string, unknown>;
+      postRequests.push({
+        path,
+        authorization: options.headers?.authorization,
+        body,
+      });
+      if (path === "/api/ontology/patch/validate") {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return {
+              schema: "graphify_ontology_patch_validation_v1",
+              patch_id: String(body.id),
+              valid: true,
+              issues: [],
+            };
+          },
+        };
+      }
+      if (path === "/api/ontology/patch/dry-run") {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return {
+              schema: "graphify_ontology_patch_apply_v1",
+              patch_id: String(body.id),
+              valid: true,
+              dry_run: true,
+              issues: [],
+              changed_files: [{ path: ".graphify/ontology/reconciliation/applied-patches.jsonl" }],
+            };
+          },
+        };
+      }
+      if (path === "/api/ontology/patch/apply") {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return {
+              schema: "graphify_ontology_patch_apply_v1",
+              patch_id: String(body.id),
+              valid: true,
+              dry_run: false,
+              issues: [],
+              changed_files: [{ path: "graphify/reconciliation/decisions.jsonl" }],
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected POST path: ${path}`);
+    };
+
+    const context = createContext({
+      console,
+      Node: MockNode,
+      URLSearchParams,
+      encodeURIComponent,
+      fetch: fetchStub,
+      document,
+      window: {
+        document,
+        fetch: fetchStub,
+        setTimeout(callback: () => void) {
+          callback();
+          return 1;
+        },
+        clearTimeout() {},
+      },
+    });
+
+    new Script(bootstrapScript).runInContext(context);
+    new Script(clientScript).runInContext(context);
+    await flushMicrotasks();
+
+    elements.patchToken.value = token;
+    elements.patchToken.dispatch("input");
+    elements.patchOperation.value = "reject_match";
+    elements.patchOperation.dispatch("change");
+    elements.patchNote.value = "Analyst rejected this merge";
+    elements.patchNote.dispatch("input");
+    await flushMicrotasks();
+    expect(elements.patchPreview.textContent).toContain("\"operation\": \"reject_match\"");
+
+    elements.patchValidate.click();
+    await flushMicrotasks();
+    elements.patchDryRun.click();
+    await flushMicrotasks();
+    elements.patchApply.click();
+    await flushMicrotasks();
+
+    expect(postRequests.map((request) => request.path)).toEqual([
+      "/api/ontology/patch/validate",
+      "/api/ontology/patch/dry-run",
+      "/api/ontology/patch/apply",
+    ]);
+    expect(postRequests.every((request) => request.authorization === `Bearer ${token}`)).toBe(true);
+    expect(postRequests.every((request) => request.body.operation === "reject_match")).toBe(true);
+    expect(postRequests.every((request) => request.body.reason === "Analyst rejected this merge")).toBe(true);
+    expect(postRequests[2]?.body.target).toMatchObject({
+      candidate_id: "character_herlock_sholmes",
+      canonical_id: "character_sherlock_holmes",
+    });
+    expect(elements.patchResult.textContent).toContain("apply succeeded");
+    expect(elements.patchResult.textContent).toContain("graphify/reconciliation/decisions.jsonl");
   });
 
   it("write-enabled shell advertises protected patch routes without leaking the bearer token", () => {

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -100,6 +100,8 @@ describe("graphify ontology studio --write", () => {
     expect(response.body).toContain("/api/ontology/rebuild-status");
     expect(response.body).toContain("Read-only studio");
     expect(response.body).toContain("disabled");
+    expect(response.body).toContain("min-width: 0;");
+    expect(response.body).toContain("overflow-wrap: anywhere;");
   });
 
   it("write-enabled shell advertises protected patch routes without leaking the bearer token", () => {


### PR DESCRIPTION
## Summary
- replace the ontology studio stub with a read-only reconciliation shell backed by the existing HTTP endpoints
- load candidate queue, selected candidate detail, rebuild status, and audit trail in the browser without adding frontend dependencies
- add focused HTML-shell tests and refresh the repo graph metadata after the code change

## Verification
- npm test -- tests/ontology-studio-write.test.ts tests/ontology-reconciliation.test.ts tests/serve.test.ts
- npm run lint
- npm run build
- npx graphify hook-rebuild