### PR TITLE
Track G G6-4: compact candidate/canonical layout (closes G6-1 S0.2 debt)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-23)
 
 ## Corpus Check
-- 286 files · ~356 996 words
+- 287 files · ~358 736 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4440 nodes · 7116 edges · 232 communities detected
+- 4463 nodes · 7160 edges · 231 communities detected
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 286 · Candidates: 306
-- Excluded: 0 untracked · 15510 ignored · 4 sensitive · 0 missing committed
+- Included files: 287 · Candidates: 307
+- Excluded: 0 untracked · 15511 ignored · 4 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `e774d80`
+- Built from Git commit: `1e8789a`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -156,79 +156,79 @@ Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee,
 
 ### Community 27 - "Community 27"
 Cohesion: 0.08
-Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
+Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.09
-Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
+Cohesion: 0.08
+Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.09
-Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
+Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.09
-Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
+Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.09
-Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
+Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
 ### Community 32 - "Community 32"
+Cohesion: 0.09
+Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
+
+### Community 33 - "Community 33"
 Cohesion: 0.10
 Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
+Cohesion: 0.14
+Nodes (34): buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeConfidence() (+26 more)
+
+### Community 35 - "Community 35"
 Cohesion: 0.06
 Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
-### Community 34 - "Community 34"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
-### Community 35 - "Community 35"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
 
-### Community 36 - "Community 36"
+### Community 38 - "Community 38"
 Cohesion: 0.08
 Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
-### Community 37 - "Community 37"
+### Community 39 - "Community 39"
 Cohesion: 0.06
 Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
 
-### Community 38 - "Community 38"
+### Community 40 - "Community 40"
 Cohesion: 0.09
 Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
 
-### Community 39 - "Community 39"
+### Community 41 - "Community 41"
 Cohesion: 0.08
 Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
-### Community 40 - "Community 40"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
-### Community 41 - "Community 41"
+### Community 43 - "Community 43"
 Cohesion: 0.14
 Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
 
-### Community 42 - "Community 42"
+### Community 44 - "Community 44"
 Cohesion: 0.10
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 43 - "Community 43"
-Cohesion: 0.10
-Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
-
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.09
-Nodes (28): decisionLogOperation(), decisionLogStatus(), decisionLogTarget(), decisionLogTouchesNode(), filterDecisionLogItems(), isInside(), isRecord(), loadOntologyReconciliationDecisionLog() (+20 more)
 
 ### Community 46 - "Community 46"
 Cohesion: 0.12
@@ -259,120 +259,120 @@ Cohesion: 0.10
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
 ### Community 53 - "Community 53"
+Cohesion: 0.13
+Nodes (21): activeViewFromQuery(), candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult() (+13 more)
+
+### Community 54 - "Community 54"
 Cohesion: 0.07
 Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.10
 Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.13
 Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.10
 Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
