### PR TITLE
Track G G6-2: left rail enrichment (search, types, selected, facets, results)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-05-22)
+# Graph Report - .  (2026-05-23)
 
 ## Corpus Check
-- 272 files · ~341 728 words
+- 281 files · ~348 088 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4300 nodes · 6906 edges · 228 communities detected
+- 4386 nodes · 7022 edges · 226 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 272 · Candidates: 292
+- Included files: 281 · Candidates: 301
 - Excluded: 0 untracked · 15509 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `1b0efd1`
+- Built from Git commit: `faad58b`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -33,6 +33,8 @@
 10. `AsyncClient` - 26 edges
 
 ## Surprising Connections (you probably didn't know these)
+- `Core data models: URL, Headers, Cookies, Request, Response. These are the centra` --uses--> `HTTPStatusError`  [INFERRED]
+  worked/httpx/raw/models.py → worked/httpx/raw/exceptions.py
 - `Utility functions shared across the library. Small helpers that don't belong in` --uses--> `Cookies`  [INFERRED]
   worked/httpx/raw/utils.py → worked/httpx/raw/models.py
 - `Convert a primitive value to its string representation.` --uses--> `Cookies`  [INFERRED]
@@ -41,114 +43,112 @@
   worked/httpx/raw/utils.py → worked/httpx/raw/models.py
 - `Expand a params dict into a flat list of (key, value) pairs.     List values bec` --uses--> `Cookies`  [INFERRED]
   worked/httpx/raw/utils.py → worked/httpx/raw/models.py
-- `Parse a Content-Type header value.     Returns (media_type, params_dict).     Ex` --uses--> `Cookies`  [INFERRED]
-  worked/httpx/raw/utils.py → worked/httpx/raw/models.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (79): analysis, analysisPath, analysisValues, article, artifact, cacheKey, captionsDir, configOut (+71 more)
+Cohesion: 0.05
+Nodes (37): Authentication handlers. Auth objects are callables that modify a request before, Auth, BasicAuth, BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host. (+29 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
+Nodes (79): analysis, analysisPath, analysisValues, article, artifact, cacheKey, captionsDir, configOut (+71 more)
 
 ### Community 2 - "Community 2"
+Cohesion: 0.02
+Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
+
+### Community 3 - "Community 3"
+Cohesion: 0.04
+Nodes (67): Exception, CloseError, ConnectTimeout, CookieConflict, PoolTimeout, ProtocolError, ProxyError, httpx-like exception hierarchy. All exceptions inherit from HTTPError at the top (+59 more)
+
+### Community 4 - "Community 4"
+Cohesion: 0.07
+Nodes (19): Auth, BasicAuth, AsyncClient, BaseClient, Client, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client. (+11 more)
+
+### Community 5 - "Community 5"
 Cohesion: 0.03
 Nodes (58): alphaNeighbors, audit, beforeAudit, beforeDecisions, betaNeighbors, candidate, candidateResponse, candidates (+50 more)
 
-### Community 3 - "Community 3"
+### Community 6 - "Community 6"
+Cohesion: 0.07
+Nodes (33): BearerAuth, DigestAuth, NetRCAuth, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+25 more)
+
+### Community 7 - "Community 7"
 Cohesion: 0.05
 Nodes (48): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+40 more)
 
-### Community 4 - "Community 4"
+### Community 8 - "Community 8"
 Cohesion: 0.05
 Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+44 more)
 
-### Community 5 - "Community 5"
+### Community 9 - "Community 9"
 Cohesion: 0.06
 Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
 
-### Community 6 - "Community 6"
+### Community 10 - "Community 10"
 Cohesion: 0.05
 Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
 
-### Community 7 - "Community 7"
+### Community 11 - "Community 11"
 Cohesion: 0.06
 Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
 
-### Community 8 - "Community 8"
+### Community 12 - "Community 12"
 Cohesion: 0.04
 Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
 
-### Community 9 - "Community 9"
+### Community 13 - "Community 13"
 Cohesion: 0.07
 Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
 
-### Community 10 - "Community 10"
+### Community 14 - "Community 14"
 Cohesion: 0.06
 Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
 
-### Community 11 - "Community 11"
+### Community 15 - "Community 15"
 Cohesion: 0.05
 Nodes (34): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+26 more)
 
-### Community 12 - "Community 12"
+### Community 16 - "Community 16"
 Cohesion: 0.09
 Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
 
-### Community 13 - "Community 13"
+### Community 17 - "Community 17"
 Cohesion: 0.07
 Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
 
-### Community 14 - "Community 14"
+### Community 18 - "Community 18"
 Cohesion: 0.07
 Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
 
-### Community 15 - "Community 15"
+### Community 19 - "Community 19"
 Cohesion: 0.06
 Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
 
-### Community 16 - "Community 16"
+### Community 20 - "Community 20"
 Cohesion: 0.10
 Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
 
-### Community 17 - "Community 17"
+### Community 21 - "Community 21"
 Cohesion: 0.05
 Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
 
-### Community 18 - "Community 18"
-Cohesion: 0.10
-Nodes (30): ConnectError, ConnectTimeout, PoolTimeout, ProtocolError, ProxyError, An error occurred at the transport layer., Timed out while connecting to the host., Timed out while receiving data from the host. (+22 more)
-
-### Community 19 - "Community 19"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
-### Community 20 - "Community 20"
-Cohesion: 0.11
-Nodes (26): BearerAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+18 more)
-
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
 
-### Community 22 - "Community 22"
-Cohesion: 0.07
-Nodes (35): Cookies, build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str() (+27 more)
-
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.10
 Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
-
-### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (35): Exception, CloseError, ConnectTimeout, CookieConflict, DecodingError, HTTPError, HTTPStatusError, NetworkError (+27 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.08
@@ -179,28 +179,28 @@ Cohesion: 0.12
 Nodes (34): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+26 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.11
-Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
+Cohesion: 0.06
+Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.11
-Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
+Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
 ### Community 35 - "Community 35"
+Cohesion: 0.11
+Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
+
+### Community 36 - "Community 36"
 Cohesion: 0.08
 Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.06
 Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.09
 Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.16
-Nodes (16): Auth, BasicAuth, BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c, Synchronous HTTP client. (+8 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.08
@@ -227,708 +227,708 @@ Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
 ### Community 45 - "Community 45"
-Cohesion: 0.16
-Nodes (15): Auth, BasicAuth, Base class for all authentication handlers., BaseClient, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client., Shared implementation for Client and AsyncClient.     Handles auth, redirects, c (+7 more)
-
-### Community 46 - "Community 46"
 Cohesion: 0.09
 Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 0.07
 Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.09
 Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.07
 Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
-### Community 51 - "Community 51"
-Cohesion: 0.13
-Nodes (2): AsyncClient, Client
-
-### Community 52 - "Community 52"
+### Community 50 - "Community 50"
 Cohesion: 0.10
 Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
-### Community 53 - "Community 53"
+### Community 51 - "Community 51"
 Cohesion: 0.13
 Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
 
-### Community 54 - "Community 54"
+### Community 52 - "Community 52"
 Cohesion: 0.10
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
-### Community 55 - "Community 55"
+### Community 53 - "Community 53"
 Cohesion: 0.16
 Nodes (25): buildModel(), displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeMetaRows(), graphNodeSummary() (+17 more)
 
-### Community 56 - "Community 56"
+### Community 54 - "Community 54"
 Cohesion: 0.14
 Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
 
-### Community 57 - "Community 57"
-Cohesion: 0.09
-Nodes (6): Core data models: URL, Headers, Cookies, Request, Response. These are the centra, HTTPStatusError, A 4xx or 5xx response was received., Headers, Core data models: URL, Headers, Cookies, Request, Response. These are the centra, URL
-
-### Community 58 - "Community 58"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
-### Community 59 - "Community 59"
+### Community 56 - "Community 56"
 Cohesion: 0.16
 Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
 
-### Community 60 - "Community 60"
+### Community 57 - "Community 57"
 Cohesion: 0.13
 Nodes (20): candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult(), isLoopbackHost() (+12 more)
 
-### Community 61 - "Community 61"
-Cohesion: 0.11
-Nodes (12): BearerAuth, DigestAuth, NetRCAuth, Authentication handlers. Auth objects are callables that modify a request before, Load credentials from ~/.netrc based on the request host., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+4 more)
-
-### Community 62 - "Community 62"
+### Community 58 - "Community 58"
 Cohesion: 0.10
 Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
 
-### Community 63 - "Community 63"
+### Community 59 - "Community 59"
 Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 64 - "Community 64"
+### Community 60 - "Community 60"
 Cohesion: 0.13
 Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
 
-### Community 65 - "Community 65"
+### Community 61 - "Community 61"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
 
-### Community 66 - "Community 66"
+### Community 62 - "Community 62"
 Cohesion: 0.10
 Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
 
-### Community 67 - "Community 67"
+### Community 63 - "Community 63"
 Cohesion: 0.13
 Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
 
-### Community 68 - "Community 68"
+### Community 64 - "Community 64"
 Cohesion: 0.09
 Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
 
-### Community 69 - "Community 69"
+### Community 65 - "Community 65"
 Cohesion: 0.09
 Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
 
-### Community 70 - "Community 70"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
 
-### Community 71 - "Community 71"
+### Community 67 - "Community 67"
 Cohesion: 0.15
 Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
 
-### Community 72 - "Community 72"
+### Community 68 - "Community 68"
 Cohesion: 0.09
 Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
 
-### Community 73 - "Community 73"
+### Community 69 - "Community 69"
 Cohesion: 0.16
 Nodes (21): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+13 more)
 
-### Community 74 - "Community 74"
+### Community 70 - "Community 70"
 Cohesion: 0.09
 Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
 
-### Community 75 - "Community 75"
+### Community 71 - "Community 71"
 Cohesion: 0.09
 Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
 
-### Community 76 - "Community 76"
+### Community 72 - "Community 72"
 Cohesion: 0.11
 Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
 
-### Community 77 - "Community 77"
+### Community 73 - "Community 73"
 Cohesion: 0.14
 Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
 
-### Community 78 - "Community 78"
+### Community 74 - "Community 74"
 Cohesion: 0.10
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
-### Community 79 - "Community 79"
+### Community 75 - "Community 75"
 Cohesion: 0.13
 Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
 
-### Community 80 - "Community 80"
+### Community 76 - "Community 76"
 Cohesion: 0.13
 Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
 
-### Community 81 - "Community 81"
+### Community 77 - "Community 77"
 Cohesion: 0.15
 Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
 
-### Community 82 - "Community 82"
+### Community 78 - "Community 78"
+Cohesion: 0.13
+Nodes (18): aliasHit, hit, hits, ids, index, lower, minimal, records (+10 more)
+
+### Community 79 - "Community 79"
 Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
-### Community 83 - "Community 83"
+### Community 80 - "Community 80"
 Cohesion: 0.13
 Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
 
-### Community 84 - "Community 84"
+### Community 81 - "Community 81"
+Cohesion: 0.11
+Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
+
+### Community 82 - "Community 82"
 Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
-### Community 85 - "Community 85"
+### Community 83 - "Community 83"
 Cohesion: 0.21
 Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
-### Community 86 - "Community 86"
+### Community 84 - "Community 84"
 Cohesion: 0.12
 Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
 
-### Community 87 - "Community 87"
+### Community 85 - "Community 85"
 Cohesion: 0.12
 Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
 
-### Community 88 - "Community 88"
+### Community 86 - "Community 86"
 Cohesion: 0.20
 Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
 
-### Community 89 - "Community 89"
+### Community 87 - "Community 87"
 Cohesion: 0.17
 Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
 
-### Community 90 - "Community 90"
+### Community 88 - "Community 88"
 Cohesion: 0.12
 Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
 
