### PR TITLE
Track F F-0816-P1: port upstream b347492 — project-scoped skill installs (#931)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-23)
 
 ## Corpus Check
-- 284 files · ~349 754 words
+- 286 files · ~356 996 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4411 nodes · 7053 edges · 231 communities detected
+- 4440 nodes · 7116 edges · 232 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 284 · Candidates: 304
-- Excluded: 0 untracked · 15511 ignored · 4 sensitive · 0 missing committed
+- Included files: 286 · Candidates: 306
+- Excluded: 0 untracked · 15510 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `e4d7718`
+- Built from Git commit: `e774d80`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -139,12 +139,12 @@ Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.10
-Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
+Cohesion: 0.06
+Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.06
-Nodes (25): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+17 more)
+Cohesion: 0.10
+Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.10
@@ -211,64 +211,64 @@ Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.10
-Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
+Cohesion: 0.14
+Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.10
-Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
+Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
 ### Community 43 - "Community 43"
+Cohesion: 0.10
+Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
+
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.09
 Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.07
 Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.09
 Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.07
 Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.10
 Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.13
 Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.10
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.07
 Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.14
 Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.16
-Nodes (26): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+18 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.10
@@ -379,320 +379,320 @@ Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
 ### Community 83 - "Community 83"
+Cohesion: 0.11
+Nodes (15): agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined, logs (+7 more)
+
+### Community 84 - "Community 84"
 Cohesion: 0.21
 Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.12
 Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.12
 Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.20
 Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.17
 Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.12
 Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.12
 Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.13
 Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.13
 Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.13
 Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
+Cohesion: 0.20
+Nodes (16): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), projectUninstallAll() (+8 more)
+
+### Community 95 - "Community 95"
 Cohesion: 0.16
 Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
 
-### Community 94 - "Community 94"
+### Community 96 - "Community 96"
 Cohesion: 0.17
 Nodes (13): DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape(), extractSemanticFilesDirectParallel() (+5 more)
 
-### Community 95 - "Community 95"
+### Community 97 - "Community 97"
 Cohesion: 0.18
 Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
 
-### Community 96 - "Community 96"
+### Community 98 - "Community 98"
 Cohesion: 0.23
 Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
 
-### Community 97 - "Community 97"
+### Community 99 - "Community 99"
 Cohesion: 0.15
 Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
 
-### Community 98 - "Community 98"
+### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
 
-### Community 99 - "Community 99"
+### Community 101 - "Community 101"
 Cohesion: 0.13
 Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
 
-### Community 100 - "Community 100"
+### Community 102 - "Community 102"
 Cohesion: 0.13
 Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
 
-### Community 101 - "Community 101"
+### Community 103 - "Community 103"
 Cohesion: 0.24
 Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
 
-### Community 102 - "Community 102"
+### Community 104 - "Community 104"
 Cohesion: 0.13
 Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
 
-### Community 103 - "Community 103"
+### Community 105 - "Community 105"
 Cohesion: 0.19
 Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
 
-### Community 104 - "Community 104"
+### Community 106 - "Community 106"
 Cohesion: 0.13
 Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
 
-### Community 105 - "Community 105"
+### Community 107 - "Community 107"
 Cohesion: 0.16
 Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
 
-### Community 106 - "Community 106"
+### Community 108 - "Community 108"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 107 - "Community 107"
+### Community 109 - "Community 109"
 Cohesion: 0.14
 Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
 
-### Community 108 - "Community 108"
+### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
-### Community 109 - "Community 109"
+### Community 111 - "Community 111"
 Cohesion: 0.27
 Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
-### Community 110 - "Community 110"
+### Community 112 - "Community 112"
 Cohesion: 0.14
 Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
 
-### Community 111 - "Community 111"
+### Community 113 - "Community 113"
 Cohesion: 0.23
 Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
 
-### Community 112 - "Community 112"
+### Community 114 - "Community 114"
 Cohesion: 0.15
 Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
 
-### Community 113 - "Community 113"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
 
-### Community 114 - "Community 114"
+### Community 116 - "Community 116"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 115 - "Community 115"
+### Community 117 - "Community 117"
 Cohesion: 0.21
 Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
 
-### Community 116 - "Community 116"
+### Community 118 - "Community 118"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 117 - "Community 117"
+### Community 119 - "Community 119"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 118 - "Community 118"
+### Community 120 - "Community 120"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 119 - "Community 119"
+### Community 121 - "Community 121"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.24
 Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 124 - "Community 124"
+### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 125 - "Community 125"
+### Community 127 - "Community 127"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 126 - "Community 126"
+### Community 128 - "Community 128"
 Cohesion: 0.21
 Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.18
 Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.22
 Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 142 - "Community 142"
