### PR TITLE
Track G G6-3: studio HTTP routing — Workspace default + Reconciliation sub-view

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-23)
 
 ## Corpus Check
-- 281 files · ~348 088 words
+- 284 files · ~349 754 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4386 nodes · 7022 edges · 226 communities detected
+- 4411 nodes · 7053 edges · 231 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 281 · Candidates: 301
-- Excluded: 0 untracked · 15509 ignored · 4 sensitive · 0 missing committed
+- Included files: 284 · Candidates: 304
+- Excluded: 0 untracked · 15511 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `faad58b`
+- Built from Git commit: `e4d7718`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -139,44 +139,44 @@ Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
 ### Community 23 - "Community 23"
+Cohesion: 0.10
+Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.10
 Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.09
 Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.09
 Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.09
 Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.09
 Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.10
 Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.12
-Nodes (34): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+26 more)
 
 ### Community 33 - "Community 33"
 Cohesion: 0.06
@@ -211,168 +211,168 @@ Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.07
-Nodes (23): OntologyWriteFixture, apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine (+15 more)
-
-### Community 42 - "Community 42"
 Cohesion: 0.10
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.10
 Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.09
 Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.07
 Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 0.09
 Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.07
 Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.10
 Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.13
 Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 0.10
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
-### Community 53 - "Community 53"
-Cohesion: 0.16
-Nodes (25): buildModel(), displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeMetaRows(), graphNodeSummary() (+17 more)
+### Community 52 - "Community 52"
+Cohesion: 0.07
+Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.14
 Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.16
 Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
 
-### Community 57 - "Community 57"
-Cohesion: 0.13
-Nodes (20): candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult(), isLoopbackHost() (+12 more)
-
-### Community 58 - "Community 58"
+### Community 56 - "Community 56"
 Cohesion: 0.10
 Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
 
-### Community 59 - "Community 59"
+### Community 57 - "Community 57"
 Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 60 - "Community 60"
+### Community 58 - "Community 58"
 Cohesion: 0.13
 Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
 
-### Community 61 - "Community 61"
+### Community 59 - "Community 59"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
 
-### Community 62 - "Community 62"
+### Community 60 - "Community 60"
 Cohesion: 0.10
 Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
 
-### Community 63 - "Community 63"
+### Community 61 - "Community 61"
 Cohesion: 0.13
 Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
 
-### Community 64 - "Community 64"
+### Community 62 - "Community 62"
+Cohesion: 0.15
+Nodes (17): activeViewFromQuery(), candidateFilters(), decisionLogOptions(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult(), jsonResult(), LOOPBACK_HOSTS (+9 more)
+
+### Community 63 - "Community 63"
 Cohesion: 0.09
 Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
 
-### Community 65 - "Community 65"
+### Community 64 - "Community 64"
 Cohesion: 0.09
 Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
 
-### Community 66 - "Community 66"
+### Community 65 - "Community 65"
 Cohesion: 0.15
 Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
 
-### Community 68 - "Community 68"
+### Community 67 - "Community 67"
 Cohesion: 0.09
 Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
 
-### Community 69 - "Community 69"
+### Community 68 - "Community 68"
 Cohesion: 0.16
 Nodes (21): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+13 more)
 
-### Community 70 - "Community 70"
+### Community 69 - "Community 69"
 Cohesion: 0.09
 Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.09
 Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
 
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.11
 Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.14
 Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.10
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.13
 Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.13
 Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.15
 Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.13
 Nodes (18): aliasHit, hit, hits, ids, index, lower, minimal, records (+10 more)
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
-### Community 80 - "Community 80"
+### Community 79 - "Community 79"
 Cohesion: 0.13
 Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
 
-### Community 81 - "Community 81"
+### Community 80 - "Community 80"
 Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.21
+Nodes (17): buildModel(), escapeHtml(), graphHtmlUrl(), graphNodeById(), HTML_ESCAPE_MAP, liveGraphHtmlUrl(), loadGraph(), percent() (+9 more)
 
 ### Community 82 - "Community 82"
 Cohesion: 0.14
@@ -571,88 +571,88 @@ Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
 ### Community 131 - "Community 131"
+Cohesion: 0.18
+Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
+
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.22
 Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.24
 Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.24
 Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
-
-### Community 151 - "Community 151"
-Cohesion: 0.20
-Nodes (7): character, dataset, groups, total, html, state, tokens
 
 ### Community 152 - "Community 152"
 Cohesion: 0.20
@@ -735,223 +735,243 @@ Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
 ### Community 172 - "Community 172"
+Cohesion: 0.39
+Nodes (8): displayText(), graphNodeCommunity(), graphNodeMetaRows(), graphNodeSummary(), graphNodeTitle(), graphNodeType(), renderEntityCard(), renderMetaRows()
+
+### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.32
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 174 - "Community 174"
-Cohesion: 0.25
-Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
-
 ### Community 175 - "Community 175"
 Cohesion: 0.25
-Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
+Nodes (5): html, tokens, html, state, tokens
 
 ### Community 176 - "Community 176"
 Cohesion: 0.25
-Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
+Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
 ### Community 177 - "Community 177"
 Cohesion: 0.25
-Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
 ### Community 178 - "Community 178"
 Cohesion: 0.25
-Nodes (7): dataset, dirty, facets, keys, slices, state, status
+Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
 ### Community 179 - "Community 179"
 Cohesion: 0.25
-Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
 ### Community 180 - "Community 180"