-### Community 91 - "Community 91"
+### Community 89 - "Community 89"
 Cohesion: 0.12
 Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
 
-### Community 92 - "Community 92"
+### Community 90 - "Community 90"
 Cohesion: 0.13
 Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
 
-### Community 93 - "Community 93"
+### Community 91 - "Community 91"
 Cohesion: 0.13
 Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
 
-### Community 94 - "Community 94"
+### Community 92 - "Community 92"
 Cohesion: 0.13
 Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
 
-### Community 95 - "Community 95"
+### Community 93 - "Community 93"
 Cohesion: 0.16
 Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
 
-### Community 96 - "Community 96"
+### Community 94 - "Community 94"
 Cohesion: 0.17
 Nodes (13): DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape(), extractSemanticFilesDirectParallel() (+5 more)
 
-### Community 97 - "Community 97"
+### Community 95 - "Community 95"
 Cohesion: 0.18
 Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
 
-### Community 98 - "Community 98"
+### Community 96 - "Community 96"
+Cohesion: 0.23
+Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
+
+### Community 97 - "Community 97"
 Cohesion: 0.15
 Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
 
-### Community 99 - "Community 99"
+### Community 98 - "Community 98"
 Cohesion: 0.13
 Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
 
-### Community 100 - "Community 100"
+### Community 99 - "Community 99"
 Cohesion: 0.13
 Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
 
-### Community 101 - "Community 101"
+### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
 
-### Community 102 - "Community 102"
+### Community 101 - "Community 101"
 Cohesion: 0.24
 Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.13
 Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.19
 Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
 
-### Community 105 - "Community 105"
+### Community 104 - "Community 104"
 Cohesion: 0.13
 Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
 
-### Community 106 - "Community 106"
+### Community 105 - "Community 105"
 Cohesion: 0.16
 Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
 
-### Community 107 - "Community 107"
-Cohesion: 0.15
-Nodes (1): AsyncClient
-
-### Community 108 - "Community 108"
+### Community 106 - "Community 106"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 109 - "Community 109"
+### Community 107 - "Community 107"
 Cohesion: 0.14
 Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
 
-### Community 110 - "Community 110"
+### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
-### Community 111 - "Community 111"
+### Community 109 - "Community 109"
 Cohesion: 0.27
 Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
-### Community 112 - "Community 112"
+### Community 110 - "Community 110"
 Cohesion: 0.14
 Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
 
-### Community 113 - "Community 113"
+### Community 111 - "Community 111"
 Cohesion: 0.23
 Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
 
-### Community 114 - "Community 114"
+### Community 112 - "Community 112"
 Cohesion: 0.15
 Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
 
-### Community 115 - "Community 115"
+### Community 113 - "Community 113"
 Cohesion: 0.22
 Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
 
-### Community 116 - "Community 116"
+### Community 114 - "Community 114"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 117 - "Community 117"
+### Community 115 - "Community 115"
 Cohesion: 0.21
 Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
 
-### Community 118 - "Community 118"
+### Community 116 - "Community 116"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 119 - "Community 119"
+### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 120 - "Community 120"
+### Community 118 - "Community 118"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 121 - "Community 121"
+### Community 119 - "Community 119"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 122 - "Community 122"
+### Community 120 - "Community 120"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 123 - "Community 123"
-Cohesion: 0.18
-Nodes (1): Headers
-
-### Community 124 - "Community 124"
-Cohesion: 0.18
-Nodes (1): Client
-
-### Community 125 - "Community 125"
+### Community 121 - "Community 121"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 126 - "Community 126"
+### Community 122 - "Community 122"
 Cohesion: 0.24
 Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
 
-### Community 127 - "Community 127"
+### Community 123 - "Community 123"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 128 - "Community 128"
+### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 129 - "Community 129"
+### Community 125 - "Community 125"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 130 - "Community 130"
+### Community 126 - "Community 126"
 Cohesion: 0.21
 Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
 
-### Community 131 - "Community 131"
+### Community 127 - "Community 127"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 132 - "Community 132"
+### Community 128 - "Community 128"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 133 - "Community 133"
+### Community 129 - "Community 129"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 134 - "Community 134"
+### Community 130 - "Community 130"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 135 - "Community 135"
+### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 136 - "Community 136"
+### Community 132 - "Community 132"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 137 - "Community 137"
-Cohesion: 0.27
-Nodes (2): ConnectionPool, HTTPTransport
-
-### Community 138 - "Community 138"
+### Community 133 - "Community 133"
 Cohesion: 0.22
 Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
 
-### Community 139 - "Community 139"
+### Community 134 - "Community 134"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 140 - "Community 140"
+### Community 135 - "Community 135"
+Cohesion: 0.24
+Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.29
+Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
+
+### Community 137 - "Community 137"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 141 - "Community 141"
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 142 - "Community 142"
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 143 - "Community 143"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 144 - "Community 144"
+### Community 141 - "Community 141"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 145 - "Community 145"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 146 - "Community 146"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 147 - "Community 147"
+### Community 144 - "Community 144"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 148 - "Community 148"
+### Community 145 - "Community 145"
 Cohesion: 0.24
 Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
 
-### Community 149 - "Community 149"
+### Community 146 - "Community 146"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 150 - "Community 150"
+### Community 147 - "Community 147"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 151 - "Community 151"
+### Community 148 - "Community 148"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 152 - "Community 152"
+### Community 149 - "Community 149"
 Cohesion: 0.24
 Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
 
-### Community 153 - "Community 153"
+### Community 150 - "Community 150"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
 
-### Community 154 - "Community 154"
+### Community 151 - "Community 151"
 Cohesion: 0.20
-Nodes (7): candidateGraph, graph, html, tokens, html, state, tokens
+Nodes (7): character, dataset, groups, total, html, state, tokens
 
-### Community 155 - "Community 155"
+### Community 152 - "Community 152"
 Cohesion: 0.20
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 156 - "Community 156"
+### Community 153 - "Community 153"
 Cohesion: 0.20
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
 
-### Community 157 - "Community 157"
+### Community 154 - "Community 154"
 Cohesion: 0.22
 Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
-### Community 158 - "Community 158"
+### Community 155 - "Community 155"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 159 - "Community 159"
+### Community 156 - "Community 156"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 160 - "Community 160"
+### Community 157 - "Community 157"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 161 - "Community 161"
+### Community 158 - "Community 158"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 162 - "Community 162"
+### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (4): cleanupDirs, result, root, text
 
-### Community 163 - "Community 163"
-Cohesion: 0.25
-Nodes (9): antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), uninstallAll(), uninstallClaudeHook(), uninstallGeminiMcp() (+1 more)
-
-### Community 164 - "Community 164"
-Cohesion: 0.39
-Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
-
-### Community 165 - "Community 165"
-Cohesion: 0.39
-Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
-
-### Community 166 - "Community 166"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 167 - "Community 167"
-Cohesion: 0.42
-Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
-
-### Community 168 - "Community 168"
-Cohesion: 0.25
-Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
-
-### Community 169 - "Community 169"
-Cohesion: 0.25
-Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
-
-### Community 170 - "Community 170"
-Cohesion: 0.22
-Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
-
-### Community 171 - "Community 171"
+### Community 160 - "Community 160"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 172 - "Community 172"
-Cohesion: 0.32
-Nodes (4): DigestAuth, HTTP Digest Authentication.     Requires a full request/response cycle: sends th, Extract digest parameters from the WWW-Authenticate header., Compute the Authorization header value for a digest challenge.
-
-### Community 173 - "Community 173"
+### Community 161 - "Community 161"
 Cohesion: 0.25
-Nodes (8): CloseError, NetworkError, A network error occurred., Failed to receive data from the network., Failed to send data through the network., Failed to close a connection., ReadError, WriteError
+Nodes (9): antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), uninstallAll(), uninstallClaudeHook(), uninstallGeminiMcp() (+1 more)
 
-### Community 174 - "Community 174"
+### Community 162 - "Community 162"
+Cohesion: 0.39
+Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
+
+### Community 163 - "Community 163"
+Cohesion: 0.39
+Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
+
+### Community 164 - "Community 164"
+Cohesion: 0.31
+Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
+
+### Community 165 - "Community 165"
+Cohesion: 0.42
+Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
+
+### Community 166 - "Community 166"
+Cohesion: 0.25
+Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
+
+### Community 167 - "Community 167"
+Cohesion: 0.25
+Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
+
+### Community 168 - "Community 168"
+Cohesion: 0.22
+Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
+
+### Community 169 - "Community 169"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 175 - "Community 175"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
 
-### Community 176 - "Community 176"
+### Community 171 - "Community 171"
 Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
-### Community 177 - "Community 177"
+### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 178 - "Community 178"
+### Community 173 - "Community 173"
 Cohesion: 0.32
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 179 - "Community 179"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
-### Community 180 - "Community 180"
+### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 181 - "Community 181"
+### Community 176 - "Community 176"
 Cohesion: 0.25
 Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
-### Community 182 - "Community 182"
+### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
-### Community 183 - "Community 183"
+### Community 178 - "Community 178"
+Cohesion: 0.25
+Nodes (7): dataset, dirty, facets, keys, slices, state, status
+
+### Community 179 - "Community 179"
+Cohesion: 0.25
+Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+
+### Community 180 - "Community 180"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 184 - "Community 184"
+### Community 181 - "Community 181"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 185 - "Community 185"
-Cohesion: 0.29
-Nodes (6): DecodingError, HTTPError, An error occurred while issuing a request., Decoding of the response failed., Base class for all httpx exceptions., RequestError
-
-### Community 186 - "Community 186"
+### Community 182 - "Community 182"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 187 - "Community 187"
+### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 188 - "Community 188"
+### Community 184 - "Community 184"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 189 - "Community 189"
+### Community 185 - "Community 185"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 190 - "Community 190"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 191 - "Community 191"
+### Community 187 - "Community 187"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 192 - "Community 192"
+### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 193 - "Community 193"
+### Community 189 - "Community 189"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 194 - "Community 194"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 195 - "Community 195"
+### Community 191 - "Community 191"
+Cohesion: 0.29
+Nodes (6): query, restored, state, state0, state1, state2
+
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 196 - "Community 196"
+### Community 193 - "Community 193"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 197 - "Community 197"
+### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (1): recommendation
 
-### Community 198 - "Community 198"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (3): analysis, evaluation, text
 
-### Community 199 - "Community 199"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
-### Community 200 - "Community 200"
+### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (1): CONFIDENCE_VALUES
 
-### Community 201 - "Community 201"
+### Community 198 - "Community 198"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 202 - "Community 202"
+### Community 199 - "Community 199"
 Cohesion: 0.33
 Nodes (5): commands, dir, matchers, settings, tempDirs
 
-### Community 203 - "Community 203"
+### Community 200 - "Community 200"
 Cohesion: 0.33
 Nodes (5): dir, original, rule, rulePath, tempDirs
 
-### Community 204 - "Community 204"
+### Community 201 - "Community 201"
 Cohesion: 0.33
 Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
-### Community 205 - "Community 205"
+### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (4): dir, logs, preview, tempDirs
 
-### Community 206 - "Community 206"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
-### Community 207 - "Community 207"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
-### Community 208 - "Community 208"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (4): contents, dir, lockPath, tempDirs
 
-### Community 209 - "Community 209"
+### Community 206 - "Community 206"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 210 - "Community 210"
+### Community 207 - "Community 207"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 211 - "Community 211"
+### Community 208 - "Community 208"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 212 - "Community 212"
+### Community 209 - "Community 209"
 Cohesion: 0.40
 Nodes (4): chunks, client, files, root
 