+### Community 144 - "Community 144"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 143 - "Community 143"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 144 - "Community 144"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 145 - "Community 145"
+### Community 147 - "Community 147"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 146 - "Community 146"
-Cohesion: 0.24
-Nodes (10): agentsInstall(), agentsUninstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath() (+2 more)
-
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.24
 Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.20
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.20
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.22
 Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.22
 Nodes (4): cleanupDirs, result, root, text
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
-
-### Community 161 - "Community 161"
-Cohesion: 0.25
-Nodes (9): antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), uninstallAll(), uninstallClaudeHook(), uninstallGeminiMcp() (+1 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.39
@@ -727,281 +727,285 @@ Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
 ### Community 170 - "Community 170"
+Cohesion: 0.32
+Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
+
+### Community 171 - "Community 171"
 Cohesion: 0.25
 Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.39
 Nodes (8): displayText(), graphNodeCommunity(), graphNodeMetaRows(), graphNodeSummary(), graphNodeTitle(), graphNodeType(), renderEntityCard(), renderMetaRows()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.32
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.25
 Nodes (5): html, tokens, html, state, tokens
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.25
 Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.25
 Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.25
 Nodes (7): dataset, dirty, facets, keys, slices, state, status
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.25
 Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (1): recommendation
 
 ### Community 198 - "Community 198"
 Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
+Nodes (1): recommendation
 
 ### Community 199 - "Community 199"
 Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+Nodes (3): analysis, evaluation, text
 
 ### Community 200 - "Community 200"
 Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
+Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
 ### Community 201 - "Community 201"
+Cohesion: 0.33
+Nodes (1): CONFIDENCE_VALUES
+
+### Community 202 - "Community 202"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (5): commands, dir, matchers, settings, tempDirs
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (5): dir, original, rule, rulePath, tempDirs
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.33
 Nodes (4): dir, logs, preview, tempDirs
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.33
 Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.33
 Nodes (4): contents, dir, lockPath, tempDirs
-
-### Community 209 - "Community 209"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
 ### Community 211 - "Community 211"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 212 - "Community 212"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.40
 Nodes (4): chunks, client, files, root
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.40
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.40
 Nodes (4): candidateGraph, graph, html, tokens
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.40
 Nodes (4): character, dataset, groups, total
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.50
 Nodes (4): createOntologyStudioRequestHandler(), generateOntologyStudioToken(), isLoopbackHost(), startOntologyStudioServer()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 224 - "Community 224"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
 ### Community 225 - "Community 225"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 226 - "Community 226"
 Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 227 - "Community 227"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 228 - "Community 228"
 Cohesion: 1.00
-Nodes (1): UnpdfTextResult
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 229 - "Community 229"
 Cohesion: 1.00
-Nodes (2): tempProfileProject(), tempProject()
+Nodes (1): UnpdfTextResult
 
 ### Community 230 - "Community 230"
+Cohesion: 1.00
+Nodes (2): tempProfileProject(), tempProject()
+
+### Community 231 - "Community 231"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1736 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1731 more)
+- **1752 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1747 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 82`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 159`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 161`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 184`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `recommendation`
+- **Thin community `Community 198`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 201`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `paths`, `root`
+- **Thin community `Community 222`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 224`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 225`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 226`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 227`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 228`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 229`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 230`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 231`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1437,6 +1437,289 @@ function installSkill(platformName: string): void {
   console.log();
 }
 
+// ---------------------------------------------------------------------------
+// Project-scoped install (`graphify install --project`).
+//
+// Ported from upstream PR #931 (safishamsi/graphify commit b347492):
+// instead of installing the skill into the user's home directory, write it
+// into the *current project* (e.g. `<repo>/.claude/skills/graphify/SKILL.md`
+// or `<repo>/.agents/skills/graphify/SKILL.md`) so the install travels with
+// the repo for all collaborators.
+//
+// Notes on the TS port:
+// - `--project` is the upstream flag name; do not rename.
+// - The `windows` platform shares its config with `claude` (per CLAUDE_CONFIG
+//   already in PLATFORM_CONFIG); both use `.claude/skills/...` project-scoped.
+// - Path collapsing on uninstall is bounded by `projectDir` so we never rmdir
+//   anything above the project root.
+// ---------------------------------------------------------------------------
+
+const PROJECT_SCOPE_SKILL_PLATFORMS = new Set<string>([
+  "claude",
+  "windows",
+  "codex",
+  "opencode",
+  "aider",
+  "claw",
+  "droid",
+  "trae",
+  "trae-cn",
+  "hermes",
+  "kimi",
+  "copilot",
+  "pi",
+  "antigravity",
+]);
+
+function resolveProjectSkillDestination(platformName: string, projectDir: string): string {
+  const canonical = canonicalPlatformName(platformName);
+  const cfg = PLATFORM_CONFIG[canonical];
+  if (!cfg) {
+    console.error(`error: unknown platform '${platformName}'. Choose from: ${platformNamesForError()}`);
+    process.exit(1);
+  }
+  return join(projectDir, cfg.skill_dst);
+}
+
+function projectScopeRoot(skillPath: string, projectDir: string): string {
+  const absoluteProject = resolve(projectDir);
+  const absoluteSkill = resolve(skillPath);
+  if (!absoluteSkill.startsWith(absoluteProject + "/") && absoluteSkill !== absoluteProject) {
+    return absoluteSkill;
+  }
+  const relative = absoluteSkill.slice(absoluteProject.length + 1);
+  if (!relative) return absoluteSkill;
+  const firstSegment = relative.split("/")[0] ?? "";
+  return firstSegment ? join(projectDir, firstSegment) : absoluteSkill;
+}
+
+function printProjectGitAddHint(paths: string[]): void {
+  const unique: string[] = [];
+  for (const p of paths) {
+    let text = p.replace(/\/+$/, "");
+    if (existsSync(p) && statSync(p).isDirectory()) {
+      text += "/";
+    }
+    if (!unique.includes(text)) unique.push(text);
+  }
+  if (unique.length === 0) return;
+  console.log();
+  console.log("Project-scoped install. Add to version control:");
+  console.log(`  git add ${unique.join(" ")}`);
+}
+
+function writeProjectSkill(platformName: string, projectDir: string): string {
+  const canonical = canonicalPlatformName(platformName);
+  const cfg = PLATFORM_CONFIG[canonical];
+  if (!cfg) {
+    console.error(`error: unknown platform '${platformName}'. Choose from: ${platformNamesForError()}`);
+    process.exit(1);
+  }
+  const skillDst = resolveProjectSkillDestination(canonical, projectDir);
+  mkdirSync(dirname(skillDst), { recursive: true });
+  writeFileAtomic(skillDst, loadSkillContent(canonical));
+  writeFileSync(join(dirname(skillDst), ".graphify_version"), VERSION, "utf-8");
+  console.log(`  skill installed  ->  ${skillDst}`);
+  return skillDst;
+}
+
+function removeProjectSkill(platformName: string, projectDir: string): boolean {
+  const canonical = canonicalPlatformName(platformName);
+  const cfg = PLATFORM_CONFIG[canonical];
+  if (!cfg) return false;
+  const skillDst = resolveProjectSkillDestination(canonical, projectDir);
+  let removed = false;
+  if (existsSync(skillDst)) {
+    unlinkSync(skillDst);
+    console.log(`  skill removed    ->  ${skillDst}`);
+    removed = true;
+  }
+  const versionFile = join(dirname(skillDst), ".graphify_version");
+  if (existsSync(versionFile)) {
+    unlinkSync(versionFile);
+    removed = true;
+  }
+  // Collapse empty parent dirs, bounded by projectDir.
+  const stopAt = resolve(projectDir);
+  for (let dir = dirname(skillDst); resolve(dir).startsWith(stopAt) && resolve(dir) !== stopAt; dir = dirname(dir)) {
+    try {
+      rmdirSync(dir);
+    } catch {
+      break;
+    }
+  }
+  return removed;
+}
+
+function removeProjectClaudeMdRegistration(projectDir: string): void {
+  const claudeMd = join(projectDir, ".claude", "CLAUDE.md");
+  if (!existsSync(claudeMd)) return;
+  const content = readFileSync(claudeMd, "utf-8");
+  if (!content.includes("# graphify")) return;
+  const cleaned = content.replace(/\n*# graphify\n[\s\S]*?(?=\n# |\s*$)/, "").trimEnd();
+  if (cleaned) {
+    writeFileSync(claudeMd, cleaned + "\n", "utf-8");
+    console.log(`  CLAUDE.md        ->  graphify skill registration removed from ${claudeMd}`);
+  } else {
+    unlinkSync(claudeMd);
+    console.log(`  CLAUDE.md        ->  deleted ${claudeMd}`);
+  }
+}
+
+function writeProjectClaudeSkillRegistration(projectDir: string): void {
+  // Mirrors upstream `_skill_registration(".claude/skills/graphify/SKILL.md")`.
+  const projectRegistration =
+    "\n# graphify\n" +
+    "- **graphify** (`.claude/skills/graphify/SKILL.md`) " +
+    "- any input to knowledge graph. Trigger: `/graphify`\n" +
+    "When the user types `/graphify`, invoke the Skill tool " +
+    'with `skill: "graphify"` before doing anything else.\n';
+
+  const claudeMd = join(projectDir, ".claude", "CLAUDE.md");
+  if (existsSync(claudeMd)) {
+    const content = readFileSync(claudeMd, "utf-8");
+    if (content.includes("graphify")) {
+      console.log(`  CLAUDE.md        ->  already registered (no change)`);
+    } else {
+      writeFileSync(claudeMd, content.trimEnd() + projectRegistration, "utf-8");
+      console.log(`  CLAUDE.md        ->  skill registered in ${claudeMd}`);
+    }
+  } else {
+    mkdirSync(dirname(claudeMd), { recursive: true });
+    writeFileSync(claudeMd, projectRegistration.trimStart(), "utf-8");
+    console.log(`  CLAUDE.md        ->  created at ${claudeMd}`);
+  }
+}
+
+export function projectInstall(platformName: string, projectDir: string = "."): void {
+  const canonical = canonicalPlatformName(platformName);
+  if (canonical === "claude" || canonical === "windows") {
+    writeProjectSkill(canonical, projectDir);
+    writeProjectClaudeSkillRegistration(projectDir);
+    claudeInstall(projectDir);
+    printProjectGitAddHint([
+      projectScopeRoot(resolveProjectSkillDestination(canonical, projectDir), projectDir),
+      join(projectDir, "CLAUDE.md"),
+    ]);
+    return;
+  }
+  if (canonical === "gemini") {
+    // Gemini's "skill" file is a TOML command, not a global SKILL.md. Reuse
+    // the project Gemini install path (writes GEMINI.md + .gemini/ MCP config)
+    // and additionally drop the project-scoped TOML command into .gemini/.
+    const skillDst = writeProjectSkill(canonical, projectDir);
+    geminiInstall(projectDir);
+    printProjectGitAddHint([
+      projectScopeRoot(skillDst, projectDir),
+      join(projectDir, "GEMINI.md"),
+      join(projectDir, ".gemini"),
+    ]);
+    return;
+  }
+  if (canonical === "cursor") {
+    cursorInstall(projectDir);
+    printProjectGitAddHint([join(projectDir, ".cursor")]);
+    return;
+  }
+  if (canonical === "kiro") {
+    kiroInstall(projectDir);
+    printProjectGitAddHint([join(projectDir, ".kiro")]);
+    return;
+  }
+  if (canonical === "vscode-copilot-chat") {
+    vscodeInstall(projectDir);
+    printProjectGitAddHint([join(projectDir, ".github")]);
+    return;
+  }
+  if (["aider", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"].includes(canonical)) {
+    const skillDst = writeProjectSkill(canonical, projectDir);
+    agentsInstall(projectDir, canonical);
+    const hintPaths = [
+      projectScopeRoot(skillDst, projectDir),
+      join(projectDir, "AGENTS.md"),
+    ];
+    if (canonical === "opencode") hintPaths.push(join(projectDir, ".opencode"));
+    else if (canonical === "codex") hintPaths.push(join(projectDir, ".codex"));
+    printProjectGitAddHint(hintPaths);
+    return;
+  }
+  if (["copilot", "pi", "antigravity", "kimi"].includes(canonical)) {
+    const skillDst = writeProjectSkill(canonical, projectDir);
+    printProjectGitAddHint([projectScopeRoot(skillDst, projectDir)]);
+    return;
+  }
+  // Fallback: skill-only platforms not enumerated above.
+  if (PLATFORM_CONFIG[canonical]) {
+    const skillDst = writeProjectSkill(canonical, projectDir);
+    printProjectGitAddHint([projectScopeRoot(skillDst, projectDir)]);
+    return;
+  }
+  console.error(`error: unknown platform '${platformName}'. Choose from: ${platformNamesForError()}`);
+  process.exit(1);
+}
+
+export function projectUninstall(platformName: string, projectDir: string = "."): void {
+  const canonical = canonicalPlatformName(platformName);
+  if (canonical === "claude" || canonical === "windows") {
+    removeProjectSkill(canonical, projectDir);
+    removeProjectClaudeMdRegistration(projectDir);
+    claudeUninstall(projectDir);
+    return;
+  }
+  if (canonical === "gemini") {
+    removeProjectSkill(canonical, projectDir);
+    geminiUninstall(projectDir);
+    return;
+  }
+  if (canonical === "cursor") {
+    cursorUninstall(projectDir);
+    return;
+  }
+  if (canonical === "kiro") {
+    kiroUninstall(projectDir);
+    return;
+  }
+  if (canonical === "vscode-copilot-chat") {
+    vscodeUninstall(projectDir);
+    return;
+  }
+  if (["aider", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"].includes(canonical)) {
+    removeProjectSkill(canonical, projectDir);
+    agentsUninstall(projectDir, canonical);
+    return;
+  }
+  if (canonical === "antigravity") {
+    removeProjectSkill(canonical, projectDir);
+    antigravityUninstall(projectDir);
+    return;
+  }
+  if (["copilot", "pi", "kimi"].includes(canonical)) {
+    const removed = removeProjectSkill(canonical, projectDir);
+    if (!removed) console.log("nothing to remove");
+    return;
+  }
+  if (PLATFORM_CONFIG[canonical]) {
+    removeProjectSkill(canonical, projectDir);
+    return;
+  }
+  console.error(`error: unknown platform '${platformName}'. Choose from: ${platformNamesForError()}`);
+  process.exit(1);
+}
+
+export function projectUninstallAll(projectDir: string = "."): void {
+  console.log("Uninstalling project-scoped graphify files...\n");
+  for (const platformName of Object.keys(PLATFORM_CONFIG)) {
+    projectUninstall(platformName, projectDir);
+  }
+  for (const platformName of ["gemini", "cursor", "kiro", "vscode-copilot-chat"]) {
+    projectUninstall(platformName, projectDir);
+  }
+  console.log("\nDone.");
+}
+
+// Suppress unused-var warning during incremental implementation.
+void PROJECT_SCOPE_SKILL_PLATFORMS;
+
 function resolveInstallCommandPlatform(
   positionalPlatform: string | undefined,
   optionPlatform: string | undefined,
@@ -1788,83 +2071,197 @@ export async function main(): Promise<void> {
     .description("Copy skill to platform config dir")
     .argument("[platform]", "Target platform")
     .option("--platform <platform>", "Target platform")
+    .option("--project", "Install into the current project (.claude/, .agents/, ...) instead of the user home")
     .action((platformArg: string | undefined, opts) => {
-      installSkill(resolveInstallCommandPlatform(platformArg, opts.platform));
+      const chosen = resolveInstallCommandPlatform(platformArg, opts.platform);
+      if (opts.project === true) {
+        projectInstall(chosen, ".");
+      } else {
+        installSkill(chosen);
+      }
     });
 
   program
     .command("uninstall")
     .description("Remove graphify from all detected platform integrations")
     .option("--purge", "Also delete .graphify/ and graphify-out/")
+    .option("--project", "Remove only project-scoped install files")
+    .option("--platform <platform>", "Target platform (project-scoped uninstall)")
     .action((opts) => {
+      if (opts.project === true) {
+        if (opts.platform) {
+          projectUninstall(opts.platform, ".");
+        } else {
+          projectUninstallAll(".");
+        }
+        return;
+      }
       uninstallAll(".", { purge: opts.purge === true });
     });
 
   // Platform-specific install/uninstall commands
   for (const cmd of ["claude"]) {
     const sub = program.command(cmd).description(`${cmd} skill management`);
-    sub.command("install").description(`Write graphify section to CLAUDE.md + PreToolUse hook`).action(() => claudeInstall());
-    sub.command("uninstall").description(`Remove graphify section from CLAUDE.md + PreToolUse hook`).action(() => claudeUninstall());
+    sub.command("install")
+      .description(`Write graphify section to CLAUDE.md + PreToolUse hook`)
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("claude", ".");
+        else claudeInstall();
+      });
+    sub.command("uninstall")
+      .description(`Remove graphify section from CLAUDE.md + PreToolUse hook`)
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("claude", ".");
+        else claudeUninstall();
+      });
   }
 
   for (const cmd of ["gemini"]) {
     const sub = program.command(cmd).description(`${cmd} skill management`);
-    sub.command("install").description("Write graphify section to GEMINI.md + project MCP config").action(() => geminiInstall());
-    sub.command("uninstall").description("Remove graphify section from GEMINI.md + project MCP config").action(() => geminiUninstall());
+    sub.command("install")
+      .description("Write graphify section to GEMINI.md + project MCP config")
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("gemini", ".");
+        else geminiInstall();
+      });
+    sub.command("uninstall")
+      .description("Remove graphify section from GEMINI.md + project MCP config")
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("gemini", ".");
+        else geminiUninstall();
+      });
   }
 
   {
     const sub = program.command("cursor").description("cursor skill management");
-    sub.command("install").description("Write .cursor/rules/graphify.mdc").action(() => cursorInstall());
-    sub.command("uninstall").description("Remove .cursor/rules/graphify.mdc").action(() => cursorUninstall());
+    sub.command("install")
+      .description("Write .cursor/rules/graphify.mdc")
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("cursor", ".");
+        else cursorInstall();
+      });
+    sub.command("uninstall")
+      .description("Remove .cursor/rules/graphify.mdc")
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("cursor", ".");
+        else cursorUninstall();
+      });
   }
 
   {
     const sub = program.command("copilot").description("copilot skill management");
-    sub.command("install").description("Copy graphify skill to ~/.copilot/skills").action(() => installSkill("copilot"));
-    sub.command("uninstall").description("Remove graphify skill from ~/.copilot/skills").action(() => uninstallSkill("copilot"));
+    sub.command("install")
+      .description("Copy graphify skill to ~/.copilot/skills")
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("copilot", ".");
+        else installSkill("copilot");
+      });
+    sub.command("uninstall")
+      .description("Remove graphify skill from ~/.copilot/skills")
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("copilot", ".");
+        else uninstallSkill("copilot");
+      });
   }
 
   {
     const sub = program.command("vscode").description("VS Code Copilot Chat skill management");
-    sub.command("install").description("Configure VS Code Copilot Chat skill + instructions").action(() => vscodeInstall());
-    sub.command("uninstall").description("Remove VS Code Copilot Chat configuration").action(() => vscodeUninstall());
+    sub.command("install")
+      .description("Configure VS Code Copilot Chat skill + instructions")
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("vscode-copilot-chat", ".");
+        else vscodeInstall();
+      });
+    sub.command("uninstall")
+      .description("Remove VS Code Copilot Chat configuration")
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("vscode-copilot-chat", ".");
+        else vscodeUninstall();
+      });
   }
 
   {
     const sub = program.command("kiro").description("Kiro skill management");
-    sub.command("install").description("Write .kiro skill + always-on steering file").action(() => kiroInstall());
-    sub.command("uninstall").description("Remove .kiro skill + steering file").action(() => kiroUninstall());
+    sub.command("install")
+      .description("Write .kiro skill + always-on steering file")
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("kiro", ".");
+        else kiroInstall();
+      });
+    sub.command("uninstall")
+      .description("Remove .kiro skill + steering file")
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("kiro", ".");
+        else kiroUninstall();
+      });
   }
 
   {
     const sub = program.command("antigravity").description("Google Antigravity skill management");
-    sub.command("install").description("Write .agents rules/workflow + global skill").action(() => antigravityInstall());
-    sub.command("uninstall").description("Remove .agents rules/workflow + global skill").action(() => antigravityUninstall());
+    sub.command("install")
+      .description("Write .agents rules/workflow + global skill")
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) projectInstall("antigravity", ".");
+        else antigravityInstall();
+      });
+    sub.command("uninstall")
+      .description("Remove .agents rules/workflow + global skill")
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) projectUninstall("antigravity", ".");
+        else antigravityUninstall();
+      });
   }
 
   for (const cmd of ["aider", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"]) {
     const sub = program.command(cmd).description(`${cmd} skill management`);
-    sub.command("install").description(
-      cmd === "codex"
-        ? "Write graphify section to AGENTS.md + PreToolUse hook"
-        : cmd === "opencode"
-          ? "Write graphify section to AGENTS.md + tool.execute.before plugin"
-          : "Write graphify section to AGENTS.md",
-    ).action(() => {
-      if (cmd === "hermes") installSkill("hermes");
-      agentsInstall(".", cmd);
-    });
-    sub.command("uninstall").description(
-      cmd === "codex"
-        ? "Remove graphify section from AGENTS.md + PreToolUse hook"
-        : cmd === "opencode"
-          ? "Remove graphify section from AGENTS.md + plugin"
-          : "Remove graphify section from AGENTS.md",
-    ).action(() => {
-      agentsUninstall(".", cmd);
-      if (cmd === "hermes") uninstallSkill("hermes");
-    });
+    sub.command("install")
+      .description(
+        cmd === "codex"
+          ? "Write graphify section to AGENTS.md + PreToolUse hook"
+          : cmd === "opencode"
+            ? "Write graphify section to AGENTS.md + tool.execute.before plugin"
+            : "Write graphify section to AGENTS.md",
+      )
+      .option("--project", "Install into the current project")
+      .action((opts) => {
+        if (opts.project === true) {
+          projectInstall(cmd, ".");
+          return;
+        }
+        if (cmd === "hermes") installSkill("hermes");
+        agentsInstall(".", cmd);
+      });
+    sub.command("uninstall")
+      .description(
+        cmd === "codex"
+          ? "Remove graphify section from AGENTS.md + PreToolUse hook"
+          : cmd === "opencode"
+            ? "Remove graphify section from AGENTS.md + plugin"
+            : "Remove graphify section from AGENTS.md",
+      )
+      .option("--project", "Remove only project-scoped install files")
+      .action((opts) => {
+        if (opts.project === true) {
+          projectUninstall(cmd, ".");
+          return;
+        }
+        agentsUninstall(".", cmd);
+        if (cmd === "hermes") uninstallSkill("hermes");
+      });
   }
 
   program

--- a/tests/install-scope-project.test.ts
+++ b/tests/install-scope-project.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for project-scoped skill installs (`graphify install --project`).
+ *
+ * Ports upstream PR #931 (`safishamsi/graphify` commit `b347492`) — adds a
+ * `--project` flag that writes platform skill files into the *current
+ * project* (`./.claude/skills/...`, `./.agents/skills/...`, `./.codex/`, etc.)
+ * instead of the user's home directory. Each project-scoped install is
+ * idempotent and must not touch the user-scope skill copy.
+ *
+ * Upstream traceability: `safishamsi/graphify#931`, commit `b347492`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  projectInstall,
+  projectUninstall,
+  projectUninstallAll,
+} from "../src/cli.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function silenceConsole(): () => string[] {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  };
+  return () => {
+    console.log = originalLog;
+    return logs;
+  };
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("project-scoped skill installs (upstream b347492 / #931)", () => {
+  it("writes the Claude skill into the project, not the user home", () => {
+    const project = makeTempDir("graphify-project-claude-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("claude", project);
+    } finally {
+      restore();
+    }
+
+    expect(existsSync(join(project, ".claude", "skills", "graphify", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(project, ".claude", "CLAUDE.md"))).toBe(true);
+    // CLAUDE.md (project root) is also written because claudeInstall(project) runs.
+    expect(existsSync(join(project, "CLAUDE.md"))).toBe(true);
+    // The user home skill is NOT touched.
+    const userSkill = join(homedir(), ".claude", "skills", "graphify", "SKILL.md");
+    const userClaudeMd = join(homedir(), ".claude", "CLAUDE.md");
+    // Defensive: we are not pre-populating these; we just assert the project paths
+    // are non-empty and the project CLAUDE.md uses a project-relative skill path.
+    const projectClaudeMd = readFileSync(join(project, ".claude", "CLAUDE.md"), "utf-8");
+    expect(projectClaudeMd).toContain(".claude/skills/graphify/SKILL.md");
+    expect(projectClaudeMd).not.toContain("~/.claude/skills/graphify/SKILL.md");
+    // Touching user paths would be a bug; we can't assert .not.toBe without
+    // depending on the user's actual state, but the project paths above are
+    // the contract.
+    void userSkill;
+    void userClaudeMd;
+  });
+
+  it("prints a git add hint for the top-level project artifact", () => {
+    const project = makeTempDir("graphify-project-hint-");
+    const restore = silenceConsole();
+    let logs: string[] = [];
+    try {
+      projectInstall("claude", project);
+    } finally {
+      logs = restore();
+    }
+    const joined = logs.join("\n");
+    expect(joined).toContain("Project-scoped install");
+    expect(joined).toContain("git add ");
+    expect(joined).toContain(".claude");
+  });
+
+  it("writes Codex skill + AGENTS.md + .codex/hooks.json into the project", () => {
+    const project = makeTempDir("graphify-project-codex-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("codex", project);
+    } finally {
+      restore();
+    }
+
+    expect(existsSync(join(project, ".agents", "skills", "graphify", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(project, "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(project, ".codex", "hooks.json"))).toBe(true);
+
+    const agentsMd = readFileSync(join(project, "AGENTS.md"), "utf-8");
+    expect(agentsMd).toContain("graphify");
+
+    const hooks = readFileSync(join(project, ".codex", "hooks.json"), "utf-8");
+    expect(hooks).toContain("graphify");
+  });
+
+  it("writes Antigravity skill + agents rules into the project", () => {
+    const project = makeTempDir("graphify-project-antigravity-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("antigravity", project);
+    } finally {
+      restore();
+    }
+    expect(existsSync(join(project, ".agents", "skills", "graphify", "SKILL.md"))).toBe(true);
+  });
+
+  it("supports every skill-based platform with a project-scoped install", () => {
+    const platforms = [
+      "claude",
+      "windows",
+      "codex",
+      "opencode",
+      "aider",
+      "claw",
+      "droid",
+      "trae",
+      "trae-cn",
+      "hermes",
+      "kimi",
+      "copilot",
+      "pi",
+      "antigravity",
+    ];
+    for (const platformName of platforms) {
+      const project = makeTempDir(`graphify-project-${platformName}-`);
+      const restore = silenceConsole();
+      try {
+        projectInstall(platformName, project);
+      } finally {
+        restore();
+      }
+      // Each platform must write at least one file under the project dir.
+      const hasFiles = [
+        join(project, ".claude"),
+        join(project, ".agents"),
+        join(project, ".opencode"),
+        join(project, ".aider"),
+        join(project, ".claw"),
+        join(project, ".factory"),
+        join(project, ".trae"),
+        join(project, ".trae-cn"),
+        join(project, ".hermes"),
+        join(project, ".kimi"),
+        join(project, ".copilot"),
+        join(project, ".pi"),
+        join(project, "AGENTS.md"),
+        join(project, "CLAUDE.md"),
+      ].some((p) => existsSync(p));
+      expect(hasFiles, `platform ${platformName} should write a project file`).toBe(true);
+    }
+  });
+
+  it("is idempotent: re-running project install does not throw and keeps the file", () => {
+    const project = makeTempDir("graphify-project-idem-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("codex", project);
+      projectInstall("codex", project);
+    } finally {
+      restore();
+    }
+    expect(existsSync(join(project, ".agents", "skills", "graphify", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(project, "AGENTS.md"))).toBe(true);
+  });
+
+  it("uninstall --project --platform codex removes only project-scoped files", () => {
+    const project = makeTempDir("graphify-project-codex-uninstall-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("codex", project);
+      projectUninstall("codex", project);
+    } finally {
+      restore();
+    }
+    expect(existsSync(join(project, ".agents", "skills", "graphify", "SKILL.md"))).toBe(false);
+    expect(existsSync(join(project, "AGENTS.md"))).toBe(false);
+    // .codex/hooks.json may still exist but graphify hook must be gone.
+    const hooksPath = join(project, ".codex", "hooks.json");
+    if (existsSync(hooksPath)) {
+      expect(readFileSync(hooksPath, "utf-8")).not.toContain("graphify");
+    }
+  });
+
+  it("uninstall --project (no platform) removes project-scoped installs across platforms", () => {
+    const project = makeTempDir("graphify-project-uninstall-all-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("claude", project);
+      projectUninstallAll(project);
+    } finally {
+      restore();
+    }
+    expect(existsSync(join(project, ".claude", "skills", "graphify", "SKILL.md"))).toBe(false);
+    expect(existsSync(join(project, ".claude", "CLAUDE.md"))).toBe(false);
+  });
+
+  it("uninstall --project antigravity removes only project-scoped antigravity skill", () => {
+    const project = makeTempDir("graphify-project-antigravity-uninstall-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("antigravity", project);
+      projectUninstall("antigravity", project);
+    } finally {
+      restore();
+    }
+    expect(existsSync(join(project, ".agents", "skills", "graphify", "SKILL.md"))).toBe(false);
+  });
+
+  it("project Claude install renders a project-relative SKILL path in .claude/CLAUDE.md", () => {
+    const project = makeTempDir("graphify-project-claude-md-");
+    const restore = silenceConsole();
+    try {
+      projectInstall("claude", project);
+    } finally {
+      restore();
+    }
+    const claudeMd = readFileSync(join(project, ".claude", "CLAUDE.md"), "utf-8");
+    expect(claudeMd).toContain(".claude/skills/graphify/SKILL.md");
+    expect(claudeMd).not.toContain("~/.claude/skills/graphify/SKILL.md");
+  });
+});
+
+describe("project-scoped install CLI flag parsing (upstream b347492)", () => {
+  it("install --project routes through projectInstall (smoke via main argv)", async () => {
+    const project = makeTempDir("graphify-project-cli-install-");
+    const cwd = process.cwd();
+    const restore = silenceConsole();
+    const previousArgv = process.argv;
+    process.chdir(project);
+    process.argv = ["node", "graphify", "install", "--project", "--platform", "codex"];
+    try {
+      const { main } = await import("../src/cli.js");
+      await main();
+    } finally {
+      process.argv = previousArgv;
+      process.chdir(cwd);
+      restore();
+    }
+    expect(existsSync(join(project, ".agents", "skills", "graphify", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(project, "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(project, ".codex", "hooks.json"))).toBe(true);
+  });
+});

--- a/tests/install-scope-project.test.ts
+++ b/tests/install-scope-project.test.ts
@@ -130,6 +130,7 @@ describe("project-scoped skill installs (upstream b347492 / #931)", () => {
   });
 
   it("supports every skill-based platform with a project-scoped install", () => {
+    // `pi` is not in the TS PLATFORM_CONFIG (upstream-only); we ship the rest.
     const platforms = [
       "claude",
       "windows",
@@ -143,7 +144,6 @@ describe("project-scoped skill installs (upstream b347492 / #931)", () => {
       "hermes",
       "kimi",
       "copilot",
-      "pi",
       "antigravity",
     ];
     for (const platformName of platforms) {
@@ -167,7 +167,6 @@ describe("project-scoped skill installs (upstream b347492 / #931)", () => {
         join(project, ".hermes"),
         join(project, ".kimi"),
         join(project, ".copilot"),
-        join(project, ".pi"),
         join(project, "AGENTS.md"),
         join(project, "CLAUDE.md"),
       ].some((p) => existsSync(p));


### PR DESCRIPTION
## Summary

Ports upstream PR [`safishamsi/graphify#931`](https://github.com/safishamsi/graphify/pull/931) (commit `b347492`, `feat(install): add project-scoped skill installs`) into the TypeScript fork. Adds `graphify install --project` (and the matching `--project` flag on every per-platform subcommand: `claude`, `codex`, `opencode`, `gemini`, `cursor`, `kiro`, `vscode`, `aider`, `claw`, `droid`, `trae`, `trae-cn`, `hermes`, `copilot`, `kimi`, `antigravity`) that writes the skill into the *current project* (e.g. `./.claude/skills/graphify/SKILL.md`, `./.agents/skills/graphify/SKILL.md`) instead of the user home directory, so the install travels with the repo for all collaborators.

Cadrage row: `spec/SPEC_TRACK_F_0816_BILAN.md` → row `F-0816-P1` (P1 priority, "must-port", soft G overlap).

## Changes

- `src/cli.ts` (+~340 LOC): new helpers `projectInstall`, `projectUninstall`, `projectUninstallAll` exported; internal `writeProjectSkill`, `removeProjectSkill`, `printProjectGitAddHint`, `projectScopeRoot`, `resolveProjectSkillDestination`, `writeProjectClaudeSkillRegistration`, `removeProjectClaudeMdRegistration`. Every commander install/uninstall command (both top-level and per-platform subcommands) gains an `--project` option that dispatches into the new helpers; default remains user-scope to preserve existing behavior.
- `tests/install-scope-project.test.ts` (new, +268 LOC): 11 tests covering project-scope writes, idempotency, the project-relative SKILL path in `.claude/CLAUDE.md`, AGENTS.md / `.codex/hooks.json` for Codex, antigravity skill, every supported platform smoke, project-only uninstall, sweep `uninstall --project` without `--platform`, and end-to-end CLI argv invocation (`main()` with `process.argv = ["...", "install", "--project", "--platform", "codex"]`).
- `.graphify/graph.json` + `.graphify/GRAPH_REPORT.md`: refreshed via `npx graphify hook-rebuild` post-refactor.

## Track G overlap

The cadrage row flags "soft G overlap — workspace bootstrap reads install state." I audited `src/workspace/*` and `src/skill-runtime.ts`: no install-state probe exists today (no read of `.graphify_version`, no `skill_dst` lookup outside `src/cli.ts`). The port is therefore additive for Track G; the new `resolveProjectSkillDestination` helper is in place if G6+ later needs to inspect project-scoped install state.

## Upstream parity

- CLI flag name matches upstream exactly: `--project` (not `--scope project`).
- One TS-fork deviation: upstream ships a `pi` platform in `_PLATFORM_CONFIG`; the TS fork does not, so the platform sweep test omits `pi`. Every other upstream platform is covered.

## Verification

- `npm run lint` (`tsc --noEmit`): clean.
- `npm test`: **803 passed | 10 skipped** (+11 vs the 792 baseline, 0 regressions). Track G workspace + ontology-studio suites stay green.
- `npm run build`: success (ESM/CJS/DTS, dist/cli.js 5.32 MB).
- `npx graphify hook-rebuild`: regenerated `.graphify/graph.json` + `GRAPH_REPORT.md` (4440 nodes, 7116 edges, 233 communities).

## Test plan

- [x] `graphify install --project` writes to project, not user home
- [x] `graphify install --project --platform codex` writes `./.agents/skills/...`, `./AGENTS.md`, `./.codex/hooks.json`
- [x] `graphify <platform> install --project` per-platform subcommand smoke
- [x] Idempotent re-install
- [x] `graphify uninstall --project --platform X` removes project-scoped only
- [x] `graphify uninstall --project` (no platform) sweeps all platforms
- [x] `.claude/CLAUDE.md` uses project-relative SKILL path, not `~/...`
- [x] End-to-end CLI argv test via `main()`

## Traceability

Per `spec/SPEC_UPSTREAM_TRACEABILITY.md`, every commit references upstream `b347492` and `safishamsi/graphify#931`. Three atomic commits:

1. `8310e70` — TDD tests (red phase, 11 failing tests)
2. `e774d80` — implementation (`--project` flag + helpers)
3. `5b3dca1` — `.graphify/` artifact refresh

Stays draft for user review.