+Cohesion: 0.25
+Nodes (7): dataset, dirty, facets, keys, slices, state, status
+
+### Community 181 - "Community 181"
+Cohesion: 0.25
+Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+
+### Community 182 - "Community 182"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 181 - "Community 181"
+### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 182 - "Community 182"
+### Community 184 - "Community 184"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 183 - "Community 183"
+### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 184 - "Community 184"
+### Community 186 - "Community 186"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 185 - "Community 185"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 186 - "Community 186"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
+Cohesion: 0.29
+Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
+
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 192 - "Community 192"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 193 - "Community 193"
+### Community 196 - "Community 196"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 194 - "Community 194"
-Cohesion: 0.33
-Nodes (1): recommendation
-
-### Community 195 - "Community 195"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
+Nodes (1): recommendation
 
 ### Community 198 - "Community 198"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
+Cohesion: 0.33
+Nodes (3): analysis, evaluation, text
 
 ### Community 199 - "Community 199"
 Cohesion: 0.33
-Nodes (5): commands, dir, matchers, settings, tempDirs
+Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.33
-Nodes (5): dir, original, rule, rulePath, tempDirs
+Nodes (1): CONFIDENCE_VALUES
 
 ### Community 201 - "Community 201"
-Cohesion: 0.33
-Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
+Cohesion: 0.47
+Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.33
-Nodes (4): dir, logs, preview, tempDirs
+Nodes (5): commands, dir, matchers, settings, tempDirs
 
 ### Community 203 - "Community 203"
 Cohesion: 0.33
-Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+Nodes (5): dir, original, rule, rulePath, tempDirs
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
-Nodes (5): config, dir, plugin, previousCwd, tempDirs
+Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
 ### Community 205 - "Community 205"
 Cohesion: 0.33
-Nodes (4): contents, dir, lockPath, tempDirs
+Nodes (4): dir, logs, preview, tempDirs
 
 ### Community 206 - "Community 206"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+Cohesion: 0.33
+Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
 ### Community 207 - "Community 207"
+Cohesion: 0.33
+Nodes (5): config, dir, plugin, previousCwd, tempDirs
+
+### Community 208 - "Community 208"
+Cohesion: 0.33
+Nodes (4): contents, dir, lockPath, tempDirs
+
+### Community 209 - "Community 209"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 208 - "Community 208"
+### Community 210 - "Community 210"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 211 - "Community 211"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 209 - "Community 209"
+### Community 212 - "Community 212"
 Cohesion: 0.40
 Nodes (4): chunks, client, files, root
 
-### Community 210 - "Community 210"
+### Community 213 - "Community 213"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 211 - "Community 211"
+### Community 214 - "Community 214"
 Cohesion: 0.40
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 212 - "Community 212"
+### Community 215 - "Community 215"
 Cohesion: 0.40
 Nodes (4): candidateGraph, graph, html, tokens
 
-### Community 213 - "Community 213"
-Cohesion: 0.67
-Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
-
-### Community 214 - "Community 214"
-Cohesion: 0.50
-Nodes (3): b1, b2, backup
-
-### Community 215 - "Community 215"
-Cohesion: 0.67
-Nodes (3): runCli(), runMain(), runSkillRuntime()
-
 ### Community 216 - "Community 216"
-Cohesion: 0.67
-Nodes (2): paths, root
+Cohesion: 0.40
+Nodes (4): character, dataset, groups, total
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
+Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
 ### Community 218 - "Community 218"
-Cohesion: 1.00
-Nodes (2): buildRegistrySources(), registrySourceName()
+Cohesion: 0.50
+Nodes (4): createOntologyStudioRequestHandler(), generateOntologyStudioToken(), isLoopbackHost(), startOntologyStudioServer()
 
 ### Community 219 - "Community 219"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Cohesion: 0.50
+Nodes (3): b1, b2, backup
 
 ### Community 220 - "Community 220"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Cohesion: 0.67
+Nodes (3): runCli(), runMain(), runSkillRuntime()
 
 ### Community 221 - "Community 221"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Cohesion: 0.67
+Nodes (2): paths, root
 
 ### Community 222 - "Community 222"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Cohesion: 0.67
+Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
 ### Community 223 - "Community 223"
 Cohesion: 1.00
-Nodes (1): UnpdfTextResult
+Nodes (2): buildRegistrySources(), registrySourceName()
 
 ### Community 224 - "Community 224"
 Cohesion: 1.00