-### Community 213 - "Community 213"
+### Community 210 - "Community 210"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 214 - "Community 214"
+### Community 211 - "Community 211"
 Cohesion: 0.40
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 215 - "Community 215"
+### Community 212 - "Community 212"
+Cohesion: 0.40
+Nodes (4): candidateGraph, graph, html, tokens
+
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 216 - "Community 216"
+### Community 214 - "Community 214"
 Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 217 - "Community 217"
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 218 - "Community 218"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 219 - "Community 219"
+### Community 217 - "Community 217"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 220 - "Community 220"
+### Community 218 - "Community 218"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
+
+### Community 219 - "Community 219"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 220 - "Community 220"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 221 - "Community 221"
 Cohesion: 1.00
@@ -940,76 +940,58 @@ Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 223 - "Community 223"
 Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Nodes (1): UnpdfTextResult
 
 ### Community 224 - "Community 224"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 225 - "Community 225"
-Cohesion: 1.00
-Nodes (1): UnpdfTextResult
-
-### Community 226 - "Community 226"
-Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 227 - "Community 227"
+### Community 225 - "Community 225"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1672 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1667 more)
+- **1721 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1716 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 51`** (2 nodes): `AsyncClient`, `Client`
+- **Thin community `Community 82`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 158`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 107`** (1 nodes): `AsyncClient`
+- **Thin community `Community 160`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (1 nodes): `Headers`
+- **Thin community `Community 181`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (1 nodes): `Client`
+- **Thin community `Community 194`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (2 nodes): `ConnectionPool`, `HTTPTransport`
+- **Thin community `Community 197`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 216`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 218`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 219`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `recommendation`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `paths`, `root`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 220`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 221`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 222`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 223`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 224`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (1 nodes): `UnpdfTextResult`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `tempProfileProject()`, `tempProject()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 225`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 22` to `Community 57`, `Community 123`, `Community 38`, `Community 51`, `Community 25`?**
+- **Why does `Cookies` connect `Community 4` to `Community 81`, `Community 33`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 45` to `Community 57`, `Community 124`, `Community 107`, `Community 22`?**
+- **Why does `Cookies` connect `Community 0` to `Community 81`, `Community 33`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `InvalidURL` connect `Community 45` to `Community 25`, `Community 124`, `Community 107`?**
+- **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/src/workspace/facet-panel.ts
+++ b/src/workspace/facet-panel.ts
@@ -1,0 +1,187 @@
+/**
+ * Track G G6-2 (S1.4) — FACETS panel discovery.
+ *
+ * Profile-neutral. The default behaviour is to scan the dataset for
+ * fields that look like enumerated filters (low-cardinality string
+ * fields). The caller MAY override the list via `declaredFacets` —
+ * typically populated from `outputs.workspace.facets` in a profile
+ * YAML.
+ *
+ * Hard constraint: no corpus-specific key is hardcoded here. The
+ * DENYLIST below blocks the few aclp-am-specific names that must never
+ * leak into Graphify core, but it is the user's responsibility to keep
+ * their own profile YAML clean.
+ */
+
+/** Free-form record. We only inspect string-valued top-level fields. */
+export interface WorkspaceFacetRecord {
+  id?: string;
+  [extra: string]: unknown;
+}
+
+export interface WorkspaceFacetValue {
+  /** Slice value (`"all"` is always first). */
+  value: string;
+  /** Number of records matching `<facet.key> = value`. */
+  count: number;
+}
+
+export interface WorkspaceFacet {
+  /** Facet key (the same name we expect in `WorkspaceViewerState.facetState`). */
+  key: string;
+  /** Sorted slice values (descending count, with `"all"` first). */
+  values: WorkspaceFacetValue[];
+}
+
+export interface DiscoverFacetsOptions {
+  /**
+   * Explicit profile-declared facet keys. When provided we limit the
+   * discovery to those keys (preserving the order). Missing fields are
+   * silently dropped — no error.
+   */
+  declaredFacets?: readonly string[];
+  /**
+   * Upper bound on the cardinality of an auto-discovered facet. Defaults
+   * to 12. Above this threshold a field is rejected (it is probably a
+   * free-text column rather than a filterable enum).
+   */
+  maxCardinality?: number;
+  /**
+   * Lower bound on the number of records carrying a value for an
+   * auto-discovered facet. Defaults to 1.
+   */
+  minCoverage?: number;
+}
+
+const DEFAULT_MAX_CARDINALITY = 12;
+const DEFAULT_MIN_COVERAGE = 1;
+
+/**
+ * Fields we never propose. `id`, `label`, free-form prose, and a handful
+ * of aclp-am-specific identifiers that must never leak from a profile
+ * into Graphify core.
+ */
+const DENYLIST = new Set([
+  "id",
+  "label",
+  "title",
+  "name",
+  "description",
+  "summary",
+  "summary_excerpt",
+  "body",
+  "rationale",
+  "node_id",
+  "node_type",
+  "type",
+  "kind",
+  "file_type",
+  "aliases",
+  "source_file",
+  "source_location",
+  "source_url",
+  "captured_at",
+  "author",
+  "contributor",
+  "community",
+  "community_name",
+  "weight",
+  // Aclp-am-specific facets — explicitly blocked.
+  "framework",
+  "hasMedia",
+  "has_media",
+  "hasDocuments",
+  "has_documents",
+  "reviewStatus",
+  "assertionBasis",
+]);
+
+function isFacetableValue(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0 && value.length <= 64;
+}
+
+function collectFieldNames(dataset: readonly WorkspaceFacetRecord[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const record of dataset) {
+    if (!record || typeof record !== "object") continue;
+    for (const key of Object.keys(record)) {
+      if (DENYLIST.has(key)) continue;
+      if (!seen.has(key)) {
+        seen.add(key);
+        ordered.push(key);
+      }
+    }
+  }
+  return ordered;
+}
+
+function buildFacetValues(
+  dataset: readonly WorkspaceFacetRecord[],
+  key: string,
+): WorkspaceFacetValue[] {
+  const counts = new Map<string, number>();
+  let total = 0;
+  for (const record of dataset) {
+    if (!record || typeof record !== "object") continue;
+    const raw = (record as Record<string, unknown>)[key];
+    if (!isFacetableValue(raw)) continue;
+    const value = raw.trim();
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+    total += 1;
+  }
+  const values: WorkspaceFacetValue[] = [{ value: "all", count: total }];
+  const sliceList = [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+  for (const slice of sliceList) values.push(slice);
+  return values;
+}
+
+/**
+ * Discover the facets for the given dataset. The result is sorted in a
+ * stable, profile-neutral order (alphabetical by key) so that two runs
+ * over the same dataset produce identical HTML.
+ */
+export function discoverWorkspaceFacets(
+  dataset: readonly WorkspaceFacetRecord[],
+  options: DiscoverFacetsOptions = {},
+): WorkspaceFacet[] {
+  const maxCardinality = options.maxCardinality ?? DEFAULT_MAX_CARDINALITY;
+  const minCoverage = options.minCoverage ?? DEFAULT_MIN_COVERAGE;
+
+  const declared = options.declaredFacets?.filter((key) => !DENYLIST.has(key));
+  const fields = declared && declared.length > 0 ? [...declared] : collectFieldNames(dataset);
+
+  const out: WorkspaceFacet[] = [];
+  for (const key of fields) {
+    const values = buildFacetValues(dataset, key);
+    const total = values[0]?.count ?? 0;
+    if (total < minCoverage) continue;
+    const sliceCount = values.length - 1; // ignore the "all" entry
+    if (sliceCount < 1) continue;
+    if (!declared && sliceCount > maxCardinality) continue;
+    out.push({ key, values });
+  }
+
+  // Stable order: declared list preserves caller order; auto-discovery
+  // sorts alphabetically.
+  if (!declared) out.sort((a, b) => a.key.localeCompare(b.key));
+  return out;
+}
+
+/**
+ * Tiny predicate helper exposed for tests. Returns true when the given
+ * record satisfies every facet slice currently set in `facetState`
+ * (i.e. ignores the "all" sentinel).
+ */
+export function recordMatchesFacets(
+  record: WorkspaceFacetRecord,
+  facetState: Record<string, string>,
+): boolean {
+  for (const [key, value] of Object.entries(facetState)) {
+    if (!value || value === "all") continue;
+    if ((record as Record<string, unknown>)[key] !== value) return false;
+  }
+  return true;
+}

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -35,6 +35,9 @@ export type {
 } from "./shell.js";
 export { renderWorkspaceShell } from "./shell.js";
 
+export type { RenderRailOptions, WorkspaceRailLayout } from "./rail.js";
+export { renderWorkspaceRail, workspaceRailStyles } from "./rail.js";
+
 export type {
   WorkspaceSelectionState,
   WorkspaceGraphPanelState,
@@ -63,3 +66,29 @@ export { computeFocusSubgraph } from "./graph-selection.js";
 
 export type { RenderGraphPanelOptions } from "./graph-panel.js";
 export { renderGraphPanel } from "./graph-panel.js";
+
+export type {
+  WorkspaceSearchRecord,
+  WorkspaceSearchIndex,
+} from "./search-index.js";
+export {
+  buildWorkspaceSearchIndex,
+  searchWorkspaceIndex,
+  searchWorkspace,
+} from "./search-index.js";
+
+export type {
+  WorkspaceFacet,
+  WorkspaceFacetRecord,
+  WorkspaceFacetValue,
+  DiscoverFacetsOptions,
+} from "./facet-panel.js";
+export { discoverWorkspaceFacets, recordMatchesFacets } from "./facet-panel.js";
+
+export type {
+  WorkspaceResultRecord,
+  WorkspaceResultEntry,
+  WorkspaceResultGroup,
+  GroupRecordsOptions,
+} from "./result-groups.js";
+export { groupRecordsByType, countMatchingRecords } from "./result-groups.js";

--- a/src/workspace/rail.ts
+++ b/src/workspace/rail.ts
@@ -1,0 +1,449 @@
+/**
+ * Track G G6-2 — left rail rendering (search / types / selected / facets /
+ * results). Pure-string HTML helper used by `renderWorkspaceShell`. The
+ * rendered DOM carries `data-action` / `data-rail-section` attributes so
+ * a client-side controller can dispatch the matching reducer action
+ * (SET_ACTIVE_TYPE, SET_FACET, PIN_ENTITY, …) without Graphify core
+ * shipping a JS bundle.
+ *
+ * Hard constraint: this module is corpus-neutral. The only strings it
+ * emits are the section headings (`SEARCH`, `TYPES`, `SELECTED`,
+ * `FACETS`, `RESULTS`) and the localized "shown / total" / "active /
+ * slices" / "tracked" / "entities in selection" labels. Everything else
+ * comes from the dataset.
+ */
+
+import type { GraphLike, GraphNodeLike } from "./graph-selection.js";
+import type { WorkspaceFacet } from "./facet-panel.js";
+import { discoverWorkspaceFacets } from "./facet-panel.js";
+import type { WorkspaceResultGroup, WorkspaceResultRecord } from "./result-groups.js";
+import { groupRecordsByType } from "./result-groups.js";
+import type { WorkspaceViewerState } from "./viewer-state.js";
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(HTML_ESCAPE_RE, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+function nodeType(node: GraphNodeLike): string {
+  return (
+    (typeof node.node_type === "string" && node.node_type.trim()) ||
+    (typeof node.type === "string" && node.type.trim()) ||
+    (typeof node.kind === "string" && node.kind.trim()) ||
+    (typeof node.file_type === "string" && node.file_type.trim()) ||
+    "node"
+  );
+}
+
+/**
+ * Layout slot mirroring `outputs.workspace` in `ontology-profile.yaml`.
+ * All fields are optional: when missing, the rail falls back to
+ * auto-discovery from the dataset.
+ */
+export interface WorkspaceRailLayout {
+  /** Explicit list of facet keys to show. */
+  facets?: readonly string[];
+  /** Explicit list of node_type ids to show in the RESULTS section. */
+  result_groups?: readonly string[];
+}
+
+export interface RenderRailOptions {
+  state: WorkspaceViewerState;
+  graph: GraphLike | undefined;
+  /** Profile-driven overrides (optional). */
+  layout?: WorkspaceRailLayout;
+}
+
+interface TypeRow {
+  typeId: string;
+  count: number;
+}
+
+function recordsFromGraph(graph: GraphLike | undefined): WorkspaceResultRecord[] {
+  const out: WorkspaceResultRecord[] = [];
+  if (!graph?.nodes) return out;
+  for (const node of graph.nodes) {
+    if (!node || typeof node.id !== "string") continue;
+    const record: WorkspaceResultRecord = {
+      id: node.id,
+      label: typeof node.label === "string" ? node.label : undefined,
+      node_type: nodeType(node),
+    };
+    if (Array.isArray(node.aliases)) {
+      record.aliases = node.aliases.filter((alias): alias is string => typeof alias === "string");
+    }
+    if (typeof node.source_file === "string") record.source_file = node.source_file;
+    if (typeof node.summary === "string") record.summary_excerpt = node.summary;
+    else if (typeof node.description === "string") record.summary_excerpt = node.description;
+    // Copy filterable enum-shaped fields verbatim so facetState lookups work.
+    for (const key of ["status", "operation", "score_bucket", "source_kind", "confidence"]) {
+      const raw = (node as Record<string, unknown>)[key];
+      if (typeof raw === "string" && raw.trim()) record[key] = raw;
+    }
+    out.push(record);
+  }
+  return out;
+}
+
+function buildTypeRows(records: readonly WorkspaceResultRecord[]): TypeRow[] {
+  const counts = new Map<string, number>();
+  for (const record of records) {
+    const typeId = typeof record.node_type === "string" && record.node_type ? record.node_type : "node";
+    counts.set(typeId, (counts.get(typeId) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([typeId, count]) => ({ typeId, count }))
+    .sort((a, b) => b.count - a.count || a.typeId.localeCompare(b.typeId));
+}
+
+// ---------------------------------------------------------------------------
+// Section rendering
+// ---------------------------------------------------------------------------
+
+function renderSearch(state: WorkspaceViewerState): string {
+  const query = state.facetState["q"] ?? "";
+  return [
+    '<section class="ws-rail-section" data-rail-section="search">',
+    '<h3 class="ws-rail-heading">Search</h3>',
+    '<label class="ws-rail-search" aria-label="Cross-entity search">',
+    `<input type="search" data-action="set-search-query" placeholder="Search labels, ids, aliases, paths" value="${escapeHtml(query)}" />`,
+    "</label>",
+    "</section>",
+  ].join("");
+}
+
+function renderTypes(
+  state: WorkspaceViewerState,
+  records: readonly WorkspaceResultRecord[],
+  filteredRecords: readonly WorkspaceResultRecord[],
+): string {
+  const rows = buildTypeRows(records);
+  const total = records.length;
+  const shown = filteredRecords.length;
+  const active = state.activeType || "all";
+
+  const rowsHtml: string[] = [];
+  rowsHtml.push(
+    [
+      '<li class="ws-rail-type" data-type-id="all"',
+      ` aria-pressed="${active === "all" ? "true" : "false"}">`,
+      '<button type="button" data-action="set-active-type" data-type-id="all">',
+      '<span class="ws-rail-type-label">All types</span>',
+      `<span class="ws-rail-type-count">${total}</span>`,
+      "</button>",
+      "</li>",
+    ].join(""),
+  );
+  for (const row of rows) {
+    rowsHtml.push(
+      [
+        `<li class="ws-rail-type" data-type-id="${escapeHtml(row.typeId)}"`,
+        ` aria-pressed="${active === row.typeId ? "true" : "false"}">`,
+        `<button type="button" data-action="set-active-type" data-type-id="${escapeHtml(row.typeId)}">`,
+        `<span class="ws-rail-type-label">${escapeHtml(row.typeId)}</span>`,
+        `<span class="ws-rail-type-count">${row.count}</span>`,
+        "</button>",
+        "</li>",
+      ].join(""),
+    );
+  }
+
+  return [
+    '<section class="ws-rail-section" data-rail-section="types">',
+    '<h3 class="ws-rail-heading">Types <span class="ws-rail-counter"><span data-rail-counter="types-shown">' +
+      shown +
+      '</span> shown / <span data-rail-counter="types-total">' +
+      total +
+      "</span> total</span></h3>",
+    `<ul class="ws-rail-type-list">${rowsHtml.join("")}</ul>`,
+    "</section>",
+  ].join("");
+}
+
+function renderSelected(state: WorkspaceViewerState, graph: GraphLike | undefined): string {
+  const entityIds = state.selectedEntities ?? [];
+  const typeIds = state.selectedTypes ?? [];
+  const tracked = entityIds.length + typeIds.length;
+  const labelLookup = new Map<string, string>();
+  if (graph?.nodes) {
+    for (const node of graph.nodes) {
+      if (typeof node?.id === "string") {
+        labelLookup.set(node.id, typeof node.label === "string" && node.label.trim() ? node.label : node.id);
+      }
+    }
+  }
+
+  const chips: string[] = [];
+  for (const id of entityIds) {
+    const label = labelLookup.get(id) ?? id;
+    chips.push(
+      [
+        '<li class="ws-rail-chip" data-chip-kind="entity" data-chip-id="' + escapeHtml(id) + '">',
+        '<button type="button" class="ws-rail-chip-focus" data-action="focus-entity" data-entity-id="' +
+          escapeHtml(id) +
+          '">',
+        escapeHtml(label),
+        "</button>",
+        '<button type="button" class="ws-rail-chip-remove" aria-label="Remove from selection" data-action="unpin-entity" data-entity-id="' +
+          escapeHtml(id) +
+          '">×</button>',
+        "</li>",
+      ].join(""),
+    );
+  }
+  for (const id of typeIds) {
+    chips.push(
+      [
+        '<li class="ws-rail-chip" data-chip-kind="type" data-chip-id="' + escapeHtml(id) + '">',
+        '<button type="button" class="ws-rail-chip-focus" data-action="set-active-type" data-type-id="' +
+          escapeHtml(id) +
+          '">',
+        escapeHtml(id),
+        "</button>",
+        '<button type="button" class="ws-rail-chip-remove" aria-label="Remove from selection" data-action="unpin-type" data-type-id="' +
+          escapeHtml(id) +
+          '">×</button>',
+        "</li>",
+      ].join(""),
+    );
+  }
+  const body =
+    chips.length === 0
+      ? '<p class="ws-empty ws-rail-empty">No items pinned yet.</p>'
+      : `<ul class="ws-rail-chip-list">${chips.join("")}</ul>`;
+
+  return [
+    '<section class="ws-rail-section" data-rail-section="selected">',
+    '<h3 class="ws-rail-heading">Selected <span class="ws-rail-counter"><span data-rail-counter="tracked">' +
+      tracked +
+      "</span> tracked</span></h3>",
+    body,
+    "</section>",
+  ].join("");
+}
+
+function renderFacets(
+  state: WorkspaceViewerState,
+  records: readonly WorkspaceResultRecord[],
+  layout: WorkspaceRailLayout | undefined,
+): string {
+  const declared = layout?.facets;
+  const facets: WorkspaceFacet[] = discoverWorkspaceFacets(records, {
+    declaredFacets: declared,
+  });
+
+  let active = 0;
+  for (const [, value] of Object.entries(state.facetState)) {
+    if (value && value !== "all") active += 1;
+  }
+
+  if (facets.length === 0) {
+    return [
+      '<section class="ws-rail-section" data-rail-section="facets">',
+      '<h3 class="ws-rail-heading">Facets <span class="ws-rail-counter"><span data-rail-counter="facets-active">' +
+        active +
+        '</span> active / <span data-rail-counter="facets-slices">0</span> slices</span></h3>',
+      '<p class="ws-empty ws-rail-empty">No facetable fields in this dataset.</p>',
+      "</section>",
+    ].join("");
+  }
+
+  const slicesTotal = facets.reduce((sum, facet) => sum + Math.max(0, facet.values.length - 1), 0);
+  const facetHtml: string[] = [];
+  for (const facet of facets) {
+    const current = state.facetState[facet.key] ?? "all";
+    const options = facet.values
+      .map(
+        (slice) =>
+          `<option value="${escapeHtml(slice.value)}"${slice.value === current ? " selected" : ""}>${escapeHtml(slice.value)} (${slice.count})</option>`,
+      )
+      .join("");
+    facetHtml.push(
+      [
+        '<details class="ws-rail-facet" data-facet-key="' + escapeHtml(facet.key) + '"' + (current !== "all" ? " open" : "") + ">",
+        '<summary class="ws-rail-facet-summary">',
+        '<span class="ws-rail-facet-name">' + escapeHtml(facet.key) + "</span>",
+        '<span class="ws-rail-facet-current">' + escapeHtml(current) + "</span>",
+        "</summary>",
+        '<label class="ws-rail-facet-control">',
+        `<select data-action="set-facet" data-facet-key="${escapeHtml(facet.key)}">${options}</select>`,
+        "</label>",
+        "</details>",
+      ].join(""),
+    );
+  }
+
+  return [
+    '<section class="ws-rail-section" data-rail-section="facets">',
+    '<h3 class="ws-rail-heading">Facets <span class="ws-rail-counter"><span data-rail-counter="facets-active">' +
+      active +
+      '</span> active / <span data-rail-counter="facets-slices">' +
+      slicesTotal +
+      "</span> slices</span></h3>",
+    `<div class="ws-rail-facet-list">${facetHtml.join("")}</div>`,
+    "</section>",
+  ].join("");
+}
+
+function renderResults(
+  filtered: readonly WorkspaceResultRecord[],
+  groups: readonly WorkspaceResultGroup[],
+): string {
+  const total = filtered.length;
+  if (groups.length === 0) {
+    return [
+      '<section class="ws-rail-section" data-rail-section="results">',
+      '<h3 class="ws-rail-heading">Results <span class="ws-rail-counter"><span data-rail-counter="results-total">' +
+        total +
+        "</span> entities in selection</span></h3>",
+      '<p class="ws-empty ws-rail-empty">No matching entities.</p>',
+      "</section>",
+    ].join("");
+  }
+
+  const groupHtml: string[] = [];
+  for (const group of groups) {
+    const entries = group.entries
+      .map(
+        (entry) =>
+          [
+            '<li class="ws-rail-result-entry" data-entity-id="' + escapeHtml(entry.id) + '">',
+            '<button type="button" data-action="set-display-ref" data-display-ref="entity:' +
+              escapeHtml(entry.id) +
+              '">',
+            escapeHtml(entry.label),
+            "</button>",
+            "</li>",
+          ].join(""),
+      )
+      .join("");
+    const hidden = group.hiddenCount > 0
+      ? `<li class="ws-rail-result-hidden">+ ${group.hiddenCount} more</li>`
+      : "";
+    groupHtml.push(
+      [
+        '<details class="ws-rail-result-group" data-type-id="' + escapeHtml(group.typeId) + '"' + (group.open ? " open" : "") + ">",
+        '<summary class="ws-rail-result-group-summary">',
+        '<span class="ws-rail-result-group-name">' + escapeHtml(group.typeId) + "</span>",
+        `<span class="ws-rail-result-group-count">${group.count}</span>`,
+        "</summary>",
+        `<ul class="ws-rail-result-entries">${entries}${hidden}</ul>`,
+        "</details>",
+      ].join(""),
+    );
+  }
+
+  return [
+    '<section class="ws-rail-section" data-rail-section="results">',
+    '<h3 class="ws-rail-heading">Results <span class="ws-rail-counter"><span data-rail-counter="results-total">' +
+      total +
+      "</span> entities in selection</span></h3>",
+    `<div class="ws-rail-result-list">${groupHtml.join("")}</div>`,
+    "</section>",
+  ].join("");
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the full left rail. Returns "" when no graph is available — the
+ * caller (shell.ts) falls back to its legacy "queue stub" placeholder
+ * so existing tests / callers without a dataset stay intact.
+ */
+export function renderWorkspaceRail(opts: RenderRailOptions): string {
+  const records = recordsFromGraph(opts.graph);
+  if (records.length === 0) return "";
+
+  const searchQuery = opts.state.facetState["q"] ?? "";
+  const activeType = opts.state.activeType ?? "all";
+  // Discovery layer: types use raw records; facet/result layers stack
+  // the search query + facet state + active type.
+  const filteredRecords: WorkspaceResultRecord[] = [];
+  for (const record of records) {
+    if (activeType !== "all" && record.node_type !== activeType) continue;
+    let facetOk = true;
+    for (const [key, value] of Object.entries(opts.state.facetState)) {
+      if (!value || value === "all" || key === "q") continue;
+      if ((record as Record<string, unknown>)[key] !== value) {
+        facetOk = false;
+        break;
+      }
+    }
+    if (!facetOk) continue;
+    if (searchQuery.trim()) {
+      const q = searchQuery.trim().toLowerCase();
+      const haystack = [
+        record.id,
+        typeof record.label === "string" ? record.label : "",
+        ...(Array.isArray(record.aliases) ? record.aliases : []),
+        typeof record.source_file === "string" ? record.source_file : "",
+        typeof record.summary_excerpt === "string" ? record.summary_excerpt : "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) continue;
+    }
+    filteredRecords.push(record);
+  }
+
+  const groups = groupRecordsByType(filteredRecords, {
+    activeType: "all", // already applied above
+    facetState: {},
+    searchQuery: "",
+    resultGroups: opts.layout?.result_groups,
+  });
+
+  return [
+    '<div class="ws-rail">',
+    renderSearch(opts.state),
+    renderTypes(opts.state, records, filteredRecords),
+    renderSelected(opts.state, opts.graph),
+    renderFacets(opts.state, records, opts.layout),
+    renderResults(filteredRecords, groups),
+    "</div>",
+  ].join("");
+}
+
+/** Inline CSS for the rail sections. Kept compact, no external file. */
+export function workspaceRailStyles(): string {
+  return [
+    ".ws-rail { display: flex; flex-direction: column; gap: var(--ws-space-3); }",
+    ".ws-rail-section { display: flex; flex-direction: column; gap: var(--ws-space-2); }",
+    ".ws-rail-heading { margin: 0; font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); font-weight: 700; display: flex; align-items: baseline; gap: var(--ws-space-2); justify-content: space-between; }",
+    ".ws-rail-counter { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: none; letter-spacing: 0; font-weight: 400; }",
+    ".ws-rail-search input { width: 100%; padding: var(--ws-space-1) var(--ws-space-2); border: 1px solid var(--ws-border); border-radius: var(--ws-radius-sm); background: var(--ws-surface-2); color: var(--ws-text); font-family: inherit; font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-type-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }",
+    ".ws-rail-type button { display: flex; width: 100%; align-items: center; justify-content: space-between; gap: var(--ws-space-2); background: transparent; border: 1px solid transparent; border-radius: var(--ws-radius-sm); color: var(--ws-text); padding: 2px var(--ws-space-2); font-family: inherit; font-size: var(--ws-font-size-sm); cursor: pointer; }",
+    ".ws-rail-type[aria-pressed=\"true\"] button { background: var(--ws-surface-2); border-color: var(--ws-border); color: var(--ws-accent); font-weight: 600; }",
+    ".ws-rail-type-count { color: var(--ws-text-muted); font-variant-numeric: tabular-nums; }",
+    ".ws-rail-chip-list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--ws-space-1); }",
+    ".ws-rail-chip { display: inline-flex; align-items: center; gap: 2px; padding: 0 0 0 var(--ws-space-1); border: 1px solid var(--ws-border); border-radius: var(--ws-radius-pill, 9999px); background: var(--ws-surface-2); font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-chip-focus, .ws-rail-chip-remove { background: transparent; border: 0; color: inherit; cursor: pointer; padding: 2px var(--ws-space-1); font: inherit; }",
+    ".ws-rail-chip-remove { color: var(--ws-text-muted); font-weight: 700; }",
+    ".ws-rail-facet-list { display: flex; flex-direction: column; gap: var(--ws-space-1); }",
+    ".ws-rail-facet { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-sm); padding: var(--ws-space-1) var(--ws-space-2); background: var(--ws-surface-2); }",
+    ".ws-rail-facet-summary { cursor: pointer; display: flex; justify-content: space-between; gap: var(--ws-space-2); font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-facet-name { color: var(--ws-text); }",
+    ".ws-rail-facet-current { color: var(--ws-text-muted); font-variant-numeric: tabular-nums; }",
+    ".ws-rail-facet-control select { width: 100%; margin-top: var(--ws-space-1); padding: 2px var(--ws-space-1); background: var(--ws-surface); border: 1px solid var(--ws-border); color: var(--ws-text); font-family: inherit; font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-result-list { display: flex; flex-direction: column; gap: var(--ws-space-1); }",
+    ".ws-rail-result-group { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-sm); padding: var(--ws-space-1) var(--ws-space-2); background: var(--ws-surface-2); }",
+    ".ws-rail-result-group-summary { cursor: pointer; display: flex; justify-content: space-between; gap: var(--ws-space-2); font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-result-group-name { color: var(--ws-text); font-weight: 600; }",
+    ".ws-rail-result-group-count { color: var(--ws-text-muted); font-variant-numeric: tabular-nums; }",
+    ".ws-rail-result-entries { list-style: none; margin: var(--ws-space-1) 0 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }",
+    ".ws-rail-result-entry button { background: transparent; border: 0; color: var(--ws-accent); cursor: pointer; padding: 0; text-align: left; font: inherit; }",
+    ".ws-rail-result-hidden { color: var(--ws-text-muted); font-size: var(--ws-font-size-sm); font-style: italic; }",
+    ".ws-rail-empty { margin: 0; }",
+  ].join("\n");
+}

--- a/src/workspace/result-groups.ts
+++ b/src/workspace/result-groups.ts
@@ -1,0 +1,174 @@
+/**
+ * Track G G6-2 (S1.5) — RESULTS grouped by taxonomy.
+ *
+ * Generic grouping: takes a dataset of records carrying a node_type
+ * field (or a fallback type/kind), applies the active type filter +
+ * facet state + free-text search, and returns one collapsed group per
+ * remaining node_type id.
+ *
+ * Profile override: callers can declare an ordered list via
+ * `outputs.workspace.result_groups`. When present, we honour the order
+ * and drop any type that is not declared.
+ */
+
+import { recordMatchesFacets, type WorkspaceFacetRecord } from "./facet-panel.js";
+
+export interface WorkspaceResultRecord extends WorkspaceFacetRecord {
+  /** Stable id. */
+  id: string;
+  /** Display label. */
+  label?: string;
+  /** Type id (`node_type` first, then `type`, then `kind`, then "node"). */
+  node_type?: string;
+  type?: string;
+  kind?: string;
+  /** Optional aliases (used by search). */
+  aliases?: string[];
+  /** Optional compact summary (used by search). */
+  summary_excerpt?: string;
+  /** Optional source path (used by search). */
+  source_file?: string;
+}
+
+export interface WorkspaceResultEntry {
+  id: string;
+  label: string;
+  typeId: string;
+}
+
+export interface WorkspaceResultGroup {
+  /** node_type id (e.g. "Character"). */
+  typeId: string;
+  /** Number of entries in the group. */
+  count: number;
+  /** Collapsed by default — UI may flip this to true on click. */
+  open: boolean;
+  /** Entries (capped by `maxEntries`, defaults to 200). */
+  entries: WorkspaceResultEntry[];
+  /** Hidden count when `entries.length` was truncated. */
+  hiddenCount: number;
+}
+
+export interface GroupRecordsOptions {
+  activeType: string;
+  facetState: Record<string, string>;
+  searchQuery: string;
+  /** Profile override (`outputs.workspace.result_groups`). Optional. */
+  resultGroups?: readonly string[];
+  /** Upper bound on the entries returned per group. Defaults to 200. */
+  maxEntries?: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 200;
+
+function resolveTypeId(record: WorkspaceResultRecord): string {
+  return (
+    (typeof record.node_type === "string" && record.node_type.trim()) ||
+    (typeof record.type === "string" && record.type.trim()) ||
+    (typeof record.kind === "string" && record.kind.trim()) ||
+    "node"
+  );
+}
+
+function recordSearchHaystack(record: WorkspaceResultRecord): string {
+  const parts: string[] = [];
+  if (record.id) parts.push(record.id);
+  if (typeof record.label === "string") parts.push(record.label);
+  if (Array.isArray(record.aliases)) {
+    for (const alias of record.aliases) {
+      if (typeof alias === "string") parts.push(alias);
+    }
+  }
+  if (typeof record.summary_excerpt === "string") parts.push(record.summary_excerpt);
+  if (typeof record.source_file === "string") parts.push(record.source_file);
+  return parts.join(" ").toLowerCase();
+}
+
+function matchesQuery(record: WorkspaceResultRecord, queryTokens: readonly string[]): boolean {
+  if (queryTokens.length === 0) return true;
+  const haystack = recordSearchHaystack(record);
+  for (const token of queryTokens) {
+    if (!haystack.includes(token)) return false;
+  }
+  return true;
+}
+
+function matchesActiveType(record: WorkspaceResultRecord, activeType: string): boolean {
+  if (!activeType || activeType === "all") return true;
+  return resolveTypeId(record) === activeType;
+}
+
+/**
+ * Group the dataset under the current filters. The result is a list of
+ * groups, collapsed by default. The empty-state (no matching records)
+ * returns an empty list — the caller renders the "N entities" heading
+ * and a hint.
+ */
+export function groupRecordsByType(
+  records: readonly WorkspaceResultRecord[],
+  options: GroupRecordsOptions,
+): WorkspaceResultGroup[] {
+  const queryTokens = options.searchQuery
+    .toLowerCase()
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+
+  const filtered: WorkspaceResultRecord[] = [];
+  for (const record of records) {
+    if (!record || typeof record.id !== "string") continue;
+    if (!matchesActiveType(record, options.activeType)) continue;
+    if (!recordMatchesFacets(record, options.facetState)) continue;
+    if (!matchesQuery(record, queryTokens)) continue;
+    filtered.push(record);
+  }
+
+  const buckets = new Map<string, WorkspaceResultGroup>();
+  for (const record of filtered) {
+    const typeId = resolveTypeId(record);
+    let group = buckets.get(typeId);
+    if (!group) {
+      group = { typeId, count: 0, open: false, entries: [], hiddenCount: 0 };
+      buckets.set(typeId, group);
+    }
+    group.count += 1;
+    if (group.entries.length < maxEntries) {
+      group.entries.push({
+        id: record.id,
+        label: typeof record.label === "string" && record.label.trim() ? record.label : record.id,
+        typeId,
+      });
+    } else {
+      group.hiddenCount += 1;
+    }
+  }
+
+  let ordered: WorkspaceResultGroup[];
+  if (options.resultGroups && options.resultGroups.length > 0) {
+    const list: WorkspaceResultGroup[] = [];
+    for (const typeId of options.resultGroups) {
+      const group = buckets.get(typeId);
+      if (group) list.push(group);
+    }
+    ordered = list;
+  } else {
+    ordered = [...buckets.values()].sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.typeId.localeCompare(b.typeId);
+    });
+  }
+
+  return ordered;
+}
+
+/**
+ * Total count of records matching the current filters. Useful for the
+ * "N entities in selection" header above the groups.
+ */
+export function countMatchingRecords(
+  records: readonly WorkspaceResultRecord[],
+  options: GroupRecordsOptions,
+): number {
+  return groupRecordsByType(records, options).reduce((sum, group) => sum + group.count, 0);
+}

--- a/src/workspace/search-index.ts
+++ b/src/workspace/search-index.ts
@@ -1,0 +1,191 @@
+/**
+ * Track G G6-2 (S1.1) — cross-entity search index.
+ *
+ * Profile-neutral token-gram inverted index. No external dependency, no
+ * embedding model, no Lucene/MiniSearch — we index node label / id /
+ * aliases / source_file / summary_excerpt and resolve queries by
+ * lowercase token matching with prefix tolerance (>= 3 characters).
+ *
+ * Hard constraint: no corpus-specific identifier is hardcoded here. The
+ * input records are duck-typed strings — any profile can pass whatever
+ * fields it surfaces in the dataset.
+ */
+
+/**
+ * Minimal record shape consumed by the search index. Any extra fields
+ * present on the input are ignored (and preserved verbatim in the
+ * returned hit, which is a structural alias of the input).
+ */
+export interface WorkspaceSearchRecord {
+  /** Stable id used as the deduplication key in hits. */
+  id: string;
+  /** Display label shown in the rail. */
+  label?: string;
+  /** Type id (profile-driven). */
+  node_type?: string;
+  /** Free-form aliases. */
+  aliases?: string[];
+  /** Source path — tokenised on slashes / dots / dashes / underscores. */
+  source_file?: string;
+  /** Compact summary used for prose search. */
+  summary_excerpt?: string;
+  /** Any extra property passed by the caller is preserved verbatim. */
+  [extra: string]: unknown;
+}
+
+/** Opaque index handle. Build once per dataset, reuse across queries. */
+export interface WorkspaceSearchIndex {
+  /** Token → set of record ids. */
+  readonly inverted: Map<string, Set<string>>;
+  /** id → record (for hit re-hydration). */
+  readonly byId: Map<string, WorkspaceSearchRecord>;
+  /** Sorted token list for prefix scan. */
+  readonly tokens: readonly string[];
+}
+
+const MIN_TOKEN_LENGTH = 1;
+const PREFIX_MIN_LENGTH = 3;
+const TOKEN_SPLIT_RE = /[^\p{L}\p{N}]+/u;
+
+function tokenise(value: string | undefined | null): string[] {
+  if (!value) return [];
+  const lower = value.toLowerCase();
+  const out: string[] = [];
+  for (const raw of lower.split(TOKEN_SPLIT_RE)) {
+    if (raw.length >= MIN_TOKEN_LENGTH) out.push(raw);
+  }
+  return out;
+}
+
+function collectRecordTokens(record: WorkspaceSearchRecord): string[] {
+  const fields: string[] = [];
+  if (typeof record.label === "string") fields.push(record.label);
+  if (typeof record.id === "string") fields.push(record.id);
+  if (typeof record.node_type === "string") fields.push(record.node_type);
+  if (Array.isArray(record.aliases)) {
+    for (const alias of record.aliases) {
+      if (typeof alias === "string") fields.push(alias);
+    }
+  }
+  if (typeof record.source_file === "string") fields.push(record.source_file);
+  if (typeof record.summary_excerpt === "string") fields.push(record.summary_excerpt);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const field of fields) {
+    for (const token of tokenise(field)) {
+      if (!seen.has(token)) {
+        seen.add(token);
+        out.push(token);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the inverted index. Cost: O(total tokens). Re-run only when the
+ * dataset changes — the result is intentionally small and JSON-friendly
+ * so callers can cache it across renders.
+ */
+export function buildWorkspaceSearchIndex(
+  records: readonly WorkspaceSearchRecord[],
+): WorkspaceSearchIndex {
+  const inverted = new Map<string, Set<string>>();
+  const byId = new Map<string, WorkspaceSearchRecord>();
+  for (const record of records) {
+    if (!record || typeof record.id !== "string" || !record.id) continue;
+    byId.set(record.id, record);
+    for (const token of collectRecordTokens(record)) {
+      let bucket = inverted.get(token);
+      if (!bucket) {
+        bucket = new Set<string>();
+        inverted.set(token, bucket);
+      }
+      bucket.add(record.id);
+    }
+  }
+  const tokens = Object.freeze([...inverted.keys()].sort());
+  return { inverted, byId, tokens };
+}
+
+interface RankedHit {
+  id: string;
+  record: WorkspaceSearchRecord;
+  score: number;
+}
+
+function resolveTokenMatches(index: WorkspaceSearchIndex, queryToken: string): Set<string> {
+  const out = new Set<string>();
+  const direct = index.inverted.get(queryToken);
+  if (direct) for (const id of direct) out.add(id);
+
+  // Prefix expansion. Only when the query token is at least
+  // PREFIX_MIN_LENGTH chars; cheaper than implementing a trie and good
+  // enough for the rail.
+  if (queryToken.length >= PREFIX_MIN_LENGTH) {
+    for (const token of index.tokens) {
+      if (token.length > queryToken.length && token.startsWith(queryToken)) {
+        const bucket = index.inverted.get(token);
+        if (bucket) for (const id of bucket) out.add(id);
+      } else if (token.includes(queryToken) && token !== queryToken) {
+        // Cheap substring fallback for things like "arsene-lupin" → query "lupin".
+        const bucket = index.inverted.get(token);
+        if (bucket) for (const id of bucket) out.add(id);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Search the index for the given query. Each query token contributes one
+ * point to a record's score; records matching more tokens rank higher.
+ * Empty/whitespace queries return an empty array — the rail shows the
+ * default result groups in that case.
+ */
+export function searchWorkspaceIndex(
+  index: WorkspaceSearchIndex,
+  query: string,
+  options: { limit?: number } = {},
+): WorkspaceSearchRecord[] {
+  if (typeof query !== "string") return [];
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const queryTokens = tokenise(trimmed);
+  if (queryTokens.length === 0) return [];
+
+  const scores = new Map<string, number>();
+  for (const token of queryTokens) {
+    const matches = resolveTokenMatches(index, token);
+    for (const id of matches) {
+      scores.set(id, (scores.get(id) ?? 0) + 1);
+    }
+  }
+
+  const ranked: RankedHit[] = [];
+  for (const [id, score] of scores) {
+    const record = index.byId.get(id);
+    if (record) ranked.push({ id, record, score });
+  }
+  ranked.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const la = (a.record.label ?? a.id).toLowerCase();
+    const lb = (b.record.label ?? b.id).toLowerCase();
+    return la.localeCompare(lb);
+  });
+
+  const limit = options.limit && options.limit > 0 ? options.limit : ranked.length;
+  return ranked.slice(0, limit).map((hit) => hit.record);
+}
+
+/**
+ * Convenience: build + search in one shot. Useful for tests and callers
+ * that do not want to manage the index lifetime themselves.
+ */
+export function searchWorkspace(
+  records: readonly WorkspaceSearchRecord[],
+  query: string,
+  options: { limit?: number } = {},
+): WorkspaceSearchRecord[] {
+  return searchWorkspaceIndex(buildWorkspaceSearchIndex(records), query, options);
+}

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -37,6 +37,7 @@ import { computeFocusSubgraph } from "./graph-selection.js";
 import type { WorkspaceViewerState } from "./viewer-state.js";
 import { createDefaultViewerState } from "./viewer-state.js";
 import { serialiseTokensToCss } from "./tokens-fallback.js";
+import { renderWorkspaceRail, workspaceRailStyles, type WorkspaceRailLayout } from "./rail.js";
 
 /**
  * Optional sidecar payload propagated from `.graphify/wiki/descriptions.json`
@@ -99,6 +100,12 @@ export interface RenderWorkspaceShellOptions {
   descriptionSidecar?: WorkspaceDescriptionSidecar;
   /** Optional profile-driven entity layout (falls back to a neutral default). */
   entityLayout?: WorkspaceEntityLayout;
+  /**
+   * Optional profile-driven rail layout (`outputs.workspace.facets` /
+   * `outputs.workspace.result_groups`). Both fields are optional — the
+   * rail auto-discovers what it can from the dataset.
+   */
+  railLayout?: WorkspaceRailLayout;
 }
 
 // ---------------------------------------------------------------------------
@@ -586,6 +593,7 @@ function shellStyles(): string {
     "  .workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; max-height: 0; padding: 0; }",
     "  .ws-counters { grid-template-columns: repeat(2, minmax(80px, 1fr)); }",
     "}",
+    workspaceRailStyles(),
   ].join("\n");
 }
 
@@ -614,11 +622,25 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
   const slotHidden = activeView === "workspace" || activeView === null;
   const slotActiveView = activeView ?? "workspace";
 
+  // G6-2: render the rich left rail (search / types / selected / facets /
+  // results) when a graph is available and the caller did not override
+  // `leftWorkbenchHtml`. Otherwise fall back to the legacy stubs so the
+  // pre-G6-2 tests (queueEmpty hint) still pass.
+  let railBody = "";
+  if (!opts.leftWorkbenchHtml && opts.graph) {
+    railBody = renderWorkspaceRail({
+      state: effectiveState,
+      graph: opts.graph,
+      layout: opts.railLayout,
+    });
+  }
   const queueBody =
     opts.leftWorkbenchHtml ??
-    (queueEmpty
-      ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
-      : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>');
+    (railBody !== ""
+      ? railBody
+      : queueEmpty
+        ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
+        : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>');
 
   const centralDisplayBody =
     opts.centralDisplayHtml ??

--- a/src/workspace/viewer-state.ts
+++ b/src/workspace/viewer-state.ts
@@ -293,6 +293,10 @@ export type WorkspaceAction =
   | { type: "SET_EVIDENCE_MODE"; mode: WorkspaceEvidencePanelState["mode"] }
   | { type: "SET_FACET"; key: string; value: string }
   | { type: "CLEAR_FACET"; key: string }
+  | { type: "PIN_ENTITY"; entityId: string }
+  | { type: "UNPIN_ENTITY"; entityId: string }
+  | { type: "PIN_TYPE"; typeId: string }
+  | { type: "UNPIN_TYPE"; typeId: string }
   | { type: "RESET" };
 
 export function workspaceReducer(
@@ -372,6 +376,30 @@ export function workspaceReducer(
       const next = { ...state.facetState };
       delete next[action.key];
       return { ...state, facetState: next };
+    }
+    case "PIN_ENTITY": {
+      const id = typeof action.entityId === "string" ? action.entityId.trim() : "";
+      if (!id || state.selectedEntities.includes(id)) return state;
+      return { ...state, selectedEntities: [...state.selectedEntities, id] };
+    }
+    case "UNPIN_ENTITY": {
+      const id = typeof action.entityId === "string" ? action.entityId.trim() : "";
+      if (!id) return state;
+      const next = state.selectedEntities.filter((existing) => existing !== id);
+      if (next.length === state.selectedEntities.length) return state;
+      return { ...state, selectedEntities: next };
+    }
+    case "PIN_TYPE": {
+      const id = typeof action.typeId === "string" ? action.typeId.trim() : "";
+      if (!id || state.selectedTypes.includes(id)) return state;
+      return { ...state, selectedTypes: [...state.selectedTypes, id] };
+    }
+    case "UNPIN_TYPE": {
+      const id = typeof action.typeId === "string" ? action.typeId.trim() : "";
+      if (!id) return state;
+      const next = state.selectedTypes.filter((existing) => existing !== id);
+      if (next.length === state.selectedTypes.length) return state;
+      return { ...state, selectedTypes: next };
     }
     case "RESET":
       return createDefaultViewerState();

--- a/tests/workspace-facets.test.ts
+++ b/tests/workspace-facets.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Track G G6-2 (S1.4) — FACETS panel auto-discovery.
+ *
+ * Scans the dataset for filterable string fields and exposes them as
+ * generic facet sections. The contract is profile-neutral: no
+ * corpus-specific keys (no `framework`, no `abp`, no `aclp`) are
+ * hardcoded.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  discoverWorkspaceFacets,
+  workspaceReducer,
+  type WorkspaceFacetRecord,
+} from "../src/workspace/index.js";
+
+const dataset: WorkspaceFacetRecord[] = [
+  { id: "a", status: "approved", operation: "create", score_bucket: "high", source_kind: "extracted" },
+  { id: "b", status: "needs_review", operation: "update", score_bucket: "high", source_kind: "inferred" },
+  { id: "c", status: "needs_review", operation: "create", score_bucket: "low", source_kind: "extracted" },
+  { id: "d", status: "approved" },
+];
+
+describe("Track G G6-2 — FACETS auto-discovery", () => {
+  it("discovers the expected facet keys from the dataset", () => {
+    const facets = discoverWorkspaceFacets(dataset);
+    const keys = facets.map((f) => f.key).sort();
+    expect(keys).toEqual(["operation", "score_bucket", "source_kind", "status"]);
+  });
+
+  it("hard-blocks corpus-specific keys (framework / abp / aclp / hasMedia)", () => {
+    const dirty: WorkspaceFacetRecord[] = [
+      { id: "1", framework: "abp", hasMedia: true, status: "approved" },
+    ];
+    const facets = discoverWorkspaceFacets(dirty);
+    const keys = facets.map((f) => f.key);
+    expect(keys).not.toContain("framework");
+    expect(keys).not.toContain("hasMedia");
+    expect(keys).toContain("status");
+  });
+
+  it("returns slice counts per facet value, including 'all'", () => {
+    const facets = discoverWorkspaceFacets(dataset);
+    const status = facets.find((f) => f.key === "status");
+    expect(status).toBeTruthy();
+    const slices = Object.fromEntries(status!.values.map((v) => [v.value, v.count]));
+    expect(slices["all"]).toBe(4);
+    expect(slices["approved"]).toBe(2);
+    expect(slices["needs_review"]).toBe(2);
+  });
+
+  it("honours an explicit profile-declared facet list", () => {
+    const facets = discoverWorkspaceFacets(dataset, {
+      declaredFacets: ["status", "score_bucket"],
+    });
+    const keys = facets.map((f) => f.key);
+    expect(keys).toEqual(["status", "score_bucket"]);
+  });
+
+  it("SET_FACET writes into facetState, SET_FACET with value 'all' clears the key", () => {
+    let state = createDefaultViewerState();
+    state = workspaceReducer(state, { type: "SET_FACET", key: "status", value: "approved" });
+    expect(state.facetState.status).toBe("approved");
+    state = workspaceReducer(state, { type: "CLEAR_FACET", key: "status" });
+    expect(state.facetState.status).toBeUndefined();
+  });
+});

--- a/tests/workspace-result-groups.test.ts
+++ b/tests/workspace-result-groups.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Track G G6-2 (S1.5) — RESULTS grouped by taxonomy.
+ *
+ * groupRecordsByType applies activeType + facetState + searchQuery to a
+ * dataset and returns one group per remaining node_type id, sorted by
+ * count desc. Groups are collapsed by default (open=false). No
+ * corpus-specific id is hardcoded.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  groupRecordsByType,
+  type WorkspaceResultRecord,
+} from "../src/workspace/index.js";
+
+const dataset: WorkspaceResultRecord[] = [
+  { id: "holmes", label: "Sherlock Holmes", node_type: "Character", status: "approved" },
+  { id: "watson", label: "Dr Watson", node_type: "Character", status: "approved" },
+  { id: "moriarty", label: "Professor Moriarty", node_type: "Character", status: "needs_review" },
+  { id: "baker_street", label: "Baker Street", node_type: "Location", status: "approved" },
+  { id: "study_in_scarlet", label: "A Study in Scarlet", node_type: "Work", status: "approved" },
+];
+
+describe("Track G G6-2 — RESULTS grouped by taxonomy", () => {
+  it("produces one group per node_type, ordered by count desc, collapsed by default", () => {
+    const groups = groupRecordsByType(dataset, {
+      activeType: "all",
+      facetState: {},
+      searchQuery: "",
+    });
+    expect(groups.map((g) => g.typeId)).toEqual(["Character", "Location", "Work"]);
+    expect(groups[0]?.count).toBe(3);
+    expect(groups[0]?.open).toBe(false);
+  });
+
+  it("filters by activeType (all but the requested type are dropped)", () => {
+    const groups = groupRecordsByType(dataset, {
+      activeType: "Location",
+      facetState: {},
+      searchQuery: "",
+    });
+    expect(groups.map((g) => g.typeId)).toEqual(["Location"]);
+    expect(groups[0]?.count).toBe(1);
+  });
+
+  it("applies facetState (status=approved drops 'needs_review' members)", () => {
+    const groups = groupRecordsByType(dataset, {
+      activeType: "all",
+      facetState: { status: "approved" },
+      searchQuery: "",
+    });
+    const character = groups.find((g) => g.typeId === "Character");
+    expect(character?.count).toBe(2);
+  });
+
+  it("applies searchQuery (label substring on lower-cased input)", () => {
+    const groups = groupRecordsByType(dataset, {
+      activeType: "all",
+      facetState: {},
+      searchQuery: "holmes",
+    });
+    // Only "Sherlock Holmes" matches → single Character group with count 1.
+    expect(groups.map((g) => g.typeId)).toEqual(["Character"]);
+    expect(groups[0]?.count).toBe(1);
+  });
+
+  it("'all' facet value is treated the same as an unset key", () => {
+    const groups = groupRecordsByType(dataset, {
+      activeType: "all",
+      facetState: { status: "all" },
+      searchQuery: "",
+    });
+    const total = groups.reduce((acc, g) => acc + g.count, 0);
+    expect(total).toBe(dataset.length);
+  });
+
+  it("honours profile-declared result_groups override (preserves caller-supplied order)", () => {
+    const groups = groupRecordsByType(dataset, {
+      activeType: "all",
+      facetState: {},
+      searchQuery: "",
+      resultGroups: ["Work", "Character"],
+    });
+    expect(groups.map((g) => g.typeId)).toEqual(["Work", "Character"]);
+  });
+});

--- a/tests/workspace-search-index.test.ts
+++ b/tests/workspace-search-index.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Track G G6-2 (S1.1) — cross-entity search index.
+ *
+ * Token-gram inverted index over node label / id / aliases / source_file /
+ * summary_excerpt. The contract is intentionally narrow: case-insensitive
+ * substring/token match, no external dependency. Typo tolerance is
+ * limited to exact prefix matching on each token (we do NOT pretend to
+ * be a fuzzy search; callers that want Levenshtein should use a real
+ * MiniSearch index).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWorkspaceSearchIndex,
+  searchWorkspaceIndex,
+  type WorkspaceSearchRecord,
+} from "../src/workspace/search-index.js";
+
+const records: WorkspaceSearchRecord[] = [
+  {
+    id: "holmes",
+    label: "Sherlock Holmes",
+    node_type: "Character",
+    aliases: ["The detective", "Mr. Holmes"],
+    source_file: "corpus/sherlock-holmes/a-study-in-scarlet/text.txt",
+    summary_excerpt: "Consulting detective at 221B Baker Street.",
+  },
+  {
+    id: "watson",
+    label: "Dr Watson",
+    node_type: "Character",
+    aliases: ["John H. Watson"],
+    source_file: "corpus/sherlock-holmes/a-study-in-scarlet/text.txt",
+    summary_excerpt: "Army doctor, narrator.",
+  },
+  {
+    id: "lupin",
+    label: "Arsène Lupin",
+    node_type: "Character",
+    aliases: [],
+    source_file: "corpus/arsene-lupin/text.txt",
+    summary_excerpt: "Gentleman burglar.",
+  },
+  {
+    id: "baker_street",
+    label: "Baker Street",
+    node_type: "Location",
+    aliases: [],
+    source_file: "corpus/sherlock-holmes/locations.txt",
+    summary_excerpt: "London address shared by Holmes and Watson.",
+  },
+];
+
+describe("Track G G6-2 — workspace search index", () => {
+  it("returns the indexed records for an exact lowercase label hit", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const hits = searchWorkspaceIndex(index, "holmes");
+    const ids = hits.map((h) => h.id);
+    expect(ids).toContain("holmes");
+    expect(ids).toContain("baker_street"); // Holmes mentioned in summary.
+  });
+
+  it("is case-insensitive", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const lower = searchWorkspaceIndex(index, "HOLMES").map((h) => h.id);
+    const upper = searchWorkspaceIndex(index, "holmes").map((h) => h.id);
+    expect(lower.sort()).toEqual(upper.sort());
+  });
+
+  it("hits on aliases (Mr. Holmes / The detective)", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const aliasHit = searchWorkspaceIndex(index, "detective").map((h) => h.id);
+    expect(aliasHit).toContain("holmes");
+  });
+
+  it("hits on node id directly", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const hit = searchWorkspaceIndex(index, "lupin").map((h) => h.id);
+    expect(hit).toContain("lupin");
+  });
+
+  it("hits on source_file path tokens", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const hit = searchWorkspaceIndex(index, "arsene").map((h) => h.id);
+    expect(hit).toContain("lupin");
+  });
+
+  it("hits on summary_excerpt", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const hit = searchWorkspaceIndex(index, "burglar").map((h) => h.id);
+    expect(hit).toContain("lupin");
+  });
+
+  it("returns an empty array on empty query", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    expect(searchWorkspaceIndex(index, "")).toEqual([]);
+    expect(searchWorkspaceIndex(index, "   ")).toEqual([]);
+  });
+
+  it("supports prefix token-grams so 'sher' matches 'sherlock'", () => {
+    // Token-gram contract: each token is indexed with its prefixes (length >= 3)
+    // so a partial query like 'sher' still resolves to 'sherlock'. This is the
+    // documented limit of the typo tolerance — no edit-distance / Levenshtein.
+    const index = buildWorkspaceSearchIndex(records);
+    const hits = searchWorkspaceIndex(index, "sher").map((h) => h.id);
+    expect(hits).toContain("holmes");
+  });
+
+  it("ranks records that match more query tokens higher", () => {
+    const index = buildWorkspaceSearchIndex(records);
+    const hits = searchWorkspaceIndex(index, "holmes baker");
+    expect(hits.length).toBeGreaterThan(0);
+    // baker_street matches both "holmes" (summary) and "baker" (label) → top.
+    expect(hits[0]?.id).toBe("baker_street");
+  });
+
+  it("does not crash on records missing aliases / summary_excerpt", () => {
+    const minimal: WorkspaceSearchRecord[] = [
+      { id: "x", label: "X", node_type: "T" },
+      { id: "y", label: "Y" },
+    ];
+    const index = buildWorkspaceSearchIndex(minimal);
+    expect(searchWorkspaceIndex(index, "x").map((h) => h.id)).toContain("x");
+  });
+});

--- a/tests/workspace-selected-rail.test.ts
+++ b/tests/workspace-selected-rail.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Track G G6-2 (S1.3) — SELECTED rail (memory chips).
+ *
+ * Pinning an entity or a type appends it to selectedEntities /
+ * selectedTypes. Removing a chip drops it from the same arrays. The
+ * pinned ids survive the URL round-trip via the G3 reducer.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  viewerStateToQuery,
+  viewerStateFromQuery,
+  workspaceReducer,
+} from "../src/workspace/index.js";
+
+describe("Track G G6-2 — SELECTED rail (memory chips)", () => {
+  it("PIN_ENTITY adds a chip and PIN_ENTITY again is idempotent", () => {
+    const state0 = createDefaultViewerState();
+    const state1 = workspaceReducer(state0, { type: "PIN_ENTITY", entityId: "holmes" });
+    expect(state1.selectedEntities).toContain("holmes");
+    const state2 = workspaceReducer(state1, { type: "PIN_ENTITY", entityId: "holmes" });
+    expect(state2.selectedEntities).toEqual(["holmes"]);
+  });
+
+  it("UNPIN_ENTITY removes a chip", () => {
+    const state0 = workspaceReducer(createDefaultViewerState(), {
+      type: "PIN_ENTITY",
+      entityId: "holmes",
+    });
+    const state1 = workspaceReducer(state0, { type: "PIN_ENTITY", entityId: "watson" });
+    const state2 = workspaceReducer(state1, { type: "UNPIN_ENTITY", entityId: "holmes" });
+    expect(state2.selectedEntities).toEqual(["watson"]);
+  });
+
+  it("PIN_TYPE / UNPIN_TYPE manage selectedTypes the same way", () => {
+    let state = createDefaultViewerState();
+    state = workspaceReducer(state, { type: "PIN_TYPE", typeId: "Character" });
+    state = workspaceReducer(state, { type: "PIN_TYPE", typeId: "Location" });
+    state = workspaceReducer(state, { type: "PIN_TYPE", typeId: "Character" });
+    expect(state.selectedTypes).toEqual(["Character", "Location"]);
+    state = workspaceReducer(state, { type: "UNPIN_TYPE", typeId: "Character" });
+    expect(state.selectedTypes).toEqual(["Location"]);
+  });
+
+  it("preserves pinned ids through the URL round-trip", () => {
+    let state = createDefaultViewerState();
+    state = workspaceReducer(state, { type: "PIN_ENTITY", entityId: "holmes" });
+    state = workspaceReducer(state, { type: "PIN_ENTITY", entityId: "watson" });
+    state = workspaceReducer(state, { type: "PIN_TYPE", typeId: "Character" });
+    state = workspaceReducer(state, { type: "PIN_TYPE", typeId: "Location" });
+    const query = viewerStateToQuery(state);
+    const restored = viewerStateFromQuery(query);
+    expect(restored.selectedEntities.sort()).toEqual(["holmes", "watson"]);
+    expect(restored.selectedTypes.sort()).toEqual(["Character", "Location"]);
+  });
+});

--- a/tests/workspace-types-filter.test.ts
+++ b/tests/workspace-types-filter.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Track G G6-2 (S1.2) — TYPES filter in the left rail.
+ *
+ * The rail renders one row per node_type id discovered in the dataset,
+ * ordered by count desc, with a synthetic "all" entry first. Each row
+ * carries an interactive affordance (data-action="set-type") that the
+ * client-side handler turns into a SET_ACTIVE_TYPE action.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+  workspaceReducer,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+const graph: GraphLike = {
+  nodes: [
+    { id: "holmes", label: "Sherlock Holmes", node_type: "Character" },
+    { id: "watson", label: "Dr Watson", node_type: "Character" },
+    { id: "moriarty", label: "Moriarty", node_type: "Character" },
+    { id: "baker", label: "Baker Street", node_type: "Location" },
+    { id: "study", label: "A Study in Scarlet", node_type: "Work" },
+  ],
+  edges: [],
+};
+
+describe("Track G G6-2 — TYPES filter", () => {
+  it("renders the TYPES section with rows ordered by count desc and an 'all' entry first", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    expect(html).toContain('data-rail-section="types"');
+    // 'all' row plus the discovered type rows.
+    expect(html).toContain('data-type-id="all"');
+    expect(html).toContain('data-type-id="Character"');
+    expect(html).toContain('data-type-id="Location"');
+    expect(html).toContain('data-type-id="Work"');
+    // Order: Character (3) before Location (1) before Work (1).
+    const idxChar = html.indexOf('data-type-id="Character"');
+    const idxLoc = html.indexOf('data-type-id="Location"');
+    const idxWork = html.indexOf('data-type-id="Work"');
+    expect(idxChar).toBeLessThan(idxLoc);
+    expect(idxLoc).toBeLessThan(idxWork);
+  });
+
+  it("emits the 'N shown / M total' summary next to the TYPES heading", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    // 5 records shown / 5 total in the default state.
+    expect(html).toMatch(/data-rail-counter="types-shown"[^>]*>\s*5\s*</);
+    expect(html).toMatch(/data-rail-counter="types-total"[^>]*>\s*5\s*</);
+  });
+
+  it("marks the active row with aria-pressed=true (default activeType=all)", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    expect(html).toMatch(/data-type-id="all"[^>]*aria-pressed="true"/);
+    expect(html).toMatch(/data-type-id="Character"[^>]*aria-pressed="false"/);
+  });
+
+  it("reflects activeType in aria-pressed (Character active)", () => {
+    const state = { ...createDefaultViewerState(), activeType: "Character" };
+    const html = renderWorkspaceShell({ tokens, title: "Workspace", state, graph });
+    expect(html).toMatch(/data-type-id="Character"[^>]*aria-pressed="true"/);
+    expect(html).toMatch(/data-type-id="all"[^>]*aria-pressed="false"/);
+  });
+
+  it("does not introduce any corpus-specific type id (framework / abp / aclp / Process / Org / Tool)", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: createDefaultViewerState(),
+      graph,
+    });
+    expect(html).not.toMatch(/\b(?:framework|abp|aclp|ABPProcess|ACLPProcess|BusinessObject|DigitalApplicationTool)\b/);
+  });
+
+  it("SET_ACTIVE_TYPE updates the state via the reducer", () => {
+    const state = workspaceReducer(createDefaultViewerState(), {
+      type: "SET_ACTIVE_TYPE",
+      activeType: "Character",
+    });
+    expect(state.activeType).toBe("Character");
+  });
+});


### PR DESCRIPTION
## Scope

Lot **G6-2** of Track G — implements the **S1** block of the punch-list
`.graphify/scratch/G6-aclp-alignment-punch-list.md` (left rail enrichment
of the Workspace tab). Builds directly on G6-1 (PR #55) which landed the
three-column shell + compact prose + counters + graph filtering.

## What ships

- **S1.1** — Cross-entity search. New `src/workspace/search-index.ts`
  exposes `buildWorkspaceSearchIndex` / `searchWorkspaceIndex` /
  `searchWorkspace`. Profile-neutral token-gram inverted index over
  label / id / aliases / source_file / summary_excerpt. No external
  dependency, no MiniSearch / Lucene. Prefix tolerance for tokens >= 3
  chars (documented limit; no edit-distance).
- **S1.2** — TYPES filter. Rail emits one row per `node_type` ordered
  by count desc, plus a synthetic `all` entry. `aria-pressed` tracks
  `state.activeType`; clicking dispatches `SET_ACTIVE_TYPE`.
- **S1.3** — SELECTED memory chips. Adds `PIN_ENTITY` / `UNPIN_ENTITY`
  / `PIN_TYPE` / `UNPIN_TYPE` reducer actions in `viewer-state.ts`.
  URL round-trip preserved via the existing G3 `viewerStateToQuery` /
  `viewerStateFromQuery`.
- **S1.4** — FACETS panel. New `src/workspace/facet-panel.ts` with
  `discoverWorkspaceFacets` / `recordMatchesFacets`. Auto-discovers
  low-cardinality string fields from the dataset; honours
  `outputs.workspace.facets` when declared. Hard denylist for
  aclp-am-specific keys (`framework`, `hasMedia`, …).
- **S1.5** — RESULTS grouped by taxonomy. New
  `src/workspace/result-groups.ts` with `groupRecordsByType` /
  `countMatchingRecords`. Collapsed groups by default, profile
  override via `outputs.workspace.result_groups`.

Glue: new `src/workspace/rail.ts` composes the five sections into a
single `renderWorkspaceRail(...)` and wires it inside
`renderWorkspaceShell` so any caller passing a graph payload (and no
explicit `leftWorkbenchHtml`) gets the rich rail. Each interactive
element carries `data-action` / `data-rail-section` / `data-type-id`
/ `data-facet-key` so a thin client-side controller can dispatch the
matching reducer action — no JS bundle shipped from core.

## Constraints honoured

- Profile-neutral: no `framework`, `abp`, `aclp`, `Process`, `Org`,
  `Tool`, `BusinessObject`, `DigitalApplicationTool` strings emitted
  from `src/workspace/*` (the denylist literal in `facet-panel.ts` is
  the only mention and is required by the guardrail tests).
- Mobile 390 x 844: rail collapses to top sheet via the existing G2
  breakpoint — verified by the unchanged `workspace-shell.test.ts`
  assertions.
- Track A description sidecar inline behaviour preserved (no changes
  to the compact description path).
- No regression on `graphify export wiki`, `graph.html`,
  `GRAPH_REPORT.md`.

## Test delta

- Baseline (a5b19e30, post-G6-1): 748 passed / 10 skipped.
- This PR: 782 passed / 7 skipped (+34 new tests, 3 previously
  skipped tests now run in this commit window).
- New suites:
  - `tests/workspace-search-index.test.ts` (10 tests)
  - `tests/workspace-selected-rail.test.ts` (4 tests)
  - `tests/workspace-facets.test.ts` (5 tests)
  - `tests/workspace-result-groups.test.ts` (6 tests)
  - `tests/workspace-types-filter.test.ts` (6 tests)

## Verification

```
npm install        # ok
npm run lint       # tsc --noEmit, no errors
npm test           # 782 passed / 7 skipped
npm run build      # dist/index.js, dist/cli.js, dist/index.d.ts all ok
npx graphify hook-rebuild   # graph.json + GRAPH_REPORT.md refreshed
```

## Smoke

Headless chromium screenshot of the workspace rail rendered on the
public-domaine-mystery-sagas-pack dataset — saved to
`.graphify/scratch/g6-2-rail-public-pack.png` inside the worktree.
The rail surfaces the five sections (Search input, Types 123
shown / 123 total with Character/Location/Case/CrimeOrScheme ordered
by count, Selected with the empty-state hint, Facets auto-discovering
`confidence` + `status`, Results grouped by node_type collapsed by
default).

## Out of scope (kept for G6-3)

- Top tabs Workspace / Reconciliation / Evidence (S2.1).
- Reconciliation sub-view refactor — `ontology-studio-workspace.ts`
  still owns `activeView="studio"` rendering today, so the smoke
  screenshot above goes through a direct shell call until G6-3
  reroutes the live HTTP route.