### PR TITLE
Track G G4: workspace graph panel

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - .  (2026-05-20)
 
 ## Corpus Check
-- 264 files · ~333,018 words
+- 264 files · ~333,000 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -14,11 +14,11 @@
 - Requested: tracked
 - Resolved: tracked (source: cli)
 - Included files: 264 · Candidates: 284
-- Excluded: 0 untracked · 15714 ignored · 4 sensitive · 0 missing committed
+- Excluded: 1 untracked · 15719 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `96ac837`
+- Built from Git commit: `9b4629e`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges

--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,23 +1,24 @@
 # Graph Report - .  (2026-05-20)
 
 ## Corpus Check
-- 251 files · ~320 038 words
+- 264 files · ~333,018 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4050 nodes · 6525 edges · 210 communities detected
+- 4168 nodes · 6672 edges · 219 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 
 ## Input Scope
-- Requested: all
-- Resolved: all (source: cli)
-- Included files: 251 · Candidates: recursive
-- Excluded: 0 untracked · 0 ignored · 0 sensitive · 0 missing committed
+- Requested: tracked
+- Resolved: tracked (source: cli)
+- Included files: 264 · Candidates: 284
+- Excluded: 0 untracked · 15714 ignored · 4 sensitive · 0 missing committed
+- Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `32d1d93`
+- Built from Git commit: `96ac837`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -45,898 +46,934 @@
 
 ## Communities
 
-### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (79): analysis, analysisPath, analysisValues, article, artifact, cacheKey, captionsDir, configOut (+71 more)
+### Community 33 - "Community 33"
+Cohesion: 0.11
+Nodes (30): GraphInstance, JSON_NOISE_LABELS, nodeCommunityMap(), isFileNode(), isConceptNode(), isJsonKeyNode(), fileCategory(), topLevelDir() (+22 more)
 
-### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
+### Community 109 - "Community 109"
+Cohesion: 0.23
+Nodes (10): estimateTokens(), querySubgraphTokens(), SAMPLE_QUESTIONS, BenchmarkOptions, loadGraph(), runBenchmark(), estimateTokens(), querySubgraphTokens() (+2 more)
 
-### Community 2 - "Community 2"
-Cohesion: 0.03
-Nodes (58): alphaNeighbors, audit, beforeAudit, beforeDecisions, betaNeighbors, candidate, candidateResponse, candidates (+50 more)
-
-### Community 3 - "Community 3"
-Cohesion: 0.05
-Nodes (48): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+40 more)
-
-### Community 4 - "Community 4"
-Cohesion: 0.05
-Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+44 more)
-
-### Community 5 - "Community 5"
-Cohesion: 0.06
-Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
-
-### Community 6 - "Community 6"
-Cohesion: 0.05
-Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
-
-### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
-
-### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
-
-### Community 9 - "Community 9"
-Cohesion: 0.07
-Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
-
-### Community 10 - "Community 10"
-Cohesion: 0.07
-Nodes (42): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+34 more)
-
-### Community 11 - "Community 11"
-Cohesion: 0.06
-Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.05
-Nodes (34): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+26 more)
+### Community 86 - "Community 86"
+Cohesion: 0.20
+Nodes (14): BuildOptions, normalizeSourceFilePath(), normalizedLabel(), dedupLabelKey(), asRecord(), asString(), sourceKey(), rootForOptions() (+6 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.09
-Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
-
-### Community 14 - "Community 14"
 Cohesion: 0.07
-Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.06
-Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.10
-Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.10
-Nodes (30): ConnectError, ConnectTimeout, PoolTimeout, ProtocolError, ProxyError, An error occurred at the transport layer., Timed out while connecting to the host., Timed out while receiving data from the host. (+22 more)
-
-### Community 20 - "Community 20"
-Cohesion: 0.06
-Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
-
-### Community 21 - "Community 21"
-Cohesion: 0.11
-Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+18 more)
+Nodes (43): StatIndexEntry, statIndex, statIndexFile(), ensureStatIndex(), flushStatIndex(), statMtimeNs(), CacheOptions, bodyContent() (+35 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.06
-Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.07
-Nodes (35): Cookies, build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str() (+27 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.10
-Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
-
-### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (30): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors() (+22 more)
-
-### Community 26 - "Community 26"
-Cohesion: 0.05
-Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
-
-### Community 27 - "Community 27"
-Cohesion: 0.07
-Nodes (35): Exception, CloseError, ConnectTimeout, CookieConflict, DecodingError, HTTPError, HTTPStatusError, NetworkError (+27 more)
-
-### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.09
-Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
-
-### Community 30 - "Community 30"
-Cohesion: 0.09
-Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.09
-Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.10
-Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.11
-Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.08
-Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
-
-### Community 35 - "Community 35"
-Cohesion: 0.06
-Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.09
-Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.16
-Nodes (16): Auth, BasicAuth, BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.08
-Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.12
-Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.10
-Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.12
-Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.16
-Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
-
-### Community 43 - "Community 43"
-Cohesion: 0.09
-Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.12
-Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.07
-Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.09
-Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.07
-Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.13
-Nodes (2): AsyncClient, Client
-
-### Community 49 - "Community 49"
-Cohesion: 0.10
-Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
-
-### Community 50 - "Community 50"
-Cohesion: 0.13
-Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
-
-### Community 51 - "Community 51"
-Cohesion: 0.10
-Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
-
-### Community 52 - "Community 52"
-Cohesion: 0.14
-Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
-
-### Community 53 - "Community 53"
-Cohesion: 0.08
-Nodes (21): OntologyWriteFixture, apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine (+13 more)
-
-### Community 54 - "Community 54"
-Cohesion: 0.09
-Nodes (6): Core data models: URL, Headers, Cookies, Request, Response. These are the centra, HTTPStatusError, A 4xx or 5xx response was received., Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, URL
-
-### Community 55 - "Community 55"
-Cohesion: 0.14
-Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.16
-Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
-
-### Community 57 - "Community 57"
-Cohesion: 0.11
-Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+4 more)
+Nodes (25): __filename, __dirname, VERSION, splitFiles(), changedFilesFromGit(), readJson(), isJsonRecord(), loadWikiDescriptionSidecarIndex() (+17 more)
 
 ### Community 58 - "Community 58"
-Cohesion: 0.10
-Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
-
-### Community 59 - "Community 59"
-Cohesion: 0.13
-Nodes (19): candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), handleOntologyStudioRequest(), htmlResult(), isLoopbackHost(), jsonResult() (+11 more)
-
-### Community 60 - "Community 60"
-Cohesion: 0.09
-Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.13
-Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
-
-### Community 62 - "Community 62"
-Cohesion: 0.13
-Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
-
-### Community 63 - "Community 63"
-Cohesion: 0.10
-Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
-
-### Community 64 - "Community 64"
-Cohesion: 0.11
-Nodes (16): AnalysisFile, analyzeGraph(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion(), main() (+8 more)
-
-### Community 65 - "Community 65"
-Cohesion: 0.13
-Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
-
-### Community 66 - "Community 66"
-Cohesion: 0.09
-Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
-
-### Community 67 - "Community 67"
-Cohesion: 0.15
-Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
-
-### Community 68 - "Community 68"
-Cohesion: 0.15
-Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
-
-### Community 69 - "Community 69"
-Cohesion: 0.09
-Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.09
-Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
-
-### Community 72 - "Community 72"
-Cohesion: 0.11
-Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.14
-Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
-
-### Community 74 - "Community 74"
-Cohesion: 0.10
-Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
-
-### Community 75 - "Community 75"
-Cohesion: 0.13
-Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
-
-### Community 76 - "Community 76"
-Cohesion: 0.15
-Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
-
-### Community 77 - "Community 77"
-Cohesion: 0.15
-Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
-
-### Community 78 - "Community 78"
-Cohesion: 0.13
-Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
-
-### Community 79 - "Community 79"
-Cohesion: 0.13
-Nodes (13): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+5 more)
-
-### Community 80 - "Community 80"
-Cohesion: 0.14
-Nodes (2): ApiClient, ApiClient
-
-### Community 81 - "Community 81"
-Cohesion: 0.21
-Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.12
-Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.12
-Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
-
-### Community 84 - "Community 84"
-Cohesion: 0.20
-Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
-
-### Community 85 - "Community 85"
-Cohesion: 0.17
-Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.12
-Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
-
-### Community 87 - "Community 87"
-Cohesion: 0.12
-Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
-
-### Community 88 - "Community 88"
-Cohesion: 0.13
-Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
-
-### Community 89 - "Community 89"
-Cohesion: 0.13
-Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.13
-Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
-
-### Community 91 - "Community 91"
 Cohesion: 0.16
-Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.17
-Nodes (13): DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape(), extractSemanticFilesDirectParallel() (+5 more)
-
-### Community 93 - "Community 93"
-Cohesion: 0.18
-Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
-
-### Community 94 - "Community 94"
-Cohesion: 0.15
-Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.13
-Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.24
-Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.13
-Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.19
-Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
-
-### Community 99 - "Community 99"
-Cohesion: 0.13
-Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.16
-Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
-
-### Community 101 - "Community 101"
-Cohesion: 0.15
-Nodes (1): AsyncClient
-
-### Community 102 - "Community 102"
-Cohesion: 0.39
-Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
-
-### Community 103 - "Community 103"
-Cohesion: 0.14
-Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
-
-### Community 104 - "Community 104"
-Cohesion: 0.33
-Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
-
-### Community 105 - "Community 105"
-Cohesion: 0.27
-Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
-
-### Community 106 - "Community 106"
-Cohesion: 0.23
-Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
-
-### Community 107 - "Community 107"
-Cohesion: 0.15
-Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
-
-### Community 108 - "Community 108"
-Cohesion: 0.23
-Nodes (11): appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions, normalizeAffectedFlows(), normalizeFlows() (+3 more)
-
-### Community 109 - "Community 109"
-Cohesion: 0.22
-Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
-
-### Community 110 - "Community 110"
-Cohesion: 0.21
-Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
-
-### Community 111 - "Community 111"
-Cohesion: 0.15
-Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.15
-Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
-
-### Community 113 - "Community 113"
-Cohesion: 0.15
-Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.26
-Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
-
-### Community 115 - "Community 115"
-Cohesion: 0.26
-Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
-
-### Community 116 - "Community 116"
-Cohesion: 0.18
-Nodes (1): Headers
-
-### Community 117 - "Community 117"
-Cohesion: 0.18
-Nodes (1): Client
-
-### Community 118 - "Community 118"
-Cohesion: 0.17
-Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
-
-### Community 119 - "Community 119"
-Cohesion: 0.24
-Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
-
-### Community 120 - "Community 120"
-Cohesion: 0.17
-Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
-
-### Community 121 - "Community 121"
-Cohesion: 0.33
-Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
-
-### Community 122 - "Community 122"
-Cohesion: 0.17
-Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
-
-### Community 123 - "Community 123"
-Cohesion: 0.17
-Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
-
-### Community 124 - "Community 124"
-Cohesion: 0.17
-Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
-
-### Community 125 - "Community 125"
-Cohesion: 0.18
-Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.25
-Nodes (4): build_graph(), Graph, build_graph(), Graph
-
-### Community 127 - "Community 127"
-Cohesion: 0.33
-Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
-
-### Community 128 - "Community 128"
-Cohesion: 0.18
-Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
-
-### Community 129 - "Community 129"
-Cohesion: 0.27
-Nodes (2): ConnectionPool, HTTPTransport
-
-### Community 130 - "Community 130"
-Cohesion: 0.22
-Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
-
-### Community 131 - "Community 131"
-Cohesion: 0.25
-Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
-
-### Community 132 - "Community 132"
-Cohesion: 0.18
-Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
-
-### Community 133 - "Community 133"
-Cohesion: 0.18
-Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
-
-### Community 134 - "Community 134"
-Cohesion: 0.18
-Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
-
-### Community 135 - "Community 135"
-Cohesion: 0.18
-Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.20
-Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
-
-### Community 137 - "Community 137"
-Cohesion: 0.18
-Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
-
-### Community 138 - "Community 138"
-Cohesion: 0.20
-Nodes (7): batch, G, impact, node, out, store, targets
-
-### Community 139 - "Community 139"
-Cohesion: 0.24
-Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
-
-### Community 140 - "Community 140"
-Cohesion: 0.24
-Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.20
-Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
+Nodes (26): writeFileAtomic(), canonicalPlatformName(), runtimeGlobalSkillPlatformName(), platformNamesForError(), resolveGlobalSkillDestination(), previewPath(), emptyPreview(), platformInstallPreview() (+18 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.42
-Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
-
-### Community 143 - "Community 143"
 Cohesion: 0.24
-Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
-
-### Community 144 - "Community 144"
-Cohesion: 0.20
-Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
-
-### Community 145 - "Community 145"
-Cohesion: 0.22
-Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
-
-### Community 146 - "Community 146"
-Cohesion: 0.28
-Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
-
-### Community 147 - "Community 147"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 148 - "Community 148"
-Cohesion: 0.22
-Nodes (2): ignoredDir, inventory
-
-### Community 149 - "Community 149"
-Cohesion: 0.22
-Nodes (4): cleanupDirs, result, root, text
-
-### Community 150 - "Community 150"
-Cohesion: 0.25
-Nodes (9): antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), uninstallAll(), uninstallClaudeHook(), uninstallGeminiMcp() (+1 more)
-
-### Community 151 - "Community 151"
-Cohesion: 0.39
-Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
-
-### Community 152 - "Community 152"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 153 - "Community 153"
-Cohesion: 0.42
-Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
+Nodes (10): opencodeConfigPath(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), getAgentsMdSection(), installOpenCodePlugin(), uninstallOpenCodePlugin(), installCodexHook(), uninstallCodexHook() (+2 more)
 
 ### Community 154 - "Community 154"
 Cohesion: 0.25
-Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
+Nodes (9): uninstallAll(), uninstallGeminiMcp(), cursorUninstall(), antigravityUninstall(), kiroUninstall(), vscodeUninstall(), uninstallClaudeHook(), claudeUninstall() (+1 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.25
-Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
+Cohesion: 0.39
+Nodes (7): canonicalizeForPartition(), partition(), splitCommunity(), ClusterOptions, cluster(), cohesionScore(), scoreAll()
 
-### Community 156 - "Community 156"
+### Community 78 - "Community 78"
+Cohesion: 0.13
+Nodes (13): NumericMapLike, StringMapLike, ReportHighRiskNode, ReportTestGap, ReportReviewOptions, GenerateReportOptions, normalizeFlows(), normalizeAffectedFlows() (+5 more)
+
+### Community 122 - "Community 122"
+Cohesion: 0.24
+Nodes (9): normalizeCommunityLabel(), readLabelsJson(), readGraphAttributeLabels(), resolveCommunityLabels(), persistCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
+
+### Community 54 - "Community 54"
+Cohesion: 0.14
+Nodes (21): DETECTION_FILE_TYPES, ConfiguredDetectionInputs, ProfileState, ConfiguredDataprepOptions, ConfiguredDataprepResult, uniqueResolved(), fullPageScreenshotExcludes(), buildConfiguredDetectionInputs() (+13 more)
+
+### Community 93 - "Community 93"
+Cohesion: 0.16
+Nodes (16): uniqueResolved(), fullPageScreenshotExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), warningFor(), recomputeDetection(), mergeScopeInspections(), mergeDetections() (+8 more)
+
+### Community 36 - "Community 36"
+Cohesion: 0.06
+Nodes (9): ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, AnalyzeChangesOptions, DetectChangesNodeRisk, DetectChangesTestGap, DetectChangesResult, DetectChangesMinimalResult (+1 more)
+
+### Community 201 - "Community 201"
+Cohesion: 0.60
+Nodes (5): uniqueSorted(), sortNodesByLocation(), mapChangesToNodes(), changedNodesFromFiles(), analyzeChanges()
+
+### Community 65 - "Community 65"
+Cohesion: 0.10
+Nodes (22): CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, IMAGE_EXTENSIONS, OFFICE_EXTENSIONS, GOOGLE_WORKSPACE_EXTENSIONS, VIDEO_EXTENSIONS, SENSITIVE_PATTERNS (+14 more)
+
+### Community 133 - "Community 133"
 Cohesion: 0.22
-Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
+Nodes (11): isSensitive(), countWords(), isNoiseDir(), matchGlob(), relativeWithin(), matchesIgnorePattern(), isIgnored(), walkDir() (+3 more)
 
-### Community 157 - "Community 157"
-Cohesion: 0.31
-Nodes (1): ConnectionPool
+### Community 206 - "Community 206"
+Cohesion: 0.67
+Nodes (4): officeParseToText(), docxToMarkdown(), xlsxToMarkdown(), convertOfficeFile()
 
-### Community 158 - "Community 158"
-Cohesion: 0.32
-Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
+### Community 202 - "Community 202"
+Cohesion: 0.50
+Nodes (5): md5File(), loadManifest(), normaliseManifestEntry(), saveManifest(), detectIncremental()
 
-### Community 159 - "Community 159"
-Cohesion: 0.25
-Nodes (8): CloseError, NetworkError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection., ReadError, WriteError
+### Community 94 - "Community 94"
+Cohesion: 0.17
+Nodes (13): DirectSemanticFile, DirectSemanticChunk, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, PackSemanticFilesOptions, DirectSemanticClientOptions, toPortableRelative(), estimateFileTokens() (+5 more)
 
-### Community 160 - "Community 160"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 161 - "Community 161"
-Cohesion: 0.25
-Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
-
-### Community 162 - "Community 162"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 163 - "Community 163"
-Cohesion: 0.32
-Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
-
-### Community 164 - "Community 164"
-Cohesion: 0.25
-Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
-
-### Community 165 - "Community 165"
-Cohesion: 0.25
-Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
+### Community 60 - "Community 60"
+Cohesion: 0.10
+Nodes (20): BACKUP_ARTIFACTS, todayIso(), backupIfProtected(), COMMUNITY_COLORS, inferNodeShape(), CONFIDENCE_SCORE_DEFAULTS, CommunityLabelsInput, CommunityLabelOptions (+12 more)
 
 ### Community 166 - "Community 166"
 Cohesion: 0.25
-Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
+Nodes (8): nodeCommunityMap(), isSvgOptions(), buildFreshnessMetadata(), computeTopologySignatureFromLinks(), computeTopologySignature(), toJson(), toGraphml(), toSvg()
 
-### Community 167 - "Community 167"
-Cohesion: 0.38
-Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
+### Community 143 - "Community 143"
+Cohesion: 0.24
+Nodes (10): isCommunityLabelOptions(), isCanvasOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile(), htmlStyles(), hyperedgeScript(), htmlScript() (+2 more)
 
-### Community 168 - "Community 168"
-Cohesion: 0.29
-Nodes (2): NumericMapLike, StringMapLike
+### Community 17 - "Community 17"
+Cohesion: 0.05
+Nodes (38): SyntaxNode, Tree, moduleRequire, _languageCache, TsconfigAliasEntry, tsconfigAliasCache, TsconfigDocument, stripJsonc() (+30 more)
 
-### Community 169 - "Community 169"
-Cohesion: 0.29
-Nodes (2): Transformer, Transformer
+### Community 104 - "Community 104"
+Cohesion: 0.39
+Nodes (15): ensureParserInit(), parseText(), resolveGrammarWasm(), loadLanguage(), qualifiedFileStem(), buildResolvableLabelIndex(), _extractPythonRationale(), extractJulia() (+7 more)
 
-### Community 170 - "Community 170"
-Cohesion: 0.29
-Nodes (6): DecodingError, HTTPError, An error occurred while issuing a request., Decoding of the response failed., Base class for all httpx exceptions., RequestError
+### Community 70 - "Community 70"
+Cohesion: 0.15
+Nodes (22): _makeId(), _readText(), _resolveName(), _importPython(), _importJava(), _importC(), _importCsharp(), _importKotlin() (+14 more)
 
-### Community 171 - "Community 171"
-Cohesion: 0.29
-Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
+### Community 134 - "Community 134"
+Cohesion: 0.25
+Nodes (11): toPortablePath(), inferCommonRoot(), projectRelativeFilePath(), loadTsconfigAliases(), normalizeJsImportTarget(), resolveJsImportTargetInfo(), resolveJsImportTarget(), remapFileNodeIds() (+3 more)
 
-### Community 172 - "Community 172"
-Cohesion: 0.43
-Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
+### Community 110 - "Community 110"
+Cohesion: 0.15
+Nodes (13): _extractGeneric(), extractPython(), extractJs(), extractJava(), extractC(), extractCpp(), extractRuby(), extractCsharp() (+5 more)
 
-### Community 173 - "Community 173"
-Cohesion: 0.33
-Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
+### Community 144 - "Community 144"
+Cohesion: 0.20
+Nodes (10): lineForIndex(), extractRegexBackedCode(), simpleGroovyTypeName(), braceDelta(), extractGroovy(), normalizeSqlObjectName(), sqlStatementBlock(), extractSql() (+2 more)
 
-### Community 174 - "Community 174"
-Cohesion: 0.29
-Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
+### Community 3 - "Community 3"
+Cohesion: 0.05
+Nodes (48): DetectEntryPointsOptions, TraceFlowsOptions, BuildFlowArtifactOptions, ReviewFlow, ReviewFlowStep, ReviewFlowDetail, ReviewFlowArtifact, AffectedFlowsResult (+40 more)
 
-### Community 175 - "Community 175"
-Cohesion: 0.29
-Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
+### Community 98 - "Community 98"
+Cohesion: 0.24
+Nodes (14): GitContext, execGit(), safeExecGit(), resolveFromGitCwd(), gitRevParse(), safeGitRevParse(), isSafeGitPath(), resolveGitContext() (+6 more)
 