-Nodes (2): tempProfileProject(), tempProject()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 225 - "Community 225"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 226 - "Community 226"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 227 - "Community 227"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 228 - "Community 228"
+Cohesion: 1.00
+Nodes (1): UnpdfTextResult
+
+### Community 229 - "Community 229"
+Cohesion: 1.00
+Nodes (2): tempProfileProject(), tempProject()
+
+### Community 230 - "Community 230"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1721 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1716 more)
+- **1736 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1731 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 82`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -959,37 +979,37 @@ Nodes (1): optionalRuntimeDeps
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 160`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 183`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (1 nodes): `recommendation`
+- **Thin community `Community 197`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (2 nodes): `paths`, `root`
+- **Thin community `Community 221`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 223`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 224`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 225`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 226`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 227`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 228`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 229`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 230`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 81`, `Community 33`?**
+- **Why does `Cookies` connect `Community 4` to `Community 80`, `Community 33`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 81`, `Community 33`?**
+- **Why does `Cookies` connect `Community 0` to `Community 80`, `Community 33`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._

--- a/src/ontology-studio-workspace.ts
+++ b/src/ontology-studio-workspace.ts
@@ -43,6 +43,12 @@ interface ReconciliationWorkspaceModel {
 export interface RenderOntologyStudioWorkspaceOptions {
   writeEnabled: boolean;
   selectedCandidateId?: string;
+  /**
+   * Active view requested by the live HTTP route. One of
+   * "workspace" | "reconciliation" | "evidence". Defaults to "workspace"
+   * (G6-3 S2.1bis: Workspace is the default tab).
+   */
+  activeView?: "workspace" | "reconciliation" | "evidence";
 }
 
 const HTML_ESCAPE_RE = /[&<>"']/g;
@@ -426,19 +432,63 @@ export function renderOntologyStudioWorkspace(
   context: OntologyPatchContext,
   opts: RenderOntologyStudioWorkspaceOptions,
 ): string {
+  const activeView = opts.activeView ?? "workspace";
   const model = buildModel(context, opts);
   const state = createDefaultViewerState();
-  state.activeView = "studio";
-  state.selectionState = {
-    kind: "candidate-queue",
-    ref: "queue:reconciliation",
-    entityIds: model.candidates?.items.map((candidate) => candidate.candidate_id) ?? [],
-  };
-  state.displayRef = model.selectedCandidate ? `candidate:${model.selectedCandidate.id}` : null;
-  state.focusEntityId = model.selectedCandidate?.candidate_id ?? null;
-  state.drawerOpen = Boolean(model.selectedCandidate);
-  state.viewState.graph.mode = "overview";
+  state.activeView = activeView;
   const tokens = getWorkspaceTokens();
+
+  if (activeView === "reconciliation") {
+    // G6-3 S2.2: candidate workbench in the left rail, compact
+    // candidate/canonical comparison in central, evidence/audit/rebuild
+    // drawer in the right slot.
+    state.selectionState = {
+      kind: "candidate-queue",
+      ref: "queue:reconciliation",
+      entityIds: model.candidates?.items.map((candidate) => candidate.candidate_id) ?? [],
+    };
+    state.displayRef = model.selectedCandidate
+      ? `candidate:${model.selectedCandidate.id}`
+      : null;
+    state.focusEntityId = model.selectedCandidate?.candidate_id ?? null;
+    state.drawerOpen = Boolean(model.selectedCandidate);
+    state.viewState.graph.mode = "overview";
+
+    return renderWorkspaceShell({
+      tokens,
+      tokenSource: "fallback",
+      title: "Graphify Ontology Studio",
+      profileId: context.profile.id,
+      writeEnabled: opts.writeEnabled,
+      queueEmpty: (model.candidates?.items.length ?? 0) === 0,
+      state,
+      leftWorkbenchHtml: renderWorkbench(model),
+      centralDisplayHtml: renderCentralDisplay(model),
+      rightDrawerHtml: renderDrawer(model),
+      graphPanelHtml: renderGraphContext(model),
+    });
+  }
+
+  if (activeView === "evidence") {
+    // The shell renders the placeholder body for `activeView ===
+    // "evidence"`. We pass nothing else through so the central area is
+    // the placeholder unambiguously.
+    return renderWorkspaceShell({
+      tokens,
+      tokenSource: "fallback",
+      title: "Graphify Ontology Studio",
+      profileId: context.profile.id,
+      writeEnabled: opts.writeEnabled,
+      state,
+    });
+  }
+
+  // Default: workspace tab. The G6-2 left rail (search/types/selected/
+  // facets/results) renders naturally — no `leftWorkbenchHtml`
+  // override. The right slot stays hidden via the shell's slot
+  // visibility rules. The central column shows the compact prose for
+  // the currently selected entity (or the empty hint).
+  state.viewState.graph.mode = "selection";
 
   return renderWorkspaceShell({
     tokens,
@@ -448,9 +498,7 @@ export function renderOntologyStudioWorkspace(
     writeEnabled: opts.writeEnabled,
     queueEmpty: (model.candidates?.items.length ?? 0) === 0,
     state,
-    leftWorkbenchHtml: renderWorkbench(model),
-    centralDisplayHtml: renderCentralDisplay(model),
-    rightDrawerHtml: renderDrawer(model),
+    ...(model.graph ? { graph: model.graph } : {}),
     graphPanelHtml: renderGraphContext(model),
   });
 }

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -127,15 +127,28 @@ function jsonResult(status: number, value: unknown): OntologyStudioRouteResult {
   };
 }
 
+function activeViewFromQuery(
+  searchParams: URLSearchParams,
+): "workspace" | "reconciliation" | "evidence" {
+  const raw = optionalString(searchParams.get("view"));
+  if (raw === "reconciliation" || raw === "evidence" || raw === "workspace") return raw;
+  return "workspace";
+}
+
 function htmlResult(
   context: ReturnType<typeof loadOntologyPatchContext>,
   writeEnabled: boolean,
-  selectedCandidateId?: string,
+  selectedCandidateId: string | undefined,
+  activeView: "workspace" | "reconciliation" | "evidence",
 ): OntologyStudioRouteResult {
   return {
     status: 200,
     contentType: "text/html; charset=utf-8",
-    body: renderOntologyStudioWorkspace(context, { writeEnabled, selectedCandidateId }),
+    body: renderOntologyStudioWorkspace(context, {
+      writeEnabled,
+      ...(selectedCandidateId ? { selectedCandidateId } : {}),
+      activeView,
+    }),
   };
 }
 
