### PR TITLE
Track F F-0816-P2: 5-row cluster (exit-codes + Unicode dedup + non-English search + env tokens + cluster-only fix)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,24 +1,24 @@
 # Graph Report - .  (2026-05-23)
 
 ## Corpus Check
-- 287 files · ~358 736 words
+- 291 files · ~361 936 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4463 nodes · 7160 edges · 231 communities detected
-- Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
+- 4477 nodes · 7177 edges · 229 communities detected
+- Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 287 · Candidates: 307
-- Excluded: 0 untracked · 15511 ignored · 4 sensitive · 0 missing committed
+- Included files: 291 · Candidates: 312
+- Excluded: 0 untracked · 15742 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `1e8789a`
+- Built from Git commit: `a66b81e`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -84,219 +84,219 @@ Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), 
 
 ### Community 9 - "Community 9"
 Cohesion: 0.06
-Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
+Nodes (52): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+44 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.06
+Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.05
 Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.06
 Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.04
 Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.07
 Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
+Cohesion: 0.05
+Nodes (35): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+27 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.06
 Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
 
-### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (34): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+26 more)
-
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.09
 Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.07
 Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.07
 Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.06
 Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.10
 Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.05
 Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.10
 Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.10
 Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.08
 Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.08
 Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.09
 Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.09
 Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.09
 Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.10
 Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.14
 Nodes (34): buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeConfidence() (+26 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.06
 Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.08
 Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.06
 Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.09
 Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.08
 Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.14
 Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.10
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
+Cohesion: 0.10
+Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
+
+### Community 47 - "Community 47"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
-### Community 46 - "Community 46"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 47 - "Community 47"
+### Community 49 - "Community 49"
 Cohesion: 0.07
 Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 48 - "Community 48"
+### Community 50 - "Community 50"
 Cohesion: 0.09
 Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
 
-### Community 49 - "Community 49"
+### Community 51 - "Community 51"
 Cohesion: 0.07
 Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.10
 Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
-### Community 51 - "Community 51"
+### Community 53 - "Community 53"
 Cohesion: 0.13
 Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
 Cohesion: 0.10
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.13
 Nodes (21): activeViewFromQuery(), candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult() (+13 more)
 
-### Community 54 - "Community 54"
+### Community 56 - "Community 56"
 Cohesion: 0.07
 Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
 
-### Community 55 - "Community 55"
-Cohesion: 0.14
-Nodes (21): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+13 more)
-
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.10
 Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.13
 Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.10
 Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
-
-### Community 62 - "Community 62"
-Cohesion: 0.11
-Nodes (16): AnalysisFile, analyzeGraph(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion(), main() (+8 more)
 
 ### Community 63 - "Community 63"
 Cohesion: 0.13
@@ -351,16 +351,16 @@ Cohesion: 0.13
 Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
 
 ### Community 76 - "Community 76"
+Cohesion: 0.12
+Nodes (19): aliasHit, hit, hits, i18nRecords, ids, index, lower, minimal (+11 more)
+
+### Community 77 - "Community 77"
 Cohesion: 0.13
 Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.15
 Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
-
-### Community 78 - "Community 78"
-Cohesion: 0.13
-Nodes (18): aliasHit, hit, hits, ids, index, lower, minimal, records (+10 more)
 
 ### Community 79 - "Community 79"
 Cohesion: 0.15
@@ -375,64 +375,64 @@ Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
 
 ### Community 82 - "Community 82"
+Cohesion: 0.13
+Nodes (13): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+5 more)
+
+### Community 83 - "Community 83"
 Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
+Cohesion: 0.15
+Nodes (14): AllChunksFailedError, DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape() (+6 more)
+
+### Community 85 - "Community 85"
 Cohesion: 0.11
 Nodes (15): agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined, logs (+7 more)
 
-### Community 84 - "Community 84"
+### Community 86 - "Community 86"
 Cohesion: 0.21
 Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
-### Community 85 - "Community 85"
+### Community 87 - "Community 87"
 Cohesion: 0.12
 Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
 
-### Community 86 - "Community 86"
+### Community 88 - "Community 88"
 Cohesion: 0.12
 Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
 
-### Community 87 - "Community 87"
+### Community 89 - "Community 89"
 Cohesion: 0.20
 Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
 
-### Community 88 - "Community 88"
+### Community 90 - "Community 90"
 Cohesion: 0.17
 Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
 
-### Community 89 - "Community 89"
+### Community 91 - "Community 91"
 Cohesion: 0.12
 Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
 
-### Community 90 - "Community 90"
+### Community 92 - "Community 92"
 Cohesion: 0.12
 Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
 
-### Community 91 - "Community 91"
+### Community 93 - "Community 93"
 Cohesion: 0.13
 Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
 
-### Community 92 - "Community 92"
+### Community 94 - "Community 94"
 Cohesion: 0.13
 Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
 
-### Community 93 - "Community 93"
+### Community 95 - "Community 95"
 Cohesion: 0.13
 Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
 
-### Community 94 - "Community 94"
+### Community 96 - "Community 96"
 Cohesion: 0.20
 Nodes (16): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), projectUninstallAll() (+8 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.16
-Nodes (16): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+8 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.17
-Nodes (13): DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape(), extractSemanticFilesDirectParallel() (+5 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.18
@@ -443,504 +443,504 @@ Cohesion: 0.23
 Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.15
-Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
-
-### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
 
-### Community 101 - "Community 101"
+### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
 
-### Community 102 - "Community 102"
+### Community 101 - "Community 101"
 Cohesion: 0.13
 Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.24
 Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.13
 Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
 
-### Community 105 - "Community 105"
+### Community 104 - "Community 104"
 Cohesion: 0.19
 Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
 
-### Community 106 - "Community 106"
+### Community 105 - "Community 105"
 Cohesion: 0.13
 Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
 
-### Community 107 - "Community 107"
+### Community 106 - "Community 106"
 Cohesion: 0.16
 Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
 
-### Community 108 - "Community 108"
+### Community 107 - "Community 107"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 109 - "Community 109"
+### Community 108 - "Community 108"
 Cohesion: 0.14
 Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
 
-### Community 110 - "Community 110"
+### Community 109 - "Community 109"
 Cohesion: 0.33
 Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
-### Community 111 - "Community 111"
+### Community 110 - "Community 110"
 Cohesion: 0.27
 Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
-### Community 112 - "Community 112"
+### Community 111 - "Community 111"
 Cohesion: 0.14
 Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
 
-### Community 113 - "Community 113"
+### Community 112 - "Community 112"
 Cohesion: 0.14
 Nodes (9): boxes, central, dir, fixture, headingMatches, pills, result, sections (+1 more)
 
-### Community 114 - "Community 114"
+### Community 113 - "Community 113"
 Cohesion: 0.23
 Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.15
 Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (8): ALLOWED_SCHEMES, BLOCKED_HOSTS, isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), validateHostname(), validateUrl()
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 118 - "Community 118"
-Cohesion: 0.21
-Nodes (9): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+1 more)
-
-### Community 119 - "Community 119"
+### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 120 - "Community 120"
+### Community 118 - "Community 118"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 121 - "Community 121"
+### Community 119 - "Community 119"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 122 - "Community 122"
+### Community 120 - "Community 120"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 123 - "Community 123"
+### Community 121 - "Community 121"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 124 - "Community 124"
+### Community 122 - "Community 122"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 125 - "Community 125"
+### Community 123 - "Community 123"
 Cohesion: 0.24
 Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
 
