### PR TITLE
Track G G5 workspace alignment

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,24 +1,24 @@
-# Graph Report - .  (2026-05-21)
+# Graph Report - .  (2026-05-22)
 
 ## Corpus Check
-- 267 files · ~336,759 words
+- 268 files · ~338,969 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4220 nodes · 6764 edges · 221 communities detected
+- 4253 nodes · 6837 edges · 223 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 
 ## Input Scope
-- Requested: tracked
-- Resolved: tracked (source: cli)
-- Included files: 267 · Candidates: 287
-- Excluded: 0 untracked · 15719 ignored · 4 sensitive · 0 missing committed
+- Requested: auto
+- Resolved: committed (source: default-auto)
+- Included files: 268 · Candidates: 288
+- Excluded: 0 untracked · 15726 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `d06f3f8`
+- Built from Git commit: `d7c6046`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -46,869 +46,841 @@
 
 ## Communities
 
-### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (79): analysis, analysisPath, analysisValues, article, artifact, cacheKey, captionsDir, configOut (+71 more)
+### Community 34 - "Community 34"
+Cohesion: 0.11
+Nodes (30): GraphInstance, JSON_NOISE_LABELS, nodeCommunityMap(), isFileNode(), isConceptNode(), isJsonKeyNode(), fileCategory(), topLevelDir() (+22 more)
 
-### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
+### Community 111 - "Community 111"
+Cohesion: 0.23
+Nodes (10): estimateTokens(), querySubgraphTokens(), SAMPLE_QUESTIONS, BenchmarkOptions, loadGraph(), runBenchmark(), estimateTokens(), querySubgraphTokens() (+2 more)
 
