### PR TITLE
Track F F-0816-M1: .ets + env(1) shebang + Swift dedup (port safishamsi rows 4 + 11b + 13)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-24)
 
 ## Corpus Check
-- 300 files · ~384 027 words
+- 301 files · ~387 748 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4531 nodes · 7247 edges · 234 communities detected
+- 4551 nodes · 7274 edges · 242 communities detected
 - Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 300 · Candidates: 322
-- Excluded: 0 untracked · 15511 ignored · 5 sensitive · 0 missing committed
+- Included files: 301 · Candidates: 323
+- Excluded: 0 untracked · 15523 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `4636d1d`
+- Built from Git commit: `0970b4c`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -84,35 +84,35 @@ Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), 
 
 ### Community 9 - "Community 9"
 Cohesion: 0.06
-Nodes (52): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+44 more)
-
-### Community 10 - "Community 10"
-Cohesion: 0.06
 Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
 
-### Community 11 - "Community 11"
+### Community 10 - "Community 10"
 Cohesion: 0.05
 Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
 
-### Community 12 - "Community 12"
+### Community 11 - "Community 11"
 Cohesion: 0.06
 Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
 
-### Community 13 - "Community 13"
+### Community 12 - "Community 12"
 Cohesion: 0.04
 Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
 
-### Community 14 - "Community 14"
+### Community 13 - "Community 13"
 Cohesion: 0.07
 Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
 
-### Community 15 - "Community 15"
+### Community 14 - "Community 14"
 Cohesion: 0.05
 Nodes (35): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+27 more)
 
-### Community 16 - "Community 16"
+### Community 15 - "Community 15"
 Cohesion: 0.06
 Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.05
+Nodes (42): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, extract(), ExtractionDiagnostic, ExtractionResult (+34 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.09
@@ -143,116 +143,116 @@ Cohesion: 0.06
 Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.05
-Nodes (38): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, ExtractionDiagnostic, ExtractionResult, ExtractorFn (+30 more)
-
-### Community 25 - "Community 25"
 Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.10
 Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
 
-### Community 27 - "Community 27"
-Cohesion: 0.10
-Nodes (34): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+26 more)
-
-### Community 28 - "Community 28"
+### Community 26 - "Community 26"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
 
-### Community 29 - "Community 29"
+### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
 
-### Community 30 - "Community 30"
+### Community 28 - "Community 28"
 Cohesion: 0.08
 Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
-### Community 31 - "Community 31"
+### Community 29 - "Community 29"
 Cohesion: 0.09
 Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 32 - "Community 32"
+### Community 30 - "Community 30"
 Cohesion: 0.09
 Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
-### Community 33 - "Community 33"
+### Community 31 - "Community 31"
 Cohesion: 0.09
 Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
-### Community 34 - "Community 34"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
 
-### Community 35 - "Community 35"
+### Community 33 - "Community 33"
 Cohesion: 0.10
-Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
+Nodes (30): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections(), recomputeDetection(), uniqueResolved() (+22 more)
 
-### Community 36 - "Community 36"
+### Community 34 - "Community 34"
 Cohesion: 0.06
 Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
-### Community 37 - "Community 37"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
-### Community 38 - "Community 38"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (30): appendMemoryFiles(), buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), isInputScopeMode(), makeScope() (+22 more)
 
-### Community 39 - "Community 39"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
 
-### Community 40 - "Community 40"
+### Community 38 - "Community 38"
+Cohesion: 0.09
+Nodes (28): BACKUP_ARTIFACTS, backupIfProtected(), buildFreshnessMetadata(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, computeTopologySignature() (+20 more)
+
+### Community 39 - "Community 39"
 Cohesion: 0.08
 Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.06
 Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.09
 Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.08
 Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.14
 Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.10
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.10
 Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.07
 Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.09
 Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
+
+### Community 51 - "Community 51"
+Cohesion: 0.09
+Nodes (26): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, envCommandArgs(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+18 more)
 
 ### Community 52 - "Community 52"
 Cohesion: 0.07
@@ -284,111 +284,111 @@ Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), bu
 
 ### Community 59 - "Community 59"
 Cohesion: 0.09
-Nodes (22): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule, hasCodeShebang() (+14 more)
-
-### Community 60 - "Community 60"
-Cohesion: 0.10
-Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 62 - "Community 62"
+### Community 60 - "Community 60"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
 
-### Community 63 - "Community 63"
+### Community 61 - "Community 61"
+Cohesion: 0.15
+Nodes (20): buildProfileChunkPrompt(), buildProfileDiscoveryPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), evidenceRequirementsSection(), genericSafetySection() (+12 more)
+
+### Community 62 - "Community 62"
 Cohesion: 0.13
 Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.09
 Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
 
-### Community 65 - "Community 65"
+### Community 64 - "Community 64"
 Cohesion: 0.09
 Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
 
-### Community 66 - "Community 66"
+### Community 65 - "Community 65"
 Cohesion: 0.15
 Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
 
-### Community 68 - "Community 68"
+### Community 67 - "Community 67"
 Cohesion: 0.09
 Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
 
-### Community 69 - "Community 69"
+### Community 68 - "Community 68"
 Cohesion: 0.16
 Nodes (21): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+13 more)
 
-### Community 70 - "Community 70"
+### Community 69 - "Community 69"
 Cohesion: 0.09
 Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.09
 Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
 
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.11
 Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.14
 Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.10
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.13
 Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.12
 Nodes (19): aliasHit, hit, hits, i18nRecords, ids, index, lower, minimal (+11 more)
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.13
 Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.15
 Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
-### Community 80 - "Community 80"
-Cohesion: 0.13
-Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
-
-### Community 81 - "Community 81"
+### Community 79 - "Community 79"
 Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
 
-### Community 82 - "Community 82"
+### Community 80 - "Community 80"
+Cohesion: 0.22
+Nodes (18): projectConfigSection(), rel(), buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection() (+10 more)
+
+### Community 81 - "Community 81"
 Cohesion: 0.17
 Nodes (14): ALLOWED_SCHEMES, BLOCKED_HOSTS, embeddedIPv4(), escapeHtml(), expandIPv6(), isPrivateIp(), isRedirectStatus(), safeFetch() (+6 more)
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.13
 Nodes (13): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+5 more)
 
-### Community 84 - "Community 84"
+### Community 83 - "Community 83"
 Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
-### Community 85 - "Community 85"
+### Community 84 - "Community 84"
 Cohesion: 0.15
 Nodes (14): AllChunksFailedError, DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape() (+6 more)
+
+### Community 85 - "Community 85"
+Cohesion: 0.11
+Nodes (17): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+9 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.11
@@ -415,32 +415,32 @@ Cohesion: 0.12
 Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.12
-Nodes (16): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+8 more)
-
-### Community 93 - "Community 93"
 Cohesion: 0.13
 Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
 
-### Community 94 - "Community 94"
+### Community 93 - "Community 93"
 Cohesion: 0.13
 Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
 
-### Community 95 - "Community 95"
+### Community 94 - "Community 94"
 Cohesion: 0.13
 Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
 
-### Community 96 - "Community 96"
+### Community 95 - "Community 95"
 Cohesion: 0.20
 Nodes (16): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), projectUninstallAll() (+8 more)
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.18
 Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
 
-### Community 98 - "Community 98"
+### Community 97 - "Community 97"
 Cohesion: 0.23
 Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
+
+### Community 98 - "Community 98"
+Cohesion: 0.15
+Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
 
 ### Community 99 - "Community 99"
 Cohesion: 0.13
@@ -504,351 +504,351 @@ Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark()
 
 ### Community 114 - "Community 114"
 Cohesion: 0.15
-Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
+Nodes (13): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+5 more)
 
 ### Community 115 - "Community 115"