+Cohesion: 0.11
+Nodes (16): AnalysisFile, analyzeGraph(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion(), main() (+8 more)
+
+### Community 63 - "Community 63"
 Cohesion: 0.13
 Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
 
-### Community 62 - "Community 62"
-Cohesion: 0.15
-Nodes (17): activeViewFromQuery(), candidateFilters(), decisionLogOptions(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult(), jsonResult(), LOOPBACK_HOSTS (+9 more)
-
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.09
 Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.09
 Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.15
 Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.09
 Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.16
 Nodes (21): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+13 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.09
 Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.09
 Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.11
 Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.14
 Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.10
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.13
 Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.13
 Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.15
 Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.13
 Nodes (18): aliasHit, hit, hits, ids, index, lower, minimal, records (+10 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.13
 Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
-
-### Community 81 - "Community 81"
-Cohesion: 0.21
-Nodes (17): buildModel(), escapeHtml(), graphHtmlUrl(), graphNodeById(), HTML_ESCAPE_MAP, liveGraphHtmlUrl(), loadGraph(), percent() (+9 more)
 
 ### Community 82 - "Community 82"
 Cohesion: 0.14
@@ -499,160 +499,160 @@ Cohesion: 0.14
 Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
 
 ### Community 113 - "Community 113"
+Cohesion: 0.14
+Nodes (9): boxes, central, dir, fixture, headingMatches, pills, result, sections (+1 more)
+
+### Community 114 - "Community 114"
 Cohesion: 0.23
 Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.15
 Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.21
 Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.24
 Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.21
 Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.18
 Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.22
 Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
-
-### Community 151 - "Community 151"
-Cohesion: 0.24
-Nodes (10): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), knownEvidenceRefs(), normalizeOntologyPatch(), stringArray() (+2 more)
 
 ### Community 152 - "Community 152"
 Cohesion: 0.38
@@ -739,124 +739,124 @@ Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
 ### Community 173 - "Community 173"
-Cohesion: 0.39
-Nodes (8): displayText(), graphNodeCommunity(), graphNodeMetaRows(), graphNodeSummary(), graphNodeTitle(), graphNodeType(), renderEntityCard(), renderMetaRows()
-
-### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 175 - "Community 175"
+### Community 174 - "Community 174"
 Cohesion: 0.32
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (5): html, tokens, html, state, tokens
 
-### Community 177 - "Community 177"
+### Community 176 - "Community 176"
 Cohesion: 0.25
 Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
-### Community 178 - "Community 178"
+### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.25
 Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.25
 Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.25
 Nodes (7): dataset, dirty, facets, keys, slices, state, status
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.25
 Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 187 - "Community 187"
+### Community 186 - "Community 186"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 188 - "Community 188"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 192 - "Community 192"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 193 - "Community 193"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 194 - "Community 194"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (1): recommendation
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.33
 Nodes (3): analysis, evaluation, text
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.33
 Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.33
 Nodes (1): CONFIDENCE_VALUES
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
+
+### Community 202 - "Community 202"
+Cohesion: 0.33
+Nodes (6): cacheOptionsFromRuntime(), loadGraph(), loadProfileRuntimeContext(), readJson(), updateCostFile(), writeJson()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.33
@@ -924,58 +924,54 @@ Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMar
 
 ### Community 219 - "Community 219"
 Cohesion: 0.50
-Nodes (4): createOntologyStudioRequestHandler(), generateOntologyStudioToken(), isLoopbackHost(), startOntologyStudioServer()
-
-### Community 220 - "Community 220"
-Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 222 - "Community 222"
+### Community 221 - "Community 221"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 223 - "Community 223"
+### Community 222 - "Community 222"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 224 - "Community 224"
+### Community 223 - "Community 223"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 225 - "Community 225"
+### Community 224 - "Community 224"
 Cohesion: 1.00
 Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 225 - "Community 225"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 226 - "Community 226"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 227 - "Community 227"
 Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 228 - "Community 228"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (1): UnpdfTextResult
 
 ### Community 229 - "Community 229"
 Cohesion: 1.00
-Nodes (1): UnpdfTextResult
-
-### Community 230 - "Community 230"
-Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 231 - "Community 231"
+### Community 230 - "Community 230"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1752 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1747 more)
+- **1761 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1756 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 82`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -983,37 +979,37 @@ Nodes (1): optionalRuntimeDeps
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 161`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 183`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (1 nodes): `recommendation`
+- **Thin community `Community 197`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `paths`, `root`
+- **Thin community `Community 221`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 223`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 224`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 225`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 226`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 227`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 228`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 229`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 230`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 80`, `Community 33`?**
+- **Why does `Cookies` connect `Community 4` to `Community 81`, `Community 35`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 80`, `Community 33`?**
+- **Why does `Cookies` connect `Community 0` to `Community 81`, `Community 35`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._

--- a/src/ontology-studio-workspace.ts
+++ b/src/ontology-studio-workspace.ts
@@ -82,24 +82,28 @@ function renderStudioStyles(): string {
     ".ws-recon-row { display: grid; gap: 2px; padding: var(--ws-space-2); border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); color: var(--ws-text); text-decoration: none; background: var(--ws-surface-2); }",
     ".ws-recon-row[data-selected='true'] { border-color: var(--ws-accent); box-shadow: inset 3px 0 0 var(--ws-accent); }",
     ".ws-recon-row small, .ws-recon-muted { color: var(--ws-text-muted); }",
-    ".ws-recon-candidate { display: grid; gap: var(--ws-space-3); max-width: 88ch; }",
+    // G6-4 — compact candidate / canonical descriptive block.
+    ".ws-recon-candidate { display: grid; gap: var(--ws-space-2); max-width: 88ch; }",
     ".ws-recon-candidate h3 { margin: 0; font-size: var(--ws-font-size-lg); line-height: var(--ws-line-height-tight); }",
-    ".ws-recon-compare { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--ws-space-3); }",
-    ".ws-recon-box { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); padding: var(--ws-space-3); background: var(--ws-surface-2); overflow-wrap: anywhere; }",
-    ".ws-recon-box h4 { margin: 0 0 var(--ws-space-1); font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }",
-    ".ws-recon-entity { display: grid; gap: var(--ws-space-2); }",
-    ".ws-recon-entity-title { margin: 0; font-weight: 650; line-height: var(--ws-line-height-tight); }",
-    ".ws-recon-entity-id { margin: 0; color: var(--ws-text-muted); font-family: var(--ws-font-family-mono); font-size: var(--ws-font-size-sm); }",
-    ".ws-recon-entity-summary { margin: 0; color: var(--ws-text); }",
-    ".ws-recon-meta { display: grid; gap: var(--ws-space-1); margin: 0; font-size: var(--ws-font-size-sm); }",
-    ".ws-recon-meta div { display: grid; grid-template-columns: minmax(7rem, 35%) 1fr; gap: var(--ws-space-2); }",
-    ".ws-recon-meta dt { color: var(--ws-text-muted); }",
-    ".ws-recon-meta dd { margin: 0; color: var(--ws-text); }",
+    ".ws-display-kicker { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }",
+    ".ws-recon-compare { display: grid; gap: var(--ws-space-1); }",
+    ".ws-recon-mapping { margin: 0; font-weight: 600; line-height: var(--ws-line-height-tight); overflow-wrap: anywhere; }",
+    ".ws-recon-mapping .ws-recon-arrow { color: var(--ws-text-muted); margin: 0 var(--ws-space-1); }",
+    ".ws-recon-ids { margin: 0; color: var(--ws-text-muted); font-family: var(--ws-font-family-mono); font-size: var(--ws-font-size-sm); overflow-wrap: anywhere; }",
+    ".ws-recon-meta-inline { margin: 0; color: var(--ws-text); font-size: var(--ws-font-size-sm); }",
+    ".ws-recon-meta-inline .ws-recon-sep { color: var(--ws-text-muted); margin: 0 var(--ws-space-1); }",
+    ".ws-recon-line { margin: 0; font-size: var(--ws-font-size-sm); color: var(--ws-text); overflow-wrap: anywhere; }",
+    ".ws-recon-line-key { color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; margin-right: var(--ws-space-1); }",
+    ".ws-recon-summary { margin: var(--ws-space-1) 0 0; display: grid; gap: var(--ws-space-1); font-size: var(--ws-font-size-sm); }",
+    ".ws-recon-summary > div { display: grid; grid-template-columns: minmax(8rem, 22%) 1fr; gap: var(--ws-space-2); align-items: baseline; }",
+    ".ws-recon-summary dt { margin: 0; color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; font-size: var(--ws-font-size-sm); font-weight: 600; }",
+    ".ws-recon-summary dd { margin: 0; color: var(--ws-text); overflow-wrap: anywhere; }",
+    ".ws-recon-summary-empty { color: var(--ws-text-muted); font-style: italic; }",
     ".ws-recon-list-inline { margin: 0; padding-left: var(--ws-space-4); }",
     ".ws-recon-warning { border: 1px solid var(--ws-warning); color: var(--ws-warning); border-radius: var(--ws-radius-md); padding: var(--ws-space-2); background: var(--ws-surface-2); }",
     ".ws-recon-accordion { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-md); padding: var(--ws-space-2); background: var(--ws-surface); }",
     ".ws-recon-accordion summary { cursor: pointer; font-weight: 600; }",
-    "@media (max-width: 768px) { .ws-recon-compare { grid-template-columns: 1fr; } }",
+    "@media (max-width: 768px) { .ws-recon-summary > div { grid-template-columns: 1fr; gap: 2px; } }",
     "</style>",
   ].join("\n");
 }
@@ -156,48 +160,126 @@ function graphNodeCommunity(node: GraphNodeLike | null): string | null {
   );
 }
 
-function graphNodeMetaRows(node: GraphNodeLike | null): Array<[string, string]> {
-  if (!node) return [];
-  const rows: Array<[string, string | null]> = [
-    ["Type", graphNodeType(node)],
-    ["Status", displayText(node.status)],
-    ["Confidence", displayText(node.confidence)],
-    ["Source", displayText(node.source_location)
-      ? `${displayText(node.source_file) ?? "source"}:${displayText(node.source_location)}`
-      : displayText(node.source_file)],
-    ["Community", graphNodeCommunity(node)],
-  ];
-  return rows.filter((row): row is [string, string] => typeof row[1] === "string");
+function graphNodeStatus(node: GraphNodeLike | null): string | null {
+  return displayText(node?.status);
 }
 
-function renderMetaRows(rows: Array<[string, string]>): string {
-  if (rows.length === 0) return "";
+function graphNodeConfidence(node: GraphNodeLike | null): string | null {
+  return displayText(node?.confidence);
+}
+
+function graphNodeSourcePath(node: GraphNodeLike | null): string | null {
+  const file = displayText(node?.source_file);
+  const loc = displayText(node?.source_location);
+  if (!file) return null;
+  return loc ? `${file}:${loc}` : file;
+}
+
+function pickFirst<T>(values: ReadonlyArray<T | null | undefined>): T | null {
+  for (const v of values) {
+    if (v !== null && v !== undefined && v !== "") return v as T;
+  }
+  return null;
+}
+
+interface CompactMetaInline {
+  type: string | null;
+  status: string | null;
+  confidence: string | null;
+}
+
+function compactMetaInline(
+  candidateNode: GraphNodeLike | null,
+  canonicalNode: GraphNodeLike | null,
+): CompactMetaInline {
+  // Prefer the canonical's authoritative facts; fall back to the
+  // candidate's when canonical is missing. This matches the ACLP
+  // workspace's "one line of meta" pattern — a single authoritative
+  // pair, not two diverging stacks.
+  return {
+    type: pickFirst([graphNodeType(canonicalNode), graphNodeType(candidateNode)]),
+    status: pickFirst([graphNodeStatus(canonicalNode), graphNodeStatus(candidateNode)]),
+    confidence: pickFirst([
+      graphNodeConfidence(canonicalNode),
+      graphNodeConfidence(candidateNode),
+    ]),
+  };
+}
+
+function renderInlineMetaRow(meta: CompactMetaInline): string {
+  const parts: string[] = [];
+  if (meta.type) parts.push(escapeHtml(meta.type));
+  if (meta.status) parts.push(escapeHtml(meta.status));
+  if (meta.confidence) parts.push(escapeHtml(meta.confidence));
+  if (parts.length === 0) return "";
   return [
-    '<dl class="ws-recon-meta">',
-    ...rows.map(([label, value]) => [
-      "<div>",
-      `<dt>${escapeHtml(label)}</dt>`,
-      `<dd>${escapeHtml(value)}</dd>`,
-      "</div>",
-    ].join("")),
-    "</dl>",
+    '<p class="ws-recon-meta-inline">',
+    parts.join('<span class="ws-recon-sep">·</span>'),
+    "</p>",
   ].join("");
 }
 
-function renderEntityCard(role: string, entityId: string, node: GraphNodeLike | null): string {
-  const summary = graphNodeSummary(node);
-  const title = graphNodeTitle(node, entityId);
+function renderKeyValueLine(slug: string, key: string, value: string | null): string {
+  if (!value) return "";
   return [
-    '<section class="ws-recon-box">',
-    `<h4>${escapeHtml(role)}</h4>`,
-    '<div class="ws-recon-entity">',
-    `<p class="ws-recon-entity-title">${escapeHtml(title)}</p>`,
-    `<p class="ws-recon-entity-id">${escapeHtml(entityId)}</p>`,
-    summary ? `<p class="ws-recon-entity-summary">${escapeHtml(summary)}</p>` : "",
-    renderMetaRows(graphNodeMetaRows(node)),
+    `<p class="ws-recon-line" data-line="${escapeHtml(slug)}">`,
+    `<span class="ws-recon-line-key">${escapeHtml(key)}</span>`,
+    escapeHtml(value),
+    "</p>",
+  ].join("");
+}
+
+function renderSummaryRow(
+  slug: string,
+  label: string,
+  items: readonly string[],
+  empty: string,
+): string {
+  const safeItems = items.filter((item) => typeof item === "string" && item.trim().length > 0);
+  const body =
+    safeItems.length === 0
+      ? `<span class="ws-recon-summary-empty">${escapeHtml(empty)}</span>`
+      : safeItems.map((item) => escapeHtml(item)).join("; ");
+  return [
+    "<div>",
+    `<dt data-term="${escapeHtml(slug)}">${escapeHtml(label)}</dt>`,
+    `<dd data-term="${escapeHtml(slug)}">${body}</dd>`,
     "</div>",
+  ].join("");
+}
+
+function renderCompactMapping(
+  candidateId: string,
+  canonicalId: string,
+  candidateNode: GraphNodeLike | null,
+  canonicalNode: GraphNodeLike | null,
+): string {
+  const candidateLabel = graphNodeTitle(candidateNode, candidateId);
+  const canonicalLabel = graphNodeTitle(canonicalNode, canonicalId);
+  const meta = compactMetaInline(candidateNode, canonicalNode);
+  const summary = graphNodeSummary(canonicalNode) ?? graphNodeSummary(candidateNode);
+  return [
+    '<section class="ws-recon-compare" data-recon-compare="candidate-canonical">',
+    [
+      '<p class="ws-recon-mapping">',
+      escapeHtml(candidateLabel),
+      '<span class="ws-recon-arrow" aria-hidden="true">→</span>',
+      escapeHtml(canonicalLabel),
+      "</p>",
+    ].join(""),
+    [
+      '<p class="ws-recon-ids">',
+      escapeHtml(candidateId),
+      '<span class="ws-recon-arrow" aria-hidden="true">→</span>',
+      escapeHtml(canonicalId),
+      "</p>",
+    ].join(""),
+    renderInlineMetaRow(meta),
+    summary ? `<p class="ws-recon-line" data-line="summary">${escapeHtml(summary)}</p>` : "",
     "</section>",
-  ].filter(Boolean).join("");
+  ]
+    .filter(Boolean)
+    .join("");
 }
 
 function renderWorkbench(model: ReconciliationWorkspaceModel): string {
@@ -245,6 +327,22 @@ function renderCentralDisplay(model: ReconciliationWorkspaceModel): string {
   }
   const candidateNode = graphNodeById(model.graph, candidate.candidate_id);
   const canonicalNode = graphNodeById(model.graph, candidate.canonical_id);
+  // G6-4 (closes G6-1 S0.2 debt) — compact prose layout.
+  //  - One <h3> for the reconcile id (kicker above it).
+  //  - One toolbar row with the 4 pill chips.
+  //  - One compact compare block: label mapping + id mapping + inline
+  //    Type · Status · Confidence row.
+  //  - Source / Community as single-line Key: value prose.
+  //  - Shared terms / Reasons / Decision basis collapse to ONE compact
+  //    <dl> with small-caps headings (no framed Card boxes).
+  const sourcePath = graphNodeSourcePath(canonicalNode) ?? graphNodeSourcePath(candidateNode);
+  const community = graphNodeCommunity(canonicalNode) ?? graphNodeCommunity(candidateNode);
+  const decisionBasis: string[] = [
+    `Operation: ${candidate.proposed_patch_operation}`,
+    `Candidate: ${candidate.candidate_id}`,
+    `Canonical: ${candidate.canonical_id}`,
+    ...candidate.evidence_refs.map((ref) => `Evidence: ${ref}`),
+  ];
   return [
     renderStudioStyles(),
     `<article class="ws-recon-candidate" data-candidate-id="${escapeHtml(candidate.id)}">`,
@@ -259,29 +357,33 @@ function renderCentralDisplay(model: ReconciliationWorkspaceModel): string {
     model.candidates?.stale || model.rebuildStatus?.needs_update
       ? '<p class="ws-recon-warning">Queue may be stale. Rebuild before applying this patch.</p>'
       : "",
-    '<div class="ws-recon-compare">',
-    renderEntityCard("Candidate", candidate.candidate_id, candidateNode),
-    renderEntityCard("Canonical", candidate.canonical_id, canonicalNode),
-    "</div>",
-    '<section class="ws-recon-box">',
-    "<h4>Shared terms</h4>",
-    renderList(candidate.shared_terms, "No shared terms."),
-    "</section>",
-    '<section class="ws-recon-box">',
-    "<h4>Reasons</h4>",
-    renderList(candidate.reasons, "No reasons."),
-    "</section>",
-    '<section class="ws-recon-box">',
-    "<h4>Decision basis</h4>",
-    renderList([
-      `Operation: ${candidate.proposed_patch_operation}`,
-      `Candidate: ${candidate.candidate_id}`,
-      `Canonical: ${candidate.canonical_id}`,
-      ...candidate.evidence_refs.map((ref) => `Evidence: ${ref}`),
-    ], "No decision basis."),
-    "</section>",
+    renderCompactMapping(
+      candidate.candidate_id,
+      candidate.canonical_id,
+      candidateNode,
+      canonicalNode,
+    ),
+    renderKeyValueLine("source", "Source:", sourcePath),
+    renderKeyValueLine("community", "Community:", community),
+    '<dl class="ws-recon-summary" data-recon-summary="true">',
+    renderSummaryRow(
+      "shared-terms",
+      "SHARED TERMS",
+      candidate.shared_terms,
+      "No shared terms.",
+    ),
+    renderSummaryRow("reasons", "REASONS", candidate.reasons, "No reasons."),
+    renderSummaryRow(
+      "decision-basis",
+      "DECISION BASIS",
+      decisionBasis,
+      "No decision basis.",
+    ),
+    "</dl>",
     "</article>",
-  ].filter(Boolean).join("");
+  ]
+    .filter(Boolean)
+    .join("");
 }
 
 function renderDrawer(model: ReconciliationWorkspaceModel): string {

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -139,11 +139,17 @@ describe("graphify ontology studio --write", () => {
     expect(result.body).toContain("Candidate component");
     expect(result.body).toContain("component-a");
     expect(result.body).toContain("Component A");
-    expect(result.body).toContain("<dt>Type</dt>");
-    expect(result.body).toContain("<dd>Component</dd>");
+    // G6-4: Type / Status / Confidence collapsed into the inline meta
+    // line. The semantic content stays reachable but the legacy
+    // <dt>Type</dt><dd>Component</dd> markup is replaced by the compact
+    // prose row.
+    expect(result.body).toContain('class="ws-recon-meta-inline"');
+    expect(result.body).toContain("Component");
     expect(result.body).toContain("manual.md#p1");
     expect(result.body).toContain("decision-audit");
-    expect(result.body).toContain("Decision basis");
+    // G6-4: "Decision basis" becomes the small-caps DT in the compact
+    // summary <dl>.
+    expect(result.body).toContain("DECISION BASIS");
     expect(result.body).not.toContain("Patch preview");
     expect(result.body).not.toContain("&quot;operation&quot;");
     expect(result.body).toContain("<b>Mode:</b> Overview");

--- a/tests/workspace-display-compact-candidate.test.ts
+++ b/tests/workspace-display-compact-candidate.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Track G G6-4 (closes G6-1 S0.2 debt) — compact candidate / canonical
+ * comparison layout.
+ *
+ * The reconciliation sub-view central column previously rendered Type /
+ * Status / Confidence / Source / Community on 5 separate Card rows (one
+ * "ws-recon-box" per side) plus Shared terms / Reasons / Decision basis
+ * each in their own framed boxes. Combined, that grew to ~480 px of
+ * vertical chrome before the counters row. G6-4 pays back the UI debt
+ * by re-using the G6-1 compact prose pattern: one H1, one row of pill
+ * chips, an inline "candidate → canonical" prose line, a "•"-separated
+ * meta row, and a single definition list for shared terms / reasons /
+ * decision basis.
+ *
+ * Profile-neutral: no corpus-specific strings. Mobile 390 × 844 must
+ * keep wrapping cleanly (no fixed widths > 1000 px).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handleOntologyStudioRequest } from "../src/ontology-studio.js";
+
+import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-g6-4-compact-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeCandidateQueue(
+  fixture: ReturnType<typeof writeOntologyWriteFixture>,
+): void {
+  const reconciliationDir = join(fixture.stateDir, "ontology", "reconciliation");
+  mkdirSync(reconciliationDir, { recursive: true });
+  writeFileSync(
+    join(reconciliationDir, "candidates.json"),
+    JSON.stringify(
+      {
+        schema: "graphify_ontology_reconciliation_candidates_v1",
+        graph_hash: "graph-hash",
+        profile_hash: "profile-hash",
+        generated_at: "2026-05-23T00:00:00.000Z",
+        candidate_count: 1,
+        candidates: [
+          {
+            id: "candidate-high",
+            kind: "entity_match",
+            status: "candidate",
+            score: 0.95,
+            candidate_id: "candidate-component",
+            canonical_id: "component-a",
+            shared_terms: ["component"],
+            evidence_refs: ["manual.md#p1", "manual.md#p2"],
+            reasons: [
+              "same node type: Component",
+              "shared normalized term(s): component",
+            ],
+            proposed_patch_operation: "accept_match",
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+}
+
+function writeGraphPreview(
+  fixture: ReturnType<typeof writeOntologyWriteFixture>,
+): void {
+  writeFileSync(
+    join(fixture.stateDir, "graph.json"),
+    JSON.stringify(
+      {
+        nodes: [
+          {
+            id: "candidate-component",
+            label: "Candidate component",
+            node_type: "Component",
+            status: "candidate",
+            confidence: "EXTRACTED",
+            source_file: "manual.md",
+            source_location: "p1",
+            community_name: "Operations chain",
+            community: 1,
+          },
+          {
+            id: "component-a",
+            label: "Component A",
+            node_type: "Component",
+            status: "validated",
+            confidence: "EXTRACTED",
+            source_file: "manual.md",
+            source_location: "p1",
+            community_name: "Operations chain",
+            community: 1,
+          },
+        ],
+        links: [],
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  writeFileSync(
+    join(fixture.stateDir, "graph.html"),
+    "<!doctype html><title>graph</title>",
+    "utf-8",
+  );
+}
+
+function reconciliationCentralBody(html: string): string {
+  // Slice everything between the opening of the central display container
+  // and the counters block. This is the surface the user perceives as the
+  // "descriptive block" we want to keep compact.
+  const start = html.indexOf('class="ws-recon-candidate"');
+  expect(start).toBeGreaterThan(-1);
+  const end = html.indexOf('class="ws-counters"', start);
+  expect(end).toBeGreaterThan(start);
+  return html.slice(start, end);
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Track G G6-4 — compact candidate / canonical layout", () => {
+  it("renders a single H1 (the reconcile id) and the 4 pill chips inline", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    expect(result.status).toBe(200);
+    const central = reconciliationCentralBody(result.body);
+    // Exactly one heading for the candidate id at the top of the central body.
+    const headingMatches = [
+      ...central.matchAll(/<h3[^>]*>([\s\S]*?)<\/h3>/g),
+    ];
+    expect(headingMatches.length).toBe(1);
+    expect(headingMatches[0]![1]).toContain("candidate-high");
+    // 4 pill chips in a single toolbar row.
+    expect(central).toContain("entity_match");
+    expect(central).toContain("candidate</span>");
+    expect(central).toContain("score 95%");
+    expect(central).toContain("accept_match");
+    const pills = [...central.matchAll(/class="ws-recon-pill"/g)];
+    expect(pills.length).toBe(4);
+  });
+
+  it("collapses Candidate / Canonical into a single inline prose row (no per-side ws-recon-box cards, no Type/Status/Confidence dl rows)", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    const central = reconciliationCentralBody(result.body);
+    // Legacy per-side cards must be gone — both labels live in one prose line.
+    expect(central).not.toMatch(/<section class="ws-recon-box">\s*<h4>Candidate<\/h4>/);
+    expect(central).not.toMatch(/<section class="ws-recon-box">\s*<h4>Canonical<\/h4>/);
+    // The 5-row vertical Type/Status/Confidence/Source/Community dt/dd
+    // structure (one row per fact, repeated twice on each side) is the
+    // exact debt we are paying back. None of those dl rows must remain.
+    expect(central).not.toMatch(/<div>\s*<dt>Type<\/dt>/);
+    expect(central).not.toMatch(/<div>\s*<dt>Status<\/dt>/);
+    expect(central).not.toMatch(/<div>\s*<dt>Confidence<\/dt>/);
+    expect(central).not.toMatch(/<div>\s*<dt>Source<\/dt>/);
+    expect(central).not.toMatch(/<div>\s*<dt>Community<\/dt>/);
+    // The arrow line conveys the mapping in plain text.
+    expect(central).toContain('class="ws-recon-mapping"');
+    expect(central).toContain("Candidate component");
+    expect(central).toContain("Component A");
+    expect(central).toContain("→");
+    // The id mapping prose + meta line carries Type/Status/Confidence
+    // inline, "•"-separated.
+    expect(central).toContain('class="ws-recon-ids"');
+    expect(central).toContain("candidate-component");
+    expect(central).toContain("component-a");
+    expect(central).toContain('class="ws-recon-meta-inline"');
+    // The compact meta line collapses Type / Status / Confidence on ONE
+    // row; we assert presence + ordering rather than the exact glue.
+    expect(central).toMatch(/Component[\s\S]*candidate[\s\S]*EXTRACTED/);
+  });
+
+  it("renders Source and Community as single-line Key: value prose, not framed boxes", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    const central = reconciliationCentralBody(result.body);
+    expect(central).toContain('class="ws-recon-line" data-line="source"');
+    expect(central).toContain("manual.md:p1");
+    expect(central).toContain('class="ws-recon-line" data-line="community"');
+    expect(central).toContain("Operations chain");
+  });
+
+  it("renders Shared terms / Reasons / Decision basis as a single compact <dl>, not as framed Card boxes", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    const central = reconciliationCentralBody(result.body);
+    // No <h4>Shared terms</h4>, <h4>Reasons</h4>, <h4>Decision basis</h4>
+    // inside .ws-recon-box framed cards anymore — they collapse into a
+    // single compact definition list.
+    expect(central).not.toMatch(/<section class="ws-recon-box">\s*<h4>Shared terms<\/h4>/);
+    expect(central).not.toMatch(/<section class="ws-recon-box">\s*<h4>Reasons<\/h4>/);
+    expect(central).not.toMatch(/<section class="ws-recon-box">\s*<h4>Decision basis<\/h4>/);
+    expect(central).toContain('class="ws-recon-summary"');
+    // Three dt/dd pairs inside one dl.
+    expect(central).toMatch(
+      /<dt[^>]*data-term="shared-terms"[^>]*>[\s\S]*?SHARED TERMS[\s\S]*?<\/dt>/,
+    );
+    expect(central).toMatch(
+      /<dt[^>]*data-term="reasons"[^>]*>[\s\S]*?REASONS[\s\S]*?<\/dt>/,
+    );
+    expect(central).toMatch(
+      /<dt[^>]*data-term="decision-basis"[^>]*>[\s\S]*?DECISION BASIS[\s\S]*?<\/dt>/,
+    );
+    // Content of the three sections is still exposed (no info loss).
+    expect(central).toContain("component"); // shared term
+    expect(central).toContain("same node type: Component"); // reason
+    expect(central).toContain("shared normalized term(s): component"); // reason
+    expect(central).toContain("accept_match"); // decision basis operation
+    expect(central).toContain("manual.md#p1"); // evidence ref
+    expect(central).toContain("manual.md#p2"); // evidence ref
+  });
+
+  it("keeps the descriptive block structurally compact (≤ 6 major structural elements between H1 and counters)", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    const central = reconciliationCentralBody(result.body);
+    // Count <section> elements inside the descriptive block (proxy for
+    // vertical height since each adds padding/border in the framed
+    // layout we are demolishing). In the verbose layout this was 5
+    // (Candidate, Canonical, Shared terms, Reasons, Decision basis).
+    const sections = [...central.matchAll(/<section\b/g)];
+    expect(sections.length).toBeLessThanOrEqual(2);
+    // .ws-recon-box (the framed Card visual unit) must not appear at all
+    // anymore: prose lines replace them.
+    const boxes = [...central.matchAll(/class="ws-recon-box"/g)];
+    expect(boxes.length).toBe(0);
+  });
+
+  it("hides the descriptive block when no candidate is selected (and emits no h3/dl/pills)", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    // Intentionally do NOT write a candidate queue: candidate set is empty.
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation",
+    );
+
+    expect(result.status).toBe(200);
+    // No central candidate article rendered.
+    expect(result.body).not.toContain('class="ws-recon-candidate"');
+    expect(result.body).not.toContain('class="ws-recon-mapping"');
+    expect(result.body).not.toContain('class="ws-recon-summary"');
+    // The reconciliation tab is still the active one (routing still works).
+    expect(result.body).toMatch(
+      /data-tab="reconciliation"[^>]*aria-selected="true"/,
+    );
+  });
+
+  it("never leaks corpus-specific strings (framework / abp / aclp / ABPProcess / BusinessObject / DigitalApplicationTool)", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    const central = reconciliationCentralBody(result.body);
+    expect(central).not.toMatch(
+      /\b(?:framework|abp|aclp|ABPProcess|ACLPProcess|BusinessObject|DigitalApplicationTool)\b/,
+    );
+  });
+
+  it("declares no fixed widths > 1000 px (mobile 390 × 844 wraps cleanly)", () => {
+    const dir = makeTempDir();
+    const fixture = writeOntologyWriteFixture(dir);
+    writeCandidateQueue(fixture);
+    writeGraphPreview(fixture);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath, write: { token: "unused" } },
+      "GET",
+      "/?view=reconciliation&candidate=candidate-high",
+    );
+
+    // Style block must not declare any width / min-width above ~1000 px,
+    // which would force horizontal scroll on a 390 px viewport.
+    expect(result.body).not.toMatch(/width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+    expect(result.body).not.toMatch(/min-width:\s*(?:1[0-9]{3,}|[2-9][0-9]{3,})px/);
+    // The "@media" breakpoint must keep collapsing the compare into a
+    // single column.
+    expect(result.body).toContain("@media (max-width: 768px)");
+  });
+});

--- a/tests/workspace-reconciliation-subview.test.ts
+++ b/tests/workspace-reconciliation-subview.test.ts
@@ -193,6 +193,17 @@ describe("Track G G6-3 — reconciliation sub-view (HTTP)", () => {
     expect(result.body).not.toMatch(
       /<aside[^>]*class="workspace-reconciliation-slot"[^>]*\shidden\b/,
     );
+    // G6-4: the candidate central column uses the compact prose layout
+    // (single H3 + 4 pills + inline mapping + Source/Community lines +
+    // summary <dl>), not the legacy 5-row Card boxes.
+    expect(result.body).toContain('class="ws-recon-mapping"');
+    expect(result.body).toContain('class="ws-recon-summary"');
+    expect(result.body).not.toMatch(
+      /<section class="ws-recon-box">\s*<h4>Candidate<\/h4>/,
+    );
+    expect(result.body).not.toMatch(
+      /<section class="ws-recon-box">\s*<h4>Shared terms<\/h4>/,
+    );
   });
 
   it("declares a mobile breakpoint that collapses the right slot to a bottom sheet at 390 px", () => {


### PR DESCRIPTION
## Summary

Pays back the G6-1 **S0.2** UI debt (`.graphify/scratch/G6-aclp-alignment-punch-list.md`) — the reconciliation candidate / canonical comparison now uses the same **compact prose pattern** as the ACLP-AM Workspace target, instead of the verbose 5-row Card stack delivered with G6-3 routing.

Before (G6-3, `.worktrees/track-g-g6-3-routing/.graphify/scratch/g6-3-reconciliation.png`): two side-by-side `ws-recon-box` cards with `Type / Status / Confidence / Source / Community` each on their own `<dt>/<dd>` row, plus three more framed boxes for Shared terms / Reasons / Decision basis. ~480 px of vertical chrome above the counters.

After (this PR, `.graphify/scratch/g6-4-reconciliation-compact.png`):
- One `<h3>` (the reconcile id) + kicker.
- One toolbar row with 4 pill chips (`entity_match` · `candidate` · `score 95%` · `accept_match`).
- One inline mapping line: `Candidate label → Canonical label`.
- One id mapping line in mono.
- One `·`-separated meta row: `Type · Status · Confidence`.
- Two `Key: value` lines for `SOURCE:` and `COMMUNITY:`.
- One `<dl class="ws-recon-summary">` with three rows for `SHARED TERMS` / `REASONS` / `DECISION BASIS`, small-caps DT + `;`-separated body.

No info loss: every semantic field (`Type`, `Status`, `Confidence`, `Source`, `Community`, `shared_terms`, `reasons`, `evidence_refs`, `proposed_patch_operation`, `candidate_id`, `canonical_id`) stays reachable. Profile-neutral: no `framework` / `abp` / `aclp` / `ABPProcess` / `BusinessObject` / `DigitalApplicationTool` strings introduced.

Commits:
- `6d58953` — TDD red tests (`tests/workspace-display-compact-candidate.test.ts` × 7 + extension of `tests/workspace-reconciliation-subview.test.ts`).
- `1e8789a` — Implementation: refactor `renderCentralDisplay` in `src/ontology-studio-workspace.ts`, swap legacy CSS, fix one Track B legacy assertion that referenced the verbose DOM.
- `c2c4b0c` — `.graphify/` refresh.

## Test plan
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [x] `npm test` → **811 passed | 10 skipped (+8 net vs 803 baseline incl. F-0816-P1)**.
- [x] Targeted: `workspace-display-compact-candidate.test.ts` (7), `workspace-reconciliation-subview.test.ts` (4), `workspace-display-compact.test.ts` (5), `workspace-shell-3col.test.ts`, `workspace-counters.test.ts`, `workspace-graph-selection-filter.test.ts`, `ontology-studio-write.test.ts` — all green.
- [x] Live smoke at `1440 × 1100`: `.graphify/scratch/g6-4-reconciliation-compact.png` matches the ACLP-AM Workspace target (compare with `.graphify/scratch/ref/aclp-am-workspace-target.png`).
- [x] No fixed widths > 1000 px → mobile 390 × 844 wraps cleanly (`.ws-recon-summary` collapses to a single column at `max-width: 768px`).
- [x] No `framework` / `abp` / `aclp` / `ABPProcess` / `BusinessObject` / `DigitalApplicationTool` introduced.

## References
- Punch-list: `.graphify/scratch/G6-aclp-alignment-punch-list.md` (item **S0.2** under `### S0 — Refonte centrale`).
- Before screenshot: `.worktrees/track-g-g6-3-routing/.graphify/scratch/g6-3-reconciliation.png`.
- After screenshot: `.graphify/scratch/g6-4-reconciliation-compact.png`.
- Target reference: `.graphify/scratch/ref/aclp-am-workspace-target.png`.