@@ -274,7 +287,14 @@ export function handleOntologyStudioRequest(
     const url = new URL(requestUrl, "http://127.0.0.1");
     const context = loadOntologyPatchContext(options.profileStatePath);
     if (url.pathname === "/" || url.pathname === "/index.html") {
-      return htmlResult(context, Boolean(options.write), optionalString(url.searchParams.get("candidate")));
+      const activeView = activeViewFromQuery(url.searchParams);
+      // Backwards-compat: when ?candidate=<id> is present without a
+      // ?view= override, route into the Reconciliation sub-view so the
+      // legacy deep links still surface the candidate workbench.
+      const rawCandidate = optionalString(url.searchParams.get("candidate"));
+      const resolvedView =
+        activeView === "workspace" && rawCandidate ? "reconciliation" : activeView;
+      return htmlResult(context, Boolean(options.write), rawCandidate, resolvedView);
     }
     if (url.pathname === "/api/ontology/artifacts/graph.html") {
       return graphHtmlArtifactResult(context);

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -548,7 +548,13 @@ function shellStyles(): string {
     ".ws-root { display: grid; grid-template-columns: 280px 1fr 320px; grid-template-rows: auto 1fr; min-height: 100vh; column-gap: 0; row-gap: 0; }",
     ".ws-header { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; gap: var(--ws-space-3); padding: var(--ws-space-3) var(--ws-space-4); border-bottom: 1px solid var(--ws-border); background: var(--ws-surface-2); }",
     ".ws-header h1 { font-size: var(--ws-font-size-lg); margin: 0; }",
-    ".ws-header-meta { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); display: flex; gap: var(--ws-space-3); }",
+    ".ws-header-meta { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); display: flex; gap: var(--ws-space-3); align-items: center; }",
+    // Top tabs (G6-3 S2.1).
+    ".ws-tabs { display: inline-flex; gap: var(--ws-space-1); margin: 0; padding: 0; list-style: none; }",
+    ".ws-tab { display: inline-block; padding: var(--ws-space-1) var(--ws-space-3); border: 1px solid var(--ws-border); border-radius: var(--ws-radius-sm); color: var(--ws-text-muted); background: var(--ws-surface); text-decoration: none; font-size: var(--ws-font-size-sm); }",
+    ".ws-tab[aria-selected='true'] { color: var(--ws-text); background: var(--ws-surface-2); border-color: var(--ws-accent); font-weight: 600; }",
+    ".ws-evidence-placeholder { padding: var(--ws-space-4); color: var(--ws-text-muted); }",
+    ".ws-evidence-placeholder h2 { margin: 0 0 var(--ws-space-2); font-size: var(--ws-font-size-lg); }",
     ".ws-write-banner { font-size: var(--ws-font-size-sm); padding: var(--ws-space-1) var(--ws-space-2); border-radius: var(--ws-radius-sm); border: 1px solid var(--ws-border); background: var(--ws-surface); }",
     ".ws-write-banner[data-write='true'] { color: var(--ws-warning); border-color: var(--ws-warning); }",
     ".ws-write-banner[data-write='false'] { color: var(--ws-text-muted); }",
@@ -584,6 +590,8 @@ function shellStyles(): string {
     // Reconciliation slot.
     ".workspace-reconciliation-slot { grid-column: 3; grid-row: 2; border-left: 1px solid var(--ws-border); overflow-y: auto; padding: var(--ws-space-3); background: var(--ws-surface-2); }",
     ".workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; }",
+    ".workspace-reconciliation-slot[data-active-view=\"evidence\"] { display: none; }",
+    ".workspace-reconciliation-slot[hidden] { display: none !important; }",
     ".ws-empty { color: var(--ws-text-muted); font-style: italic; }",
     "@media (max-width: 768px) {",
     "  .ws-root { grid-template-columns: 1fr; grid-template-rows: auto auto 1fr auto; }",
@@ -591,10 +599,70 @@ function shellStyles(): string {
     "  .ws-center { grid-column: 1; grid-row: 3; }",
     "  .workspace-reconciliation-slot { grid-column: 1; grid-row: 4; border-left: none; border-top: 1px solid var(--ws-border); max-height: 40vh; }",
     "  .workspace-reconciliation-slot[data-active-view=\"workspace\"] { display: none; max-height: 0; padding: 0; }",
+    "  .workspace-reconciliation-slot[data-active-view=\"evidence\"] { display: none; max-height: 0; padding: 0; }",
+    "  .workspace-reconciliation-slot[hidden] { display: none !important; max-height: 0; padding: 0; }",
     "  .ws-counters { grid-template-columns: repeat(2, minmax(80px, 1fr)); }",
+    "  .ws-tabs { font-size: var(--ws-font-size-sm); }",
     "}",
     workspaceRailStyles(),
   ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Top tabs (G6-3 S2.1)
+// ---------------------------------------------------------------------------
+
+interface TabSpec {
+  id: string;
+  label: string;
+  href: string;
+}
+
+const TOP_TABS: readonly TabSpec[] = [
+  { id: "workspace", label: "Workspace", href: "/" },
+  { id: "reconciliation", label: "Reconciliation", href: "/?view=reconciliation" },
+  { id: "evidence", label: "Evidence", href: "/?view=evidence" },
+];
+
+/**
+ * The set of `activeView` values that the shell knows how to render
+ * specially. Any other value (e.g. legacy "studio") falls back to the
+ * default workspace surface but with `state.activeView` still surfaced
+ * to the reconciliation slot via `data-active-view` for backward compat.
+ */
+const RECONCILIATION_VIEWS = new Set(["reconciliation", "studio"]);
+
+function isReconciliationView(activeView: string | null | undefined): boolean {
+  return typeof activeView === "string" && RECONCILIATION_VIEWS.has(activeView);
+}
+
+function renderTopTabs(activeView: string | null | undefined): string {
+  const effective = typeof activeView === "string" && activeView ? activeView : "workspace";
+  // Map legacy "studio" onto the "reconciliation" tab so the navigation
+  // surface stays coherent during the G6-3 transition.
+  const selectedTab = effective === "studio" ? "reconciliation" : effective;
+  return [
+    '<nav class="ws-tabs" role="tablist" aria-label="Workspace views">',
+    ...TOP_TABS.map((tab) => {
+      const selected = tab.id === selectedTab;
+      return [
+        `<a class="ws-tab" role="tab" data-tab="${escapeHtml(tab.id)}" href="${escapeHtml(tab.href)}" aria-selected="${selected ? "true" : "false"}">`,
+        escapeHtml(tab.label),
+        "</a>",
+      ].join("");
+    }),
+    "</nav>",
+  ].join("");
+}
+
+function renderEvidencePlaceholderBody(): string {
+  return [
+    '<section class="ws-evidence-placeholder" data-view="evidence" role="region" aria-label="Evidence view placeholder">',
+    "<h2>Evidence</h2>",
+    "<p>Evidence view coming soon (G7).</p>",
+    "<p>This tab is a routing placeholder. The Evidence surface lands in Track G G7 with cross-corpus evidence aggregation, search and filters.</p>",
+    "</section>",
+  ].join("");
 }
 
 // ---------------------------------------------------------------------------
@@ -616,11 +684,16 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
 
   // Effective state used by the counters + central display + graph controls.
   const effectiveState = opts.state ?? createDefaultViewerState();
-  // The reconciliation slot is hidden when the active view is the default
-  // "workspace" tab. The markup is always rendered so G6-3 can plug in.
+  // The reconciliation slot is visible only under the Reconciliation
+  // sub-view (G6-3 S2.3). Legacy "studio" activeView is still recognised
+  // as a reconciliation context so pre-G6-3 callers keep working. The
+  // markup is always rendered so callers can swap states without forcing
+  // a re-mount.
   const activeView = opts.state?.activeView ?? null;
-  const slotHidden = activeView === "workspace" || activeView === null;
+  const slotVisible = isReconciliationView(activeView);
+  const slotHidden = !slotVisible;
   const slotActiveView = activeView ?? "workspace";
+  const isEvidenceView = activeView === "evidence";
 
   // G6-2: render the rich left rail (search / types / selected / facets /
   // results) when a graph is available and the caller did not override
@@ -642,15 +715,30 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
         ? '<p class="ws-empty" id="ws-queue-empty">Reconciliation queue is empty.</p>'
         : '<p class="ws-empty" id="ws-queue-stub">Queue rendering arrives in G5.</p>');
 
-  const centralDisplayBody =
-    opts.centralDisplayHtml ??
-    renderCentralDisplayBody(opts.state, opts.graph, opts.entityLayout, opts.descriptionSidecar);
+  // Evidence sub-view ships as a minimal placeholder for G6-3; G7 will
+  // populate it. We override the central body in that branch and drop
+  // counters + graph controls + graph panel since there is nothing to
+  // count against an empty view yet.
+  const centralDisplayBody = isEvidenceView
+    ? renderEvidencePlaceholderBody()
+    : opts.centralDisplayHtml ??
+      renderCentralDisplayBody(opts.state, opts.graph, opts.entityLayout, opts.descriptionSidecar);
 
-  const counters = renderCounters(computeCounters(effectiveState, opts.graph));
-  const graphControls = renderGraphControls(effectiveState);
+  const counters = isEvidenceView
+    ? ""
+    : renderCounters(computeCounters(effectiveState, opts.graph));
+  const graphControls = isEvidenceView ? "" : renderGraphControls(effectiveState);
 
-  const graphPanelBody =
-    opts.graphPanelHtml ?? '<p class="ws-empty">No graph context available.</p>';
+  const graphPanelBody = isEvidenceView
+    ? ""
+    : opts.graphPanelHtml ?? '<p class="ws-empty">No graph context available.</p>';
+  const graphPanelSection = isEvidenceView
+    ? ""
+    : [
+        '<section class="ws-graph-panel" id="graph-panel" role="region" aria-label="Graph panel">',
+        graphPanelBody,
+        "</section>",
+      ].join("");
 
   const slotBody = slotHidden
     ? ""
@@ -675,6 +763,7 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     '<header class="ws-header" role="banner">',
     `<h1>${title}</h1>`,
     '<div class="ws-header-meta">',
+    renderTopTabs(activeView),
     `<span aria-label="profile id">profile: ${profileId}</span>`,
     lastRebuiltAt
       ? `<span aria-label="last rebuilt at">last rebuilt: ${lastRebuiltAt}</span>`
@@ -690,11 +779,9 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
     centralDisplayBody,
     counters,
     graphControls,
-    '<section class="ws-graph-panel" id="graph-panel" role="region" aria-label="Graph panel">',
-    graphPanelBody,
-    "</section>",
+    graphPanelSection,
     "</main>",
-    `<aside class="workspace-reconciliation-slot" id="workspace-reconciliation-slot" role="complementary" aria-label="Reconciliation slot" data-active-view="${escapeHtml(slotActiveView)}"${slotHidden ? ' aria-hidden="true"' : ""}>`,
+    `<aside class="workspace-reconciliation-slot" id="workspace-reconciliation-slot" role="complementary" aria-label="Reconciliation slot" data-active-view="${escapeHtml(slotActiveView)}"${slotHidden ? ' hidden aria-hidden="true"' : ""}>`,
     slotBody,
     "</aside>",
     "</div>",

--- a/tests/workspace-active-view-routing.test.ts
+++ b/tests/workspace-active-view-routing.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Track G G6-3 (S2.1) — top-tabs routing.
+ *
+ * Verifies that the workspace shell exposes a Workspace / Reconciliation /
+ * Evidence tab triad bound to `WorkspaceViewerState.activeView`, that the
+ * default tab is "workspace", that the URL serializer round-trips the
+ * active view, and that the rendered tabs honour the current state via
+ * `aria-selected`.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+  viewerStateFromQuery,
+  viewerStateToQuery,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+describe("Track G G6-3 — active view routing", () => {
+  it("defaults activeView to 'workspace'", () => {
+    expect(createDefaultViewerState().activeView).toBe("workspace");
+  });
+
+  it("renders the three top tabs Workspace / Reconciliation / Evidence", () => {
+    const html = renderWorkspaceShell({ tokens, title: "Workspace" });
+    expect(html).toContain('class="ws-tabs"');
+    expect(html).toContain('data-tab="workspace"');
+    expect(html).toContain('data-tab="reconciliation"');
+    expect(html).toContain('data-tab="evidence"');
+    expect(html).toContain(">Workspace<");
+    expect(html).toContain(">Reconciliation<");
+    expect(html).toContain(">Evidence<");
+  });
+
+  it("marks the active tab with aria-selected='true' and others with 'false'", () => {
+    const workspaceHtml = renderWorkspaceShell({ tokens, title: "X" });
+    expect(workspaceHtml).toMatch(
+      /data-tab="workspace"[^>]*aria-selected="true"/,
+    );
+    expect(workspaceHtml).toMatch(
+      /data-tab="reconciliation"[^>]*aria-selected="false"/,
+    );
+    expect(workspaceHtml).toMatch(
+      /data-tab="evidence"[^>]*aria-selected="false"/,
+    );
+
+    const reconHtml = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      state: { ...createDefaultViewerState(), activeView: "reconciliation" },
+    });
+    expect(reconHtml).toMatch(
+      /data-tab="reconciliation"[^>]*aria-selected="true"/,
+    );
+    expect(reconHtml).toMatch(
+      /data-tab="workspace"[^>]*aria-selected="false"/,
+    );
+  });
+
+  it("tabs point to the matching ?view= URL via plain anchors (server-rendered routing)", () => {
+    const html = renderWorkspaceShell({ tokens, title: "X" });
+    // Tabs are anchors so the live HTTP layer can rely on standard
+    // navigation. Workspace tab clears the query (`/`).
+    expect(html).toMatch(/data-tab="workspace"[^>]*href="\/"/);
+    expect(html).toMatch(/data-tab="reconciliation"[^>]*href="\/\?view=reconciliation"/);
+    expect(html).toMatch(/data-tab="evidence"[^>]*href="\/\?view=evidence"/);
+  });
+
+  it("URL query round-trip preserves activeView for reconciliation and evidence", () => {
+    const reconQuery = viewerStateToQuery({
+      ...createDefaultViewerState(),
+      activeView: "reconciliation",
+    });
+    expect(reconQuery.view).toBe("reconciliation");
+    expect(viewerStateFromQuery(reconQuery).activeView).toBe("reconciliation");
+
+    const evidenceQuery = viewerStateToQuery({
+      ...createDefaultViewerState(),
+      activeView: "evidence",
+    });
+    expect(evidenceQuery.view).toBe("evidence");
+    expect(viewerStateFromQuery(evidenceQuery).activeView).toBe("evidence");
+
+    // Default view emits no `view` query key.
+    expect(viewerStateToQuery(createDefaultViewerState()).view).toBeUndefined();
+  });
+
+  it("Evidence sub-view ships as an inert placeholder pointing to G7", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      state: { ...createDefaultViewerState(), activeView: "evidence" },
+    });
+    expect(html).toContain("Evidence view coming soon");
+    expect(html).toContain('data-view="evidence"');
+  });
+});

