### PR TITLE
Track C-3.5: profile-aware visual encoding per ontology node type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 This fork (`graphifyy@*`) is the TypeScript line. Pre-`0.7.x` entries below refer to the upstream Python Graphify line.
 
+## Unreleased
+
+Track C-3.5 — profile-aware visual encoding per ontology node type (cosmetic-only).
+
+- `ontology-profile.yaml` may now declare a vis.js `shape` and a `color_hex` per `node_types.*.visual_encoding` (validated against the `dot / square / triangle / box / diamond / star / hexagon` enum and `^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$`).
+- `graphify export html` (plus the implicit HTML re-export from `cluster-only` and the main extract run) reads `node_type` on each node and resolves shape + border/background color from the profile in priority over `inferNodeShape(file_type, source_file)`. When no profile is provided or no `visual_encoding` is declared, the HTML output is byte-identical to before.
+- `graphify export html` accepts an explicit `--profile <path>` so an ontology profile can be applied to an existing graph without touching `graphify.yaml`.
+- TS-only delta: no upstream Python parity gap, no graph schema change, no bundled dep change.
+
 ## 0.9.5 (2026-05-19)
 
 Track F upstream parity follow-up — Rust cross-crate `INFERRED` suppression.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,6 +202,32 @@ function writeJson(path: string, value: unknown): void {
   writeFileSync(resolved, JSON.stringify(value, null, 2), "utf-8");
 }
 