+Cohesion: 0.15
+Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
+
+### Community 116 - "Community 116"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 116 - "Community 116"
-Cohesion: 0.15
-Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
-
 ### Community 117 - "Community 117"
 Cohesion: 0.15
-Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
+Nodes (10): allEdges, allNodes, edges, fooNodes, merged, methodEdges, methodTargets, nodes (+2 more)
 
 ### Community 118 - "Community 118"
 Cohesion: 0.15
-Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
+Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
 ### Community 119 - "Community 119"
+Cohesion: 0.15
+Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
+
+### Community 120 - "Community 120"
+Cohesion: 0.15
+Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
+
+### Community 121 - "Community 121"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 122 - "Community 122"
-Cohesion: 0.24
-Nodes (9): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), cleanupDirs, dir, labelsPath (+1 more)
-
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.21
 Nodes (12): canonicalFilePath(), countWords(), detect(), findVcsRoot(), isIgnored(), isNoiseDir(), isSensitive(), loadGraphifyignore() (+4 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.21
 Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.18
 Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 135 - "Community 135"
-Cohesion: 0.25
-Nodes (11): extract(), extractWithDiagnostics(), _importJs(), inferCommonRoot(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds() (+3 more)
-
 ### Community 136 - "Community 136"
+Cohesion: 0.29
+Nodes (11): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+3 more)
+
+### Community 137 - "Community 137"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 147 - "Community 147"
-Cohesion: 0.20
-Nodes (7): batch, G, impact, node, out, store, targets
-
 ### Community 148 - "Community 148"
-Cohesion: 0.24
-Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
+Cohesion: 0.20
+Nodes (5): fixtureRoot, profile, projectConfig, registries, report
 
 ### Community 149 - "Community 149"
 Cohesion: 0.20
-Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
+Nodes (7): batch, G, impact, node, out, store, targets
 
 ### Community 150 - "Community 150"
+Cohesion: 0.24
+Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
+
+### Community 151 - "Community 151"
+Cohesion: 0.20
+Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
+
+### Community 152 - "Community 152"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 151 - "Community 151"
+### Community 153 - "Community 153"
+Cohesion: 0.31
+Nodes (9): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+1 more)
+
+### Community 154 - "Community 154"
 Cohesion: 0.24
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 152 - "Community 152"
+### Community 155 - "Community 155"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
 
-### Community 153 - "Community 153"
+### Community 156 - "Community 156"
 Cohesion: 0.20
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 154 - "Community 154"
+### Community 157 - "Community 157"
 Cohesion: 0.20
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
 
-### Community 155 - "Community 155"
+### Community 158 - "Community 158"
 Cohesion: 0.22
 Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
-### Community 156 - "Community 156"
+### Community 159 - "Community 159"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 157 - "Community 157"
+### Community 160 - "Community 160"
+Cohesion: 0.22
+Nodes (6): cleanupDirs, dir, graphText, labels, labelsPath, reportText
+
+### Community 161 - "Community 161"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 158 - "Community 158"
+### Community 162 - "Community 162"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 159 - "Community 159"
+### Community 163 - "Community 163"
 Cohesion: 0.22
 Nodes (4): cleanupDirs, result, root, text
 
-### Community 160 - "Community 160"
+### Community 164 - "Community 164"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 161 - "Community 161"
+### Community 165 - "Community 165"
 Cohesion: 0.39
 Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
 
-### Community 162 - "Community 162"
+### Community 166 - "Community 166"
 Cohesion: 0.39
 Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
 
-### Community 163 - "Community 163"
+### Community 167 - "Community 167"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 164 - "Community 164"
+### Community 168 - "Community 168"
 Cohesion: 0.42
 Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
 
-### Community 165 - "Community 165"
+### Community 169 - "Community 169"
 Cohesion: 0.42
 Nodes (8): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl()
 
-### Community 166 - "Community 166"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
 
-### Community 167 - "Community 167"
+### Community 171 - "Community 171"
 Cohesion: 0.25
 Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
 
-### Community 168 - "Community 168"
+### Community 172 - "Community 172"
 Cohesion: 0.22
 Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
-
-### Community 169 - "Community 169"
-Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
-
-### Community 170 - "Community 170"
-Cohesion: 0.32
-Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
-
-### Community 171 - "Community 171"
-Cohesion: 0.25
-Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
-
-### Community 172 - "Community 172"
-Cohesion: 0.36
-Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
 ### Community 174 - "Community 174"
-Cohesion: 0.25
-Nodes (5): html, tokens, html, state, tokens
+Cohesion: 0.32
+Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
 
 ### Community 175 - "Community 175"
