### PR TITLE
Track F F-0816-P4: stale wiki cleanup + gitignore fallback + --exclude flag + NAT64 SSRF fix (port safishamsi 9e6192a)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-24)
 
 ## Corpus Check
-- 295 files · ~363 862 words
+- 300 files · ~384 027 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4503 nodes · 7214 edges · 231 communities detected
+- 4531 nodes · 7247 edges · 234 communities detected
 - Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 295 · Candidates: 316
-- Excluded: 0 untracked · 15512 ignored · 5 sensitive · 0 missing committed
+- Included files: 300 · Candidates: 322
+- Excluded: 0 untracked · 15511 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `1d55558`
+- Built from Git commit: `4636d1d`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -139,16 +139,16 @@ Cohesion: 0.10
 Nodes (41): assertGraphJsonFileSize(), assertGraphJsonSize(), GraphSizeMode, buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl() (+33 more)
 
 ### Community 23 - "Community 23"
+Cohesion: 0.06
+Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.05
 Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.06
-Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
-
 ### Community 25 - "Community 25"
 Cohesion: 0.06
-Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
+Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.10
@@ -200,103 +200,103 @@ Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurp
 
 ### Community 38 - "Community 38"
 Cohesion: 0.11
-Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
+Nodes (30): appendMemoryFiles(), buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), isInputScopeMode(), makeScope() (+22 more)
 
 ### Community 39 - "Community 39"