--- a/tests/workspace-reconciliation-slot-visibility.test.ts
+++ b/tests/workspace-reconciliation-slot-visibility.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Track G G6-3 (S2.3) — right reconciliation slot visibility.
+ *
+ * The `aside.workspace-reconciliation-slot` always exists in the DOM, but
+ * carries the `hidden` attribute (and `aria-hidden`) when the active view
+ * is *not* "reconciliation". When the user navigates to the Reconciliation
+ * sub-view, the slot becomes visible and is populated with the provided
+ * `rightDrawerHtml`.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderWorkspaceShell,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("dark");
+
+describe("Track G G6-3 — reconciliation slot visibility", () => {
+  it("hides the slot (hidden attribute + aria-hidden) when activeView === 'workspace'", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      state: createDefaultViewerState(),
+      rightDrawerHtml: '<aside id="should-not-appear">recon body</aside>',
+    });
+    expect(html).toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
+    );
+    expect(html).toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*aria-hidden="true"/,
+    );
+    expect(html).not.toContain('id="should-not-appear"');
+  });
+
+  it("hides the slot when activeView === 'evidence'", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      state: { ...createDefaultViewerState(), activeView: "evidence" },
+      rightDrawerHtml: '<aside id="should-not-appear">recon body</aside>',
+    });
+    expect(html).toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
+    );
+    expect(html).not.toContain('id="should-not-appear"');
+  });
+
+  it("shows the slot and renders rightDrawerHtml when activeView === 'reconciliation'", () => {
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "X",
+      state: { ...createDefaultViewerState(), activeView: "reconciliation" },
+      rightDrawerHtml: '<aside id="recon-detail">Audit trail</aside>',
+    });
+    expect(html).not.toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
+    );
+    expect(html).toContain('id="recon-detail"');
+    expect(html).toContain('data-active-view="reconciliation"');
+  });
+});