-### Community 126 - "Community 126"
+### Community 124 - "Community 124"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 127 - "Community 127"
+### Community 125 - "Community 125"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 128 - "Community 128"
+### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 129 - "Community 129"
+### Community 127 - "Community 127"
 Cohesion: 0.21
 Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
 
-### Community 130 - "Community 130"
+### Community 128 - "Community 128"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 131 - "Community 131"
+### Community 129 - "Community 129"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 132 - "Community 132"
+### Community 130 - "Community 130"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 133 - "Community 133"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 134 - "Community 134"
+### Community 132 - "Community 132"
 Cohesion: 0.18
 Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
 
-### Community 135 - "Community 135"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 136 - "Community 136"
+### Community 134 - "Community 134"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 137 - "Community 137"
+### Community 135 - "Community 135"
 Cohesion: 0.22
 Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
 
-### Community 138 - "Community 138"
+### Community 136 - "Community 136"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 139 - "Community 139"
+### Community 137 - "Community 137"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 140 - "Community 140"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 141 - "Community 141"
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 142 - "Community 142"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 143 - "Community 143"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 144 - "Community 144"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 145 - "Community 145"
+### Community 143 - "Community 143"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 146 - "Community 146"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 147 - "Community 147"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 148 - "Community 148"
+### Community 146 - "Community 146"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 149 - "Community 149"
+### Community 147 - "Community 147"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 150 - "Community 150"
+### Community 148 - "Community 148"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 151 - "Community 151"
+### Community 149 - "Community 149"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 152 - "Community 152"
+### Community 150 - "Community 150"
+Cohesion: 0.24
+Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
+
+### Community 151 - "Community 151"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.20
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.20
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.22
 Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
-### Community 156 - "Community 156"
+### Community 155 - "Community 155"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 157 - "Community 157"
+### Community 156 - "Community 156"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (4): cleanupDirs, result, root, text
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.39
 Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.39
 Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 165 - "Community 165"
+### Community 164 - "Community 164"
 Cohesion: 0.42
 Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
 
-### Community 166 - "Community 166"
+### Community 165 - "Community 165"
 Cohesion: 0.25
 Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.25
 Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
 
-### Community 168 - "Community 168"
+### Community 167 - "Community 167"
 Cohesion: 0.22
 Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
 
-### Community 169 - "Community 169"
+### Community 168 - "Community 168"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.32
 Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
 
-### Community 171 - "Community 171"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 174 - "Community 174"
-Cohesion: 0.32
-Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
-
-### Community 175 - "Community 175"
+### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (5): html, tokens, html, state, tokens
 
-### Community 176 - "Community 176"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
-### Community 177 - "Community 177"
+### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 178 - "Community 178"
+### Community 176 - "Community 176"
 Cohesion: 0.25
 Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
-### Community 179 - "Community 179"
+### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
-### Community 180 - "Community 180"
+### Community 178 - "Community 178"
 Cohesion: 0.25
 Nodes (7): dataset, dirty, facets, keys, slices, state, status
 
-### Community 181 - "Community 181"
+### Community 179 - "Community 179"
 Cohesion: 0.25
 Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
 
-### Community 182 - "Community 182"
+### Community 180 - "Community 180"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 183 - "Community 183"
+### Community 181 - "Community 181"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 184 - "Community 184"
+### Community 182 - "Community 182"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 185 - "Community 185"
+### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 186 - "Community 186"
+### Community 184 - "Community 184"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 187 - "Community 187"
+### Community 185 - "Community 185"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 188 - "Community 188"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 189 - "Community 189"
+### Community 187 - "Community 187"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 190 - "Community 190"
+### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 191 - "Community 191"
+### Community 189 - "Community 189"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 192 - "Community 192"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 193 - "Community 193"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 194 - "Community 194"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 195 - "Community 195"
+### Community 193 - "Community 193"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 196 - "Community 196"
+### Community 194 - "Community 194"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 197 - "Community 197"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (1): recommendation
 
-### Community 198 - "Community 198"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (3): analysis, evaluation, text
 
-### Community 199 - "Community 199"
+### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
-### Community 200 - "Community 200"
+### Community 198 - "Community 198"
 Cohesion: 0.33
 Nodes (1): CONFIDENCE_VALUES
 
-### Community 201 - "Community 201"
+### Community 199 - "Community 199"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 202 - "Community 202"
-Cohesion: 0.33
-Nodes (6): cacheOptionsFromRuntime(), loadGraph(), loadProfileRuntimeContext(), readJson(), updateCostFile(), writeJson()
-
-### Community 203 - "Community 203"
+### Community 200 - "Community 200"
 Cohesion: 0.33
 Nodes (5): commands, dir, matchers, settings, tempDirs
 
-### Community 204 - "Community 204"
+### Community 201 - "Community 201"
 Cohesion: 0.33
 Nodes (5): dir, original, rule, rulePath, tempDirs
 
-### Community 205 - "Community 205"
+### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
-### Community 206 - "Community 206"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (4): dir, logs, preview, tempDirs
 
-### Community 207 - "Community 207"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
-### Community 208 - "Community 208"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
-### Community 209 - "Community 209"
-Cohesion: 0.33
-Nodes (4): contents, dir, lockPath, tempDirs
-
-### Community 210 - "Community 210"
+### Community 206 - "Community 206"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 211 - "Community 211"
+### Community 207 - "Community 207"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 212 - "Community 212"
+### Community 208 - "Community 208"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 213 - "Community 213"
+### Community 209 - "Community 209"
 Cohesion: 0.40
 Nodes (4): chunks, client, files, root
 
-### Community 214 - "Community 214"
+### Community 210 - "Community 210"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 215 - "Community 215"
+### Community 211 - "Community 211"
 Cohesion: 0.40
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 216 - "Community 216"
+### Community 212 - "Community 212"
 Cohesion: 0.40
 Nodes (4): candidateGraph, graph, html, tokens
 
-### Community 217 - "Community 217"
+### Community 213 - "Community 213"
 Cohesion: 0.40
 Nodes (4): character, dataset, groups, total
 
-### Community 218 - "Community 218"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 219 - "Community 219"
+### Community 215 - "Community 215"
 Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 220 - "Community 220"
+### Community 216 - "Community 216"
+Cohesion: 0.50
+Nodes (2): extraction, out
+
+### Community 217 - "Community 217"
+Cohesion: 0.50
+Nodes (1): { root, files, cleanup }
+
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 221 - "Community 221"
+### Community 219 - "Community 219"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 222 - "Community 222"
+### Community 220 - "Community 220"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 223 - "Community 223"
+### Community 221 - "Community 221"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
+
+### Community 222 - "Community 222"
+Cohesion: 1.00
+Nodes (2): average(), evaluateReviewAnalysis()
+
+### Community 223 - "Community 223"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 224 - "Community 224"
 Cohesion: 1.00
@@ -952,64 +952,60 @@ Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 226 - "Community 226"
 Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Nodes (1): UnpdfTextResult
 
 ### Community 227 - "Community 227"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 228 - "Community 228"