-### Community 2 - "Community 2"
-Cohesion: 0.03
-Nodes (58): alphaNeighbors, audit, beforeAudit, beforeDecisions, betaNeighbors, candidate, candidateResponse, candidates (+50 more)
-
-### Community 3 - "Community 3"
-Cohesion: 0.05
-Nodes (48): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+40 more)
-
-### Community 4 - "Community 4"
-Cohesion: 0.05
-Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+44 more)
-
-### Community 5 - "Community 5"
-Cohesion: 0.06
-Nodes (53): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderMetricsCard(), renderViewerSurface() (+45 more)
-
-### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
-
-### Community 7 - "Community 7"
-Cohesion: 0.05
-Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
-
-### Community 8 - "Community 8"
-Cohesion: 0.06
-Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
-
-### Community 9 - "Community 9"
-Cohesion: 0.04
-Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
-
-### Community 10 - "Community 10"
-Cohesion: 0.07
-Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
-
-### Community 11 - "Community 11"
-Cohesion: 0.06
-Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.05
-Nodes (34): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+26 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.09
-Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
+### Community 87 - "Community 87"
+Cohesion: 0.20
+Nodes (14): BuildOptions, normalizeSourceFilePath(), normalizedLabel(), dedupLabelKey(), asRecord(), asString(), sourceKey(), rootForOptions() (+6 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.07
-Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.06
-Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.10
-Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.05
-Nodes (37): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+29 more)
-
-### Community 20 - "Community 20"
-Cohesion: 0.10
-Nodes (30): ConnectError, ConnectTimeout, PoolTimeout, ProtocolError, ProxyError, An error occurred at the transport layer., Timed out while connecting to the host., Timed out while receiving data from the host. (+22 more)
-
-### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.11
-Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+18 more)
+Nodes (43): StatIndexEntry, statIndex, statIndexFile(), ensureStatIndex(), flushStatIndex(), statMtimeNs(), CacheOptions, bodyContent() (+35 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.06
-Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.07
-Nodes (35): Cookies, build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str() (+27 more)
-
-### Community 25 - "Community 25"
-Cohesion: 0.10
-Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
-
-### Community 26 - "Community 26"
-Cohesion: 0.05
-Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
-
-### Community 27 - "Community 27"
-Cohesion: 0.08
-Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
-
-### Community 28 - "Community 28"
-Cohesion: 0.07
-Nodes (35): Exception, CloseError, ConnectTimeout, CookieConflict, DecodingError, HTTPError, HTTPStatusError, NetworkError (+27 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.08
-Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
-
-### Community 30 - "Community 30"
-Cohesion: 0.09
-Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.09
-Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.09
-Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.09
-Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.10
-Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
-
-### Community 35 - "Community 35"
-Cohesion: 0.11
-Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.11
-Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.08
-Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.06
-Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.09
-Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.16
-Nodes (16): Auth, BasicAuth, BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.08
-Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.12
-Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
-
-### Community 43 - "Community 43"
-Cohesion: 0.10
-Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.12
-Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.16
-Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.12
-Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.07
-Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.09
-Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
-
-### Community 49 - "Community 49"
-Cohesion: 0.07
-Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
-
-### Community 50 - "Community 50"
-Cohesion: 0.13
-Nodes (2): AsyncClient, Client
-
-### Community 51 - "Community 51"
-Cohesion: 0.10
-Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
-
-### Community 52 - "Community 52"
-Cohesion: 0.13
-Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
-
-### Community 53 - "Community 53"
-Cohesion: 0.10
-Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
-
-### Community 54 - "Community 54"
-Cohesion: 0.14
-Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.09
-Nodes (6): Core data models: URL, Headers, Cookies, Request, Response. These are the centra, HTTPStatusError, A 4xx or 5xx response was received., Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, URL
-
-### Community 56 - "Community 56"
-Cohesion: 0.14
-Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
-
-### Community 57 - "Community 57"
-Cohesion: 0.16
-Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
-
-### Community 58 - "Community 58"
-Cohesion: 0.11
-Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+4 more)
+Nodes (25): __filename, __dirname, VERSION, splitFiles(), changedFilesFromGit(), readJson(), isJsonRecord(), loadWikiDescriptionSidecarIndex() (+17 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.10
-Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
+Cohesion: 0.16
+Nodes (26): writeFileAtomic(), canonicalPlatformName(), runtimeGlobalSkillPlatformName(), platformNamesForError(), resolveGlobalSkillDestination(), previewPath(), emptyPreview(), platformInstallPreview() (+18 more)
 
-### Community 60 - "Community 60"
-Cohesion: 0.09
-Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
+### Community 144 - "Community 144"
+Cohesion: 0.24
+Nodes (10): opencodeConfigPath(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), getAgentsMdSection(), installOpenCodePlugin(), uninstallOpenCodePlugin(), installCodexHook(), uninstallCodexHook() (+2 more)
 
-### Community 61 - "Community 61"
-Cohesion: 0.13
-Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
+### Community 157 - "Community 157"
+Cohesion: 0.25
+Nodes (9): uninstallAll(), uninstallGeminiMcp(), cursorUninstall(), antigravityUninstall(), kiroUninstall(), vscodeUninstall(), uninstallClaudeHook(), claudeUninstall() (+1 more)
 
-### Community 62 - "Community 62"
-Cohesion: 0.13
-Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
-
-### Community 63 - "Community 63"
-Cohesion: 0.10
-Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
-
-### Community 64 - "Community 64"
-Cohesion: 0.11
-Nodes (16): AnalysisFile, analyzeGraph(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion(), main() (+8 more)
-
-### Community 65 - "Community 65"
-Cohesion: 0.13
-Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
-
-### Community 66 - "Community 66"
-Cohesion: 0.09
-Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
-
-### Community 67 - "Community 67"
-Cohesion: 0.09
-Nodes (20): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+12 more)
-
-### Community 68 - "Community 68"
-Cohesion: 0.09
-Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
-
-### Community 69 - "Community 69"
-Cohesion: 0.15
-Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.15
-Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
-
-### Community 72 - "Community 72"
-Cohesion: 0.09
-Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.09
-Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
-
-### Community 74 - "Community 74"
-Cohesion: 0.11
-Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
-
-### Community 75 - "Community 75"
-Cohesion: 0.14
-Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
-
-### Community 76 - "Community 76"
-Cohesion: 0.10
-Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
-
-### Community 77 - "Community 77"
-Cohesion: 0.15
-Nodes (15): candidateFilters(), decisionLogOptions(), handleOntologyStudioRequest(), htmlResult(), jsonResult(), LOOPBACK_HOSTS, OntologyStudioHandlerOptions, OntologyStudioRouteResult (+7 more)
+### Community 158 - "Community 158"
+Cohesion: 0.39
+Nodes (7): canonicalizeForPartition(), partition(), splitCommunity(), ClusterOptions, cluster(), cohesionScore(), scoreAll()
 
 ### Community 78 - "Community 78"
 Cohesion: 0.13
-Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
+Nodes (13): NumericMapLike, StringMapLike, ReportHighRiskNode, ReportTestGap, ReportReviewOptions, GenerateReportOptions, normalizeFlows(), normalizeAffectedFlows() (+5 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.24
+Nodes (9): normalizeCommunityLabel(), readLabelsJson(), readGraphAttributeLabels(), resolveCommunityLabels(), persistCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
+
+### Community 56 - "Community 56"
+Cohesion: 0.14
+Nodes (21): DETECTION_FILE_TYPES, ConfiguredDetectionInputs, ProfileState, ConfiguredDataprepOptions, ConfiguredDataprepResult, uniqueResolved(), fullPageScreenshotExcludes(), buildConfiguredDetectionInputs() (+13 more)
+
+### Community 94 - "Community 94"
+Cohesion: 0.16
+Nodes (16): uniqueResolved(), fullPageScreenshotExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), warningFor(), recomputeDetection(), mergeScopeInspections(), mergeDetections() (+8 more)
+
+### Community 37 - "Community 37"
+Cohesion: 0.06
+Nodes (9): ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, AnalyzeChangesOptions, DetectChangesNodeRisk, DetectChangesTestGap, DetectChangesResult, DetectChangesMinimalResult (+1 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.60
+Nodes (5): uniqueSorted(), sortNodesByLocation(), mapChangesToNodes(), changedNodesFromFiles(), analyzeChanges()
+
+### Community 65 - "Community 65"
+Cohesion: 0.10
+Nodes (22): CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, IMAGE_EXTENSIONS, OFFICE_EXTENSIONS, GOOGLE_WORKSPACE_EXTENSIONS, VIDEO_EXTENSIONS, SENSITIVE_PATTERNS (+14 more)
+
+### Community 135 - "Community 135"
+Cohesion: 0.22
+Nodes (11): isSensitive(), countWords(), isNoiseDir(), matchGlob(), relativeWithin(), matchesIgnorePattern(), isIgnored(), walkDir() (+3 more)
+
+### Community 209 - "Community 209"
+Cohesion: 0.67
+Nodes (4): officeParseToText(), docxToMarkdown(), xlsxToMarkdown(), convertOfficeFile()
+
+### Community 205 - "Community 205"
+Cohesion: 0.50
+Nodes (5): md5File(), loadManifest(), normaliseManifestEntry(), saveManifest(), detectIncremental()
+
+### Community 95 - "Community 95"
+Cohesion: 0.17
+Nodes (13): DirectSemanticFile, DirectSemanticChunk, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, PackSemanticFilesOptions, DirectSemanticClientOptions, toPortableRelative(), estimateFileTokens() (+5 more)
+
+### Community 61 - "Community 61"
+Cohesion: 0.10
+Nodes (20): BACKUP_ARTIFACTS, todayIso(), backupIfProtected(), COMMUNITY_COLORS, inferNodeShape(), CONFIDENCE_SCORE_DEFAULTS, CommunityLabelsInput, CommunityLabelOptions (+12 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.25
+Nodes (8): nodeCommunityMap(), isSvgOptions(), buildFreshnessMetadata(), computeTopologySignatureFromLinks(), computeTopologySignature(), toJson(), toGraphml(), toSvg()
+
+### Community 145 - "Community 145"
+Cohesion: 0.24
+Nodes (10): isCommunityLabelOptions(), isCanvasOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile(), htmlStyles(), hyperedgeScript(), htmlScript() (+2 more)
+
+### Community 18 - "Community 18"
+Cohesion: 0.05
+Nodes (38): SyntaxNode, Tree, moduleRequire, _languageCache, TsconfigAliasEntry, tsconfigAliasCache, TsconfigDocument, stripJsonc() (+30 more)
+
+### Community 106 - "Community 106"
+Cohesion: 0.39
+Nodes (15): ensureParserInit(), parseText(), resolveGrammarWasm(), loadLanguage(), qualifiedFileStem(), buildResolvableLabelIndex(), _extractPythonRationale(), extractJulia() (+7 more)
+
+### Community 70 - "Community 70"
+Cohesion: 0.15
+Nodes (22): _makeId(), _readText(), _resolveName(), _importPython(), _importJava(), _importC(), _importCsharp(), _importKotlin() (+14 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.25
+Nodes (11): toPortablePath(), inferCommonRoot(), projectRelativeFilePath(), loadTsconfigAliases(), normalizeJsImportTarget(), resolveJsImportTargetInfo(), resolveJsImportTarget(), remapFileNodeIds() (+3 more)
+
+### Community 112 - "Community 112"
+Cohesion: 0.15
+Nodes (13): _extractGeneric(), extractPython(), extractJs(), extractJava(), extractC(), extractCpp(), extractRuby(), extractCsharp() (+5 more)
+
+### Community 146 - "Community 146"
+Cohesion: 0.20
+Nodes (10): lineForIndex(), extractRegexBackedCode(), simpleGroovyTypeName(), braceDelta(), extractGroovy(), normalizeSqlObjectName(), sqlStatementBlock(), extractSql() (+2 more)
+
+### Community 3 - "Community 3"
+Cohesion: 0.05
+Nodes (48): DetectEntryPointsOptions, TraceFlowsOptions, BuildFlowArtifactOptions, ReviewFlow, ReviewFlowStep, ReviewFlowDetail, ReviewFlowArtifact, AffectedFlowsResult (+40 more)
+
+### Community 100 - "Community 100"
+Cohesion: 0.24
+Nodes (14): GitContext, execGit(), safeExecGit(), resolveFromGitCwd(), gitRevParse(), safeGitRevParse(), isSafeGitPath(), resolveGitContext() (+6 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.18
+Nodes (13): GOOGLE_WORKSPACE_EXTENSIONS, EXPORT_MIME_TYPE_BY_EXTENSION, GoogleWorkspaceShortcut, GoogleWorkspaceFetcher, ConvertGoogleWorkspaceOptions, extractFileIdFromUrl(), extractResourceKey(), readGoogleShortcut() (+5 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.39
+Nodes (8): SerializedGraphData, createGraph(), isDirectedGraph(), loadGraphFromData(), serializeGraph(), toUndirectedGraph(), forEachTraversalNeighbor(), traversalNeighbors()
+
+### Community 42 - "Community 42"
+Cohesion: 0.10
+Nodes (28): HookDefinition, HOOKS, GRAPH_GITATTR_LINES, installHook(), uninstallHook(), hookBlockRegex(), escapeRegExp(), readTextFile() (+20 more)
+
+### Community 189 - "Community 189"
+Cohesion: 0.33
+Nodes (3): ToHtmlOptions, HtmlWriter, SafeToHtmlOptions
+
+### Community 194 - "Community 194"
+Cohesion: 0.33
+Nodes (1): CONFIDENCE_VALUES
+
+### Community 132 - "Community 132"
+Cohesion: 0.33
+Nodes (10): VALID_DENSITY, VALID_ROUTING_SIGNAL, isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray() (+2 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.14
+Nodes (16): ExportImageDataprepBatchRequestsOptions, ExportImageDataprepBatchRequestsResult, ImportImageDataprepBatchResultsOptions, ImportImageDataprepBatchResultsResult, readJsonl(), asRecord(), readCaption(), artifactHasDeepRoute() (+8 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.12
+Nodes (26): ImageDataprepSourceKind, ImageDataprepArtifact, ImageDataprepManifest, BuildImageDataprepManifestOptions, RunImageDataprepOptions, RunImageDataprepResult, sha256(), fileHash() (+18 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.07
+Nodes (40): ImageRoutingLabel, ImageRoute, ImageRoutingCalibrationDecision, ImageRoutingLabelEntry, ImageRoutingLabelsFile, ImageRoutingRuleBucket, ImageRoutingRulesFile, ImageRoutingSample (+32 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.09
+Nodes (18): cleanupDirs, detection, dir, G, communities, cohesion, labels, gods (+10 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.33
+Nodes (13): yamlStr(), yamlQuoted(), safeFilename(), detectUrlType(), htmlToMarkdown(), fetchTweet(), fetchWebpage(), fetchArxiv() (+5 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.13
+Nodes (21): InspectInputScopeOptions, InputScopeInventory, InputScopeSelection, GitScopeContext, VALID_SCOPE_MODES, toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
+
+### Community 160 - "Community 160"
+Cohesion: 0.31
+Nodes (9): splitGitLines(), pathspecForPrefix(), resolveGitScopeContext(), makeScope(), countGitPaths(), gitInventory(), buildGitInventory(), fallbackAllScope() (+1 more)
+
+### Community 41 - "Community 41"
+Cohesion: 0.12
+Nodes (30): WorktreeMetadata, BranchMetadata, LifecycleMetadata, RefreshLifecycleOptions, PruneCandidate, PrunePlan, readJson(), writeJson() (+22 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.05
+Nodes (34): LlmExecutionCapability, LlmExecutionMode, DirectLlmProvider, DIRECT_LLM_PROVIDERS, TextJsonGenerationInput, VisionJsonAnalysisInput, BatchVisionExportInput, BatchVisionImportInput (+26 more)
+
+### Community 125 - "Community 125"
+Cohesion: 0.17
+Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, tempDirs, dir, mesh, client
+
+### Community 180 - "Community 180"
+Cohesion: 0.43
+Nodes (5): MergeGraphJsonResult, readGraph(), hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles()
+
+### Community 170 - "Community 170"
+Cohesion: 0.36
+Nodes (6): MergeGraphsOptions, MergeGraphsResult, mergedGraphType(), mergeHyperedgesFromGraphs(), mergeGraphsFromFiles(), mergeHyperedges()
+
+### Community 64 - "Community 64"
+Cohesion: 0.13
+Nodes (21): MigrationAction, MigrationEntryType, MigrationEntry, MigrationGitAdvice, GraphifyOutMigrationPlan, GraphifyOutMigrationResult, MigrationOptions, shellQuote() (+13 more)
 
 ### Community 79 - "Community 79"
+Cohesion: 0.15
+Nodes (15): MinimalContextRisk, BuildMinimalContextOptions, MinimalContextResult, uniqueSorted(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames() (+7 more)
+
+### Community 38 - "Community 38"
+Cohesion: 0.09
+Nodes (30): OntologyDiscoveryProposalKind, OntologyDiscoveryProposalAction, OntologyDiscoverySampleOptions, OntologyDiscoverySampleFile, OntologyDiscoverySampleRegistryRecord, OntologyDiscoverySample, OntologyDiscoveryProposal, OntologyDiscoveryProposalsFile (+22 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.06
+Nodes (33): OntologyOutputConfig, CompileOntologyOutputsOptions, CompileOntologyOutputsResult, CompiledNode, CompiledRelation, sha256(), stringValue(), ontologyNodeType() (+25 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.42
+Nodes (7): ProfilePatchRuntimeContext, readJson(), optionalJson(), stringValue(), evidenceRefsFromSources(), loadProfilePatchRuntimeContext(), loadOntologyPatchContext()
+
+### Community 46 - "Community 46"
+Cohesion: 0.09
+Nodes (28): ONTOLOGY_RECONCILIATION_DECISION_LOG_SCHEMA, OntologyPatchOperation, OntologyPatchStatus, OntologyPatch, OntologyPatchNode, OntologyPatchRelation, OntologyPatchContext, OntologyPatchIssue (+20 more)
+
+### Community 147 - "Community 147"
+Cohesion: 0.42
+Nodes (10): nonEmptyString(), addError(), nodeType(), nodeById(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateSetStatus() (+2 more)
+
+### Community 148 - "Community 148"
+Cohesion: 0.24
+Nodes (10): stringArray(), addWarning(), knownEvidenceRefs(), validateEvidenceRefs(), normalizeOntologyPatch(), validateOntologyPatch(), appendJsonLine(), auditPath() (+2 more)
+
+### Community 17 - "Community 17"
+Cohesion: 0.10
+Nodes (43): DEFAULT_STATUSES, VALID_CITATION_MINIMUMS, VIS_JS_SHAPE_LIST, VIS_JS_SHAPES, asRecord(), asStringArray(), normalizeStringMap(), stableForHash() (+35 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.33
+Nodes (11): OntologyRebuildStatusResponse, readableStatePath(), ontologyReconciliationCandidatesPath(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), loadReadonlyReconciliationCandidates(), reconciliationQueueIsStale(), listOntologyReconciliationCandidates() (+3 more)
+
+### Community 66 - "Community 66"
 Cohesion: 0.13
-Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
-
-### Community 80 - "Community 80"
-Cohesion: 0.15
-Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
-
-### Community 81 - "Community 81"
-Cohesion: 0.15
-Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
+Nodes (20): ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA, ONTOLOGY_RECONCILIATION_CANDIDATES_RESPONSE_SCHEMA, OntologyReconciliationCandidateKind, OntologyReconciliationCandidateStatus, OntologyReconciliationCandidate, OntologyReconciliationCandidateQueue, OntologyReconciliationCandidateFilter, OntologyReconciliationCandidatesResponse (+12 more)
 
 ### Community 82 - "Community 82"
+Cohesion: 0.21
+Nodes (17): ReconciliationWorkspaceModel, RenderOntologyStudioWorkspaceOptions, HTML_ESCAPE_MAP, escapeHtml(), percent(), renderStudioStyles(), renderList(), graphNodeById() (+9 more)
+
+### Community 171 - "Community 171"
+Cohesion: 0.39
+Nodes (8): displayText(), graphNodeTitle(), graphNodeType(), graphNodeSummary(), graphNodeCommunity(), graphNodeMetaRows(), renderMetaRows(), renderEntityCard()
+
+### Community 97 - "Community 97"
+Cohesion: 0.15
+Nodes (10): LOOPBACK_HOSTS, OntologyStudioWriteOptions, OntologyStudioHandlerOptions, StartOntologyStudioServerOptions, StartedOntologyStudioServer, OntologyStudioRouteResult, isLoopbackHost(), generateOntologyStudioToken() (+2 more)
+
+### Community 149 - "Community 149"
+Cohesion: 0.31
+Nodes (10): optionalString(), optionalNumber(), optionalInteger(), candidateFilters(), decisionLogOptions(), jsonResult(), htmlResult(), graphHtmlArtifactResult() (+2 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.15
+Nodes (21): GraphifyPathOptions, GraphifyScratchPaths, GraphifyLegacyRootScratchPaths, GraphifyProfilePaths, GraphifyImageDataprepPaths, GraphifyOntologyOutputPaths, GraphifyPaths, statePath() (+13 more)
+
+### Community 53 - "Community 53"
 Cohesion: 0.13
-Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
+Nodes (26): PDF_IMAGE_EXTENSIONS, PdfPreparationArtifact, PdfPreparationOptions, MistralOcrModule, cloneDetection(), countWords(), metadataPath(), listImageArtifacts() (+18 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.12
+Nodes (23): PdfOcrMode, PdfTextLayerProvider, PdfPreflightOptions, PdfPreflightResult, PdfTextLayerResult, UnpdfTextResult, normalizeText(), countWords() (+15 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.13
+Nodes (15): BuildProjectOptions, BuildProjectWarning, BuildProjectArtifacts, BuildProjectResult, countNonCodeFiles(), formatDiagnosticSummary(), fileList(), buildProject() (+7 more)
+
+### Community 6 - "Community 6"
+Cohesion: 0.06
+Nodes (49): PortablePathIssueKind, PortablePathIssue, PortableCheckResult, LOCAL_LIFECYCLE_FILES, LOCAL_LIFECYCLE_PREFIXES, TEXT_ARTIFACT_EXTENSIONS, isWindowsAbsolutePath(), hasSchemePrefix() (+41 more)
+
+### Community 30 - "Community 30"
+Cohesion: 0.09
+Nodes (32): CommandRunner, PullRequestSummary, PullRequestDetails, WorktreePrInfo, PrCommandOptions, defaultRunner, optionsWithDefaults(), normalizeString() (+24 more)
+
+### Community 33 - "Community 33"
+Cohesion: 0.10
+Nodes (33): ProfilePromptState, ProfilePromptOptions, ProfilePromptChunk, sampleLimit(), nodeTypeSection(), relationTypeSection(), relationMetadataSection(), registrySection() (+25 more)
+
+### Community 102 - "Community 102"
+Cohesion: 0.19
+Nodes (12): readRegistryRows(), field(), normalizeRegistryRecord(), loadProfileRegistry(), safeIdPart(), registryRecordsToExtraction(), readRegistryRows(), field() (+4 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.10
+Nodes (34): ProfileReportGraphData, ProfileReportPdfArtifact, ProfileReportContext, rel(), stringValue(), graphNodes(), graphLinks(), projectConfigSection() (+26 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.09
+Nodes (32): ProfileValidationSeverity, ProfileValidationIssue, ProfileValidationContext, ProfileValidationResult, stringValue(), stringArray(), citations(), addIssue() (+24 more)
+
+### Community 58 - "Community 58"
+Cohesion: 0.14
+Nodes (23): CONFIG_CANDIDATES, VALID_PDF_OCR_MODES, VALID_CITATION_MINIMUMS, VALID_LLM_EXECUTION_MODES, VALID_IMAGE_ARTIFACT_SOURCES, VALID_INPUT_SCOPE_MODES, asRecord(), asStringArray() (+15 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.06
+Nodes (23): CommitRecommendationConfidence, CommitRecommendationStaleness, CommitRecommendationGroup, CommitRecommendation, CommitRecommendationOptions, FileGraphInfo, GroupDraft, normalizePath() (+15 more)
+
+### Community 195 - "Community 195"
+Cohesion: 0.47
+Nodes (6): uniqueSorted(), mergeDrafts(), stalenessFrom(), minConfidence(), groupConfidence(), buildCommitRecommendation()
+
+### Community 88 - "Community 88"
+Cohesion: 0.17
+Nodes (13): CloneRepoOptions, CloneRepoResult, GithubRepoRef, execGit(), maybeGithubRepo(), repoNameFromUrl(), defaultCloneDestination(), cloneRepo() (+5 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.07
+Nodes (11): ReviewRiskLevel, ReviewBlastRadius, ReviewImpactedCommunity, ReviewMultimodalSafety, ReviewAnalysis, ReviewAnalysisOptions, ReviewEvaluationCase, ReviewEvaluationCaseResult (+3 more)
+
+### Community 172 - "Community 172"
+Cohesion: 0.25
+Nodes (8): uniqueSorted(), riskLevel(), communityRisk(), nodeCommunities(), buildBlastRadius(), impactedCommunities(), multimodalSafety(), buildReviewAnalysis()
+
+### Community 218 - "Community 218"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 219 - "Community 219"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 11 - "Community 11"
+Cohesion: 0.06
+Nodes (39): ReviewBenchmarkCase, ReviewBenchmarkOptions, ReviewBenchmarkTokenBudgetStatus, ReviewBenchmarkMetrics, ReviewBenchmarkCaseResult, ReviewBenchmarkResult, normalize(), uniqueSorted() (+31 more)
+
+### Community 5 - "Community 5"
+Cohesion: 0.05
+Nodes (52): ReviewContextDetailLevel, ReviewContextRisk, BuildReviewContextOptions, ReviewContextPayload, ReviewContextResult, normalizePath(), uniqueSorted(), sourceMatches() (+44 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.13
+Nodes (16): ReviewGraphNodeKind, ReviewGraphNode, ReviewGraphEdge, ReviewImpactRadius, ReviewGraphStats, ReviewGraphStoreLike, KNOWN_KINDS, normalizePath() (+8 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.05
+Nodes (38): ReviewNode, ReviewChain, ReviewDelta, ReviewDeltaOptions, compareStrings(), normalizePath(), uniqueSorted(), maybeCommunity() (+30 more)
+
+### Community 173 - "Community 173"
+Cohesion: 0.32
+Nodes (6): normalizeSearchText(), textMatchesQuery(), scoreSearchText(), terms, exact, substring
+
+### Community 113 - "Community 113"
+Cohesion: 0.22
+Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, validateUrl(), isPrivateIp(), validateHostname(), isRedirectStatus(), safeFetch(), safeFetchText()
+
+### Community 123 - "Community 123"
+Cohesion: 0.17
+Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }, tempDirs, imagePath, packageJson, packageLock, outputDir
+
+### Community 49 - "Community 49"
+Cohesion: 0.09
+Nodes (16): ServeOptions, McpToolDefinition, McpResourceDefinition, GraphSnapshot, ReloadingGraphStore, MCP_RESOURCES, graphPath, loadGraph() (+8 more)
+
+### Community 162 - "Community 162"
+Cohesion: 0.25
+Nodes (9): GraphFileSignature, validateGraphFilePath(), readGraphData(), loadGraphSnapshot(), createReloadingGraphStore(), getVersion(), communitiesFromGraph(), serve() (+1 more)
+
+### Community 114 - "Community 114"
+Cohesion: 0.21
+Nodes (13): communityName(), mcpField(), nodeDisplayLabel(), scoreNodes(), bfs(), dfs(), subgraphToText(), findNode() (+5 more)
+
+### Community 181 - "Community 181"
+Cohesion: 0.29
+Nodes (7): toolGodNodes(), toolGraphStats(), communityLabelsFromGraph(), resourceConfidenceAudit(), resourceSurprises(), resourceQuestions(), readMcpResource()
+
+### Community 183 - "Community 183"
+Cohesion: 0.33
+Nodes (7): optionalString(), optionalNumber(), optionalInteger(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog(), ontologyAppliedPatchesPath()
+
+### Community 182 - "Community 182"
+Cohesion: 0.43
+Nodes (7): toolListReconciliationCandidates(), toolOntologyRebuildStatus(), readableStatePath(), ontologyReconciliationCandidatesPath(), ontologyNeedsUpdatePath(), loadReadonlyReconciliationCandidates(), reconciliationQueueIsStale()
+
+### Community 127 - "Community 127"
+Cohesion: 0.17
+Nodes (7): tempDirs, bannedReportFirstPatterns, paths, dir, claudeSettings, old, updated
+
+### Community 43 - "Community 43"
+Cohesion: 0.10
+Nodes (22): __filename, __dirname, AnalysisFile, readJson(), writeJson(), scopeOptionDescription(), cacheOptionsFromRuntime(), ProfileRuntimeContext (+14 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.08
+Nodes (31): FirstHopHub, FirstHopCommunity, FirstHopSummary, FirstHopSummaryOptions, compareStrings(), round(), maybeCommunity(), communityLabels() (+23 more)
+
+### Community 31 - "Community 31"
+Cohesion: 0.09
+Nodes (35): URL_PREFIXES, CACHED_AUDIO_EXTENSIONS, REQUIRED_MODEL_FILES, SUPPORTED_MODELS, MODEL_ALIASES, FasterWhisperSegment, FasterWhisperTranscriptionOptions, FasterWhisperModel (+27 more)
+
+### Community 184 - "Community 184"
+Cohesion: 0.33
+Nodes (4): RenderTreeOptions, TreeNeighbor, nodeLabel(), renderTree()
+
+### Community 1 - "Community 1"
+Cohesion: 0.02
+Nodes (82): FileType, Confidence, GraphifyInputScopeMode, GraphifyResolvedInputScopeMode, InputScopeSource, InputScopeInspection, GraphNode, GraphEdge (+74 more)
+
+### Community 220 - "Community 220"
+Cohesion: 1.00
+Nodes (1): UnpdfTextResult
+
+### Community 163 - "Community 163"
+Cohesion: 0.25
+Nodes (7): VALID_FILE_TYPES, VALID_CONFIDENCES, REQUIRED_NODE_FIELDS, REQUIRED_EDGE_FIELDS, validateExtraction(), assertValid(), errors
+
+### Community 115 - "Community 115"
+Cohesion: 0.21
+Nodes (9): WATCHED_EXTENSIONS, mergeHyperedges(), builtFromCommit(), rebuildCode(), CheckUpdateResult, checkUpdate(), rebuildLockPath(), acquireRebuildLock() (+1 more)
+
+### Community 164 - "Community 164"
+Cohesion: 0.22
+Nodes (4): WIKI_DESCRIPTION_BATCH_SCHEMA, BuildWikiDescriptionBatchOptions, WikiDescriptionBatchResultRecord, ParseWikiDescriptionBatchOptions
+
+### Community 29 - "Community 29"
+Cohesion: 0.09
+Nodes (36): RawNode, RawCommunity, WikiDescriptionTargetContext, WikiDescriptionNeighbor, CollectWikiDescriptionTargetsOptions, WikiDescriptionTargetCollection, BuildWikiDescriptionPromptOptions, GenerateWikiDescriptionSidecarsClients (+28 more)
+
+### Community 36 - "Community 36"
+Cohesion: 0.08
+Nodes (32): WIKI_DESCRIPTION_SCHEMA, WIKI_DESCRIPTION_PROMPT_VERSION, WikiDescriptionTargetKind, WikiDescriptionStatus, WikiDescriptionExecutionMode, WikiDescriptionEvidenceRef, WikiDescriptionGenerator, WikiDescriptionCacheKeyInput (+24 more)
+
+### Community 109 - "Community 109"
+Cohesion: 0.27
+Nodes (12): WikiPageRef, safeFilename(), uniquePageRefs(), normalizeFlows(), flowsThroughNodes(), crossCommunityLinks(), renderDescription(), communityArticle() (+4 more)
+
+### Community 4 - "Community 4"
+Cohesion: 0.06
+Nodes (54): RenderGraphPanelOptions, HTML_ESCAPE_MAP, escapeHtml(), escapeUrl(), modeLabel(), renderMetricsCard(), renderViewerSurface(), renderLiveGraphScript() (+46 more)
+
+### Community 19 - "Community 19"
+Cohesion: 0.05
+Nodes (37): graph, graphJsonShape, focused, strongOnly, withWeak, state, subgraph, tokens (+29 more)
+
+### Community 119 - "Community 119"
+Cohesion: 0.26
+Nodes (11): qn(), addFunction(), addCall(), makeFlowStore(), { artifact, store, ids }, result, { artifact, store }, qn() (+3 more)
+
+### Community 174 - "Community 174"
+Cohesion: 0.25
+Nodes (7): tempDirs, section, dir, agents, home, skillPath, skill
+
+### Community 110 - "Community 110"
+Cohesion: 0.14
+Nodes (12): G, gods, labels, godIds, communities, surprises, first, second (+4 more)
+
+### Community 210 - "Community 210"
+Cohesion: 0.50
+Nodes (3): backup, b1, b2
+
+### Community 175 - "Community 175"
+Cohesion: 0.25
+Nodes (6): cleanupDirs, dir, graphPath, graph, edge, attrs
+
+### Community 150 - "Community 150"
+Cohesion: 0.20
+Nodes (9): SAMPLE_EXTRACTION, G, edge, attrs, ext, hyper, hyperedges, ext1 (+1 more)
+
+### Community 196 - "Community 196"
+Cohesion: 0.33
+Nodes (5): tempDirs, dir, settings, commands, matchers
+
+### Community 0 - "Community 0"
+Cohesion: 0.02
+Nodes (79): tempDirs, dir, graphPath, graphDir, output, source, destRoot, dest (+71 more)
+
+### Community 221 - "Community 221"
+Cohesion: 1.00
+Nodes (2): tempProject(), tempProfileProject()
+
+### Community 212 - "Community 212"
+Cohesion: 0.67
+Nodes (3): runCli(), runSkillRuntime(), runMain()
+
+### Community 72 - "Community 72"
+Cohesion: 0.09
+Nodes (18): tempDirs, dir, skillDir, configOut, profileOut, statePath, extractionPath, reportPath (+10 more)
+
+### Community 89 - "Community 89"
+Cohesion: 0.12
+Nodes (15): G, result, allNodes, sizes, louvainMock, partition, nodes, first (+7 more)
+
+### Community 176 - "Community 176"
+Cohesion: 0.25
+Nodes (7): tempDirs, section, skill, readme, dir, hooks, commands
+
+### Community 99 - "Community 99"
+Cohesion: 0.13
+Nodes (10): cleanupDirs, fixtureRoot, root, config, inputs, detection, filtered, paths (+2 more)
+
+### Community 185 - "Community 185"
+Cohesion: 0.29
+Nodes (6): tempDirs, home, previousCwd, skillPath, versionPath, readme
+
+### Community 197 - "Community 197"
+Cohesion: 0.33
+Nodes (5): tempDirs, dir, rule, rulePath, original
+
+### Community 62 - "Community 62"
+Cohesion: 0.09
+Nodes (21): qn(), addNode(), parsed, G, funcA, funcB, store, nodes (+13 more)
+
+### Community 90 - "Community 90"
+Cohesion: 0.12
+Nodes (16): codeExts, result, sourceDir, subDir, repoDir, packagesDir, inventory, filePath (+8 more)
+
+### Community 206 - "Community 206"
+Cohesion: 0.40
+Nodes (4): root, files, chunks, client
+
+### Community 137 - "Community 137"
+Cohesion: 0.18
+Nodes (9): PROVIDERS, providerSelection, tempDirs, tempDir, outputPath, client, output, audit (+1 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.18
+Nodes (9): cleanupDirs, dir, graphPath, warnings, graph, written, persisted, outputPath (+1 more)
+
+### Community 139 - "Community 139"
+Cohesion: 0.18
+Nodes (10): cleanupDirs, dir, filePath, calls, importEdge, demoNode, callTargets, runNode (+2 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.09
+Nodes (15): validate(), process(), main(), HttpClient, Server, NewServer(), validate(), process() (+7 more)
+
+### Community 40 - "Community 40"
+Cohesion: 0.08
+Nodes (12): DataProcessor, Processor, GraphifyDemo, IProcessor, DataProcessor, Processor, Get-Data(), Process-Items() (+4 more)
 
 ### Community 83 - "Community 83"
 Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
-### Community 84 - "Community 84"
-Cohesion: 0.21
-Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
-
-### Community 85 - "Community 85"
-Cohesion: 0.12
-Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.12
-Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
-
-### Community 87 - "Community 87"
-Cohesion: 0.20
-Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
-
-### Community 88 - "Community 88"
-Cohesion: 0.17
-Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
-
-### Community 89 - "Community 89"
-Cohesion: 0.12
-Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.12
-Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
-
-### Community 91 - "Community 91"
-Cohesion: 0.13
-Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.13
-Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
-
-### Community 93 - "Community 93"
-Cohesion: 0.13
-Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
-
-### Community 94 - "Community 94"
-Cohesion: 0.16
-Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.17
-Nodes (13): DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape(), extractSemanticFilesDirectParallel() (+5 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.18
-Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.15
-Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.13
-Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
-
-### Community 99 - "Community 99"
-Cohesion: 0.24
-Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.13
-Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
-
-### Community 101 - "Community 101"
-Cohesion: 0.19
-Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
-
-### Community 102 - "Community 102"
-Cohesion: 0.13
-Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
-
-### Community 103 - "Community 103"
-Cohesion: 0.16
-Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
-
-### Community 104 - "Community 104"
-Cohesion: 0.15
-Nodes (1): AsyncClient
-
-### Community 105 - "Community 105"
-Cohesion: 0.39
-Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
-
-### Community 106 - "Community 106"
-Cohesion: 0.14
-Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
-
-### Community 107 - "Community 107"
-Cohesion: 0.33
-Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
-
-### Community 108 - "Community 108"
-Cohesion: 0.27
-Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
-
-### Community 109 - "Community 109"
-Cohesion: 0.14
-Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
-
-### Community 110 - "Community 110"
-Cohesion: 0.23
-Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
-
-### Community 111 - "Community 111"
-Cohesion: 0.15
-Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.22
-Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
-
-### Community 113 - "Community 113"
-Cohesion: 0.21
-Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.21
-Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
-
-### Community 115 - "Community 115"
-Cohesion: 0.15
-Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
-
-### Community 116 - "Community 116"
-Cohesion: 0.15
-Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
-
-### Community 117 - "Community 117"
-Cohesion: 0.15
-Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
-
-### Community 118 - "Community 118"
-Cohesion: 0.26
-Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
-
-### Community 119 - "Community 119"
-Cohesion: 0.26
-Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
-
-### Community 120 - "Community 120"
-Cohesion: 0.18
-Nodes (1): Headers
-
-### Community 121 - "Community 121"
-Cohesion: 0.18
-Nodes (1): Client
-
-### Community 122 - "Community 122"
-Cohesion: 0.17
-Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
-
-### Community 123 - "Community 123"
-Cohesion: 0.24
-Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
-
-### Community 124 - "Community 124"
-Cohesion: 0.17
-Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
-
-### Community 125 - "Community 125"
-Cohesion: 0.33
-Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.17
-Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
-
-### Community 127 - "Community 127"
-Cohesion: 0.17
-Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
-
-### Community 128 - "Community 128"
-Cohesion: 0.17
-Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.18
-Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
-
-### Community 130 - "Community 130"
-Cohesion: 0.25
-Nodes (4): build_graph(), Graph, build_graph(), Graph
-
-### Community 131 - "Community 131"
-Cohesion: 0.33
-Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
-
-### Community 132 - "Community 132"
-Cohesion: 0.18
-Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
-
-### Community 133 - "Community 133"
-Cohesion: 0.27
-Nodes (2): ConnectionPool, HTTPTransport
-
-### Community 134 - "Community 134"
-Cohesion: 0.22
-Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
-
-### Community 135 - "Community 135"
-Cohesion: 0.25
-Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.18
-Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
-
-### Community 137 - "Community 137"
-Cohesion: 0.18
-Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
-
-### Community 138 - "Community 138"
-Cohesion: 0.18
-Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
-
-### Community 139 - "Community 139"
-Cohesion: 0.18
-Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
-
-### Community 140 - "Community 140"
-Cohesion: 0.20
-Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.18
-Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
-
-### Community 142 - "Community 142"
-Cohesion: 0.20
-Nodes (7): batch, G, impact, node, out, store, targets
-
-### Community 143 - "Community 143"
-Cohesion: 0.24
-Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
-
-### Community 144 - "Community 144"
-Cohesion: 0.24
-Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
-
-### Community 145 - "Community 145"
-Cohesion: 0.20
-Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
-
-### Community 146 - "Community 146"
-Cohesion: 0.42
-Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
-
-### Community 147 - "Community 147"
-Cohesion: 0.20
-Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
-
-### Community 148 - "Community 148"
-Cohesion: 0.20
-Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
-
-### Community 149 - "Community 149"
-Cohesion: 0.22
-Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
-
-### Community 150 - "Community 150"
-Cohesion: 0.28
-Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
-
-### Community 151 - "Community 151"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 152 - "Community 152"
-Cohesion: 0.22
-Nodes (2): ignoredDir, inventory
-
-### Community 153 - "Community 153"
-Cohesion: 0.22
-Nodes (4): cleanupDirs, result, root, text
-
-### Community 154 - "Community 154"
-Cohesion: 0.25
-Nodes (9): antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), uninstallAll(), uninstallClaudeHook(), uninstallGeminiMcp() (+1 more)
-
-### Community 155 - "Community 155"
-Cohesion: 0.39
-Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
-
-### Community 156 - "Community 156"
-Cohesion: 0.39
-Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
-
-### Community 157 - "Community 157"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 158 - "Community 158"
-Cohesion: 0.42
-Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
-
-### Community 159 - "Community 159"
-Cohesion: 0.25
-Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
-
-### Community 160 - "Community 160"
-Cohesion: 0.25
-Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
-
-### Community 161 - "Community 161"
-Cohesion: 0.22
-Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
-
-### Community 162 - "Community 162"
-Cohesion: 0.31
-Nodes (1): ConnectionPool
-
-### Community 163 - "Community 163"
-Cohesion: 0.32
-Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
-
-### Community 164 - "Community 164"
-Cohesion: 0.25
-Nodes (8): CloseError, NetworkError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection., ReadError, WriteError
-
-### Community 165 - "Community 165"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 166 - "Community 166"
-Cohesion: 0.25
-Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
-
-### Community 167 - "Community 167"
-Cohesion: 0.36
-Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
-
-### Community 168 - "Community 168"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 169 - "Community 169"
-Cohesion: 0.32
-Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
-
-### Community 170 - "Community 170"
-Cohesion: 0.25
-Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
-
-### Community 171 - "Community 171"
-Cohesion: 0.25
-Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
-
-### Community 172 - "Community 172"
-Cohesion: 0.25
-Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
-
-### Community 173 - "Community 173"
-Cohesion: 0.38
-Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
-
-### Community 174 - "Community 174"
+### Community 178 - "Community 178"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 175 - "Community 175"
-Cohesion: 0.29
-Nodes (6): DecodingError, HTTPError, An error occurred while issuing a request., Decoding of the response failed., Base class for all httpx exceptions., RequestError
+### Community 131 - "Community 131"
+Cohesion: 0.25
+Nodes (4): Graph, build_graph(), Graph, build_graph()
 
-### Community 176 - "Community 176"
-Cohesion: 0.43
-Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
+### Community 84 - "Community 84"
+Cohesion: 0.21
+Nodes (10): compute_score(), normalize(), run_analysis(), Analyzer, Fixture: functions and methods that call each other - for call-graph extraction, compute_score(), normalize(), run_analysis() (+2 more)
 
-### Community 177 - "Community 177"
-Cohesion: 0.29
-Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
-
-### Community 178 - "Community 178"
-Cohesion: 0.43
-Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
-
-### Community 179 - "Community 179"
-Cohesion: 0.33
-Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
-
-### Community 180 - "Community 180"
-Cohesion: 0.33
-Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
-
-### Community 181 - "Community 181"
-Cohesion: 0.29
-Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
-
-### Community 182 - "Community 182"
-Cohesion: 0.29
-Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
-
-### Community 183 - "Community 183"
-Cohesion: 0.29
-Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
-
-### Community 184 - "Community 184"
-Cohesion: 0.29
-Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
-
-### Community 185 - "Community 185"
-Cohesion: 0.33
-Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
+### Community 26 - "Community 26"
+Cohesion: 0.05
+Nodes (34): tempDirs, qn(), addFunction(), G, entry, helper, caller, decorated (+26 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
+Cohesion: 0.29
+Nodes (6): tempDirs, dir, geminiMd, settings, skill, readme
 
-### Community 187 - "Community 187"
-Cohesion: 0.33
-Nodes (1): recommendation
-
-### Community 188 - "Community 188"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
-
-### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
-
-### Community 190 - "Community 190"
-Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
-
-### Community 191 - "Community 191"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 192 - "Community 192"
-Cohesion: 0.33
-Nodes (6): cacheOptionsFromRuntime(), loadGraph(), loadProfileRuntimeContext(), readJson(), updateCostFile(), writeJson()
-
-### Community 193 - "Community 193"
-Cohesion: 0.33
-Nodes (5): commands, dir, matchers, settings, tempDirs
-
-### Community 194 - "Community 194"
-Cohesion: 0.33
-Nodes (5): dir, original, rule, rulePath, tempDirs
-
-### Community 195 - "Community 195"
-Cohesion: 0.33
-Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (4): dir, logs, preview, tempDirs
-
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
-
-### Community 198 - "Community 198"
-Cohesion: 0.33
-Nodes (5): config, dir, plugin, previousCwd, tempDirs
-
-### Community 199 - "Community 199"
-Cohesion: 0.33
-Nodes (4): contents, dir, lockPath, tempDirs
-
-### Community 200 - "Community 200"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
-
-### Community 201 - "Community 201"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
-
-### Community 202 - "Community 202"
-Cohesion: 0.50
-Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
-
-### Community 203 - "Community 203"
-Cohesion: 0.40
-Nodes (4): chunks, client, files, root
-
-### Community 204 - "Community 204"
-Cohesion: 0.40
-Nodes (4): changelog, lock, pkg, workflow
-
-### Community 205 - "Community 205"
-Cohesion: 0.40
-Nodes (4): graphifyOut, long, result, tmpDir
-
-### Community 206 - "Community 206"
-Cohesion: 0.67
-Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
-
-### Community 207 - "Community 207"
-Cohesion: 0.50
-Nodes (4): createOntologyStudioRequestHandler(), generateOntologyStudioToken(), isLoopbackHost(), startOntologyStudioServer()
-
-### Community 208 - "Community 208"
-Cohesion: 0.50
-Nodes (3): b1, b2, backup
-
-### Community 209 - "Community 209"
-Cohesion: 0.67
-Nodes (1): OntologyWriteFixture
-
-### Community 210 - "Community 210"
-Cohesion: 0.67
-Nodes (3): runCli(), runMain(), runSkillRuntime()
+### Community 116 - "Community 116"
+Cohesion: 0.15
+Nodes (9): tempDirs, googleEnvKeys, previousEnv, dir, stub, shortcut, fetcher, rendered (+1 more)
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (2): paths, root
+Nodes (1): OntologyWriteFixture
 
-### Community 212 - "Community 212"
+### Community 117 - "Community 117"
+Cohesion: 0.15
+Nodes (10): dir, htmlPath, warnings, G, communities, result, html, profile (+2 more)
+
+### Community 67 - "Community 67"
+Cohesion: 0.09
+Nodes (21): { confidence_score: _ignored, ...rest }, { id: _ignored, ...rest }, graph, h, items, serialized, reloaded, result (+13 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.10
+Nodes (16): cleanupDirs, root, out, result, line, input, outputDir, captionsDir (+8 more)
+
+### Community 92 - "Community 92"
+Cohesion: 0.13
+Nodes (11): cleanupDirs, root, image, config, result, directImage, cropDir, cropImage (+3 more)
+
+### Community 101 - "Community 101"
+Cohesion: 0.13
+Nodes (12): cleanupDirs, root, labelsPath, rulesPath, route, result, missing, ambiguous (+4 more)
+
+### Community 198 - "Community 198"
+Cohesion: 0.33
+Nodes (5): cleanupDirs, downloadAudioMock, dir, expected, rendered
+
+### Community 155 - "Community 155"
+Cohesion: 0.22
+Nodes (2): inventory, ignoredDir
+
+### Community 199 - "Community 199"
+Cohesion: 0.33
+Nodes (4): tempDirs, preview, dir, logs
+
+### Community 9 - "Community 9"
+Cohesion: 0.04
+Nodes (51): files, worktreeRoot, labels, relations, fileNodes, importEdge, pageNode, widgetNode (+43 more)
+
+### Community 187 - "Community 187"
+Cohesion: 0.29
+Nodes (6): head, metadata, stale, analyzed, worktreeDir, plan
+
+### Community 93 - "Community 93"
+Cohesion: 0.13
+Nodes (13): generateTextMock, openaiMock, anthropicMock, googleMock, mistralMock, cohereMock, cleanupDirs, root (+5 more)
+
+### Community 151 - "Community 151"
+Cohesion: 0.20
+Nodes (8): tempDirs, dir, ancestor, current, other, result, merged, tooManyNodes
+
+### Community 156 - "Community 156"
+Cohesion: 0.22
+Nodes (4): cleanupDirs, root, result, text
+
+### Community 120 - "Community 120"
+Cohesion: 0.26
+Nodes (11): qn(), addFunction(), addCall(), makeStore(), { store }, result, { store, flows }, qn() (+3 more)
+
+### Community 200 - "Community 200"
+Cohesion: 0.33
+Nodes (5): tempDirs, tmpDir, pdfPath, outputDir, markdown
+
+### Community 152 - "Community 152"
+Cohesion: 0.22
+Nodes (9): fixtureRoot, semanticDetection(), discoveryContext(), sample, repeat, context, proposals, diff (+1 more)
+
+### Community 98 - "Community 98"
+Cohesion: 0.15
+Nodes (15): tempDirs, fixtureRoot, tempProfileProject(), runCli(), runSkillRuntime(), runMain(), prepareProject(), cliOut (+7 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.09
+Nodes (18): cleanupDirs, profile, root, valid, invalid, context, badStatus, badRelation (+10 more)
+
+### Community 85 - "Community 85"
+Cohesion: 0.12
+Nodes (10): cleanupDirs, root, profilePath, profile, raw, errors, config, bound (+2 more)
+
+### Community 140 - "Community 140"
+Cohesion: 0.18
+Nodes (9): profile, dir, path, queue, loaded, response, filters, first (+1 more)
+
+### Community 55 - "Community 55"
+Cohesion: 0.07
+Nodes (22): tempDirs, dir, token, fixture, result, graphArtifact, { body, headers }, json (+14 more)
+
+### Community 201 - "Community 201"
+Cohesion: 0.33
+Nodes (5): tempDirs, dir, plugin, config, previousCwd
+
+### Community 213 - "Community 213"
+Cohesion: 0.67
+Nodes (2): root, paths
+
+### Community 68 - "Community 68"
+Cohesion: 0.09
+Nodes (22): FIXTURES_DIR, TMP_OUT, result, exts, raw, errors, realErrors, allClustered (+14 more)
+
+### Community 141 - "Community 141"
+Cohesion: 0.20
+Nodes (9): tempDirs, runCliInTemp(), runCliWithEnvironment(), rule, workflow, home, project, skill (+1 more)
+
+### Community 86 - "Community 86"
+Cohesion: 0.12
+Nodes (14): tempDirs, fixtureRoot, root, prompt, semanticExtraction, extraction, profileValidation, graph (+6 more)
+
+### Community 133 - "Community 133"
+Cohesion: 0.18
+Nodes (8): fixtureRoot, prompt, state, documentPrompt, imagePrompt, extraction, sample, profile
+
+### Community 103 - "Community 103"
+Cohesion: 0.13
+Nodes (12): cleanupDirs, root, config, profile, registries, jsonPath, yamlPath, components (+4 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.14
+Nodes (9): cleanupDirs, root, result, configDir, configPath, loaded, raw, errors (+1 more)
+
+### Community 191 - "Community 191"
+Cohesion: 0.33
+Nodes (1): recommendation
+
+### Community 207 - "Community 207"
+Cohesion: 0.40
+Nodes (4): pkg, lock, changelog, workflow
+
+### Community 142 - "Community 142"
+Cohesion: 0.18
+Nodes (10): G, communities, cohesion, labels, gods, surprises, detection, report (+2 more)
+
+### Community 192 - "Community 192"
+Cohesion: 0.33
+Nodes (3): analysis, text, evaluation
+
+### Community 143 - "Community 143"
+Cohesion: 0.20
+Nodes (7): store, node, impact, targets, G, out, batch
+
+### Community 208 - "Community 208"
+Cohesion: 0.40
+Nodes (4): long, tmpDir, graphifyOut, result
+
+### Community 2 - "Community 2"
+Cohesion: 0.03
+Nodes (58): tempDirs, tsRoot, graphifyOutRoot, cliPath, packageVersion, dir, graphPath, [clientTransport, serverTransport] (+50 more)
+
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 213 - "Community 213"
-Cohesion: 1.00
-Nodes (2): buildRegistrySources(), registrySourceName()
+### Community 188 - "Community 188"
+Cohesion: 0.29
+Nodes (6): SKILLS, ALL_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, DISTRIBUTED_SKILL_DOCS, TRIGGER_DESCRIPTION_DOCS, content
 
-### Community 214 - "Community 214"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+### Community 118 - "Community 118"
+Cohesion: 0.15
+Nodes (10): { WhisperModelMock, freeMock, transcribeMock }, tempDirs, spawnSyncMock, hash, cached, video, outDir, modelDir (+2 more)
 
-### Community 215 - "Community 215"
+### Community 202 - "Community 202"
+Cohesion: 0.33
+Nodes (4): tempDirs, dir, lockPath, contents
+
+### Community 91 - "Community 91"
+Cohesion: 0.13
+Nodes (15): tempDirs, dir, mkGraph(), graph, communities, targets, outputPath, exportInput (+7 more)
+
+### Community 50 - "Community 50"
+Cohesion: 0.07
+Nodes (24): tempDirs, mkGraph(), graph, communities, targets, prompt, outputDir, persistedSidecar (+16 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.17
+Nodes (10): generator, base, cache_key, sidecar, result, fresh, stale, communityBase (+2 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.17
+Nodes (11): G, communities, labels, count, index, flows, generator, descriptions (+3 more)
+
+### Community 222 - "Community 222"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (1): optionalRuntimeDeps
+
+### Community 8 - "Community 8"
+Cohesion: 0.06
+Nodes (50): handle_upload(), handle_get(), handle_delete(), handle_list(), handle_search(), handle_enrich(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
+
+### Community 52 - "Community 52"
+Cohesion: 0.10
+Nodes (26): parse_file(), parse_markdown(), parse_json(), parse_plaintext(), parse_and_save(), batch_parse(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+
+### Community 54 - "Community 54"
+Cohesion: 0.10
+Nodes (26): normalize_text(), extract_keywords(), enrich_document(), find_cross_references(), process_and_save(), reprocess_all(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters. (+18 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.11
+Nodes (32): _ensure_storage(), load_index(), save_index(), save_parsed(), save_processed(), load_record(), delete_record(), list_records() (+24 more)
+
+### Community 27 - "Community 27"
+Cohesion: 0.07
+Nodes (35): Exception, CookieConflict, httpx-like exception hierarchy. All exceptions inherit from HTTPError at the top, Attempted to look up a cookie by name but multiple cookies exist., HTTPError, RequestError, ConnectTimeout, ReadTimeout (+27 more)
+
+### Community 60 - "Community 60"
+Cohesion: 0.11
+Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication., HTTP Digest Authentication.     Requires a full request/response cycle: sends th (+4 more)
+
+### Community 45 - "Community 45"
+Cohesion: 0.16
+Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., Timeout, Limits, BaseClient, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
+
+### Community 105 - "Community 105"
+Cohesion: 0.15
+Nodes (1): AsyncClient
+
+### Community 122 - "Community 122"
+Cohesion: 0.18
+Nodes (1): Client
+
+### Community 179 - "Community 179"
+Cohesion: 0.29
+Nodes (6): HTTPError, RequestError, DecodingError, Base class for all httpx exceptions., An error occurred while issuing a request., Decoding of the response failed.
+
+### Community 20 - "Community 20"
+Cohesion: 0.10
+Nodes (30): TransportError, TimeoutException, ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout, ConnectError, ProxyError (+22 more)
+
+### Community 167 - "Community 167"
+Cohesion: 0.25
+Nodes (8): NetworkError, ReadError, WriteError, CloseError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection.
+
+### Community 57 - "Community 57"
+Cohesion: 0.09
+Nodes (6): HTTPStatusError, A 4xx or 5xx response was received., URL, Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, Core data models: URL, Headers, Cookies, Request, Response. These are the centra
+
+### Community 134 - "Community 134"
+Cohesion: 0.27
+Nodes (2): ConnectionPool, HTTPTransport
+
+### Community 24 - "Community 24"
+Cohesion: 0.07
+Nodes (35): primitive_value_to_str(), normalize_header_key(), flatten_queryparams(), parse_content_type(), obfuscate_sensitive_headers(), unset_all_cookies(), is_known_encoding(), build_url_with_params() (+27 more)
+
+### Community 10 - "Community 10"
+Cohesion: 0.07
+Nodes (48): _node_community_map(), _is_file_node(), god_nodes(), surprising_connections(), _is_concept_node(), _file_category(), _top_level_dir(), _surprise_score() (+40 more)
+
+### Community 177 - "Community 177"
+Cohesion: 0.38
+Nodes (6): build_from_json(), build(), Merge multiple extraction results into one graph., build_from_json(), build(), Merge multiple extraction results into one graph.
+
+### Community 74 - "Community 74"
+Cohesion: 0.11
+Nodes (20): build_graph(), cluster(), _split_community(), cohesion_score(), score_all(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi (+12 more)
+
+### Community 203 - "Community 203"
+Cohesion: 0.60
+Nodes (5): uniqueSorted(), sortNodesByLocation(), mapChangesToNodes(), changedNodesFromFiles(), analyzeChanges()
+
+### Community 154 - "Community 154"
+Cohesion: 0.31
+Nodes (9): splitGitLines(), pathspecForPrefix(), resolveGitScopeContext(), makeScope(), countGitPaths(), gitInventory(), buildGitInventory(), fallbackAllScope() (+1 more)
+
+### Community 190 - "Community 190"
+Cohesion: 0.47
+Nodes (6): uniqueSorted(), mergeDrafts(), stalenessFrom(), minConfidence(), groupConfidence(), buildCommitRecommendation()
+
+### Community 168 - "Community 168"
+Cohesion: 0.25
+Nodes (8): uniqueSorted(), riskLevel(), communityRisk(), nodeCommunities(), buildBlastRadius(), impactedCommunities(), multimodalSafety(), buildReviewAnalysis()
 
 ### Community 216 - "Community 216"
 Cohesion: 1.00
@@ -918,72 +890,108 @@ Nodes (2): average(), evaluateReviewAnalysis()
 Cohesion: 1.00
 Nodes (2): formatMetric(), reviewEvaluationToText()
 
-### Community 218 - "Community 218"
-Cohesion: 1.00
-Nodes (1): UnpdfTextResult
+### Community 153 - "Community 153"
+Cohesion: 0.28
+Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 219 - "Community 219"
-Cohesion: 1.00
-Nodes (2): tempProfileProject(), tempProject()
+### Community 80 - "Community 80"
+Cohesion: 0.15
+Nodes (14): Geometry, LinearAlgebra, Base, Shape, Point, Circle, area(), describe() (+6 more)
 
-### Community 220 - "Community 220"
+### Community 130 - "Community 130"
+Cohesion: 0.18
+Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
+
+### Community 39 - "Community 39"
+Cohesion: 0.16
+Nodes (16): Auth, BasicAuth, Timeout, Limits, BaseClient, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
+
+### Community 22 - "Community 22"
+Cohesion: 0.11
+Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication., Load credentials from ~/.netrc based on the request host. (+18 more)
+
+### Community 166 - "Community 166"
+Cohesion: 0.32
+Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
+
+### Community 51 - "Community 51"
+Cohesion: 0.13
+Nodes (2): Client, AsyncClient
+
+### Community 121 - "Community 121"
+Cohesion: 0.18
+Nodes (1): Headers
+
+### Community 165 - "Community 165"
+Cohesion: 0.31
+Nodes (1): ConnectionPool
+
+### Community 193 - "Community 193"
+Cohesion: 0.33
+Nodes (6): scoreNodes(), bfs(), dfs(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+
+### Community 104 - "Community 104"
+Cohesion: 0.16
+Nodes (15): asRecord(), asStringArray(), asBoolean(), asString(), asNumber(), resolvePath(), parsePdfOcrMode(), parseCitationMinimum() (+7 more)
+
+### Community 215 - "Community 215"
 Cohesion: 1.00
-Nodes (1): optionalRuntimeDeps
+Nodes (2): registrySourceName(), buildRegistrySources()
 
 ## Knowledge Gaps
-- **1637 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1632 more)
+- **1642 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1637 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 50`** (2 nodes): `AsyncClient`, `Client`
+- **Thin community `Community 194`** (1 nodes): `CONFIDENCE_VALUES`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 218`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 219`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 220`** (1 nodes): `UnpdfTextResult`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 221`** (2 nodes): `tempProject()`, `tempProfileProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 104`** (1 nodes): `AsyncClient`
+- **Thin community `Community 178`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (1 nodes): `Headers`
+- **Thin community `Community 211`** (1 nodes): `OntologyWriteFixture`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (1 nodes): `Client`
+- **Thin community `Community 155`** (2 nodes): `inventory`, `ignoredDir`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (2 nodes): `ConnectionPool`, `HTTPTransport`
+- **Thin community `Community 213`** (2 nodes): `root`, `paths`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 191`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 222`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 105`** (1 nodes): `AsyncClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (1 nodes): `recommendation`
+- **Thin community `Community 122`** (1 nodes): `Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (1 nodes): `CONFIDENCE_VALUES`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (1 nodes): `OntologyWriteFixture`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (2 nodes): `paths`, `root`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 134`** (2 nodes): `ConnectionPool`, `HTTPTransport`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 216`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 217`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 51`** (2 nodes): `Client`, `AsyncClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 121`** (1 nodes): `Headers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 165`** (1 nodes): `ConnectionPool`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 215`** (2 nodes): `registrySourceName()`, `buildRegistrySources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 24` to `Community 55`, `Community 120`, `Community 40`, `Community 50`, `Community 28`?**
+- **Why does `Cookies` connect `Community 24` to `Community 57`, `Community 121`, `Community 39`, `Community 51`, `Community 27`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 45` to `Community 55`, `Community 121`, `Community 104`, `Community 24`?**
+- **Why does `Cookies` connect `Community 45` to `Community 57`, `Community 122`, `Community 105`, `Community 24`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `InvalidURL` connect `Community 45` to `Community 28`, `Community 121`, `Community 104`?**
+- **Why does `InvalidURL` connect `Community 45` to `Community 27`, `Community 122`, `Community 105`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/src/export.ts
+++ b/src/export.ts
@@ -14,6 +14,7 @@ import {
   toNumericMap,
   toStringMap,
 } from "./collections.js";
+import { getWorkspaceTokens, serialiseTokensToCss } from "./workspace/tokens-fallback.js";
 
 // ---------------------------------------------------------------------------
 // backupIfProtected — upstream 6939494 (#834)
@@ -604,58 +605,71 @@ export async function pushToNeo4j(
 // ---------------------------------------------------------------------------
 
 function htmlStyles(): string {
+  const workspaceCss = serialiseTokensToCss(getWorkspaceTokens());
   return `<style>
+  :root {
+${workspaceCss
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n")}
+    --graph-overlay: rgba(15, 23, 42, 0.45);
+    --graph-focus-shadow: rgba(78, 121, 167, 0.55);
+    --graph-weak-text: var(--ws-text-muted);
+    --graph-muted-strong: var(--ws-text-muted);
+    --graph-node-label: var(--ws-text);
+    --graph-neighbor-border: var(--ws-border);
+  }
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0f0f1a; color: #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; display: flex; height: 100vh; overflow: hidden; }
+  body { background: var(--ws-surface); color: var(--ws-text); font-family: var(--ws-font-family-sans); display: flex; height: 100vh; overflow: hidden; }
   /* Skip link visible only on focus, lets keyboard users jump past the canvas. */
-  .skip-link { position: absolute; top: -40px; left: 8px; background: #4E79A7; color: #fff; padding: 6px 12px; border-radius: 0 0 4px 4px; z-index: 1000; text-decoration: none; }
+  .skip-link { position: absolute; top: -40px; left: var(--ws-space-2); background: var(--ws-accent); color: #fff; padding: var(--ws-space-1) var(--ws-space-3); border-radius: 0 0 var(--ws-radius-sm) var(--ws-radius-sm); z-index: 1000; text-decoration: none; }
   .skip-link:focus { top: 0; }
   /* Visually hidden but exposed to screen readers. */
   .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
   /* Focus visible everywhere, WCAG-compliant outline. */
-  :focus-visible { outline: 3px solid #ffd54f; outline-offset: 2px; box-shadow: 0 0 0 4px rgba(78, 121, 167, 0.55); }
-  #graph { flex: 1; outline: none; }
-  #graph:focus-visible { box-shadow: inset 0 0 0 3px #ffd54f; }
-  #sidebar { width: 280px; background: #1a1a2e; border-left: 1px solid #2a2a4e; display: flex; flex-direction: column; overflow: hidden; }
-  #search-wrap { padding: 12px; border-bottom: 1px solid #2a2a4e; }
-  #search { width: 100%; background: #0f0f1a; border: 1px solid #3a3a5e; color: #e0e0e0; padding: 7px 10px; border-radius: 6px; font-size: 13px; outline: none; }
-  #search:focus { border-color: #4E79A7; }
-  #search-results { max-height: 140px; overflow-y: auto; padding: 4px 12px; border-bottom: 1px solid #2a2a4e; display: none; }
-  .search-item { padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .search-item:hover, .search-item:focus { background: #2a2a4e; }
-  #info-panel { padding: 14px; border-bottom: 1px solid #2a2a4e; min-height: 140px; }
-  #info-panel h3 { font-size: 13px; color: #aaa; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
-  #info-content { font-size: 13px; color: #ccc; line-height: 1.6; }
+  :focus-visible { outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); box-shadow: 0 0 0 4px var(--graph-focus-shadow); }
+  #graph { flex: 1; outline: none; background: var(--ws-surface); }
+  #graph:focus-visible { box-shadow: inset 0 0 0 3px var(--ws-outline-color); }
+  #sidebar { width: 280px; background: var(--ws-surface-2); border-left: 1px solid var(--ws-border); display: flex; flex-direction: column; overflow: hidden; }
+  #search-wrap { padding: var(--ws-space-3); border-bottom: 1px solid var(--ws-border); }
+  #search { width: 100%; background: var(--ws-surface); border: 1px solid var(--ws-border); color: var(--ws-text); padding: 7px 10px; border-radius: var(--ws-radius-md); font-size: 13px; outline: none; }
+  #search:focus { border-color: var(--ws-accent); }
+  #search-results { max-height: 140px; overflow-y: auto; padding: 4px 12px; border-bottom: 1px solid var(--ws-border); display: none; }
+  .search-item { padding: 4px 6px; cursor: pointer; border-radius: var(--ws-radius-sm); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .search-item:hover, .search-item:focus { background: var(--ws-border); }
+  #info-panel { padding: 14px; border-bottom: 1px solid var(--ws-border); min-height: 140px; }
+  #info-panel h3 { font-size: 13px; color: var(--ws-text-muted); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+  #info-content { font-size: 13px; color: var(--ws-text); line-height: 1.6; }
   #info-content .field { margin-bottom: 5px; }
-  #info-content .field b { color: #e0e0e0; }
-  #info-content .empty { color: #777; font-style: italic; } /* WCAG AA: bumped from #555 (3.8:1) to #777 (5.0:1) */
-  .neighbor-link { display: block; padding: 2px 6px; margin: 2px 0; border-radius: 3px; cursor: pointer; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 3px solid #333; }
-  .neighbor-link:hover, .neighbor-link:focus { background: #2a2a4e; }
+  #info-content .field b { color: var(--ws-text); }
+  #info-content .empty { color: var(--graph-weak-text); font-style: italic; }
+  .neighbor-link { display: block; padding: 2px 6px; margin: 2px 0; border-radius: 3px; cursor: pointer; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 3px solid var(--graph-neighbor-border); }
+  .neighbor-link:hover, .neighbor-link:focus { background: var(--ws-border); }
   #neighbors-list { max-height: 160px; overflow-y: auto; margin-top: 4px; }
-  #legend-wrap { flex: 1; overflow-y: auto; padding: 12px; }
-  #legend-wrap h3 { font-size: 13px; color: #aaa; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.05em; }
-  .legend-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer; border-radius: 4px; font-size: 12px; }
-  .legend-item:hover, .legend-item:focus-within { background: #2a2a4e; padding-left: 4px; }
+  #legend-wrap { flex: 1; overflow-y: auto; padding: var(--ws-space-3); }
+  #legend-wrap h3 { font-size: 13px; color: var(--ws-text-muted); margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .legend-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer; border-radius: var(--ws-radius-sm); font-size: 12px; }
+  .legend-item:hover, .legend-item:focus-within { background: var(--ws-border); padding-left: 4px; }
   .legend-item.dimmed { opacity: 0.45; } /* WCAG: bumped from 0.35 for better contrast in dimmed state */
   .legend-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
-  .legend-cb { accent-color: #4E79A7; cursor: pointer; flex-shrink: 0; }
+  .legend-cb { accent-color: var(--ws-accent); cursor: pointer; flex-shrink: 0; }
   .legend-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .legend-count { color: #888; font-size: 11px; } /* WCAG AA: bumped from #666 to #888 */
-  #legend-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; font-size: 11px; color: #aaa; }
+  .legend-count { color: var(--graph-muted-strong); font-size: 11px; }
+  #legend-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; font-size: 11px; color: var(--ws-text-muted); }
   #legend-controls label { display: flex; align-items: center; gap: 6px; cursor: pointer; }
-  #stats { padding: 10px 14px; border-top: 1px solid #2a2a4e; font-size: 11px; color: #888; } /* WCAG AA */
+  #stats { padding: 10px 14px; border-top: 1px solid var(--ws-border); font-size: 11px; color: var(--graph-muted-strong); }
   /* Help overlay modal. */
-  #help-button { position: fixed; bottom: 12px; right: 296px; width: 36px; height: 36px; border-radius: 50%; background: #2a2a4e; color: #e0e0e0; border: 1px solid #3a3a5e; font-size: 16px; font-weight: bold; cursor: pointer; z-index: 100; }
-  #help-button:hover, #help-button:focus { background: #3a3a5e; }
-  #help-overlay { display: none; position: fixed; inset: 0; background: rgba(0, 0, 0, 0.75); z-index: 200; align-items: center; justify-content: center; }
+  #help-button { position: fixed; bottom: 12px; right: 296px; width: 36px; height: 36px; border-radius: 50%; background: var(--ws-border); color: var(--ws-text); border: 1px solid var(--ws-border); font-size: 16px; font-weight: bold; cursor: pointer; z-index: 100; }
+  #help-button:hover, #help-button:focus { background: var(--ws-surface-2); }
+  #help-overlay { display: none; position: fixed; inset: 0; background: var(--graph-overlay); z-index: 200; align-items: center; justify-content: center; }
   #help-overlay.open { display: flex; }
-  #help-modal { background: #1a1a2e; color: #e0e0e0; padding: 24px 28px; border-radius: 8px; max-width: 480px; max-height: 80vh; overflow-y: auto; border: 1px solid #3a3a5e; }
+  #help-modal { background: var(--ws-surface-2); color: var(--ws-text); padding: 24px 28px; border-radius: var(--ws-radius-lg); max-width: 480px; max-height: 80vh; overflow-y: auto; border: 1px solid var(--ws-border); }
   #help-modal h2 { font-size: 16px; margin-bottom: 12px; }
-  #help-modal kbd { background: #0f0f1a; border: 1px solid #3a3a5e; border-radius: 3px; padding: 1px 6px; font-family: monospace; font-size: 12px; }
+  #help-modal kbd { background: var(--ws-surface); border: 1px solid var(--ws-border); border-radius: 3px; padding: 1px 6px; font-family: var(--ws-font-family-mono); font-size: 12px; }
   #help-modal dl { display: grid; grid-template-columns: auto 1fr; gap: 6px 12px; margin: 12px 0; font-size: 13px; }
-  #help-modal dt { color: #ffd54f; }
-  #help-close { float: right; background: none; border: none; color: #aaa; font-size: 18px; cursor: pointer; }
-  #help-close:hover, #help-close:focus { color: #e0e0e0; }
+  #help-modal dt { color: var(--ws-outline-color); }
+  #help-close { float: right; background: none; border: none; color: var(--ws-text-muted); font-size: 18px; cursor: pointer; }
+  #help-close:hover, #help-close:focus { color: var(--ws-text); }
   /* High-contrast mode (system preference + manual toggle). */
   @media (prefers-contrast: more) {
     body, #sidebar, #search { background: #000; color: #fff; }
@@ -792,16 +806,16 @@ function showInfo(nodeId) {
   const neighborIds = network.getConnectedNodes(nodeId);
   const neighborItems = neighborIds.map(nid => {
     const nb = nodesDS.get(nid);
-    const color = nb ? nb.color.background : '#555';
+    const color = nb ? nb.color.background : 'var(--ws-border)';
     return \`<span class="neighbor-link" style="border-left-color:\${color}" onclick="focusNode('\${nid}')">\${nb ? nb.label : nid}</span>\`;
   }).join('');
   document.getElementById('info-content').innerHTML = \`
     <div class="field"><b>\${n.label}</b></div>
-    <div class="field">Type: \${n._file_type || 'unknown'} <span style="color:#888;font-size:11px">(shape: \${n._shape})</span></div>
+    <div class="field">Type: \${n._file_type || 'unknown'} <span style="color:var(--ws-text-muted);font-size:11px">(shape: \${n._shape})</span></div>
     <div class="field">Community: \${n._community_name}</div>
     <div class="field">Source: \${n._source_file || '-'}</div>
     <div class="field">Degree: \${n._degree}</div>
-    \${neighborIds.length ? \`<div class="field" style="margin-top:8px;color:#aaa;font-size:11px">Neighbors (\${neighborIds.length})</div><div id="neighbors-list">\${neighborItems}</div>\` : ''}
+    \${neighborIds.length ? \`<div class="field" style="margin-top:8px;color:var(--ws-text-muted);font-size:11px">Neighbors (\${neighborIds.length})</div><div id="neighbors-list">\${neighborItems}</div>\` : ''}
   \`;
 }
 
@@ -1001,6 +1015,7 @@ export function toHtml(
   const communityLabels = normalizeCommunityLabels(communityLabelsOrOptions);
   const memberCounts = normalizeMemberCounts(communityLabelsOrOptions);
   const profile = normalizeProfile(communityLabelsOrOptions);
+  const workspaceTheme = getWorkspaceTokens();
   if (G.order > MAX_NODES_FOR_VIZ) {
     throw new Error(
       `Graph has ${G.order} nodes - too large for HTML viz. ` +
@@ -1063,10 +1078,10 @@ export function toHtml(
       color: {
         background: isOutlinedShape ? "rgba(0,0,0,0)" : color,
         border: color,
-        highlight: { background: "#ffffff", border: color },
+        highlight: { background: workspaceTheme.colour.surface, border: color },
       },
       size: Math.round(size * 10) / 10,
-      font: { size: fontSize, color: "#ffffff" },
+      font: { size: fontSize, color: workspaceTheme.colour.text },
       title: label,
       community: cid,
       community_name: sanitizeLabel(communityLabels?.get(cid) ?? `Community ${cid}`),
@@ -1085,7 +1100,7 @@ export function toHtml(
     title: string;
     dashes: boolean | number[];
     width: number;
-    color: { opacity: number };
+    color: { color: string; highlight: string; hover: string; opacity: number };
     confidence: string;
     relation: string;
   }
@@ -1100,7 +1115,12 @@ export function toHtml(
       title: `${relation} [${confidence}]`,
       dashes: inferEdgeDashes(relation, confidence),
       width: confidence === "EXTRACTED" ? 2 : 1,
-      color: { opacity: confidence === "EXTRACTED" ? 0.7 : 0.35 },
+      color: {
+        color: workspaceTheme.colour["text-muted"],
+        highlight: workspaceTheme.colour.accent,
+        hover: workspaceTheme.colour.accent,
+        opacity: confidence === "EXTRACTED" ? 0.7 : 0.35,
+      },
       confidence,
       relation,
     });
@@ -1163,17 +1183,17 @@ ${htmlStyles()}
     </div>
     <div id="legend" role="group" aria-label="Community filters"></div>
     <h3 id="shapes-heading" style="margin-top:14px">Shapes</h3>
-    <ul id="shape-legend" aria-labelledby="shapes-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:#bbb">
+    <ul id="shape-legend" aria-labelledby="shapes-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:var(--ws-text-muted)">
       <li>● dot &mdash; code</li>
-      <li><span style="display:inline-block;width:10px;height:10px;background:#bbb;vertical-align:middle"></span> square (filled) &mdash; test</li>
+      <li><span style="display:inline-block;width:10px;height:10px;background:var(--ws-text-muted);vertical-align:middle"></span> square (filled) &mdash; test</li>
       <li>▲ triangle &mdash; config (yaml/toml/...)</li>
       <li>◆ diamond &mdash; type definition (.d.ts)</li>
-      <li><span style="display:inline-block;width:10px;height:10px;border:1px solid #bbb;background:transparent;vertical-align:middle"></span> box (outline) &mdash; document / paper / concept</li>
+      <li><span style="display:inline-block;width:10px;height:10px;border:1px solid var(--ws-text-muted);background:transparent;vertical-align:middle"></span> box (outline) &mdash; document / paper / concept</li>
       <li>★ star &mdash; image</li>
       <li>⬢ hexagon &mdash; video</li>
     </ul>
     <h3 id="relations-heading" style="margin-top:14px">Edges</h3>
-    <ul id="relation-legend" aria-labelledby="relations-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:#bbb">
+    <ul id="relation-legend" aria-labelledby="relations-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:var(--ws-text-muted)">
       <li>━━━━ solid &mdash; calls / strong (EXTRACTED)</li>
       <li>┄┄┄┄ dashed &mdash; imports_from</li>
       <li>┈┈┈┈ dotted &mdash; tested_by / validated_by</li>
@@ -1197,7 +1217,7 @@ ${htmlStyles()}
       <dt><kbd>F1</kbd> / <kbd>?</kbd></dt><dd>Toggle this help</dd>
       <dt><kbd>HC</kbd> button</dt><dd>Toggle high-contrast theme</dd>
     </dl>
-    <p style="font-size:12px;color:#aaa;margin-top:8px">Search input announces match counts; selecting a node announces its community and degree.</p>
+    <p style="font-size:12px;color:var(--ws-text-muted);margin-top:8px">Search input announces match counts; selecting a node announces its community and degree.</p>
   </div>
 </div>
 ${htmlScript(nodesJson, edgesJson, legendJson)}

--- a/src/ontology-studio-workspace.ts
+++ b/src/ontology-studio-workspace.ts
@@ -1,0 +1,456 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type {
+  OntologyPatchContext,
+  OntologyReconciliationDecisionLogResponse,
+} from "./ontology-patch.js";
+import {
+  getOntologyRebuildStatus,
+  getOntologyReconciliationCandidate,
+  listOntologyReconciliationCandidates,
+  previewOntologyDecisionLog,
+  type OntologyRebuildStatusResponse,
+} from "./ontology-reconciliation-api.js";
+import type {
+  OntologyReconciliationCandidate,
+  OntologyReconciliationCandidatesResponse,
+} from "./ontology-reconciliation.js";
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderGraphPanel,
+  renderWorkspaceShell,
+  type GraphLike,
+  type GraphNodeLike,
+} from "./workspace/index.js";
+
+interface ReconciliationWorkspaceModel {
+  writeEnabled: boolean;
+  candidates: OntologyReconciliationCandidatesResponse | null;
+  candidatesError: string | null;
+  selectedCandidate: OntologyReconciliationCandidate | null;
+  selectedCandidateError: string | null;
+  decisionLog: OntologyReconciliationDecisionLogResponse | null;
+  decisionLogError: string | null;
+  rebuildStatus: OntologyRebuildStatusResponse | null;
+  graph: GraphLike | null;
+  graphHtmlUrl: string | null;
+  liveGraphHtmlUrl: string | null;
+}
+
+export interface RenderOntologyStudioWorkspaceOptions {
+  writeEnabled: boolean;
+  selectedCandidateId?: string;
+}
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "").replace(HTML_ESCAPE_RE, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+function candidateHref(id: string): string {
+  return `/?candidate=${encodeURIComponent(id)}`;
+}
+
+function percent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function renderStudioStyles(): string {
+  return [
+    "<style>",
+    ".ws-recon-stack { display: grid; gap: var(--ws-space-3); }",
+    ".ws-recon-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: var(--ws-space-2); color: var(--ws-text-muted); font-size: var(--ws-font-size-sm); }",
+    ".ws-recon-pill { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-sm); padding: 2px var(--ws-space-2); background: var(--ws-surface-2); color: var(--ws-text); }",
+    ".ws-recon-list { display: grid; gap: var(--ws-space-2); }",
+    ".ws-recon-row { display: grid; gap: 2px; padding: var(--ws-space-2); border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); color: var(--ws-text); text-decoration: none; background: var(--ws-surface-2); }",
+    ".ws-recon-row[data-selected='true'] { border-color: var(--ws-accent); box-shadow: inset 3px 0 0 var(--ws-accent); }",
+    ".ws-recon-row small, .ws-recon-muted { color: var(--ws-text-muted); }",
+    ".ws-recon-candidate { display: grid; gap: var(--ws-space-3); max-width: 88ch; }",
+    ".ws-recon-candidate h3 { margin: 0; font-size: var(--ws-font-size-lg); line-height: var(--ws-line-height-tight); }",
+    ".ws-recon-compare { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--ws-space-3); }",
+    ".ws-recon-box { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); padding: var(--ws-space-3); background: var(--ws-surface-2); overflow-wrap: anywhere; }",
+    ".ws-recon-box h4 { margin: 0 0 var(--ws-space-1); font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }",
+    ".ws-recon-entity { display: grid; gap: var(--ws-space-2); }",
+    ".ws-recon-entity-title { margin: 0; font-weight: 650; line-height: var(--ws-line-height-tight); }",
+    ".ws-recon-entity-id { margin: 0; color: var(--ws-text-muted); font-family: var(--ws-font-family-mono); font-size: var(--ws-font-size-sm); }",
+    ".ws-recon-entity-summary { margin: 0; color: var(--ws-text); }",
+    ".ws-recon-meta { display: grid; gap: var(--ws-space-1); margin: 0; font-size: var(--ws-font-size-sm); }",
+    ".ws-recon-meta div { display: grid; grid-template-columns: minmax(7rem, 35%) 1fr; gap: var(--ws-space-2); }",
+    ".ws-recon-meta dt { color: var(--ws-text-muted); }",
+    ".ws-recon-meta dd { margin: 0; color: var(--ws-text); }",
+    ".ws-recon-list-inline { margin: 0; padding-left: var(--ws-space-4); }",
+    ".ws-recon-warning { border: 1px solid var(--ws-warning); color: var(--ws-warning); border-radius: var(--ws-radius-md); padding: var(--ws-space-2); background: var(--ws-surface-2); }",
+    ".ws-recon-accordion { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); padding: var(--ws-space-2); background: var(--ws-surface); }",
+    ".ws-recon-accordion summary { cursor: pointer; font-weight: 600; }",
+    "@media (max-width: 768px) { .ws-recon-compare { grid-template-columns: 1fr; } }",
+    "</style>",
+  ].join("\n");
+}
+
+function renderList(values: readonly string[], empty: string): string {
+  if (values.length === 0) return `<p class="ws-empty">${escapeHtml(empty)}</p>`;
+  return [
+    '<ul class="ws-recon-list-inline">',
+    ...values.map((value) => `<li>${escapeHtml(value)}</li>`),
+    "</ul>",
+  ].join("");
+}
+
+function displayText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function graphNodeById(graph: GraphLike | null, id: string): GraphNodeLike | null {
+  return (graph?.nodes ?? []).find((node) => node.id === id) ?? null;
+}
+
+function graphNodeTitle(node: GraphNodeLike | null, fallbackId: string): string {
+  return (
+    displayText(node?.label) ??
+    displayText(node?.title) ??
+    displayText(node?.name) ??
+    fallbackId
+  );
+}
+
+function graphNodeType(node: GraphNodeLike | null): string | null {
+  return (
+    displayText(node?.node_type) ??
+    displayText(node?.type) ??
+    displayText(node?.kind) ??
+    displayText(node?.file_type)
+  );
+}
+
+function graphNodeSummary(node: GraphNodeLike | null): string | null {
+  return (
+    displayText(node?.description) ??
+    displayText(node?.summary) ??
+    displayText(node?.body)
+  );
+}
+
+function graphNodeCommunity(node: GraphNodeLike | null): string | null {
+  return (
+    displayText(node?.community_name) ??
+    (typeof node?.community === "number" ? `Community ${node.community}` : null)
+  );
+}
+
+function graphNodeMetaRows(node: GraphNodeLike | null): Array<[string, string]> {
+  if (!node) return [];
+  const rows: Array<[string, string | null]> = [
+    ["Type", graphNodeType(node)],
+    ["Status", displayText(node.status)],
+    ["Confidence", displayText(node.confidence)],
+    ["Source", displayText(node.source_location)
+      ? `${displayText(node.source_file) ?? "source"}:${displayText(node.source_location)}`
+      : displayText(node.source_file)],
+    ["Community", graphNodeCommunity(node)],
+  ];
+  return rows.filter((row): row is [string, string] => typeof row[1] === "string");
+}
+
+function renderMetaRows(rows: Array<[string, string]>): string {
+  if (rows.length === 0) return "";
+  return [
+    '<dl class="ws-recon-meta">',
+    ...rows.map(([label, value]) => [
+      "<div>",
+      `<dt>${escapeHtml(label)}</dt>`,
+      `<dd>${escapeHtml(value)}</dd>`,
+      "</div>",
+    ].join("")),
+    "</dl>",
+  ].join("");
+}
+
+function renderEntityCard(role: string, entityId: string, node: GraphNodeLike | null): string {
+  const summary = graphNodeSummary(node);
+  const title = graphNodeTitle(node, entityId);
+  return [
+    '<section class="ws-recon-box">',
+    `<h4>${escapeHtml(role)}</h4>`,
+    '<div class="ws-recon-entity">',
+    `<p class="ws-recon-entity-title">${escapeHtml(title)}</p>`,
+    `<p class="ws-recon-entity-id">${escapeHtml(entityId)}</p>`,
+    summary ? `<p class="ws-recon-entity-summary">${escapeHtml(summary)}</p>` : "",
+    renderMetaRows(graphNodeMetaRows(node)),
+    "</div>",
+    "</section>",
+  ].filter(Boolean).join("");
+}
+
+function renderWorkbench(model: ReconciliationWorkspaceModel): string {
+  if (model.candidatesError) {
+    return `<p class="ws-empty" id="ws-queue-empty">${escapeHtml(model.candidatesError)}</p>`;
+  }
+  const candidates = model.candidates;
+  if (!candidates || candidates.items.length === 0) {
+    return '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>';
+  }
+  const selectedId = model.selectedCandidate?.id ?? "";
+  return [
+    '<div class="ws-recon-stack" id="candidate-list">',
+    '<div class="ws-recon-toolbar" role="status">',
+    `<span class="ws-recon-pill">${candidates.total} candidate(s)</span>`,
+    `<span class="ws-recon-pill">stale: ${candidates.stale ? "yes" : "no"}</span>`,
+    `<span class="ws-recon-pill">mode: ${model.writeEnabled ? "write" : "read-only"}</span>`,
+    "</div>",
+    '<nav class="ws-recon-list" aria-label="Reconciliation candidates">',
+    ...candidates.items.map((candidate) => [
+      `<a class="ws-recon-row" href="${candidateHref(candidate.id)}" data-selected="${candidate.id === selectedId ? "true" : "false"}">`,
+      `<strong>${escapeHtml(candidate.id)}</strong>`,
+      `<small>${escapeHtml(candidate.candidate_id)} -> ${escapeHtml(candidate.canonical_id)}</small>`,
+      `<small>${escapeHtml(candidate.proposed_patch_operation)} - score ${percent(candidate.score)}</small>`,
+      "</a>",
+    ].join("")),
+    "</nav>",
+    "</div>",
+  ].join("");
+}
+
+function renderCentralDisplay(model: ReconciliationWorkspaceModel): string {
+  const candidate = model.selectedCandidate;
+  if (model.selectedCandidateError) {
+    return [
+      renderStudioStyles(),
+      `<p class="ws-empty">${escapeHtml(model.selectedCandidateError)}</p>`,
+    ].join("");
+  }
+  if (!candidate) {
+    return [
+      renderStudioStyles(),
+      '<p class="ws-empty">No reconciliation candidate selected.</p>',
+    ].join("");
+  }
+  const candidateNode = graphNodeById(model.graph, candidate.candidate_id);
+  const canonicalNode = graphNodeById(model.graph, candidate.canonical_id);
+  return [
+    renderStudioStyles(),
+    `<article class="ws-recon-candidate" data-candidate-id="${escapeHtml(candidate.id)}">`,
+    '<div class="ws-display-kicker">Reconciliation candidate</div>',
+    `<h3>${escapeHtml(candidate.id)}</h3>`,
+    '<div class="ws-recon-toolbar">',
+    `<span class="ws-recon-pill">${escapeHtml(candidate.kind)}</span>`,
+    `<span class="ws-recon-pill">${escapeHtml(candidate.status)}</span>`,
+    `<span class="ws-recon-pill">score ${percent(candidate.score)}</span>`,
+    `<span class="ws-recon-pill">${escapeHtml(candidate.proposed_patch_operation)}</span>`,
+    "</div>",
+    model.candidates?.stale || model.rebuildStatus?.needs_update
+      ? '<p class="ws-recon-warning">Queue may be stale. Rebuild before applying this patch.</p>'
+      : "",
+    '<div class="ws-recon-compare">',
+    renderEntityCard("Candidate", candidate.candidate_id, candidateNode),
+    renderEntityCard("Canonical", candidate.canonical_id, canonicalNode),
+    "</div>",
+    '<section class="ws-recon-box">',
+    "<h4>Shared terms</h4>",
+    renderList(candidate.shared_terms, "No shared terms."),
+    "</section>",
+    '<section class="ws-recon-box">',
+    "<h4>Reasons</h4>",
+    renderList(candidate.reasons, "No reasons."),
+    "</section>",
+    '<section class="ws-recon-box">',
+    "<h4>Decision basis</h4>",
+    renderList([
+      `Operation: ${candidate.proposed_patch_operation}`,
+      `Candidate: ${candidate.candidate_id}`,
+      `Canonical: ${candidate.canonical_id}`,
+      ...candidate.evidence_refs.map((ref) => `Evidence: ${ref}`),
+    ], "No decision basis."),
+    "</section>",
+    "</article>",
+  ].filter(Boolean).join("");
+}
+
+function renderDrawer(model: ReconciliationWorkspaceModel): string {
+  const candidate = model.selectedCandidate;
+  const evidence = candidate?.evidence_refs ?? [];
+  const seenPatchIds = new Set<string>();
+  const decisions = (model.decisionLog?.items ?? []).filter((item) => {
+    const id = typeof item.patch.id === "string" ? item.patch.id : "";
+    if (!id || seenPatchIds.has(id)) return false;
+    seenPatchIds.add(id);
+    return true;
+  });
+  return [
+    '<div class="ws-recon-stack">',
+    '<details class="ws-recon-accordion" open>',
+    "<summary>Evidence</summary>",
+    renderList(evidence, "No evidence refs on the selected candidate."),
+    "</details>",
+    '<details class="ws-recon-accordion" open>',
+    "<summary>Audit trail</summary>",
+    model.decisionLogError
+      ? `<p class="ws-empty">${escapeHtml(model.decisionLogError)}</p>`
+      : renderList(
+        decisions.map((item) => {
+          const id = typeof item.patch.id === "string" ? item.patch.id : "unknown";
+          const operation = typeof item.patch.operation === "string" ? item.patch.operation : "unknown";
+          return `${id} - ${operation} - ${item.source}`;
+        }),
+        "No audit entries.",
+      ),
+    "</details>",
+    '<details class="ws-recon-accordion">',
+    "<summary>Rebuild status</summary>",
+    model.rebuildStatus
+      ? renderList([
+        `needs_update: ${model.rebuildStatus.needs_update ? "yes" : "no"}`,
+        `candidates_match: ${model.rebuildStatus.candidates_match ? "yes" : "no"}`,
+        `decision_log_available: ${model.rebuildStatus.decision_log_available ? "yes" : "no"}`,
+      ], "No rebuild status.")
+      : '<p class="ws-empty">No rebuild status.</p>',
+    "</details>",
+    "</div>",
+  ].join("");
+}
+
+function renderGraphContext(model: ReconciliationWorkspaceModel): string {
+  const status = model.rebuildStatus;
+  if (!model.graph) {
+    return status
+      ? [
+        '<div class="ws-recon-toolbar" role="status">',
+        `<span class="ws-recon-pill">graph: ${escapeHtml(status.graph_hash ?? "unknown")}</span>`,
+        `<span class="ws-recon-pill">profile: ${escapeHtml(status.profile_hash ?? "unknown")}</span>`,
+        `<span class="ws-recon-pill">candidates: ${escapeHtml(status.candidates.candidate_count ?? 0)}</span>`,
+        "</div>",
+      ].join("")
+      : '<p class="ws-empty">No graph context available.</p>';
+  }
+  const state = createDefaultViewerState();
+  state.viewState.graph.mode = "overview";
+  return renderGraphPanel({
+    graph: model.graph,
+    state,
+    tokens: getWorkspaceTokens(),
+    ...(model.graphHtmlUrl ? { graphHtmlUrl: model.graphHtmlUrl } : {}),
+    ...(model.liveGraphHtmlUrl ? { liveGraphHtmlUrl: model.liveGraphHtmlUrl } : {}),
+    height: 560,
+  });
+}
+
+function loadGraph(stateDir: string): GraphLike | null {
+  const graphPath = join(stateDir, "graph.json");
+  if (!existsSync(graphPath)) return null;
+  try {
+    return JSON.parse(readFileSync(graphPath, "utf-8")) as GraphLike;
+  } catch {
+    return null;
+  }
+}
+
+function graphHtmlUrl(stateDir: string): string | null {
+  const graphHtmlPath = join(stateDir, "graph.html");
+  return existsSync(graphHtmlPath) ? pathToFileURL(graphHtmlPath).href : null;
+}
+
+function liveGraphHtmlUrl(stateDir: string): string | null {
+  return existsSync(join(stateDir, "graph.html")) ? "/api/ontology/artifacts/graph.html" : null;
+}
+
+function buildModel(
+  context: OntologyPatchContext,
+  opts: RenderOntologyStudioWorkspaceOptions,
+): ReconciliationWorkspaceModel {
+  let candidates: OntologyReconciliationCandidatesResponse | null = null;
+  let candidatesError: string | null = null;
+  try {
+    candidates = listOntologyReconciliationCandidates(context, {
+      sort: "score",
+      order: "desc",
+      limit: 50,
+    });
+  } catch (error) {
+    candidatesError = error instanceof Error ? error.message : String(error);
+  }
+
+  const selectedCandidateId = opts.selectedCandidateId ?? candidates?.items[0]?.id;
+  let selectedCandidate: OntologyReconciliationCandidate | null = null;
+  let selectedCandidateError: string | null = null;
+  if (selectedCandidateId) {
+    try {
+      selectedCandidate = getOntologyReconciliationCandidate(context, selectedCandidateId);
+    } catch (error) {
+      selectedCandidateError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  let decisionLog: OntologyReconciliationDecisionLogResponse | null = null;
+  let decisionLogError: string | null = null;
+  try {
+    decisionLog = previewOntologyDecisionLog(context, { source: "both", limit: 20 });
+  } catch (error) {
+    decisionLogError = error instanceof Error ? error.message : String(error);
+  }
+
+  let rebuildStatus: OntologyRebuildStatusResponse | null = null;
+  try {
+    rebuildStatus = getOntologyRebuildStatus(context);
+  } catch {
+    rebuildStatus = null;
+  }
+
+  return {
+    writeEnabled: opts.writeEnabled,
+    candidates,
+    candidatesError,
+    selectedCandidate,
+    selectedCandidateError,
+    decisionLog,
+    decisionLogError,
+    rebuildStatus,
+    graph: loadGraph(context.stateDir),
+    graphHtmlUrl: graphHtmlUrl(context.stateDir),
+    liveGraphHtmlUrl: liveGraphHtmlUrl(context.stateDir),
+  };
+}
+
+export function renderOntologyStudioWorkspace(
+  context: OntologyPatchContext,
+  opts: RenderOntologyStudioWorkspaceOptions,
+): string {
+  const model = buildModel(context, opts);
+  const state = createDefaultViewerState();
+  state.activeView = "studio";
+  state.selectionState = {
+    kind: "candidate-queue",
+    ref: "queue:reconciliation",
+    entityIds: model.candidates?.items.map((candidate) => candidate.candidate_id) ?? [],
+  };
+  state.displayRef = model.selectedCandidate ? `candidate:${model.selectedCandidate.id}` : null;
+  state.focusEntityId = model.selectedCandidate?.candidate_id ?? null;
+  state.drawerOpen = Boolean(model.selectedCandidate);
+  state.viewState.graph.mode = "overview";
+  const tokens = getWorkspaceTokens();
+
+  return renderWorkspaceShell({
+    tokens,
+    tokenSource: "fallback",
+    title: "Graphify Ontology Studio",
+    profileId: context.profile.id,
+    writeEnabled: opts.writeEnabled,
+    queueEmpty: (model.candidates?.items.length ?? 0) === 0,
+    state,
+    leftWorkbenchHtml: renderWorkbench(model),
+    centralDisplayHtml: renderCentralDisplay(model),
+    rightDrawerHtml: renderDrawer(model),
+    graphPanelHtml: renderGraphContext(model),
+  });
+}

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -1,10 +1,13 @@
 import { randomBytes } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { join } from "node:path";
 import type { AddressInfo } from "node:net";
 import { URL } from "node:url";
 
 import { applyOntologyPatch, validateOntologyPatch } from "./ontology-patch.js";
 import { loadOntologyPatchContext } from "./ontology-patch-context.js";
+import { renderOntologyStudioWorkspace } from "./ontology-studio-workspace.js";
 import {
   getOntologyRebuildStatus,
   getOntologyReconciliationCandidate,
@@ -124,30 +127,27 @@ function jsonResult(status: number, value: unknown): OntologyStudioRouteResult {
   };
 }
 
-function htmlResult(writeEnabled: boolean): OntologyStudioRouteResult {
-  const writeBlock = writeEnabled
-    ? `<p><strong>Write mode is enabled.</strong> Mutation routes under <code>/api/ontology/patch/*</code> require an <code>Authorization: Bearer &lt;token&gt;</code> header.</p>`
-    : `<p>This server is read-only. Start with <code>--write</code> to enable patch mutation routes.</p>`;
+function htmlResult(
+  context: ReturnType<typeof loadOntologyPatchContext>,
+  writeEnabled: boolean,
+  selectedCandidateId?: string,
+): OntologyStudioRouteResult {
   return {
     status: 200,
     contentType: "text/html; charset=utf-8",
-    body: `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Graphify Ontology Studio</title>
-  <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.45; }
-    code { background: #f2f4f7; padding: 0.1rem 0.25rem; border-radius: 4px; }
-  </style>
-</head>
-<body>
-  <h1>Graphify Ontology Studio</h1>
-  <p>Read-only reconciliation APIs are available under <code>/api/ontology</code>.</p>
-  ${writeBlock}
-</body>
-</html>`,
+    body: renderOntologyStudioWorkspace(context, { writeEnabled, selectedCandidateId }),
+  };
+}
+
+function graphHtmlArtifactResult(context: ReturnType<typeof loadOntologyPatchContext>): OntologyStudioRouteResult {
+  const graphHtmlPath = join(context.stateDir, "graph.html");
+  if (!existsSync(graphHtmlPath)) {
+    return jsonResult(404, { error: "graph.html not found" });
+  }
+  return {
+    status: 200,
+    contentType: "text/html; charset=utf-8",
+    body: readFileSync(graphHtmlPath, "utf-8"),
   };
 }
 
@@ -274,7 +274,10 @@ export function handleOntologyStudioRequest(
     const url = new URL(requestUrl, "http://127.0.0.1");
     const context = loadOntologyPatchContext(options.profileStatePath);
     if (url.pathname === "/" || url.pathname === "/index.html") {
-      return htmlResult(Boolean(options.write));
+      return htmlResult(context, Boolean(options.write), optionalString(url.searchParams.get("candidate")));
+    }
+    if (url.pathname === "/api/ontology/artifacts/graph.html") {
+      return graphHtmlArtifactResult(context);
     }
     if (url.pathname === "/api/ontology/reconciliation/candidates") {
       return jsonResult(200, listOntologyReconciliationCandidates(context, candidateFilters(url.searchParams)));

--- a/src/types/optional-deps.d.ts
+++ b/src/types/optional-deps.d.ts
@@ -27,7 +27,8 @@ declare module "unpdf" {
 }
 
 declare module "@sentropic/design-system/tokens" {
-  export const workspaceTokens: unknown;
-  const defaultTokens: unknown;
+  import type { WorkspaceThemedTokens } from "../workspace/tokens.js";
+  export const workspaceTokens: WorkspaceThemedTokens;
+  const defaultTokens: WorkspaceThemedTokens;
   export default defaultTokens;
 }

--- a/src/workspace/graph-panel.ts
+++ b/src/workspace/graph-panel.ts
@@ -36,6 +36,8 @@ export interface RenderGraphPanelOptions {
   tokens: WorkspaceTokens;
   /** Optional URL/path to a `graphify export html` artefact. */
   graphHtmlUrl?: string;
+  /** Optional same-origin URL used when the workspace is served over HTTP. */
+  liveGraphHtmlUrl?: string;
   /**
    * Optional height of the iframe / placeholder, in CSS pixels.
    * Defaults to 480.
@@ -102,12 +104,25 @@ function renderMetricsCard(subgraph: FocusSubgraph, state: WorkspaceViewerState)
 function renderViewerSurface(opts: RenderGraphPanelOptions): string {
   const height = Math.max(120, Math.round(opts.height ?? 480));
   const url = opts.graphHtmlUrl ? escapeUrl(opts.graphHtmlUrl) : "";
+  const liveUrl = opts.liveGraphHtmlUrl ? escapeUrl(opts.liveGraphHtmlUrl) : "";
   if (!url) {
     return [
       '<div class="ws-graph-placeholder" id="ws-graph-network">',
       "<p>Graph surface unavailable.</p>",
       "</div>",
     ].join("");
+  }
+  if (liveUrl) {
+    return [
+      '<iframe',
+      `  srcdoc="${escapeHtml("<p>Loading graph surface...</p>")}"`,
+      `  data-ws-file-graph-src="${url}"`,
+      `  data-ws-live-graph-src="${liveUrl}"`,
+      `  title="Graphify graph surface"`,
+      `  style="width:100%;height:${height}px;border:1px solid var(--ws-border);border-radius:var(--ws-radius-md);background:var(--ws-surface);"`,
+      '  sandbox="allow-scripts"',
+      "></iframe>",
+    ].join("\n");
   }
   return [
     '<iframe',
@@ -116,6 +131,24 @@ function renderViewerSurface(opts: RenderGraphPanelOptions): string {
     `  style="width:100%;height:${height}px;border:1px solid var(--ws-border);border-radius:var(--ws-radius-md);background:var(--ws-surface);"`,
     '  sandbox="allow-scripts"',
     "></iframe>",
+  ].join("\n");
+}
+
+function renderLiveGraphScript(enabled: boolean): string {
+  if (!enabled) return "";
+  return [
+    "<script>",
+    "(() => {",
+    '  const frame = document.querySelector("iframe[data-ws-file-graph-src]");',
+    "  if (!frame) return;",
+    '  const fileSrc = frame.getAttribute("data-ws-file-graph-src");',
+    '  const liveSrc = frame.getAttribute("data-ws-live-graph-src");',
+    '  const src = window.location.protocol === "file:" || !liveSrc ? fileSrc : liveSrc;',
+    '  if (!src) return;',
+    '  frame.removeAttribute("srcdoc");',
+    '  frame.setAttribute("src", src);',
+    "})();",
+    "</script>",
   ].join("\n");
 }
 
@@ -129,5 +162,10 @@ export function renderGraphPanel(opts: RenderGraphPanelOptions): string {
     ".ws-graph-placeholder code { background: var(--ws-surface-2); padding: 0 var(--ws-space-1); border-radius: var(--ws-radius-sm); }",
     "</style>",
   ].join("\n");
-  return [styles, renderMetricsCard(subgraph, opts.state), renderViewerSurface(opts)].join("\n");
+  return [
+    styles,
+    renderMetricsCard(subgraph, opts.state),
+    renderViewerSurface(opts),
+    renderLiveGraphScript(Boolean(opts.liveGraphHtmlUrl)),
+  ].filter(Boolean).join("\n");
 }

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -14,15 +14,19 @@ export type {
   WorkspaceFocusRingTokens,
   WorkspaceTokens,
   WorkspaceThemedTokens,
+  WorkspaceTokenSource,
+  WorkspaceTheme,
+  ResolvedWorkspaceTokens,
   WorkspaceTokenGroup,
 } from "./tokens.js";
-export { WORKSPACE_TOKEN_GROUPS } from "./tokens.js";
+export { DEFAULT_WORKSPACE_THEME, WORKSPACE_TOKEN_GROUPS } from "./tokens.js";
 export {
   getWorkspaceTokens,
   getWorkspaceTokensFallback,
+  resolveWorkspaceTokens,
   serialiseTokensToCss,
 } from "./tokens-fallback.js";
-export { tryGetDsTokens } from "./tokens-ds.js";
+export { normaliseDesignSystemTokens, tryGetDsTokens } from "./tokens-ds.js";
 
 export type { RenderWorkspaceShellOptions } from "./shell.js";
 export { renderWorkspaceShell } from "./shell.js";

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -37,7 +37,7 @@
  * inside #graph-panel (G4), reconciliation rebind (G5).
  */
 
-import type { WorkspaceTokens } from "./tokens.js";
+import type { WorkspaceTokens, WorkspaceTokenSource } from "./tokens.js";
 import type { GraphEdgeLike, GraphLike, GraphNodeLike } from "./graph-selection.js";
 import type { WorkspaceViewerState } from "./viewer-state.js";
 import { serialiseTokensToCss } from "./tokens-fallback.js";
@@ -45,6 +45,8 @@ import { serialiseTokensToCss } from "./tokens-fallback.js";
 export interface RenderWorkspaceShellOptions {
   /** Resolved tokens for the active theme. */
   tokens: WorkspaceTokens;
+  /** Whether tokens came from @sentropic/design-system or the local fallback. */
+  tokenSource?: WorkspaceTokenSource;
   /** Workspace title displayed in the header. Sanitised. */
   title: string;
   /**
@@ -70,6 +72,12 @@ export interface RenderWorkspaceShellOptions {
   queueEmpty?: boolean;
   /** Trusted internal HTML fragment rendered inside the graph panel slot. */
   graphPanelHtml?: string;
+  /** Trusted internal HTML fragment rendered inside the left workbench slot. */
+  leftWorkbenchHtml?: string;
+  /** Trusted internal HTML fragment rendered inside the central display slot. */
+  centralDisplayHtml?: string;
+  /** Trusted internal HTML fragment rendered inside the detail drawer slot. */
+  rightDrawerHtml?: string;
   /** Current workspace state. Used to resolve the central display item. */
   state?: WorkspaceViewerState;
   /** Graph payload (typically loaded from `.graphify/graph.json`). */
@@ -282,19 +290,23 @@ function shellStyles(): string {
  */
 export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string {
   const tokens = opts.tokens;
+  const tokenSource = escapeHtml(opts.tokenSource ?? "fallback");
   const title = escapeHtml(opts.title);
   const profileId = opts.profileId ? escapeHtml(opts.profileId) : "—";
   const lastRebuiltAt = opts.lastRebuiltAt ? escapeHtml(opts.lastRebuiltAt) : "";
   const writeFlag = opts.writeEnabled === true;
   const queueEmpty = opts.queueEmpty === true;
   const tokensCss = serialiseTokensToCss(tokens);
-  const queueBody = queueEmpty
+  const queueBody = opts.leftWorkbenchHtml ?? (queueEmpty
     ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
-    : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>';
+    : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>');
   const graphPanelBody =
     opts.graphPanelHtml ??
     '<p class="ws-empty">No graph context available.</p>';
-  const centralDisplayBody = renderCentralDisplayBody(opts.state, opts.graph);
+  const centralDisplayBody = opts.centralDisplayHtml ?? renderCentralDisplayBody(opts.state, opts.graph);
+  const rightDrawerBody =
+    opts.rightDrawerHtml ??
+    '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>';
 
   return [
     "<!DOCTYPE html>",
@@ -310,7 +322,7 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     "</head>",
     "<body>",
     '<a class="ws-skip-link" href="#central-display">Skip to central display</a>',
-    '<div class="ws-root" role="application" aria-label="Graphify ontology workspace">',
+    `<div class="ws-root" role="application" aria-label="Graphify ontology workspace" data-token-source="${tokenSource}">`,
     '<header class="ws-header" role="banner">',
     `<h1>${title}</h1>`,
     '<div class="ws-header-meta">',
@@ -335,7 +347,7 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     "</main>",
     '<aside class="ws-right" id="right-drawer" role="complementary" aria-label="Detail drawer">',
     '<h2 class="ws-region-heading">Detail</h2>',
-    '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>',
+    rightDrawerBody,
     "</aside>",
     "</div>",
     "</body>",

--- a/src/workspace/tokens-ds.ts
+++ b/src/workspace/tokens-ds.ts
@@ -13,20 +13,73 @@
  * subpath), this adapter's success path becomes the primary token
  * source and the fallback becomes a safety net.
  */
-import type { WorkspaceThemedTokens } from "./tokens.js";
+import {
+  WORKSPACE_TOKEN_GROUPS,
+  type WorkspaceThemedTokens,
+  type WorkspaceTokenGroup,
+  type WorkspaceTokens,
+} from "./tokens.js";
 
 interface DsTokensModuleShape {
   workspaceTokens?: WorkspaceThemedTokens;
   default?: WorkspaceThemedTokens;
 }
 
-function isThemedTokens(value: unknown): value is WorkspaceThemedTokens {
-  if (!value || typeof value !== "object") return false;
-  const v = value as { light?: unknown; dark?: unknown };
-  return (
-    !!v.light && typeof v.light === "object" &&
-    !!v.dark && typeof v.dark === "object"
-  );
+const REQUIRED_KEYS: Record<WorkspaceTokenGroup, readonly string[]> = {
+  colour: [
+    "surface",
+    "surface-2",
+    "border",
+    "text",
+    "text-muted",
+    "accent",
+    "danger",
+    "success",
+    "warning",
+  ],
+  typography: [
+    "font-family-sans",
+    "font-family-mono",
+    "font-size-sm",
+    "font-size-md",
+    "font-size-lg",
+    "line-height-tight",
+    "line-height-normal",
+  ],
+  spacing: [
+    "space-0",
+    "space-1",
+    "space-2",
+    "space-3",
+    "space-4",
+    "space-5",
+    "space-6",
+    "space-7",
+  ],
+  radius: ["radius-sm", "radius-md", "radius-lg"],
+  elevation: ["shadow-card", "shadow-popover"],
+  focusRing: ["outline", "outline-offset", "outline-color"],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasStringKeys(value: unknown, keys: readonly string[]): boolean {
+  if (!isRecord(value)) return false;
+  return keys.every((key) => typeof value[key] === "string" && value[key].length > 0);
+}
+
+function isWorkspaceTokens(value: unknown): value is WorkspaceTokens {
+  if (!isRecord(value)) return false;
+  return WORKSPACE_TOKEN_GROUPS.every((group) => hasStringKeys(value[group], REQUIRED_KEYS[group]));
+}
+
+export function normaliseDesignSystemTokens(value: unknown): WorkspaceThemedTokens | null {
+  if (!isRecord(value)) return null;
+  const candidate = value as { light?: unknown; dark?: unknown };
+  if (!isWorkspaceTokens(candidate.light) || !isWorkspaceTokens(candidate.dark)) return null;
+  return value as unknown as WorkspaceThemedTokens;
 }
 
 /**
@@ -39,7 +92,7 @@ export async function tryGetDsTokens(): Promise<WorkspaceThemedTokens | null> {
       /* @vite-ignore */ "@sentropic/design-system/tokens"
     )) as DsTokensModuleShape;
     const candidate = mod.workspaceTokens ?? mod.default;
-    return isThemedTokens(candidate) ? candidate : null;
+    return normaliseDesignSystemTokens(candidate);
   } catch {
     return null;
   }

--- a/src/workspace/tokens-fallback.ts
+++ b/src/workspace/tokens-fallback.ts
@@ -10,9 +10,13 @@
  * token contract.
  */
 import type {
+  WorkspaceTheme,
+  ResolvedWorkspaceTokens,
   WorkspaceTokens,
   WorkspaceThemedTokens,
 } from "./tokens.js";
+import { DEFAULT_WORKSPACE_THEME } from "./tokens.js";
+import { tryGetDsTokens } from "./tokens-ds.js";
 
 const SHARED_TYPOGRAPHY = Object.freeze({
   "font-family-sans":
@@ -102,15 +106,33 @@ export function getWorkspaceTokensFallback(): WorkspaceThemedTokens {
 }
 
 /**
- * Convenience: get the fallback tokens for a single theme. `dark` is
- * the default (matches the current graph.html dark palette so the
- * workspace shell and the graph viewer feel cohesive when shown
- * side-by-side during reconciliation).
+ * Convenience: get the fallback tokens for a single theme. The default
+ * follows the design-system default theme instead of forcing a dark
+ * override at each call site.
  */
 export function getWorkspaceTokens(
-  theme: "light" | "dark" = "dark",
+  theme: WorkspaceTheme = DEFAULT_WORKSPACE_THEME,
 ): WorkspaceTokens {
   return theme === "light" ? LIGHT_TOKENS : DARK_TOKENS;
+}
+
+export async function resolveWorkspaceTokens(
+  theme: WorkspaceTheme = DEFAULT_WORKSPACE_THEME,
+): Promise<ResolvedWorkspaceTokens> {
+  const dsTokens = await tryGetDsTokens();
+  if (dsTokens) {
+    return {
+      source: "design-system",
+      themedTokens: dsTokens,
+      tokens: dsTokens[theme],
+    };
+  }
+  const themedTokens = getWorkspaceTokensFallback();
+  return {
+    source: "fallback",
+    themedTokens,
+    tokens: themedTokens[theme],
+  };
 }
 
 /**

--- a/src/workspace/tokens.ts
+++ b/src/workspace/tokens.ts
@@ -103,6 +103,17 @@ export interface WorkspaceThemedTokens {
   dark: WorkspaceTokens;
 }
 
+export type WorkspaceTheme = keyof WorkspaceThemedTokens;
+export const DEFAULT_WORKSPACE_THEME: WorkspaceTheme = "light";
+
+export type WorkspaceTokenSource = "design-system" | "fallback";
+
+export interface ResolvedWorkspaceTokens {
+  source: WorkspaceTokenSource;
+  themedTokens: WorkspaceThemedTokens;
+  tokens: WorkspaceTokens;
+}
+
 /** Top-level roles enumerated for the test suite to assert coverage. */
 export const WORKSPACE_TOKEN_GROUPS = [
   "colour",

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -56,6 +56,33 @@ describe("safeToHtml", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("aligns standalone graph HTML with the workspace token contract", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-token-theme-"));
+    const htmlPath = join(dir, "graph.html");
+
+    const G = new Graph();
+    G.addNode("a", { label: "A", source_file: "src/a.ts", file_type: "code" });
+    const communities = new Map([[0, ["a"]]]);
+
+    toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
+
+    const html = readFileSync(htmlPath, "utf-8");
+    expect(html).toContain("--ws-surface: #ffffff;");
+    expect(html).toContain("--ws-surface-2: #f5f6f8;");
+    expect(html).toContain("body { background: var(--ws-surface); color: var(--ws-text);");
+    expect(html).toContain("#graph { flex: 1; outline: none; background: var(--ws-surface);");
+    expect(html).toContain("#sidebar { width: 280px; background: var(--ws-surface-2); border-left: 1px solid var(--ws-border);");
+    expect(html).toContain("--graph-weak-text: var(--ws-text-muted);");
+    expect(html).toContain("--graph-muted-strong: var(--ws-text-muted);");
+    expect(html).toContain("--graph-node-label: var(--ws-text);");
+    expect(html).toContain("--graph-neighbor-border: var(--ws-border);");
+    expect(html).not.toContain("body { background: #0f0f1a;");
+    expect(html).not.toContain("color:#aaa");
+    expect(html).not.toContain("color:#bbb");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("does not crash when source_file is nullish", () => {
     const dir = mkdtempSync(join(tmpdir(), "graphify-html-export-"));
     const htmlPath = join(dir, "graph.html");

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   createOntologyStudioRequestHandler,
   generateOntologyStudioToken,
+  handleOntologyStudioRequest,
   startOntologyStudioServer,
 } from "../src/ontology-studio.js";
 
@@ -30,6 +31,79 @@ function postBody(payload: unknown): { body: string; headers: Record<string, str
   };
 }
 
+function writeCandidateQueue(fixture: ReturnType<typeof writeOntologyWriteFixture>): void {
+  const reconciliationDir = join(fixture.stateDir, "ontology", "reconciliation");
+  mkdirSync(reconciliationDir, { recursive: true });
+  writeFileSync(
+    join(reconciliationDir, "candidates.json"),
+    JSON.stringify({
+      schema: "graphify_ontology_reconciliation_candidates_v1",
+      graph_hash: "graph-hash",
+      profile_hash: "profile-hash",
+      generated_at: "2026-05-21T00:00:00.000Z",
+      candidate_count: 1,
+      candidates: [
+        {
+          id: "candidate-high",
+          kind: "entity_match",
+          status: "candidate",
+          score: 0.91,
+          candidate_id: "candidate-component",
+          canonical_id: "component-a",
+          shared_terms: ["component"],
+          evidence_refs: ["manual.md#p1"],
+          reasons: ["same node type: Component"],
+          proposed_patch_operation: "accept_match",
+        },
+      ],
+    }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(
+    fixture.auditPath,
+    JSON.stringify({
+      patch: { ...fixture.patch, id: "decision-audit", created_at: "2026-05-21T01:00:00.000Z" },
+      applied_at: "2026-05-21T02:00:00.000Z",
+    }) + "\n",
+    "utf-8",
+  );
+}
+
+function writeGraphPreview(fixture: ReturnType<typeof writeOntologyWriteFixture>): void {
+  writeFileSync(
+    join(fixture.stateDir, "graph.json"),
+    JSON.stringify({
+      nodes: [
+        {
+          id: "candidate-component",
+          label: "Candidate component",
+          node_type: "Component",
+          status: "candidate",
+          confidence: "EXTRACTED",
+          source_file: "manual.md",
+          source_location: "p1",
+          community: 1,
+        },
+        {
+          id: "component-a",
+          label: "Component A",
+          node_type: "Component",
+          status: "validated",
+          confidence: "EXTRACTED",
+          source_file: "manual.md",
+          source_location: "p1",
+          community: 1,
+        },
+      ],
+      links: [
+        { source: "candidate-component", target: "component-a", relation: "candidate_match", confidence: "EXTRACTED" },
+      ],
+    }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(join(fixture.stateDir, "graph.html"), "<!doctype html><title>graph</title>", "utf-8");
+}
+
 afterEach(() => {
   while (tempDirs.length) {
     const dir = tempDirs.pop();
@@ -42,6 +116,49 @@ describe("graphify ontology studio --write", () => {
     const token = generateOntologyStudioToken();
     expect(token).toMatch(/^[0-9a-f]{48}$/);
     expect(generateOntologyStudioToken()).not.toBe(token);
+  });
+
+  it("renders the G5 workspace shell on the studio root route", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?candidate=candidate-high",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.contentType).toBe("text/html; charset=utf-8");
+    expect(result.body).toContain('data-token-source="fallback"');
+    expect(result.body).toContain('id="candidate-list"');
+    expect(result.body).toContain('data-candidate-id="candidate-high"');
+    expect(result.body).toContain("candidate-component");
+    expect(result.body).toContain("Candidate component");
+    expect(result.body).toContain("component-a");
+    expect(result.body).toContain("Component A");
+    expect(result.body).toContain("<dt>Type</dt>");
+    expect(result.body).toContain("<dd>Component</dd>");
+    expect(result.body).toContain("manual.md#p1");
+    expect(result.body).toContain("decision-audit");
+    expect(result.body).toContain("Decision basis");
+    expect(result.body).not.toContain("Patch preview");
+    expect(result.body).not.toContain("&quot;operation&quot;");
+    expect(result.body).toContain("<b>Mode:</b> Overview");
+    expect(result.body).toContain('title="Graphify graph surface"');
+    expect(result.body).toContain(encodeURI(`file://${fixture.stateDir}/graph.html`));
+    expect(result.body).toContain('data-ws-live-graph-src="/api/ontology/artifacts/graph.html"');
+    expect(result.body).not.toContain("Read-only reconciliation APIs are available");
+
+    const graphArtifact = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/api/ontology/artifacts/graph.html",
+    );
+    expect(graphArtifact.status).toBe(200);
+    expect(graphArtifact.body).toContain("<title>graph</title>");
   });
 
   it("refuses --write when host is not loopback", async () => {

--- a/tests/workspace-shell.test.ts
+++ b/tests/workspace-shell.test.ts
@@ -21,6 +21,24 @@ describe("Track G G2 — workspace shell scaffold", () => {
     expect(html).toContain('role="application"');
   });
 
+  it("marks the token source and lets studio routes fill each workspace region", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      tokenSource: "fallback",
+      title: "Ontology workspace",
+      leftWorkbenchHtml: '<nav id="candidate-list">Candidate queue</nav>',
+      centralDisplayHtml: '<article id="candidate-detail">Candidate detail</article>',
+      rightDrawerHtml: '<aside id="audit-detail">Audit trail</aside>',
+    });
+
+    expect(html).toContain('data-token-source="fallback"');
+    expect(html).toContain('<nav id="candidate-list">Candidate queue</nav>');
+    expect(html).toContain('<article id="candidate-detail">Candidate detail</article>');
+    expect(html).toContain('<aside id="audit-detail">Audit trail</aside>');
+    expect(html).not.toContain("Queue rendering arrives in G5.");
+    expect(html).not.toContain("Evidence / relations / audit trail accordion arrives with G5.");
+  });
+
   it("keeps central display copy neutral until item rendering is wired", () => {
     const html = renderWorkspaceShell({ tokens, title: "Ontology workspace" });
     expect(html).toContain("No display item selected.");

--- a/tests/workspace-tokens.test.ts
+++ b/tests/workspace-tokens.test.ts
@@ -4,6 +4,8 @@ import {
   WORKSPACE_TOKEN_GROUPS,
   getWorkspaceTokens,
   getWorkspaceTokensFallback,
+  normaliseDesignSystemTokens,
+  resolveWorkspaceTokens,
   serialiseTokensToCss,
   tryGetDsTokens,
   type WorkspaceTokens,
@@ -17,10 +19,10 @@ describe("Track G G1 — workspace token fallback", () => {
     expect(themed.light).not.toBe(themed.dark);
   });
 
-  it("defaults getWorkspaceTokens() to the dark theme", () => {
-    const dark = getWorkspaceTokens();
-    const explicit = getWorkspaceTokens("dark");
-    expect(dark).toBe(explicit);
+  it("defaults getWorkspaceTokens() to the design-system default theme", () => {
+    const defaultTheme = getWorkspaceTokens();
+    const explicit = getWorkspaceTokens("light");
+    expect(defaultTheme).toBe(explicit);
   });
 
   it("exposes every required token group on every theme", () => {
@@ -91,5 +93,25 @@ describe("Track G G1 — workspace token fallback", () => {
   it("returns null from tryGetDsTokens when @sentropic/design-system is absent", async () => {
     const ds = await tryGetDsTokens();
     expect(ds).toBeNull();
+  });
+
+  it("validates the full design-system token shape before accepting it", () => {
+    const fallback = getWorkspaceTokensFallback();
+    expect(normaliseDesignSystemTokens(fallback)).toBe(fallback);
+    expect(normaliseDesignSystemTokens({
+      light: { ...fallback.light, colour: { ...fallback.light.colour, accent: 42 } },
+      dark: fallback.dark,
+    })).toBeNull();
+    expect(normaliseDesignSystemTokens({
+      light: fallback.light,
+      dark: { ...fallback.dark, focusRing: undefined },
+    })).toBeNull();
+  });
+
+  it("resolves the active tokens with an explicit source label", async () => {
+    const resolved = await resolveWorkspaceTokens();
+    expect(resolved.source).toBe("fallback");
+    expect(resolved.tokens).toBe(getWorkspaceTokens());
+    expect(resolved.themedTokens.light).toBe(getWorkspaceTokens());
   });
 });


### PR DESCRIPTION
Finality: continue Track G after G4.5 by making the ontology studio usable for reconciliation UAT instead of an API placeholder.

Changes:
- The workspace shell and standalone graph export now use the workspace default light token contract; the graph canvas itself has a light surface, muted text tokens, light labels, and light relation colors.
- The studio root route renders the G5 workspace shell with the reconciliation queue, candidate/canonical entity cards, evidence, audit drawer and rebuild status.
- The technical JSON Patch Preview block was removed from the main UI; the candidate view now renders decision basis and graph-backed entity metadata.
- The graph panel opens in full Overview mode by default and embeds the existing .graphify/graph.html surface.
- The graph iframe keeps a file:// source for local UAT exports and switches to /api/ontology/artifacts/graph.html when served over the local HTTP studio, so the graph is visible in both modes.
- .graphify artifacts rebuilt with npx graphify hook-rebuild.

Verification:
- npm run lint
- npm test (733 passed, 7 skipped)
- npm run build
- npx graphify hook-rebuild (completed; optional parser warnings on fixture files only)
- Playwright HTTP UAT: Graphify Ontology Studio, 0 console errors, graph iframe route served.
- GitHub TypeScript CI run 26263902313: green.

UAT:
- file:///home/antoinefa/src/graphify/.worktrees/track-g-g5-workspace-alignment/.graphify/uat/g5-workspace-alignment-public-pack.html