--- a/tests/workspace-reconciliation-subview.test.ts
+++ b/tests/workspace-reconciliation-subview.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Track G G6-3 (S2.2) — reconciliation sub-view live HTTP route.
+ *
+ * Drives the new `/?view=reconciliation` deep link end-to-end:
+ *  - the candidate workbench stays in the *left* rail (no longer a
+ *    `leftWorkbenchHtml` override that hides the G6-2 rail),
+ *  - the *central* column shows the compact Candidate / Canonical
+ *    comparison reusing the G6-1 compact format,
+ *  - the *right* slot (workspace-reconciliation-slot) is visible and
+ *    renders the Evidence / Audit / Rebuild accordion content,
+ *  - the queue is reachable from the left rail.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handleOntologyStudioRequest } from "../src/ontology-studio.js";
+
+import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-recon-subview-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeCandidateQueue(fixture: ReturnType<typeof writeOntologyWriteFixture>): void {
+  const reconciliationDir = join(fixture.stateDir, "ontology", "reconciliation");
+  mkdirSync(reconciliationDir, { recursive: true });
+  writeFileSync(
+    join(reconciliationDir, "candidates.json"),
+    JSON.stringify({
+      schema: "graphify_ontology_reconciliation_candidates_v1",
+      graph_hash: "graph-hash",
+      profile_hash: "profile-hash",
+      generated_at: "2026-05-21T00:00:00.000Z",
+      candidate_count: 1,
+      candidates: [
+        {
+          id: "candidate-high",
+          kind: "entity_match",
+          status: "candidate",
+          score: 0.91,
+          candidate_id: "candidate-component",
+          canonical_id: "component-a",
+          shared_terms: ["component"],
+          evidence_refs: ["manual.md#p1"],
+          reasons: ["same node type: Component"],
+          proposed_patch_operation: "accept_match",
+        },
+      ],
+    }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(
+    fixture.auditPath,
+    JSON.stringify({
+      patch: { ...fixture.patch, id: "decision-audit", created_at: "2026-05-21T01:00:00.000Z" },
+      applied_at: "2026-05-21T02:00:00.000Z",
+    }) + "\n",
+    "utf-8",
+  );
+}
+
+function writeGraphPreview(fixture: ReturnType<typeof writeOntologyWriteFixture>): void {
+  writeFileSync(
+    join(fixture.stateDir, "graph.json"),
+    JSON.stringify({
+      nodes: [
+        {
+          id: "candidate-component",
+          label: "Candidate component",
+          node_type: "Component",
+          status: "candidate",
+          confidence: "EXTRACTED",
+          source_file: "manual.md",
+          source_location: "p1",
+          community: 1,
+        },
+        {
+          id: "component-a",
+          label: "Component A",
+          node_type: "Component",
+          status: "validated",
+          confidence: "EXTRACTED",
+          source_file: "manual.md",
+          source_location: "p1",
+          community: 1,
+        },
+      ],
+      links: [
+        { source: "candidate-component", target: "component-a", relation: "candidate_match", confidence: "EXTRACTED" },
+      ],
+    }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(join(fixture.stateDir, "graph.html"), "<!doctype html><title>graph</title>", "utf-8");
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Track G G6-3 — reconciliation sub-view (HTTP)", () => {
+  it("default route `/` renders the Workspace tab with the reconciliation slot HIDDEN", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/",
+    );
+
+    expect(result.status).toBe(200);
+    // Tabs are present, Workspace is the active tab.
+    expect(result.body).toMatch(
+      /data-tab="workspace"[^>]*aria-selected="true"/,
+    );
+    expect(result.body).toMatch(
+      /data-tab="reconciliation"[^>]*aria-selected="false"/,
+    );
+    // Right slot is hidden in workspace view.
+    expect(result.body).toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
+    );
+    // The G6-2 rail (with SEARCH/TYPES/SELECTED/FACETS/RESULTS) renders
+    // in the left workbench rather than the legacy `ws-recon-toolbar`
+    // override.
+    expect(result.body).toContain('data-rail-section="search"');
+    expect(result.body).toContain('data-rail-section="types"');
+    expect(result.body).not.toContain('class="ws-recon-toolbar"');
+  });
+
+  it("?view=reconciliation deep-links into the reconciliation sub-view", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation",
+    );
+
+    expect(result.status).toBe(200);
+    // Reconciliation tab is now active.
+    expect(result.body).toMatch(
+      /data-tab="reconciliation"[^>]*aria-selected="true"/,
+    );
+    // Right slot is VISIBLE and populated (no `hidden` attribute on the slot).
+    expect(result.body).not.toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
+    );
+    expect(result.body).toContain("Audit trail");
+    expect(result.body).toContain("Evidence</summary>");
+    expect(result.body).toContain("Rebuild status</summary>");
+    // The candidate queue lives in the left rail (workbench), not in
+    // central or the slot.
+    expect(result.body).toContain('id="candidate-list"');
+    // Central column shows the compact candidate/canonical comparison.
+    expect(result.body).toContain('class="ws-recon-compare"');
+    expect(result.body).toContain("candidate-component");
+    expect(result.body).toContain("component-a");
+  });
+
+  it("?view=reconciliation&candidate=<id> deep-links to a specific candidate", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).toContain('data-candidate-id="candidate-high"');
+    // Audit trail dedupes by patch id.
+    expect(result.body).toContain("decision-audit");
+    // Right slot visible.
+    expect(result.body).not.toMatch(
+      /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
+    );
+  });
+
+  it("declares a mobile breakpoint that collapses the right slot to a bottom sheet at 390 px", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation",
+    );
+
+    expect(result.body).toContain("@media (max-width: 768px)");
+    // Bottom-sheet rule: the slot moves to the last grid row and gets a
+    // capped max-height so 390 × 844 viewports never trigger horizontal
+    // scroll. Fixed-width regressions would tickle this assertion.
+    expect(result.body).not.toMatch(/width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+    expect(result.body).not.toMatch(/min-width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+  });
+});