-Cohesion: 1.00
-Nodes (1): UnpdfTextResult
-
-### Community 229 - "Community 229"
-Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 230 - "Community 230"
+### Community 228 - "Community 228"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1761 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1756 more)
+- **1765 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1760 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 82`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 158`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 160`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 181`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `recommendation`
+- **Thin community `Community 195`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 198`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `paths`, `root`
+- **Thin community `Community 216`** (2 nodes): `extraction`, `out`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 217`** (1 nodes): `{ root, files, cleanup }`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 219`** (2 nodes): `paths`, `root`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 221`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 222`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 223`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 224`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 225`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 226`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 227`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `UnpdfTextResult`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `tempProfileProject()`, `tempProject()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 228`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 81`, `Community 35`?**
+- **Why does `Cookies` connect `Community 4` to `Community 81`, `Community 36`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 81`, `Community 35`?**
+- **Why does `Cookies` connect `Community 0` to `Community 81`, `Community 36`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._

--- a/src/build.ts
+++ b/src/build.ts
@@ -46,10 +46,25 @@ function normalizeSourceFilePath(value: unknown, root?: string): string | undefi
   return normalised;
 }
 
+// Unicode word characters (letters + digits across scripts) plus underscore.
+// Ports safishamsi 86109e9 (#937) to TypeScript: Python's
+// `re.sub(r"[\W_]+", " ", label.casefold(), flags=re.UNICODE)` becomes
+// `replace(/[^\p{L}\p{N}]+/gu, " ")` in JS (since `\W` is ASCII-only
+// without `u`, we spell the inverted Unicode class explicitly).
+const UNICODE_NON_WORD = /[^\p{L}\p{N}]+/gu;
+// ASCII-only labels still go through the legacy 3-char noise gate
+// (intentional TS delta documented in tests/build-merge.test.ts).
+// Non-ASCII labels carry meaningful semantic weight at 2 characters
+// (e.g. 前端, 東京) and must not be silently skipped.
+const ASCII_ONLY = /^[\x20-\x7E]*$/;
+
 function normalizedLabel(value: string): string {
+  // NFKC canonicalises width/compatibility variants (e.g. fullwidth digits
+  // １２３ → 123) so labels that differ only in glyph form dedup together.
   return value
+    .normalize("NFKC")
     .toLowerCase()
-    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(UNICODE_NON_WORD, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -59,7 +74,9 @@ function dedupLabelKey(node: Extraction["nodes"][number]): string | null {
   const label = normalizedLabel(rawLabel);
   if (!label) return null;
   const compactLabel = label.replace(/ /g, "");
-  if (compactLabel.length <= 3 || SKU_LIKE_LABEL.test(rawLabel)) return null;
+  const isAsciiOnly = ASCII_ONLY.test(rawLabel);
+  if (isAsciiOnly && compactLabel.length <= 3) return null;
+  if (SKU_LIKE_LABEL.test(rawLabel)) return null;
   return label;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3333,6 +3333,13 @@ export async function main(): Promise<void> {
         process.exit(1);
       }
 
+      // Track F F-0816-P2 row 15 (port safishamsi 076e6b7 / #934):
+      // Re-clustering must survive the case where the output directory
+      // around graph.json was partially archived. Recreating the state
+      // dir (idempotent on the happy path) keeps writeFileSync(...)
+      // from blowing up with ENOENT before any side-effect.
+      mkdirSync(paths.stateDir, { recursive: true });
+
       const G = makeGraphPortable(loadGraphFromData(JSON.parse(readFileSync(paths.graph, "utf-8"))), root);
       const { cluster, scoreAll } = await import("./cluster.js");
       const { godNodes, surprisingConnections, suggestQuestions } = await import("./analyze.js");

--- a/src/direct-llm-extract.ts
+++ b/src/direct-llm-extract.ts
@@ -209,6 +209,35 @@ export function createDirectSemanticExtractionClient(
   };
 }
 
+/**
+ * Track F F-0816-P2 row 3 (port safishamsi 3238b32 / #889): typed error
+ * raised when every semantic chunk in a fresh extraction errored. The
+ * CLI catches this and exits non-zero with the backend name in the
+ * stderr message so CI checking exit status no longer silently passes.
+ */
+export class AllChunksFailedError extends Error {
+  override readonly name = "AllChunksFailedError";
+  readonly backend: string;
+  readonly totalChunks: number;
+  readonly totalFiles: number;
+  readonly chunkErrors: ReadonlyArray<{ chunkIndex: number; error: Error }>;
+  constructor(input: {
+    backend: string;
+    totalChunks: number;
+    totalFiles: number;
+    chunkErrors: Array<{ chunkIndex: number; error: Error }>;
+  }) {
+    const hint = "If you see 'requires the X package', run `npm install X` and retry.";
+    super(
+      `all semantic chunks failed for backend '${input.backend}' (${input.totalChunks} chunk(s), ${input.totalFiles} file(s)) - see per-chunk errors above. ${hint}`,
+    );
+    this.backend = input.backend;
+    this.totalChunks = input.totalChunks;
+    this.totalFiles = input.totalFiles;
+    this.chunkErrors = input.chunkErrors;
+  }
+}
+
 export async function extractSemanticFilesDirectParallel(
   files: string[],
   options: DirectSemanticExtractionOptions,
@@ -216,6 +245,12 @@ export async function extractSemanticFilesDirectParallel(
   const chunks = packSemanticFilesByTokenBudget(files, { tokenBudget: options.tokenBudget });
   const maxConcurrency = Math.max(1, Math.floor(options.maxConcurrency ?? 4));
   const results: Partial<Extraction>[] = new Array(chunks.length);
+  // Track per-chunk success so we can surface a clear non-zero exit when
+  // every chunk errored (e.g. backend SDK missing, invalid API key,
+  // network outage). Per-chunk failures are otherwise non-fatal: we
+  // print to stderr and let the remaining chunks try.
+  const chunkErrors: Array<{ chunkIndex: number; error: Error }> = [];
+  let succeeded = 0;
   let nextIndex = 0;
 
   async function worker(): Promise<void> {
@@ -223,15 +258,38 @@ export async function extractSemanticFilesDirectParallel(
       const index = nextIndex++;
       const chunk = chunks[index]!;
       const semanticFiles = chunk.files.map((file) => readSemanticFile(options.root, file));
-      results[index] = await options.client.extractChunk({
-        chunkIndex: index,
-        chunkCount: chunks.length,
-        files: semanticFiles,
-      });
+      try {
+        results[index] = await options.client.extractChunk({
+          chunkIndex: index,
+          chunkCount: chunks.length,
+          files: semanticFiles,
+        });
+        succeeded += 1;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        chunkErrors.push({ chunkIndex: index, error });
+        // eslint-disable-next-line no-console
+        console.error(
+          `[graphify extract] chunk ${index + 1}/${chunks.length} failed: ${error.message}`,
+        );
+      }
     }
   }
 
   const workerCount = Math.min(maxConcurrency, chunks.length);
   await Promise.all(Array.from({ length: workerCount }, () => worker()));
-  return mergeExtractions(results);
+
+  // Mirror upstream `__main__.py` guard: if a fresh extraction was
+  // requested (chunks.length > 0) and zero chunks completed, abort
+  // before the merge / cluster / write phase.
+  if (chunks.length > 0 && succeeded === 0) {
+    throw new AllChunksFailedError({
+      backend: options.client.provider,
+      totalChunks: chunks.length,
+      totalFiles: files.length,
+      chunkErrors,
+    });
+  }
+
+  return mergeExtractions(results.filter((entry) => entry !== undefined) as Partial<Extraction>[]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,6 +283,7 @@ export type { PdfPreparationArtifact, PdfPreparationOptions } from "./pdf-ocr.js
 export { prepareSemanticDetection } from "./semantic-prepare.js";
 export type { SemanticPreparationOptions, SemanticPreparationResult } from "./semantic-prepare.js";
 export {
+  AllChunksFailedError,
   createDirectSemanticExtractionClient,
   extractSemanticFilesDirectParallel,
   packSemanticFilesByTokenBudget,

--- a/src/llm-execution.ts
+++ b/src/llm-execution.ts
@@ -381,11 +381,37 @@ export function createAssistantVisionJsonClient(options: AssistantLlmClientOptio
   };
 }
 
+/**
+ * Track F F-0816-P2 row 14 (port safishamsi 06a9b72 / #973): honor the
+ * `GRAPHIFY_MAX_OUTPUT_TOKENS` environment override when the caller did
+ * not pass an explicit value. Upstream Python `_resolve_max_tokens` does
+ * the same for all OpenAI-compatible backends (gemini, openai, kimi,
+ * deepseek, ollama) plus Claude / Bedrock; in this TS fork the equivalent
+ * routing point is `createDirectTextJsonClient`.
+ *
+ * Precedence — explicit > env > undefined — matches the upstream cfg
+ * precedence (caller cfg dict wins over env, env wins over default).
+ * Invalid / non-positive env values are silently ignored so a typo in
+ * the shell does not surprise a long-running CI job.
+ */
+export function resolveMaxOutputTokens(explicit?: number): number | undefined {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const raw = process.env.GRAPHIFY_MAX_OUTPUT_TOKENS;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
 export function createDirectTextJsonClient(options: DirectTextJsonClientOptions): TextJsonGenerationClient {
   const provider = options.provider;
   const model = options.model?.trim() || defaultDirectLlmModel(provider);
   const temperature = options.temperature ?? 0;
-  const maxOutputTokens = options.maxOutputTokens;
+  const maxOutputTokens = resolveMaxOutputTokens(options.maxOutputTokens);
   return {
     mode: "direct",
     provider,

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,6 +5,43 @@ export function normalizeSearchText(value: string): string {
     .toLowerCase();
 }
 
+/**
+ * Split a query into searchable terms, filtering only short pure-English
+ * tokens (length <= 2 ASCII chars). Centralised here so the MCP CLI,
+ * `query_graph`, and any future benchmark/scoring code share the same
+ * tokenisation rule. Mirrors upstream `graphify.serve._query_terms`
+ * (safishamsi 020cca2 / #964): two-character CJK / Cyrillic / Greek
+ * terms must remain searchable, English stopwords like "to"/"of" stay
+ * filtered.
+ *
+ * Behaviour:
+ * - splits on whitespace
+ * - lowercases each raw token
+ * - drops the token if it is composed entirely of ASCII a-z and shorter
+ *   than 3 chars; non-ASCII (or mixed) tokens of any length are kept
+ */
+export function queryTerms(question: string): string[] {
+  if (typeof question !== "string") return [];
+  const out: string[] = [];
+  for (const raw of question.split(/\s+/)) {
+    const term = raw.toLowerCase().trim();
+    if (!term) continue;
+    let englishOnly = true;
+    for (let i = 0; i < term.length; i++) {
+      const ch = term.charCodeAt(i);
+      // 0x61..0x7A is "a".."z"; anything else (digits, punctuation, CJK,
+      // accented letters) breaks the "pure English" classification.
+      if (ch < 0x61 || ch > 0x7a) {
+        englishOnly = false;
+        break;
+      }
+    }
+    if (englishOnly && term.length <= 2) continue;
+    out.push(term);
+  }
+  return out;
+}
+
 export function textMatchesQuery(text: string, query: string): boolean {
   const normalizedText = normalizeSearchText(text);
   const terms = normalizeSearchText(query).split(/\s+/).filter(Boolean);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -15,7 +15,7 @@ import {
 } from "./graph.js";
 import { resolveGraphInputPath } from "./paths.js";
 import { validateGraphPath, sanitizeLabel } from "./security.js";
-import { normalizeSearchText, scoreSearchText, textMatchesQuery } from "./search.js";
+import { normalizeSearchText, queryTerms, scoreSearchText, textMatchesQuery } from "./search.js";
 import {
   godNodes as computeGodNodes,
   surprisingConnections,
@@ -335,10 +335,10 @@ function toolQueryGraph(G: Graph, args: Record<string, unknown>): string {
   const mode = (args.mode as string) ?? "bfs";
   const depth = Math.min(Number(args.depth ?? 3), 6);
   const budget = Number(args.token_budget ?? 2000);
-  const terms = question
-    .split(/\s+/)
-    .filter((t) => t.length > 2)
-    .map(normalizeSearchText);
+  // Track F F-0816-P2 row 12 (port safishamsi 020cca2 / #964):
+  // queryTerms() centralises the "filter short English noise only" rule
+  // so two-character non-English query tokens (e.g. 前端) remain searchable.
+  const terms = queryTerms(question).map(normalizeSearchText);
 
   const scored = scoreNodes(G, terms);
   const startNodes = scored.slice(0, 3).map(([, nid]) => nid);

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -1496,6 +1496,22 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         { input: 0, output: 0 },
         { labelsPath },
       );
+      // Track F F-0816-P2 row 15 (port safishamsi 076e6b7 / #934):
+      // cluster-only crashed when the output directory had been archived
+      // and only --graph pointed at a surviving backup. Recreate the
+      // parent directories of every output artifact before any write so
+      // the command stays idempotent across archive/restore workflows.
+      // (Upstream applies the same `mkdir(parents=True, exist_ok=True)`
+      // contract.)
+      for (const target of [
+        resolve(opts.graphOut),
+        resolve(opts.reportOut),
+        resolve(opts.analysisOut),
+        labelsPath,
+        ...(opts.htmlOut ? [resolve(opts.htmlOut)] : []),
+      ]) {
+        mkdirSync(dirname(target), { recursive: true });
+      }
       toJson(G, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
       });

--- a/tests/build-cjk-label-dedup.test.ts
+++ b/tests/build-cjk-label-dedup.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Track F F-0816-P2 (row 6) — port of safishamsi 86109e9 (#937).
+ *
+ * `deduplicateByLabel` used ASCII-only character class `[^a-z0-9 ]+` in the
+ * canonical dedup key, so any node whose label was entirely composed of
+ * CJK / Cyrillic / Greek / accented characters collapsed to the empty
+ * string and was silently skipped from the dedup pass. Upstream switched
+ * to a Unicode-aware normalization: NFKC + casefold + collapse runs of
+ * non-word characters. Match that behavior so CJK labels are deduplicated
+ * the same way ASCII labels already were.
+ *
+ * The existing TS guard against short noise (`compactLabel.length <= 3`)
+ * is kept as an intentional delta but must NOT silently exclude CJK
+ * tokens that already carry meaningful semantic weight at 2 characters.
+ */
+import { describe, expect, it } from "vitest";
+
+import { deduplicateByLabel } from "../src/build.js";
+import type { Extraction } from "../src/types.js";
+
+function ext(nodes: Extraction["nodes"], edges: Extraction["edges"] = []): Extraction {
+  return {
+    nodes,
+    edges,
+    hyperedges: [],
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+}
+
+describe("Track F F-0816-P2 (row 6) — CJK/Unicode label dedup", () => {
+  it("deduplicates duplicate CJK labels across chunks", () => {
+    // 前端 (Frontend) appears twice from two semantic chunks. Pre-fix:
+    // both labels normalized to "" via [^a-z0-9 ] and were left intact.
+    const extraction = ext([
+      { id: "frontend_c1", label: "前端开发", source_file: "docs/前端.md", file_type: "document" },
+      { id: "frontend", label: "前端开发", source_file: "docs/前端.md", file_type: "document" },
+    ], [
+      { source: "frontend_c1", target: "frontend", relation: "mentions", confidence: "EXTRACTED", source_file: "docs/前端.md" },
+    ]);
+    const out = deduplicateByLabel(extraction);
+    // The two CJK-only labels must collapse to a single node.
+    expect(out.nodes).toHaveLength(1);
+    // Self-loop edges are dropped after dedup.
+    expect(out.edges.filter((e) => e.source !== e.target)).toHaveLength(0);
+  });
+
+  it("deduplicates accented Latin labels via NFKC + casefold", () => {
+    const extraction = ext([
+      { id: "cafe_c1", label: "Café Société", source_file: "docs/cafe.md", file_type: "document" },
+      { id: "cafe", label: "café société", source_file: "docs/cafe.md", file_type: "document" },
+    ]);
+    const out = deduplicateByLabel(extraction);
+    expect(out.nodes).toHaveLength(1);
+  });
+
+  it("keeps non-CJK SKU-like labels untouched (existing TS intentional delta)", () => {
+    const extraction = ext([
+      { id: "sku_c1", label: "ABC-123", source_file: "data/skus.md", file_type: "document" },
+      { id: "sku_c2", label: "abc-123", source_file: "data/skus2.md", file_type: "document" },
+    ]);
+    const out = deduplicateByLabel(extraction);
+    // SKU-like labels are intentionally excluded from dedup — preserve.
+    expect(out.nodes).toHaveLength(2);
+  });
+
+  it("does not over-merge distinct CJK labels", () => {
+    const extraction = ext([
+      { id: "frontend", label: "前端开发", source_file: "docs/frontend.md", file_type: "document" },
+      { id: "backend", label: "后端开发", source_file: "docs/backend.md", file_type: "document" },
+    ]);
+    const out = deduplicateByLabel(extraction);
+    expect(out.nodes).toHaveLength(2);
+  });
+
+  it("treats fullwidth and halfwidth digits as equivalent via NFKC", () => {
+    // NFKC canonicalises fullwidth digits "１２３" to "123", letting Unicode
+    // labels with mixed widths dedup the same way ASCII ones already do.
+    const extraction = ext([
+      { id: "topic_c1", label: "Topic１２３", source_file: "docs/t.md", file_type: "document" },
+      { id: "topic_c2", label: "Topic123", source_file: "docs/t.md", file_type: "document" },
+    ]);
+    const out = deduplicateByLabel(extraction);
+    expect(out.nodes).toHaveLength(1);
+  });
+});

--- a/tests/cli-cluster-only-missing-graphify-out.test.ts
+++ b/tests/cli-cluster-only-missing-graphify-out.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Track F F-0816-P2 (row 15) — port of safishamsi 076e6b7 (#934).
+ *
+ * `cluster-only` crashed with FileNotFoundError when the output directory
+ * (`graphify-out/` in Python, `.graphify/` in TS) did not exist - typical
+ * workflow: archive / move the output dir, point `--graph` at a backup
+ * `graph.json`, run `cluster-only` again. Upstream fix is one line:
+ * `out.mkdir(parents=True, exist_ok=True)` before any write. Port the
+ * same behaviour to the TS skill-runtime `cluster-only` command and to
+ * the public `graphify cluster-only` path that reuses `.graphify/` as
+ * its implicit output dir.
+ */
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function tempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-cluster-only-missing-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function fixtureGraph() {
+  return {
+    directed: false,
+    graph: {},
+    nodes: [
+      { id: "alpha", label: "AlphaService", source_file: "src/alpha.ts", file_type: "code" },
+      { id: "beta", label: "BetaRepository", source_file: "src/beta.ts", file_type: "code" },
+    ],
+    links: [
+      { source: "alpha", target: "beta", relation: "uses", confidence: "EXTRACTED", source_file: "src/alpha.ts" },
+    ],
+  };
+}
+
+async function runSkillRuntime(args: string[]): Promise<{ exitCode: number; errors: string }> {
+  const { main } = await import("../src/skill-runtime.js");
+  const originalExit = process.exit;
+  const originalError = console.error;
+  const errors: string[] = [];
+  console.error = (...msg: unknown[]) => { errors.push(msg.join(" ")); };
+  process.exit = ((code?: string | number | null) => {
+    throw new Error(`process.exit ${code ?? 0}`);
+  }) as typeof process.exit;
+  try {
+    await main(["node", "skill-runtime", ...args]);
+    return { exitCode: 0, errors: errors.join("\n") };
+  } catch (err) {
+    const m = (err as Error).message.match(/^process\.exit (\d+)/);
+    if (m) return { exitCode: Number(m[1]), errors: errors.join("\n") };
+    errors.push((err as Error).message);
+    return { exitCode: 1, errors: errors.join("\n") };
+  } finally {
+    process.exit = originalExit;
+    console.error = originalError;
+  }
+}
+
+describe("Track F F-0816-P2 (row 15) — cluster-only when output dir is missing", () => {
+  it("skill-runtime cluster-only creates missing output dirs before writing", async () => {
+    const root = tempProject();
+    // Graph backup lives outside the (deleted) output directory.
+    const backupDir = join(root, "backup");
+    mkdirSync(backupDir, { recursive: true });
+    const graphSrc = join(backupDir, "graph.json");
+    writeFileSync(graphSrc, JSON.stringify(fixtureGraph()), "utf-8");
+
+    // Output paths point inside a `.graphify/` directory that does NOT exist yet.
+    const outDir = join(root, ".graphify");
+    const graphOut = join(outDir, "graph.json");
+    const reportOut = join(outDir, "GRAPH_REPORT.md");
+    const analysisOut = join(outDir, ".graphify_analysis.json");
+    expect(existsSync(outDir)).toBe(false);
+
+    const result = await runSkillRuntime([
+      "cluster-only",
+      "--graph", graphSrc,
+      "--root", root,
+      "--graph-out", graphOut,
+      "--report-out", reportOut,
+      "--analysis-out", analysisOut,
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(graphOut)).toBe(true);
+    expect(existsSync(reportOut)).toBe(true);
+    expect(existsSync(analysisOut)).toBe(true);
+    // graph.json round-trips with the input nodes.
+    const out = JSON.parse(readFileSync(graphOut, "utf-8")) as { nodes: Array<{ id: string }> };
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("public CLI cluster-only re-creates .graphify/ subdirs when only graph.json survived", async () => {
+    const root = tempProject();
+    // Seed .graphify/graph.json then delete sibling artifacts to mimic the
+    // upstream scenario (user archived the rest of the output directory).
+    const stateDir = join(root, ".graphify");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, "graph.json"), JSON.stringify(fixtureGraph()), "utf-8");
+    // Pre-fix: writeFileSync(report) blew up if any subdir on the path
+    // had been removed. Simulate by removing the (otherwise existing)
+    // `.graphify/scratch/` parent the analysis JSON would land under.
+    // We just verify the command completes cleanly when `.graphify/`
+    // contains only graph.json.
+
+    const { main } = await import("../src/cli.js");
+    const originalArgv = process.argv;
+    const originalCwd = process.cwd();
+    const originalLog = console.log;
+    const originalErr = console.error;
+    const originalWarn = console.warn;
+    const originalExit = process.exit;
+    const errors: string[] = [];
+    const logs: string[] = [];
+    let exitCode = 0;
+    console.log = (...m: unknown[]) => { logs.push(m.join(" ")); };
+    console.error = (...m: unknown[]) => { errors.push(m.join(" ")); };
+    console.warn = () => undefined;
+    process.exit = ((code?: string | number | null) => {
+      exitCode = Number(code ?? 0);
+      throw new Error("__exit__");
+    }) as typeof process.exit;
+
+    process.argv = ["node", "graphify", "cluster-only", root];
+    process.chdir(root);
+    try {
+      await main();
+    } catch (err) {
+      if ((err as Error).message !== "__exit__") {
+        errors.push((err as Error).message);
+        exitCode = 1;
+      }
+    } finally {
+      process.argv = originalArgv;
+      process.chdir(originalCwd);
+      console.log = originalLog;
+      console.error = originalErr;
+      console.warn = originalWarn;
+      process.exit = originalExit;
+    }
+
+    // Sanity: no fatal error string.
+    expect(errors.join("\n")).not.toMatch(/ENOENT|FileNotFound/);
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(stateDir, "GRAPH_REPORT.md"))).toBe(true);
+    // graph.html ALSO landed; the .graphify/ scratch artifact too.
+    void dirname; // keep import (used by readability of test); no-op
+  });
+});

--- a/tests/extract-all-chunks-fail.test.ts
+++ b/tests/extract-all-chunks-fail.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Track F F-0816-P2 (row 3) — port of safishamsi 3238b32 (#889).
+ *
+ * Upstream: when `graphify extract --backend <name>` runs without the
+ * backend SDK installed, every semantic chunk errors inside
+ * `extract_corpus_parallel`. The per-chunk failures print to stderr but
+ * the function returned the empty merged accumulator anyway, so extract
+ * proceeded to write an AST-only graph.json and exit 0. CI that checks
+ * exit status saw success even though the requested semantic pass
+ * produced no nodes.
+ *
+ * Port: per-chunk errors are swallowed (printed to stderr, do not abort
+ * the run), and after all chunks have been attempted the CLI fails
+ * loudly with a non-zero exit if zero chunks succeeded out of the
+ * requested set.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  extractSemanticFilesDirectParallel,
+  AllChunksFailedError,
+} from "../src/direct-llm-extract.js";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function tempCorpus(): { root: string; cleanup: () => void; files: string[] } {
+  const root = mkdtempSync(join(tmpdir(), "graphify-extract-fail-"));
+  const files = [
+    join(root, "doc-a.md"),
+    join(root, "doc-b.md"),
+  ];
+  writeFileSync(files[0], "# Doc A\nFirst document.", "utf-8");
+  writeFileSync(files[1], "# Doc B\nSecond document.", "utf-8");
+  return { root, files, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe("Track F F-0816-P2 (row 3) — all chunks fail surfaces a typed error", () => {
+  it("throws AllChunksFailedError when every chunk's extractChunk rejects", async () => {
+    const { root, files, cleanup } = tempCorpus();
+    try {
+      await expect(
+        extractSemanticFilesDirectParallel(files, {
+          root,
+          client: {
+            provider: "anthropic",
+            async extractChunk() {
+              throw new Error("backend SDK missing: anthropic");
+            },
+          },
+          tokenBudget: 10,
+          maxConcurrency: 1,
+        }),
+      ).rejects.toBeInstanceOf(AllChunksFailedError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("AllChunksFailedError carries backend + chunk counts for the CLI message", async () => {
+    const { root, files, cleanup } = tempCorpus();
+    try {
+      let caught: AllChunksFailedError | undefined;
+      try {
+        await extractSemanticFilesDirectParallel(files, {
+          root,
+          client: {
+            provider: "gemini",
+            async extractChunk() {
+              throw new Error("HTTP 401 invalid api key");
+            },
+          },
+          tokenBudget: 10,
+          maxConcurrency: 1,
+        });
+      } catch (err) {
+        if (err instanceof AllChunksFailedError) caught = err;
+      }
+      expect(caught).toBeDefined();
+      expect(caught!.backend).toBe("gemini");
+      expect(caught!.totalChunks).toBeGreaterThanOrEqual(1);
+      expect(caught!.totalFiles).toBe(2);
+      expect(caught!.message).toMatch(/all semantic chunks failed/);
+      expect(caught!.message).toMatch(/gemini/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returns merged extraction when at least one chunk succeeds (other chunks errored)", async () => {
+    const { root, files, cleanup } = tempCorpus();
+    try {
+      let call = 0;
+      const result = await extractSemanticFilesDirectParallel(files, {
+        root,
+        client: {
+          provider: "anthropic",
+          async extractChunk() {
+            call += 1;
+            if (call === 1) throw new Error("transient 429");
+            return {
+              nodes: [{ id: "doc-a", label: "Doc A", source_file: "doc-a.md", file_type: "document" }],
+              edges: [],
+              input_tokens: 10,
+              output_tokens: 5,
+            };
+          },
+        },
+        tokenBudget: 10,
+        maxConcurrency: 1,
+      });
+      expect(result.nodes).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rethrows AllChunksFailedError unchanged from a parallel run", async () => {
+    const { root, files, cleanup } = tempCorpus();
+    try {
+      await expect(
+        extractSemanticFilesDirectParallel(files, {
+          root,
+          client: {
+            provider: "openai",
+            async extractChunk() {
+              throw new Error("HTTP 500");
+            },
+          },
+          tokenBudget: 1, // force at least 2 chunks
+          maxConcurrency: 2,
+        }),
+      ).rejects.toBeInstanceOf(AllChunksFailedError);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/llm-mesh-max-output-tokens-env.test.ts
+++ b/tests/llm-mesh-max-output-tokens-env.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Track F F-0816-P2 (row 14) — port of safishamsi 06a9b72 (#973).
+ *
+ * Upstream OpenAI-compatible LLM backends silently ignored the documented
+ * `GRAPHIFY_MAX_OUTPUT_TOKENS` env override when the backend cfg dict
+ * already carried a hardcoded value. Symptom for gemini-2.5-pro: 16k cap
+ * truncated multi-document chunks mid-JSON, producing cascading
+ * `Unterminated string at column ...` parse errors and bisect-retry
+ * storms that billed input tokens without producing graph nodes.
+ *
+ * In the TS fork the equivalent surface is `createDirectTextJsonClient`
+ * in src/llm-execution.ts. The default `maxOutputTokens` resolution now
+ * reads `process.env.GRAPHIFY_MAX_OUTPUT_TOKENS` when the caller does
+ * NOT pass an explicit override; an explicit caller value still wins.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  resolveMaxOutputTokens,
+  createDirectTextJsonClient,
+} from "../src/llm-execution.js";
+
+describe("Track F F-0816-P2 (row 14) — GRAPHIFY_MAX_OUTPUT_TOKENS env", () => {
+  const savedEnv = process.env.GRAPHIFY_MAX_OUTPUT_TOKENS;
+
+  beforeEach(() => {
+    delete process.env.GRAPHIFY_MAX_OUTPUT_TOKENS;
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.GRAPHIFY_MAX_OUTPUT_TOKENS;
+    else process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = savedEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when env var is unset and no explicit value", () => {
+    expect(resolveMaxOutputTokens(undefined)).toBeUndefined();
+  });
+
+  it("honours the env var when no explicit value is supplied", () => {
+    process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "32000";
+    expect(resolveMaxOutputTokens(undefined)).toBe(32000);
+  });
+
+  it("explicit caller value still wins over env override (matches upstream cfg precedence)", () => {
+    process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "32000";
+    expect(resolveMaxOutputTokens(8192)).toBe(8192);
+  });
+
+  it("rejects non-integer / non-positive env values silently", () => {
+    process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "not-a-number";
+    expect(resolveMaxOutputTokens(undefined)).toBeUndefined();
+    process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "0";
+    expect(resolveMaxOutputTokens(undefined)).toBeUndefined();
+    process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "-512";
+    expect(resolveMaxOutputTokens(undefined)).toBeUndefined();
+  });
+
+  it("plumbs the env value into createDirectTextJsonClient.generateJson", async () => {
+    // Mock the ai SDK so the test does not actually call any backend.
+    let observed: { temperature?: number; maxOutputTokens?: number } | undefined;
+    vi.doMock("ai", () => ({
+      async generateText(args: { temperature?: number; maxOutputTokens?: number }): Promise<{
+        text: string;
+        finishReason: string;
+        usage: Record<string, number>;
+      }> {
+        observed = { temperature: args.temperature, maxOutputTokens: args.maxOutputTokens };
+        return { text: '{"ok":true}', finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } };
+      },
+    }));
+    // resolveDirectModel routes through ai-sdk providers; we mock the
+    // provider too so the test does not require provider credentials.
+    vi.doMock("@ai-sdk/openai", () => ({
+      openai: () => ({ provider: "openai" }),
+    }));
+
+    process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "12345";
+    process.env.OPENAI_API_KEY = "sk-test-key-for-graphify";
+
+    // Re-import the module under test after mocking deps.
+    vi.resetModules();
+    const llmModule = await import("../src/llm-execution.js");
+    const client = llmModule.createDirectTextJsonClient({ provider: "openai", model: "gpt-5.5" });
+    void client; // suppress unused warning if test bails early
+
+    // The plumbing happens inside generateJson — exercise it.
+    await llmModule.createDirectTextJsonClient({ provider: "openai", model: "gpt-5.5" }).generateJson({
+      schema: "graphify_extraction_v1",
+      prompt: "test",
+    });
+
+    expect(observed).toBeDefined();
+    expect(observed!.maxOutputTokens).toBe(12345);
+  });
+});

--- a/tests/serve-query-terms.test.ts
+++ b/tests/serve-query-terms.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Track F F-0816-P2 (row 12) — port of safishamsi 020cca2 (#964).
+ *
+ * Upstream `serve.py` and `benchmark.py` filtered every query token with
+ * `len > 2`, which dropped two-character Chinese / Japanese / Korean
+ * terms (e.g. 前端, 依赖, 安装) while trying to suppress short English
+ * noise. Upstream introduced a centralised `_query_terms()` helper that
+ * applies the length gate only to pure-English tokens so mixed and
+ * non-English terms remain searchable. Port the same contract via
+ * `queryTerms()` in src/search.ts and route the MCP `query_graph`
+ * tokenization through it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { queryTerms } from "../src/search.js";
+
+describe("Track F F-0816-P2 (row 12) — queryTerms", () => {
+  it("keeps two-character non-English terms (CJK)", () => {
+    expect(queryTerms("前端 dependency 依赖 install 安装 to of 包管理器 项目约定 a前"))
+      .toEqual(["前端", "dependency", "依赖", "install", "安装", "包管理器", "项目约定", "a前"]);
+  });
+
+  it("filters short pure-English noise (<=2 chars)", () => {
+    expect(queryTerms("to of by a an it of in on")).toEqual([]);
+    expect(queryTerms("the cat is on a mat")).toEqual(["the", "cat", "mat"]);
+  });
+
+  it("normalises case for English tokens", () => {
+    expect(queryTerms("AlphaService BetaRepository")).toEqual([
+      "alphaservice",
+      "betarepository",
+    ]);
+  });
+
+  it("returns empty array on empty / whitespace input", () => {
+    expect(queryTerms("")).toEqual([]);
+    expect(queryTerms("   \n\t")).toEqual([]);
+  });
+
+  it("treats mixed ASCII+CJK tokens as non-English (kept)", () => {
+    // Single ASCII char prefixed before CJK ("a前") is not pure English -
+    // upstream keeps it. Same goes for words like "前end" or "café".
+    expect(queryTerms("a前 café résumé")).toEqual(["a前", "café", "résumé"]);
+  });
+
+  it("filters short Latin-with-diacritic tokens like é but keeps semantic CJK pairs", () => {
+    // A single accented letter like "é" alone is still short noise; the
+    // upstream helper does not treat single accented chars as semantic.
+    // We follow the upstream rule: short non-English (length <= 2) tokens
+    // that contain ANY non-ASCII char are kept.
+    expect(queryTerms("é 前 ok hello")).toEqual(["é", "前", "hello"]);
+  });
+});

--- a/tests/workspace-search-index.test.ts
+++ b/tests/workspace-search-index.test.ts
@@ -122,4 +122,45 @@ describe("Track G G6-2 — workspace search index", () => {
     const index = buildWorkspaceSearchIndex(minimal);
     expect(searchWorkspaceIndex(index, "x").map((h) => h.id)).toContain("x");
   });
+
+  // Track F F-0816-P2 row 12 (port safishamsi 020cca2 / #964): verify that
+  // non-English query terms are still searchable via the workspace rail
+  // index. The G6-2 index already tokenises on Unicode `\p{L}\p{N}`, so
+  // CJK / French / Arabic labels must round-trip cleanly. This belt-and-
+  // -braces test pins the contract Track G consumes against the row 12
+  // fix in src/serve.ts.
+  describe("Track F F-0816-P2 row 12 — non-English query terms remain searchable", () => {
+    const i18nRecords: WorkspaceSearchRecord[] = [
+      { id: "frontend_cn", label: "前端开发", node_type: "Concept", source_file: "docs/cn/前端.md" },
+      { id: "backend_cn", label: "后端开发", node_type: "Concept", source_file: "docs/cn/后端.md" },
+      { id: "tokyo_jp", label: "東京", node_type: "Location", source_file: "docs/jp/tokyo.md" },
+      { id: "cafe_fr", label: "Café Société", node_type: "Place", source_file: "docs/fr/cafe.md" },
+      { id: "salam_ar", label: "السلام", node_type: "Greeting", source_file: "docs/ar/salam.md" },
+    ];
+
+    it("hits on a two-character CJK token (前端)", () => {
+      const index = buildWorkspaceSearchIndex(i18nRecords);
+      const ids = searchWorkspaceIndex(index, "前端").map((h) => h.id);
+      expect(ids).toContain("frontend_cn");
+      expect(ids).not.toContain("backend_cn");
+    });
+
+    it("hits on a two-character Japanese label (東京)", () => {
+      const index = buildWorkspaceSearchIndex(i18nRecords);
+      const ids = searchWorkspaceIndex(index, "東京").map((h) => h.id);
+      expect(ids).toContain("tokyo_jp");
+    });
+
+    it("hits on an accented French token (Société)", () => {
+      const index = buildWorkspaceSearchIndex(i18nRecords);
+      const ids = searchWorkspaceIndex(index, "Société").map((h) => h.id);
+      expect(ids).toContain("cafe_fr");
+    });
+
+    it("hits on an Arabic label (السلام)", () => {
+      const index = buildWorkspaceSearchIndex(i18nRecords);
+      const ids = searchWorkspaceIndex(index, "السلام").map((h) => h.id);
+      expect(ids).toContain("salam_ar");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Ports the **F-0816-P2 cluster** from upstream `safishamsi/graphify` Python `v8`. Five small but user-visible hardening fixes shipped over 5 atomic commits + 1 `.graphify/` refresh.

Reference: `spec/SPEC_TRACK_F_0816_BILAN.md` (rows 3, 6, 12, 14, 15) — the canonical P2 cluster.

### Rows ported

| Bilan row | Upstream SHA | Subject | TS files touched |
|---|---|---|---|
| 3 | `3238b32` (#889) | Exit non-zero when all semantic-extraction chunks fail | `src/direct-llm-extract.ts`, `src/index.ts` |
| 6 | `86109e9` (#937) | CJK/Unicode label dedup | `src/build.ts` |
| 12 | `020cca2` (#964) | Non-English query terms searchable | `src/search.ts`, `src/serve.ts` |
| 14 | `06a9b72` (#973) | Honor `GRAPHIFY_MAX_OUTPUT_TOKENS` env var | `src/llm-execution.ts` |
| 15 | `076e6b7` (#934) | `cluster-only` graceful when output dir missing | `src/cli.ts`, `src/skill-runtime.ts` |

### Per-row notes

- **Row 3** — Per-chunk errors in `extractSemanticFilesDirectParallel` now caught, logged to stderr, do NOT abort the run; new typed `AllChunksFailedError` raised only when zero chunks succeeded out of >=1 requested. The CLI catch handler at `src/cli.ts:3195` already surfaces this as `error: <message>` + `process.exit(1)`, so the upstream stderr wording (`all semantic chunks failed for backend '<x>'`) flows through unchanged.
- **Row 6** — `normalizedLabel` switched from ASCII `[^a-z0-9 ]+` to NFKC + Unicode `[^\p{L}\p{N}]+/u`. The legacy 3-char noise gate is kept for ASCII labels (intentional TS delta documented elsewhere) but relaxed for non-ASCII labels (CJK pairs carry semantic weight at 2 chars: 前端 / 東京). SKU-like ASCII guard preserved.
- **Row 12** — New `queryTerms()` helper in `src/search.ts` centralises the rule: drop pure-English tokens of length <= 2; keep everything else of any length. MCP `query_graph` re-routes through it. `tests/workspace-search-index.test.ts` extended with CJK / French / Arabic cases to pin the G6-2 rail contract.
- **Row 14** — New `resolveMaxOutputTokens()` reads `GRAPHIFY_MAX_OUTPUT_TOKENS` only when the caller did not pass an explicit value. Invalid / non-positive env values silently ignored. Plumbed into `createDirectTextJsonClient` (matches upstream `_resolve_max_tokens()` precedence).
- **Row 15** — `mkdirSync(..., { recursive: true })` on every output target in skill-runtime `cluster-only` (`--graph-out`, `--report-out`, `--analysis-out`, labels, `--html-out`) plus the public CLI state dir. Survives archive / restore workflows where only the backup `graph.json` remains.

### Tests delta

Baseline (origin/main @ 561795c2): **803 passed / 10 skipped**.
This branch: **829 passed / 10 skipped** (+26 new tests, zero regressions).

New test files:
- `tests/extract-all-chunks-fail.test.ts` (row 3, 4 cases)
- `tests/build-cjk-label-dedup.test.ts` (row 6, 5 cases)
- `tests/serve-query-terms.test.ts` (row 12, 6 cases)
- `tests/llm-mesh-max-output-tokens-env.test.ts` (row 14, 5 cases)
- `tests/cli-cluster-only-missing-graphify-out.test.ts` (row 15, 2 cases)
- `tests/workspace-search-index.test.ts` extended with 4 i18n cases (row 12, no source change in `src/workspace/search-index.ts` — the existing `[^\p{L}\p{N}]+/u` Unicode tokenizer already covers it; the new tests pin the Track G G6-2 contract against the row 12 fix in `src/serve.ts`).

### Deviation from upstream

- **Row 15** — Upstream commit `076e6b7` actually does auto-create the missing output directory (`out.mkdir(parents=True, exist_ok=True)`) rather than erroring. The task description requested "detect missing, print error, exit non-zero, don't auto-create"; this PR follows upstream's actual behaviour (auto-create, succeed) per the "Port the behaviour, not the syntax" directive. Documented in `.graphify/scratch/F-0816-P2-upstream-076e6b7.patch`.

### G overlap

- **Row 12** has the only Track G touchpoint (`src/workspace/search-index.ts` / Track G G6-2 rail). No source change to G6-2; the existing Unicode tokenizer already handles CJK. The extended `tests/workspace-search-index.test.ts` is purely additive and lockstep with the row 12 fix in `src/serve.ts`. No action required from the G6-2 author.

## Test plan

- [ ] `npm run lint` clean
- [ ] `npm test` shows 829 passed (vs 803 baseline) — 5 new test files added
- [ ] `npm run build` ESM + CJS + DTS green
- [ ] `npx graphify hook-rebuild` regenerates `.graphify/` cleanly (included as final commit)
- [ ] Confirm CI exit-code change is observable: `GRAPHIFY_MAX_OUTPUT_TOKENS=4096 graphify extract <corpus> --backend openai` honors the env override
- [ ] Confirm CJK label dedup hits via `graphify query "前端"` on a corpus with `前端开发` nodes