+Cohesion: 0.11
+Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
+
+### Community 40 - "Community 40"
 Cohesion: 0.08
 Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.06
 Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.09
 Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.08
 Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.14
 Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.10
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.10
 Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.07
 Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.09
 Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.07
 Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.10
 Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.13
 Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.10
 Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.13
 Nodes (21): activeViewFromQuery(), candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult() (+13 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.07
 Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
+Cohesion: 0.09
+Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule, hasCodeShebang() (+14 more)
+
+### Community 60 - "Community 60"
 Cohesion: 0.10
 Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
 
-### Community 59 - "Community 59"
+### Community 61 - "Community 61"
 Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 60 - "Community 60"
-Cohesion: 0.13
-Nodes (21): appendMemoryFiles(), isInputScopeMode(), parseInputScopeMode(), resolveCliInputScopeSelection(), resolveConfiguredInputScopeSelection(), toPosixPath(), toRepoRelative(), walkFiles() (+13 more)
-
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
-
-### Community 62 - "Community 62"
-Cohesion: 0.10
-Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, findVcsRoot(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+14 more)
 
 ### Community 63 - "Community 63"
 Cohesion: 0.13
@@ -375,40 +375,40 @@ Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
 
 ### Community 82 - "Community 82"
+Cohesion: 0.17
+Nodes (14): ALLOWED_SCHEMES, BLOCKED_HOSTS, embeddedIPv4(), escapeHtml(), expandIPv6(), isPrivateIp(), isRedirectStatus(), safeFetch() (+6 more)
+
+### Community 83 - "Community 83"
 Cohesion: 0.13
 Nodes (13): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+5 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.15
 Nodes (14): AllChunksFailedError, DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape() (+6 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.11
 Nodes (15): agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined, logs (+7 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.21
 Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.12
 Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.12
 Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.20
 Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.17
-Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.12
@@ -439,108 +439,108 @@ Cohesion: 0.18
 Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.20
-Nodes (12): ALLOWED_SCHEMES, BLOCKED_HOSTS, escapeHtml(), isPrivateIp(), isRedirectStatus(), safeFetch(), safeFetchText(), sanitizeMetadata() (+4 more)
-
-### Community 99 - "Community 99"
 Cohesion: 0.23
 Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
 
-### Community 100 - "Community 100"
+### Community 99 - "Community 99"
 Cohesion: 0.13
 Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
 
-### Community 101 - "Community 101"
+### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
 
-### Community 102 - "Community 102"
+### Community 101 - "Community 101"
 Cohesion: 0.13
 Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.24
 Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.13
 Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
 
-### Community 105 - "Community 105"
+### Community 104 - "Community 104"
 Cohesion: 0.19
 Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
 
-### Community 106 - "Community 106"
+### Community 105 - "Community 105"
 Cohesion: 0.13
 Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
 
-### Community 107 - "Community 107"
+### Community 106 - "Community 106"
 Cohesion: 0.16
 Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
 
-### Community 108 - "Community 108"
+### Community 107 - "Community 107"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 109 - "Community 109"
+### Community 108 - "Community 108"
 Cohesion: 0.14
 Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
 
-### Community 110 - "Community 110"
+### Community 109 - "Community 109"
 Cohesion: 0.33
 Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
-### Community 111 - "Community 111"
+### Community 110 - "Community 110"
 Cohesion: 0.27
 Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
-### Community 112 - "Community 112"
+### Community 111 - "Community 111"
 Cohesion: 0.14
 Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
 
-### Community 113 - "Community 113"
+### Community 112 - "Community 112"
 Cohesion: 0.14
 Nodes (9): boxes, central, dir, fixture, headingMatches, pills, result, sections (+1 more)
 
-### Community 114 - "Community 114"
+### Community 113 - "Community 113"
 Cohesion: 0.23
 Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.15
 Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.24
 Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.21
+Nodes (12): canonicalFilePath(), countWords(), detect(), findVcsRoot(), isIgnored(), isNoiseDir(), isSensitive(), loadGraphifyignore() (+4 more)
 
 ### Community 124 - "Community 124"
 Cohesion: 0.17
@@ -587,48 +587,48 @@ Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
 ### Community 135 - "Community 135"
-Cohesion: 0.22
-Nodes (11): canonicalFilePath(), countWords(), detect(), isIgnored(), isNoiseDir(), isSensitive(), matchesIgnorePattern(), matchGlob() (+3 more)
-
-### Community 136 - "Community 136"
 Cohesion: 0.25
 Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
+
+### Community 145 - "Community 145"
+Cohesion: 0.18
+Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
 
 ### Community 146 - "Community 146"
 Cohesion: 0.18
@@ -679,36 +679,36 @@ Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
 ### Community 158 - "Community 158"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (4): cleanupDirs, result, root, text
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.39
 Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.39
 Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 165 - "Community 165"
+### Community 164 - "Community 164"
 Cohesion: 0.42
 Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
+
+### Community 165 - "Community 165"
+Cohesion: 0.42
+Nodes (8): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.25
@@ -760,254 +760,266 @@ Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
 ### Community 178 - "Community 178"
 Cohesion: 0.25
-Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+Nodes (5): cacheRoot, cleanupDirs, destination, result, source
 
 ### Community 179 - "Community 179"
 Cohesion: 0.25
-Nodes (7): dataset, dirty, facets, keys, slices, state, status
+Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
 ### Community 180 - "Community 180"
 Cohesion: 0.25
-Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+Nodes (7): dataset, dirty, facets, keys, slices, state, status
 
 ### Community 181 - "Community 181"
+Cohesion: 0.25
+Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+
+### Community 182 - "Community 182"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (1): recommendation
 
 ### Community 197 - "Community 197"
 Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
+Nodes (1): recommendation
 
 ### Community 198 - "Community 198"
 Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+Nodes (3): analysis, evaluation, text
 
 ### Community 199 - "Community 199"
 Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
+Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
 ### Community 200 - "Community 200"
+Cohesion: 0.33
+Nodes (1): CONFIDENCE_VALUES
+
+### Community 201 - "Community 201"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (5): commands, dir, matchers, settings, tempDirs
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (5): dir, original, rule, rulePath, tempDirs
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (4): dir, logs, preview, tempDirs
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.33
 Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.33
 Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
-### Community 207 - "Community 207"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
-
 ### Community 208 - "Community 208"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+Cohesion: 0.33
+Nodes (4): article, descriptions, G, generator
 
 ### Community 209 - "Community 209"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 210 - "Community 210"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 211 - "Community 211"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 210 - "Community 210"
-Cohesion: 0.40
-Nodes (4): chunks, client, files, root
-
-### Community 211 - "Community 211"
-Cohesion: 0.40
-Nodes (4): changelog, lock, pkg, workflow
-
 ### Community 212 - "Community 212"
 Cohesion: 0.40
-Nodes (4): graphifyOut, long, result, tmpDir
+Nodes (4): r1, r2, r3, result
 
 ### Community 213 - "Community 213"
 Cohesion: 0.40
-Nodes (4): candidateGraph, graph, html, tokens
+Nodes (4): chunks, client, files, root
 
 ### Community 214 - "Community 214"
 Cohesion: 0.40
-Nodes (4): character, dataset, groups, total
+Nodes (4): changelog, lock, pkg, workflow
 
 ### Community 215 - "Community 215"
+Cohesion: 0.40
+Nodes (4): graphifyOut, long, result, tmpDir
+
+### Community 216 - "Community 216"
+Cohesion: 0.40
+Nodes (4): candidateGraph, graph, html, tokens
+
+### Community 217 - "Community 217"
+Cohesion: 0.40
+Nodes (4): character, dataset, groups, total
+
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 216 - "Community 216"
+### Community 219 - "Community 219"
 Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 217 - "Community 217"
+### Community 220 - "Community 220"
 Cohesion: 0.50
 Nodes (2): extraction, out
 
-### Community 218 - "Community 218"
+### Community 221 - "Community 221"
 Cohesion: 0.50
 Nodes (1): { root, files, cleanup }
 
-### Community 219 - "Community 219"
+### Community 222 - "Community 222"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 220 - "Community 220"
+### Community 223 - "Community 223"
 Cohesion: 0.67
 Nodes (1): html
 
-### Community 221 - "Community 221"
+### Community 224 - "Community 224"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 222 - "Community 222"
+### Community 225 - "Community 225"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 223 - "Community 223"
+### Community 226 - "Community 226"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 224 - "Community 224"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 225 - "Community 225"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 226 - "Community 226"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
 ### Community 227 - "Community 227"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 228 - "Community 228"
 Cohesion: 1.00
-Nodes (1): UnpdfTextResult
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 229 - "Community 229"
 Cohesion: 1.00
-Nodes (2): tempProfileProject(), tempProject()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 230 - "Community 230"
+Cohesion: 1.00
+Nodes (2): formatMetric(), reviewEvaluationToText()
+
+### Community 231 - "Community 231"
+Cohesion: 1.00
+Nodes (1): UnpdfTextResult
+
+### Community 232 - "Community 232"
+Cohesion: 1.00
+Nodes (2): tempProfileProject(), tempProject()
+
+### Community 233 - "Community 233"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1781 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1776 more)
+- **1799 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1794 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 84`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 158`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 160`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 183`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (1 nodes): `recommendation`
+- **Thin community `Community 197`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (2 nodes): `extraction`, `out`
+- **Thin community `Community 220`** (2 nodes): `extraction`, `out`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (1 nodes): `{ root, files, cleanup }`
+- **Thin community `Community 221`** (1 nodes): `{ root, files, cleanup }`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (1 nodes): `html`
+- **Thin community `Community 223`** (1 nodes): `html`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `paths`, `root`
+- **Thin community `Community 224`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 226`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 227`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 228`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 229`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 230`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 231`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 232`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 233`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,17 @@ function splitFiles(value?: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Commander.js accumulator callback for repeatable `--exclude <glob>` flags.
+ * Used by `detect`, `detect-incremental`, and `extract` to forward CLI-supplied
+ * ignore patterns into `DetectOptions.extraExcludes` (port of upstream PR #947,
+ * commit 9e6192a).
+ */
+function collectExclude(value: string, previous: string[] = []): string[] {
+  if (!value) return previous;
+  return [...previous, value];
+}
+
 function changedFilesFromGit(options: { base?: string; head?: string; staged?: boolean }): string[] {
   if (options.staged) {
     return splitFiles(safeExecGit(".", ["diff", "--name-only", "--cached", "--"]) ?? "");
@@ -2840,6 +2851,12 @@ export async function main(): Promise<void> {
     .option("--out <path>")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
+    .option(
+      "--exclude <pattern>",
+      "Extra .graphifyignore-style pattern to skip (repeatable; port of upstream PR #947)",
+      collectExclude,
+      [] as string[],
+    )
     .action(async (inputPath, opts) => {
       const { detect } = await import("./detect.js");
       const root = resolve(inputPath);
@@ -2849,6 +2866,7 @@ export async function main(): Promise<void> {
         candidateFiles: inventory.candidateFiles,
         candidateRoot: inventory.scope.git_root ?? root,
         scope: inventory.scope,
+        extraExcludes: Array.isArray(opts.exclude) ? opts.exclude : [],
       });
       if (opts.out) {
         writeJson(opts.out, result);
@@ -2865,6 +2883,12 @@ export async function main(): Promise<void> {
     .option("--out <path>")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
+    .option(
+      "--exclude <pattern>",
+      "Extra .graphifyignore-style pattern to skip (repeatable; port of upstream PR #947)",
+      collectExclude,
+      [] as string[],
+    )
     .action(async (inputPath, opts) => {
       const { detectIncremental } = await import("./detect.js");
       const root = resolve(inputPath);
@@ -2874,6 +2898,7 @@ export async function main(): Promise<void> {
         candidateFiles: inventory.candidateFiles,
         candidateRoot: inventory.scope.git_root ?? root,
         scope: inventory.scope,
+        extraExcludes: Array.isArray(opts.exclude) ? opts.exclude : [],
       });
       if (opts.out) {
         writeJson(opts.out, result);
@@ -2896,6 +2921,12 @@ export async function main(): Promise<void> {
     .option("--no-cluster", "Write the raw merged extraction and skip graph clustering/reporting")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
+    .option(
+      "--exclude <pattern>",
+      "Extra .graphifyignore-style pattern to skip (repeatable; port of upstream PR #947)",
+      collectExclude,
+      [] as string[],
+    )
     .action(async (inputPath, opts) => {
       try {
         const root = resolve(inputPath);
@@ -2921,6 +2952,7 @@ export async function main(): Promise<void> {
           candidateFiles: inventory.candidateFiles,
           candidateRoot: inventory.scope.git_root ?? root,
           scope: inventory.scope,
+          extraExcludes: Array.isArray(opts.exclude) ? opts.exclude : [],
         });
         const originalDocumentFiles = [...(rawDetection.files.document ?? [])];
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -186,6 +186,9 @@ const SKIP_DIRS = new Set([
   "dist", "build", "target", "out", "site-packages", "lib64",
   ".pytest_cache", ".mypy_cache", ".ruff_cache", ".tox", ".eggs",
   DEFAULT_GRAPHIFY_STATE_DIR, LEGACY_GRAPHIFY_STATE_DIR,
+  // git worktree convention (port of upstream PR #947) -- sibling checkouts
+  // are always redundant relative to the primary worktree at the scan root.
+  ".worktrees",
 ]);
 
 const VCS_MARKERS = [".git", ".hg", ".svn", "_darcs", ".fossil"];
@@ -254,7 +257,17 @@ function loadGraphifyignore(root: string): GraphifyIgnoreRule[] {
 
   const patterns: GraphifyIgnoreRule[] = [];
   for (const dir of dirs) {
-    const ignoreFile = join(dir, ".graphifyignore");
+    // Prefer .graphifyignore; fall back to .gitignore so projects that
+    // already maintain a .gitignore get sensible defaults without
+    // duplicating it. Port of upstream PR #945 / commit 9e6192a.
+    //
+    // Note: an explicit empty .graphifyignore wins over any .gitignore in
+    // the same directory (existsSync() is true), so users keep a way to
+    // opt out of the fallback by `touch .graphifyignore`.
+    let ignoreFile = join(dir, ".graphifyignore");
+    if (!existsSync(ignoreFile)) {
+      ignoreFile = join(dir, ".gitignore");
+    }
     if (!existsSync(ignoreFile)) continue;
     for (const raw of readFileSync(ignoreFile, "utf-8").split(/\r?\n/)) {
       const parsed = parseGraphifyignoreLine(raw);

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -397,6 +397,15 @@ export interface DetectOptions {
   candidateFiles?: string[] | null;
   candidateRoot?: string;
   scope?: InputScopeInspection;
+  /**
+   * Additional ignore patterns appended to the loaded
+   * `.graphifyignore` / `.gitignore` rules. Each pattern uses
+   * gitignore syntax and is anchored at the scan root. Patterns are
+   * applied *after* the loaded rules so they override negations.
+   *
+   * Port of upstream `--exclude` flag (PR #947, commit 9e6192a).
+   */
+  extraExcludes?: string[] | null;
 }
 
 interface ManifestEntry {
@@ -438,6 +447,17 @@ export function detect(root: string, options?: DetectOptions): DetectionResult {
   const rootResolved = resolve(root);
   const paths = resolveGraphifyPaths({ root: rootResolved });
   const ignorePatterns = loadGraphifyignore(rootResolved);
+  // CLI --exclude patterns are anchored at the scan root and appended last
+  // so they win over any .graphifyignore / .gitignore rules (port of
+  // upstream PR #947 / commit 9e6192a). Empty/whitespace-only entries are
+  // dropped via parseGraphifyignoreLine().
+  if (options?.extraExcludes && options.extraExcludes.length > 0) {
+    for (const raw of options.extraExcludes) {
+      const parsed = parseGraphifyignoreLine(raw);
+      if (!parsed) continue;
+      ignorePatterns.push({ anchor: rootResolved, pattern: parsed.pattern, negated: parsed.negated });
+    }
+  }
   const convertedDir = paths.convertedDir;
   const memoryDir = paths.memoryDir;
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -66,6 +66,75 @@ export function validateUrlSync(url: string): string {
   return url;
 }
 
+/**
+ * Expand an IPv6 string to its canonical 8-group form so prefix checks can
+ * inspect the high bits without parsing every shorthand.
+ */
+function expandIPv6(addr: string): number[] | null {
+  if (!net.isIPv6(addr)) return null;
+
+  // Embedded IPv4 dotted form (e.g. `::ffff:1.2.3.4`): translate the dotted
+  // tail into two 16-bit groups before expansion.
+  let work = addr;
+  const lastColon = work.lastIndexOf(":");
+  if (lastColon >= 0 && work.slice(lastColon + 1).includes(".")) {
+    const tail = work.slice(lastColon + 1);
+    if (!net.isIPv4(tail)) return null;
+    const [a, b, c, d] = tail.split(".").map(Number) as [number, number, number, number];
+    work = `${work.slice(0, lastColon)}:${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
+  }
+
+  const [head, tail] = work.split("::") as [string, string | undefined];
+  const headGroups = head ? head.split(":").filter(Boolean) : [];
+  const tailGroups = tail !== undefined ? tail.split(":").filter(Boolean) : [];
+  if (tail === undefined && headGroups.length !== 8) return null;
+
+  const missing = 8 - headGroups.length - tailGroups.length;
+  if (missing < 0) return null;
+  const groups = [
+    ...headGroups,
+    ...Array(missing).fill("0"),
+    ...tailGroups,
+  ].map((g) => parseInt(g, 16));
+  if (groups.length !== 8 || groups.some((g) => Number.isNaN(g))) return null;
+  return groups;
+}
+
+/**
+ * Unwrap an IPv6 that carries an embedded IPv4 in the low 32 bits to its
+ * dotted-decimal form. Recognises:
+ *   - RFC 4291 IPv4-mapped IPv6 (`::ffff:0:0/96`)
+ *   - RFC 6052 NAT64 Well-Known Prefix (`64:ff9b::/96`)
+ *
+ * Python's `ipaddress.is_reserved` returns True for the NAT64 prefix so the
+ * upstream Python guard (`safishamsi/graphify` commit `9e6192a`) had a
+ * false-positive on legitimate public IPv4 traffic routed via NAT64. The TS
+ * port mirrors that fix by unwrapping the embedded IPv4 first and running
+ * the private-IP test against the embedded address instead of the wrapper.
+ */
+function embeddedIPv4(addr: string): string | null {
+  const groups = expandIPv6(addr);
+  if (!groups) return null;
+
+  const isIPv4Mapped =
+    groups[0] === 0 && groups[1] === 0 && groups[2] === 0 &&
+    groups[3] === 0 && groups[4] === 0 && groups[5] === 0xffff;
+  const isNat64WellKnown =
+    groups[0] === 0x64 && groups[1] === 0xff9b &&
+    groups[2] === 0 && groups[3] === 0 && groups[4] === 0 && groups[5] === 0;
+
+  if (!isIPv4Mapped && !isNat64WellKnown) return null;
+
+  const high = groups[6] ?? 0;
+  const low = groups[7] ?? 0;
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join(".");
+}
+
 function isPrivateIp(addr: string): boolean {
   if (net.isIPv4(addr)) {
     const parts = addr.split(".").map(Number);
@@ -80,6 +149,13 @@ function isPrivateIp(addr: string): boolean {
     return false;
   }
   if (net.isIPv6(addr)) {
+    // RFC 4291 / RFC 6052: defer the verdict to the embedded IPv4 when the
+    // wrapper is an IPv4-mapped IPv6 or a NAT64 Well-Known Prefix address.
+    // Port of upstream safishamsi/graphify commit `9e6192a`.
+    const embedded = embeddedIPv4(addr);
+    if (embedded !== null) {
+      return isPrivateIp(embedded);
+    }
     const lower = addr.toLowerCase();
     if (lower === "::1" || lower.startsWith("fe80:") || lower.startsWith("fc") || lower.startsWith("fd")) {
       return true;
@@ -94,9 +170,16 @@ async function validateHostname(hostname: string, url: string): Promise<void> {
     throw new Error(`Blocked cloud metadata endpoint '${hostname}'. Got: ${url}`);
   }
 
-  if (net.isIP(hostname)) {
-    if (isPrivateIp(hostname)) {
-      throw new Error(`Blocked private/internal IP ${hostname} (resolved from '${hostname}'). Got: ${url}`);
+  // Node's URL parser keeps the `[...]` brackets around IPv6 hostnames; strip
+  // them so `net.isIP` and `isPrivateIp` see the literal address (port of
+  // upstream NAT64 fix; precondition for the embedded IPv4 unwrap).
+  const literal = hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname;
+
+  if (net.isIP(literal)) {
+    if (isPrivateIp(literal)) {
+      throw new Error(`Blocked private/internal IP ${literal} (resolved from '${hostname}'). Got: ${url}`);
     }
     return;
   }

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -341,7 +341,38 @@ export function toWiki(
     descriptions?: WikiDescriptionSidecarIndex;
   },
 ): number {
-  const communityMap = toNumericMap(communities);
+  const communityMapRaw = toNumericMap(communities);
+
+  // Filter stale node IDs that exist in `communities` but no longer in `G`.
+  // The analysis JSON can drift from the live graph after dedup / re-extract /
+  // update; without this filter the downstream `G.degree()` / `G.neighbors()`
+  // calls throw `NotFoundGraphError` and the whole wiki export aborts.
+  //
+  // Port of upstream safishamsi/graphify commit `9e6192a` (PR #936), TS-adapted:
+  // upstream uses Python's `print(..., file=sys.stderr)` and raises
+  // `ValueError` when every community is empty after filtering. We use
+  // `console.warn` (already the project's stderr channel) and throw a plain
+  // `Error` with the same human message.
+  let droppedCount = 0;
+  const communityMap = new Map<number, string[]>();
+  for (const [cid, nodes] of communityMapRaw) {
+    const kept = nodes.filter((nid) => G.hasNode(nid));
+    droppedCount += nodes.length - kept.length;
+    if (kept.length > 0) communityMap.set(cid, kept);
+  }
+  if (droppedCount > 0) {
+    console.warn(
+      `wiki: dropped ${droppedCount} stale node ID(s) not in graph ` +
+        `(${communityMap.size} communities remaining)`,
+    );
+  }
+  if (communityMap.size === 0) {
+    throw new Error(
+      "all community node IDs are stale — none exist in the graph. " +
+        "Re-run `graphify extract .` to regenerate .graphify_analysis.json.",
+    );
+  }
+
   mkdirSync(outputDir, { recursive: true });
   for (const entry of readdirSync(outputDir, { withFileTypes: true })) {
     if (entry.isFile() && entry.name.endsWith(".md")) {

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -14,6 +14,7 @@ import {
   type WikiDescriptionSidecar,
   type WikiDescriptionSidecarIndex,
 } from "./wiki-descriptions.js";
+import { sanitizeMetadata } from "./security.js";
 
 interface WikiPageRef {
   key: string;
@@ -93,12 +94,29 @@ function crossCommunityLinks(
 function renderDescription(sidecar: WikiDescriptionSidecar | undefined): string[] {
   if (!sidecar || sidecar.status !== "generated") return [];
   if (validateWikiDescriptionSidecar(sidecar).length > 0) return [];
+  // Free-form fields (LLM-generated description text + evidence refs) flow
+  // from extraction into rendered wiki markdown verbatim. Run them through
+  // `sanitizeMetadata` so control characters are stripped and HTML-special
+  // characters are escaped (port of upstream `sanitize_metadata` helper,
+  // PR #956 / commit b6127aa). Canonical fields (`label`, `source_file`,
+  // `relation`, `confidence`) are deliberately NOT routed through this path
+  // -- they were already sanitised at extract/export boundaries and a
+  // second pass would double-escape legitimate slashes/labels (P3 deviation
+  // note 2). F-0816-P4 / S4.5.
+  const cleaned = sanitizeMetadata({
+    description: sidecar.description,
+    evidence_refs: sidecar.evidence_refs,
+  });
+  const description = String(cleaned.description ?? "");
+  const refs = Array.isArray(cleaned.evidence_refs)
+    ? (cleaned.evidence_refs as unknown[]).map((ref) => String(ref ?? ""))
+    : [];
   return [
     "## Description",
     "",
-    sidecar.description,
+    description,
     "",
-    `Evidence: ${sidecar.evidence_refs.map((ref) => `\`${ref}\``).join(", ")}`,
+    `Evidence: ${refs.map((ref) => `\`${ref}\``).join(", ")}`,
     "",
   ];
 }

--- a/tests/cli-exclude-flag.test.ts
+++ b/tests/cli-exclude-flag.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression tests for F-0816-P4 / S4.3.
+ *
+ * Port of upstream safishamsi/graphify commit `9e6192a` (PR #947):
+ * `--exclude <pattern>` is a repeatable CLI flag that injects extra ignore
+ * patterns at the scan root. The patterns win over `.graphifyignore` /
+ * `.gitignore` because they're appended last and gitignore semantics keep
+ * the last-matching rule.
+ *
+ * The TS port exposes this as `extraExcludes` on `DetectOptions` so all
+ * `detect()` call sites (CLI, watch, pipeline, skill-runtime,
+ * configured-dataprep) can forward `--exclude` patterns without each one
+ * re-implementing glob handling.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { detect } from "../src/detect.js";
+
+describe("detect --exclude / extraExcludes (F-0816-P4 / S4.3, upstream #947)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `graphify-detect-exclude-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("excludes a single file pattern via extraExcludes", () => {
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "internal.py"), "x = 2");
+
+    const result = detect(tmpDir, { extraExcludes: ["internal.py"] });
+    const code = result.files.code;
+
+    expect(code.some((f) => f.endsWith("main.py"))).toBe(true);
+    expect(code.some((f) => f.endsWith("internal.py"))).toBe(false);
+  });
+
+  it("excludes a directory pattern via extraExcludes", () => {
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    mkdirSync(join(tmpDir, "legacy"));
+    writeFileSync(join(tmpDir, "legacy", "old.py"), "y = 2");
+
+    const result = detect(tmpDir, { extraExcludes: ["legacy/"] });
+    const code = result.files.code;
+
+    expect(code.some((f) => f.endsWith("main.py"))).toBe(true);
+    expect(code.some((f) => f.includes("legacy"))).toBe(false);
+  });
+
+  it("supports repeated --exclude patterns (additive)", () => {
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "internal.py"), "x = 2");
+    mkdirSync(join(tmpDir, "legacy"));
+    writeFileSync(join(tmpDir, "legacy", "old.py"), "x = 3");
+
+    const result = detect(tmpDir, { extraExcludes: ["internal.py", "legacy/"] });
+    const code = result.files.code;
+
+    expect(code.some((f) => f.endsWith("main.py"))).toBe(true);
+    expect(code.some((f) => f.endsWith("internal.py"))).toBe(false);
+    expect(code.some((f) => f.includes("legacy"))).toBe(false);
+  });
+
+  it("supports glob patterns (suffix *)", () => {
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "schema.generated.py"), "x = 2");
+    writeFileSync(join(tmpDir, "types.generated.py"), "x = 3");
+
+    const result = detect(tmpDir, { extraExcludes: ["*.generated.py"] });
+    const code = result.files.code;
+
+    expect(code.some((f) => f.endsWith("main.py"))).toBe(true);
+    expect(code.some((f) => f.includes("generated"))).toBe(false);
+  });
+
+  it("--exclude wins over .graphifyignore negations (appended last)", () => {
+    // .graphifyignore would re-include negated.py; --exclude must still ban it.
+    writeFileSync(join(tmpDir, ".graphifyignore"), "*.py\n!negated.py\n");
+    writeFileSync(join(tmpDir, "negated.py"), "x = 1");
+    writeFileSync(join(tmpDir, "main.py"), "x = 2");
+
+    const result = detect(tmpDir, { extraExcludes: ["negated.py"] });
+
+    expect(result.files.code.some((f) => f.endsWith("negated.py"))).toBe(false);
+    expect(result.files.code.some((f) => f.endsWith("main.py"))).toBe(false);
+  });
+
+  it("undefined / empty extraExcludes is a no-op", () => {
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "internal.py"), "x = 2");
+
+    const r1 = detect(tmpDir);
+    const r2 = detect(tmpDir, { extraExcludes: [] });
+    const r3 = detect(tmpDir, { extraExcludes: undefined });
+
+    expect(r1.files.code).toHaveLength(2);
+    expect(r2.files.code).toHaveLength(2);
+    expect(r3.files.code).toHaveLength(2);
+  });
+});

--- a/tests/detect-gitignore-fallback.test.ts
+++ b/tests/detect-gitignore-fallback.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression tests for F-0816-P4 / S4.2.
+ *
+ * Port of upstream safishamsi/graphify commit `9e6192a` (PR #945 / #947):
+ * when no `.graphifyignore` exists in a directory, fall back to `.gitignore`
+ * in the same directory so projects that already maintain a gitignore get
+ * sensible defaults without having to duplicate it. `.graphifyignore` keeps
+ * absolute priority — if it exists, `.gitignore` is ignored entirely (no
+ * merging).
+ *
+ * Also asserts that `.worktrees/` is part of the always-skipped directory
+ * set (the upstream patch adds it to `_SKIP_DIRS` so sibling git worktree
+ * checkouts are never indexed redundantly).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { detect } from "../src/detect.js";
+
+describe("detect .gitignore fallback (F-0816-P4 / S4.2, upstream #945)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `graphify-detect-gitignore-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("honors .gitignore when no .graphifyignore exists", () => {
+    // Mark this as a repo root so loadGraphifyignore walks stop here
+    mkdirSync(join(tmpDir, ".git"));
+    writeFileSync(join(tmpDir, ".gitignore"), "vendor/\n*.generated.py\n");
+    mkdirSync(join(tmpDir, "vendor"));
+    writeFileSync(join(tmpDir, "vendor", "lib.py"), "x = 1");
+    writeFileSync(join(tmpDir, "main.py"), "print('hi')");
+    writeFileSync(join(tmpDir, "schema.generated.py"), "x = 1");
+
+    const result = detect(tmpDir);
+    const code = result.files.code;
+
+    expect(code.some((f) => f.endsWith("main.py"))).toBe(true);
+    expect(code.some((f) => f.includes("vendor"))).toBe(false);
+    expect(code.some((f) => f.includes("generated"))).toBe(false);
+  });
+
+  it("prefers .graphifyignore over .gitignore when both exist", () => {
+    mkdirSync(join(tmpDir, ".git"));
+    // .gitignore would exclude main.py; .graphifyignore excludes only other.py
+    writeFileSync(join(tmpDir, ".gitignore"), "main.py\n");
+    writeFileSync(join(tmpDir, ".graphifyignore"), "other.py\n");
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "other.py"), "x = 2");
+
+    const result = detect(tmpDir);
+    const code = result.files.code;
+
+    // .gitignore must NOT be applied because .graphifyignore exists
+    expect(code.some((f) => f.endsWith("main.py"))).toBe(true);
+    // .graphifyignore IS applied
+    expect(code.some((f) => f.endsWith("other.py"))).toBe(false);
+  });
+
+  it("does nothing extra when neither ignore file exists", () => {
+    mkdirSync(join(tmpDir, ".git"));
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "other.py"), "x = 2");
+
+    const result = detect(tmpDir);
+
+    expect(result.files.code).toHaveLength(2);
+    expect(result.graphifyignore_patterns).toBe(0);
+  });
+
+  it("treats an explicit empty .graphifyignore as no patterns (no fallback)", () => {
+    // User intent: empty .graphifyignore explicitly disables fallback.
+    mkdirSync(join(tmpDir, ".git"));
+    writeFileSync(join(tmpDir, ".graphifyignore"), "");
+    writeFileSync(join(tmpDir, ".gitignore"), "main.py\n");
+    writeFileSync(join(tmpDir, "main.py"), "x = 1");
+
+    const result = detect(tmpDir);
+
+    expect(result.files.code.some((f) => f.endsWith("main.py"))).toBe(true);
+    expect(result.graphifyignore_patterns).toBe(0);
+  });
+
+  it("skips files under .worktrees/ (F-0816-P4 / S4.2, upstream #947)", () => {
+    mkdirSync(join(tmpDir, ".worktrees", "feature-branch"), { recursive: true });
+    writeFileSync(join(tmpDir, ".worktrees", "feature-branch", "main.py"), "x = 1");
+    writeFileSync(join(tmpDir, "app.py"), "y = 2");
+
+    const result = detect(tmpDir);
+    const code = result.files.code;
+
+    expect(code.some((f) => f.endsWith("app.py"))).toBe(true);
+    expect(code.some((f) => f.includes(".worktrees"))).toBe(false);
+  });
+});

--- a/tests/ssrf-nat64-allowlist.test.ts
+++ b/tests/ssrf-nat64-allowlist.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for F-0816-P4 / S4.4.
+ *
+ * Port of upstream safishamsi/graphify commit `9e6192a` (security.py):
+ * the SSRF guard mis-classified addresses in the RFC 6052 NAT64 Well-Known
+ * Prefix (`64:ff9b::/96`) as private/reserved because Python's
+ * `ipaddress.is_reserved` returns True for that range. NAT64 addresses
+ * legitimately embed *public* IPv4 in the low 32 bits, so the fix unwraps
+ * the embedded IPv4 and runs the private-IP check against the embedded
+ * address instead of the IPv6 wrapper.
+ *
+ * The TS port mirrors the same contract via `isPrivateIp`: an IPv6 address
+ * inside `64:ff9b::/96` is treated like its embedded IPv4 (private iff the
+ * embedded IPv4 is private). IPv4-mapped IPv6 (`::ffff:a.b.c.d`, RFC 4291)
+ * gets the same unwrap because that's also a legitimate IPv4-in-IPv6 path
+ * Node's `dns.lookup` can return on dual-stack hosts.
+ */
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { validateUrl } from "../src/security.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("validateUrl NAT64 / IPv4-mapped IPv6 unwrap (F-0816-P4 / S4.4)", () => {
+  it("accepts a NAT64 address embedding a public IPv4 (64:ff9b::8.8.8.8)", async () => {
+    // 64:ff9b::8.8.8.8 == 64:ff9b::0808:0808
+    await expect(validateUrl("http://[64:ff9b::0808:0808]/")).resolves.toBeTruthy();
+  });
+
+  it("rejects a NAT64 address embedding a private IPv4 (64:ff9b::127.0.0.1)", async () => {
+    // 64:ff9b::127.0.0.1 == 64:ff9b::7f00:1
+    await expect(validateUrl("http://[64:ff9b::7f00:1]/")).rejects.toThrow(/Blocked private\/internal IP/);
+  });
+
+  it("rejects a NAT64 address embedding 10.0.0.1 (private IPv4)", async () => {
+    // 64:ff9b::10.0.0.1 == 64:ff9b::0a00:1
+    await expect(validateUrl("http://[64:ff9b::a00:1]/")).rejects.toThrow(/Blocked private\/internal IP/);
+  });
+
+  it("accepts an IPv4-mapped IPv6 with a public embedded IPv4 (::ffff:8.8.8.8)", async () => {
+    // ::ffff:8.8.8.8 == ::ffff:0808:0808
+    await expect(validateUrl("http://[::ffff:0808:0808]/")).resolves.toBeTruthy();
+  });
+
+  it("rejects an IPv4-mapped IPv6 with a loopback embedded IPv4 (::ffff:127.0.0.1)", async () => {
+    // ::ffff:127.0.0.1 == ::ffff:7f00:1
+    await expect(validateUrl("http://[::ffff:7f00:1]/")).rejects.toThrow(/Blocked private\/internal IP/);
+  });
+
+  it("still rejects loopback IPv6 ::1", async () => {
+    await expect(validateUrl("http://[::1]/")).rejects.toThrow(/Blocked private\/internal IP/);
+  });
+
+  it("still rejects link-local IPv6 (fe80::)", async () => {
+    await expect(validateUrl("http://[fe80::1]/")).rejects.toThrow(/Blocked private\/internal IP/);
+  });
+});

--- a/tests/wiki-sanitize-metadata.test.ts
+++ b/tests/wiki-sanitize-metadata.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for F-0816-P4 / S4.5.
+ *
+ * Extends the `sanitizeMetadata` helper introduced by F-0816-P3
+ * (`src/security.ts`, commit `2974b1c`) to the wiki export site.
+ *
+ * Scope (per P3 deviation note 2): only the free-form metadata fields
+ * embedded in wiki output are sanitised — at the moment, the LLM-generated
+ * `description` text and the `evidence_refs` list carried by wiki
+ * description sidecars. Canonical fields (`label`, `source_file`,
+ * `relation`, `confidence`) are NOT double-sanitised — they already went
+ * through `sanitizeLabel` at extract/export boundaries.
+ *
+ * Concretely: control characters are stripped and HTML-special characters
+ * are escaped in the rendered description text and evidence ref code
+ * spans, so a malicious doc text propagated through an LLM-extracted
+ * description cannot inject markup into the wiki article.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { toWiki } from "../src/wiki.js";
+import {
+  WIKI_DESCRIPTION_PROMPT_VERSION,
+  WIKI_DESCRIPTION_SCHEMA,
+  buildWikiDescriptionCacheKey,
+  type WikiDescriptionSidecarIndex,
+} from "../src/wiki-descriptions.js";
+
+const generator = {
+  mode: "assistant" as const,
+  provider: "assistant",
+  model: null,
+  prompt_version: WIKI_DESCRIPTION_PROMPT_VERSION,
+};
+
+function buildDescriptions(
+  communityDesc: string,
+  evidenceRefs: string[],
+): WikiDescriptionSidecarIndex {
+  return {
+    schema: "graphify_wiki_description_index_v1",
+    graph_hash: "graph-a",
+    prompt_version: WIKI_DESCRIPTION_PROMPT_VERSION,
+    communities: {
+      "0": {
+        schema: WIKI_DESCRIPTION_SCHEMA,
+        target_id: "community:0",
+        target_kind: "community",
+        graph_hash: "graph-a",
+        status: "generated",
+        description: communityDesc,
+        evidence_refs: evidenceRefs,
+        confidence: 0.82,
+        cache_key: buildWikiDescriptionCacheKey({
+          target_id: "community:0",
+          target_kind: "community",
+          graph_hash: "graph-a",
+          ...generator,
+        }),
+        generator,
+      },
+    },
+    nodes: {},
+  };
+}
+
+describe("toWiki sanitizes free-form description metadata (F-0816-P4 / S4.5)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `graphify-wiki-sanitize-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("escapes HTML-special characters in description text", () => {
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("n1", { label: "A", source_file: "a.py", community: 0 });
+    G.mergeNode("n2", { label: "B", source_file: "b.py", community: 0 });
+    G.mergeEdge("n1", "n2", { relation: "calls", confidence: "EXTRACTED" });
+    const descriptions = buildDescriptions(
+      'Module <script>alert("xss")</script> & co',
+      ["a.py#A"],
+    );
+
+    toWiki(
+      G,
+      new Map([[0, ["n1", "n2"]]]),
+      tmpDir,
+      {
+        communityLabels: new Map([[0, "Module"]]),
+        descriptions,
+      },
+    );
+
+    const article = readFileSync(join(tmpDir, "Module.md"), "utf-8");
+    // The raw <script> markup must not appear verbatim in the output.
+    expect(article).not.toContain("<script>");
+    expect(article).not.toContain("alert(\"xss\")");
+    // The escaped form (or some safe substitute) must be present in its place.
+    expect(article).toMatch(/&lt;script&gt;|alert\(&quot;xss&quot;\)/);
+  });
+
+  it("strips control characters from description text", () => {
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("n1", { label: "A", source_file: "a.py", community: 0 });
+    G.mergeNode("n2", { label: "B", source_file: "b.py", community: 0 });
+    G.mergeEdge("n1", "n2", { relation: "calls", confidence: "EXTRACTED" });
+    const descriptions = buildDescriptions(
+      "Module summary\x00with\x07control\x1fchars",
+      ["a.py#A"],
+    );
+
+    toWiki(
+      G,
+      new Map([[0, ["n1", "n2"]]]),
+      tmpDir,
+      {
+        communityLabels: new Map([[0, "Module"]]),
+        descriptions,
+      },
+    );
+
+    const article = readFileSync(join(tmpDir, "Module.md"), "utf-8");
+    expect(article).not.toMatch(/[\x00\x07\x1f]/);
+    expect(article).toContain("Module summarywithcontrolchars");
+  });
+
+  it("escapes HTML-special characters in evidence refs", () => {
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("n1", { label: "A", source_file: "a.py", community: 0 });
+    G.mergeNode("n2", { label: "B", source_file: "b.py", community: 0 });
+    G.mergeEdge("n1", "n2", { relation: "calls", confidence: "EXTRACTED" });
+    const descriptions = buildDescriptions(
+      "Plain description",
+      ["a.py#<script>"],
+    );
+
+    toWiki(
+      G,
+      new Map([[0, ["n1", "n2"]]]),
+      tmpDir,
+      {
+        communityLabels: new Map([[0, "Module"]]),
+        descriptions,
+      },
+    );
+
+    const article = readFileSync(join(tmpDir, "Module.md"), "utf-8");
+    expect(article).not.toContain("<script>");
+    // The escaped form is present somewhere in the Evidence line.
+    expect(article).toMatch(/Evidence:.*&lt;script&gt;/);
+  });
+
+  it("preserves canonical fields (label, source_file) untouched -- no double sanitization", () => {
+    const G = new Graph({ type: "undirected" });
+    // Canonical fields are pre-sanitised at extract time; wiki must not
+    // re-escape them (otherwise legitimate paths and labels get double-escaped).
+    G.mergeNode("n1", { label: "ParserAndLexer", source_file: "src/lex_parse.ts", community: 0 });
+    G.mergeNode("n2", { label: "Render", source_file: "src/render.ts", community: 0 });
+    G.mergeEdge("n1", "n2", { relation: "calls", confidence: "EXTRACTED" });
+
+    toWiki(
+      G,
+      new Map([[0, ["n1", "n2"]]]),
+      tmpDir,
+      { communityLabels: new Map([[0, "Core"]]) },
+    );
+
+    const article = readFileSync(join(tmpDir, "Core.md"), "utf-8");
+    // The literal `&` in canonical labels would be a sign of double-sanitising
+    // because ParserAndLexer has none. The source path slash must remain as `/`.
+    expect(article).toContain("ParserAndLexer");
+    expect(article).toContain("src/lex_parse.ts");
+    expect(article).toContain("src/render.ts");
+    expect(article).not.toContain("src&#x2f;");
+    expect(article).not.toContain("src&#47;");
+  });
+});

--- a/tests/wiki-stale-nodes-cleanup.test.ts
+++ b/tests/wiki-stale-nodes-cleanup.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression tests for F-0816-P4 / S4.1.
+ *
+ * Port of upstream safishamsi/graphify commit `9e6192a` (PR #936):
+ * `wiki.py` would crash with `TypeError` on `sorted(G.degree(stale_id))`
+ * when the communities dict carried node IDs that no longer existed in `G`
+ * (drift introduced by dedup / re-extract / update). The fix filters stale
+ * IDs before iteration and emits a single stderr warning showing the drop
+ * count. If *every* community node is stale the call raises `ValueError`
+ * with a helpful message instead of silently writing an empty wiki.
+ *
+ * The TS port mirrors the same contract: stale node IDs are dropped from
+ * communities before article rendering, a single stderr warning is emitted,
+ * and an empty-after-filter situation raises an Error.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { toWiki } from "../src/wiki.js";
+
+function makeGraph(): Graph {
+  const G = new Graph({ type: "undirected" });
+  G.mergeNode("n1", { label: "parse", source_file: "parser.ts", community: 0 });
+  G.mergeNode("n2", { label: "lex", source_file: "lexer.ts", community: 0 });
+  G.mergeNode("n3", { label: "render", source_file: "render.ts", community: 1 });
+  G.mergeNode("n4", { label: "draw", source_file: "render.ts", community: 1 });
+  G.mergeEdge("n1", "n2", { relation: "calls", confidence: "EXTRACTED" });
+  G.mergeEdge("n3", "n4", { relation: "calls", confidence: "EXTRACTED" });
+  return G;
+}
+
+const LABELS = new Map([
+  [0, "Parsing Layer"],
+  [1, "Rendering Layer"],
+]);
+
+describe("toWiki stale community node filter (F-0816-P4 / S4.1, upstream #936)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `graphify-wiki-stale-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("silently drops stale node IDs and still writes the community article", () => {
+    const G = makeGraph();
+    // "ghost" is in the communities dict but no longer in the graph
+    const communities = new Map([
+      [0, ["n1", "n2", "ghost"]],
+      [1, ["n3", "n4"]],
+    ]);
+
+    const count = toWiki(G, communities, tmpDir, { communityLabels: LABELS });
+
+    expect(count).toBe(2);
+    expect(existsSync(join(tmpDir, "Parsing_Layer.md"))).toBe(true);
+    expect(existsSync(join(tmpDir, "Rendering_Layer.md"))).toBe(true);
+    const article = readFileSync(join(tmpDir, "Parsing_Layer.md"), "utf-8");
+    expect(article).toContain("parse");
+    expect(article).not.toContain("ghost");
+  });
+
+  it("drops a community entirely when every one of its nodes is stale", () => {
+    const G = makeGraph();
+    const communities = new Map([
+      [0, ["n1", "n2"]],
+      [1, ["only_stale_a", "only_stale_b"]],
+    ]);
+
+    const count = toWiki(G, communities, tmpDir, { communityLabels: LABELS });
+
+    expect(count).toBe(1);
+    expect(existsSync(join(tmpDir, "Parsing_Layer.md"))).toBe(true);
+    expect(existsSync(join(tmpDir, "Rendering_Layer.md"))).toBe(false);
+  });
+
+  it("raises when every community node is stale (upstream raises ValueError)", () => {
+    const G = makeGraph();
+    const allStale = new Map([
+      [0, ["ghost1", "ghost2"]],
+      [1, ["ghost3"]],
+    ]);
+
+    expect(() => toWiki(G, allStale, tmpDir, { communityLabels: LABELS })).toThrow(/stale/i);
+  });
+
+  it("emits a single stderr warning showing the drop count", () => {
+    const G = makeGraph();
+    const communities = new Map([
+      [0, ["n1", "stale1", "stale2"]],
+      [1, ["n3", "n4"]],
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    toWiki(G, communities, tmpDir, { communityLabels: LABELS });
+
+    expect(warn).toHaveBeenCalled();
+    const formatted = warn.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(formatted).toMatch(/stale/i);
+    expect(formatted).toContain("2");
+  });
+
+  it("is silent when no nodes are stale", () => {
+    const G = makeGraph();
+    const communities = new Map([
+      [0, ["n1", "n2"]],
+      [1, ["n3", "n4"]],
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    toWiki(G, communities, tmpDir, { communityLabels: LABELS });
+
+    const stale = warn.mock.calls.filter((args) => /stale/i.test(args.join(" ")));
+    expect(stale).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Track F F-0816-P4 closes lot 4 of the safishamsi/graphify port (upstream commit `9e6192a`, PRs #936 / #945 / #947). Five atomic steps land independently:

- **S4.1** — stale wiki nodes cleanup on incremental rebuild (port of upstream PR #936)
- **S4.2** — `.gitignore` fallback when `.graphifyignore` is missing (port of upstream PR #945 / `9e6192a`)
- **S4.3** — `--exclude <glob>` CLI flag on `detect`, `detect-incremental`, and `extract`, threaded through `DetectOptions.extraExcludes`. Repeatable, anchored at scan root, appended *after* the loaded ignore rules so it wins over any `.graphifyignore` negations (port of upstream PR #947)
- **S4.4** — NAT64 SSRF false-positive fix: IPv6 addresses inside `64:ff9b::/96` (RFC 6052 NAT64 well-known prefix) and `::ffff:/96` (RFC 4291 IPv4-mapped) now unwrap to their embedded IPv4 before the private-IP check, so legitimate public IPv4 routed via NAT64 is no longer blocked. Also strips the URL parser's `[…]` brackets around IPv6 literals so the literal IP check actually runs (pre-existing latent bug). Port of `security.py` change in upstream `9e6192a`
- **S4.5** — apply `sanitizeMetadata` (introduced by P3 `2974b1c` / upstream PR #956) at the wiki export site. Sanitises only the free-form fields surfaced in rendered wiki articles (`description` text and `evidence_refs`); canonical fields (`label`, `source_file`, `relation`, `confidence`) are deliberately untouched -- they were already sanitised at extract/export boundaries and a second pass would double-escape legitimate slashes/labels (P3 deviation note 2)

## Upstream references

- Commit: safishamsi/graphify `9e6192a`
- PRs: #936 (wiki cleanup), #945 (gitignore fallback), #947 (--exclude flag), #956 (sanitize_metadata helper, already ported in P3)

## Test plan

- [x] `tests/cli-exclude-flag.test.ts` -- 6 cases (single file, dir, repeated, glob, negation override, no-op)
- [x] `tests/ssrf-nat64-allowlist.test.ts` -- 7 cases (public-IPv4-in-NAT64, private-IPv4-in-NAT64, IPv4-mapped variants, loopback, link-local)
- [x] `tests/wiki-sanitize-metadata.test.ts` -- 4 cases (HTML escape, control-char strip, evidence ref escape, canonical fields untouched)
- [x] Full suite: 890 passed / 10 skipped, lint clean (tsc --noEmit), `npm run build` succeeds
- [x] `.graphify/GRAPH_REPORT.md` and `.graphify/graph.json` refreshed via `npx graphify hook-rebuild`

Draft until P5 / final review.