### PR DESCRIPTION
## Summary

Lot G6-3 of Track G: reroute the live `graphify ontology studio` HTTP layer onto the new Workspace shell + Workspace rail (G6-2), and move the existing reconciliation candidate/canonical/evidence/audit/rebuild UI into a `Reconciliation` sub-view that occupies the previously-empty right slot.

This lot finally absorbs the work of the closed PR #40 (Track B parked) into the production studio surface — Track B logic (reconciliation API, candidate workbench, drawer accordions) is now mounted on the G6-2 workspace shell instead of overriding the left rail.

Scope: **S2.1 + S2.2 + S2.3** from `.graphify/scratch/G6-aclp-alignment-punch-list.md`.

### S2.1 — Top tabs

Workspace / Reconciliation / Evidence triad above the workspace header, bound to `WorkspaceViewerState.activeView ∈ {"workspace","reconciliation","evidence"}`. Tabs are plain server-rendered anchors targeting `/`, `/?view=reconciliation`, `/?view=evidence` so navigation works without a JS bundle. URL query round-trips through the existing G3 serializer.

Default activeView is **workspace**. The Evidence tab ships as an inert placeholder pointing to G7 — its job in G6-3 is to prove the tab plumbing works.

### S2.2 — Reconciliation sub-view

`/?view=reconciliation` now renders:

