### PR TITLE
Track G G6-1 — three-column shell + compact display + graph controls + counters

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-22)
 
 ## Corpus Check
-- 268 files · ~338,969 words
+- 272 files · ~341 728 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4253 nodes · 6837 edges · 223 communities detected
+- 4300 nodes · 6906 edges · 228 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 268 · Candidates: 288
-- Excluded: 0 untracked · 15726 ignored · 4 sensitive · 0 missing committed
+- Included files: 272 · Candidates: 292
+- Excluded: 0 untracked · 15509 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `d7c6046`
+- Built from Git commit: `1b0efd1`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -46,952 +46,970 @@
 
 ## Communities
 
-### Community 34 - "Community 34"
-Cohesion: 0.11
-Nodes (30): GraphInstance, JSON_NOISE_LABELS, nodeCommunityMap(), isFileNode(), isConceptNode(), isJsonKeyNode(), fileCategory(), topLevelDir() (+22 more)
-
-### Community 111 - "Community 111"
-Cohesion: 0.23
-Nodes (10): estimateTokens(), querySubgraphTokens(), SAMPLE_QUESTIONS, BenchmarkOptions, loadGraph(), runBenchmark(), estimateTokens(), querySubgraphTokens() (+2 more)
-
-### Community 87 - "Community 87"
-Cohesion: 0.20
-Nodes (14): BuildOptions, normalizeSourceFilePath(), normalizedLabel(), dedupLabelKey(), asRecord(), asString(), sourceKey(), rootForOptions() (+6 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.07
-Nodes (43): StatIndexEntry, statIndex, statIndexFile(), ensureStatIndex(), flushStatIndex(), statMtimeNs(), CacheOptions, bodyContent() (+35 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.06
-Nodes (25): __filename, __dirname, VERSION, splitFiles(), changedFilesFromGit(), readJson(), isJsonRecord(), loadWikiDescriptionSidecarIndex() (+17 more)
-
-### Community 59 - "Community 59"
-Cohesion: 0.16
-Nodes (26): writeFileAtomic(), canonicalPlatformName(), runtimeGlobalSkillPlatformName(), platformNamesForError(), resolveGlobalSkillDestination(), previewPath(), emptyPreview(), platformInstallPreview() (+18 more)
-
-### Community 144 - "Community 144"
-Cohesion: 0.24
-Nodes (10): opencodeConfigPath(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), getAgentsMdSection(), installOpenCodePlugin(), uninstallOpenCodePlugin(), installCodexHook(), uninstallCodexHook() (+2 more)
-
-### Community 157 - "Community 157"
-Cohesion: 0.25
-Nodes (9): uninstallAll(), uninstallGeminiMcp(), cursorUninstall(), antigravityUninstall(), kiroUninstall(), vscodeUninstall(), uninstallClaudeHook(), claudeUninstall() (+1 more)
-
-### Community 158 - "Community 158"
-Cohesion: 0.39
-Nodes (7): canonicalizeForPartition(), partition(), splitCommunity(), ClusterOptions, cluster(), cohesionScore(), scoreAll()
-
-### Community 78 - "Community 78"
-Cohesion: 0.13
-Nodes (13): NumericMapLike, StringMapLike, ReportHighRiskNode, ReportTestGap, ReportReviewOptions, GenerateReportOptions, normalizeFlows(), normalizeAffectedFlows() (+5 more)
-
-### Community 124 - "Community 124"
-Cohesion: 0.24
-Nodes (9): normalizeCommunityLabel(), readLabelsJson(), readGraphAttributeLabels(), resolveCommunityLabels(), persistCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.14
-Nodes (21): DETECTION_FILE_TYPES, ConfiguredDetectionInputs, ProfileState, ConfiguredDataprepOptions, ConfiguredDataprepResult, uniqueResolved(), fullPageScreenshotExcludes(), buildConfiguredDetectionInputs() (+13 more)
-
-### Community 94 - "Community 94"
-Cohesion: 0.16
-Nodes (16): uniqueResolved(), fullPageScreenshotExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), warningFor(), recomputeDetection(), mergeScopeInspections(), mergeDetections() (+8 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.06
-Nodes (9): ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, AnalyzeChangesOptions, DetectChangesNodeRisk, DetectChangesTestGap, DetectChangesResult, DetectChangesMinimalResult (+1 more)
-
-### Community 204 - "Community 204"
-Cohesion: 0.60
-Nodes (5): uniqueSorted(), sortNodesByLocation(), mapChangesToNodes(), changedNodesFromFiles(), analyzeChanges()
-
-### Community 65 - "Community 65"
-Cohesion: 0.10
-Nodes (22): CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, IMAGE_EXTENSIONS, OFFICE_EXTENSIONS, GOOGLE_WORKSPACE_EXTENSIONS, VIDEO_EXTENSIONS, SENSITIVE_PATTERNS (+14 more)
-
-### Community 135 - "Community 135"
-Cohesion: 0.22
-Nodes (11): isSensitive(), countWords(), isNoiseDir(), matchGlob(), relativeWithin(), matchesIgnorePattern(), isIgnored(), walkDir() (+3 more)
-
-### Community 209 - "Community 209"
-Cohesion: 0.67
-Nodes (4): officeParseToText(), docxToMarkdown(), xlsxToMarkdown(), convertOfficeFile()
-
-### Community 205 - "Community 205"
-Cohesion: 0.50
-Nodes (5): md5File(), loadManifest(), normaliseManifestEntry(), saveManifest(), detectIncremental()
-
-### Community 95 - "Community 95"
-Cohesion: 0.17
-Nodes (13): DirectSemanticFile, DirectSemanticChunk, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, PackSemanticFilesOptions, DirectSemanticClientOptions, toPortableRelative(), estimateFileTokens() (+5 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.10
-Nodes (20): BACKUP_ARTIFACTS, todayIso(), backupIfProtected(), COMMUNITY_COLORS, inferNodeShape(), CONFIDENCE_SCORE_DEFAULTS, CommunityLabelsInput, CommunityLabelOptions (+12 more)
-
-### Community 169 - "Community 169"
-Cohesion: 0.25
-Nodes (8): nodeCommunityMap(), isSvgOptions(), buildFreshnessMetadata(), computeTopologySignatureFromLinks(), computeTopologySignature(), toJson(), toGraphml(), toSvg()
-
-### Community 145 - "Community 145"
-Cohesion: 0.24
-Nodes (10): isCommunityLabelOptions(), isCanvasOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile(), htmlStyles(), hyperedgeScript(), htmlScript() (+2 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (38): SyntaxNode, Tree, moduleRequire, _languageCache, TsconfigAliasEntry, tsconfigAliasCache, TsconfigDocument, stripJsonc() (+30 more)
-
-### Community 106 - "Community 106"
-Cohesion: 0.39
-Nodes (15): ensureParserInit(), parseText(), resolveGrammarWasm(), loadLanguage(), qualifiedFileStem(), buildResolvableLabelIndex(), _extractPythonRationale(), extractJulia() (+7 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.15
-Nodes (22): _makeId(), _readText(), _resolveName(), _importPython(), _importJava(), _importC(), _importCsharp(), _importKotlin() (+14 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.25
-Nodes (11): toPortablePath(), inferCommonRoot(), projectRelativeFilePath(), loadTsconfigAliases(), normalizeJsImportTarget(), resolveJsImportTargetInfo(), resolveJsImportTarget(), remapFileNodeIds() (+3 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.15
-Nodes (13): _extractGeneric(), extractPython(), extractJs(), extractJava(), extractC(), extractCpp(), extractRuby(), extractCsharp() (+5 more)
-
-### Community 146 - "Community 146"
-Cohesion: 0.20
-Nodes (10): lineForIndex(), extractRegexBackedCode(), simpleGroovyTypeName(), braceDelta(), extractGroovy(), normalizeSqlObjectName(), sqlStatementBlock(), extractSql() (+2 more)
-
-### Community 3 - "Community 3"
-Cohesion: 0.05
-Nodes (48): DetectEntryPointsOptions, TraceFlowsOptions, BuildFlowArtifactOptions, ReviewFlow, ReviewFlowStep, ReviewFlowDetail, ReviewFlowArtifact, AffectedFlowsResult (+40 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.24
-Nodes (14): GitContext, execGit(), safeExecGit(), resolveFromGitCwd(), gitRevParse(), safeGitRevParse(), isSafeGitPath(), resolveGitContext() (+6 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.18
-Nodes (13): GOOGLE_WORKSPACE_EXTENSIONS, EXPORT_MIME_TYPE_BY_EXTENSION, GoogleWorkspaceShortcut, GoogleWorkspaceFetcher, ConvertGoogleWorkspaceOptions, extractFileIdFromUrl(), extractResourceKey(), readGoogleShortcut() (+5 more)
-
-### Community 159 - "Community 159"
-Cohesion: 0.39
-Nodes (8): SerializedGraphData, createGraph(), isDirectedGraph(), loadGraphFromData(), serializeGraph(), toUndirectedGraph(), forEachTraversalNeighbor(), traversalNeighbors()
-
-### Community 42 - "Community 42"
-Cohesion: 0.10
-Nodes (28): HookDefinition, HOOKS, GRAPH_GITATTR_LINES, installHook(), uninstallHook(), hookBlockRegex(), escapeRegExp(), readTextFile() (+20 more)
-
-### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (3): ToHtmlOptions, HtmlWriter, SafeToHtmlOptions
-
-### Community 194 - "Community 194"
-Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
-
-### Community 132 - "Community 132"
-Cohesion: 0.33
-Nodes (10): VALID_DENSITY, VALID_ROUTING_SIGNAL, isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray() (+2 more)
-
-### Community 75 - "Community 75"
-Cohesion: 0.14
-Nodes (16): ExportImageDataprepBatchRequestsOptions, ExportImageDataprepBatchRequestsResult, ImportImageDataprepBatchResultsOptions, ImportImageDataprepBatchResultsResult, readJsonl(), asRecord(), readCaption(), artifactHasDeepRoute() (+8 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.12
-Nodes (26): ImageDataprepSourceKind, ImageDataprepArtifact, ImageDataprepManifest, BuildImageDataprepManifestOptions, RunImageDataprepOptions, RunImageDataprepResult, sha256(), fileHash() (+18 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (40): ImageRoutingLabel, ImageRoute, ImageRoutingCalibrationDecision, ImageRoutingLabelEntry, ImageRoutingLabelsFile, ImageRoutingRuleBucket, ImageRoutingRulesFile, ImageRoutingSample (+32 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (18): cleanupDirs, detection, dir, G, communities, cohesion, labels, gods (+10 more)
-
-### Community 108 - "Community 108"
-Cohesion: 0.33
-Nodes (13): yamlStr(), yamlQuoted(), safeFilename(), detectUrlType(), htmlToMarkdown(), fetchTweet(), fetchWebpage(), fetchArxiv() (+5 more)
-
-### Community 63 - "Community 63"
-Cohesion: 0.13
-Nodes (21): InspectInputScopeOptions, InputScopeInventory, InputScopeSelection, GitScopeContext, VALID_SCOPE_MODES, toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
-
-### Community 160 - "Community 160"
-Cohesion: 0.31
-Nodes (9): splitGitLines(), pathspecForPrefix(), resolveGitScopeContext(), makeScope(), countGitPaths(), gitInventory(), buildGitInventory(), fallbackAllScope() (+1 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.12
-Nodes (30): WorktreeMetadata, BranchMetadata, LifecycleMetadata, RefreshLifecycleOptions, PruneCandidate, PrunePlan, readJson(), writeJson() (+22 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.05
-Nodes (34): LlmExecutionCapability, LlmExecutionMode, DirectLlmProvider, DIRECT_LLM_PROVIDERS, TextJsonGenerationInput, VisionJsonAnalysisInput, BatchVisionExportInput, BatchVisionImportInput (+26 more)
-
-### Community 125 - "Community 125"
-Cohesion: 0.17
-Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, tempDirs, dir, mesh, client
-
-### Community 180 - "Community 180"
-Cohesion: 0.43
-Nodes (5): MergeGraphJsonResult, readGraph(), hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles()
-
-### Community 170 - "Community 170"
-Cohesion: 0.36
-Nodes (6): MergeGraphsOptions, MergeGraphsResult, mergedGraphType(), mergeHyperedgesFromGraphs(), mergeGraphsFromFiles(), mergeHyperedges()
-
-### Community 64 - "Community 64"
-Cohesion: 0.13
-Nodes (21): MigrationAction, MigrationEntryType, MigrationEntry, MigrationGitAdvice, GraphifyOutMigrationPlan, GraphifyOutMigrationResult, MigrationOptions, shellQuote() (+13 more)
-
-### Community 79 - "Community 79"
-Cohesion: 0.15
-Nodes (15): MinimalContextRisk, BuildMinimalContextOptions, MinimalContextResult, uniqueSorted(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames() (+7 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.09
-Nodes (30): OntologyDiscoveryProposalKind, OntologyDiscoveryProposalAction, OntologyDiscoverySampleOptions, OntologyDiscoverySampleFile, OntologyDiscoverySampleRegistryRecord, OntologyDiscoverySample, OntologyDiscoveryProposal, OntologyDiscoveryProposalsFile (+22 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.06
-Nodes (33): OntologyOutputConfig, CompileOntologyOutputsOptions, CompileOntologyOutputsResult, CompiledNode, CompiledRelation, sha256(), stringValue(), ontologyNodeType() (+25 more)
-
-### Community 161 - "Community 161"
-Cohesion: 0.42
-Nodes (7): ProfilePatchRuntimeContext, readJson(), optionalJson(), stringValue(), evidenceRefsFromSources(), loadProfilePatchRuntimeContext(), loadOntologyPatchContext()
-
-### Community 46 - "Community 46"
-Cohesion: 0.09
-Nodes (28): ONTOLOGY_RECONCILIATION_DECISION_LOG_SCHEMA, OntologyPatchOperation, OntologyPatchStatus, OntologyPatch, OntologyPatchNode, OntologyPatchRelation, OntologyPatchContext, OntologyPatchIssue (+20 more)
-
-### Community 147 - "Community 147"
-Cohesion: 0.42
-Nodes (10): nonEmptyString(), addError(), nodeType(), nodeById(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateSetStatus() (+2 more)
-
-### Community 148 - "Community 148"
-Cohesion: 0.24
-Nodes (10): stringArray(), addWarning(), knownEvidenceRefs(), validateEvidenceRefs(), normalizeOntologyPatch(), validateOntologyPatch(), appendJsonLine(), auditPath() (+2 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.10
-Nodes (43): DEFAULT_STATUSES, VALID_CITATION_MINIMUMS, VIS_JS_SHAPE_LIST, VIS_JS_SHAPES, asRecord(), asStringArray(), normalizeStringMap(), stableForHash() (+35 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.33
-Nodes (11): OntologyRebuildStatusResponse, readableStatePath(), ontologyReconciliationCandidatesPath(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), loadReadonlyReconciliationCandidates(), reconciliationQueueIsStale(), listOntologyReconciliationCandidates() (+3 more)
-
-### Community 66 - "Community 66"
-Cohesion: 0.13
-Nodes (20): ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA, ONTOLOGY_RECONCILIATION_CANDIDATES_RESPONSE_SCHEMA, OntologyReconciliationCandidateKind, OntologyReconciliationCandidateStatus, OntologyReconciliationCandidate, OntologyReconciliationCandidateQueue, OntologyReconciliationCandidateFilter, OntologyReconciliationCandidatesResponse (+12 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.21
-Nodes (17): ReconciliationWorkspaceModel, RenderOntologyStudioWorkspaceOptions, HTML_ESCAPE_MAP, escapeHtml(), percent(), renderStudioStyles(), renderList(), graphNodeById() (+9 more)
-
-### Community 171 - "Community 171"
-Cohesion: 0.39
-Nodes (8): displayText(), graphNodeTitle(), graphNodeType(), graphNodeSummary(), graphNodeCommunity(), graphNodeMetaRows(), renderMetaRows(), renderEntityCard()
-
-### Community 97 - "Community 97"
-Cohesion: 0.15
-Nodes (10): LOOPBACK_HOSTS, OntologyStudioWriteOptions, OntologyStudioHandlerOptions, StartOntologyStudioServerOptions, StartedOntologyStudioServer, OntologyStudioRouteResult, isLoopbackHost(), generateOntologyStudioToken() (+2 more)
-
-### Community 149 - "Community 149"
-Cohesion: 0.31
-Nodes (10): optionalString(), optionalNumber(), optionalInteger(), candidateFilters(), decisionLogOptions(), jsonResult(), htmlResult(), graphHtmlArtifactResult() (+2 more)
-
-### Community 69 - "Community 69"
-Cohesion: 0.15
-Nodes (21): GraphifyPathOptions, GraphifyScratchPaths, GraphifyLegacyRootScratchPaths, GraphifyProfilePaths, GraphifyImageDataprepPaths, GraphifyOntologyOutputPaths, GraphifyPaths, statePath() (+13 more)
-
-### Community 53 - "Community 53"
-Cohesion: 0.13
-Nodes (26): PDF_IMAGE_EXTENSIONS, PdfPreparationArtifact, PdfPreparationOptions, MistralOcrModule, cloneDetection(), countWords(), metadataPath(), listImageArtifacts() (+18 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.12
-Nodes (23): PdfOcrMode, PdfTextLayerProvider, PdfPreflightOptions, PdfPreflightResult, PdfTextLayerResult, UnpdfTextResult, normalizeText(), countWords() (+15 more)
-
-### Community 81 - "Community 81"
-Cohesion: 0.13
-Nodes (15): BuildProjectOptions, BuildProjectWarning, BuildProjectArtifacts, BuildProjectResult, countNonCodeFiles(), formatDiagnosticSummary(), fileList(), buildProject() (+7 more)
-
-### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (49): PortablePathIssueKind, PortablePathIssue, PortableCheckResult, LOCAL_LIFECYCLE_FILES, LOCAL_LIFECYCLE_PREFIXES, TEXT_ARTIFACT_EXTENSIONS, isWindowsAbsolutePath(), hasSchemePrefix() (+41 more)
-
-### Community 30 - "Community 30"
-Cohesion: 0.09
-Nodes (32): CommandRunner, PullRequestSummary, PullRequestDetails, WorktreePrInfo, PrCommandOptions, defaultRunner, optionsWithDefaults(), normalizeString() (+24 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.10
-Nodes (33): ProfilePromptState, ProfilePromptOptions, ProfilePromptChunk, sampleLimit(), nodeTypeSection(), relationTypeSection(), relationMetadataSection(), registrySection() (+25 more)
-
-### Community 102 - "Community 102"
-Cohesion: 0.19
-Nodes (12): readRegistryRows(), field(), normalizeRegistryRecord(), loadProfileRegistry(), safeIdPart(), registryRecordsToExtraction(), readRegistryRows(), field() (+4 more)
-
-### Community 25 - "Community 25"
-Cohesion: 0.10
-Nodes (34): ProfileReportGraphData, ProfileReportPdfArtifact, ProfileReportContext, rel(), stringValue(), graphNodes(), graphLinks(), projectConfigSection() (+26 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.09
-Nodes (32): ProfileValidationSeverity, ProfileValidationIssue, ProfileValidationContext, ProfileValidationResult, stringValue(), stringArray(), citations(), addIssue() (+24 more)
-
-### Community 58 - "Community 58"
-Cohesion: 0.14
-Nodes (23): CONFIG_CANDIDATES, VALID_PDF_OCR_MODES, VALID_CITATION_MINIMUMS, VALID_LLM_EXECUTION_MODES, VALID_IMAGE_ARTIFACT_SOURCES, VALID_INPUT_SCOPE_MODES, asRecord(), asStringArray() (+15 more)
-
-### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (23): CommitRecommendationConfidence, CommitRecommendationStaleness, CommitRecommendationGroup, CommitRecommendation, CommitRecommendationOptions, FileGraphInfo, GroupDraft, normalizePath() (+15 more)
-
-### Community 195 - "Community 195"
-Cohesion: 0.47
-Nodes (6): uniqueSorted(), mergeDrafts(), stalenessFrom(), minConfidence(), groupConfidence(), buildCommitRecommendation()
-
-### Community 88 - "Community 88"
-Cohesion: 0.17
-Nodes (13): CloneRepoOptions, CloneRepoResult, GithubRepoRef, execGit(), maybeGithubRepo(), repoNameFromUrl(), defaultCloneDestination(), cloneRepo() (+5 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.07
-Nodes (11): ReviewRiskLevel, ReviewBlastRadius, ReviewImpactedCommunity, ReviewMultimodalSafety, ReviewAnalysis, ReviewAnalysisOptions, ReviewEvaluationCase, ReviewEvaluationCaseResult (+3 more)
-
-### Community 172 - "Community 172"
-Cohesion: 0.25
-Nodes (8): uniqueSorted(), riskLevel(), communityRisk(), nodeCommunities(), buildBlastRadius(), impactedCommunities(), multimodalSafety(), buildReviewAnalysis()
-
-### Community 218 - "Community 218"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 219 - "Community 219"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 11 - "Community 11"
-Cohesion: 0.06
-Nodes (39): ReviewBenchmarkCase, ReviewBenchmarkOptions, ReviewBenchmarkTokenBudgetStatus, ReviewBenchmarkMetrics, ReviewBenchmarkCaseResult, ReviewBenchmarkResult, normalize(), uniqueSorted() (+31 more)
-
-### Community 5 - "Community 5"
-Cohesion: 0.05
-Nodes (52): ReviewContextDetailLevel, ReviewContextRisk, BuildReviewContextOptions, ReviewContextPayload, ReviewContextResult, normalizePath(), uniqueSorted(), sourceMatches() (+44 more)
-
-### Community 77 - "Community 77"
-Cohesion: 0.13
-Nodes (16): ReviewGraphNodeKind, ReviewGraphNode, ReviewGraphEdge, ReviewImpactRadius, ReviewGraphStats, ReviewGraphStoreLike, KNOWN_KINDS, normalizePath() (+8 more)
-
-### Community 7 - "Community 7"
-Cohesion: 0.05
-Nodes (38): ReviewNode, ReviewChain, ReviewDelta, ReviewDeltaOptions, compareStrings(), normalizePath(), uniqueSorted(), maybeCommunity() (+30 more)
-
-### Community 173 - "Community 173"
-Cohesion: 0.32
-Nodes (6): normalizeSearchText(), textMatchesQuery(), scoreSearchText(), terms, exact, substring
-
-### Community 113 - "Community 113"
-Cohesion: 0.22
-Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, validateUrl(), isPrivateIp(), validateHostname(), isRedirectStatus(), safeFetch(), safeFetchText()
-
-### Community 123 - "Community 123"
-Cohesion: 0.17
-Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }, tempDirs, imagePath, packageJson, packageLock, outputDir
-
-### Community 49 - "Community 49"
-Cohesion: 0.09
-Nodes (16): ServeOptions, McpToolDefinition, McpResourceDefinition, GraphSnapshot, ReloadingGraphStore, MCP_RESOURCES, graphPath, loadGraph() (+8 more)
-
-### Community 162 - "Community 162"
-Cohesion: 0.25
-Nodes (9): GraphFileSignature, validateGraphFilePath(), readGraphData(), loadGraphSnapshot(), createReloadingGraphStore(), getVersion(), communitiesFromGraph(), serve() (+1 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.21
-Nodes (13): communityName(), mcpField(), nodeDisplayLabel(), scoreNodes(), bfs(), dfs(), subgraphToText(), findNode() (+5 more)
-
-### Community 181 - "Community 181"
-Cohesion: 0.29
-Nodes (7): toolGodNodes(), toolGraphStats(), communityLabelsFromGraph(), resourceConfidenceAudit(), resourceSurprises(), resourceQuestions(), readMcpResource()
-
-### Community 183 - "Community 183"
-Cohesion: 0.33
-Nodes (7): optionalString(), optionalNumber(), optionalInteger(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog(), ontologyAppliedPatchesPath()
-
-### Community 182 - "Community 182"
-Cohesion: 0.43
-Nodes (7): toolListReconciliationCandidates(), toolOntologyRebuildStatus(), readableStatePath(), ontologyReconciliationCandidatesPath(), ontologyNeedsUpdatePath(), loadReadonlyReconciliationCandidates(), reconciliationQueueIsStale()
-
-### Community 127 - "Community 127"
-Cohesion: 0.17
-Nodes (7): tempDirs, bannedReportFirstPatterns, paths, dir, claudeSettings, old, updated
-
-### Community 43 - "Community 43"
-Cohesion: 0.10
-Nodes (22): __filename, __dirname, AnalysisFile, readJson(), writeJson(), scopeOptionDescription(), cacheOptionsFromRuntime(), ProfileRuntimeContext (+14 more)
-
-### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (31): FirstHopHub, FirstHopCommunity, FirstHopSummary, FirstHopSummaryOptions, compareStrings(), round(), maybeCommunity(), communityLabels() (+23 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.09
-Nodes (35): URL_PREFIXES, CACHED_AUDIO_EXTENSIONS, REQUIRED_MODEL_FILES, SUPPORTED_MODELS, MODEL_ALIASES, FasterWhisperSegment, FasterWhisperTranscriptionOptions, FasterWhisperModel (+27 more)
-
-### Community 184 - "Community 184"
-Cohesion: 0.33
-Nodes (4): RenderTreeOptions, TreeNeighbor, nodeLabel(), renderTree()
+### Community 0 - "Community 0"
+Cohesion: 0.02
+Nodes (79): analysis, analysisPath, analysisValues, article, artifact, cacheKey, captionsDir, configOut (+71 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (82): FileType, Confidence, GraphifyInputScopeMode, GraphifyResolvedInputScopeMode, InputScopeSource, InputScopeInspection, GraphNode, GraphEdge (+74 more)
-
-### Community 220 - "Community 220"
-Cohesion: 1.00
-Nodes (1): UnpdfTextResult
-
-### Community 163 - "Community 163"
-Cohesion: 0.25
-Nodes (7): VALID_FILE_TYPES, VALID_CONFIDENCES, REQUIRED_NODE_FIELDS, REQUIRED_EDGE_FIELDS, validateExtraction(), assertValid(), errors
-
-### Community 115 - "Community 115"
-Cohesion: 0.21
-Nodes (9): WATCHED_EXTENSIONS, mergeHyperedges(), builtFromCommit(), rebuildCode(), CheckUpdateResult, checkUpdate(), rebuildLockPath(), acquireRebuildLock() (+1 more)
-
-### Community 164 - "Community 164"
-Cohesion: 0.22
-Nodes (4): WIKI_DESCRIPTION_BATCH_SCHEMA, BuildWikiDescriptionBatchOptions, WikiDescriptionBatchResultRecord, ParseWikiDescriptionBatchOptions
-
-### Community 29 - "Community 29"
-Cohesion: 0.09
-Nodes (36): RawNode, RawCommunity, WikiDescriptionTargetContext, WikiDescriptionNeighbor, CollectWikiDescriptionTargetsOptions, WikiDescriptionTargetCollection, BuildWikiDescriptionPromptOptions, GenerateWikiDescriptionSidecarsClients (+28 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.08
-Nodes (32): WIKI_DESCRIPTION_SCHEMA, WIKI_DESCRIPTION_PROMPT_VERSION, WikiDescriptionTargetKind, WikiDescriptionStatus, WikiDescriptionExecutionMode, WikiDescriptionEvidenceRef, WikiDescriptionGenerator, WikiDescriptionCacheKeyInput (+24 more)
-
-### Community 109 - "Community 109"
-Cohesion: 0.27
-Nodes (12): WikiPageRef, safeFilename(), uniquePageRefs(), normalizeFlows(), flowsThroughNodes(), crossCommunityLinks(), renderDescription(), communityArticle() (+4 more)
-
-### Community 4 - "Community 4"
-Cohesion: 0.06
-Nodes (54): RenderGraphPanelOptions, HTML_ESCAPE_MAP, escapeHtml(), escapeUrl(), modeLabel(), renderMetricsCard(), renderViewerSurface(), renderLiveGraphScript() (+46 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.05
-Nodes (37): graph, graphJsonShape, focused, strongOnly, withWeak, state, subgraph, tokens (+29 more)
-
-### Community 119 - "Community 119"
-Cohesion: 0.26
-Nodes (11): qn(), addFunction(), addCall(), makeFlowStore(), { artifact, store, ids }, result, { artifact, store }, qn() (+3 more)
-
-### Community 174 - "Community 174"
-Cohesion: 0.25
-Nodes (7): tempDirs, section, dir, agents, home, skillPath, skill
-
-### Community 110 - "Community 110"
-Cohesion: 0.14
-Nodes (12): G, gods, labels, godIds, communities, surprises, first, second (+4 more)
-
-### Community 210 - "Community 210"
-Cohesion: 0.50
-Nodes (3): backup, b1, b2
-
-### Community 175 - "Community 175"
-Cohesion: 0.25
-Nodes (6): cleanupDirs, dir, graphPath, graph, edge, attrs
-
-### Community 150 - "Community 150"
-Cohesion: 0.20
-Nodes (9): SAMPLE_EXTRACTION, G, edge, attrs, ext, hyper, hyperedges, ext1 (+1 more)
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (5): tempDirs, dir, settings, commands, matchers
-
-### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (79): tempDirs, dir, graphPath, graphDir, output, source, destRoot, dest (+71 more)
-
-### Community 221 - "Community 221"
-Cohesion: 1.00
-Nodes (2): tempProject(), tempProfileProject()
-
-### Community 212 - "Community 212"
-Cohesion: 0.67
-Nodes (3): runCli(), runSkillRuntime(), runMain()
-
-### Community 72 - "Community 72"
-Cohesion: 0.09
-Nodes (18): tempDirs, dir, skillDir, configOut, profileOut, statePath, extractionPath, reportPath (+10 more)
-
-### Community 89 - "Community 89"
-Cohesion: 0.12
-Nodes (15): G, result, allNodes, sizes, louvainMock, partition, nodes, first (+7 more)
-
-### Community 176 - "Community 176"
-Cohesion: 0.25
-Nodes (7): tempDirs, section, skill, readme, dir, hooks, commands
-
-### Community 99 - "Community 99"
-Cohesion: 0.13
-Nodes (10): cleanupDirs, fixtureRoot, root, config, inputs, detection, filtered, paths (+2 more)
-
-### Community 185 - "Community 185"
-Cohesion: 0.29
-Nodes (6): tempDirs, home, previousCwd, skillPath, versionPath, readme
-
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (5): tempDirs, dir, rule, rulePath, original
-
-### Community 62 - "Community 62"
-Cohesion: 0.09
-Nodes (21): qn(), addNode(), parsed, G, funcA, funcB, store, nodes (+13 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.12
-Nodes (16): codeExts, result, sourceDir, subDir, repoDir, packagesDir, inventory, filePath (+8 more)
-
-### Community 206 - "Community 206"
-Cohesion: 0.40
-Nodes (4): root, files, chunks, client
-
-### Community 137 - "Community 137"
-Cohesion: 0.18
-Nodes (9): PROVIDERS, providerSelection, tempDirs, tempDir, outputPath, client, output, audit (+1 more)
-
-### Community 138 - "Community 138"
-Cohesion: 0.18
-Nodes (9): cleanupDirs, dir, graphPath, warnings, graph, written, persisted, outputPath (+1 more)
-
-### Community 139 - "Community 139"
-Cohesion: 0.18
-Nodes (10): cleanupDirs, dir, filePath, calls, importEdge, demoNode, callTargets, runNode (+2 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.09
-Nodes (15): validate(), process(), main(), HttpClient, Server, NewServer(), validate(), process() (+7 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.08
-Nodes (12): DataProcessor, Processor, GraphifyDemo, IProcessor, DataProcessor, Processor, Get-Data(), Process-Items() (+4 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.14
-Nodes (2): ApiClient, ApiClient
-
-### Community 178 - "Community 178"
-Cohesion: 0.29
-Nodes (2): Transformer, Transformer
-
-### Community 131 - "Community 131"
-Cohesion: 0.25
-Nodes (4): Graph, build_graph(), Graph, build_graph()
-
-### Community 84 - "Community 84"
-Cohesion: 0.21
-Nodes (10): compute_score(), normalize(), run_analysis(), Analyzer, Fixture: functions and methods that call each other - for call-graph extraction, compute_score(), normalize(), run_analysis() (+2 more)
-
-### Community 26 - "Community 26"
-Cohesion: 0.05
-Nodes (34): tempDirs, qn(), addFunction(), G, entry, helper, caller, decorated (+26 more)
-
-### Community 186 - "Community 186"
-Cohesion: 0.29
-Nodes (6): tempDirs, dir, geminiMd, settings, skill, readme
-
-### Community 116 - "Community 116"
-Cohesion: 0.15
-Nodes (9): tempDirs, googleEnvKeys, previousEnv, dir, stub, shortcut, fetcher, rendered (+1 more)
-
-### Community 211 - "Community 211"
-Cohesion: 0.67
-Nodes (1): OntologyWriteFixture
-
-### Community 117 - "Community 117"
-Cohesion: 0.15
-Nodes (10): dir, htmlPath, warnings, G, communities, result, html, profile (+2 more)
-
-### Community 67 - "Community 67"
-Cohesion: 0.09
-Nodes (21): { confidence_score: _ignored, ...rest }, { id: _ignored, ...rest }, graph, h, items, serialized, reloaded, result (+13 more)
-
-### Community 76 - "Community 76"
-Cohesion: 0.10
-Nodes (16): cleanupDirs, root, out, result, line, input, outputDir, captionsDir (+8 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.13
-Nodes (11): cleanupDirs, root, image, config, result, directImage, cropDir, cropImage (+3 more)
-
-### Community 101 - "Community 101"
-Cohesion: 0.13
-Nodes (12): cleanupDirs, root, labelsPath, rulesPath, route, result, missing, ambiguous (+4 more)
-
-### Community 198 - "Community 198"
-Cohesion: 0.33
-Nodes (5): cleanupDirs, downloadAudioMock, dir, expected, rendered
-
-### Community 155 - "Community 155"
-Cohesion: 0.22
-Nodes (2): inventory, ignoredDir
-
-### Community 199 - "Community 199"
-Cohesion: 0.33
-Nodes (4): tempDirs, preview, dir, logs
-
-### Community 9 - "Community 9"
-Cohesion: 0.04
-Nodes (51): files, worktreeRoot, labels, relations, fileNodes, importEdge, pageNode, widgetNode (+43 more)
-
-### Community 187 - "Community 187"
-Cohesion: 0.29
-Nodes (6): head, metadata, stale, analyzed, worktreeDir, plan
-
-### Community 93 - "Community 93"
-Cohesion: 0.13
-Nodes (13): generateTextMock, openaiMock, anthropicMock, googleMock, mistralMock, cohereMock, cleanupDirs, root (+5 more)
-
-### Community 151 - "Community 151"
-Cohesion: 0.20
-Nodes (8): tempDirs, dir, ancestor, current, other, result, merged, tooManyNodes
-
-### Community 156 - "Community 156"
-Cohesion: 0.22
-Nodes (4): cleanupDirs, root, result, text
-
-### Community 120 - "Community 120"
-Cohesion: 0.26
-Nodes (11): qn(), addFunction(), addCall(), makeStore(), { store }, result, { store, flows }, qn() (+3 more)
-
-### Community 200 - "Community 200"
-Cohesion: 0.33
-Nodes (5): tempDirs, tmpDir, pdfPath, outputDir, markdown
-
-### Community 152 - "Community 152"
-Cohesion: 0.22
-Nodes (9): fixtureRoot, semanticDetection(), discoveryContext(), sample, repeat, context, proposals, diff (+1 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.15
-Nodes (15): tempDirs, fixtureRoot, tempProfileProject(), runCli(), runSkillRuntime(), runMain(), prepareProject(), cliOut (+7 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.09
-Nodes (18): cleanupDirs, profile, root, valid, invalid, context, badStatus, badRelation (+10 more)
-
-### Community 85 - "Community 85"
-Cohesion: 0.12
-Nodes (10): cleanupDirs, root, profilePath, profile, raw, errors, config, bound (+2 more)
-
-### Community 140 - "Community 140"
-Cohesion: 0.18
-Nodes (9): profile, dir, path, queue, loaded, response, filters, first (+1 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.07
-Nodes (22): tempDirs, dir, token, fixture, result, graphArtifact, { body, headers }, json (+14 more)
-
-### Community 201 - "Community 201"
-Cohesion: 0.33
-Nodes (5): tempDirs, dir, plugin, config, previousCwd
-
-### Community 213 - "Community 213"
-Cohesion: 0.67
-Nodes (2): root, paths
-
-### Community 68 - "Community 68"
-Cohesion: 0.09
-Nodes (22): FIXTURES_DIR, TMP_OUT, result, exts, raw, errors, realErrors, allClustered (+14 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.20
-Nodes (9): tempDirs, runCliInTemp(), runCliWithEnvironment(), rule, workflow, home, project, skill (+1 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.12
-Nodes (14): tempDirs, fixtureRoot, root, prompt, semanticExtraction, extraction, profileValidation, graph (+6 more)
-
-### Community 133 - "Community 133"
-Cohesion: 0.18
-Nodes (8): fixtureRoot, prompt, state, documentPrompt, imagePrompt, extraction, sample, profile
-
-### Community 103 - "Community 103"
-Cohesion: 0.13
-Nodes (12): cleanupDirs, root, config, profile, registries, jsonPath, yamlPath, components (+4 more)
-
-### Community 107 - "Community 107"
-Cohesion: 0.14
-Nodes (9): cleanupDirs, root, result, configDir, configPath, loaded, raw, errors (+1 more)
-
-### Community 191 - "Community 191"
-Cohesion: 0.33
-Nodes (1): recommendation
-
-### Community 207 - "Community 207"
-Cohesion: 0.40
-Nodes (4): pkg, lock, changelog, workflow
-
-### Community 142 - "Community 142"
-Cohesion: 0.18
-Nodes (10): G, communities, cohesion, labels, gods, surprises, detection, report (+2 more)
-
-### Community 192 - "Community 192"
-Cohesion: 0.33
-Nodes (3): analysis, text, evaluation
-
-### Community 143 - "Community 143"
-Cohesion: 0.20
-Nodes (7): store, node, impact, targets, G, out, batch
-
-### Community 208 - "Community 208"
-Cohesion: 0.40
-Nodes (4): long, tmpDir, graphifyOut, result
+Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.03
-Nodes (58): tempDirs, tsRoot, graphifyOutRoot, cliPath, packageVersion, dir, graphPath, [clientTransport, serverTransport] (+50 more)
+Nodes (58): alphaNeighbors, audit, beforeAudit, beforeDecisions, betaNeighbors, candidate, candidateResponse, candidates (+50 more)
 
-### Community 214 - "Community 214"
-Cohesion: 0.67
-Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
+### Community 3 - "Community 3"
+Cohesion: 0.05
+Nodes (48): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+40 more)
 
-### Community 188 - "Community 188"
-Cohesion: 0.29
-Nodes (6): SKILLS, ALL_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, DISTRIBUTED_SKILL_DOCS, TRIGGER_DESCRIPTION_DOCS, content
+### Community 4 - "Community 4"
+Cohesion: 0.05
+Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+44 more)
 
-### Community 118 - "Community 118"
-Cohesion: 0.15
-Nodes (10): { WhisperModelMock, freeMock, transcribeMock }, tempDirs, spawnSyncMock, hash, cached, video, outDir, modelDir (+2 more)
+### Community 5 - "Community 5"
+Cohesion: 0.06
+Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
 
-### Community 202 - "Community 202"
-Cohesion: 0.33
-Nodes (4): tempDirs, dir, lockPath, contents
+### Community 6 - "Community 6"
+Cohesion: 0.05
+Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
 
-### Community 91 - "Community 91"
-Cohesion: 0.13
-Nodes (15): tempDirs, dir, mkGraph(), graph, communities, targets, outputPath, exportInput (+7 more)
-
-### Community 50 - "Community 50"
-Cohesion: 0.07
-Nodes (24): tempDirs, mkGraph(), graph, communities, targets, prompt, outputDir, persistedSidecar (+16 more)
-
-### Community 128 - "Community 128"
-Cohesion: 0.17
-Nodes (10): generator, base, cache_key, sidecar, result, fresh, stale, communityBase (+2 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.17
-Nodes (11): G, communities, labels, count, index, flows, generator, descriptions (+3 more)
-
-### Community 222 - "Community 222"
-Cohesion: 1.00
-Nodes (1): optionalRuntimeDeps
+### Community 7 - "Community 7"
+Cohesion: 0.06
+Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
 
 ### Community 8 - "Community 8"
+Cohesion: 0.04
+Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.07
+Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.06
-Nodes (50): handle_upload(), handle_get(), handle_delete(), handle_list(), handle_search(), handle_enrich(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
+Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
 
-### Community 52 - "Community 52"
+### Community 11 - "Community 11"
+Cohesion: 0.05
+Nodes (34): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+26 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.09
+Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.07
+Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.07
+Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.06
+Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.10
-Nodes (26): parse_file(), parse_markdown(), parse_json(), parse_plaintext(), parse_and_save(), batch_parse(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
 
-### Community 54 - "Community 54"
+### Community 17 - "Community 17"
+Cohesion: 0.05
+Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.10
-Nodes (26): normalize_text(), extract_keywords(), enrich_document(), find_cross_references(), process_and_save(), reprocess_all(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters. (+18 more)
+Nodes (30): ConnectError, ConnectTimeout, PoolTimeout, ProtocolError, ProxyError, An error occurred at the transport layer., Timed out while connecting to the host., Timed out while receiving data from the host. (+22 more)
 
-### Community 35 - "Community 35"
+### Community 19 - "Community 19"
+Cohesion: 0.06
+Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
+
+### Community 20 - "Community 20"
 Cohesion: 0.11
-Nodes (32): _ensure_storage(), load_index(), save_index(), save_parsed(), save_processed(), load_record(), delete_record(), list_records() (+24 more)
+Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+18 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.06
+Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
+
+### Community 22 - "Community 22"
+Cohesion: 0.07
+Nodes (35): Cookies, build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str() (+27 more)
+
+### Community 23 - "Community 23"
+Cohesion: 0.10
+Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
+
+### Community 24 - "Community 24"
+Cohesion: 0.05
+Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.07
+Nodes (35): Exception, CloseError, ConnectTimeout, CookieConflict, DecodingError, HTTPError, HTTPStatusError, NetworkError (+27 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.08
+Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.07
-Nodes (35): Exception, CookieConflict, httpx-like exception hierarchy. All exceptions inherit from HTTPError at the top, Attempted to look up a cookie by name but multiple cookies exist., HTTPError, RequestError, ConnectTimeout, ReadTimeout (+27 more)
+Cohesion: 0.09
+Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 60 - "Community 60"
+### Community 28 - "Community 28"
+Cohesion: 0.09
+Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
+
+### Community 29 - "Community 29"
+Cohesion: 0.09
+Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
+
+### Community 30 - "Community 30"
+Cohesion: 0.09
+Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
+
+### Community 31 - "Community 31"
+Cohesion: 0.10
+Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.12
+Nodes (34): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+26 more)
+
+### Community 33 - "Community 33"
 Cohesion: 0.11
-Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication., HTTP Digest Authentication.     Requires a full request/response cycle: sends th (+4 more)
+Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.11
+Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.08
+Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
+
+### Community 36 - "Community 36"
+Cohesion: 0.06
+Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
+
+### Community 37 - "Community 37"
+Cohesion: 0.09
+Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
+
+### Community 38 - "Community 38"
+Cohesion: 0.16
+Nodes (16): Auth, BasicAuth, BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
+
+### Community 39 - "Community 39"
+Cohesion: 0.08
+Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
+
+### Community 40 - "Community 40"
+Cohesion: 0.12
+Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
+
+### Community 41 - "Community 41"
+Cohesion: 0.07
+Nodes (23): OntologyWriteFixture, apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine (+15 more)
+
+### Community 42 - "Community 42"
+Cohesion: 0.10
+Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.10
+Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.12
+Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
 ### Community 45 - "Community 45"
 Cohesion: 0.16
-Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., Timeout, Limits, BaseClient, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
+Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
 
-### Community 105 - "Community 105"
-Cohesion: 0.15
-Nodes (1): AsyncClient
-
-### Community 122 - "Community 122"
-Cohesion: 0.18
-Nodes (1): Client
-
-### Community 179 - "Community 179"
-Cohesion: 0.29
-Nodes (6): HTTPError, RequestError, DecodingError, Base class for all httpx exceptions., An error occurred while issuing a request., Decoding of the response failed.
-
-### Community 20 - "Community 20"
-Cohesion: 0.10
-Nodes (30): TransportError, TimeoutException, ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout, ConnectError, ProxyError (+22 more)
-
-### Community 167 - "Community 167"
-Cohesion: 0.25
-Nodes (8): NetworkError, ReadError, WriteError, CloseError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection.
-
-### Community 57 - "Community 57"
+### Community 46 - "Community 46"
 Cohesion: 0.09
-Nodes (6): HTTPStatusError, A 4xx or 5xx response was received., URL, Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, Core data models: URL, Headers, Cookies, Request, Response. These are the centra
+Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
 
-### Community 134 - "Community 134"
-Cohesion: 0.27
-Nodes (2): ConnectionPool, HTTPTransport
+### Community 47 - "Community 47"
+Cohesion: 0.12
+Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 24 - "Community 24"
+### Community 48 - "Community 48"
 Cohesion: 0.07
-Nodes (35): primitive_value_to_str(), normalize_header_key(), flatten_queryparams(), parse_content_type(), obfuscate_sensitive_headers(), unset_all_cookies(), is_known_encoding(), build_url_with_params() (+27 more)
+Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 10 - "Community 10"
+### Community 49 - "Community 49"
+Cohesion: 0.09
+Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
+
+### Community 50 - "Community 50"
 Cohesion: 0.07
-Nodes (48): _node_community_map(), _is_file_node(), god_nodes(), surprising_connections(), _is_concept_node(), _file_category(), _top_level_dir(), _surprise_score() (+40 more)
-
-### Community 177 - "Community 177"
-Cohesion: 0.38
-Nodes (6): build_from_json(), build(), Merge multiple extraction results into one graph., build_from_json(), build(), Merge multiple extraction results into one graph.
-
-### Community 74 - "Community 74"
-Cohesion: 0.11
-Nodes (20): build_graph(), cluster(), _split_community(), cohesion_score(), score_all(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi (+12 more)
-
-### Community 203 - "Community 203"
-Cohesion: 0.60
-Nodes (5): uniqueSorted(), sortNodesByLocation(), mapChangesToNodes(), changedNodesFromFiles(), analyzeChanges()
-
-### Community 154 - "Community 154"
-Cohesion: 0.31
-Nodes (9): splitGitLines(), pathspecForPrefix(), resolveGitScopeContext(), makeScope(), countGitPaths(), gitInventory(), buildGitInventory(), fallbackAllScope() (+1 more)
-
-### Community 190 - "Community 190"
-Cohesion: 0.47
-Nodes (6): uniqueSorted(), mergeDrafts(), stalenessFrom(), minConfidence(), groupConfidence(), buildCommitRecommendation()
-
-### Community 168 - "Community 168"
-Cohesion: 0.25
-Nodes (8): uniqueSorted(), riskLevel(), communityRisk(), nodeCommunities(), buildBlastRadius(), impactedCommunities(), multimodalSafety(), buildReviewAnalysis()
-
-### Community 216 - "Community 216"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 217 - "Community 217"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 153 - "Community 153"
-Cohesion: 0.28
-Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
-
-### Community 80 - "Community 80"
-Cohesion: 0.15
-Nodes (14): Geometry, LinearAlgebra, Base, Shape, Point, Circle, area(), describe() (+6 more)
-
-### Community 130 - "Community 130"
-Cohesion: 0.18
-Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.16
-Nodes (16): Auth, BasicAuth, Timeout, Limits, BaseClient, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.11
-Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication., Load credentials from ~/.netrc based on the request host. (+18 more)
-
-### Community 166 - "Community 166"
-Cohesion: 0.32
-Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
+Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.13
-Nodes (2): Client, AsyncClient
+Nodes (2): AsyncClient, Client
+
+### Community 52 - "Community 52"
+Cohesion: 0.10
+Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+
+### Community 53 - "Community 53"
+Cohesion: 0.13
+Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
+
+### Community 54 - "Community 54"
+Cohesion: 0.10
+Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
+
+### Community 55 - "Community 55"
+Cohesion: 0.16
+Nodes (25): buildModel(), displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeMetaRows(), graphNodeSummary() (+17 more)
+
+### Community 56 - "Community 56"
+Cohesion: 0.14
+Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
+
+### Community 57 - "Community 57"
+Cohesion: 0.09
+Nodes (6): Core data models: URL, Headers, Cookies, Request, Response. These are the centra, HTTPStatusError, A 4xx or 5xx response was received., Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, URL
+
+### Community 58 - "Community 58"
+Cohesion: 0.14
+Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
+
+### Community 59 - "Community 59"
+Cohesion: 0.16
+Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
+
+### Community 60 - "Community 60"
+Cohesion: 0.13
+Nodes (20): candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult(), isLoopbackHost() (+12 more)
+
+### Community 61 - "Community 61"
+Cohesion: 0.11
+Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+4 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.10
+Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.09
+Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
+
+### Community 64 - "Community 64"
+Cohesion: 0.13
+Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
+
+### Community 65 - "Community 65"
+Cohesion: 0.13
+Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.10
+Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
+
+### Community 67 - "Community 67"
+Cohesion: 0.13
+Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
+
+### Community 68 - "Community 68"
+Cohesion: 0.09
+Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.09
+Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
+
+### Community 70 - "Community 70"
+Cohesion: 0.15
+Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.15
+Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.09
+Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.16
+Nodes (21): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+13 more)
+
+### Community 74 - "Community 74"
+Cohesion: 0.09
+Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.09
+Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.11
+Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.14
+Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
+
+### Community 78 - "Community 78"
+Cohesion: 0.10
+Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.13
+Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
+
+### Community 80 - "Community 80"
+Cohesion: 0.13
+Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.15
+Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
+
+### Community 82 - "Community 82"
+Cohesion: 0.15
+Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
+
+### Community 83 - "Community 83"
+Cohesion: 0.13
+Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
+
+### Community 84 - "Community 84"
+Cohesion: 0.14
+Nodes (2): ApiClient, ApiClient
+
+### Community 85 - "Community 85"
+Cohesion: 0.21
+Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
+
+### Community 86 - "Community 86"
+Cohesion: 0.12
+Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
+
+### Community 87 - "Community 87"
+Cohesion: 0.12
+Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
+
+### Community 88 - "Community 88"
+Cohesion: 0.20
+Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
+
+### Community 89 - "Community 89"
+Cohesion: 0.17
+Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
+
+### Community 90 - "Community 90"
+Cohesion: 0.12
+Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
+
+### Community 91 - "Community 91"
+Cohesion: 0.12
+Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
+
+### Community 92 - "Community 92"
+Cohesion: 0.13
+Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
+
+### Community 93 - "Community 93"
+Cohesion: 0.13
+Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
+
+### Community 94 - "Community 94"
+Cohesion: 0.13
+Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
+
+### Community 95 - "Community 95"
+Cohesion: 0.16
+Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.17
+Nodes (13): DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape(), extractSemanticFilesDirectParallel() (+5 more)
+
+### Community 97 - "Community 97"
+Cohesion: 0.18
+Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
+
+### Community 98 - "Community 98"
+Cohesion: 0.15
+Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
+
+### Community 99 - "Community 99"
+Cohesion: 0.13
+Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
+
+### Community 100 - "Community 100"
+Cohesion: 0.13
+Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
+
+### Community 101 - "Community 101"
+Cohesion: 0.13
+Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
+
+### Community 102 - "Community 102"
+Cohesion: 0.24
+Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
+
+### Community 103 - "Community 103"
+Cohesion: 0.13
+Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
+
+### Community 104 - "Community 104"
+Cohesion: 0.19
+Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
+
+### Community 105 - "Community 105"
+Cohesion: 0.13
+Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
+
+### Community 106 - "Community 106"
+Cohesion: 0.16
+Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.15
+Nodes (1): AsyncClient
+
+### Community 108 - "Community 108"
+Cohesion: 0.39
+Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
+
+### Community 109 - "Community 109"
+Cohesion: 0.14
+Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
+
+### Community 110 - "Community 110"
+Cohesion: 0.33
+Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
+
+### Community 111 - "Community 111"
+Cohesion: 0.27
+Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
+
+### Community 112 - "Community 112"
+Cohesion: 0.14
+Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
+
+### Community 113 - "Community 113"
+Cohesion: 0.23
+Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
+
+### Community 114 - "Community 114"
+Cohesion: 0.15
+Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
+
+### Community 115 - "Community 115"
+Cohesion: 0.22
+Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
+
+### Community 116 - "Community 116"
+Cohesion: 0.21
+Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
+
+### Community 117 - "Community 117"
+Cohesion: 0.21
+Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
+
+### Community 118 - "Community 118"
+Cohesion: 0.15
+Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
+
+### Community 119 - "Community 119"
+Cohesion: 0.15
+Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
+
+### Community 120 - "Community 120"
+Cohesion: 0.15
+Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
 ### Community 121 - "Community 121"
+Cohesion: 0.26
+Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
+
+### Community 122 - "Community 122"
+Cohesion: 0.26
+Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
+
+### Community 123 - "Community 123"
 Cohesion: 0.18
 Nodes (1): Headers
 
+### Community 124 - "Community 124"
+Cohesion: 0.18
+Nodes (1): Client
+
+### Community 125 - "Community 125"
+Cohesion: 0.17
+Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
+
+### Community 126 - "Community 126"
+Cohesion: 0.24
+Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.17
+Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
+
+### Community 128 - "Community 128"
+Cohesion: 0.33
+Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.17
+Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
+
+### Community 130 - "Community 130"
+Cohesion: 0.21
+Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
+
+### Community 131 - "Community 131"
+Cohesion: 0.17
+Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
+
+### Community 132 - "Community 132"
+Cohesion: 0.17
+Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
+
+### Community 133 - "Community 133"
+Cohesion: 0.18
+Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
+
+### Community 134 - "Community 134"
+Cohesion: 0.25
+Nodes (4): build_graph(), Graph, build_graph(), Graph
+
+### Community 135 - "Community 135"
+Cohesion: 0.33
+Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.18
+Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
+
+### Community 137 - "Community 137"
+Cohesion: 0.27
+Nodes (2): ConnectionPool, HTTPTransport
+
+### Community 138 - "Community 138"
+Cohesion: 0.22
+Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
+
+### Community 139 - "Community 139"
+Cohesion: 0.25
+Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
+
+### Community 140 - "Community 140"
+Cohesion: 0.18
+Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
+
+### Community 141 - "Community 141"
+Cohesion: 0.18
+Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
+
+### Community 142 - "Community 142"
+Cohesion: 0.18
+Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
+
+### Community 143 - "Community 143"
+Cohesion: 0.18
+Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
+
+### Community 144 - "Community 144"
+Cohesion: 0.20
+Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
+
+### Community 145 - "Community 145"
+Cohesion: 0.18
+Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
+
+### Community 146 - "Community 146"
+Cohesion: 0.18
+Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
+
+### Community 147 - "Community 147"
+Cohesion: 0.20
+Nodes (7): batch, G, impact, node, out, store, targets
+
+### Community 148 - "Community 148"
+Cohesion: 0.24
+Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
+
+### Community 149 - "Community 149"
+Cohesion: 0.24
+Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
+
+### Community 150 - "Community 150"
+Cohesion: 0.20
+Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
+
+### Community 151 - "Community 151"
+Cohesion: 0.42
+Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
+
+### Community 152 - "Community 152"
+Cohesion: 0.24
+Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
+
+### Community 153 - "Community 153"
+Cohesion: 0.38
+Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
+
+### Community 154 - "Community 154"
+Cohesion: 0.20
+Nodes (7): candidateGraph, graph, html, tokens, html, state, tokens
+
+### Community 155 - "Community 155"
+Cohesion: 0.20
+Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
+
+### Community 156 - "Community 156"
+Cohesion: 0.20
+Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
+
+### Community 157 - "Community 157"
+Cohesion: 0.22
+Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
+
+### Community 158 - "Community 158"
+Cohesion: 0.20
+Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.28
+Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
+
+### Community 160 - "Community 160"
+Cohesion: 0.31
+Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.22
+Nodes (2): ignoredDir, inventory
+
+### Community 162 - "Community 162"
+Cohesion: 0.22
+Nodes (4): cleanupDirs, result, root, text
+
+### Community 163 - "Community 163"
+Cohesion: 0.25
+Nodes (9): antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), uninstallAll(), uninstallClaudeHook(), uninstallGeminiMcp() (+1 more)
+
+### Community 164 - "Community 164"
+Cohesion: 0.39
+Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
+
 ### Community 165 - "Community 165"
+Cohesion: 0.39
+Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
+
+### Community 166 - "Community 166"
+Cohesion: 0.31
+Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
+
+### Community 167 - "Community 167"
+Cohesion: 0.42
+Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
+
+### Community 168 - "Community 168"
+Cohesion: 0.25
+Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.25
+Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
+
+### Community 170 - "Community 170"
+Cohesion: 0.22
+Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
+
+### Community 171 - "Community 171"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 193 - "Community 193"
-Cohesion: 0.33
-Nodes (6): scoreNodes(), bfs(), dfs(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+### Community 172 - "Community 172"
+Cohesion: 0.32
+Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
 
-### Community 104 - "Community 104"
-Cohesion: 0.16
-Nodes (15): asRecord(), asStringArray(), asBoolean(), asString(), asNumber(), resolvePath(), parsePdfOcrMode(), parseCitationMinimum() (+7 more)
+### Community 173 - "Community 173"
+Cohesion: 0.25
+Nodes (8): CloseError, NetworkError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection., ReadError, WriteError
+
+### Community 174 - "Community 174"
+Cohesion: 0.25
+Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
+
+### Community 175 - "Community 175"
+Cohesion: 0.25
+Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
+
+### Community 176 - "Community 176"
+Cohesion: 0.36
+Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
+
+### Community 177 - "Community 177"
+Cohesion: 0.25
+Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
+
+### Community 178 - "Community 178"
+Cohesion: 0.32
+Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
+
+### Community 179 - "Community 179"
+Cohesion: 0.25
+Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
+
+### Community 180 - "Community 180"
+Cohesion: 0.25
+Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
+
+### Community 181 - "Community 181"
+Cohesion: 0.25
+Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
+
+### Community 182 - "Community 182"
+Cohesion: 0.25
+Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+
+### Community 183 - "Community 183"
+Cohesion: 0.38
+Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
+
+### Community 184 - "Community 184"
+Cohesion: 0.29
+Nodes (2): Transformer, Transformer
+
+### Community 185 - "Community 185"
+Cohesion: 0.29
+Nodes (6): DecodingError, HTTPError, An error occurred while issuing a request., Decoding of the response failed., Base class for all httpx exceptions., RequestError
+
+### Community 186 - "Community 186"
+Cohesion: 0.43
+Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
+
+### Community 187 - "Community 187"
+Cohesion: 0.29
+Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
+
+### Community 188 - "Community 188"
+Cohesion: 0.43
+Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
+
+### Community 189 - "Community 189"
+Cohesion: 0.33
+Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
+
+### Community 190 - "Community 190"
+Cohesion: 0.33
+Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
+
+### Community 191 - "Community 191"
+Cohesion: 0.29
+Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
+
+### Community 192 - "Community 192"
+Cohesion: 0.29
+Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
+
+### Community 193 - "Community 193"
+Cohesion: 0.29
+Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
+
+### Community 194 - "Community 194"
+Cohesion: 0.29
+Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
+
+### Community 195 - "Community 195"
+Cohesion: 0.33
+Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
+
+### Community 196 - "Community 196"
+Cohesion: 0.47
+Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
+
+### Community 197 - "Community 197"
+Cohesion: 0.33
+Nodes (1): recommendation
+
+### Community 198 - "Community 198"
+Cohesion: 0.33
+Nodes (3): analysis, evaluation, text
+
+### Community 199 - "Community 199"
+Cohesion: 0.33
+Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+
+### Community 200 - "Community 200"
+Cohesion: 0.33
+Nodes (1): CONFIDENCE_VALUES
+
+### Community 201 - "Community 201"
+Cohesion: 0.47
+Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
+
+### Community 202 - "Community 202"
+Cohesion: 0.33
+Nodes (5): commands, dir, matchers, settings, tempDirs
+
+### Community 203 - "Community 203"
+Cohesion: 0.33
+Nodes (5): dir, original, rule, rulePath, tempDirs
+
+### Community 204 - "Community 204"
+Cohesion: 0.33
+Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
+
+### Community 205 - "Community 205"
+Cohesion: 0.33
+Nodes (4): dir, logs, preview, tempDirs
+
+### Community 206 - "Community 206"
+Cohesion: 0.33
+Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+
+### Community 207 - "Community 207"
+Cohesion: 0.33
+Nodes (5): config, dir, plugin, previousCwd, tempDirs
+
+### Community 208 - "Community 208"
+Cohesion: 0.33
+Nodes (4): contents, dir, lockPath, tempDirs
+
+### Community 209 - "Community 209"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 210 - "Community 210"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 211 - "Community 211"
+Cohesion: 0.50
+Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
+
+### Community 212 - "Community 212"
+Cohesion: 0.40
+Nodes (4): chunks, client, files, root
+
+### Community 213 - "Community 213"
+Cohesion: 0.40
+Nodes (4): changelog, lock, pkg, workflow
+
+### Community 214 - "Community 214"
+Cohesion: 0.40
+Nodes (4): graphifyOut, long, result, tmpDir
 
 ### Community 215 - "Community 215"
+Cohesion: 0.67
+Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
+
+### Community 216 - "Community 216"
+Cohesion: 0.50
+Nodes (3): b1, b2, backup
+
+### Community 217 - "Community 217"
+Cohesion: 0.67
+Nodes (3): runCli(), runMain(), runSkillRuntime()
+
+### Community 218 - "Community 218"
+Cohesion: 0.67
+Nodes (2): paths, root
+
+### Community 219 - "Community 219"
+Cohesion: 0.67
+Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
+
+### Community 220 - "Community 220"
 Cohesion: 1.00
-Nodes (2): registrySourceName(), buildRegistrySources()
+Nodes (2): buildRegistrySources(), registrySourceName()
+
+### Community 221 - "Community 221"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 222 - "Community 222"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 223 - "Community 223"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 224 - "Community 224"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 225 - "Community 225"
+Cohesion: 1.00
+Nodes (1): UnpdfTextResult
+
+### Community 226 - "Community 226"
+Cohesion: 1.00
+Nodes (2): tempProfileProject(), tempProject()
+
+### Community 227 - "Community 227"
+Cohesion: 1.00
+Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1642 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1637 more)
+- **1672 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1667 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 194`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 51`** (2 nodes): `AsyncClient`, `Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 84`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 107`** (1 nodes): `AsyncClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 123`** (1 nodes): `Headers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `tempProject()`, `tempProfileProject()`
+- **Thin community `Community 124`** (1 nodes): `Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 137`** (2 nodes): `ConnectionPool`, `HTTPTransport`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 161`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (1 nodes): `OntologyWriteFixture`
+- **Thin community `Community 171`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (2 nodes): `inventory`, `ignoredDir`
+- **Thin community `Community 184`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (2 nodes): `root`, `paths`
+- **Thin community `Community 197`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (1 nodes): `recommendation`
+- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 218`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (1 nodes): `AsyncClient`
+- **Thin community `Community 220`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (1 nodes): `Client`
+- **Thin community `Community 221`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (2 nodes): `ConnectionPool`, `HTTPTransport`
+- **Thin community `Community 222`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 223`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 224`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (2 nodes): `Client`, `AsyncClient`
+- **Thin community `Community 225`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (1 nodes): `Headers`
+- **Thin community `Community 226`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (1 nodes): `ConnectionPool`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (2 nodes): `registrySourceName()`, `buildRegistrySources()`
+- **Thin community `Community 227`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 24` to `Community 57`, `Community 121`, `Community 39`, `Community 51`, `Community 27`?**
+- **Why does `Cookies` connect `Community 22` to `Community 57`, `Community 123`, `Community 38`, `Community 51`, `Community 25`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 45` to `Community 57`, `Community 122`, `Community 105`, `Community 24`?**
+- **Why does `Cookies` connect `Community 45` to `Community 57`, `Community 124`, `Community 107`, `Community 22`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `InvalidURL` connect `Community 45` to `Community 27`, `Community 122`, `Community 105`?**
+- **Why does `InvalidURL` connect `Community 45` to `Community 25`, `Community 124`, `Community 107`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -28,7 +28,11 @@ export {
 } from "./tokens-fallback.js";
 export { normaliseDesignSystemTokens, tryGetDsTokens } from "./tokens-ds.js";
 
-export type { RenderWorkspaceShellOptions } from "./shell.js";
+export type {
+  RenderWorkspaceShellOptions,
+  WorkspaceDescriptionSidecar,
+  WorkspaceEntityLayout,
+} from "./shell.js";
 export { renderWorkspaceShell } from "./shell.js";
 
 export type {

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -1,42 +1,68 @@
 /**
- * Track G G2 / G6-1 (S0.1) — workspace shell static scaffold.
- *
- * Produces the server-rendered HTML scaffold consumed by
- * `graphify ontology studio` (read-only by default; mutation surface
- * is gated behind --write per existing patterns in src/serve.ts and
- * src/ontology-studio.ts and is wired in G5).
- *
- * G6-1 (S0.1) absorbs the ACLP-AM Workspace tab three-column layout:
- * left rail · central column (display + graph) · right reconciliation
- * slot. The right slot is HIDDEN when the active view is "workspace"
- * (default) but the markup is always present so G6-3 can plug Track B
- * reconciliation content in without touching the shell shape.
+ * Track G G6-1 — workspace shell (three-column scaffolding).
  *
  * Layout — desktop (>= 769 px):
  *
- *   +----- Header ---------------------------------+
- *   | Title · status · profile-id                 |
- *   +----+----------------------------+-----------+
- *   | LW | CentralDisplay             |  Recon.   |
- *   |    |                            |   slot    |
- *   |    |  ----  GraphPanel ----     | (hidden   |
- *   |    |                            |  in       |
- *   +----+----------------------------+  workspace+
- *                                       active view)
+ *   +----- Header ----------------------------------------------+
+ *   | Title · status · profile-id                              |
+ *   +----+-----------------------------------+-----------------+
+ *   | LW | CompactDescription                | Reconciliation  |
+ *   |    | Counters                          | slot            |
+ *   |    | GraphControls                     | (empty when     |
+ *   |    | GraphPanel                        |  active view is |
+ *   |    |                                   |  "workspace")   |
+ *   +----+-----------------------------------+-----------------+
  *
- * Layout — mobile (<= 768 px): the slot collapses to display:none in
- * the default workspace view to keep the 390 px viewport scroll-free.
+ * Layout — mobile (<= 768 px):
  *
- * Track C inheritance is mandatory:
- *   - skip-link (first focusable element) jumps to #central-display
- *   - ARIA: each named region declares role + aria-label.
- *   - focus-visible respects the workspace focus-ring tokens.
+ *   +----- Header ----------------------------------------------+
+ *   | LeftWorkbench (top sheet)                                 |
+ *   +-----------------------------------------------------------+
+ *   | CompactDescription                                        |
+ *   | Counters                                                  |
+ *   | GraphControls                                             |
+ *   | GraphPanel                                                |
+ *   +-----------------------------------------------------------+
+ *   | Reconciliation slot — collapsed to display:none when      |
+ *   | activeView === "workspace"                                |
+ *
+ * Strictly profile-neutral: no corpus-specific strings. Slot markup is
+ * always emitted so future sub-views (G6-3) can plug Track B evidence/
+ * audit/rebuild into the existing structure.
  */
 
 import type { WorkspaceTokens, WorkspaceTokenSource } from "./tokens.js";
 import type { GraphEdgeLike, GraphLike, GraphNodeLike } from "./graph-selection.js";
+import { computeFocusSubgraph } from "./graph-selection.js";
 import type { WorkspaceViewerState } from "./viewer-state.js";
+import { createDefaultViewerState } from "./viewer-state.js";
 import { serialiseTokensToCss } from "./tokens-fallback.js";
+
+/**
+ * Optional sidecar payload propagated from `.graphify/wiki/descriptions.json`
+ * (schema `graphify_wiki_description_v1`). Only the fields needed by the
+ * compact description block are typed here so the shell stays decoupled
+ * from the full wiki-descriptions API surface.
+ */
+export interface WorkspaceDescriptionSidecar {
+  status: "generated" | "insufficient_evidence";
+  target_id: string;
+  target_kind: "node" | "community";
+  description?: string | null;
+}
+
+/**
+ * Optional profile-driven layout configuration. Mirrors the
+ * `outputs.workspace.entity_layout` slot in `ontology-profile.yaml`.
+ * Any unknown key is preserved verbatim — Graphify core never inspects
+ * it; only profile adapters do.
+ */
+export interface WorkspaceEntityLayout {
+  /** Display order of the inline fact lines under the title. */
+  inline_facts?: string[];
+  /** Sections to render below the inline facts (defaults to aliases / relations / evidence). */
+  sections?: string[];
+}
 
 export interface RenderWorkspaceShellOptions {
   /** Resolved tokens for the active theme. */
@@ -45,26 +71,13 @@ export interface RenderWorkspaceShellOptions {
   tokenSource?: WorkspaceTokenSource;
   /** Workspace title displayed in the header. Sanitised. */
   title: string;
-  /**
-   * Optional profile identifier displayed in the header (e.g.
-   * "public-domain-mystery-uat"). Sanitised.
-   */
+  /** Optional profile identifier displayed in the header. */
   profileId?: string;
-  /**
-   * Optional last-rebuild timestamp (ISO 8601, displayed verbatim if
-   * provided). Sanitised.
-   */
+  /** Optional last-rebuild timestamp displayed verbatim. */
   lastRebuiltAt?: string;
-  /**
-   * Read-only vs write-enabled indicator. The shell renders a clear
-   * banner; actual write gating lives in src/serve.ts / src/ontology-studio.ts.
-   */
+  /** Read-only vs write-enabled indicator. */
   writeEnabled?: boolean;
-  /**
-   * When true the LeftWorkbench rail renders a "queue is empty" hint
-   * instead of a stub list. Used by G5 to surface freshly-empty
-   * reconciliation queues without crashing the shell render path.
-   */
+  /** When true the LeftWorkbench rail renders a "queue is empty" hint. */
   queueEmpty?: boolean;
   /** Trusted internal HTML fragment rendered inside the graph panel slot. */
   graphPanelHtml?: string;
@@ -72,13 +85,25 @@ export interface RenderWorkspaceShellOptions {
   leftWorkbenchHtml?: string;
   /** Trusted internal HTML fragment rendered inside the central display slot. */
   centralDisplayHtml?: string;
-  /** Trusted internal HTML fragment rendered inside the detail drawer slot. */
+  /**
+   * Trusted internal HTML fragment rendered inside the reconciliation
+   * slot. Honoured only when `state.activeView !== "workspace"` (or when
+   * no state is passed — legacy callers without G6 state).
+   */
   rightDrawerHtml?: string;
   /** Current workspace state. Used to resolve the central display item. */
   state?: WorkspaceViewerState;
   /** Graph payload (typically loaded from `.graphify/graph.json`). */
   graph?: GraphLike;
+  /** Optional Track A description sidecar for the focused entity. */
+  descriptionSidecar?: WorkspaceDescriptionSidecar;
+  /** Optional profile-driven entity layout (falls back to a neutral default). */
+  entityLayout?: WorkspaceEntityLayout;
 }
+
+// ---------------------------------------------------------------------------
+// HTML / Markdown helpers
+// ---------------------------------------------------------------------------
 
 const HTML_ESCAPE_RE = /[&<>"']/g;
 const HTML_ESCAPE_MAP: Record<string, string> = {
@@ -118,29 +143,41 @@ function nodeTitle(node: GraphNodeLike): string {
   );
 }
 
-function nodeSummary(node: GraphNodeLike): string | null {
-  const directSummary =
+function nodeDirectSummary(node: GraphNodeLike): string | null {
+  return (
     displayValue(node.summary) ??
     displayValue(node.description) ??
-    displayValue(node.body);
-  if (directSummary) return directSummary;
-
-  const sourceFile = displayValue(node.source_file);
-  const sourceLocation = displayValue(node.source_location);
-  const community =
-    displayValue(node.community_name) ??
-    (typeof node.community === "number" ? `Community ${node.community}` : null);
-  const details: string[] = [];
-  if (sourceFile) {
-    details.push(`Source: ${sourceLocation ? `${sourceFile}:${sourceLocation}` : sourceFile}`);
-  }
-  if (community) details.push(`Community: ${community}`);
-  return details.length > 0 ? details.join("\n") : null;
+    displayValue(node.body)
+  );
 }
 
-function truncateDisplayText(value: string): string {
-  const max = 1200;
-  return value.length > max ? `${value.slice(0, max - 3)}...` : value;
+function nodeSourcePath(node: GraphNodeLike): string | null {
+  const sourceFile = displayValue(node.source_file);
+  const sourceLocation = displayValue(node.source_location);
+  if (!sourceFile) return null;
+  return sourceLocation ? `${sourceFile}:${sourceLocation}` : sourceFile;
+}
+
+function nodeCommunity(node: GraphNodeLike): string | null {
+  return (
+    displayValue(node.community_name) ??
+    (typeof node.community === "number" ? `Community ${node.community}` : null)
+  );
+}
+
+function nodeAliases(node: GraphNodeLike): string[] {
+  const raw = node.aliases;
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of raw) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
 }
 
 function graphEdges(graph: GraphLike | undefined): GraphEdgeLike[] {
@@ -155,49 +192,213 @@ function countEdgeEvidence(edge: GraphEdgeLike): number {
   for (const value of arrays) {
     if (Array.isArray(value)) return value.length;
   }
-  if (
-    typeof edge.evidence === "string" ||
-    typeof edge.source_file === "string"
-  ) {
+  if (typeof edge.evidence === "string" || typeof edge.source_file === "string") {
     return 1;
   }
   return 0;
 }
 
-function renderDisplayMetrics(metrics: Array<[string, number]>): string {
-  const items = metrics.map(
-    ([label, value]) => `<span><b>${escapeHtml(label)}:</b> ${value}</span>`,
-  );
-  return ['<div class="ws-display-metrics">', ...items, "</div>"].join("");
+/**
+ * Render a Track A markdown description as safe inline HTML. Supports
+ * `**bold**` and `*italic*` runs only; anything else stays as escaped
+ * text. The contract intentionally stays minimal to avoid pulling a full
+ * Markdown engine into the shell.
+ */
+function renderInlineMarkdown(markdown: string): string {
+  const escaped = escapeHtml(markdown.trim());
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/(^|[^*])\*(?!\s)(.+?)\*(?!\*)/g, "$1<em>$2</em>");
 }
 
-function renderNodeDisplay(
+// ---------------------------------------------------------------------------
+// Compact description rendering
+// ---------------------------------------------------------------------------
+
+const DEFAULT_INLINE_FACTS = ["type", "status", "source", "community"];
+const DEFAULT_SECTIONS = ["aliases", "relations", "evidence"];
+
+interface CompactDescriptionContext {
+  displayRef: string;
+  requestedKind: string;
+  title: string;
+  facts: Array<{ key: string; label: string; value: string }>;
+  description: string | null;
+  aliases: string[];
+  relations: GraphEdgeLike[];
+  evidenceCount: number;
+}
+
+function buildNodeFacts(
+  node: GraphNodeLike,
+  requestedKind: string,
+): Array<{ key: string; label: string; value: string }> {
+  const facts: Array<{ key: string; label: string; value: string }> = [];
+  const type =
+    displayValue(node.node_type) ??
+    displayValue(node.type) ??
+    displayValue(node.kind) ??
+    displayValue(node.file_type);
+  if (type) facts.push({ key: "type", label: "Type", value: type });
+  else if (requestedKind !== "entity") facts.push({ key: "type", label: "Type", value: requestedKind });
+  const status = displayValue(node.status);
+  if (status) facts.push({ key: "status", label: "Status", value: status });
+  const confidence = displayValue(node.confidence);
+  if (confidence) facts.push({ key: "confidence", label: "Confidence", value: confidence });
+  const source = nodeSourcePath(node);
+  if (source) facts.push({ key: "source", label: "Source", value: source });
+  const community = nodeCommunity(node);
+  if (community) facts.push({ key: "community", label: "Community", value: community });
+  return facts;
+}
+
+function orderFacts(
+  facts: Array<{ key: string; label: string; value: string }>,
+  order: string[] | undefined,
+): Array<{ key: string; label: string; value: string }> {
+  const requested = (order && order.length > 0 ? order : DEFAULT_INLINE_FACTS).map((k) => k.toLowerCase());
+  const byKey = new Map(facts.map((f) => [f.key, f]));
+  const out: Array<{ key: string; label: string; value: string }> = [];
+  const seen = new Set<string>();
+  for (const key of requested) {
+    const fact = byKey.get(key);
+    if (fact) {
+      out.push(fact);
+      seen.add(key);
+    }
+  }
+  // Preserve any extra facts that the profile didn't list explicitly.
+  for (const fact of facts) {
+    if (!seen.has(fact.key)) out.push(fact);
+  }
+  return out;
+}
+
+function renderCompactSections(
+  ctx: CompactDescriptionContext,
+  sections: string[] | undefined,
+): string {
+  const requested = (sections && sections.length > 0 ? sections : DEFAULT_SECTIONS).map((s) => s.toLowerCase());
+  const parts: string[] = [];
+  for (const section of requested) {
+    if (section === "aliases") {
+      if (ctx.aliases.length === 0) continue;
+      parts.push(
+        [
+          '<section class="ws-compact-section ws-compact-aliases">',
+          '<h4 class="ws-compact-section-heading">Aliases</h4>',
+          `<p class="ws-compact-section-body">${ctx.aliases.map((a) => escapeHtml(a)).join(" / ")}</p>`,
+          "</section>",
+        ].join(""),
+      );
+    } else if (section === "relations") {
+      const total = ctx.relations.length;
+      const body =
+        total === 0
+          ? '<p class="ws-compact-section-body ws-compact-section-empty">none</p>'
+          : `<p class="ws-compact-section-body">${total} relation${total === 1 ? "" : "s"}</p>`;
+      parts.push(
+        [
+          '<section class="ws-compact-section ws-compact-relations">',
+          '<h4 class="ws-compact-section-heading">Relations</h4>',
+          body,
+          "</section>",
+        ].join(""),
+      );
+    } else if (section === "evidence") {
+      const sources = new Set<string>();
+      for (const edge of ctx.relations) {
+        const sf = displayValue(edge.source_file);
+        if (sf) sources.add(sf);
+      }
+      const body =
+        ctx.evidenceCount === 0 && sources.size === 0
+          ? '<p class="ws-compact-section-body ws-compact-section-empty">none</p>'
+          : `<p class="ws-compact-section-body">${ctx.evidenceCount} ref${ctx.evidenceCount === 1 ? "" : "s"}${sources.size > 0 ? ` · ${[...sources].map((s) => escapeHtml(s)).join(", ")}` : ""}</p>`;
+      parts.push(
+        [
+          '<section class="ws-compact-section ws-compact-evidence">',
+          '<h4 class="ws-compact-section-heading">Evidence</h4>',
+          body,
+          "</section>",
+        ].join(""),
+      );
+    }
+  }
+  return parts.join("");
+}
+
+function renderCompactDescription(
+  ctx: CompactDescriptionContext,
+  layout: WorkspaceEntityLayout | undefined,
+  sidecar: WorkspaceDescriptionSidecar | undefined,
+): string {
+  const facts = orderFacts(ctx.facts, layout?.inline_facts);
+  const factsLine =
+    facts.length === 0
+      ? ""
+      : `<p class="ws-compact-facts">${facts
+          .map(
+            (f) =>
+              `<span class="ws-compact-fact" data-fact="${escapeHtml(f.key)}"><span class="ws-compact-fact-label">${escapeHtml(f.label)}:</span> ${escapeHtml(f.value)}</span>`,
+          )
+          .join(" · ")}</p>`;
+
+  // Track A description rules: when sidecar is "insufficient_evidence",
+  // hide the description silently. When "generated", inline the markdown.
+  // When no sidecar is provided, fall back to the node's own summary.
+  let descriptionBlock = "";
+  if (sidecar) {
+    if (sidecar.status === "generated" && typeof sidecar.description === "string" && sidecar.description.trim()) {
+      descriptionBlock = `<p class="ws-compact-description">${renderInlineMarkdown(sidecar.description)}</p>`;
+    }
+    // insufficient_evidence → silently omit.
+  } else if (ctx.description) {
+    descriptionBlock = `<p class="ws-compact-description">${escapeHtml(ctx.description)}</p>`;
+  }
+
+  return [
+    `<article class="ws-compact" data-display-ref="${escapeHtml(ctx.displayRef)}">`,
+    '<div class="ws-compact-kicker">Selected item</div>',
+    `<h3 class="ws-compact-title">${escapeHtml(ctx.title)}</h3>`,
+    factsLine,
+    descriptionBlock,
+    renderCompactSections(ctx, layout?.sections),
+    "</article>",
+  ]
+    .filter(Boolean)
+    .join("");
+}
+
+function renderEntityDisplay(
   displayRef: string,
   requestedKind: string,
   node: GraphNodeLike,
   edges: GraphEdgeLike[],
+  layout: WorkspaceEntityLayout | undefined,
+  sidecar: WorkspaceDescriptionSidecar | undefined,
 ): string {
   const relatedEdges = edges.filter((edge) => edge.source === node.id || edge.target === node.id);
   const evidenceCount = relatedEdges.reduce((sum, edge) => sum + countEdgeEvidence(edge), 0);
-  const summary = nodeSummary(node);
-  const kind = requestedKind === "entity" ? nodeType(node) : nodeType(node) || requestedKind;
-  return [
-    `<article class="ws-display-item" data-display-ref="${escapeHtml(displayRef)}">`,
-    '<div class="ws-display-kicker">Selected item</div>',
-    `<h3>${escapeHtml(nodeTitle(node))}</h3>`,
-    `<p class="ws-display-kind">${escapeHtml(kind)}</p>`,
-    summary
-      ? `<p class="ws-display-summary">${escapeHtml(truncateDisplayText(summary))}</p>`
-      : '<p class="ws-empty">No summary available.</p>',
-    renderDisplayMetrics([
-      ["Relations", relatedEdges.length],
-      ["Evidence", evidenceCount],
-    ]),
-    "</article>",
-  ].join("");
+  const ctx: CompactDescriptionContext = {
+    displayRef,
+    requestedKind,
+    title: nodeTitle(node),
+    facts: buildNodeFacts(node, requestedKind),
+    description: nodeDirectSummary(node),
+    aliases: nodeAliases(node),
+    relations: relatedEdges,
+    evidenceCount,
+  };
+  return renderCompactDescription(ctx, layout, sidecar);
 }
 
-function renderTypeDisplay(displayRef: string, typeId: string, graph: GraphLike): string {
+function renderTypeDisplay(
+  displayRef: string,
+  typeId: string,
+  graph: GraphLike,
+  layout: WorkspaceEntityLayout | undefined,
+): string {
   const nodes = graph.nodes ?? [];
   const members = nodes.filter((node) => nodeType(node) === typeId);
   const memberIds = new Set(members.map((node) => node.id));
@@ -205,23 +406,27 @@ function renderTypeDisplay(displayRef: string, typeId: string, graph: GraphLike)
     (edge) => memberIds.has(edge.source) || memberIds.has(edge.target),
   );
   const evidenceCount = relatedEdges.reduce((sum, edge) => sum + countEdgeEvidence(edge), 0);
-  return [
-    `<article class="ws-display-item" data-display-ref="${escapeHtml(displayRef)}">`,
-    '<div class="ws-display-kicker">Selected item</div>',
-    `<h3>${escapeHtml(typeId)}</h3>`,
-    '<p class="ws-display-kind">Type</p>',
-    renderDisplayMetrics([
-      ["Members", members.length],
-      ["Relations", relatedEdges.length],
-      ["Evidence", evidenceCount],
-    ]),
-    "</article>",
-  ].join("");
+  const ctx: CompactDescriptionContext = {
+    displayRef,
+    requestedKind: "type",
+    title: typeId,
+    facts: [
+      { key: "type", label: "Type", value: "Type" },
+      { key: "members", label: "Members", value: String(members.length) },
+    ],
+    description: null,
+    aliases: [],
+    relations: relatedEdges,
+    evidenceCount,
+  };
+  return renderCompactDescription(ctx, layout, undefined);
 }
 
 function renderCentralDisplayBody(
   state: WorkspaceViewerState | undefined,
   graph: GraphLike | undefined,
+  layout: WorkspaceEntityLayout | undefined,
+  sidecar: WorkspaceDescriptionSidecar | undefined,
 ): string {
   const displayRef = state?.displayRef?.trim();
   if (!displayRef) return '<p class="ws-empty">No display item selected.</p>';
@@ -234,13 +439,96 @@ function renderCentralDisplayBody(
   }
 
   if (requestedKind === "type" || requestedKind === "taxonomy") {
-    return renderTypeDisplay(displayRef, id, graph);
+    return renderTypeDisplay(displayRef, id, graph, layout);
   }
 
   const node = (graph.nodes ?? []).find((candidate) => candidate.id === id);
   if (!node) return '<p class="ws-empty">Selected item is unavailable.</p>';
-  return renderNodeDisplay(displayRef, requestedKind, node, graphEdges(graph));
+  return renderEntityDisplay(displayRef, requestedKind, node, graphEdges(graph), layout, sidecar);
 }
+
+// ---------------------------------------------------------------------------
+// Counters
+// ---------------------------------------------------------------------------
+
+interface CountersValues {
+  selectedEntities: number;
+  selectedClasses: number;
+  visibleNodes: number;
+  visibleEdges: number;
+}
+
+function computeCounters(
+  state: WorkspaceViewerState | undefined,
+  graph: GraphLike | undefined,
+): CountersValues {
+  const selectedEntities = new Set<string>([
+    ...(state?.selectedEntities ?? []),
+    ...(state?.selectionState.entityIds ?? []),
+  ]).size;
+  const selectedClasses = new Set<string>(state?.selectedTypes ?? []).size;
+
+  if (!graph || !state) {
+    const nodes = graph?.nodes?.length ?? 0;
+    const edges = (graph?.edges ?? graph?.links ?? []).length;
+    return { selectedEntities, selectedClasses, visibleNodes: nodes, visibleEdges: edges };
+  }
+  const sub = computeFocusSubgraph(graph, state);
+  return {
+    selectedEntities,
+    selectedClasses,
+    visibleNodes: sub.metrics.nodes,
+    visibleEdges: sub.metrics.edges,
+  };
+}
+
+function renderCounters(values: CountersValues): string {
+  const items: Array<[keyof CountersValues, string, string]> = [
+    ["selectedEntities", "selected-entities", "Selected entities"],
+    ["selectedClasses", "selected-classes", "Selected classes"],
+    ["visibleNodes", "visible-nodes", "Visible nodes"],
+    ["visibleEdges", "visible-edges", "Visible edges"],
+  ];
+  return [
+    '<div class="ws-counters" role="group" aria-label="Workspace counters">',
+    ...items.map(([key, slug, label]) =>
+      [
+        `<div class="ws-counter" data-counter="${slug}">`,
+        `<span class="ws-counter-value">${values[key]}</span>`,
+        `<span class="ws-counter-label">${label}</span>`,
+        "</div>",
+      ].join(""),
+    ),
+    "</div>",
+  ].join("");
+}
+
+// ---------------------------------------------------------------------------
+// Graph controls (mode toggle + weak links + legend)
+// ---------------------------------------------------------------------------
+
+function renderGraphControls(state: WorkspaceViewerState | undefined): string {
+  const mode = state?.viewState.graph.mode ?? "selection";
+  const weak = state?.viewState.graph.showWeakLinks ?? false;
+  return [
+    '<div class="ws-graph-controls" role="group" aria-label="Graph controls">',
+    '<div class="ws-graph-mode-toggle" data-control="graph-mode-toggle">',
+    `<label><input type="radio" name="ws-graph-mode" value="selection"${mode === "selection" ? " checked" : ""} /> Selection</label>`,
+    `<label><input type="radio" name="ws-graph-mode" value="focus"${mode === "focus" ? " checked" : ""} /> Focus</label>`,
+    "</div>",
+    `<label class="ws-graph-weak-links"><input type="checkbox" data-control="graph-weak-links"${weak ? " checked" : ""} /> Show weak links</label>`,
+    '<ul class="ws-graph-legend" aria-label="Graph legend">',
+    '<li><span class="ws-legend-swatch ws-legend-strong"></span> Strong links</li>',
+    '<li><span class="ws-legend-swatch ws-legend-explicit"></span> Explicit / attested</li>',
+    '<li><span class="ws-legend-swatch ws-legend-weak"></span> Weak links</li>',
+    "</ul>",
+    "</div>",
+  ].join("");
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
 
 function shellStyles(): string {
   return [
@@ -259,32 +547,54 @@ function shellStyles(): string {
     ".ws-write-banner[data-write='false'] { color: var(--ws-text-muted); }",
     ".ws-left { grid-column: 1; grid-row: 2; border-right: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface); }",
     ".ws-center { grid-column: 2; grid-row: 2; overflow-y: auto; padding: var(--ws-space-4); background: var(--ws-surface); }",
-    ".ws-graph-panel { margin-top: var(--ws-space-5); padding-top: var(--ws-space-3); border-top: 1px solid var(--ws-border); }",
+    // Compact description.
+    ".ws-compact { display: grid; gap: var(--ws-space-2); max-width: 88ch; }",
+    ".ws-compact-kicker { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }",
+    ".ws-compact-title { margin: 0; font-size: var(--ws-font-size-lg); line-height: var(--ws-line-height-tight); }",
+    ".ws-compact-facts { margin: 0; color: var(--ws-text-muted); font-size: var(--ws-font-size-sm); display: flex; flex-wrap: wrap; gap: var(--ws-space-2); }",
+    ".ws-compact-fact-label { color: var(--ws-text); font-weight: 600; }",
+    ".ws-compact-description { margin: 0; }",
+    ".ws-compact-section { display: grid; gap: 0; }",
+    ".ws-compact-section-heading { margin: 0; font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); font-weight: 600; }",
+    ".ws-compact-section-body { margin: 0; color: var(--ws-text); }",
+    ".ws-compact-section-empty { color: var(--ws-text-muted); font-style: italic; }",
+    // Counters.
+    ".ws-counters { display: grid; grid-template-columns: repeat(4, minmax(80px, 1fr)); gap: var(--ws-space-2); margin: var(--ws-space-4) 0 var(--ws-space-3); }",
+    ".ws-counter { display: grid; gap: 2px; padding: var(--ws-space-2); border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); background: var(--ws-surface-2); text-align: center; }",
+    ".ws-counter-value { font-size: var(--ws-font-size-lg); font-weight: 700; color: var(--ws-text); }",
+    ".ws-counter-label { font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); }",
+    // Graph panel + controls.
+    ".ws-graph-panel { margin-top: var(--ws-space-3); padding-top: var(--ws-space-3); border-top: 1px solid var(--ws-border); }",
+    ".ws-graph-controls { display: flex; flex-wrap: wrap; align-items: center; gap: var(--ws-space-3); margin-bottom: var(--ws-space-3); font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); }",
+    ".ws-graph-mode-toggle { display: flex; gap: var(--ws-space-2); }",
+    ".ws-graph-mode-toggle label, .ws-graph-weak-links { display: inline-flex; align-items: center; gap: var(--ws-space-1); cursor: pointer; }",
+    ".ws-graph-legend { display: flex; flex-wrap: wrap; gap: var(--ws-space-3); margin: 0; padding: 0; list-style: none; }",
+    ".ws-graph-legend li { display: inline-flex; align-items: center; gap: var(--ws-space-1); }",
+    ".ws-legend-swatch { width: 12px; height: 4px; border-radius: 2px; display: inline-block; background: var(--ws-text-muted); }",
+    ".ws-legend-strong { background: var(--ws-accent); }",
+    ".ws-legend-explicit { background: var(--ws-text); }",
+    ".ws-legend-weak { background: var(--ws-text-muted); opacity: 0.6; }",
+    // Reconciliation slot.
     ".workspace-reconciliation-slot { grid-column: 3; grid-row: 2; border-left: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface-2); }",
     ".workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; }",
-    ".ws-region-heading { font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); margin: 0 0 var(--ws-space-2); }",
     ".ws-empty { color: var(--ws-text-muted); font-style: italic; }",
-    ".ws-display-item { display: grid; gap: var(--ws-space-2); max-width: 72ch; }",
-    ".ws-display-kicker { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }",
-    ".ws-display-item h3 { margin: 0; font-size: var(--ws-font-size-lg); line-height: var(--ws-line-height-tight); }",
-    ".ws-display-kind { margin: 0; color: var(--ws-text-muted); }",
-    ".ws-display-summary { margin: 0; white-space: pre-wrap; }",
-    ".ws-display-metrics { display: flex; flex-wrap: wrap; gap: var(--ws-space-3); font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); }",
-    ".ws-display-metrics b { color: var(--ws-text); font-weight: 600; }",
     "@media (max-width: 768px) {",
     "  .ws-root { grid-template-columns: 1fr; grid-template-rows: auto auto 1fr auto; }",
     "  .ws-left { grid-column: 1; grid-row: 2; border-right: none; border-bottom: 1px solid var(--ws-border); max-height: 40vh; }",
     "  .ws-center { grid-column: 1; grid-row: 3; }",
     "  .workspace-reconciliation-slot { grid-column: 1; grid-row: 4; border-left: none; border-top: 1px solid var(--ws-border); max-height: 40vh; }",
     "  .workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; max-height: 0; padding: 0; }",
+    "  .ws-counters { grid-template-columns: repeat(2, minmax(80px, 1fr)); }",
     "}",
   ].join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// Top-level renderer
+// ---------------------------------------------------------------------------
+
 /**
  * Renders the workspace shell as a self-contained HTML5 document.
- * G3..G5 will refine the inner regions; this baseline guarantees the
- * layout, the accessibility scaffolding, and the token-driven theming.
  */
 export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string {
   const tokens = opts.tokens;
@@ -295,20 +605,31 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
   const writeFlag = opts.writeEnabled === true;
   const queueEmpty = opts.queueEmpty === true;
   const tokensCss = serialiseTokensToCss(tokens);
-  const queueBody = opts.leftWorkbenchHtml ?? (queueEmpty
-    ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
-    : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>');
-  const graphPanelBody =
-    opts.graphPanelHtml ??
-    '<p class="ws-empty">No graph context available.</p>';
-  const centralDisplayBody = opts.centralDisplayHtml ?? renderCentralDisplayBody(opts.state, opts.graph);
-  // G6-1 (S0.1): the right column is now a named reconciliation slot. It
-  // is HIDDEN (empty markup + aria-hidden) when the active view is the
-  // default "workspace" tab — only a future reconciliation sub-view
-  // (G6-3) opens it.
+
+  // Effective state used by the counters + central display + graph controls.
+  const effectiveState = opts.state ?? createDefaultViewerState();
+  // The reconciliation slot is hidden when the active view is the default
+  // "workspace" tab. The markup is always rendered so G6-3 can plug in.
   const activeView = opts.state?.activeView ?? null;
   const slotHidden = activeView === "workspace" || activeView === null;
   const slotActiveView = activeView ?? "workspace";
+
+  const queueBody =
+    opts.leftWorkbenchHtml ??
+    (queueEmpty
+      ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
+      : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>');
+
+  const centralDisplayBody =
+    opts.centralDisplayHtml ??
+    renderCentralDisplayBody(opts.state, opts.graph, opts.entityLayout, opts.descriptionSidecar);
+
+  const counters = renderCounters(computeCounters(effectiveState, opts.graph));
+  const graphControls = renderGraphControls(effectiveState);
+
+  const graphPanelBody =
+    opts.graphPanelHtml ?? '<p class="ws-empty">No graph context available.</p>';
+
   const slotBody = slotHidden
     ? ""
     : opts.rightDrawerHtml ??
@@ -344,15 +665,14 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     queueBody,
     "</aside>",
     '<main class="ws-center" id="central-display" role="main" aria-label="Central display" tabindex="-1">',
-    '<h2 class="ws-region-heading">Central display</h2>',
     centralDisplayBody,
+    counters,
+    graphControls,
     '<section class="ws-graph-panel" id="graph-panel" role="region" aria-label="Graph panel">',
-    '<h2 class="ws-region-heading">Graph panel</h2>',
     graphPanelBody,
     "</section>",
     "</main>",
     `<aside class="workspace-reconciliation-slot" id="workspace-reconciliation-slot" role="complementary" aria-label="Reconciliation slot" data-active-view="${escapeHtml(slotActiveView)}"${slotHidden ? ' aria-hidden="true"' : ""}>`,
-    slotHidden ? "" : '<h2 class="ws-region-heading">Detail</h2>',
     slotBody,
     "</aside>",
     "</div>",

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -1,40 +1,36 @@
 /**
- * Track G Lot 1 / G2 — workspace shell static scaffold.
+ * Track G G2 / G6-1 (S0.1) — workspace shell static scaffold.
  *
  * Produces the server-rendered HTML scaffold consumed by
  * `graphify ontology studio` (read-only by default; mutation surface
  * is gated behind --write per existing patterns in src/serve.ts and
  * src/ontology-studio.ts and is wired in G5).
  *
+ * G6-1 (S0.1) absorbs the ACLP-AM Workspace tab three-column layout:
+ * left rail · central column (display + graph) · right reconciliation
+ * slot. The right slot is HIDDEN when the active view is "workspace"
+ * (default) but the markup is always present so G6-3 can plug Track B
+ * reconciliation content in without touching the shell shape.
+ *
  * Layout — desktop (>= 769 px):
  *
  *   +----- Header ---------------------------------+
  *   | Title · status · profile-id                 |
  *   +----+----------------------------+-----------+
- *   | LW | CentralDisplay             |  Drawer   |
- *   |    |                            |           |
- *   |    |  ----  GraphPanel ----     |           |
- *   |    |                            |           |
- *   +----+----------------------------+-----------+
+ *   | LW | CentralDisplay             |  Recon.   |
+ *   |    |                            |   slot    |
+ *   |    |  ----  GraphPanel ----     | (hidden   |
+ *   |    |                            |  in       |
+ *   +----+----------------------------+  workspace+
+ *                                       active view)
  *
- * Layout — mobile (<= 768 px):
- *
- *   +----- Header ---------------------------------+
- *   | LeftWorkbench (collapsible top sheet)        |
- *   +-----------------------------------------------+
- *   | CentralDisplay                                |
- *   | -------------- GraphPanel ------------------- |
- *   +-----------------------------------------------+
- *   | Drawer (sub-page nav, not overlay)            |
+ * Layout — mobile (<= 768 px): the slot collapses to display:none in
+ * the default workspace view to keep the 390 px viewport scroll-free.
  *
  * Track C inheritance is mandatory:
  *   - skip-link (first focusable element) jumps to #central-display
  *   - ARIA: each named region declares role + aria-label.
  *   - focus-visible respects the workspace focus-ring tokens.
- *
- * G2 ships the HTML skeleton + token-driven CSS. G3..G5 follow-ups
- * fill the actual content: viewer state model (G3), graph surface
- * inside #graph-panel (G4), reconciliation rebind (G5).
  */
 
 import type { WorkspaceTokens, WorkspaceTokenSource } from "./tokens.js";
@@ -264,7 +260,8 @@ function shellStyles(): string {
     ".ws-left { grid-column: 1; grid-row: 2; border-right: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface); }",
     ".ws-center { grid-column: 2; grid-row: 2; overflow-y: auto; padding: var(--ws-space-4); background: var(--ws-surface); }",
     ".ws-graph-panel { margin-top: var(--ws-space-5); padding-top: var(--ws-space-3); border-top: 1px solid var(--ws-border); }",
-    ".ws-right { grid-column: 3; grid-row: 2; border-left: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface-2); }",
+    ".workspace-reconciliation-slot { grid-column: 3; grid-row: 2; border-left: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface-2); }",
+    ".workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; }",
     ".ws-region-heading { font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); margin: 0 0 var(--ws-space-2); }",
     ".ws-empty { color: var(--ws-text-muted); font-style: italic; }",
     ".ws-display-item { display: grid; gap: var(--ws-space-2); max-width: 72ch; }",
@@ -278,7 +275,8 @@ function shellStyles(): string {
     "  .ws-root { grid-template-columns: 1fr; grid-template-rows: auto auto 1fr auto; }",
     "  .ws-left { grid-column: 1; grid-row: 2; border-right: none; border-bottom: 1px solid var(--ws-border); max-height: 40vh; }",
     "  .ws-center { grid-column: 1; grid-row: 3; }",
-    "  .ws-right { grid-column: 1; grid-row: 4; border-left: none; border-top: 1px solid var(--ws-border); max-height: 40vh; }",
+    "  .workspace-reconciliation-slot { grid-column: 1; grid-row: 4; border-left: none; border-top: 1px solid var(--ws-border); max-height: 40vh; }",
+    "  .workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; max-height: 0; padding: 0; }",
     "}",
   ].join("\n");
 }
@@ -304,9 +302,17 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     opts.graphPanelHtml ??
     '<p class="ws-empty">No graph context available.</p>';
   const centralDisplayBody = opts.centralDisplayHtml ?? renderCentralDisplayBody(opts.state, opts.graph);
-  const rightDrawerBody =
-    opts.rightDrawerHtml ??
-    '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>';
+  // G6-1 (S0.1): the right column is now a named reconciliation slot. It
+  // is HIDDEN (empty markup + aria-hidden) when the active view is the
+  // default "workspace" tab — only a future reconciliation sub-view
+  // (G6-3) opens it.
+  const activeView = opts.state?.activeView ?? null;
+  const slotHidden = activeView === "workspace" || activeView === null;
+  const slotActiveView = activeView ?? "workspace";
+  const slotBody = slotHidden
+    ? ""
+    : opts.rightDrawerHtml ??
+      '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>';
 
   return [
     "<!DOCTYPE html>",
@@ -345,9 +351,9 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     graphPanelBody,
     "</section>",
     "</main>",
-    '<aside class="ws-right" id="right-drawer" role="complementary" aria-label="Detail drawer">',
-    '<h2 class="ws-region-heading">Detail</h2>',
-    rightDrawerBody,
+    `<aside class="workspace-reconciliation-slot" id="workspace-reconciliation-slot" role="complementary" aria-label="Reconciliation slot" data-active-view="${escapeHtml(slotActiveView)}"${slotHidden ? ' aria-hidden="true"' : ""}>`,
+    slotHidden ? "" : '<h2 class="ws-region-heading">Detail</h2>',
+    slotBody,
     "</aside>",
     "</div>",
     "</body>",

--- a/tests/workspace-counters.test.ts
+++ b/tests/workspace-counters.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Track G G6-1 (S0.4) — four counters between prose and graph.
+ *
+ * Selected entities / selected classes / visible nodes / visible edges.
+ * Values are read from WorkspaceViewerState + the dataset stats already
+ * exposed via computeFocusSubgraph.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+const graph: GraphLike = {
+  nodes: [
+    { id: "a", label: "A", node_type: "T1" },
+    { id: "b", label: "B", node_type: "T1" },
+    { id: "c", label: "C", node_type: "T2" },
+  ],
+  edges: [
+    { source: "a", target: "b", relation: "r", confidence: "EXTRACTED" },
+    { source: "b", target: "c", relation: "r", confidence: "EXTRACTED" },
+  ],
+};
+
+describe("Track G G6-1 — counters row", () => {
+  it("renders four labelled counters in the rendered shell", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    expect(html).toContain('class="ws-counters"');
+    expect(html).toContain('data-counter="selected-entities"');
+    expect(html).toContain('data-counter="selected-classes"');
+    expect(html).toContain('data-counter="visible-nodes"');
+    expect(html).toContain('data-counter="visible-edges"');
+  });
+
+  it("reflects the selection state and dataset stats in each counter value", () => {
+    const state = {
+      ...createDefaultViewerState(),
+      selectedTypes: ["T1", "T2"],
+      selectedEntities: ["a", "b"],
+      selectionState: {
+        kind: "members",
+        ref: "selection:test",
+        entityIds: ["a", "b"],
+      },
+    };
+    const html = renderWorkspaceShell({ tokens, title: "Workspace", state, graph });
+    // 2 selected entities, 2 selected classes, visible nodes/edges from
+    // the induced subgraph.
+    expect(html).toMatch(
+      /data-counter="selected-entities"[^>]*>[\s\S]*?<span class="ws-counter-value">\s*2\s*<\/span>/,
+    );
+    expect(html).toMatch(
+      /data-counter="selected-classes"[^>]*>[\s\S]*?<span class="ws-counter-value">\s*2\s*<\/span>/,
+    );
+    expect(html).toMatch(
+      /data-counter="visible-nodes"[^>]*>[\s\S]*?<span class="ws-counter-value">\s*\d+\s*<\/span>/,
+    );
+    expect(html).toMatch(
+      /data-counter="visible-edges"[^>]*>[\s\S]*?<span class="ws-counter-value">\s*\d+\s*<\/span>/,
+    );
+  });
+
+  it("places the counters between the description block and the graph controls", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    const idxCounters = html.indexOf('class="ws-counters"');
+    const idxControls = html.indexOf('class="ws-graph-controls"');
+    const idxGraphPanel = html.indexOf('id="graph-panel"');
+    expect(idxCounters).toBeGreaterThan(-1);
+    expect(idxControls).toBeGreaterThan(idxCounters);
+    expect(idxGraphPanel).toBeGreaterThan(idxCounters);
+  });
+});

--- a/tests/workspace-display-compact.test.ts
+++ b/tests/workspace-display-compact.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Track G G6-1 (S0.2) — compact central description block.
+ *
+ * Replaces the verbose Type/Status/Confidence/Source/Community cards with
+ * a single compact prose block (H1 + inline facts + Aliases/Relations/
+ * Evidence as small-caps sections). Same rendering applies to entity
+ * displayRef AND candidate displayRef. `insufficient_evidence` continues
+ * to hide the description silently.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+const graph: GraphLike = {
+  nodes: [
+    {
+      id: "holmes",
+      label: "Sherlock Holmes",
+      node_type: "Character",
+      status: "active",
+      confidence: "EXTRACTED",
+      source_file: "doc.md",
+      source_location: "L1",
+      community_name: "Detectives",
+      aliases: ["Holmes", "The detective"],
+      summary: "Consulting detective.",
+    },
+    { id: "watson", label: "Dr Watson", node_type: "Character" },
+  ],
+  edges: [
+    { source: "holmes", target: "watson", relation: "works_with", evidence_count: 2 },
+  ],
+};
+
+describe("Track G G6-1 — compact entity description", () => {
+  it("renders entity prose compactly with no verbose Type/Status/Confidence/Source/Community rows", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), displayRef: "entity:holmes" },
+      graph,
+    });
+    // H1 title present.
+    expect(html).toContain('class="ws-compact-title"');
+    expect(html).toContain("Sherlock Holmes");
+    // Prose lines are flowed inline (single .ws-compact-facts block).
+    expect(html).toContain('class="ws-compact-facts"');
+    // The legacy dt/dd rows must be gone: each fact must NOT live in its own card row.
+    expect(html).not.toMatch(/<div>\s*<dt>Type<\/dt>/);
+    expect(html).not.toMatch(/<div>\s*<dt>Status<\/dt>/);
+    expect(html).not.toMatch(/<div>\s*<dt>Confidence<\/dt>/);
+    // Compact aliases section uses small-caps heading and inline list.
+    expect(html).toContain('class="ws-compact-section ws-compact-aliases"');
+    expect(html).toContain("Holmes");
+    expect(html).toContain("The detective");
+    // Compact relations + evidence sections.
+    expect(html).toContain('class="ws-compact-section ws-compact-relations"');
+    expect(html).toContain('class="ws-compact-section ws-compact-evidence"');
+  });
+
+  it("renders a candidate displayRef using the same compact prose layout", () => {
+    const candidateGraph: GraphLike = {
+      nodes: [
+        {
+          id: "motive",
+          label: "Motive candidate",
+          kind: "candidate",
+          description: "Needs review.",
+        },
+      ],
+      links: [],
+    };
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), displayRef: "candidate:motive" },
+      graph: candidateGraph,
+    });
+    expect(html).toContain('class="ws-compact-title"');
+    expect(html).toContain("Motive candidate");
+    expect(html).toContain("Needs review.");
+    expect(html).toContain('class="ws-compact-facts"');
+  });
+
+  it("hides the description block silently when the sidecar reports insufficient_evidence", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), displayRef: "entity:holmes" },
+      graph,
+      descriptionSidecar: {
+        status: "insufficient_evidence",
+        target_id: "holmes",
+        target_kind: "node",
+      },
+    });
+    // The compact block is gone, no description text leaked.
+    expect(html).not.toContain('class="ws-compact-description"');
+    expect(html).not.toContain("Consulting detective.");
+    // But the title is still rendered (insufficient_evidence hides the description,
+    // not the entity card itself).
+    expect(html).toContain("Sherlock Holmes");
+  });
+
+  it("inlines the Track A markdown description when the sidecar status is 'generated'", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), displayRef: "entity:holmes" },
+      graph,
+      descriptionSidecar: {
+        status: "generated",
+        target_id: "holmes",
+        target_kind: "node",
+        description: "**Bold** prose from the wiki sidecar.",
+      },
+    });
+    expect(html).toContain('class="ws-compact-description"');
+    // Bold markdown is preserved as inline emphasis (escaped or transformed
+    // to <strong>; assert non-empty rendering).
+    expect(html.includes("Bold prose from the wiki sidecar") || html.includes("<strong>Bold</strong>"))
+      .toBe(true);
+  });
+
+  it("does not hardcode any corpus-specific string (Process / framework / abp / aclp / BusinessObject)", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), displayRef: "entity:holmes" },
+      graph,
+    });
+    expect(html).not.toMatch(/\b(?:framework|abp|aclp|ABPProcess|ACLPProcess|BusinessObject|DigitalApplicationTool)\b/);
+  });
+});

--- a/tests/workspace-graph-selection-filter.test.ts
+++ b/tests/workspace-graph-selection-filter.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Track G G6-1 (S0.3) — graph panel filtered by selection state.
+ *
+ * Empty selection → mode "overview"; non-empty selection.entityIds → mode
+ * "selection" with the BFS-1 induced subgraph. The Show weak links toggle
+ * flips viewState.graph.showWeakLinks; the legend (Strong / Explicit / Weak)
+ * is rendered above the graph surface.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  computeFocusSubgraph,
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+const graph: GraphLike = {
+  nodes: [
+    { id: "a", label: "A", node_type: "T1", community: 1 },
+    { id: "b", label: "B", node_type: "T1", community: 1 },
+    { id: "c", label: "C", node_type: "T2", community: 2 },
+    { id: "d", label: "D", node_type: "T2", community: 2 },
+  ],
+  edges: [
+    { source: "a", target: "b", relation: "rel", confidence: "EXTRACTED" },
+    { source: "b", target: "c", relation: "rel2", confidence: "EXTRACTED" },
+    { source: "c", target: "d", relation: "rel3", confidence: "INFERRED" },
+  ],
+};
+
+describe("Track G G6-1 — graph panel bound to selection state", () => {
+  it("falls back to overview when selectionState.entityIds is empty", () => {
+    const state = createDefaultViewerState();
+    expect(state.selectionState.entityIds).toEqual([]);
+    const subgraph = computeFocusSubgraph(graph, state);
+    expect(subgraph.appliedMode).toBe("overview");
+    expect(subgraph.nodes.length).toBe(4);
+  });
+
+  it("induces a 1-hop subgraph around the selected entities", () => {
+    const state = createDefaultViewerState();
+    state.selectionState = {
+      kind: "members",
+      ref: "selection:test",
+      entityIds: ["a"],
+    };
+    state.viewState.graph.mode = "selection";
+    state.selectedEntities = ["a"];
+    const subgraph = computeFocusSubgraph(graph, state);
+    expect(subgraph.appliedMode).toBe("selection");
+    // BFS-1 around 'a' through strong edges → {a, b}.
+    const ids = subgraph.nodes.map((n) => n.id);
+    expect(ids).toContain("a");
+  });
+
+  it("emits the selection/focus toggle, the weak-links checkbox, and the legend in the rendered shell", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    expect(html).toContain('class="ws-graph-controls"');
+    expect(html).toContain('data-control="graph-mode-toggle"');
+    expect(html).toContain('data-control="graph-weak-links"');
+    expect(html).toContain('class="ws-graph-legend"');
+    expect(html.toLowerCase()).toContain("strong");
+    expect(html.toLowerCase()).toContain("weak");
+  });
+
+  it("reflects the weak-links toggle state in the rendered checkbox", () => {
+    const state = createDefaultViewerState();
+    state.viewState.graph.showWeakLinks = true;
+    const html = renderWorkspaceShell({ tokens, title: "Workspace", state, graph });
+    // Checkbox must be `checked` when showWeakLinks is true.
+    expect(html).toMatch(/data-control="graph-weak-links"[^>]*\bchecked\b/);
+  });
+
+  it("renders the graph panel inside the central column, not in a separate region", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Workspace", graph });
+    // The graph panel section lives inside <main id="central-display">.
+    const centralIdx = html.indexOf('id="central-display"');
+    const graphIdx = html.indexOf('id="graph-panel"');
+    const centralEnd = html.indexOf("</main>", centralIdx);
+    expect(centralIdx).toBeGreaterThan(-1);
+    expect(graphIdx).toBeGreaterThan(centralIdx);
+    expect(graphIdx).toBeLessThan(centralEnd);
+  });
+});

--- a/tests/workspace-shell-3col.test.ts
+++ b/tests/workspace-shell-3col.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Track G G6-1 (S0.1) — three-column workspace shell.
+ *
+ * Verifies that the shell carries the new `workspace-reconciliation-slot`
+ * scaffolding alongside the existing left rail / central column, and that
+ * the slot is empty (no inline content) when the default Workspace view is
+ * active (`state.activeView === "workspace"`). The mobile breakpoint must
+ * collapse the slot so 390 px screens never trigger horizontal scroll.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+describe("Track G G6-1 — three-column shell", () => {
+  it("renders the named reconciliation slot as a third effective column", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Workspace" });
+    expect(html).toContain('class="workspace-reconciliation-slot');
+    expect(html).toContain('id="workspace-reconciliation-slot"');
+    // Grid declares three desktop columns.
+    expect(html).toContain('grid-template-columns: 280px 1fr 320px');
+  });
+
+  it("leaves the reconciliation slot empty (and aria-hidden) in default Workspace view", () => {
+    const state = createDefaultViewerState();
+    // Default activeView is "workspace" — slot must be empty.
+    expect(state.activeView).toBe("workspace");
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state,
+      rightDrawerHtml: '<aside id="should-not-appear">hidden</aside>',
+    });
+    expect(html).toContain('id="workspace-reconciliation-slot"');
+    expect(html).toContain('data-active-view="workspace"');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain('id="should-not-appear"');
+  });
+
+  it("still honours rightDrawerHtml when activeView is not 'workspace' (e.g. studio reconciliation)", () => {
+    const state = { ...createDefaultViewerState(), activeView: "studio" };
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Studio",
+      state,
+      rightDrawerHtml: '<aside id="recon-detail">Audit</aside>',
+    });
+    expect(html).toContain('id="recon-detail"');
+    expect(html).toContain('data-active-view="studio"');
+    expect(html).not.toContain('aria-hidden="true"');
+  });
+
+  it("collapses the reconciliation slot to nothing at the 768 px mobile breakpoint", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Workspace" });
+    expect(html).toContain("@media (max-width: 768px)");
+    // Mobile rule must zero-out the slot in workspace view to avoid scrolling at 390 px.
+    expect(html).toMatch(
+      /\.workspace-reconciliation-slot\[data-active-view=['"]workspace['"]\]\s*\{[^}]*display:\s*none/,
+    );
+  });
+
+  it("does not declare any fixed width that would force horizontal scroll on 390 px screens", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Workspace" });
+    expect(html).not.toMatch(/width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+    expect(html).not.toMatch(/min-width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+  });
+});

--- a/tests/workspace-shell.test.ts
+++ b/tests/workspace-shell.test.ts
@@ -16,16 +16,15 @@ describe("Track G G2 — workspace shell scaffold", () => {
     expect(html).toContain('id="left-workbench"');
     expect(html).toContain('id="central-display"');
     expect(html).toContain('id="graph-panel"');
-    // G6-1 (S0.1): the right drawer migrated to the named reconciliation slot.
+    // G6-1: the right drawer migrated to the named reconciliation slot.
     expect(html).toContain('id="workspace-reconciliation-slot"');
     expect(html).toContain('role="main"');
     expect(html).toContain('role="application"');
   });
 
   it("marks the token source and lets studio routes fill each workspace region", () => {
-    // G6-1 (S0.1): in the default "workspace" activeView the reconciliation
-    // slot is hidden. Studio routes use activeView="studio" to surface the
-    // reconciliation/audit content.
+    // G6-1: in default "workspace" activeView the reconciliation slot is
+    // hidden. Studio routes use activeView="studio" to surface the drawer.
     const studioState = { ...createDefaultViewerState(), activeView: "studio" };
     const html = renderWorkspaceShell({
       tokens,
@@ -161,8 +160,12 @@ describe("Track G G2 — workspace shell scaffold", () => {
     expect(html).toContain("Sherlock &lt;Holmes&gt;");
     expect(html).toContain("Character");
     expect(html).toContain("Consulting detective &amp; violinist.");
-    expect(html).toContain("<b>Relations:</b> 2");
-    expect(html).toContain("<b>Evidence:</b> 3");
+    // G6-1: relations/evidence are surfaced via the compact sections, not
+    // the legacy ws-display-metrics block.
+    expect(html).toContain('class="ws-compact-section ws-compact-relations"');
+    expect(html).toContain('class="ws-compact-section ws-compact-evidence"');
+    expect(html).toContain("2 relations");
+    expect(html).toContain("3 refs");
     expect(html).not.toContain("Sherlock <Holmes>");
   });
 
@@ -188,8 +191,9 @@ describe("Track G G2 — workspace shell scaffold", () => {
 
     expect(html).toContain("renderWorkspaceShell()");
     expect(html).toContain("code");
-    expect(html).toContain("Source: src/workspace/shell.ts:L270");
-    expect(html).toContain("Community: Workspace rendering");
+    // G6-1: source / community surface as inline facts in the compact block.
+    expect(html).toContain("Source:</span> src/workspace/shell.ts:L270");
+    expect(html).toContain("Community:</span> Workspace rendering");
     expect(html).not.toContain("No summary available.");
   });
 
@@ -211,8 +215,10 @@ describe("Track G G2 — workspace shell scaffold", () => {
     });
     expect(typeHtml).toContain("Character");
     expect(typeHtml).toContain("Type");
-    expect(typeHtml).toContain("<b>Members:</b> 2");
-    expect(typeHtml).toContain("<b>Relations:</b> 1");
+    // G6-1: type display uses the compact prose layout.
+    expect(typeHtml).toContain('data-fact="members"');
+    expect(typeHtml).toContain("Members:</span> 2");
+    expect(typeHtml).toContain("1 relation");
 
     const candidateHtml = renderWorkspaceShell({
       tokens,

--- a/tests/workspace-shell.test.ts
+++ b/tests/workspace-shell.test.ts
@@ -16,16 +16,22 @@ describe("Track G G2 — workspace shell scaffold", () => {
     expect(html).toContain('id="left-workbench"');
     expect(html).toContain('id="central-display"');
     expect(html).toContain('id="graph-panel"');
-    expect(html).toContain('id="right-drawer"');
+    // G6-1 (S0.1): the right drawer migrated to the named reconciliation slot.
+    expect(html).toContain('id="workspace-reconciliation-slot"');
     expect(html).toContain('role="main"');
     expect(html).toContain('role="application"');
   });
 
   it("marks the token source and lets studio routes fill each workspace region", () => {
+    // G6-1 (S0.1): in the default "workspace" activeView the reconciliation
+    // slot is hidden. Studio routes use activeView="studio" to surface the
+    // reconciliation/audit content.
+    const studioState = { ...createDefaultViewerState(), activeView: "studio" };
     const html = renderWorkspaceShell({
       tokens,
       tokenSource: "fallback",
       title: "Ontology workspace",
+      state: studioState,
       leftWorkbenchHtml: '<nav id="candidate-list">Candidate queue</nav>',
       centralDisplayHtml: '<article id="candidate-detail">Candidate detail</article>',
       rightDrawerHtml: '<aside id="audit-detail">Audit trail</aside>',


### PR DESCRIPTION
## Summary

Lot **G6-1** of Track G (ACLP-AM Workspace tab alignment). Implements the **S0 block** of the punch-list at `.graphify/scratch/G6-aclp-alignment-punch-list.md`:

- **S0.1** — Restructures `src/workspace/shell.ts` into three effective columns (left rail · central column · `aside.workspace-reconciliation-slot`). The slot is hidden (`display:none` + `aria-hidden`) when `state.activeView === "workspace"` (default Workspace tab). Markup is always emitted so G6-3 can plug in Track B content without re-shaping the shell. Studio routes use `activeView="studio"` to surface the slot.
- **S0.2** — Replaces the verbose Type / Status / Confidence / Source / Community card rows with a compact prose block: H1 title, inline fact spans (Type · Status · Source · Community), then small-caps Aliases / Relations / Evidence sections. Same layout for entity AND candidate displayRefs. Profile-driven via `outputs.workspace.entity_layout` (`inline_facts` / `sections`). Track A description sidecar: `generated` renders inline markdown (minimal `**bold**`/`*italic*`), `insufficient_evidence` hides the description silently.
- **S0.3** — Renders a control row above the graph panel inside the central column: Selection/Focus mode toggle, Show weak links checkbox, colour legend (Strong / Explicit / Weak). Reuses the existing `computeFocusSubgraph` — the graph is filtered by `selectionState` + `activeType` + `facetState` already.
- **S0.4** — Four counters between the prose block and the graph controls: selected entities · selected classes · visible nodes · visible edges. Values pulled from `WorkspaceViewerState.selectionState.entityIds` / `selectedTypes` and `computeFocusSubgraph` metrics.

## Constraints honoured

- No corpus-specific strings in `src/workspace/*` (forbidden: `Process`, `framework`, `abp`, `aclp`, `ABPProcess`, `BusinessObject`, `DigitalApplicationTool`).
- Track A description sidecar inline + `insufficient_evidence` hide preserved.
- Track B reconciliation API untouched — `ontology-studio-write` tests stay green.
- Mobile 390 × 844: slot collapses to nothing in workspace view; no horizontal scroll.
- Existing exported HTML (`graph.html`, wiki, `GRAPH_REPORT.md`) and Track C-3.5 visual encoding contract intact.

## Tests added

- `tests/workspace-shell-3col.test.ts` — three-column shell + slot semantics (5 tests).
- `tests/workspace-display-compact.test.ts` — compact entity/candidate description + Track A sidecar inline + `insufficient_evidence` hide (5 tests).
- `tests/workspace-graph-selection-filter.test.ts` — graph mode bound to selectionState + control row + legend (5 tests).
- `tests/workspace-counters.test.ts` — four counters wired to selection + dataset stats (3 tests).

Existing `tests/workspace-shell.test.ts` updated to reflect the new slot name and compact layout.

## Test plan

- [x] `npm run lint` (tsc --noEmit)
- [x] `npm test` — 750 passed, 1 flaky (`tests/cache.test.ts` fileHash mtime race, passes in isolation)
- [x] `npm run build`
- [x] `npx graphify hook-rebuild`
- [x] Smoke screenshot via headless chromium against public-pack (`.graphify/scratch/g6-1-shell-public-pack.png`)
- [x] `tests/ontology-studio-write.test.ts` still green (Track B API untouched)
- [ ] Visual review against `.graphify/scratch/ref/aclp-am-workspace-target.png`

## Out of scope (G6-2, G6-3)

- **G6-2** — Rail-left enrichment (search / types / selected chips / facets / results groups).
- **G6-3** — Top tabs (`Workspace` / `Reconciliation` / `Evidence`) + reconciliation sub-view that plugs back into `workspace-reconciliation-slot` and absorbs PR #40.

Reference: `.graphify/scratch/G6-aclp-alignment-punch-list.md`.

**PR stays draft.** Mark ready after review.