-### Community 176 - "Community 176"
-Cohesion: 0.29
-Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
+### Community 95 - "Community 95"
+Cohesion: 0.18
+Nodes (13): GOOGLE_WORKSPACE_EXTENSIONS, EXPORT_MIME_TYPE_BY_EXTENSION, GoogleWorkspaceShortcut, GoogleWorkspaceFetcher, ConvertGoogleWorkspaceOptions, extractFileIdFromUrl(), extractResourceKey(), readGoogleShortcut() (+5 more)
 
-### Community 177 - "Community 177"
-Cohesion: 0.29
-Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
+### Community 156 - "Community 156"
+Cohesion: 0.39
+Nodes (8): SerializedGraphData, createGraph(), isDirectedGraph(), loadGraphFromData(), serializeGraph(), toUndirectedGraph(), forEachTraversalNeighbor(), traversalNeighbors()
 
-### Community 178 - "Community 178"
-Cohesion: 0.33
-Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
-
-### Community 179 - "Community 179"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 180 - "Community 180"
-Cohesion: 0.33
-Nodes (1): recommendation
-
-### Community 181 - "Community 181"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
-
-### Community 182 - "Community 182"
-Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
-
-### Community 183 - "Community 183"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 184 - "Community 184"
-Cohesion: 0.33
-Nodes (6): cacheOptionsFromRuntime(), loadGraph(), loadProfileRuntimeContext(), readJson(), updateCostFile(), writeJson()
+### Community 41 - "Community 41"
+Cohesion: 0.10
+Nodes (28): HookDefinition, HOOKS, GRAPH_GITATTR_LINES, installHook(), uninstallHook(), hookBlockRegex(), escapeRegExp(), readTextFile() (+20 more)
 
 ### Community 185 - "Community 185"
 Cohesion: 0.33
-Nodes (5): commands, dir, matchers, settings, tempDirs
-
-### Community 186 - "Community 186"
-Cohesion: 0.33
-Nodes (5): dir, original, rule, rulePath, tempDirs
-
-### Community 187 - "Community 187"
-Cohesion: 0.33
-Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
-
-### Community 188 - "Community 188"
-Cohesion: 0.33
-Nodes (4): dir, logs, preview, tempDirs
-
-### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+Nodes (3): ToHtmlOptions, HtmlWriter, SafeToHtmlOptions
 
 ### Community 190 - "Community 190"
 Cohesion: 0.33