+/**
+ * Track C-3.5: best-effort loader for the ontology profile used by HTML
+ * export visual encoding overrides. Returns undefined if no graphify.yaml
+ * project config exists, or if the profile cannot be loaded — this is a
+ * cosmetic-only enhancement, so a missing or broken profile must NEVER
+ * fail the surrounding HTML export. If `explicitPath` is provided we honor
+ * --profile; otherwise we auto-discover graphify.yaml under `root`.
+ */
+async function tryLoadHtmlOntologyProfile(
+  root: string,
+  explicitPath?: string,
+): Promise<import("./types.js").NormalizedOntologyProfile | undefined> {
+  try {
+    const { loadOntologyProfile } = await import("./ontology-profile.js");
+    if (explicitPath) {
+      return loadOntologyProfile(resolve(explicitPath));
+    }
+    const discovery = discoverProjectConfig(root);
+    if (!discovery.found || !discovery.path) return undefined;
+    const projectConfig = loadProjectConfig(discovery.path);
+    return loadOntologyProfile(projectConfig.profile.resolvedPath, { projectConfig });
+  } catch {
+    return undefined;
+  }
+}
+
 function parsePositiveIntegerOption(value: unknown, name: string): number | undefined {
   if (value === undefined || value === null || value === "") return undefined;
   const parsed = Number.parseInt(String(value), 10);
@@ -2696,9 +2722,21 @@ export async function main(): Promise<void> {
 
         writeFileSync(paths.report, report, "utf-8");
         toJson(G, communities, paths.graph, { communityLabels: labels, force: true });
-        safeToHtml(G, communities, paths.html, { communityLabels: labels }, {
-          onWarning: (message) => console.warn(message),
-        });
+        // Track C-3.5: pick up ontology profile for visual encoding override
+        // when a graphify.yaml + ontology-profile is present in the project.
+        const ontologyProfileForExtractHtml = await tryLoadHtmlOntologyProfile(root);
+        safeToHtml(
+          G,
+          communities,
+          paths.html,
+          {
+            communityLabels: labels,
+            ...(ontologyProfileForExtractHtml ? { profile: ontologyProfileForExtractHtml } : {}),
+          },
+          {
+            onWarning: (message) => console.warn(message),
+          },
+        );
         persistCommunityLabels(labels, paths.scratch.labels);
         writeJson(paths.scratch.analysis, {
           communities: Object.fromEntries([...communities.entries()].map(([key, value]) => [String(key), value])),
@@ -2897,9 +2935,21 @@ export async function main(): Promise<void> {
       );
       writeFileSync(paths.report, report, "utf-8");
       toJson(G, communities, paths.graph, { communityLabels: labels });
-      safeToHtml(G, communities, paths.html, { communityLabels: labels }, {
-        onWarning: (message) => console.warn(message),
-      });
+      // Track C-3.5: opportunistically load the ontology profile so HTML
+      // export can override shape/color per node_type when declared.
+      const ontologyProfileForHtml = await tryLoadHtmlOntologyProfile(root);
+      safeToHtml(
+        G,
+        communities,
+        paths.html,
+        {
+          communityLabels: labels,
+          ...(ontologyProfileForHtml ? { profile: ontologyProfileForHtml } : {}),
+        },
+        {
+          onWarning: (message) => console.warn(message),
+        },
+      );
       persistCommunityLabels(labels, paths.scratch.labels);
       const analysis = {
         communities: Object.fromEntries([...communities.entries()].map(([key, value]) => [String(key), value])),
@@ -3016,6 +3066,10 @@ export async function main(): Promise<void> {
     .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
     .option("--out <path>", "Path to write graph.html")
     .option("--no-viz", "Skip HTML export and remove any stale output")
+    .option(
+      "--profile <path>",
+      "Optional ontology profile YAML for per-node-type visual encoding (Track C-3.5)",
+    )
     .action(async (opts) => {
       try {
         const graphPath = resolveGraphInputPath(opts.graph);
@@ -3028,10 +3082,26 @@ export async function main(): Promise<void> {
         const G = loadCliGraph(graphPath);
         const communities = communitiesFromCliGraph(G);
         const labels = communityLabelsFromCliGraph(G, communities);
+        // Track C-3.5: --profile wins over graphify.yaml auto-discovery,
+        // but auto-discovery still happens relative to the graph dir when
+        // --profile is omitted, so an existing graphify.yaml is honored.
+        const ontologyProfileForHtml = await tryLoadHtmlOntologyProfile(
+          dirname(graphPath),
+          typeof opts.profile === "string" ? opts.profile : undefined,
+        );
         const { safeToHtml } = await import("./html-export.js");
-        const written = safeToHtml(G, communities, outPath, { communityLabels: labels }, {
-          onWarning: (message) => console.warn(message),
-        });
+        const written = safeToHtml(
+          G,
+          communities,
+          outPath,
+          {
+            communityLabels: labels,
+            ...(ontologyProfileForHtml ? { profile: ontologyProfileForHtml } : {}),
+          },
+          {
+            onWarning: (message) => console.warn(message),
+          },
+        );
         if (!written) {
           process.exit(1);
         }

--- a/src/export.ts
+++ b/src/export.ts
@@ -7,7 +7,7 @@ import Graph from "graphology";
 import { sanitizeLabel, escapeHtml } from "./security.js";
 import { isDirectedGraph } from "./graph.js";
 import { safeGitRevParse } from "./git.js";
-import type { Hyperedge } from "./types.js";
+import type { Hyperedge, NormalizedOntologyProfile, OntologyVisualEncoding } from "./types.js";
 import {
   type NumericMapLike,
   type StringMapLike,
@@ -83,7 +83,12 @@ const CONFIDENCE_SCORE_DEFAULTS: Record<string, number> = {
 
 type CommunityLabelsInput = NumericMapLike<string>;
 type CommunityLabelOptions = { communityLabels?: CommunityLabelsInput };
-type HtmlOptions = CommunityLabelOptions & { memberCounts?: NumericMapLike<number> };
+type HtmlOptions = CommunityLabelOptions & {
+  memberCounts?: NumericMapLike<number>;
+  /** Track C-3.5: optional ontology profile carrying per-node-type
+   *  visual_encoding (shape + color_hex) overrides for the HTML export. */
+  profile?: NormalizedOntologyProfile;
+};
 type JsonOptions = CommunityLabelOptions & { force?: boolean };
 type SvgOptions = CommunityLabelOptions & { figsize?: [number, number] };
 type CanvasOptions = CommunityLabelOptions & { nodeFilenames?: StringMapLike<string> };
@@ -131,7 +136,8 @@ function isCommunityLabelOptions(
   return !(value instanceof Map) && (
     Object.prototype.hasOwnProperty.call(value, "communityLabels") ||
     Object.prototype.hasOwnProperty.call(value, "memberCounts") ||
-    Object.prototype.hasOwnProperty.call(value, "force")
+    Object.prototype.hasOwnProperty.call(value, "force") ||
+    Object.prototype.hasOwnProperty.call(value, "profile")
   );
 }
 
@@ -169,6 +175,57 @@ function normalizeMemberCounts(
   if (!labelsOrOptions || !isCommunityLabelOptions(labelsOrOptions)) return undefined;
   if (!("memberCounts" in labelsOrOptions) || !labelsOrOptions.memberCounts) return undefined;
   return toNumericMap(labelsOrOptions.memberCounts);
+}
+
+function normalizeProfile(
+  labelsOrOptions?: CommunityLabelsInput | HtmlOptions,
+): NormalizedOntologyProfile | undefined {
+  if (!labelsOrOptions || !isCommunityLabelOptions(labelsOrOptions)) return undefined;
+  return (labelsOrOptions as HtmlOptions).profile ?? undefined;
+}
+
+/**
+ * Track C-3.5: pick the vis.js node shape with the following precedence:
+ *  1. The matching profile node_type's `visual_encoding.shape` (if any).
+ *  2. The legacy file_type / source_file inference (inferNodeShape).
+ *
+ * Pure function: when `profile` is undefined OR the node has no node_type
+ * OR the type has no visual_encoding.shape, the result is identical to the
+ * legacy code path, so existing HTML outputs remain bit-stable.
+ */
+export function resolveNodeShape(args: {
+  nodeType: string;
+  fileType: string;
+  sourceFile: string;
+  profile?: NormalizedOntologyProfile;
+}): string {
+  const ve = lookupVisualEncoding(args.profile, args.nodeType);
+  if (ve?.shape) return ve.shape;
+  return inferNodeShape(args.fileType, args.sourceFile);
+}
+
+/**
+ * Track C-3.5: pick the per-node color from the profile's
+ * `visual_encoding.color_hex` if declared, else fall back to the legacy
+ * community-palette color.
+ */
+export function resolveNodeColor(args: {
+  nodeType: string;
+  profile?: NormalizedOntologyProfile;
+  fallback: string;
+}): string {
+  const ve = lookupVisualEncoding(args.profile, args.nodeType);
+  if (ve?.color_hex) return ve.color_hex;
+  return args.fallback;
+}
+
+function lookupVisualEncoding(
+  profile: NormalizedOntologyProfile | undefined,
+  nodeType: string,
+): OntologyVisualEncoding | undefined {
+  if (!profile || !nodeType) return undefined;
+  const entry = profile.node_types?.[nodeType];
+  return entry?.visual_encoding;
 }
 
 function buildFreshnessMetadata(outputPath: string): { built_from_commit?: string } {
@@ -850,6 +907,7 @@ export function toHtml(
   const communityMap = toNumericMap(communities);
   const communityLabels = normalizeCommunityLabels(communityLabelsOrOptions);
   const memberCounts = normalizeMemberCounts(communityLabelsOrOptions);
+  const profile = normalizeProfile(communityLabelsOrOptions);
   if (G.order > MAX_NODES_FOR_VIZ) {
     throw new Error(
       `Graph has ${G.order} nodes - too large for HTML viz. ` +
@@ -883,7 +941,7 @@ export function toHtml(
   const visNodes: VisNode[] = [];
   G.forEachNode((nodeId, data) => {
     const cid = nodeComm.get(nodeId) ?? 0;
-    const color = COMMUNITY_COLORS[cid % COMMUNITY_COLORS.length]!;
+    const paletteColor = COMMUNITY_COLORS[cid % COMMUNITY_COLORS.length]!;
     const label = sanitizeLabel((data.label as string) ?? nodeId);
     const deg = degree.get(nodeId) ?? 1;
     const memberCount = memberCounts?.get(cid) ?? 1;
@@ -893,12 +951,18 @@ export function toHtml(
     const fontSize = memberCounts ? 12 : (deg >= maxDeg * 0.15 ? 12 : 0);
     const sourceFile = (data.source_file as string) ?? "";
     const fileType = (data.file_type as string) ?? "";
-    const shape = inferNodeShape(fileType, sourceFile);
+    // Track C-3.5: read node_type (canonical attribute on ontology graphs;
+    // legacy `type` is tolerated as fallback) and resolve shape + color
+    // via the profile first, with file_type/community palette as fallback.
+    const nodeType = (data.node_type as string) ?? (data.type as string) ?? "";
+    const shape = resolveNodeShape({ nodeType, fileType, sourceFile, profile });
+    const color = resolveNodeColor({ nodeType, profile, fallback: paletteColor });
     // C-final-1: shape "box" (document/paper/concept) renders as outline-only
     // so it is visually distinct from "square" (test) which stays solid-filled.
     // vis.js draws a filled rectangle when color.background is a color; setting
     // background to a transparent value keeps the border (color) and shows the
-    // label cleanly without the fill blob.
+    // label cleanly without the fill blob. Stays consistent whether `box`
+    // comes from inferNodeShape or from a profile visual_encoding override.
     const isOutlinedShape = shape === "box";
     visNodes.push({
       id: nodeId,

--- a/src/ontology-profile.ts
+++ b/src/ontology-profile.ts
@@ -29,6 +29,12 @@ import type {
 const DEFAULT_STATUSES = ["candidate", "attached", "needs_review", "validated", "rejected", "superseded"];
 const VALID_CITATION_MINIMUMS = new Set(["file", "page", "section", "paragraph"]);
 
+// Track C-3.5: vis.js shapes accepted in OntologyNodeType.visual_encoding.shape.
+// Keep aligned with src/export.ts inferNodeShape and OntologyVisualEncodingShape.
+const VIS_JS_SHAPE_LIST = ["dot", "square", "triangle", "box", "diamond", "star", "hexagon"] as const;
+const VIS_JS_SHAPES = new Set<string>(VIS_JS_SHAPE_LIST);
+const VISUAL_ENCODING_COLOR_HEX_REGEX = /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/;
+
 function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -242,6 +248,33 @@ export function validateOntologyProfile(profile: OntologyProfile): string[] {
   }
   if (!knownStatuses.has(hardening.default_status)) {
     errors.push(`hardening.default_status references unknown status ${hardening.default_status}`);
+  }
+
+  // Track C-3.5: validate optional visual_encoding (shape + color_hex) per node type.
+  for (const [nodeTypeId, nodeType] of Object.entries(nodeTypes)) {
+    const visual = (nodeType as { visual_encoding?: unknown }).visual_encoding;
+    if (visual === undefined || visual === null) continue;
+    if (typeof visual !== "object" || Array.isArray(visual)) {
+      errors.push(`node_types.${nodeTypeId}.visual_encoding must be an object`);
+      continue;
+    }
+    const ve = visual as { shape?: unknown; color_hex?: unknown };
+    if (ve.shape !== undefined) {
+      const shape = String(ve.shape);
+      if (!VIS_JS_SHAPES.has(shape)) {
+        errors.push(
+          `node_types.${nodeTypeId}.visual_encoding.shape must be one of ${VIS_JS_SHAPE_LIST.join(", ")} (got ${shape})`,
+        );
+      }
+    }
+    if (ve.color_hex !== undefined) {
+      const color = String(ve.color_hex);
+      if (!VISUAL_ENCODING_COLOR_HEX_REGEX.test(color)) {
+        errors.push(
+          `node_types.${nodeTypeId}.visual_encoding.color_hex must match /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/ (got ${color})`,
+        );
+      }
+    }
   }
 
   for (const [relationId, relation] of Object.entries(relationTypes)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -472,11 +472,37 @@ export interface OntologyMapping {
   [key: string]: unknown;
 }
 
+/**
+ * Track C-3.5 — vis.js shape names valid for the HTML export visual
+ * encoding override carried by a profile's `node_types.*.visual_encoding`.
+ * Keep this list in sync with {@link src/export.ts}'s inferNodeShape /
+ * resolveNodeShape so the legend, the override, and the inference all
+ * speak the same vocabulary.
+ */
+export type OntologyVisualEncodingShape =
+  | "dot"
+  | "square"
+  | "triangle"
+  | "box"
+  | "diamond"
+  | "star"
+  | "hexagon";
+
+export interface OntologyVisualEncoding {
+  shape?: OntologyVisualEncodingShape;
+  /** "#RRGGBB" or "#RRGGBBAA" hex color used for the node border (and
+   *  background for non-outlined shapes). Validated by
+   *  validateOntologyProfile. */
+  color_hex?: string;
+}
+
 export interface OntologyNodeType {
   aliases?: string[];
   registry?: string;
   source_backed?: boolean;
   status_policy?: string;
+  /** Track C-3.5: per-node-type visual encoding override for HTML export. */
+  visual_encoding?: OntologyVisualEncoding;
 }
 
 export interface OntologyRelationType {

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -227,3 +227,188 @@ describe("toHtml visual encoding (Track C3)", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+describe("toHtml visual encoding (Track C-3.5: profile-aware)", () => {
+  function makeProfile(nodeTypes: Record<string, { visual_encoding?: { shape?: string; color_hex?: string } }>) {
+    return {
+      id: "test-profile",
+      version: "1",
+      default_language: "en",
+      profile_hash: "deadbeef",
+      node_types: nodeTypes as Record<string, { visual_encoding?: { shape?: "diamond" | "star"; color_hex?: string } }>,
+      relation_types: {},
+      registries: {},
+      citation_policy: {
+        minimum_granularity: "page",
+        require_source_file: true,
+        allow_bbox: "when_available",
+      },
+      hardening: {
+        statuses: ["candidate"],
+        default_status: "candidate",
+        promotion_requires: [],
+        status_transitions: [],
+      },
+      inference_policy: {
+        allow_inferred_relations: false,
+        allowed_relation_types: [],
+        require_evidence_refs: false,
+      },
+      evidence_policy: {
+        require_evidence_refs: false,
+        min_refs: 0,
+        node_types: [],
+        relation_types: [],
+      },
+      hierarchies: {},
+      outputs: {
+        ontology: {
+          enabled: false,
+          artifact_schema: "",
+          canonical_node_types: [],
+          source_node_types: [],
+          occurrence_node_types: [],
+          alias_fields: [],
+          relation_exports: [],
+          wiki: {
+            enabled: false,
+            page_node_types: [],
+            include_backlinks: false,
+            include_source_snippets: false,
+          },
+        },
+      },
+    } as unknown as Parameters<typeof toHtml>[3] extends infer T
+      ? T extends { profile?: infer P } ? P : never
+      : never;
+  }
+
+  it("uses profile visual_encoding.shape over inferNodeShape when node_type matches", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-c35-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    G.addNode("c1", {
+      label: "Detective",
+      source_file: "corpus/characters/detective.md",
+      file_type: "document",
+      node_type: "Character",
+    });
+    G.addNode("k1", {
+      label: "Murder",
+      source_file: "corpus/crimes/murder.md",
+      file_type: "document",
+      node_type: "Crime",
+    });
+    G.addUndirectedEdge("c1", "k1", { relation: "investigates", confidence: "EXTRACTED" });
+    const communities = new Map([[0, ["c1", "k1"]]]);
+    const profile = makeProfile({
+      Character: { visual_encoding: { shape: "diamond", color_hex: "#11AABB" } },
+      Crime: { visual_encoding: { shape: "star" } },
+    });
+
+    toHtml(G, communities, htmlPath, {
+      communityLabels: new Map([[0, "Core"]]),
+      profile,
+    });
+    const html = readFileSync(htmlPath, "utf-8");
+
+    // Per-node shape overridden by profile.
+    expect(html).toMatch(/"id":"c1"[\s\S]*?"shape":"diamond"/);
+    expect(html).toMatch(/"id":"k1"[\s\S]*?"shape":"star"/);
+    // Profile color_hex used for Character border (and background since shape != box).
+    expect(html).toMatch(/"id":"c1"[^{]*\{[^}]*"border":"#11AABB"/);
+    expect(html).toMatch(/"id":"c1"[^{]*\{[^}]*"background":"#11AABB"/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("falls back to inferNodeShape when profile does not declare visual_encoding for that type", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-c35-fb-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    // Character has visual_encoding -> diamond override.
+    G.addNode("c1", {
+      label: "Detective",
+      source_file: "corpus/c.md",
+      file_type: "document",
+      node_type: "Character",
+    });
+    // UnknownType has NO entry -> falls back to inferNodeShape (document -> box).
+    G.addNode("u1", {
+      label: "Unknown",
+      source_file: "corpus/u.md",
+      file_type: "document",
+      node_type: "UnknownType",
+    });
+    // No node_type at all -> falls back to inferNodeShape (document -> box).
+    G.addNode("d1", {
+      label: "PlainDoc",
+      source_file: "corpus/d.md",
+      file_type: "document",
+    });
+    G.addUndirectedEdge("c1", "u1", { relation: "links_to", confidence: "EXTRACTED" });
+    G.addUndirectedEdge("c1", "d1", { relation: "links_to", confidence: "EXTRACTED" });
+    const communities = new Map([[0, ["c1", "u1", "d1"]]]);
+    const profile = makeProfile({
+      Character: { visual_encoding: { shape: "diamond" } },
+    });
+
+    toHtml(G, communities, htmlPath, {
+      communityLabels: new Map([[0, "Core"]]),
+      profile,
+    });
+    const html = readFileSync(htmlPath, "utf-8");
+
+    expect(html).toMatch(/"id":"c1"[\s\S]*?"shape":"diamond"/);
+    // u1 has a node_type with no visual_encoding -> fallback to file_type=document -> box.
+    expect(html).toMatch(/"id":"u1"[\s\S]*?"shape":"box"/);
+    // d1 has no node_type -> fallback to file_type=document -> box.
+    expect(html).toMatch(/"id":"d1"[\s\S]*?"shape":"box"/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("box shape resolved via profile still gets transparent background (outlined)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-c35-box-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    G.addNode("n1", {
+      label: "Concept",
+      source_file: "src/a.ts",
+      file_type: "code",
+      node_type: "Concept",
+    });
+    const communities = new Map([[0, ["n1"]]]);
+    const profile = makeProfile({
+      Concept: { visual_encoding: { shape: "box", color_hex: "#445566" } },
+    });
+
+    toHtml(G, communities, htmlPath, {
+      communityLabels: new Map([[0, "Core"]]),
+      profile,
+    });
+    const html = readFileSync(htmlPath, "utf-8");
+
+    expect(html).toMatch(/"id":"n1"[\s\S]*?"shape":"box"/);
+    expect(html).toMatch(/"id":"n1"[^{]*\{[^}]*"background":"rgba\(0,0,0,0\)"/);
+    expect(html).toMatch(/"id":"n1"[^{]*\{[^}]*"border":"#445566"/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("output is byte-identical when profile is undefined vs omitted (regression: no breakage)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-c35-noop-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    G.addNode("a", { label: "A", source_file: "src/a.ts", file_type: "code", node_type: "Character" });
+    G.addNode("b", { label: "B", source_file: "src/b.ts", file_type: "code" });
+    G.addUndirectedEdge("a", "b", { relation: "uses", confidence: "EXTRACTED" });
+    const communities = new Map([[0, ["a", "b"]]]);
+
+    toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
+    const noProfile = readFileSync(htmlPath, "utf-8");
+    toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]), profile: undefined });
+    const undefProfile = readFileSync(htmlPath, "utf-8");
+
+    // Output strictly identical; profile undefined must not change the HTML.
+    expect(undefProfile).toBe(noProfile);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/ontology-profile.test.ts
+++ b/tests/ontology-profile.test.ts
@@ -368,6 +368,69 @@ describe("ontology profile loader", () => {
     );
   });
 
+  it("accepts visual_encoding shape + color_hex on node types (Track C-3.5)", () => {
+    const raw = parseOntologyProfile(
+      [
+        "id: visual-encoding-demo",
+        "version: 1",
+        "node_types:",
+        "  Character:",
+        "    visual_encoding:",
+        "      shape: diamond",
+        "      color_hex: '#11AABB'",
+        "  Crime:",
+        "    visual_encoding:",
+        "      shape: star",
+        "      color_hex: '#FF000088'",
+        "relation_types: {}",
+        "",
+      ].join("\n"),
+      "ontology-profile.yaml",
+    );
+    expect(validateOntologyProfile(raw)).toEqual([]);
+    const profile = normalizeOntologyProfile(raw);
+    expect(profile.node_types.Character.visual_encoding).toEqual({ shape: "diamond", color_hex: "#11AABB" });
+    expect(profile.node_types.Crime.visual_encoding).toEqual({ shape: "star", color_hex: "#FF000088" });
+  });
+
+  it("rejects unknown vis.js shapes in visual_encoding (Track C-3.5)", () => {
+    const raw = parseOntologyProfile(
+      [
+        "id: bad-visual",
+        "version: 1",
+        "node_types:",
+        "  Character:",
+        "    visual_encoding:",
+        "      shape: heptagon",
+        "relation_types: {}",
+        "",
+      ].join("\n"),
+      "ontology-profile.yaml",
+    );
+    expect(validateOntologyProfile(raw)).toContain(
+      "node_types.Character.visual_encoding.shape must be one of dot, square, triangle, box, diamond, star, hexagon (got heptagon)",
+    );
+  });
+
+  it("rejects malformed color_hex in visual_encoding (Track C-3.5)", () => {
+    const raw = parseOntologyProfile(
+      [
+        "id: bad-color",
+        "version: 1",
+        "node_types:",
+        "  Character:",
+        "    visual_encoding:",
+        "      color_hex: 'red'",
+        "relation_types: {}",
+        "",
+      ].join("\n"),
+      "ontology-profile.yaml",
+    );
+    expect(validateOntologyProfile(raw)).toContain(
+      "node_types.Character.visual_encoding.color_hex must match /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/ (got red)",
+    );
+  });
+
   it("computes a stable hash independent of object key order", () => {
     const first = normalizeOntologyProfile(parseOntologyProfile(validProfileYaml(), "a.yaml"));
     const second = normalizeOntologyProfile({


### PR DESCRIPTION
## Summary

- Lets `ontology-profile.yaml` declare a vis.js `shape` and a `color_hex` per `node_types.*.visual_encoding`, validated against the `dot / square / triangle / box / diamond / star / hexagon` enum and `/^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/`.
- `toHtml` resolves shape + border/background color from the profile in priority over `inferNodeShape(file_type, source_file)` / community palette. When no profile is provided or no `visual_encoding` is declared, output is byte-identical to before. `box` carried by an override stays outlined (transparent background), consistent with PR #36's outlined-box rule.
- `graphify extract`, `graphify cluster-only`, and `graphify export html` opportunistically pick up the profile via `graphify.yaml` auto-discovery; `graphify export html` also accepts an explicit `--profile <path>`.
- Cosmetic-only TS-only delta: no graph schema change, no new npm dependency, no upstream Python parity gap.

## Implementation notes

- TDD: tests pinned the contract before the implementation landed (see commit `d07235e`).
- Atomic commits: tests, schema/validation, export resolver, CLI wiring, CHANGELOG.
- Pre-existing `tsc --noEmit` and `tsup` DTS build error (`TS5103: Invalid value for '--ignoreDeprecations'`) is unaffected by this PR and reproduces on `origin/main`. ESM + CJS builds succeed.

## Test plan

- [x] `npm test` — 636 passed, 7 skipped (was 633 passed, 10 skipped; +3 net coverage on new branches: profile shape override, fallback to `inferNodeShape` when profile omits the type, outlined `box` from profile override).
- [x] `npm run build` — ESM + CJS green; DTS step fails on the pre-existing TS5103 only (also fails on `origin/main`).
- [x] Profile-undefined byte-identical regression assertion (`toHtml` called twice with the same path, with and without `profile: undefined`).
- [ ] (Manual, downstream) Run `graphify export html --profile <path>` against the public-domaine-mystery-sagas-pack profile and confirm Character/Crime nodes render with the declared shapes.