-Cohesion: 0.25
-Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
+Cohesion: 0.39
+Nodes (8): _importJs(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds(), resolveJsImportTarget(), resolveJsImportTargetInfo(), toPortablePath()
 
 ### Community 176 - "Community 176"
-Cohesion: 0.25
-Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
+Cohesion: 0.36
+Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.25
-Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
+Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.25
-Nodes (5): cacheRoot, cleanupDirs, destination, result, source
+Nodes (5): html, tokens, html, state, tokens
 
 ### Community 179 - "Community 179"
 Cohesion: 0.25
-Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
 ### Community 180 - "Community 180"
 Cohesion: 0.25
-Nodes (7): dataset, dirty, facets, keys, slices, state, status
+Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
 ### Community 181 - "Community 181"
 Cohesion: 0.25
-Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
 ### Community 182 - "Community 182"
+Cohesion: 0.25
+Nodes (5): cacheRoot, cleanupDirs, destination, result, source
+
+### Community 183 - "Community 183"
+Cohesion: 0.25
+Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+
+### Community 184 - "Community 184"
+Cohesion: 0.25
+Nodes (7): dataset, dirty, facets, keys, slices, state, status
+
+### Community 185 - "Community 185"
+Cohesion: 0.25
+Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+
+### Community 186 - "Community 186"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 183 - "Community 183"
+### Community 187 - "Community 187"
+Cohesion: 0.38
+Nodes (7): buildProfileState(), dataprepReport(), resolveConfigPath(), runConfiguredDataprep(), writeJson(), writeProfileState(), writeRegistries()
+
+### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 184 - "Community 184"
+### Community 189 - "Community 189"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 185 - "Community 185"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 186 - "Community 186"
+### Community 191 - "Community 191"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 187 - "Community 187"
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 188 - "Community 188"
+### Community 193 - "Community 193"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 189 - "Community 189"
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 190 - "Community 190"
+### Community 195 - "Community 195"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 191 - "Community 191"
+### Community 196 - "Community 196"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 192 - "Community 192"
+### Community 197 - "Community 197"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 193 - "Community 193"
+### Community 198 - "Community 198"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 194 - "Community 194"
+### Community 199 - "Community 199"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 195 - "Community 195"
-Cohesion: 0.33
-Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
-
-### Community 196 - "Community 196"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (1): recommendation
-
-### Community 198 - "Community 198"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
-
-### Community 199 - "Community 199"
-Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
-
 ### Community 200 - "Community 200"
 Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
+Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
 ### Community 201 - "Community 201"
 Cohesion: 0.47
@@ -856,178 +856,212 @@ Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minCon
 
 ### Community 202 - "Community 202"
 Cohesion: 0.33
-Nodes (5): commands, dir, matchers, settings, tempDirs
+Nodes (1): recommendation
 
 ### Community 203 - "Community 203"
 Cohesion: 0.33
-Nodes (5): dir, original, rule, rulePath, tempDirs
+Nodes (3): analysis, evaluation, text
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
-Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
+Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
 ### Community 205 - "Community 205"
-Cohesion: 0.33
-Nodes (4): dir, logs, preview, tempDirs
+Cohesion: 0.67
+Nodes (5): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels()
 
 ### Community 206 - "Community 206"
 Cohesion: 0.33
-Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+Nodes (1): CONFIDENCE_VALUES
 
 ### Community 207 - "Community 207"
-Cohesion: 0.33
-Nodes (5): config, dir, plugin, previousCwd, tempDirs
+Cohesion: 0.47
+Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.33
-Nodes (4): article, descriptions, G, generator
+Nodes (5): commands, dir, matchers, settings, tempDirs
 
 ### Community 209 - "Community 209"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+Cohesion: 0.33
+Nodes (4): cleanupDirs, dir, labelsPath, resolved
 
 ### Community 210 - "Community 210"
+Cohesion: 0.33
+Nodes (5): dir, original, rule, rulePath, tempDirs
+
+### Community 211 - "Community 211"
+Cohesion: 0.33
+Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
+
+### Community 212 - "Community 212"
+Cohesion: 0.33
+Nodes (4): dir, logs, preview, tempDirs
+
+### Community 213 - "Community 213"
+Cohesion: 0.33
+Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+
+### Community 214 - "Community 214"
+Cohesion: 0.33
+Nodes (5): config, dir, plugin, previousCwd, tempDirs
+
+### Community 215 - "Community 215"
+Cohesion: 0.33
+Nodes (4): article, descriptions, G, generator
+
+### Community 216 - "Community 216"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 211 - "Community 211"
+### Community 217 - "Community 217"
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+
+### Community 218 - "Community 218"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 212 - "Community 212"
+### Community 219 - "Community 219"
 Cohesion: 0.40
 Nodes (4): r1, r2, r3, result
 
-### Community 213 - "Community 213"
+### Community 220 - "Community 220"
 Cohesion: 0.40
 Nodes (4): chunks, client, files, root
 
-### Community 214 - "Community 214"
+### Community 221 - "Community 221"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 215 - "Community 215"
+### Community 222 - "Community 222"
 Cohesion: 0.40
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 216 - "Community 216"
+### Community 223 - "Community 223"
 Cohesion: 0.40
 Nodes (4): candidateGraph, graph, html, tokens
 
-### Community 217 - "Community 217"
+### Community 224 - "Community 224"
 Cohesion: 0.40
 Nodes (4): character, dataset, groups, total
 
-### Community 218 - "Community 218"
+### Community 225 - "Community 225"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 219 - "Community 219"
+### Community 226 - "Community 226"
 Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 220 - "Community 220"
+### Community 227 - "Community 227"
 Cohesion: 0.50
 Nodes (2): extraction, out
 
-### Community 221 - "Community 221"
+### Community 228 - "Community 228"
 Cohesion: 0.50
 Nodes (1): { root, files, cleanup }
 
-### Community 222 - "Community 222"
+### Community 229 - "Community 229"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 223 - "Community 223"
+### Community 230 - "Community 230"
 Cohesion: 0.67
 Nodes (1): html
 
-### Community 224 - "Community 224"
+### Community 231 - "Community 231"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 225 - "Community 225"
+### Community 232 - "Community 232"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 226 - "Community 226"
+### Community 233 - "Community 233"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 227 - "Community 227"
+### Community 234 - "Community 234"
 Cohesion: 1.00
 Nodes (2): average(), evaluateReviewAnalysis()
 
-### Community 228 - "Community 228"
+### Community 235 - "Community 235"
 Cohesion: 1.00
 Nodes (2): formatMetric(), reviewEvaluationToText()
 
-### Community 229 - "Community 229"
+### Community 236 - "Community 236"
 Cohesion: 1.00
 Nodes (2): average(), evaluateReviewAnalysis()
 
-### Community 230 - "Community 230"
+### Community 237 - "Community 237"
 Cohesion: 1.00
 Nodes (2): formatMetric(), reviewEvaluationToText()
 
-### Community 231 - "Community 231"
+### Community 238 - "Community 238"
 Cohesion: 1.00
 Nodes (1): UnpdfTextResult
 
-### Community 232 - "Community 232"
+### Community 239 - "Community 239"
 Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 233 - "Community 233"
+### Community 240 - "Community 240"
+Cohesion: 1.00
+Nodes (1): result
+
+### Community 241 - "Community 241"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1799 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1794 more)
+- **1811 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1806 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 84`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 162`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 164`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 188`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `recommendation`
+- **Thin community `Community 202`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 206`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `extraction`, `out`
+- **Thin community `Community 227`** (2 nodes): `extraction`, `out`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (1 nodes): `{ root, files, cleanup }`
+- **Thin community `Community 228`** (1 nodes): `{ root, files, cleanup }`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (1 nodes): `html`
+- **Thin community `Community 230`** (1 nodes): `html`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `paths`, `root`
+- **Thin community `Community 231`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 233`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 234`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 235`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 236`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 237`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 238`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 239`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 240`** (1 nodes): `result`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 241`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 81`, `Community 36`?**
+- **Why does `Cookies` connect `Community 4` to `Community 79`, `Community 34`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 81`, `Community 36`?**
+- **Why does `Cookies` connect `Community 0` to `Community 79`, `Community 34`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -76,13 +76,249 @@ function looksLikePaper(filePath: string): boolean {
 
 const ASSET_DIR_MARKERS = new Set([".imageset", ".xcassets", ".appiconset", ".colorset", ".launchimage"]);
 
-function hasCodeShebang(filePath: string): boolean {
-  try {
-    const firstLine = readFileSync(filePath, "utf-8").split(/\r?\n/, 1)[0] ?? "";
-    return firstLine.startsWith("#!");
-  } catch {
-    return false;
+// Interpreter names that mark a shebang-only file as CODE. Mirrors upstream
+// `_SHEBANG_CODE_INTERPRETERS` (port of safishamsi b6127aa sub).
+const SHEBANG_CODE_INTERPRETERS = new Set([
+  "python", "python3", "python2",
+  "ruby", "perl", "node", "nodejs",
+  "bash", "sh", "dash", "zsh", "fish", "ksh", "tcsh",
+  "lua", "php", "julia", "Rscript",
+]);
+
+/**
+ * POSIX-style shell tokenizer covering the subset of `shlex.split` that
+ * shebang lines actually exercise: single/double quotes, backslash escapes
+ * outside single quotes, whitespace-separated tokens. Throws on unbalanced
+ * quotes (matches shlex behavior) so the caller can fall back to None.
+ */
+function shellSplit(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  let hasToken = false;
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i]!;
+    if (inSingle) {
+      if (c === "'") { inSingle = false; continue; }
+      current += c;
+      continue;
+    }
+    if (inDouble) {
+      if (c === "\\" && i + 1 < input.length) {
+        const next = input[i + 1]!;
+        if (next === "\"" || next === "\\" || next === "$" || next === "`" || next === "\n") {
+          current += next;
+          i++;
+          continue;
+        }
+        current += c;
+        continue;
+      }
+      if (c === "\"") { inDouble = false; continue; }
+      current += c;
+      continue;
+    }
+    if (c === "'") { inSingle = true; hasToken = true; continue; }
+    if (c === "\"") { inDouble = true; hasToken = true; continue; }
+    if (c === "\\" && i + 1 < input.length) {
+      current += input[i + 1]!;
+      i++;
+      hasToken = true;
+      continue;
+    }
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      if (hasToken) {
+        tokens.push(current);
+        current = "";
+        hasToken = false;
+      }
+      continue;
+    }
+    current += c;
+    hasToken = true;
   }
+  if (inSingle || inDouble) {
+    throw new Error("unbalanced quote");
+  }
+  if (hasToken) tokens.push(current);
+  return tokens;
+}
+
+function splitEnvS(value: string, rest: string[]): string[] {
+  const packed = [value, ...rest].join(" ").trim();
+  return shellSplit(packed);
+}
+
+/**
+ * Strip leading env(1) options and var assignments, return the trailing
+ * command argv. Covers macOS/BSD and GNU coreutils env documented spellings.
+ *
+ * POSIX/macOS short forms:
+ *     env [-0iv] [-C workdir] [-P utilpath] [-S string]
+ *         [-u name] [name=value ...] [utility [argument ...]]
+ *
+ * GNU coreutils long/compact forms additionally supported:
+ *     --argv0=ARG / -a ARG / -aARG
+ *     --unset=NAME / --unset NAME / -u NAME / -uNAME
+ *     --chdir=DIR / --chdir DIR / -C DIR / -CDIR
+ *     --split-string=STRING / --split-string STRING
+ *     -S STRING / -SSTRING / -vS STRING / -vSSTRING
+ *     --ignore-environment / --null / --debug / --list-signal-handling
+ *     --default-signal[=SIG] / --ignore-signal[=SIG] / --block-signal[=SIG]
+ *
+ * `-S` / `--split-string` payloads are themselves env-style argument lists
+ * per the GNU shebang synopsis:
+ *     #!/usr/bin/env -[v]S[option]... [name=value]... command [args]...
+ * so after splitting the payload we recursively re-parse it with
+ * `allowSplit=false` (a nested -S inside a split payload is rejected to
+ * bound recursion).
+ *
+ * Unknown hyphen-prefixed args yield [] (we refuse to guess whether their
+ * next token is an interpreter or an operand).
+ *
+ * Port of upstream safishamsi b6127aa sub (`_env_command_args`).
+ */
+function envCommandArgs(args: string[], allowSplit: boolean = true): string[] {
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i]!;
+
+    if (arg === "--") {
+      return args.slice(i + 1);
+    }
+
+    // Split-string forms: tokenize the packed payload, then re-parse it as
+    // env args (so leading assignments/flags inside the payload are skipped
+    // before the interpreter is identified).
+    if (allowSplit) {
+      if (arg === "-S") {
+        if (i + 1 >= args.length) return [];
+        return envCommandArgs(splitEnvS(args.slice(i + 1).join(" "), []), false);
+      }
+      if (arg.startsWith("-S") && arg.length > 2) {
+        return envCommandArgs(splitEnvS(arg.slice(2), args.slice(i + 1)), false);
+      }
+      if (arg === "-vS") {
+        if (i + 1 >= args.length) return [];
+        return envCommandArgs(splitEnvS(args.slice(i + 1).join(" "), []), false);
+      }
+      if (arg.startsWith("-vS") && arg.length > 3) {
+        return envCommandArgs(splitEnvS(arg.slice(3), args.slice(i + 1)), false);
+      }
+      if (arg.startsWith("--split-string=")) {
+        return envCommandArgs(splitEnvS(arg.slice("--split-string=".length), args.slice(i + 1)), false);
+      }
+      if (arg === "--split-string") {
+        if (i + 1 >= args.length) return [];
+        return envCommandArgs(splitEnvS(args[i + 1]!, args.slice(i + 2)), false);
+      }
+    }
+
+    // Options with separate required operand
+    if (arg === "-u" || arg === "-C" || arg === "-P" || arg === "-a" ||
+        arg === "--unset" || arg === "--chdir" || arg === "--argv0") {
+      if (i + 2 > args.length) return [];
+      i += 2;
+      continue;
+    }
+
+    // Clumped short option + operand (e.g. `-uPYTHONPATH`)
+    if (
+      (arg.startsWith("-u") || arg.startsWith("-C") || arg.startsWith("-P") || arg.startsWith("-a"))
+      && arg.length > 2 && !arg.startsWith("--")
+    ) {
+      i += 1;
+      continue;
+    }
+
+    // Long option with `=` operand
+    if (arg.startsWith("--unset=") || arg.startsWith("--chdir=") || arg.startsWith("--argv0=")) {
+      i += 1;
+      continue;
+    }
+
+    // No-operand flags
+    if (arg === "-" || arg === "-i" || arg === "-0" || arg === "-v" ||
+        arg === "--ignore-environment" || arg === "--null" ||
+        arg === "--debug" || arg === "--list-signal-handling") {
+      i += 1;
+      continue;
+    }
+
+    // Signal-handling long flags (with or without =SIG operand — treated as
+    // no-effect for interpreter-resolution purposes)
+    if (arg.startsWith("--default-signal") || arg.startsWith("--ignore-signal") ||
+        arg.startsWith("--block-signal")) {
+      i += 1;
+      continue;
+    }
+
+    // Unknown hyphen-prefixed: refuse to guess
+    if (arg.startsWith("-")) return [];
+
+    // Inline NAME=value assignment
+    if (arg.includes("=")) {
+      i += 1;
+      continue;
+    }
+
+    // First non-option, non-assignment token starts the command argv
+    return args.slice(i);
+  }
+
+  return [];
+}
+
+/**
+ * Return the interpreter basename from a shebang line, or null if there is
+ * no shebang / the file is unreadable / parsing fails.
+ *
+ * Handles forms that a naive parser misses:
+ *   - `#!/usr/bin/env -S python3 -u`     (env -S split-args form)
+ *   - `#!/usr/bin/env -i bash`           (no-operand env flags)
+ *   - `#!/usr/bin/env -u VAR python3`    (env options with operands)
+ *   - `#!/usr/bin/env -C /tmp python3`   (env -C workdir)
+ *   - `#!/usr/bin/env -P /bin python3`   (env -P utilpath)
+ *   - `#!/usr/bin/env DEBUG=1 python3`   (inline var assignment)
+ *   - `#!"/usr/local/bin/python with spaces"`  (shellSplit handles quotes)
+ *
+ * Port of upstream safishamsi b6127aa sub (`_shebang_interpreter`).
+ */
+export function shebangInterpreter(filePath: string): string | null {
+  let first: Buffer;
+  try {
+    const fd = readFileSync(filePath);
+    first = fd.subarray(0, 256);
+  } catch {
+    return null;
+  }
+  if (first.length < 2 || first[0] !== 0x23 /* # */ || first[1] !== 0x21 /* ! */) {
+    return null;
+  }
+  const nl = first.indexOf(0x0a);
+  const lineBuf = nl >= 0 ? first.subarray(0, nl) : first;
+  // Decode as UTF-8 with replacement on errors (Buffer toString default).
+  const line = lineBuf.toString("utf-8").slice(2).trim();
+  let parts: string[];
+  try {
+    parts = shellSplit(line);
+  } catch {
+    return null;
+  }
+  if (parts.length === 0) return null;
+  let interp = basename(parts[0]!);
+  if (interp === "env") {
+    const envArgs = envCommandArgs(parts.slice(1));
+    if (envArgs.length === 0) return null;
+    interp = basename(envArgs[0]!);
+  }
+  return interp;
+}
+
+function hasCodeShebang(filePath: string): boolean {
+  const interp = shebangInterpreter(filePath);
+  return interp !== null && SHEBANG_CODE_INTERPRETERS.has(interp);
 }
 
 export function classifyFile(filePath: string): FileType | null {

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -22,6 +22,10 @@ export const CODE_EXTENSIONS = new Set([
   ".lua", ".toc", ".zig", ".ps1", ".ex", ".exs", ".m", ".mm", ".jl", ".vue",
   ".svelte", ".astro", ".dart", ".v", ".sv", ".mjs", ".ejs", ".sql", ".r", ".groovy",
   ".gradle", ".luau", ".f", ".f90", ".f95", ".f03", ".f08",
+  // ArkTS — TypeScript-superset used by HarmonyOS / OpenHarmony app development.
+  // Tree-sitter TypeScript already handles .ets AST extraction; detect just
+  // needed to recognize the extension. Port of upstream safishamsi 52d75bd / #926.
+  ".ets",
 ]);
 
 export const DOC_EXTENSIONS = new Set([".md", ".mdx", ".qmd", ".txt", ".rst", ".html", ".yaml", ".yml"]);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1308,6 +1308,14 @@ export interface ExtractionResult {
   nodes: GraphNode[];
   edges: GraphEdge[];
   error?: string;
+  /**
+   * Swift `extension Foo` class_declarations found in this file. tree-sitter-swift
+   * parses both `class Foo` and `extension Foo` as `class_declaration`; same-file
+   * duplicates collapse via seen_ids (the per-file id carries the file stem) but
+   * cross-file extensions don't — they're collected here for a corpus-level
+   * merge after every file has been parsed. Port of upstream safishamsi 406bea4 / #969.
+   */
+  swift_extensions?: Array<{ nid: string; label: string }>;
 }
 
 async function _extractGeneric(
@@ -1339,6 +1347,12 @@ async function _extractGeneric(
   const edges: GraphEdge[] = [];
   const seenIds = new Set<string>();
   const functionBodies: Array<[string, SyntaxNode]> = [];
+  // tree-sitter-swift parses both `class Foo` and `extension Foo` as
+  // `class_declaration`. Same-file pairs collapse via seenIds, but cross-file
+  // extensions don't (the per-file id carries the file stem), so they're
+  // collected here for a corpus-level merge after every file has been parsed.
+  // Port of upstream safishamsi 406bea4 / #969.
+  const swiftExtensions: Array<{ nid: string; label: string }> = [];
 
   function addNode(nid: string, label: string, line: number): void {
     if (!seenIds.has(nid)) {
@@ -1392,6 +1406,16 @@ async function _extractGeneric(
       const line = node.startPosition.row + 1;
       addNode(classNid, className, line);
       addEdge(fileNid, classNid, "contains", line);
+
+      // Swift extension dedup: tree-sitter-swift parses both `class Foo` and
+      // `extension Foo` as `class_declaration`, with `extension Foo` carrying
+      // an "extension" child node. Collect these so a corpus-level merge can
+      // collapse cross-file extension nodes onto their canonical type. Port
+      // of upstream safishamsi 406bea4 / #969.
+      if (config.tsModule === "tree_sitter_swift" &&
+          node.children.some((c) => c.type === "extension")) {
+        swiftExtensions.push({ nid: classNid, label: className });
+      }
 
       // Python-specific: inheritance
       if (config.tsModule === "tree_sitter_python") {
@@ -1813,7 +1837,11 @@ async function _extractGeneric(
     return validIds.has(src) && (validIds.has(tgt) || edge.relation === "imports" || edge.relation === "imports_from");
   });
 
-  return { nodes, edges: cleanEdges };
+  const result: ExtractionResult = { nodes, edges: cleanEdges };
+  if (swiftExtensions.length > 0) {
+    result.swift_extensions = swiftExtensions;
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -4349,6 +4377,85 @@ const _DISPATCH: Record<string, ExtractorFn> = {
 };
 
 /**
+ * Collapse cross-file Swift `extension Foo` nodes into the canonical `Foo`.
+ *
+ * tree-sitter-swift reuses `class_declaration` for both `class Foo` and
+ * `extension Foo`, and per-file node ids carry the file stem, so each file
+ * that extends `Foo` produces its own `Foo` node. The match is done by label:
+ * when exactly one non-extension declaration shares the label, extension
+ * nodes redirect onto it. Extensions of types outside the corpus (no match)
+ * and ambiguous labels (more than one match) are left untouched — picking
+ * arbitrarily would invent edges.
+ *
+ * Port of upstream safishamsi 406bea4 / #969 (`_merge_swift_extensions`).
+ */
+export function _mergeSwiftExtensions(
+  perFile: ExtractionResult[],
+  allNodes: GraphNode[],
+  allEdges: GraphEdge[],
+): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const extensionNids = new Set<string>();
+  const extensionLabels = new Map<string, string>();
+  for (const result of perFile) {
+    for (const ext of result.swift_extensions ?? []) {
+      extensionNids.add(ext.nid);
+      extensionLabels.set(ext.nid, ext.label);
+    }
+  }
+
+  if (extensionNids.size === 0) {
+    return { nodes: allNodes, edges: allEdges };
+  }
+
+  const labelToCanonical = new Map<string, string[]>();
+  for (const n of allNodes) {
+    if (extensionNids.has(n.id)) continue;
+    const label = n.label;
+    if (!label) continue;
+    const existing = labelToCanonical.get(label);
+    if (existing) existing.push(n.id);
+    else labelToCanonical.set(label, [n.id]);
+  }
+
+  const remap = new Map<string, string>();
+  for (const extNid of extensionNids) {
+    const label = extensionLabels.get(extNid)!;
+    const candidates = labelToCanonical.get(label) ?? [];
+    if (candidates.length !== 1) continue;
+    const canonicalNid = candidates[0]!;
+    if (canonicalNid !== extNid) {
+      remap.set(extNid, canonicalNid);
+    }
+  }
+
+  if (remap.size === 0) {
+    return { nodes: allNodes, edges: allEdges };
+  }
+
+  const remappedNodes = allNodes.filter((n) => !remap.has(n.id));
+
+  // Each extension file's `contains` edge ends up pointing at the canonical
+  // type — multiple files containing the same node is the intended shape:
+  // the type owns the methods, the files own their slice. Self-loops are
+  // dropped (e.g. an in-file extension method whose call already pointed at
+  // the canonical type).
+  const rewritten: GraphEdge[] = [];
+  const seenKeys = new Set<string>();
+  for (const e of allEdges) {
+    const src = remap.get(e.source) ?? e.source;
+    const tgt = remap.get(e.target) ?? e.target;
+    if (src === tgt) continue;
+    const remapped: GraphEdge = { ...e, source: src, target: tgt };
+    const key = `${src}\0${tgt}\0${remapped.relation}\0${remapped.source_file ?? ""}\0${remapped.source_location ?? ""}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    rewritten.push(remapped);
+  }
+
+  return { nodes: remappedNodes, edges: rewritten };
+}
+
+/**
  * Extract AST nodes and edges from a list of code files.
  *
  * Two-pass process:
@@ -4413,8 +4520,8 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
     process.stderr.write(`  AST extraction: ${total}/${total} files (100%)\n`);
   }
 
-  const allNodes: GraphNode[] = [];
-  const allEdges: GraphEdge[] = [];
+  let allNodes: GraphNode[] = [];
+  let allEdges: GraphEdge[] = [];
   for (const result of perFile) {
     allNodes.push(...(result.nodes ?? []));
     allEdges.push(...(result.edges ?? []));
@@ -4422,6 +4529,14 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
 
   // Add cross-file class-level edges (Python only)
   remapFileNodeIds(allNodes, allEdges, normalizedPaths, root);
+
+  // Collapse cross-file Swift `extension Foo` nodes onto the canonical `Foo`.
+  // Port of upstream safishamsi 406bea4 / #969. Runs after remapFileNodeIds
+  // and before Python cross-file import resolution so the canonical Swift
+  // nodes are in place for any downstream edge resolution.
+  const swiftMerged = _mergeSwiftExtensions(perFile, allNodes, allEdges);
+  allNodes = swiftMerged.nodes;
+  allEdges = swiftMerged.edges;
 
   const pyPaths = normalizedPaths.filter((p) => extname(p) === ".py");
   if (pyPaths.length > 0) {

--- a/tests/detect.test.ts
+++ b/tests/detect.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, readFileSync, writeFileSync, rmSync, statSync, symlinkSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { detect, classifyFile, detectIncremental, saveManifest } from "../src/detect.js";
+import { detect, classifyFile, detectIncremental, saveManifest, shebangInterpreter } from "../src/detect.js";
 import { inspectInputScope } from "../src/input-scope.js";
 import { execGit } from "../src/git.js";
 import { FileType } from "../src/types.js";
@@ -346,6 +346,206 @@ describe("detect", () => {
     const result = detect(tmpDir);
 
     expect(result.files.code).toEqual([join(tmpDir, "deploy")]);
+  });
+
+  // -------------------------------------------------------------------------
+  // env(1) shebang option-form parsing (port of upstream safishamsi b6127aa sub)
+  //
+  // Upstream `_shebang_file_type` historically only parsed `#!/usr/bin/env
+  // <interp>`. The full coreutils / BSD env synopsis is much richer:
+  //     #!/usr/bin/env [-vi0] [-S string] [-u name] [-C dir] [-P path]
+  //                    [name=value...] command [args]...
+  // The new parser strips env options + assignments before resolving the
+  // interpreter, and refuses to guess on unknown options.
+  // -------------------------------------------------------------------------
+
+  it("shebang: plain absolute interpreter path returns the basename", () => {
+    const script = join(tmpDir, "plain");
+    writeFileSync(script, "#!/usr/bin/python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: env single-arg form resolves to the interpreter, not 'env'", () => {
+    const script = join(tmpDir, "env_single");
+    writeFileSync(script, "#!/usr/bin/env python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: env -S split-args form recovers the interpreter", () => {
+    const script = join(tmpDir, "env_dashs");
+    writeFileSync(script, "#!/usr/bin/env -S python3 -u\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+    expect(classifyFile(script)).toBe(FileType.CODE);
+  });
+
+  it("shebang: env -i bash skips env flags and resolves the interpreter", () => {
+    const script = join(tmpDir, "env_flags");
+    writeFileSync(script, "#!/usr/bin/env -i bash\necho hi\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("bash");
+    expect(classifyFile(script)).toBe(FileType.CODE);
+  });
+
+  it("shebang: env DEBUG=1 python3 skips var=value assignments", () => {
+    const script = join(tmpDir, "env_assign");
+    writeFileSync(script, "#!/usr/bin/env DEBUG=1 python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+    expect(classifyFile(script)).toBe(FileType.CODE);
+  });
+
+  it("shebang: file without shebang returns null", () => {
+    const script = join(tmpDir, "no_shebang");
+    writeFileSync(script, "print('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBeNull();
+  });
+
+  it("shebang: env -u VAR python3 skips -u and its operand", () => {
+    const script = join(tmpDir, "env_unset");
+    writeFileSync(script, "#!/usr/bin/env -u PYTHONPATH python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+    expect(classifyFile(script)).toBe(FileType.CODE);
+  });
+
+  it("shebang: env -C /tmp python3 skips -C and its workdir operand", () => {
+    const script = join(tmpDir, "env_chdir");
+    writeFileSync(script, "#!/usr/bin/env -C /tmp python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: env -P /bin python3 skips -P and its utilpath operand", () => {
+    const script = join(tmpDir, "env_path");
+    writeFileSync(script, "#!/usr/bin/env -P /bin python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: env -i -S \"python3 -u\" handles -S after another env flag", () => {
+    const script = join(tmpDir, "env_flag_dash_s");
+    writeFileSync(script, "#!/usr/bin/env -i -S \"python3 -u\"\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: clumped -uPYTHONPATH form (no space between flag and operand)", () => {
+    const script = join(tmpDir, "env_clumped");
+    writeFileSync(script, "#!/usr/bin/env -uPYTHONPATH python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: env -u with no operand returns null", () => {
+    const script = join(tmpDir, "env_missing_op");
+    writeFileSync(script, "#!/usr/bin/env -u\n", "utf-8");
+    expect(shebangInterpreter(script)).toBeNull();
+  });
+
+  it("shebang: GNU --split-string='python3 -u' (`=` operand form)", () => {
+    const script = join(tmpDir, "env_split_eq");
+    writeFileSync(script, "#!/usr/bin/env --split-string='python3 -u'\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU --split-string \"python3 -u\" (separate operand)", () => {
+    const script = join(tmpDir, "env_split_sep");
+    writeFileSync(script, "#!/usr/bin/env --split-string \"python3 -u\"\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU -a alias python3 skips both -a and its argv0 operand", () => {
+    const script = join(tmpDir, "env_argv0");
+    writeFileSync(script, "#!/usr/bin/env -a alias python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: compact -Spython3 -u form (no space between -S and packed string)", () => {
+    const script = join(tmpDir, "env_compact_dash_s");
+    writeFileSync(script, "#!/usr/bin/env -Spython3 -u\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: compact -vSpython3 (-v plus compact -S)", () => {
+    const script = join(tmpDir, "env_compact_vs");
+    writeFileSync(script, "#!/usr/bin/env -vSpython3 -u\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU --unset PYTHONPATH python3 (separate operand)", () => {
+    const script = join(tmpDir, "env_long_unset");
+    writeFileSync(script, "#!/usr/bin/env --unset PYTHONPATH python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU --unset=PYTHONPATH python3 (`=` operand form)", () => {
+    const script = join(tmpDir, "env_long_unset_eq");
+    writeFileSync(script, "#!/usr/bin/env --unset=PYTHONPATH python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU --chdir /tmp python3 (separate operand)", () => {
+    const script = join(tmpDir, "env_long_chdir");
+    writeFileSync(script, "#!/usr/bin/env --chdir /tmp python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU --chdir=/tmp python3 (`=` operand form)", () => {
+    const script = join(tmpDir, "env_long_chdir_eq");
+    writeFileSync(script, "#!/usr/bin/env --chdir=/tmp python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: GNU signal-handling flags skip transparently", () => {
+    const script = join(tmpDir, "env_signal");
+    writeFileSync(script, "#!/usr/bin/env --default-signal=TERM --ignore-signal=PIPE python3\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: unknown hyphen-prefixed env option returns null (refuse to guess)", () => {
+    const script = join(tmpDir, "env_unknown");
+    writeFileSync(script, "#!/usr/bin/env --no-such-flag python3\n", "utf-8");
+    expect(shebangInterpreter(script)).toBeNull();
+  });
+
+  it("shebang: -S payload carries NAME=value assignments before the interpreter", () => {
+    const script = join(tmpDir, "env_s_assignment");
+    writeFileSync(
+      script,
+      "#!/usr/bin/env -S PYTHONPATH=/opt/custom:${PYTHONPATH} python3\nprint('x')\n",
+      "utf-8",
+    );
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: -S payload carries env flags before the interpreter", () => {
+    const script = join(tmpDir, "env_s_flag");
+    writeFileSync(script, "#!/usr/bin/env -S -i OLDUSER=${USER} python3\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: --split-string= payload carries assignments before the interpreter", () => {
+    const script = join(tmpDir, "env_long_split_assignment");
+    writeFileSync(
+      script,
+      "#!/usr/bin/env --split-string='PYTHONPATH=/opt/custom:${PYTHONPATH} python3 -u'\nprint('x')\n",
+      "utf-8",
+    );
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: nested -S inside a -S payload is rejected (recursion-bounded)", () => {
+    const script = join(tmpDir, "env_nested_split");
+    writeFileSync(script, "#!/usr/bin/env -S -S python3 -u\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBeNull();
+  });
+
+  it("shebang: -vS packed payload also re-parses for leading assignments", () => {
+    const script = join(tmpDir, "env_vs_assignment");
+    writeFileSync(script, "#!/usr/bin/env -vS DEBUG=1 python3 -u\nprint('x')\n", "utf-8");
+    expect(shebangInterpreter(script)).toBe("python3");
+  });
+
+  it("shebang: file with unknown interpreter is not classified as CODE", () => {
+    // Upstream's whitelist refuses to classify e.g. `awk` shebangs as CODE
+    // (we have no extractor for them). Mirrors the conservative upstream
+    // _shebang_file_type behavior.
+    const script = join(tmpDir, "report");
+    writeFileSync(script, "#!/usr/bin/awk -f\n", "utf-8");
+    expect(classifyFile(script)).toBeNull();
   });
 
   it("filters explicit scope inventory through detect and preserves scope diagnostics", () => {

--- a/tests/detect.test.ts
+++ b/tests/detect.test.ts
@@ -63,6 +63,13 @@ describe("classifyFile", () => {
     }
   });
 
+  it("classifies .ets (ArkTS / HarmonyOS) as CODE", () => {
+    // Port of upstream safishamsi 52d75bd / #926: .ets is the primary language
+    // for HarmonyOS/OpenHarmony app development. Without this, detect()
+    // silently skips all .ets source files.
+    expect(classifyFile("Sources/index.ets")).toBe(FileType.CODE);
+  });
+
   it("classifies Blade templates as CODE", () => {
     expect(classifyFile("resources/views/welcome.blade.php")).toBe(FileType.CODE);
   });

--- a/tests/extract-swift-extensions.test.ts
+++ b/tests/extract-swift-extensions.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _mergeSwiftExtensions, extract, type ExtractionResult } from "../src/extract.js";
+import type { GraphNode, GraphEdge } from "../src/types.js";
+
+/**
+ * Regression: cross-file `extension Foo` nodes must collapse onto the canonical
+ * `Foo` class. tree-sitter-swift parses both `class Foo` and `extension Foo`
+ * as `class_declaration`, and per-file node ids carry the file stem, so
+ * without a corpus-level merge each file would emit its own Foo. Port of
+ * upstream safishamsi 406bea4 / #969.
+ *
+ * The merge logic is exercised directly with synthetic per-file results so
+ * the test is deterministic regardless of whether tree-sitter-swift is
+ * installed in the test environment (the grammar is an optional peer dep).
+ * A real-grammar integration test is included but auto-skips when the
+ * grammar isn't available.
+ */
+describe("_mergeSwiftExtensions (upstream #969)", () => {
+  function mkNode(id: string, label: string, file: string): GraphNode {
+    return { id, label, file_type: "code", source_file: file, source_location: "L1" };
+  }
+  function mkEdge(src: string, tgt: string, rel: string, file: string): GraphEdge {
+    return {
+      source: src, target: tgt, relation: rel,
+      confidence: "EXTRACTED", source_file: file, source_location: "L1", weight: 1.0,
+    };
+  }
+
+  it("collapses an extension node onto the canonical class node when label matches exactly one", () => {
+    // Per-file 1: class Foo with method one()
+    // Per-file 2: extension Foo with method two() — tree-sitter emits both as
+    //             class_declaration; the extension node label is "Foo" but its
+    //             id carries the second file's stem.
+    const fooClassId = "Foo_Foo";        // stem(Foo) + label(Foo)
+    const fooExtId = "Foo_Ext_Foo";      // stem(Foo+Ext) + label(Foo)
+    const oneId = "Foo_Foo_one";
+    const twoId = "Foo_Ext_Foo_two";
+
+    const perFile: ExtractionResult[] = [
+      {
+        nodes: [
+          mkNode("Foo", "Foo.swift", "Foo.swift"),
+          mkNode(fooClassId, "Foo", "Foo.swift"),
+          mkNode(oneId, "one()", "Foo.swift"),
+        ],
+        edges: [
+          mkEdge("Foo", fooClassId, "contains", "Foo.swift"),
+          mkEdge(fooClassId, oneId, "method", "Foo.swift"),
+        ],
+      },
+      {
+        nodes: [
+          mkNode("Foo_Ext", "Foo+Ext.swift", "Foo+Ext.swift"),
+          mkNode(fooExtId, "Foo", "Foo+Ext.swift"),
+          mkNode(twoId, "two()", "Foo+Ext.swift"),
+        ],
+        edges: [
+          mkEdge("Foo_Ext", fooExtId, "contains", "Foo+Ext.swift"),
+          mkEdge(fooExtId, twoId, "method", "Foo+Ext.swift"),
+        ],
+        swift_extensions: [{ nid: fooExtId, label: "Foo" }],
+      },
+    ];
+
+    const allNodes = perFile.flatMap((r) => r.nodes);
+    const allEdges = perFile.flatMap((r) => r.edges);
+    const merged = _mergeSwiftExtensions(perFile, allNodes, allEdges);
+
+    const fooNodes = merged.nodes.filter((n) => n.label === "Foo");
+    expect(fooNodes.length).toBe(1);
+    expect(fooNodes[0]!.id).toBe(fooClassId);
+
+    // The extension's method edge must have been rewritten to the canonical id.
+    const methodEdges = merged.edges.filter((e) => e.relation === "method");
+    const methodTargets = methodEdges.map((e) => `${e.source}→${e.target}`);
+    expect(methodTargets).toContain(`${fooClassId}→${oneId}`);
+    expect(methodTargets).toContain(`${fooClassId}→${twoId}`);
+  });
+
+  it("leaves extensions of types outside the corpus untouched (no canonical match)", () => {
+    // `extension Array { … }` references a stdlib type with no class
+    // declaration in the corpus; no canonical match → no remap → node stays.
+    const arrayExtId = "ArrayExt_Array";
+    const helperId = "ArrayExt_Array_helper";
+    const perFile: ExtractionResult[] = [
+      {
+        nodes: [
+          mkNode("ArrayExt", "ArrayExt.swift", "ArrayExt.swift"),
+          mkNode(arrayExtId, "Array", "ArrayExt.swift"),
+          mkNode(helperId, "helper()", "ArrayExt.swift"),
+        ],
+        edges: [
+          mkEdge("ArrayExt", arrayExtId, "contains", "ArrayExt.swift"),
+          mkEdge(arrayExtId, helperId, "method", "ArrayExt.swift"),
+        ],
+        swift_extensions: [{ nid: arrayExtId, label: "Array" }],
+      },
+    ];
+
+    const allNodes = perFile.flatMap((r) => r.nodes);
+    const allEdges = perFile.flatMap((r) => r.edges);
+    const merged = _mergeSwiftExtensions(perFile, allNodes, allEdges);
+
+    expect(merged.nodes.filter((n) => n.label === "Array").length).toBe(1);
+    expect(merged.nodes.some((n) => n.id === arrayExtId)).toBe(true);
+  });
+
+  it("leaves ambiguous-label extensions untouched (multiple candidates)", () => {
+    // Two unrelated `class Foo` declarations + an `extension Foo`. Upstream
+    // refuses to pick: any choice would invent edges. Both classes stay,
+    // and the extension stays as its own node.
+    const fooAId = "A_Foo";
+    const fooBId = "B_Foo";
+    const fooExtId = "Ext_Foo";
+    const perFile: ExtractionResult[] = [
+      {
+        nodes: [mkNode("A", "A.swift", "A.swift"), mkNode(fooAId, "Foo", "A.swift")],
+        edges: [mkEdge("A", fooAId, "contains", "A.swift")],
+      },
+      {
+        nodes: [mkNode("B", "B.swift", "B.swift"), mkNode(fooBId, "Foo", "B.swift")],
+        edges: [mkEdge("B", fooBId, "contains", "B.swift")],
+      },
+      {
+        nodes: [mkNode("Ext", "Ext.swift", "Ext.swift"), mkNode(fooExtId, "Foo", "Ext.swift")],
+        edges: [mkEdge("Ext", fooExtId, "contains", "Ext.swift")],
+        swift_extensions: [{ nid: fooExtId, label: "Foo" }],
+      },
+    ];
+
+    const allNodes = perFile.flatMap((r) => r.nodes);
+    const allEdges = perFile.flatMap((r) => r.edges);
+    const merged = _mergeSwiftExtensions(perFile, allNodes, allEdges);
+
+    expect(merged.nodes.filter((n) => n.label === "Foo").length).toBe(3);
+  });
+
+  it("drops self-loop edges created by the remap", () => {
+    // Pre-remap: extension Foo node has a self-relation that ends up as
+    // canonical->canonical after the merge — those self-loops must drop.
+    const fooClassId = "Foo_Foo";
+    const fooExtId = "Foo_Ext_Foo";
+    const perFile: ExtractionResult[] = [
+      {
+        nodes: [mkNode(fooClassId, "Foo", "Foo.swift")],
+        edges: [],
+      },
+      {
+        nodes: [mkNode(fooExtId, "Foo", "Foo+Ext.swift")],
+        edges: [mkEdge(fooExtId, fooClassId, "uses", "Foo+Ext.swift")],
+        swift_extensions: [{ nid: fooExtId, label: "Foo" }],
+      },
+    ];
+
+    const allNodes = perFile.flatMap((r) => r.nodes);
+    const allEdges = perFile.flatMap((r) => r.edges);
+    const merged = _mergeSwiftExtensions(perFile, allNodes, allEdges);
+
+    expect(merged.edges.filter((e) => e.source === e.target).length).toBe(0);
+  });
+
+  it("collapses duplicate edges after remap (same src/tgt/relation key)", () => {
+    // Two extension nodes that both redirect to the same canonical produce
+    // duplicate edges; the seenKeys dedup must keep only one.
+    const fooClassId = "Foo_Foo";
+    const ext1 = "F1_Foo";
+    const ext2 = "F2_Foo";
+    const helperId = "Common_helper";
+    const perFile: ExtractionResult[] = [
+      { nodes: [mkNode(fooClassId, "Foo", "Foo.swift"), mkNode(helperId, "helper", "Common.swift")], edges: [] },
+      {
+        nodes: [mkNode(ext1, "Foo", "F1.swift")],
+        edges: [mkEdge(ext1, helperId, "uses", "F1.swift")],
+        swift_extensions: [{ nid: ext1, label: "Foo" }],
+      },
+      {
+        nodes: [mkNode(ext2, "Foo", "F1.swift")],
+        edges: [mkEdge(ext2, helperId, "uses", "F1.swift")],
+        swift_extensions: [{ nid: ext2, label: "Foo" }],
+      },
+    ];
+
+    const allNodes = perFile.flatMap((r) => r.nodes);
+    const allEdges = perFile.flatMap((r) => r.edges);
+    const merged = _mergeSwiftExtensions(perFile, allNodes, allEdges);
+
+    const usesEdges = merged.edges.filter((e) => e.relation === "uses");
+    expect(usesEdges.length).toBe(1);
+    expect(usesEdges[0]!.source).toBe(fooClassId);
+    expect(usesEdges[0]!.target).toBe(helperId);
+  });
+
+  it("returns inputs unchanged when no extensions present", () => {
+    const nodes = [mkNode("Foo_Foo", "Foo", "Foo.swift")];
+    const edges: GraphEdge[] = [];
+    const merged = _mergeSwiftExtensions([{ nodes, edges }], nodes, edges);
+    expect(merged.nodes).toBe(nodes);
+    expect(merged.edges).toBe(edges);
+  });
+});
+
+describe("Swift cross-file extension dedup (integration via real grammar)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "graphify-swift-ext-int-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("collapses `extension Foo` from a sibling file onto canonical `class Foo`", async () => {
+    writeFileSync(join(dir, "Foo.swift"), "class Foo {\n    func one() {}\n}\n");
+    writeFileSync(join(dir, "Foo+Ext.swift"), "extension Foo {\n    func two() {}\n}\n");
+
+    const result = await extract([
+      join(dir, "Foo.swift"),
+      join(dir, "Foo+Ext.swift"),
+    ]);
+
+    // If tree-sitter-swift isn't installed in this environment, the extractor
+    // returns empty nodes; skip the assertion rather than fail.
+    const fooNodes = result.nodes.filter((n) => n.label === "Foo");
+    if (fooNodes.length === 0) {
+      // grammar absent — covered by the synthetic unit tests above
+      return;
+    }
+    expect(fooNodes.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Bundles three trivial parser/detect ports from upstream `safishamsi/graphify` Python `v8` into the TypeScript fork (Track F lot F-0816-M1, per `spec/SPEC_TRACK_F_0816_BILAN.md`):

- **Row 4** — `.ets` (ArkTS / HarmonyOS) extension added to `CODE_EXTENSIONS`.
  Upstream: `safishamsi/graphify@52d75bd` (PR #926).
- **Row 11b** — env(1) shebang option-form parsing audit. Replaces the lax `firstLine.startsWith("#!")` with the full upstream `_shebang_interpreter` + `_env_command_args` semantics: interpreter whitelist (`SHEBANG_CODE_INTERPRETERS`), POSIX-style `shellSplit`, and `envCommandArgs` covering macOS/BSD and GNU coreutils `env` spellings (`-S`, `-vS`, `--split-string`, `-u`, `-C`, `-P`, `-a`, `--unset`, `--chdir`, `--argv0`, `--ignore-environment`, signal-handling flags, etc.). Unknown hyphen-prefixed args refuse to guess.
  Upstream: `safishamsi/graphify@b6127aa` (sub-extract of PR #956).
- **Row 13** — Swift cross-file `extension Foo` dedup. tree-sitter-swift parses both `class Foo` and `extension Foo` as `class_declaration`, and per-file ids carry the file stem, so sibling-file extensions produced duplicate `Foo` nodes. Per-file extraction now tags extension class_declarations on `ExtractionResult.swift_extensions`; the corpus-level `_mergeSwiftExtensions` runs after `remapFileNodeIds` and collapses extension nodes onto the unique canonical declaration (label-match), rewriting edges (self-loops dropped, duplicates collapsed) and leaving ambiguous matches / out-of-corpus types untouched.
  Upstream: `safishamsi/graphify@406bea4` (PR #969).

## Commits

- `9264676` — row 4: add `.ets` extension to `CODE_EXTENSIONS`
- `686c512` — row 11b: env(1) shebang option-form parsing audit
- `0970b4c` — row 13: Swift extension nodes dedup
- `1b94c81` — refresh `.graphify` after the parser/detect ports

## Tests

- Baseline post-P4: 890 passed / 10 skipped (115 files).
- After this lot: **927 passed** / 10 skipped (116 files) — **+37 new tests**, zero regressions.
- +1 row 4 (`classifyFile` for `.ets`)
- +29 row 11b (shebang interpreter parsing: plain, env, env `-S`/`-vS`/`--split-string`, env flags with/without operands, GNU long/equals/clumped forms, signal-handling flags, nested-`-S` rejection, unknown-interpreter `awk` case)
- +7 row 13 (`_mergeSwiftExtensions` unit tests: canonical collapse, out-of-corpus untouched, ambiguous-label untouched, self-loop drop, duplicate-edge collapse, no-op when no extensions, plus a real-grammar integration test that auto-skips when `tree-sitter-swift` is absent)

## Verification

- [x] `npm install`
- [x] `npm run lint` (no errors)
- [x] `npm test` (927 passed / 10 skipped)
- [x] `npm run build` (ESM / CJS / DTS all clean)
- [x] `npx graphify hook-rebuild` (.graphify refreshed)

## Upstream references

- `52d75bd` `fix: add .ets (ArkTS) extension to CODE_EXTENSIONS` (#926)
- `b6127aa` `feat(multigraph): add runtime compatibility probe` (#956) — sub-extract `_shebang_interpreter` / `_env_command_args`
- `406bea4` `fix swift extension nodes duplicating across files` (#969)