-Nodes (5): config, dir, plugin, previousCwd, tempDirs
+Nodes (1): CONFIDENCE_VALUES
+
+### Community 130 - "Community 130"
+Cohesion: 0.33
+Nodes (10): VALID_DENSITY, VALID_ROUTING_SIGNAL, isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray() (+2 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.14
+Nodes (16): ExportImageDataprepBatchRequestsOptions, ExportImageDataprepBatchRequestsResult, ImportImageDataprepBatchResultsOptions, ImportImageDataprepBatchResultsResult, readJsonl(), asRecord(), readCaption(), artifactHasDeepRoute() (+8 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.12
+Nodes (26): ImageDataprepSourceKind, ImageDataprepArtifact, ImageDataprepManifest, BuildImageDataprepManifestOptions, RunImageDataprepOptions, RunImageDataprepResult, sha256(), fileHash() (+18 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.07
+Nodes (40): ImageRoutingLabel, ImageRoute, ImageRoutingCalibrationDecision, ImageRoutingLabelEntry, ImageRoutingLabelsFile, ImageRoutingRuleBucket, ImageRoutingRulesFile, ImageRoutingSample (+32 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.09
+Nodes (18): cleanupDirs, detection, dir, G, communities, cohesion, labels, gods (+10 more)
+
+### Community 106 - "Community 106"
+Cohesion: 0.33
+Nodes (13): yamlStr(), yamlQuoted(), safeFilename(), detectUrlType(), htmlToMarkdown(), fetchTweet(), fetchWebpage(), fetchArxiv() (+5 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.13
+Nodes (21): InspectInputScopeOptions, InputScopeInventory, InputScopeSelection, GitScopeContext, VALID_SCOPE_MODES, toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
+
+### Community 157 - "Community 157"
+Cohesion: 0.31
+Nodes (9): splitGitLines(), pathspecForPrefix(), resolveGitScopeContext(), makeScope(), countGitPaths(), gitInventory(), buildGitInventory(), fallbackAllScope() (+1 more)
+
+### Community 40 - "Community 40"
+Cohesion: 0.12
+Nodes (30): WorktreeMetadata, BranchMetadata, LifecycleMetadata, RefreshLifecycleOptions, PruneCandidate, PrunePlan, readJson(), writeJson() (+22 more)
+
+### Community 11 - "Community 11"
+Cohesion: 0.05
+Nodes (34): LlmExecutionCapability, LlmExecutionMode, DirectLlmProvider, DIRECT_LLM_PROVIDERS, TextJsonGenerationInput, VisionJsonAnalysisInput, BatchVisionExportInput, BatchVisionImportInput (+26 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.17
+Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, tempDirs, dir, mesh, client
+
+### Community 176 - "Community 176"
+Cohesion: 0.43
+Nodes (5): MergeGraphJsonResult, readGraph(), hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles()
+
+### Community 167 - "Community 167"
+Cohesion: 0.36
+Nodes (6): MergeGraphsOptions, MergeGraphsResult, mergedGraphType(), mergeHyperedgesFromGraphs(), mergeGraphsFromFiles(), mergeHyperedges()
+
+### Community 64 - "Community 64"
+Cohesion: 0.13
+Nodes (21): MigrationAction, MigrationEntryType, MigrationEntry, MigrationGitAdvice, GraphifyOutMigrationPlan, GraphifyOutMigrationResult, MigrationOptions, shellQuote() (+13 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.15
+Nodes (15): MinimalContextRisk, BuildMinimalContextOptions, MinimalContextResult, uniqueSorted(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames() (+7 more)
+
+### Community 37 - "Community 37"
+Cohesion: 0.09
+Nodes (30): OntologyDiscoveryProposalKind, OntologyDiscoveryProposalAction, OntologyDiscoverySampleOptions, OntologyDiscoverySampleFile, OntologyDiscoverySampleRegistryRecord, OntologyDiscoverySample, OntologyDiscoveryProposal, OntologyDiscoveryProposalsFile (+22 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.06
+Nodes (33): OntologyOutputConfig, CompileOntologyOutputsOptions, CompileOntologyOutputsResult, CompiledNode, CompiledRelation, sha256(), stringValue(), ontologyNodeType() (+25 more)
+
+### Community 158 - "Community 158"
+Cohesion: 0.42
+Nodes (7): ProfilePatchRuntimeContext, readJson(), optionalJson(), stringValue(), evidenceRefsFromSources(), loadProfilePatchRuntimeContext(), loadOntologyPatchContext()
+
+### Community 45 - "Community 45"
+Cohesion: 0.09
+Nodes (28): ONTOLOGY_RECONCILIATION_DECISION_LOG_SCHEMA, OntologyPatchOperation, OntologyPatchStatus, OntologyPatch, OntologyPatchNode, OntologyPatchRelation, OntologyPatchContext, OntologyPatchIssue (+20 more)
+
+### Community 145 - "Community 145"
+Cohesion: 0.42
+Nodes (10): nonEmptyString(), addError(), nodeType(), nodeById(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateSetStatus() (+2 more)
+
+### Community 146 - "Community 146"
+Cohesion: 0.24
+Nodes (10): stringArray(), addWarning(), knownEvidenceRefs(), validateEvidenceRefs(), normalizeOntologyPatch(), validateOntologyPatch(), appendJsonLine(), auditPath() (+2 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.10
+Nodes (43): DEFAULT_STATUSES, VALID_CITATION_MINIMUMS, VIS_JS_SHAPE_LIST, VIS_JS_SHAPES, asRecord(), asStringArray(), normalizeStringMap(), stableForHash() (+35 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.33
+Nodes (11): OntologyRebuildStatusResponse, readableStatePath(), ontologyReconciliationCandidatesPath(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), loadReadonlyReconciliationCandidates(), reconciliationQueueIsStale(), listOntologyReconciliationCandidates() (+3 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.13
+Nodes (20): ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA, ONTOLOGY_RECONCILIATION_CANDIDATES_RESPONSE_SCHEMA, OntologyReconciliationCandidateKind, OntologyReconciliationCandidateStatus, OntologyReconciliationCandidate, OntologyReconciliationCandidateQueue, OntologyReconciliationCandidateFilter, OntologyReconciliationCandidatesResponse (+12 more)
+
+### Community 61 - "Community 61"
+Cohesion: 0.13
+Nodes (19): LOOPBACK_HOSTS, OntologyStudioWriteOptions, OntologyStudioHandlerOptions, StartOntologyStudioServerOptions, StartedOntologyStudioServer, OntologyStudioRouteResult, optionalString(), optionalNumber() (+11 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.15
+Nodes (21): GraphifyPathOptions, GraphifyScratchPaths, GraphifyLegacyRootScratchPaths, GraphifyProfilePaths, GraphifyImageDataprepPaths, GraphifyOntologyOutputPaths, GraphifyPaths, statePath() (+13 more)
+
+### Community 52 - "Community 52"
+Cohesion: 0.13
+Nodes (26): PDF_IMAGE_EXTENSIONS, PdfPreparationArtifact, PdfPreparationOptions, MistralOcrModule, cloneDetection(), countWords(), metadataPath(), listImageArtifacts() (+18 more)
+
+### Community 46 - "Community 46"
+Cohesion: 0.12
+Nodes (23): PdfOcrMode, PdfTextLayerProvider, PdfPreflightOptions, PdfPreflightResult, PdfTextLayerResult, UnpdfTextResult, normalizeText(), countWords() (+15 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.13
+Nodes (15): BuildProjectOptions, BuildProjectWarning, BuildProjectArtifacts, BuildProjectResult, countNonCodeFiles(), formatDiagnosticSummary(), fileList(), buildProject() (+7 more)
+
+### Community 5 - "Community 5"
+Cohesion: 0.06
+Nodes (49): PortablePathIssueKind, PortablePathIssue, PortableCheckResult, LOCAL_LIFECYCLE_FILES, LOCAL_LIFECYCLE_PREFIXES, TEXT_ARTIFACT_EXTENSIONS, isWindowsAbsolutePath(), hasSchemePrefix() (+41 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.10
+Nodes (33): ProfilePromptState, ProfilePromptOptions, ProfilePromptChunk, sampleLimit(), nodeTypeSection(), relationTypeSection(), relationMetadataSection(), registrySection() (+25 more)
+
+### Community 100 - "Community 100"
+Cohesion: 0.19
+Nodes (12): readRegistryRows(), field(), normalizeRegistryRecord(), loadProfileRegistry(), safeIdPart(), registryRecordsToExtraction(), readRegistryRows(), field() (+4 more)
+
+### Community 24 - "Community 24"
+Cohesion: 0.10
+Nodes (34): ProfileReportGraphData, ProfileReportPdfArtifact, ProfileReportContext, rel(), stringValue(), graphNodes(), graphLinks(), projectConfigSection() (+26 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.09
+Nodes (32): ProfileValidationSeverity, ProfileValidationIssue, ProfileValidationContext, ProfileValidationResult, stringValue(), stringArray(), citations(), addIssue() (+24 more)
+
+### Community 57 - "Community 57"
+Cohesion: 0.14
+Nodes (23): CONFIG_CANDIDATES, VALID_PDF_OCR_MODES, VALID_CITATION_MINIMUMS, VALID_LLM_EXECUTION_MODES, VALID_IMAGE_ARTIFACT_SOURCES, VALID_INPUT_SCOPE_MODES, asRecord(), asStringArray() (+15 more)
+
+### Community 20 - "Community 20"
+Cohesion: 0.06
+Nodes (23): CommitRecommendationConfidence, CommitRecommendationStaleness, CommitRecommendationGroup, CommitRecommendation, CommitRecommendationOptions, FileGraphInfo, GroupDraft, normalizePath() (+15 more)
 
 ### Community 191 - "Community 191"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+Cohesion: 0.47
+Nodes (6): uniqueSorted(), mergeDrafts(), stalenessFrom(), minConfidence(), groupConfidence(), buildCommitRecommendation()
 
-### Community 192 - "Community 192"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+### Community 87 - "Community 87"
+Cohesion: 0.17
+Nodes (13): CloneRepoOptions, CloneRepoResult, GithubRepoRef, execGit(), maybeGithubRepo(), repoNameFromUrl(), defaultCloneDestination(), cloneRepo() (+5 more)
 
-### Community 193 - "Community 193"
-Cohesion: 0.50
-Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
+### Community 47 - "Community 47"
+Cohesion: 0.07
+Nodes (11): ReviewRiskLevel, ReviewBlastRadius, ReviewImpactedCommunity, ReviewMultimodalSafety, ReviewAnalysis, ReviewAnalysisOptions, ReviewEvaluationCase, ReviewEvaluationCaseResult (+3 more)
 
-### Community 194 - "Community 194"
-Cohesion: 0.40
-Nodes (4): chunks, client, files, root
+### Community 168 - "Community 168"
+Cohesion: 0.25
+Nodes (8): uniqueSorted(), riskLevel(), communityRisk(), nodeCommunities(), buildBlastRadius(), impactedCommunities(), multimodalSafety(), buildReviewAnalysis()
 
-### Community 195 - "Community 195"
-Cohesion: 0.40
-Nodes (4): changelog, lock, pkg, workflow
-
-### Community 196 - "Community 196"
-Cohesion: 0.40
-Nodes (4): graphifyOut, long, result, tmpDir
-
-### Community 197 - "Community 197"
-Cohesion: 0.67
-Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
-
-### Community 198 - "Community 198"
-Cohesion: 0.50
-Nodes (3): b1, b2, backup
-
-### Community 199 - "Community 199"
-Cohesion: 0.67
-Nodes (3): runCli(), runMain(), runSkillRuntime()
-
-### Community 200 - "Community 200"
-Cohesion: 0.67
-Nodes (2): paths, root
-
-### Community 201 - "Community 201"
-Cohesion: 0.67
-Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
-
-### Community 202 - "Community 202"
-Cohesion: 1.00
-Nodes (2): buildRegistrySources(), registrySourceName()
-
-### Community 203 - "Community 203"
+### Community 214 - "Community 214"
 Cohesion: 1.00
 Nodes (2): average(), evaluateReviewAnalysis()
 
-### Community 204 - "Community 204"
+### Community 215 - "Community 215"
 Cohesion: 1.00
 Nodes (2): formatMetric(), reviewEvaluationToText()
 
-### Community 205 - "Community 205"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+### Community 10 - "Community 10"
+Cohesion: 0.06
+Nodes (39): ReviewBenchmarkCase, ReviewBenchmarkOptions, ReviewBenchmarkTokenBudgetStatus, ReviewBenchmarkMetrics, ReviewBenchmarkCaseResult, ReviewBenchmarkResult, normalize(), uniqueSorted() (+31 more)
 
-### Community 206 - "Community 206"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+### Community 4 - "Community 4"
+Cohesion: 0.05
+Nodes (52): ReviewContextDetailLevel, ReviewContextRisk, BuildReviewContextOptions, ReviewContextPayload, ReviewContextResult, normalizePath(), uniqueSorted(), sourceMatches() (+44 more)
 
-### Community 207 - "Community 207"
+### Community 77 - "Community 77"
+Cohesion: 0.13
+Nodes (16): ReviewGraphNodeKind, ReviewGraphNode, ReviewGraphEdge, ReviewImpactRadius, ReviewGraphStats, ReviewGraphStoreLike, KNOWN_KINDS, normalizePath() (+8 more)
+
+### Community 6 - "Community 6"
+Cohesion: 0.05
+Nodes (38): ReviewNode, ReviewChain, ReviewDelta, ReviewDeltaOptions, compareStrings(), normalizePath(), uniqueSorted(), maybeCommunity() (+30 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.32
+Nodes (6): normalizeSearchText(), textMatchesQuery(), scoreSearchText(), terms, exact, substring
+
+### Community 111 - "Community 111"
+Cohesion: 0.22
+Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, validateUrl(), isPrivateIp(), validateHostname(), isRedirectStatus(), safeFetch(), safeFetchText()
+
+### Community 121 - "Community 121"
+Cohesion: 0.17
+Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }, tempDirs, imagePath, packageJson, packageLock, outputDir
+
+### Community 48 - "Community 48"
+Cohesion: 0.09
+Nodes (16): ServeOptions, McpToolDefinition, McpResourceDefinition, GraphSnapshot, ReloadingGraphStore, MCP_RESOURCES, graphPath, loadGraph() (+8 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.25
+Nodes (9): GraphFileSignature, validateGraphFilePath(), readGraphData(), loadGraphSnapshot(), createReloadingGraphStore(), getVersion(), communitiesFromGraph(), serve() (+1 more)
+
+### Community 112 - "Community 112"
+Cohesion: 0.21
+Nodes (13): communityName(), mcpField(), nodeDisplayLabel(), scoreNodes(), bfs(), dfs(), subgraphToText(), findNode() (+5 more)
+
+### Community 177 - "Community 177"
+Cohesion: 0.29
+Nodes (7): toolGodNodes(), toolGraphStats(), communityLabelsFromGraph(), resourceConfidenceAudit(), resourceSurprises(), resourceQuestions(), readMcpResource()
+
+### Community 179 - "Community 179"
+Cohesion: 0.33
+Nodes (7): optionalString(), optionalNumber(), optionalInteger(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog(), ontologyAppliedPatchesPath()
+
+### Community 178 - "Community 178"
+Cohesion: 0.43
+Nodes (7): toolListReconciliationCandidates(), toolOntologyRebuildStatus(), readableStatePath(), ontologyReconciliationCandidatesPath(), ontologyNeedsUpdatePath(), loadReadonlyReconciliationCandidates(), reconciliationQueueIsStale()
+
+### Community 125 - "Community 125"
+Cohesion: 0.17
+Nodes (7): tempDirs, bannedReportFirstPatterns, paths, dir, claudeSettings, old, updated
+
+### Community 42 - "Community 42"
+Cohesion: 0.10
+Nodes (22): __filename, __dirname, AnalysisFile, readJson(), writeJson(), scopeOptionDescription(), cacheOptionsFromRuntime(), ProfileRuntimeContext (+14 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.08
+Nodes (31): FirstHopHub, FirstHopCommunity, FirstHopSummary, FirstHopSummaryOptions, compareStrings(), round(), maybeCommunity(), communityLabels() (+23 more)
+
+### Community 30 - "Community 30"
+Cohesion: 0.09
+Nodes (35): URL_PREFIXES, CACHED_AUDIO_EXTENSIONS, REQUIRED_MODEL_FILES, SUPPORTED_MODELS, MODEL_ALIASES, FasterWhisperSegment, FasterWhisperTranscriptionOptions, FasterWhisperModel (+27 more)
+
+### Community 180 - "Community 180"
+Cohesion: 0.33
+Nodes (4): RenderTreeOptions, TreeNeighbor, nodeLabel(), renderTree()
+
+### Community 1 - "Community 1"
+Cohesion: 0.02
+Nodes (82): FileType, Confidence, GraphifyInputScopeMode, GraphifyResolvedInputScopeMode, InputScopeSource, InputScopeInspection, GraphNode, GraphEdge (+74 more)
+
+### Community 216 - "Community 216"
 Cohesion: 1.00
 Nodes (1): UnpdfTextResult
 
-### Community 208 - "Community 208"
+### Community 160 - "Community 160"
+Cohesion: 0.25
+Nodes (7): VALID_FILE_TYPES, VALID_CONFIDENCES, REQUIRED_NODE_FIELDS, REQUIRED_EDGE_FIELDS, validateExtraction(), assertValid(), errors
+
+### Community 113 - "Community 113"
+Cohesion: 0.21
+Nodes (9): WATCHED_EXTENSIONS, mergeHyperedges(), builtFromCommit(), rebuildCode(), CheckUpdateResult, checkUpdate(), rebuildLockPath(), acquireRebuildLock() (+1 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.22
+Nodes (4): WIKI_DESCRIPTION_BATCH_SCHEMA, BuildWikiDescriptionBatchOptions, WikiDescriptionBatchResultRecord, ParseWikiDescriptionBatchOptions
+
+### Community 29 - "Community 29"
+Cohesion: 0.09
+Nodes (36): RawNode, RawCommunity, WikiDescriptionTargetContext, WikiDescriptionNeighbor, CollectWikiDescriptionTargetsOptions, WikiDescriptionTargetCollection, BuildWikiDescriptionPromptOptions, GenerateWikiDescriptionSidecarsClients (+28 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.08
+Nodes (32): WIKI_DESCRIPTION_SCHEMA, WIKI_DESCRIPTION_PROMPT_VERSION, WikiDescriptionTargetKind, WikiDescriptionStatus, WikiDescriptionExecutionMode, WikiDescriptionEvidenceRef, WikiDescriptionGenerator, WikiDescriptionCacheKeyInput (+24 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.27
+Nodes (12): WikiPageRef, safeFilename(), uniquePageRefs(), normalizeFlows(), flowsThroughNodes(), crossCommunityLinks(), renderDescription(), communityArticle() (+4 more)
+
+### Community 18 - "Community 18"
+Cohesion: 0.08
+Nodes (38): RenderGraphPanelOptions, HTML_ESCAPE_MAP, escapeHtml(), escapeUrl(), modeLabel(), renderMetricsCard(), renderViewerSurface(), renderGraphPanel() (+30 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.05
+Nodes (33): graph, graphJsonShape, focused, strongOnly, withWeak, state, subgraph, tokens (+25 more)
+
+### Community 192 - "Community 192"
+Cohesion: 0.47
+Nodes (5): RenderWorkspaceShellOptions, HTML_ESCAPE_MAP, escapeHtml(), shellStyles(), renderWorkspaceShell()
+
+### Community 117 - "Community 117"
+Cohesion: 0.26
+Nodes (11): qn(), addFunction(), addCall(), makeFlowStore(), { artifact, store, ids }, result, { artifact, store }, qn() (+3 more)
+
+### Community 170 - "Community 170"
+Cohesion: 0.25
+Nodes (7): tempDirs, section, dir, agents, home, skillPath, skill
+
+### Community 108 - "Community 108"
+Cohesion: 0.14
+Nodes (12): G, gods, labels, godIds, communities, surprises, first, second (+4 more)
+
+### Community 207 - "Community 207"
+Cohesion: 0.50
+Nodes (3): backup, b1, b2
+
+### Community 171 - "Community 171"
+Cohesion: 0.25
+Nodes (6): cleanupDirs, dir, graphPath, graph, edge, attrs
+
+### Community 147 - "Community 147"
+Cohesion: 0.20
+Nodes (9): SAMPLE_EXTRACTION, G, edge, attrs, ext, hyper, hyperedges, ext1 (+1 more)
+
+### Community 193 - "Community 193"
+Cohesion: 0.33
+Nodes (5): tempDirs, dir, settings, commands, matchers
+
+### Community 0 - "Community 0"
+Cohesion: 0.02
+Nodes (79): tempDirs, dir, graphPath, graphDir, output, source, destRoot, dest (+71 more)
+
+### Community 217 - "Community 217"
 Cohesion: 1.00
-Nodes (2): tempProfileProject(), tempProject()
+Nodes (2): tempProject(), tempProfileProject()
+
+### Community 208 - "Community 208"
+Cohesion: 0.67
+Nodes (3): runCli(), runSkillRuntime(), runMain()
+
+### Community 72 - "Community 72"
+Cohesion: 0.09
+Nodes (18): tempDirs, dir, skillDir, configOut, profileOut, statePath, extractionPath, reportPath (+10 more)
+
+### Community 88 - "Community 88"
+Cohesion: 0.12
+Nodes (15): G, result, allNodes, sizes, louvainMock, partition, nodes, first (+7 more)
+
+### Community 172 - "Community 172"
+Cohesion: 0.25
+Nodes (7): tempDirs, section, skill, readme, dir, hooks, commands
+
+### Community 97 - "Community 97"
+Cohesion: 0.13
+Nodes (10): cleanupDirs, fixtureRoot, root, config, inputs, detection, filtered, paths (+2 more)
+
+### Community 181 - "Community 181"
+Cohesion: 0.29
+Nodes (6): tempDirs, home, previousCwd, skillPath, versionPath, readme
+
+### Community 194 - "Community 194"
+Cohesion: 0.33
+Nodes (5): tempDirs, dir, rule, rulePath, original
+
+### Community 62 - "Community 62"
+Cohesion: 0.09
+Nodes (21): qn(), addNode(), parsed, G, funcA, funcB, store, nodes (+13 more)
+
+### Community 89 - "Community 89"
+Cohesion: 0.12
+Nodes (16): codeExts, result, sourceDir, subDir, repoDir, packagesDir, inventory, filePath (+8 more)
+
+### Community 203 - "Community 203"
+Cohesion: 0.40
+Nodes (4): root, files, chunks, client
+
+### Community 135 - "Community 135"
+Cohesion: 0.18
+Nodes (9): PROVIDERS, providerSelection, tempDirs, tempDir, outputPath, client, output, audit (+1 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.18
+Nodes (9): cleanupDirs, dir, graphPath, warnings, graph, written, persisted, outputPath (+1 more)
+
+### Community 137 - "Community 137"
+Cohesion: 0.18
+Nodes (10): cleanupDirs, dir, filePath, calls, importEdge, demoNode, callTargets, runNode (+2 more)
+
+### Community 31 - "Community 31"
+Cohesion: 0.09
+Nodes (15): validate(), process(), main(), HttpClient, Server, NewServer(), validate(), process() (+7 more)
+
+### Community 39 - "Community 39"
+Cohesion: 0.08
+Nodes (12): DataProcessor, Processor, GraphifyDemo, IProcessor, DataProcessor, Processor, Get-Data(), Process-Items() (+4 more)
+
+### Community 82 - "Community 82"
+Cohesion: 0.14
+Nodes (2): ApiClient, ApiClient
+
+### Community 174 - "Community 174"
+Cohesion: 0.29
+Nodes (2): Transformer, Transformer
+
+### Community 129 - "Community 129"
+Cohesion: 0.25
+Nodes (4): Graph, build_graph(), Graph, build_graph()
+
+### Community 83 - "Community 83"
+Cohesion: 0.21
+Nodes (10): compute_score(), normalize(), run_analysis(), Analyzer, Fixture: functions and methods that call each other - for call-graph extraction, compute_score(), normalize(), run_analysis() (+2 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.05
+Nodes (34): tempDirs, qn(), addFunction(), G, entry, helper, caller, decorated (+26 more)
+
+### Community 182 - "Community 182"
+Cohesion: 0.29
+Nodes (6): tempDirs, dir, geminiMd, settings, skill, readme
+
+### Community 114 - "Community 114"
+Cohesion: 0.15
+Nodes (9): tempDirs, googleEnvKeys, previousEnv, dir, stub, shortcut, fetcher, rendered (+1 more)
+
+### Community 55 - "Community 55"
+Cohesion: 0.08
+Nodes (21): OntologyWriteFixture, tempDirs, dir, token, fixture, { body, headers }, json, fixedToken (+13 more)
+
+### Community 115 - "Community 115"
+Cohesion: 0.15
+Nodes (10): dir, htmlPath, warnings, G, communities, result, html, profile (+2 more)
+
+### Community 67 - "Community 67"
+Cohesion: 0.09
+Nodes (21): { confidence_score: _ignored, ...rest }, { id: _ignored, ...rest }, graph, h, items, serialized, reloaded, result (+13 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.10
+Nodes (16): cleanupDirs, root, out, result, line, input, outputDir, captionsDir (+8 more)
+
+### Community 91 - "Community 91"
+Cohesion: 0.13
+Nodes (11): cleanupDirs, root, image, config, result, directImage, cropDir, cropImage (+3 more)
+
+### Community 99 - "Community 99"
+Cohesion: 0.13
+Nodes (12): cleanupDirs, root, labelsPath, rulesPath, route, result, missing, ambiguous (+4 more)
+
+### Community 195 - "Community 195"
+Cohesion: 0.33
+Nodes (5): cleanupDirs, downloadAudioMock, dir, expected, rendered
+
+### Community 152 - "Community 152"
+Cohesion: 0.22
+Nodes (2): inventory, ignoredDir
+
+### Community 196 - "Community 196"
+Cohesion: 0.33
+Nodes (4): tempDirs, preview, dir, logs
+
+### Community 8 - "Community 8"
+Cohesion: 0.04
+Nodes (51): files, worktreeRoot, labels, relations, fileNodes, importEdge, pageNode, widgetNode (+43 more)
+
+### Community 183 - "Community 183"
+Cohesion: 0.29
+Nodes (6): head, metadata, stale, analyzed, worktreeDir, plan
+
+### Community 92 - "Community 92"
+Cohesion: 0.13
+Nodes (13): generateTextMock, openaiMock, anthropicMock, googleMock, mistralMock, cohereMock, cleanupDirs, root (+5 more)
+
+### Community 148 - "Community 148"
+Cohesion: 0.20
+Nodes (8): tempDirs, dir, ancestor, current, other, result, merged, tooManyNodes
+
+### Community 153 - "Community 153"
+Cohesion: 0.22
+Nodes (4): cleanupDirs, root, result, text
+
+### Community 118 - "Community 118"
+Cohesion: 0.26
+Nodes (11): qn(), addFunction(), addCall(), makeStore(), { store }, result, { store, flows }, qn() (+3 more)
+
+### Community 197 - "Community 197"
+Cohesion: 0.33
+Nodes (5): tempDirs, tmpDir, pdfPath, outputDir, markdown
+
+### Community 149 - "Community 149"
+Cohesion: 0.22
+Nodes (9): fixtureRoot, semanticDetection(), discoveryContext(), sample, repeat, context, proposals, diff (+1 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.15
+Nodes (15): tempDirs, fixtureRoot, tempProfileProject(), runCli(), runSkillRuntime(), runMain(), prepareProject(), cliOut (+7 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.09
+Nodes (18): cleanupDirs, profile, root, valid, invalid, context, badStatus, badRelation (+10 more)
+
+### Community 84 - "Community 84"
+Cohesion: 0.12
+Nodes (10): cleanupDirs, root, profilePath, profile, raw, errors, config, bound (+2 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.18
+Nodes (9): profile, dir, path, queue, loaded, response, filters, first (+1 more)
+
+### Community 198 - "Community 198"
+Cohesion: 0.33
+Nodes (5): tempDirs, dir, plugin, config, previousCwd
 
 ### Community 209 - "Community 209"
+Cohesion: 0.67
+Nodes (2): root, paths
+
+### Community 68 - "Community 68"
+Cohesion: 0.09
+Nodes (22): FIXTURES_DIR, TMP_OUT, result, exts, raw, errors, realErrors, allClustered (+14 more)
+
+### Community 139 - "Community 139"
+Cohesion: 0.20
+Nodes (9): tempDirs, runCliInTemp(), runCliWithEnvironment(), rule, workflow, home, project, skill (+1 more)
+
+### Community 85 - "Community 85"
+Cohesion: 0.12
+Nodes (14): tempDirs, fixtureRoot, root, prompt, semanticExtraction, extraction, profileValidation, graph (+6 more)
+
+### Community 131 - "Community 131"
+Cohesion: 0.18
+Nodes (8): fixtureRoot, prompt, state, documentPrompt, imagePrompt, extraction, sample, profile
+
+### Community 101 - "Community 101"
+Cohesion: 0.13
+Nodes (12): cleanupDirs, root, config, profile, registries, jsonPath, yamlPath, components (+4 more)
+
+### Community 105 - "Community 105"
+Cohesion: 0.14
+Nodes (9): cleanupDirs, root, result, configDir, configPath, loaded, raw, errors (+1 more)
+
+### Community 187 - "Community 187"
+Cohesion: 0.33
+Nodes (1): recommendation
+
+### Community 204 - "Community 204"
+Cohesion: 0.40
+Nodes (4): pkg, lock, changelog, workflow
+
+### Community 140 - "Community 140"
+Cohesion: 0.18
+Nodes (10): G, communities, cohesion, labels, gods, surprises, detection, report (+2 more)
+
+### Community 188 - "Community 188"
+Cohesion: 0.33
+Nodes (3): analysis, text, evaluation
+
+### Community 141 - "Community 141"
+Cohesion: 0.20
+Nodes (7): store, node, impact, targets, G, out, batch
+
+### Community 205 - "Community 205"
+Cohesion: 0.40
+Nodes (4): long, tmpDir, graphifyOut, result
+
+### Community 2 - "Community 2"
+Cohesion: 0.03
+Nodes (58): tempDirs, tsRoot, graphifyOutRoot, cliPath, packageVersion, dir, graphPath, [clientTransport, serverTransport] (+50 more)
+
+### Community 210 - "Community 210"
+Cohesion: 0.67
+Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
+
+### Community 184 - "Community 184"
+Cohesion: 0.29
+Nodes (6): SKILLS, ALL_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, DISTRIBUTED_SKILL_DOCS, TRIGGER_DESCRIPTION_DOCS, content
+
+### Community 116 - "Community 116"
+Cohesion: 0.15
+Nodes (10): { WhisperModelMock, freeMock, transcribeMock }, tempDirs, spawnSyncMock, hash, cached, video, outDir, modelDir (+2 more)
+
+### Community 199 - "Community 199"
+Cohesion: 0.33
+Nodes (4): tempDirs, dir, lockPath, contents
+
+### Community 90 - "Community 90"
+Cohesion: 0.13
+Nodes (15): tempDirs, dir, mkGraph(), graph, communities, targets, outputPath, exportInput (+7 more)
+
+### Community 49 - "Community 49"
+Cohesion: 0.07
+Nodes (24): tempDirs, mkGraph(), graph, communities, targets, prompt, outputDir, persistedSidecar (+16 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.17
+Nodes (10): generator, base, cache_key, sidecar, result, fresh, stale, communityBase (+2 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.17
+Nodes (11): G, communities, labels, count, index, flows, generator, descriptions (+3 more)
+
+### Community 218 - "Community 218"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
+### Community 7 - "Community 7"
+Cohesion: 0.06
+Nodes (50): handle_upload(), handle_get(), handle_delete(), handle_list(), handle_search(), handle_enrich(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
+
+### Community 51 - "Community 51"
+Cohesion: 0.10
+Nodes (26): parse_file(), parse_markdown(), parse_json(), parse_plaintext(), parse_and_save(), batch_parse(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+
+### Community 53 - "Community 53"
+Cohesion: 0.10
+Nodes (26): normalize_text(), extract_keywords(), enrich_document(), find_cross_references(), process_and_save(), reprocess_all(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters. (+18 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.11
+Nodes (32): _ensure_storage(), load_index(), save_index(), save_parsed(), save_processed(), load_record(), delete_record(), list_records() (+24 more)
+
+### Community 27 - "Community 27"
+Cohesion: 0.07
+Nodes (35): Exception, CookieConflict, httpx-like exception hierarchy. All exceptions inherit from HTTPError at the top, Attempted to look up a cookie by name but multiple cookies exist., HTTPError, RequestError, ConnectTimeout, ReadTimeout (+27 more)
+
+### Community 59 - "Community 59"
+Cohesion: 0.11
+Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication., HTTP Digest Authentication.     Requires a full request/response cycle: sends th (+4 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.16
+Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., Timeout, Limits, BaseClient, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
+
+### Community 103 - "Community 103"
+Cohesion: 0.15
+Nodes (1): AsyncClient
+
+### Community 120 - "Community 120"
+Cohesion: 0.18
+Nodes (1): Client
+
+### Community 175 - "Community 175"
+Cohesion: 0.29
+Nodes (6): HTTPError, RequestError, DecodingError, Base class for all httpx exceptions., An error occurred while issuing a request., Decoding of the response failed.
+
+### Community 19 - "Community 19"
+Cohesion: 0.10
+Nodes (30): TransportError, TimeoutException, ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout, ConnectError, ProxyError (+22 more)
+
+### Community 164 - "Community 164"
+Cohesion: 0.25
+Nodes (8): NetworkError, ReadError, WriteError, CloseError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection.
+
+### Community 56 - "Community 56"
+Cohesion: 0.09
+Nodes (6): HTTPStatusError, A 4xx or 5xx response was received., URL, Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, Core data models: URL, Headers, Cookies, Request, Response. These are the centra
+
+### Community 132 - "Community 132"
+Cohesion: 0.27
+Nodes (2): ConnectionPool, HTTPTransport
+
+### Community 23 - "Community 23"
+Cohesion: 0.07
+Nodes (35): primitive_value_to_str(), normalize_header_key(), flatten_queryparams(), parse_content_type(), obfuscate_sensitive_headers(), unset_all_cookies(), is_known_encoding(), build_url_with_params() (+27 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.07
+Nodes (48): _node_community_map(), _is_file_node(), god_nodes(), surprising_connections(), _is_concept_node(), _file_category(), _top_level_dir(), _surprise_score() (+40 more)
+
+### Community 173 - "Community 173"
+Cohesion: 0.38
+Nodes (6): build_from_json(), build(), Merge multiple extraction results into one graph., build_from_json(), build(), Merge multiple extraction results into one graph.
+
+### Community 74 - "Community 74"
+Cohesion: 0.11
+Nodes (20): build_graph(), cluster(), _split_community(), cohesion_score(), score_all(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi (+12 more)
+
+### Community 200 - "Community 200"
+Cohesion: 0.60
+Nodes (5): uniqueSorted(), sortNodesByLocation(), mapChangesToNodes(), changedNodesFromFiles(), analyzeChanges()
+
+### Community 151 - "Community 151"
+Cohesion: 0.31
+Nodes (9): splitGitLines(), pathspecForPrefix(), resolveGitScopeContext(), makeScope(), countGitPaths(), gitInventory(), buildGitInventory(), fallbackAllScope() (+1 more)
+
+### Community 186 - "Community 186"
+Cohesion: 0.47
+Nodes (6): uniqueSorted(), mergeDrafts(), stalenessFrom(), minConfidence(), groupConfidence(), buildCommitRecommendation()
+
+### Community 165 - "Community 165"
+Cohesion: 0.25
+Nodes (8): uniqueSorted(), riskLevel(), communityRisk(), nodeCommunities(), buildBlastRadius(), impactedCommunities(), multimodalSafety(), buildReviewAnalysis()
+
+### Community 212 - "Community 212"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 213 - "Community 213"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 150 - "Community 150"
+Cohesion: 0.28
+Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
+
+### Community 80 - "Community 80"
+Cohesion: 0.15
+Nodes (14): Geometry, LinearAlgebra, Base, Shape, Point, Circle, area(), describe() (+6 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.18
+Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
+
+### Community 38 - "Community 38"
+Cohesion: 0.16
+Nodes (16): Auth, BasicAuth, Timeout, Limits, BaseClient, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.11
+Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication., Load credentials from ~/.netrc based on the request host. (+18 more)
+
+### Community 163 - "Community 163"
+Cohesion: 0.32
+Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
+
+### Community 50 - "Community 50"
+Cohesion: 0.13
+Nodes (2): Client, AsyncClient
+
+### Community 119 - "Community 119"
+Cohesion: 0.18
+Nodes (1): Headers
+
+### Community 162 - "Community 162"
+Cohesion: 0.31
+Nodes (1): ConnectionPool
+
+### Community 189 - "Community 189"
+Cohesion: 0.33
+Nodes (6): scoreNodes(), bfs(), dfs(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+
+### Community 102 - "Community 102"
+Cohesion: 0.16
+Nodes (15): asRecord(), asStringArray(), asBoolean(), asString(), asNumber(), resolvePath(), parsePdfOcrMode(), parseCitationMinimum() (+7 more)
+
+### Community 211 - "Community 211"
+Cohesion: 1.00
+Nodes (2): registrySourceName(), buildRegistrySources()
+
 ## Knowledge Gaps
-- **1546 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1541 more)
+- **1621 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1616 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 48`** (2 nodes): `AsyncClient`, `Client`
+- **Thin community `Community 190`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 80`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 214`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 101`** (1 nodes): `AsyncClient`
+- **Thin community `Community 215`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (1 nodes): `Headers`
+- **Thin community `Community 216`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (1 nodes): `Client`
+- **Thin community `Community 217`** (2 nodes): `tempProject()`, `tempProfileProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (2 nodes): `ConnectionPool`, `HTTPTransport`
+- **Thin community `Community 82`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 174`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 152`** (2 nodes): `inventory`, `ignoredDir`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (2 nodes): `NumericMapLike`, `StringMapLike`
+- **Thin community `Community 209`** (2 nodes): `root`, `paths`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 187`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (1 nodes): `recommendation`
+- **Thin community `Community 218`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (2 nodes): `paths`, `root`
+- **Thin community `Community 103`** (1 nodes): `AsyncClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 120`** (1 nodes): `Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 132`** (2 nodes): `ConnectionPool`, `HTTPTransport`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 212`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 213`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 50`** (2 nodes): `Client`, `AsyncClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 119`** (1 nodes): `Headers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 162`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 211`** (2 nodes): `registrySourceName()`, `buildRegistrySources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 23` to `Community 54`, `Community 116`, `Community 37`, `Community 48`, `Community 27`?**
+- **Why does `Cookies` connect `Community 23` to `Community 56`, `Community 119`, `Community 38`, `Community 50`, `Community 27`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 42` to `Community 54`, `Community 117`, `Community 101`, `Community 23`?**
+- **Why does `Cookies` connect `Community 44` to `Community 56`, `Community 120`, `Community 103`, `Community 23`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `InvalidURL` connect `Community 42` to `Community 27`, `Community 117`, `Community 101`?**
+- **Why does `InvalidURL` connect `Community 44` to `Community 27`, `Community 120`, `Community 103`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/src/types/optional-deps.d.ts
+++ b/src/types/optional-deps.d.ts
@@ -25,3 +25,9 @@ declare module "unpdf" {
     options?: { mergePages?: boolean },
   ): Promise<UnpdfTextResult>;
 }
+
+declare module "@sentropic/design-system/tokens" {
+  export const workspaceTokens: unknown;
+  const defaultTokens: unknown;
+  export default defaultTokens;
+}

--- a/src/workspace/graph-panel.ts
+++ b/src/workspace/graph-panel.ts
@@ -1,0 +1,133 @@
+/**
+ * Track G Lot 1 / G4 — graph panel renderer.
+ *
+ * Server-rendered metrics header + optional graph viewer surface. Two
+ * rendering paths:
+ *
+ *   - When `graphHtmlUrl` is set, the panel emits an iframe pointing
+ *     at a Graphify-generated HTML export (e.g. ".graphify/graph.html").
+ *     The full vis.js bootstrap is reused from the existing
+ *     `graphify export html` output; this lot does not duplicate it.
+ *
+ *   - When `graphHtmlUrl` is absent, the panel emits a bounded empty
+ *     state for skill-runtime / MCP environments where the HTML export
+ *     has not been produced yet.
+ *
+ * The metrics header is always rendered and reflects the focus
+ * subgraph computed by `computeFocusSubgraph`. It changes as the
+ * viewer state changes (focus / hops / showWeakLinks / selection),
+ * giving the user an immediate read on how a state change reshapes
+ * the slice.
+ *
+ * No client-side framework, no JS bundling. Pure HTML strings.
+ */
+
+import type { WorkspaceViewerState } from "./viewer-state.js";
+import type { FocusSubgraph, GraphLike } from "./graph-selection.js";
+import type { WorkspaceTokens } from "./tokens.js";
+import { computeFocusSubgraph } from "./graph-selection.js";
+
+export interface RenderGraphPanelOptions {
+  /** Current workspace state. */
+  state: WorkspaceViewerState;
+  /** Graph payload (typically loaded from `.graphify/graph.json`). */
+  graph: GraphLike;
+  /** Resolved tokens for the active theme. */
+  tokens: WorkspaceTokens;
+  /** Optional URL/path to a `graphify export html` artefact. */
+  graphHtmlUrl?: string;
+  /**
+   * Optional height of the iframe / placeholder, in CSS pixels.
+   * Defaults to 480.
+   */
+  height?: number;
+}
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(HTML_ESCAPE_RE, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+function escapeUrl(value: string): string {
+  // Keep this conservative: drop everything that could break out of
+  // a quoted src attribute or that resembles a javascript: scheme.
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (/^\s*javascript:/i.test(trimmed)) return "";
+  return escapeHtml(trimmed);
+}
+
+function modeLabel(mode: FocusSubgraph["appliedMode"]): string {
+  switch (mode) {
+    case "overview":
+      return "Overview";
+    case "focus":
+      return "Focus";
+    case "selection":
+      return "Selection";
+  }
+}
+
+function renderMetricsCard(subgraph: FocusSubgraph, state: WorkspaceViewerState): string {
+  const m = subgraph.metrics;
+  const hops = state.viewState.graph.focusHops;
+  const weak = state.viewState.graph.showWeakLinks ? "yes" : "no";
+  const focus = state.focusEntityId ? escapeHtml(state.focusEntityId) : "—";
+  const fields = [
+    `<span><b>Mode:</b> ${modeLabel(subgraph.appliedMode)}</span>`,
+    `<span><b>Nodes:</b> ${m.nodes}</span>`,
+    `<span><b>Edges:</b> ${m.edges}</span>`,
+    `<span><b>Communities:</b> ${m.communities}</span>`,
+    `<span><b>Density:</b> ${m.density.toFixed(4)}</span>`,
+    `<span><b>Avg degree:</b> ${m.averageDegree.toFixed(2)}</span>`,
+    `<span><b>Focus:</b> ${focus}</span>`,
+    `<span><b>Hops:</b> ${hops}</span>`,
+    `<span><b>Weak links:</b> ${weak}</span>`,
+  ];
+  return [
+    '<div class="ws-graph-metrics" role="status" aria-live="polite">',
+    ...fields,
+    "</div>",
+  ].join("");
+}
+
+function renderViewerSurface(opts: RenderGraphPanelOptions): string {
+  const height = Math.max(120, Math.round(opts.height ?? 480));
+  const url = opts.graphHtmlUrl ? escapeUrl(opts.graphHtmlUrl) : "";
+  if (!url) {
+    return [
+      '<div class="ws-graph-placeholder" id="ws-graph-network">',
+      "<p>Graph surface unavailable.</p>",
+      "</div>",
+    ].join("");
+  }
+  return [
+    '<iframe',
+    `  src="${url}"`,
+    `  title="Graphify graph surface"`,
+    `  style="width:100%;height:${height}px;border:1px solid var(--ws-border);border-radius:var(--ws-radius-md);background:var(--ws-surface);"`,
+    '  sandbox="allow-scripts"',
+    "></iframe>",
+  ].join("\n");
+}
+
+export function renderGraphPanel(opts: RenderGraphPanelOptions): string {
+  const subgraph = computeFocusSubgraph(opts.graph, opts.state);
+  const styles = [
+    "<style>",
+    ".ws-graph-metrics { display: flex; flex-wrap: wrap; gap: var(--ws-space-3); font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); margin-bottom: var(--ws-space-3); }",
+    ".ws-graph-metrics b { color: var(--ws-text); font-weight: 600; }",
+    ".ws-graph-placeholder { padding: var(--ws-space-4); border: 1px dashed var(--ws-border); border-radius: var(--ws-radius-md); color: var(--ws-text-muted); }",
+    ".ws-graph-placeholder code { background: var(--ws-surface-2); padding: 0 var(--ws-space-1); border-radius: var(--ws-radius-sm); }",
+    "</style>",
+  ].join("\n");
+  return [styles, renderMetricsCard(subgraph, opts.state), renderViewerSurface(opts)].join("\n");
+}

--- a/src/workspace/graph-selection.ts
+++ b/src/workspace/graph-selection.ts
@@ -1,0 +1,203 @@
+/**
+ * Track G Lot 1 / G4 — focus subgraph selection.
+ *
+ * Pure-data slicing of a Graphify graph.json payload driven by the
+ * workspace viewer state. No vis.js, no DOM; this module is the
+ * server-side bridge that decides what the graph panel renders.
+ *
+ * Three modes from `viewState.graph.mode`:
+ *
+ *   - "overview"  — return the full graph, optionally filtered for weak links.
+ *   - "focus"     — BFS `focusHops` around `focusEntityId`, optionally weak-filtered.
+ *   - "selection" — limit to nodes whose type or id belongs to the workbench memory
+ *                   (`selectedTypes` ∪ `selectedEntities` ∪ `selectionState.entityIds`).
+ *
+ * The function never mutates its inputs and never reads anything
+ * outside the provided graph + state.
+ */
+
+import type { WorkspaceViewerState } from "./viewer-state.js";
+
+export interface GraphNodeLike {
+  id: string;
+  label?: string;
+  type?: string;
+  node_type?: string;
+  community?: number;
+  community_name?: string;
+  source_file?: string;
+  [key: string]: unknown;
+}
+
+export interface GraphEdgeLike {
+  source: string;
+  target: string;
+  relation?: string;
+  confidence?: string;
+  [key: string]: unknown;
+}
+
+export interface GraphLike {
+  nodes: GraphNodeLike[];
+  /** Graphify's persisted graph.json uses `links`; tests/adapters may pass `edges`. */
+  links?: GraphEdgeLike[];
+  edges?: GraphEdgeLike[];
+}
+
+export interface FocusSubgraphMetrics {
+  nodes: number;
+  edges: number;
+  communities: number;
+  density: number;
+  averageDegree: number;
+  /** Highest-degree node id in the slice, or null when empty. */
+  topHubId: string | null;
+}
+
+export interface FocusSubgraph {
+  nodes: GraphNodeLike[];
+  edges: GraphEdgeLike[];
+  metrics: FocusSubgraphMetrics;
+  /** Echoes the slicing mode actually applied (may differ from state when state is invalid). */
+  appliedMode: "overview" | "focus" | "selection";
+}
+
+function nodeType(node: GraphNodeLike): string | undefined {
+  return node.node_type ?? node.type;
+}
+
+function isStrongEdge(edge: GraphEdgeLike): boolean {
+  const conf = (edge.confidence ?? "EXTRACTED").toUpperCase();
+  return conf === "EXTRACTED";
+}
+
+function computeMetrics(nodes: GraphNodeLike[], edges: GraphEdgeLike[]): FocusSubgraphMetrics {
+  const n = nodes.length;
+  const m = edges.length;
+  const communities = new Set<number>();
+  const degree = new Map<string, number>();
+  for (const node of nodes) {
+    if (typeof node.community === "number") communities.add(node.community);
+    degree.set(node.id, 0);
+  }
+  for (const edge of edges) {
+    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1);
+    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1);
+  }
+  let topHubId: string | null = null;
+  let topDeg = -1;
+  for (const [id, deg] of degree) {
+    if (deg > topDeg) {
+      topDeg = deg;
+      topHubId = id;
+    }
+  }
+  const maxPairs = n > 1 ? (n * (n - 1)) / 2 : 0;
+  const density = maxPairs > 0 ? m / maxPairs : 0;
+  const averageDegree = n > 0 ? (2 * m) / n : 0;
+  return {
+    nodes: n,
+    edges: m,
+    communities: communities.size,
+    density: Math.round(density * 10000) / 10000,
+    averageDegree: Math.round(averageDegree * 10000) / 10000,
+    topHubId: n === 0 ? null : topHubId,
+  };
+}
+
+function bfsNeighbours(
+  startId: string,
+  hops: number,
+  adjacency: Map<string, Set<string>>,
+): Set<string> {
+  const visited = new Set<string>([startId]);
+  if (hops <= 0) return visited;
+  let frontier: string[] = [startId];
+  for (let h = 0; h < hops; h++) {
+    const next: string[] = [];
+    for (const cur of frontier) {
+      const ns = adjacency.get(cur);
+      if (!ns) continue;
+      for (const nb of ns) {
+        if (visited.has(nb)) continue;
+        visited.add(nb);
+        next.push(nb);
+      }
+    }
+    if (next.length === 0) break;
+    frontier = next;
+  }
+  return visited;
+}
+
+function buildAdjacency(edges: GraphEdgeLike[]): Map<string, Set<string>> {
+  const adj = new Map<string, Set<string>>();
+  for (const edge of edges) {
+    if (!adj.has(edge.source)) adj.set(edge.source, new Set());
+    if (!adj.has(edge.target)) adj.set(edge.target, new Set());
+    adj.get(edge.source)!.add(edge.target);
+    adj.get(edge.target)!.add(edge.source);
+  }
+  return adj;
+}
+
+/**
+ * Returns the subgraph that the workspace graph panel should render,
+ * based on the active viewer state. Pure function: never mutates its
+ * inputs.
+ */
+export function computeFocusSubgraph(
+  graph: GraphLike,
+  state: WorkspaceViewerState,
+): FocusSubgraph {
+  const allNodes = graph.nodes ?? [];
+  const allEdges = graph.edges ?? graph.links ?? [];
+  const showWeak = state.viewState.graph.showWeakLinks;
+  const candidateEdges = showWeak ? allEdges : allEdges.filter(isStrongEdge);
+
+  let mode: FocusSubgraph["appliedMode"] = state.viewState.graph.mode;
+
+  // Mode "focus" requires a focus entity to be meaningful.
+  if (mode === "focus" && !state.focusEntityId) {
+    mode = "overview";
+  }
+
+  // Mode "selection" requires at least one memory entry to be meaningful.
+  const selectionSet = new Set<string>([
+    ...state.selectedEntities,
+    ...state.selectionState.entityIds,
+  ]);
+  const selectionTypes = new Set<string>(state.selectedTypes);
+  if (mode === "selection" && selectionSet.size === 0 && selectionTypes.size === 0) {
+    mode = "overview";
+  }
+
+  let nodes: GraphNodeLike[] = [];
+  if (mode === "overview") {
+    nodes = allNodes.slice();
+  } else if (mode === "focus") {
+    const adj = buildAdjacency(candidateEdges);
+    const hops = state.viewState.graph.focusHops;
+    const reachable = bfsNeighbours(state.focusEntityId as string, hops, adj);
+    nodes = allNodes.filter((n) => reachable.has(n.id));
+  } else {
+    // selection
+    nodes = allNodes.filter((n) => {
+      if (selectionSet.has(n.id)) return true;
+      const t = nodeType(n);
+      return t !== undefined && selectionTypes.has(t);
+    });
+  }
+
+  const nodeIds = new Set<string>(nodes.map((n) => n.id));
+  const edges = candidateEdges.filter(
+    (e) => nodeIds.has(e.source) && nodeIds.has(e.target),
+  );
+
+  return {
+    nodes,
+    edges,
+    metrics: computeMetrics(nodes, edges),
+    appliedMode: mode,
+  };
+}

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -43,3 +43,15 @@ export {
   viewerStateFromQuery,
   workspaceReducer,
 } from "./viewer-state.js";
+
+export type {
+  GraphNodeLike,
+  GraphEdgeLike,
+  GraphLike,
+  FocusSubgraphMetrics,
+  FocusSubgraph,
+} from "./graph-selection.js";
+export { computeFocusSubgraph } from "./graph-selection.js";
+
+export type { RenderGraphPanelOptions } from "./graph-panel.js";
+export { renderGraphPanel } from "./graph-panel.js";

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -164,7 +164,7 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     "</aside>",
     '<main class="ws-center" id="central-display" role="main" aria-label="Central display" tabindex="-1">',
     '<h2 class="ws-region-heading">Central display</h2>',
-    '<p class="ws-empty">Entity / type / candidate description renders here (G4 fills the markdown body, including Track A wiki sidecar inlining).</p>',
+    '<p class="ws-empty">No display item selected.</p>',
     '<section class="ws-graph-panel" id="graph-panel" role="region" aria-label="Graph panel">',
     '<h2 class="ws-region-heading">Graph panel</h2>',
     graphPanelBody,

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -66,6 +66,8 @@ export interface RenderWorkspaceShellOptions {
    * reconciliation queues without crashing the shell render path.
    */
   queueEmpty?: boolean;
+  /** Trusted internal HTML fragment rendered inside the graph panel slot. */
+  graphPanelHtml?: string;
 }
 
 const HTML_ESCAPE_RE = /[&<>"']/g;
@@ -127,6 +129,9 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
   const queueBody = queueEmpty
     ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
     : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>';
+  const graphPanelBody =
+    opts.graphPanelHtml ??
+    '<p class="ws-empty">No graph context available.</p>';
 
   return [
     "<!DOCTYPE html>",
@@ -162,7 +167,7 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     '<p class="ws-empty">Entity / type / candidate description renders here (G4 fills the markdown body, including Track A wiki sidecar inlining).</p>',
     '<section class="ws-graph-panel" id="graph-panel" role="region" aria-label="Graph panel">',
     '<h2 class="ws-region-heading">Graph panel</h2>',
-    '<p class="ws-empty">vis.js graph surface arrives in G4.</p>',
+    graphPanelBody,
     "</section>",
     "</main>",
     '<aside class="ws-right" id="right-drawer" role="complementary" aria-label="Detail drawer">',

--- a/tests/workspace-graph-panel.test.ts
+++ b/tests/workspace-graph-panel.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeFocusSubgraph,
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderGraphPanel,
+  renderWorkspaceShell,
+  workspaceReducer,
+  type GraphLike,
+  type WorkspaceViewerState,
+} from "../src/workspace/index.js";
+
+const graph: GraphLike = {
+  nodes: [
+    { id: "holmes", label: "Sherlock Holmes", node_type: "Character", community: 1 },
+    { id: "watson", label: "Dr Watson", node_type: "Character", community: 1 },
+    { id: "crime", label: "Lauriston Gardens murder", node_type: "CrimeOrScheme", community: 2 },
+    { id: "ring", label: "Woman's wedding ring", node_type: "Evidence", community: 2 },
+  ],
+  edges: [
+    { source: "holmes", target: "watson", relation: "works_with", confidence: "EXTRACTED" },
+    { source: "watson", target: "crime", relation: "observes", confidence: "INFERRED" },
+    { source: "crime", target: "ring", relation: "leaves_evidence", confidence: "EXTRACTED" },
+  ],
+};
+
+const graphJsonShape: GraphLike = {
+  nodes: graph.nodes,
+  links: graph.edges,
+};
+
+function withGraphState(
+  state: WorkspaceViewerState,
+  patch: Partial<WorkspaceViewerState["viewState"]["graph"]>,
+): WorkspaceViewerState {
+  return {
+    ...state,
+    viewState: {
+      ...state.viewState,
+      graph: { ...state.viewState.graph, ...patch },
+    },
+  };
+}
+
+describe("Track G G4 — graph panel", () => {
+  it("slices a focus graph through strong edges unless weak links are enabled", () => {
+    const focused = workspaceReducer(createDefaultViewerState(), {
+      type: "SET_FOCUS_ENTITY",
+      focusEntityId: "holmes",
+    });
+    const strongOnly = computeFocusSubgraph(
+      graph,
+      withGraphState(focused, { mode: "focus", focusHops: 2, showWeakLinks: false }),
+    );
+    expect(strongOnly.appliedMode).toBe("focus");
+    expect(strongOnly.nodes.map((n) => n.id)).toEqual(["holmes", "watson"]);
+    expect(strongOnly.edges.map((e) => e.relation)).toEqual(["works_with"]);
+
+    const withWeak = computeFocusSubgraph(
+      graph,
+      withGraphState(focused, { mode: "focus", focusHops: 2, showWeakLinks: true }),
+    );
+    expect(withWeak.nodes.map((n) => n.id)).toEqual(["holmes", "watson", "crime"]);
+    expect(withWeak.edges.map((e) => e.relation)).toEqual(["works_with", "observes"]);
+  });
+
+  it("selects graph nodes from workbench memory by type and entity id", () => {
+    const state = withGraphState(
+      {
+        ...createDefaultViewerState(),
+        selectedTypes: ["Evidence"],
+        selectedEntities: ["holmes"],
+        selectionState: { kind: "members", ref: "queue:needs_review", entityIds: ["crime"] },
+      },
+      { mode: "selection", showWeakLinks: true },
+    );
+
+    const subgraph = computeFocusSubgraph(graph, state);
+    expect(subgraph.appliedMode).toBe("selection");
+    expect(subgraph.nodes.map((n) => n.id)).toEqual(["holmes", "crime", "ring"]);
+    expect(subgraph.edges.map((e) => e.relation)).toEqual(["leaves_evidence"]);
+    expect(subgraph.metrics).toMatchObject({
+      nodes: 3,
+      edges: 1,
+      communities: 2,
+      topHubId: "crime",
+    });
+  });
+
+  it("accepts native graph.json links as the edge collection", () => {
+    const state = withGraphState(createDefaultViewerState(), { mode: "overview" });
+    const subgraph = computeFocusSubgraph(graphJsonShape, state);
+    expect(subgraph.metrics.edges).toBe(2);
+    expect(subgraph.edges.map((e) => e.relation)).toEqual([
+      "works_with",
+      "leaves_evidence",
+    ]);
+  });
+
+  it("renders metrics and safely embeds an exported graph surface", () => {
+    const tokens = getWorkspaceTokens("dark");
+    const state = withGraphState(createDefaultViewerState(), { mode: "overview" });
+
+    const html = renderGraphPanel({
+      graph,
+      state: { ...state, focusEntityId: "<bad>" },
+      tokens,
+      graphHtmlUrl: 'graph.html" onload="alert(1)',
+      height: 320,
+    });
+
+    expect(html).toContain("<b>Nodes:</b> 4");
+    expect(html).toContain("<b>Edges:</b> 2");
+    expect(html).toContain("<b>Mode:</b> Overview");
+    expect(html).toContain("&lt;bad&gt;");
+    expect(html).toContain('height:320px');
+    expect(html).toContain("graph.html&quot; onload=&quot;alert(1)");
+    expect(html).not.toContain('" onload="alert(1)');
+    expect(html).toContain('sandbox="allow-scripts"');
+    expect(html).not.toContain("allow-same-origin");
+  });
+
+  it("blocks javascript graph URLs and keeps the placeholder bounded", () => {
+    const html = renderGraphPanel({
+      graph,
+      state: createDefaultViewerState(),
+      tokens: getWorkspaceTokens("dark"),
+      graphHtmlUrl: "javascript:alert(1)",
+      height: 80,
+    });
+    expect(html).not.toContain("<iframe");
+    expect(html).not.toContain("javascript:alert(1)");
+    expect(html).not.toContain("graphify export");
+    expect(html).toContain("ws-graph-placeholder");
+  });
+
+  it("lets the workspace shell replace the G2 graph stub with the rendered panel", () => {
+    const graphPanelHtml = '<div id="custom-graph-panel">Graph metrics</div>';
+    const html = renderWorkspaceShell({
+      tokens: getWorkspaceTokens("dark"),
+      title: "Ontology workspace",
+      graphPanelHtml,
+    });
+
+    expect(html).toContain(graphPanelHtml);
+    expect(html).not.toContain("vis.js graph surface arrives in G4.");
+  });
+});

--- a/tests/workspace-shell.test.ts
+++ b/tests/workspace-shell.test.ts
@@ -20,6 +20,13 @@ describe("Track G G2 — workspace shell scaffold", () => {
     expect(html).toContain('role="application"');
   });
 
+  it("keeps central display copy neutral until item rendering is wired", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Ontology workspace" });
+    expect(html).toContain("No display item selected.");
+    expect(html).not.toContain("G4 fills");
+    expect(html).not.toContain("Track A wiki sidecar");
+  });
+
   it("escapes the title so HTML in user input cannot break the shell", () => {
     const html = renderWorkspaceShell({
       tokens,


### PR DESCRIPTION
## Summary
- Add a pure workspace graph-selection layer for overview, focus, and selection slices over Graphify `graph.json` payloads.
- Add a server-rendered graph panel with metrics, safe optional iframe embedding, and shell slot wiring.
- Add workspace G4 tests and a declaration shim for optional `@sentropic/design-system/tokens` so lint works without the package installed.

## Validation
- `npx vitest run tests/workspace-tokens.test.ts tests/workspace-shell.test.ts tests/workspace-viewer-state.test.ts tests/workspace-graph-panel.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (rerun outside sandbox because server tests need 127.0.0.1 listen)
- `git diff --check`
- `node dist/cli.js portable-check .graphify`
- `npx graphify hook-rebuild --scope tracked`