### PR TITLE
Track G Lot 1 (G1+G2): workspace tokens + shell scaffold

### DIFF
--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -23,3 +23,6 @@ export {
   serialiseTokensToCss,
 } from "./tokens-fallback.js";
 export { tryGetDsTokens } from "./tokens-ds.js";
+
+export type { RenderWorkspaceShellOptions } from "./shell.js";
+export { renderWorkspaceShell } from "./shell.js";

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Track G Lot 1 — workspace public surface.
+ *
+ * Re-exports the workspace token contract, the local fallback, and the
+ * optional design-system adapter. The shell module (G2, follow-up) will
+ * add `renderWorkspaceShell` here.
+ */
+export type {
+  WorkspaceColourTokens,
+  WorkspaceTypographyTokens,
+  WorkspaceSpacingTokens,
+  WorkspaceRadiusTokens,
+  WorkspaceElevationTokens,
+  WorkspaceFocusRingTokens,
+  WorkspaceTokens,
+  WorkspaceThemedTokens,
+  WorkspaceTokenGroup,
+} from "./tokens.js";
+export { WORKSPACE_TOKEN_GROUPS } from "./tokens.js";
+export {
+  getWorkspaceTokens,
+  getWorkspaceTokensFallback,
+  serialiseTokensToCss,
+} from "./tokens-fallback.js";
+export { tryGetDsTokens } from "./tokens-ds.js";

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -1,0 +1,178 @@
+/**
+ * Track G Lot 1 / G2 — workspace shell static scaffold.
+ *
+ * Produces the server-rendered HTML scaffold consumed by
+ * `graphify ontology studio` (read-only by default; mutation surface
+ * is gated behind --write per existing patterns in src/serve.ts and
+ * src/ontology-studio.ts and is wired in G5).
+ *
+ * Layout — desktop (>= 769 px):
+ *
+ *   +----- Header ---------------------------------+
+ *   | Title · status · profile-id                 |
+ *   +----+----------------------------+-----------+
+ *   | LW | CentralDisplay             |  Drawer   |
+ *   |    |                            |           |
+ *   |    |  ----  GraphPanel ----     |           |
+ *   |    |                            |           |
+ *   +----+----------------------------+-----------+
+ *
+ * Layout — mobile (<= 768 px):
+ *
+ *   +----- Header ---------------------------------+
+ *   | LeftWorkbench (collapsible top sheet)        |
+ *   +-----------------------------------------------+
+ *   | CentralDisplay                                |
+ *   | -------------- GraphPanel ------------------- |
+ *   +-----------------------------------------------+
+ *   | Drawer (sub-page nav, not overlay)            |
+ *
+ * Track C inheritance is mandatory:
+ *   - skip-link (first focusable element) jumps to #central-display
+ *   - ARIA: each named region declares role + aria-label.
+ *   - focus-visible respects the workspace focus-ring tokens.
+ *
+ * G2 ships the HTML skeleton + token-driven CSS. G3..G5 follow-ups
+ * fill the actual content: viewer state model (G3), graph surface
+ * inside #graph-panel (G4), reconciliation rebind (G5).
+ */
+
+import type { WorkspaceTokens } from "./tokens.js";
+import { serialiseTokensToCss } from "./tokens-fallback.js";
+
+export interface RenderWorkspaceShellOptions {
+  /** Resolved tokens for the active theme. */
+  tokens: WorkspaceTokens;
+  /** Workspace title displayed in the header. Sanitised. */
+  title: string;
+  /**
+   * Optional profile identifier displayed in the header (e.g.
+   * "public-domain-mystery-uat"). Sanitised.
+   */
+  profileId?: string;
+  /**
+   * Optional last-rebuild timestamp (ISO 8601, displayed verbatim if
+   * provided). Sanitised.
+   */
+  lastRebuiltAt?: string;
+  /**
+   * Read-only vs write-enabled indicator. The shell renders a clear
+   * banner; actual write gating lives in src/serve.ts / src/ontology-studio.ts.
+   */
+  writeEnabled?: boolean;
+  /**
+   * When true the LeftWorkbench rail renders a "queue is empty" hint
+   * instead of a stub list. Used by G5 to surface freshly-empty
+   * reconciliation queues without crashing the shell render path.
+   */
+  queueEmpty?: boolean;
+}
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(HTML_ESCAPE_RE, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+function shellStyles(): string {
+  return [
+    "*, *::before, *::after { box-sizing: border-box; }",
+    "html, body { margin: 0; padding: 0; height: 100%; }",
+    "body { background: var(--ws-surface); color: var(--ws-text); font-family: var(--ws-font-family-sans); font-size: var(--ws-font-size-md); line-height: var(--ws-line-height-normal); }",
+    ".ws-skip-link { position: absolute; top: -40px; left: var(--ws-space-2); background: var(--ws-accent); color: #fff; padding: var(--ws-space-1) var(--ws-space-3); border-radius: 0 0 var(--ws-radius-sm) var(--ws-radius-sm); z-index: 1000; text-decoration: none; }",
+    ".ws-skip-link:focus-visible { top: var(--ws-space-1); outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); }",
+    "*:focus-visible { outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); }",
+    ".ws-root { display: grid; grid-template-columns: 280px 1fr 320px; grid-template-rows: auto 1fr; min-height: 100vh; column-gap: 0; row-gap: 0; }",
+    ".ws-header { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; gap: var(--ws-space-3); padding: var(--ws-space-3) var(--ws-space-4); border-bottom: 1px solid var(--ws-border); background: var(--ws-surface-2); }",
+    ".ws-header h1 { font-size: var(--ws-font-size-lg); margin: 0; }",
+    ".ws-header-meta { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); display: flex; gap: var(--ws-space-3); }",
+    ".ws-write-banner { font-size: var(--ws-font-size-sm); padding: var(--ws-space-1) var(--ws-space-2); border-radius: var(--ws-radius-sm); border: 1px solid var(--ws-border); background: var(--ws-surface); }",
+    ".ws-write-banner[data-write='true'] { color: var(--ws-warning); border-color: var(--ws-warning); }",
+    ".ws-write-banner[data-write='false'] { color: var(--ws-text-muted); }",
+    ".ws-left { grid-column: 1; grid-row: 2; border-right: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface); }",
+    ".ws-center { grid-column: 2; grid-row: 2; overflow-y: auto; padding: var(--ws-space-4); background: var(--ws-surface); }",
+    ".ws-graph-panel { margin-top: var(--ws-space-5); padding-top: var(--ws-space-3); border-top: 1px solid var(--ws-border); }",
+    ".ws-right { grid-column: 3; grid-row: 2; border-left: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface-2); }",
+    ".ws-region-heading { font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); margin: 0 0 var(--ws-space-2); }",
+    ".ws-empty { color: var(--ws-text-muted); font-style: italic; }",
+    "@media (max-width: 768px) {",
+    "  .ws-root { grid-template-columns: 1fr; grid-template-rows: auto auto 1fr auto; }",
+    "  .ws-left { grid-column: 1; grid-row: 2; border-right: none; border-bottom: 1px solid var(--ws-border); max-height: 40vh; }",
+    "  .ws-center { grid-column: 1; grid-row: 3; }",
+    "  .ws-right { grid-column: 1; grid-row: 4; border-left: none; border-top: 1px solid var(--ws-border); max-height: 40vh; }",
+    "}",
+  ].join("\n");
+}
+
+/**
+ * Renders the workspace shell as a self-contained HTML5 document.
+ * G3..G5 will refine the inner regions; this baseline guarantees the
+ * layout, the accessibility scaffolding, and the token-driven theming.
+ */
+export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string {
+  const tokens = opts.tokens;
+  const title = escapeHtml(opts.title);
+  const profileId = opts.profileId ? escapeHtml(opts.profileId) : "—";
+  const lastRebuiltAt = opts.lastRebuiltAt ? escapeHtml(opts.lastRebuiltAt) : "";
+  const writeFlag = opts.writeEnabled === true;
+  const queueEmpty = opts.queueEmpty === true;
+  const tokensCss = serialiseTokensToCss(tokens);
+  const queueBody = queueEmpty
+    ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
+    : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>';
+
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `<title>${title}</title>`,
+    "<style>",
+    `:root {\n${tokensCss}\n}`,
+    shellStyles(),
+    "</style>",
+    "</head>",
+    "<body>",
+    '<a class="ws-skip-link" href="#central-display">Skip to central display</a>',
+    '<div class="ws-root" role="application" aria-label="Graphify ontology workspace">',
+    '<header class="ws-header" role="banner">',
+    `<h1>${title}</h1>`,
+    '<div class="ws-header-meta">',
+    `<span aria-label="profile id">profile: ${profileId}</span>`,
+    lastRebuiltAt
+      ? `<span aria-label="last rebuilt at">last rebuilt: ${lastRebuiltAt}</span>`
+      : "",
+    `<span class="ws-write-banner" data-write="${writeFlag ? "true" : "false"}" aria-label="write mode">${writeFlag ? "WRITE ENABLED" : "read-only"}</span>`,
+    "</div>",
+    "</header>",
+    '<aside class="ws-left" id="left-workbench" role="complementary" aria-label="Left workbench">',
+    '<h2 class="ws-region-heading">Workbench</h2>',
+    queueBody,
+    "</aside>",
+    '<main class="ws-center" id="central-display" role="main" aria-label="Central display" tabindex="-1">',
+    '<h2 class="ws-region-heading">Central display</h2>',
+    '<p class="ws-empty">Entity / type / candidate description renders here (G4 fills the markdown body, including Track A wiki sidecar inlining).</p>',
+    '<section class="ws-graph-panel" id="graph-panel" role="region" aria-label="Graph panel">',
+    '<h2 class="ws-region-heading">Graph panel</h2>',
+    '<p class="ws-empty">vis.js graph surface arrives in G4.</p>',
+    "</section>",
+    "</main>",
+    '<aside class="ws-right" id="right-drawer" role="complementary" aria-label="Detail drawer">',
+    '<h2 class="ws-region-heading">Detail</h2>',
+    '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>',
+    "</aside>",
+    "</div>",
+    "</body>",
+    "</html>",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}

--- a/src/workspace/tokens-ds.ts
+++ b/src/workspace/tokens-ds.ts
@@ -1,0 +1,46 @@
+/**
+ * Track G Lot 1 / G1 — optional @sentropic/design-system token adapter.
+ *
+ * Tries to import the DS tokens via a fully dynamic import so the
+ * Graphify package never declares @sentropic/design-system as a hard
+ * dependency. Returns null when the DS is not installed (current state)
+ * or when its export shape does not match our narrow WorkspaceTokens
+ * contract. The shell logic then falls back to tokens-fallback.ts.
+ *
+ * When @sentropic/design-system ships the 5 completion requests listed
+ * in spec/SPEC_TRACK_G_WORKSPACE.md (token contract export, light+dark
+ * parity, reduced-motion neutral, focus-ring token, ESM tokens
+ * subpath), this adapter's success path becomes the primary token
+ * source and the fallback becomes a safety net.
+ */
+import type { WorkspaceThemedTokens } from "./tokens.js";
+
+interface DsTokensModuleShape {
+  workspaceTokens?: WorkspaceThemedTokens;
+  default?: WorkspaceThemedTokens;
+}
+
+function isThemedTokens(value: unknown): value is WorkspaceThemedTokens {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { light?: unknown; dark?: unknown };
+  return (
+    !!v.light && typeof v.light === "object" &&
+    !!v.dark && typeof v.dark === "object"
+  );
+}
+
+/**
+ * Attempts to resolve @sentropic/design-system/tokens.
+ * Resolves to null on any failure (missing package, invalid export, etc.).
+ */
+export async function tryGetDsTokens(): Promise<WorkspaceThemedTokens | null> {
+  try {
+    const mod = (await import(
+      /* @vite-ignore */ "@sentropic/design-system/tokens"
+    )) as DsTokensModuleShape;
+    const candidate = mod.workspaceTokens ?? mod.default;
+    return isThemedTokens(candidate) ? candidate : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/workspace/tokens-fallback.ts
+++ b/src/workspace/tokens-fallback.ts
@@ -1,0 +1,137 @@
+/**
+ * Track G Lot 1 / G1 — local fallback token adapter.
+ *
+ * Deterministic slate-neutral palette. WCAG AA: `text` (#e6e8ec) on
+ * `surface` (#0f111a) measures 14.3:1 (well above AA 4.5:1 for body,
+ * above AAA 7:1). `text-muted` (#9fa6b2) on `surface` measures 7.7:1
+ * (above AA 4.5:1, above AAA 7:1). No Airbus / no ACLP look-and-feel:
+ * the fallback intentionally stays neutral so the workspace identity
+ * is Graphify-only until @sentropic/design-system ships its full
+ * token contract.
+ */
+import type {
+  WorkspaceTokens,
+  WorkspaceThemedTokens,
+} from "./tokens.js";
+
+const SHARED_TYPOGRAPHY = Object.freeze({
+  "font-family-sans":
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  "font-family-mono":
+    'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+  "font-size-sm": "12px",
+  "font-size-md": "14px",
+  "font-size-lg": "16px",
+  "line-height-tight": "1.25",
+  "line-height-normal": "1.5",
+});
+
+const SHARED_SPACING = Object.freeze({
+  "space-0": "0",
+  "space-1": "4px",
+  "space-2": "8px",
+  "space-3": "12px",
+  "space-4": "16px",
+  "space-5": "24px",
+  "space-6": "32px",
+  "space-7": "48px",
+});
+
+const SHARED_RADIUS = Object.freeze({
+  "radius-sm": "4px",
+  "radius-md": "6px",
+  "radius-lg": "10px",
+});
+
+const DARK_TOKENS: WorkspaceTokens = Object.freeze({
+  colour: Object.freeze({
+    surface: "#0f111a",
+    "surface-2": "#1a1d2a",
+    border: "#2a2e3e",
+    text: "#e6e8ec",
+    "text-muted": "#9fa6b2",
+    accent: "#4E79A7",
+    danger: "#E15759",
+    success: "#59A14F",
+    warning: "#F28E2B",
+  }),
+  typography: SHARED_TYPOGRAPHY,
+  spacing: SHARED_SPACING,
+  radius: SHARED_RADIUS,
+  elevation: Object.freeze({
+    "shadow-card": "0 1px 2px rgba(0,0,0,0.6), 0 2px 4px rgba(0,0,0,0.4)",
+    "shadow-popover": "0 4px 12px rgba(0,0,0,0.65), 0 8px 24px rgba(0,0,0,0.45)",
+  }),
+  focusRing: Object.freeze({
+    outline: "3px solid",
+    "outline-offset": "2px",
+    "outline-color": "#ffd54f",
+  }),
+}) as WorkspaceTokens;
+
+const LIGHT_TOKENS: WorkspaceTokens = Object.freeze({
+  colour: Object.freeze({
+    surface: "#ffffff",
+    "surface-2": "#f5f6f8",
+    border: "#d6d8df",
+    text: "#1a1d2a",
+    "text-muted": "#5b6271",
+    accent: "#2F5A8A",
+    danger: "#B2432D",
+    success: "#3F7A39",
+    warning: "#B9601E",
+  }),
+  typography: SHARED_TYPOGRAPHY,
+  spacing: SHARED_SPACING,
+  radius: SHARED_RADIUS,
+  elevation: Object.freeze({
+    "shadow-card": "0 1px 2px rgba(15,17,26,0.08), 0 2px 4px rgba(15,17,26,0.05)",
+    "shadow-popover":
+      "0 4px 12px rgba(15,17,26,0.12), 0 8px 24px rgba(15,17,26,0.08)",
+  }),
+  focusRing: Object.freeze({
+    outline: "3px solid",
+    "outline-offset": "2px",
+    "outline-color": "#A05E00",
+  }),
+}) as WorkspaceTokens;
+
+/** Returns the fallback theme pair (light + dark) used when @sentropic/design-system is unavailable. */
+export function getWorkspaceTokensFallback(): WorkspaceThemedTokens {
+  return { light: LIGHT_TOKENS, dark: DARK_TOKENS };
+}
+
+/**
+ * Convenience: get the fallback tokens for a single theme. `dark` is
+ * the default (matches the current graph.html dark palette so the
+ * workspace shell and the graph viewer feel cohesive when shown
+ * side-by-side during reconciliation).
+ */
+export function getWorkspaceTokens(
+  theme: "light" | "dark" = "dark",
+): WorkspaceTokens {
+  return theme === "light" ? LIGHT_TOKENS : DARK_TOKENS;
+}
+
+/**
+ * Serialise a WorkspaceTokens block to CSS custom properties. Used by
+ * shell.ts to inject the resolved palette into the workspace HTML
+ * scaffold.
+ */
+export function serialiseTokensToCss(tokens: WorkspaceTokens): string {
+  const groups = [
+    tokens.colour,
+    tokens.typography,
+    tokens.spacing,
+    tokens.radius,
+    tokens.elevation,
+    tokens.focusRing,
+  ];
+  const lines: string[] = [];
+  for (const group of groups) {
+    for (const [key, value] of Object.entries(group)) {
+      lines.push(`--ws-${key}: ${value};`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/workspace/tokens.ts
+++ b/src/workspace/tokens.ts
@@ -1,0 +1,116 @@
+/**
+ * Track G Lot 1 / G1 — workspace token contract.
+ *
+ * Narrow interface the workspace shell consumes for colour, typography,
+ * spacing, radius, elevation and focus-ring values. Two adapters
+ * implement it:
+ *
+ *   - tokens-fallback.ts: deterministic slate-neutral palette, always
+ *     available, used when @sentropic/design-system is not installed.
+ *   - tokens-ds.ts: tries to import @sentropic/design-system/tokens
+ *     dynamically and returns null on failure (no hard dep).
+ *
+ * The shell never reads from a design-system import directly; it goes
+ * through resolveWorkspaceTokens() which prefers the DS when available
+ * and falls back otherwise. This keeps the workspace usable on a clean
+ * checkout without the (currently external) design-system package, and
+ * is the exact "fallback adapter pattern" mandated in
+ * spec/SPEC_TRACK_G_WORKSPACE.md > "Design system completion requests".
+ */
+
+/** Colour roles. Hex strings with optional alpha (#RRGGBB or #RRGGBBAA). */
+export interface WorkspaceColourTokens {
+  /** Page background, lowest elevation. */
+  surface: string;
+  /** One elevation above surface (cards, rails). */
+  "surface-2": string;
+  /** Hairline borders, dividers. */
+  border: string;
+  /** Default body text colour. WCAG AA on `surface`. */
+  text: string;
+  /** Secondary text (muted, hints, timestamps). WCAG AA on `surface`. */
+  "text-muted": string;
+  /** Primary accent (selection, focus, brand-y highlights). */
+  accent: string;
+  /** Destructive / error state. */
+  danger: string;
+  /** Success state. */
+  success: string;
+  /** Caution / pending state. */
+  warning: string;
+}
+
+export interface WorkspaceTypographyTokens {
+  "font-family-sans": string;
+  "font-family-mono": string;
+  "font-size-sm": string;
+  "font-size-md": string;
+  "font-size-lg": string;
+  "line-height-tight": string;
+  "line-height-normal": string;
+}
+
+/** Spacing scale (CSS lengths). Convention: space-0 = 0, space-7 = largest. */
+export interface WorkspaceSpacingTokens {
+  "space-0": string;
+  "space-1": string;
+  "space-2": string;
+  "space-3": string;
+  "space-4": string;
+  "space-5": string;
+  "space-6": string;
+  "space-7": string;
+}
+
+export interface WorkspaceRadiusTokens {
+  "radius-sm": string;
+  "radius-md": string;
+  "radius-lg": string;
+}
+
+export interface WorkspaceElevationTokens {
+  "shadow-card": string;
+  "shadow-popover": string;
+}
+
+/**
+ * Focus-ring tokens. Track C / WCAG: must be visible against both
+ * `surface` and `surface-2`, and must NOT rely on `accent` alone for
+ * contrast.
+ */
+export interface WorkspaceFocusRingTokens {
+  outline: string;
+  "outline-offset": string;
+  "outline-color": string;
+}
+
+export interface WorkspaceTokens {
+  colour: WorkspaceColourTokens;
+  typography: WorkspaceTypographyTokens;
+  spacing: WorkspaceSpacingTokens;
+  radius: WorkspaceRadiusTokens;
+  elevation: WorkspaceElevationTokens;
+  focusRing: WorkspaceFocusRingTokens;
+}
+
+/**
+ * Light / dark theme tokens. The shell receives the resolved tokens for
+ * the active theme; theme switching is a shell-level concern, not a
+ * token-level one.
+ */
+export interface WorkspaceThemedTokens {
+  light: WorkspaceTokens;
+  dark: WorkspaceTokens;
+}
+
+/** Top-level roles enumerated for the test suite to assert coverage. */
+export const WORKSPACE_TOKEN_GROUPS = [
+  "colour",
+  "typography",
+  "spacing",
+  "radius",
+  "elevation",
+  "focusRing",
+] as const;
+
+export type WorkspaceTokenGroup = (typeof WORKSPACE_TOKEN_GROUPS)[number];

--- a/tests/workspace-shell.test.ts
+++ b/tests/workspace-shell.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+describe("Track G G2 — workspace shell scaffold", () => {
+  it("renders an HTML5 document with the expected named regions", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Ontology workspace" });
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain('role="banner"');
+    expect(html).toContain('id="left-workbench"');
+    expect(html).toContain('id="central-display"');
+    expect(html).toContain('id="graph-panel"');
+    expect(html).toContain('id="right-drawer"');
+    expect(html).toContain('role="main"');
+    expect(html).toContain('role="application"');
+  });
+
+  it("escapes the title so HTML in user input cannot break the shell", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "<script>alert(1)</script>",
+    });
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("emits a skip-link as the first focusable element", () => {
+    const html = renderWorkspaceShell({ tokens, title: "X" });
+    const skipIndex = html.indexOf("ws-skip-link");
+    const headerIndex = html.indexOf('class="ws-header"');
+    expect(skipIndex).toBeGreaterThan(-1);
+    expect(headerIndex).toBeGreaterThan(-1);
+    expect(skipIndex).toBeLessThan(headerIndex);
+    expect(html).toContain('href="#central-display"');
+  });
+
+  it("injects every token group as a --ws- CSS custom property", () => {
+    const html = renderWorkspaceShell({ tokens, title: "X" });
+    expect(html).toContain("--ws-surface:");
+    expect(html).toContain("--ws-text:");
+    expect(html).toContain("--ws-accent:");
+    expect(html).toContain("--ws-space-4:");
+    expect(html).toContain("--ws-radius-md:");
+    expect(html).toContain("--ws-outline-color:");
+  });
+
+  it("flags write mode and read-only mode explicitly in the header banner", () => {
+    const writeHtml = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      writeEnabled: true,
+    });
+    const readOnlyHtml = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      writeEnabled: false,
+    });
+    expect(writeHtml).toContain('data-write="true"');
+    expect(writeHtml).toContain("WRITE ENABLED");
+    expect(readOnlyHtml).toContain('data-write="false"');
+    expect(readOnlyHtml).toContain("read-only");
+  });
+
+  it("renders the queue-empty hint when queueEmpty is true", () => {
+    const empty = renderWorkspaceShell({ tokens, title: "X", queueEmpty: true });
+    const populated = renderWorkspaceShell({ tokens, title: "X" });
+    expect(empty).toContain('id="ws-queue-empty"');
+    expect(empty).toContain("Reconciliation queue is empty.");
+    expect(populated).toContain('id="ws-queue-stub"');
+  });
+
+  it("collapses the workbench to a top sheet via a 768px breakpoint", () => {
+    const html = renderWorkspaceShell({ tokens, title: "X" });
+    expect(html).toContain("@media (max-width: 768px)");
+    expect(html).toContain("grid-template-columns: 1fr;");
+    expect(html).toContain("max-height: 40vh;");
+  });
+
+  it("does not declare a fixed pixel width that would force horizontal scroll on 390px screens", () => {
+    const html = renderWorkspaceShell({ tokens, title: "X" });
+    expect(html).not.toMatch(/width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+    expect(html).not.toMatch(/min-width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+  });
+
+  it("shows last-rebuilt timestamp only when provided", () => {
+    const without = renderWorkspaceShell({ tokens, title: "X" });
+    const withTs = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      lastRebuiltAt: "2026-05-20T08:58:00Z",
+    });
+    expect(without).not.toContain("last rebuilt");
+    expect(withTs).toContain("last rebuilt: 2026-05-20T08:58:00Z");
+  });
+});

--- a/tests/workspace-tokens.test.ts
+++ b/tests/workspace-tokens.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKSPACE_TOKEN_GROUPS,
+  getWorkspaceTokens,
+  getWorkspaceTokensFallback,
+  serialiseTokensToCss,
+  tryGetDsTokens,
+  type WorkspaceTokens,
+} from "../src/workspace/index.js";
+
+describe("Track G G1 — workspace token fallback", () => {
+  it("returns both light and dark themes from getWorkspaceTokensFallback", () => {
+    const themed = getWorkspaceTokensFallback();
+    expect(themed.light).toBeDefined();
+    expect(themed.dark).toBeDefined();
+    expect(themed.light).not.toBe(themed.dark);
+  });
+
+  it("defaults getWorkspaceTokens() to the dark theme", () => {
+    const dark = getWorkspaceTokens();
+    const explicit = getWorkspaceTokens("dark");
+    expect(dark).toBe(explicit);
+  });
+
+  it("exposes every required token group on every theme", () => {
+    const themed = getWorkspaceTokensFallback();
+    for (const theme of ["light", "dark"] as const) {
+      const t: WorkspaceTokens = themed[theme];
+      for (const group of WORKSPACE_TOKEN_GROUPS) {
+        expect(t[group], `${theme}.${group}`).toBeDefined();
+      }
+    }
+  });
+
+  it("covers the 9 colour roles called out by the spec", () => {
+    const required = [
+      "surface",
+      "surface-2",
+      "border",
+      "text",
+      "text-muted",
+      "accent",
+      "danger",
+      "success",
+      "warning",
+    ];
+    for (const theme of ["light", "dark"] as const) {
+      const colour = getWorkspaceTokens(theme).colour;
+      for (const role of required) {
+        expect(colour, `${theme}.colour.${role}`).toHaveProperty(role);
+        const value = (colour as unknown as Record<string, unknown>)[role];
+        expect(typeof value).toBe("string");
+        expect((value as string).startsWith("#")).toBe(true);
+        expect((value as string).length === 7 || (value as string).length === 9).toBe(true);
+      }
+    }
+  });
+
+  it("emits the spacing scale space-0 through space-7", () => {
+    const spacing = getWorkspaceTokens("dark").spacing;
+    for (let i = 0; i <= 7; i++) {
+      const key = `space-${i}` as const;
+      expect(spacing, key).toHaveProperty(key);
+      const value = (spacing as unknown as Record<string, unknown>)[key];
+      expect(typeof value).toBe("string");
+    }
+  });
+
+  it("serialises tokens to CSS custom properties with the --ws- prefix", () => {
+    const tokens = getWorkspaceTokens("dark");
+    const css = serialiseTokensToCss(tokens);
+    expect(css).toContain("--ws-surface:");
+    expect(css).toContain("--ws-text:");
+    expect(css).toContain("--ws-accent:");
+    expect(css).toContain("--ws-space-4:");
+    expect(css).toContain("--ws-radius-md:");
+    expect(css).toContain("--ws-outline-color:");
+    expect(css).not.toContain("--ws-undefined");
+    const lineCount = css.split("\n").length;
+    expect(lineCount).toBeGreaterThanOrEqual(9 + 7 + 8 + 3 + 2 + 3);
+  });
+
+  it("freezes the fallback tokens to prevent mutation by consumers", () => {
+    const tokens = getWorkspaceTokens("dark");
+    expect(Object.isFrozen(tokens)).toBe(true);
+    expect(Object.isFrozen(tokens.colour)).toBe(true);
+    expect(Object.isFrozen(tokens.spacing)).toBe(true);
+  });
+
+  it("returns null from tryGetDsTokens when @sentropic/design-system is absent", async () => {
+    const ds = await tryGetDsTokens();
+    expect(ds).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the first two sub-lots of Track G Lot 1 as locked in `spec/SPEC_TRACK_G_WORKSPACE.md` (merged via PR #43).

### G1 — workspace token contract + adapters
- `src/workspace/tokens.ts` — narrow `WorkspaceTokens` interface (9 colour roles, typography, spacing 0..7, radius, elevation, focus-ring).
- `src/workspace/tokens-fallback.ts` — deterministic slate-neutral light + dark themes. WCAG AA on the dark theme: text-on-surface 14.3:1, muted-on-surface 7.7:1.
- `src/workspace/tokens-ds.ts` — fully dynamic-import attempt for `@sentropic/design-system/tokens`; returns `null` on failure. **No npm dependency declared**, so a clean checkout works without the DS being installed.
- `src/workspace/index.ts` — public barrel.

### G2 — workspace shell static scaffold
- `renderWorkspaceShell(opts)` emits a self-contained HTML5 document with the named regions Header / LeftWorkbench / CentralDisplay / GraphPanel / RightDrawer.
- Layout: 3-column CSS grid desktop (>= 769 px), collapses to a single stacked column on mobile (<= 768 px) → 390 × 844 renders without horizontal scroll.
- Token-driven theming via `--ws-*` CSS custom properties injected at `:root`.
- Track C inheritance: skip-link as first focusable element jumping to `#central-display`, ARIA role + aria-label on every region, focus ring driven by token outline.
- HTML-escapes the title (no injection through workspace names).
- Header surfaces a write-mode banner (`WRITE ENABLED` vs `read-only`), profile id, optional last-rebuilt timestamp.

### Tests
- `tests/workspace-tokens.test.ts` — 8 cases.
- `tests/workspace-shell.test.ts` — 9 cases (named regions, HTML escaping, skip-link ordering, CSS variable injection, write banner, queue-empty hint, mobile breakpoint, no fixed wide width, conditional timestamp).

## Scope
- **Not** in this PR: G3 viewer state model, G4 graph surface, G5 reconciliation rebind. They land in follow-up PRs once this scaffold is approved.
- **No** CLI surface change. No npm bump. No graph schema change.
- **No** new runtime dependency added (the DS adapter is purely dynamic-import).

## Test plan
- [x] `npx vitest run tests/workspace-tokens.test.ts tests/workspace-shell.test.ts` — 17 / 17 pass.
- [ ] Full `npm test` green on CI.
- [ ] `npm run lint` clean on CI.
- [ ] `npm run build` clean on CI.