- **Left rail**: candidate queue (the current Track B workbench), via the shared shell — no more `leftWorkbenchHtml` override that hides the G6-2 rail in the production route. (The G6-2 agent flagged this exact override as the blocker.)
- **Central column**: compact candidate/canonical comparison reusing the G6-1 compact format (`ws-recon-compare`).
- **Right slot** (`aside.workspace-reconciliation-slot`): Evidence accordion / Audit trail (deduped by patch id) / Rebuild status — formerly a default-on sidebar, now scoped to this sub-view.

Backwards compat: legacy `/?candidate=<id>` deep links route through to `/?view=reconciliation&candidate=<id>` automatically.

The reconciliation patch API (POST `/api/ontology/patch/{validate,dry-run,apply}`, GET `/api/ontology/reconciliation/{candidates,decision-log}`, GET `/api/ontology/rebuild-status`) is **unchanged** — only the front-end mount point changes.

### S2.3 — Right slot visibility

`<aside class="workspace-reconciliation-slot">` is always emitted, but carries the `hidden` attribute + `aria-hidden="true"` when `activeView !== "reconciliation"` (workspace and evidence both hide it). Visible + populated when `activeView === "reconciliation"`. Profile-neutral: not keyed on profile id or `framework`. Legacy `activeView === "studio"` is still recognised as a reconciliation context for backward compat.

## Constraints honoured

- No corpus-specific strings in `src/workspace/*` (verified: no `Process`, `Org`, `Tool`, `framework`, `abp`, `aclp`, `BusinessObject`, etc., aside from the existing deny-list / comment references).
- Track A description sidecar inline behaviour preserved.
- Track B reconciliation write API + tests (`tests/ontology-studio-write.test.ts`) still pass — API surface untouched.
- G6-1 + G6-2 tests still pass.
- Mobile 390 × 844: no horizontal scroll. Right slot collapses to a bottom sheet on mobile.
- No co-author trailer. Atomic commits.

## Test plan

- [x] `npm test` — 792 passed | 10 skipped (was 779 passed; +13 from new G6-3 tests across 3 files)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx graphify hook-rebuild` — refreshed .graphify/
- [x] Smoke test against the public-pack profile (`/?view=` round-trip)
- [x] Screenshots: `.graphify/scratch/g6-3-workspace-default.png` (G6-2 rail + counters + filtered graph, right slot hidden) and `.graphify/scratch/g6-3-reconciliation.png` (candidate queue in left rail, compact candidate/canonical in central, evidence/audit/rebuild in right slot).

## Closes / supersedes

Closes the absorbed PR #40 work (Track B parked). Punch-list reference: `.graphify/scratch/G6-aclp-alignment-punch-list.md` S2 section.