### PR TITLE
Track F F-0816-Opt-Affected: extend review-delta with deeper import resolution (port safishamsi e44e6e9)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-24)
 
 ## Corpus Check
-- 301 files · ~387 748 words
+- 304 files · ~389 521 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4551 nodes · 7274 edges · 242 communities detected
+- 4573 nodes · 7311 edges · 250 communities detected
 - Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 301 · Candidates: 323
-- Excluded: 0 untracked · 15523 ignored · 5 sensitive · 0 missing committed
+- Included files: 304 · Candidates: 326
+- Excluded: 0 untracked · 15768 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `0970b4c`
+- Built from Git commit: `97e6244`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -87,156 +87,156 @@ Cohesion: 0.06
 Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.05
-Nodes (38): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+30 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.06
 Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
 
-### Community 12 - "Community 12"
+### Community 11 - "Community 11"
 Cohesion: 0.04
 Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
 
-### Community 13 - "Community 13"
+### Community 12 - "Community 12"
 Cohesion: 0.07
 Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
 
-### Community 14 - "Community 14"
+### Community 13 - "Community 13"
 Cohesion: 0.05
 Nodes (35): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+27 more)
 
-### Community 15 - "Community 15"
+### Community 14 - "Community 14"
 Cohesion: 0.06
 Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
 
-### Community 16 - "Community 16"
+### Community 15 - "Community 15"
 Cohesion: 0.05
 Nodes (42): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, extract(), ExtractionDiagnostic, ExtractionResult (+34 more)
 
-### Community 17 - "Community 17"
+### Community 16 - "Community 16"
 Cohesion: 0.09
 Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
 
-### Community 18 - "Community 18"
+### Community 17 - "Community 17"
 Cohesion: 0.07
 Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
 
-### Community 19 - "Community 19"
+### Community 18 - "Community 18"
 Cohesion: 0.07
 Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.06
 Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
 
-### Community 21 - "Community 21"
+### Community 20 - "Community 20"
 Cohesion: 0.10
 Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
 
-### Community 22 - "Community 22"
+### Community 21 - "Community 21"
 Cohesion: 0.10
 Nodes (41): assertGraphJsonFileSize(), assertGraphJsonSize(), GraphSizeMode, buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl() (+33 more)
 
-### Community 23 - "Community 23"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
 
-### Community 24 - "Community 24"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
-### Community 25 - "Community 25"
+### Community 24 - "Community 24"
 Cohesion: 0.10
 Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.08
 Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
-### Community 29 - "Community 29"
+### Community 28 - "Community 28"
 Cohesion: 0.09
 Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 30 - "Community 30"
+### Community 29 - "Community 29"
 Cohesion: 0.09
 Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 0.09
 Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.09
 Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.10
 Nodes (30): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections(), recomputeDetection(), uniqueResolved() (+22 more)
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.06
 Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.11
 Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (30): appendMemoryFiles(), buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), isInputScopeMode(), makeScope() (+22 more)
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.09
 Nodes (28): BACKUP_ARTIFACTS, backupIfProtected(), buildFreshnessMetadata(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, computeTopologySignature() (+20 more)
 
-### Community 39 - "Community 39"
+### Community 38 - "Community 38"
 Cohesion: 0.08
 Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
 
-### Community 40 - "Community 40"
+### Community 39 - "Community 39"
 Cohesion: 0.06
 Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.09
 Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.08
 Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.14
 Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.10
 Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.10
 Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.08
+Nodes (15): compareNodes(), compareStrings(), neighborCommunities(), riskFor(), BARREL_BASENAMES, compareNodes(), compareStrings(), ComputeAffectedFilesOptions (+7 more)
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
@@ -595,473 +595,513 @@ Cohesion: 0.29
 Nodes (11): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+3 more)
 
 ### Community 137 - "Community 137"
+Cohesion: 0.29
+Nodes (11): buildReviewDelta(), changedNodeIds(), clampDepth(), computeAffectedFiles(), dirname(), expandChangedIdsViaBarrels(), highRiskChains(), impactedNodeIds() (+3 more)
+
+### Community 138 - "Community 138"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.18
 Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.20
 Nodes (5): fixtureRoot, profile, projectConfig, registries, report
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.31
 Nodes (9): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+1 more)
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.24
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.20
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.20
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.22
 Nodes (6): cleanupDirs, dir, graphText, labels, labelsPath, reportText
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.22
 Nodes (4): cleanupDirs, result, root, text
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.39
 Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.39
 Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.42
 Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.42
 Nodes (8): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.25
 Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.22
 Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.32
 Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.39
 Nodes (8): _importJs(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds(), resolveJsImportTarget(), resolveJsImportTargetInfo(), toPortablePath()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 178 - "Community 178"
-Cohesion: 0.25
-Nodes (5): html, tokens, html, state, tokens
-
 ### Community 179 - "Community 179"
 Cohesion: 0.25
-Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
+Nodes (8): basename(), isBarrelPath(), isTestPath(), maybeCommunity(), nodeInfo(), normalizePath(), sourceMatches(), stem()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.25
-Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
+Nodes (5): html, tokens, html, state, tokens
 
 ### Community 181 - "Community 181"
 Cohesion: 0.25
-Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
+Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
 ### Community 182 - "Community 182"
 Cohesion: 0.25
-Nodes (5): cacheRoot, cleanupDirs, destination, result, source
+Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
 ### Community 183 - "Community 183"
 Cohesion: 0.25
-Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
 ### Community 184 - "Community 184"
 Cohesion: 0.25
-Nodes (7): dataset, dirty, facets, keys, slices, state, status
+Nodes (5): cacheRoot, cleanupDirs, destination, result, source
 
 ### Community 185 - "Community 185"
 Cohesion: 0.25
-Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
 ### Community 186 - "Community 186"
+Cohesion: 0.25
+Nodes (7): dataset, dirty, facets, keys, slices, state, status
+
+### Community 187 - "Community 187"
+Cohesion: 0.25
+Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+
+### Community 188 - "Community 188"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.38
 Nodes (7): buildProfileState(), dataprepReport(), resolveConfigPath(), runConfiguredDataprep(), writeJson(), writeProfileState(), writeRegistries()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.43
 Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 195 - "Community 195"
+### Community 197 - "Community 197"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 197 - "Community 197"
+### Community 199 - "Community 199"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 198 - "Community 198"
+### Community 200 - "Community 200"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 199 - "Community 199"
+### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 200 - "Community 200"
+### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 201 - "Community 201"
+### Community 203 - "Community 203"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 202 - "Community 202"
-Cohesion: 0.33
-Nodes (1): recommendation
-
-### Community 203 - "Community 203"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
+Nodes (1): recommendation
 
 ### Community 205 - "Community 205"
-Cohesion: 0.67
-Nodes (5): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels()
+Cohesion: 0.33
+Nodes (3): analysis, evaluation, text
 
 ### Community 206 - "Community 206"
 Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
+Nodes (6): buildReviewDelta(), changedNodeIds(), highRiskChains(), impactedNodeIds(), likelyTestGaps(), uniqueSorted()
 
 ### Community 207 - "Community 207"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
+Cohesion: 0.33
+Nodes (6): isTestPath(), maybeCommunity(), nodeInfo(), normalizePath(), sourceMatches(), stem()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.33
-Nodes (5): commands, dir, matchers, settings, tempDirs
+Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
 ### Community 209 - "Community 209"
-Cohesion: 0.33
-Nodes (4): cleanupDirs, dir, labelsPath, resolved
+Cohesion: 0.67
+Nodes (5): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.33
-Nodes (5): dir, original, rule, rulePath, tempDirs
+Nodes (1): CONFIDENCE_VALUES
 
 ### Community 211 - "Community 211"
-Cohesion: 0.33
-Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
+Cohesion: 0.47
+Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.33
-Nodes (4): dir, logs, preview, tempDirs
+Nodes (5): commands, dir, matchers, settings, tempDirs
 
 ### Community 213 - "Community 213"
 Cohesion: 0.33
-Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+Nodes (4): cleanupDirs, dir, labelsPath, resolved
 
 ### Community 214 - "Community 214"
 Cohesion: 0.33
-Nodes (5): config, dir, plugin, previousCwd, tempDirs
+Nodes (5): dir, original, rule, rulePath, tempDirs
 
 ### Community 215 - "Community 215"
 Cohesion: 0.33
-Nodes (4): article, descriptions, G, generator
+Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
 
 ### Community 216 - "Community 216"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+Cohesion: 0.33
+Nodes (4): dir, logs, preview, tempDirs
 
 ### Community 217 - "Community 217"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
+Cohesion: 0.33
+Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
 ### Community 218 - "Community 218"
-Cohesion: 0.50
-Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
+Cohesion: 0.33
+Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
 ### Community 219 - "Community 219"
-Cohesion: 0.40
-Nodes (4): r1, r2, r3, result
+Cohesion: 0.33
+Nodes (4): article, descriptions, G, generator
 
 ### Community 220 - "Community 220"
-Cohesion: 0.40
-Nodes (4): chunks, client, files, root
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
 ### Community 221 - "Community 221"
 Cohesion: 0.40
-Nodes (4): changelog, lock, pkg, workflow
+Nodes (2): delta, text
 
 ### Community 222 - "Community 222"
-Cohesion: 0.40
-Nodes (4): graphifyOut, long, result, tmpDir
+Cohesion: 0.60
+Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
 ### Community 223 - "Community 223"
-Cohesion: 0.40
-Nodes (4): candidateGraph, graph, html, tokens
+Cohesion: 0.50
+Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
 ### Community 224 - "Community 224"
 Cohesion: 0.40
-Nodes (4): character, dataset, groups, total
+Nodes (4): r1, r2, r3, result
 
 ### Community 225 - "Community 225"
-Cohesion: 0.67
-Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
+Cohesion: 0.40
+Nodes (4): chunks, client, files, root
 
 ### Community 226 - "Community 226"
-Cohesion: 0.50
-Nodes (3): b1, b2, backup
+Cohesion: 0.40
+Nodes (4): changelog, lock, pkg, workflow
 
 ### Community 227 - "Community 227"
-Cohesion: 0.50
-Nodes (2): extraction, out
+Cohesion: 0.40
+Nodes (4): graphifyOut, long, result, tmpDir
 
 ### Community 228 - "Community 228"
-Cohesion: 0.50
-Nodes (1): { root, files, cleanup }
+Cohesion: 0.40
+Nodes (4): candidateGraph, graph, html, tokens
 
 ### Community 229 - "Community 229"
-Cohesion: 0.67
-Nodes (3): runCli(), runMain(), runSkillRuntime()
+Cohesion: 0.40
+Nodes (4): character, dataset, groups, total
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (1): html
+Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
 ### Community 231 - "Community 231"
+Cohesion: 0.50
+Nodes (2): delta, G
+
+### Community 232 - "Community 232"
+Cohesion: 0.50
+Nodes (3): b1, b2, backup
+
+### Community 233 - "Community 233"
+Cohesion: 0.50
+Nodes (2): extraction, out
+
+### Community 234 - "Community 234"
+Cohesion: 0.50
+Nodes (1): { root, files, cleanup }
+
+### Community 235 - "Community 235"
+Cohesion: 0.50
+Nodes (2): result, text
+
+### Community 236 - "Community 236"
+Cohesion: 0.67
+Nodes (3): runCli(), runMain(), runSkillRuntime()
+
+### Community 237 - "Community 237"
+Cohesion: 0.67
+Nodes (1): html
+
+### Community 238 - "Community 238"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 232 - "Community 232"
+### Community 239 - "Community 239"
+Cohesion: 0.67
+Nodes (1): delta
+
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 233 - "Community 233"
+### Community 241 - "Community 241"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 234 - "Community 234"
+### Community 242 - "Community 242"
 Cohesion: 1.00
 Nodes (2): average(), evaluateReviewAnalysis()
 
-### Community 235 - "Community 235"
+### Community 243 - "Community 243"
 Cohesion: 1.00
 Nodes (2): formatMetric(), reviewEvaluationToText()
 
-### Community 236 - "Community 236"
+### Community 244 - "Community 244"
 Cohesion: 1.00
 Nodes (2): average(), evaluateReviewAnalysis()
 
-### Community 237 - "Community 237"
+### Community 245 - "Community 245"
 Cohesion: 1.00
 Nodes (2): formatMetric(), reviewEvaluationToText()
 
-### Community 238 - "Community 238"
+### Community 246 - "Community 246"
 Cohesion: 1.00
 Nodes (1): UnpdfTextResult
 
-### Community 239 - "Community 239"
+### Community 247 - "Community 247"
 Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 240 - "Community 240"
+### Community 248 - "Community 248"
 Cohesion: 1.00
 Nodes (1): result
 
-### Community 241 - "Community 241"
+### Community 249 - "Community 249"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1811 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1806 more)
+- **1819 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1814 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 163`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 165`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 190`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (1 nodes): `recommendation`
+- **Thin community `Community 204`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 210`** (1 nodes): `CONFIDENCE_VALUES`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `extraction`, `out`
+- **Thin community `Community 221`** (2 nodes): `delta`, `text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `{ root, files, cleanup }`
+- **Thin community `Community 231`** (2 nodes): `delta`, `G`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `html`
+- **Thin community `Community 233`** (2 nodes): `extraction`, `out`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `paths`, `root`
+- **Thin community `Community 234`** (1 nodes): `{ root, files, cleanup }`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 235`** (2 nodes): `result`, `text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 237`** (1 nodes): `html`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 238`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 239`** (1 nodes): `delta`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 241`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 242`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 243`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (1 nodes): `result`
+- **Thin community `Community 244`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 245`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 246`** (1 nodes): `UnpdfTextResult`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 247`** (2 nodes): `tempProfileProject()`, `tempProject()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 248`** (1 nodes): `result`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 249`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 79`, `Community 34`?**
+- **Why does `Cookies` connect `Community 4` to `Community 79`, `Community 33`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 79`, `Community 34`?**
+- **Why does `Cookies` connect `Community 0` to `Community 79`, `Community 33`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4119,6 +4119,7 @@ export async function main(): Promise<void> {
     .option("--max-nodes <n>", "Maximum impacted nodes", "80")
     .option("--max-chains <n>", "Maximum high-risk chains", "8")
     .option("--depth <n>", "BFS depth on the import graph (1..5, default 1)", "1")
+    .option("--affected", "Emit only the affected-files list (one path per line); equivalent to upstream `graphify affected` on the review-delta surface")
     .action(async (files, opts) => {
       const changedFiles = [
         ...files,
@@ -4141,6 +4142,15 @@ export async function main(): Promise<void> {
       const raw = JSON.parse(rf(gp, "utf-8"));
       const G = loadGraphFromData(raw);
       const depth = Number.parseInt(String(opts.depth ?? "1"), 10);
+      if (opts.affected) {
+        const { computeAffectedFiles, affectedFilesToText } = await import("./review.js");
+        const affected = computeAffectedFiles(G, resolvedChangedFiles, {
+          depth,
+          maxNodes: Number(opts.maxNodes),
+        });
+        console.log(affectedFilesToText(affected));
+        return;
+      }
       const { buildReviewDelta, reviewDeltaToText } = await import("./review.js");
       const delta = buildReviewDelta(G, resolvedChangedFiles, {
         maxNodes: Number(opts.maxNodes),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4118,6 +4118,7 @@ export async function main(): Promise<void> {
     .option("--staged", "Use staged changes only")
     .option("--max-nodes <n>", "Maximum impacted nodes", "80")
     .option("--max-chains <n>", "Maximum high-risk chains", "8")
+    .option("--depth <n>", "BFS depth on the import graph (1..5, default 1)", "1")
     .action(async (files, opts) => {
       const changedFiles = [
         ...files,
@@ -4139,10 +4140,12 @@ export async function main(): Promise<void> {
       }
       const raw = JSON.parse(rf(gp, "utf-8"));
       const G = loadGraphFromData(raw);
+      const depth = Number.parseInt(String(opts.depth ?? "1"), 10);
       const { buildReviewDelta, reviewDeltaToText } = await import("./review.js");
       const delta = buildReviewDelta(G, resolvedChangedFiles, {
         maxNodes: Number(opts.maxNodes),
         maxChains: Number(opts.maxChains),
+        depth,
       });
       console.log(reviewDeltaToText(delta));
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,8 +299,8 @@ export type {
 export type { LlmExecutionMode } from "./llm-execution.js";
 export { buildFirstHopSummary, firstHopSummaryToText } from "./summary.js";
 export type { FirstHopSummary, FirstHopHub, FirstHopCommunity, FirstHopSummaryOptions } from "./summary.js";
-export { buildReviewDelta, reviewDeltaToText } from "./review.js";
-export type { ReviewDelta, ReviewNode, ReviewChain, ReviewDeltaOptions } from "./review.js";
+export { buildReviewDelta, reviewDeltaToText, computeAffectedFiles, affectedFilesToText } from "./review.js";
+export type { ReviewDelta, ReviewNode, ReviewChain, ReviewDeltaOptions, ComputeAffectedFilesOptions } from "./review.js";
 export { buildReviewAnalysis, reviewAnalysisToText, evaluateReviewAnalysis, reviewEvaluationToText } from "./review-analysis.js";
 export type { ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewImpactedCommunity, ReviewMultimodalSafety, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationResult, ReviewEvaluationOptions, ReviewRiskLevel } from "./review-analysis.js";
 export { createReviewGraphStore } from "./review-store.js";

--- a/src/review.ts
+++ b/src/review.ts
@@ -37,6 +37,23 @@ export interface ReviewDeltaOptions {
   maxNodes?: number;
   maxHubs?: number;
   maxChains?: number;
+  /**
+   * BFS traversal depth on the import graph when computing impacted nodes.
+   * Default 1 preserves prior behavior (direct neighbors only). Clamped to [1, 5].
+   * Higher values let cross-language import chains contribute to the
+   * impacted set (port of safishamsi e44e6e9 `graphify affected --depth`).
+   */
+  depth?: number;
+}
+
+const MAX_AFFECTED_DEPTH = 5;
+const DEFAULT_AFFECTED_DEPTH = 1;
+
+function clampDepth(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_AFFECTED_DEPTH;
+  if (value < 1) return DEFAULT_AFFECTED_DEPTH;
+  if (value > MAX_AFFECTED_DEPTH) return MAX_AFFECTED_DEPTH;
+  return Math.floor(value);
 }
 
 function compareStrings(a: string, b: string): number {
@@ -97,12 +114,28 @@ function changedNodeIds(G: Graph, changedFiles: string[]): string[] {
   return result.sort(compareStrings);
 }
 
-function impactedNodeIds(G: Graph, starts: string[], maxNodes: number): string[] {
+function impactedNodeIds(
+  G: Graph,
+  starts: string[],
+  maxNodes: number,
+  depth: number = DEFAULT_AFFECTED_DEPTH,
+): string[] {
+  const safeDepth = clampDepth(depth);
   const impacted = new Set(starts);
-  for (const nodeId of starts) {
-    forEachTraversalNeighbor(G, nodeId, (neighbor) => {
-      if (impacted.size < maxNodes) impacted.add(neighbor);
-    });
+  let frontier: string[] = [...starts];
+  for (let hop = 0; hop < safeDepth; hop += 1) {
+    if (frontier.length === 0 || impacted.size >= maxNodes) break;
+    const nextFrontier: string[] = [];
+    for (const nodeId of frontier) {
+      if (impacted.size >= maxNodes) break;
+      forEachTraversalNeighbor(G, nodeId, (neighbor) => {
+        if (impacted.size >= maxNodes) return;
+        if (impacted.has(neighbor)) return;
+        impacted.add(neighbor);
+        nextFrontier.push(neighbor);
+      });
+    }
+    frontier = nextFrontier;
   }
   return [...impacted].sort((a, b) => G.degree(b) - G.degree(a) || compareStrings(a, b));
 }
@@ -228,9 +261,10 @@ export function buildReviewDelta(
   const maxNodes = Math.max(1, options.maxNodes ?? 80);
   const maxHubs = Math.max(0, options.maxHubs ?? 8);
   const maxChains = Math.max(0, options.maxChains ?? 8);
+  const depth = clampDepth(options.depth);
   const changedFiles = uniqueSorted(changedFilesInput);
   const changedIds = changedNodeIds(G, changedFiles);
-  const impactedIds = impactedNodeIds(G, changedIds, maxNodes);
+  const impactedIds = impactedNodeIds(G, changedIds, maxNodes, depth);
   const impactedSet = new Set(impactedIds);
   const changedNodes = changedIds.map((nodeId) => nodeInfo(G, nodeId)).sort(compareNodes);
   const impactedNodes = impactedIds.map((nodeId) => nodeInfo(G, nodeId)).sort(compareNodes);

--- a/src/review.ts
+++ b/src/review.ts
@@ -3,8 +3,43 @@ import Graph from "graphology";
 
 import { isFileNode } from "./analyze.js";
 import { CODE_EXTENSIONS } from "./detect.js";
-import { forEachTraversalNeighbor } from "./graph.js";
+import { forEachTraversalNeighbor, isDirectedGraph } from "./graph.js";
 import { sanitizeLabel } from "./security.js";
+
+const IMPORT_RELATIONS = new Set(["imports", "imports_from", "re_exports", "re-exports"]);
+const BARREL_BASENAMES = new Set([
+  "index.ts",
+  "index.tsx",
+  "index.js",
+  "index.jsx",
+  "index.mjs",
+  "index.cjs",
+  "__init__.py",
+  "mod.rs",
+  "lib.rs",
+]);
+
+function basename(path: string): string {
+  const normalized = normalizePath(path);
+  const idx = normalized.lastIndexOf("/");
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}
+
+function dirname(path: string): string {
+  const normalized = normalizePath(path);
+  const idx = normalized.lastIndexOf("/");
+  return idx >= 0 ? normalized.slice(0, idx) : "";
+}
+
+function isBarrelPath(path: string | null | undefined): boolean {
+  if (!path) return false;
+  return BARREL_BASENAMES.has(basename(path).toLowerCase());
+}
+
+function sourceFileOf(G: Graph, nodeId: string): string | null {
+  const value = G.getNodeAttribute(nodeId, "source_file");
+  return typeof value === "string" && value.length > 0 ? normalizePath(value) : null;
+}
 
 export interface ReviewNode {
   id: string;
@@ -112,6 +147,85 @@ function changedNodeIds(G: Graph, changedFiles: string[]): string[] {
     }
   });
   return result.sort(compareStrings);
+}
+
+/**
+ * For each changed node whose source file is in a directory that contains
+ * a barrel / re-export file (index.ts, __init__.py, mod.rs, lib.rs, ...),
+ * also include the barrel file's nodes and the barrel's inbound consumers
+ * as "changed" if the barrel imports from the changed file (i.e. is acting
+ * as a re-export). This makes consumers of the barrel surface as affected
+ * at depth 1, matching upstream safishamsi e44e6e9 `re_exports` edge
+ * semantics without requiring a new edge kind in the TS extractor.
+ */
+function expandChangedIdsViaBarrels(G: Graph, changedIds: string[]): string[] {
+  if (changedIds.length === 0) return changedIds;
+  const expanded = new Set(changedIds);
+  const directed = isDirectedGraph(G);
+
+  const changedFileSet = new Set<string>();
+  for (const id of changedIds) {
+    const file = sourceFileOf(G, id);
+    if (file) changedFileSet.add(file);
+  }
+  if (changedFileSet.size === 0) return [...expanded].sort(compareStrings);
+
+  const candidateDirs = new Set<string>();
+  for (const file of changedFileSet) candidateDirs.add(dirname(file));
+
+  // Identify barrels in the same directory as any changed file that re-export
+  // (import_from) the changed file.
+  const barrelNodes: string[] = [];
+  G.forEachNode((nodeId, attrs) => {
+    const source = typeof attrs.source_file === "string" ? attrs.source_file : null;
+    if (!isBarrelPath(source)) return;
+    const normalized = source ? normalizePath(source) : "";
+    if (!normalized) return;
+    if (!candidateDirs.has(dirname(normalized))) return;
+    let importsChanged = false;
+    if (directed) {
+      G.forEachOutboundEdge(nodeId, (_edge, edgeAttrs, _src, target) => {
+        if (importsChanged) return;
+        const relation = typeof edgeAttrs.relation === "string" ? edgeAttrs.relation : "";
+        if (!IMPORT_RELATIONS.has(relation)) return;
+        const targetFile = sourceFileOf(G, target);
+        if (targetFile && changedFileSet.has(targetFile)) importsChanged = true;
+      });
+    } else {
+      G.forEachEdge(nodeId, (_edge, edgeAttrs, source2, target) => {
+        if (importsChanged) return;
+        const relation = typeof edgeAttrs.relation === "string" ? edgeAttrs.relation : "";
+        if (!IMPORT_RELATIONS.has(relation)) return;
+        const other = target === nodeId ? source2 : target;
+        const otherFile = sourceFileOf(G, other);
+        if (otherFile && changedFileSet.has(otherFile)) importsChanged = true;
+      });
+    }
+    if (importsChanged) barrelNodes.push(nodeId);
+  });
+
+  // Add barrels and their inbound consumers (re-export propagation) to the
+  // changed set. On directed graphs we follow inbound import edges from the
+  // barrel; on undirected graphs we use the generic neighbor iterator.
+  for (const barrelId of barrelNodes) {
+    if (!expanded.has(barrelId)) expanded.add(barrelId);
+    if (directed) {
+      G.forEachInboundEdge(barrelId, (_edge, edgeAttrs, source) => {
+        const relation = typeof edgeAttrs.relation === "string" ? edgeAttrs.relation : "";
+        if (!IMPORT_RELATIONS.has(relation)) return;
+        if (!expanded.has(source)) expanded.add(source);
+      });
+    } else {
+      G.forEachEdge(barrelId, (_edge, edgeAttrs, source, target) => {
+        const relation = typeof edgeAttrs.relation === "string" ? edgeAttrs.relation : "";
+        if (!IMPORT_RELATIONS.has(relation)) return;
+        const other = source === barrelId ? target : source;
+        if (!expanded.has(other)) expanded.add(other);
+      });
+    }
+  }
+
+  return [...expanded].sort(compareStrings);
 }
 
 function impactedNodeIds(
@@ -263,7 +377,8 @@ export function buildReviewDelta(
   const maxChains = Math.max(0, options.maxChains ?? 8);
   const depth = clampDepth(options.depth);
   const changedFiles = uniqueSorted(changedFilesInput);
-  const changedIds = changedNodeIds(G, changedFiles);
+  const initialChangedIds = changedNodeIds(G, changedFiles);
+  const changedIds = expandChangedIdsViaBarrels(G, initialChangedIds);
   const impactedIds = impactedNodeIds(G, changedIds, maxNodes, depth);
   const impactedSet = new Set(impactedIds);
   const changedNodes = changedIds.map((nodeId) => nodeInfo(G, nodeId)).sort(compareNodes);

--- a/src/review.ts
+++ b/src/review.ts
@@ -460,3 +460,43 @@ export function reviewDeltaToText(delta: ReviewDelta): string {
   lines.push("", `Next best action: ${delta.next_best_action}`);
   return lines.join("\n");
 }
+
+export interface ComputeAffectedFilesOptions {
+  /** BFS depth on the import graph (default 1, clamped to [1, 5]). */
+  depth?: number;
+  /** Cap on impacted node set during traversal (default 1024). */
+  maxNodes?: number;
+}
+
+/**
+ * Return the sorted list of files affected by a diff, computed by BFS over
+ * the import graph (with barrel re-export expansion). Convenience surface
+ * for `graphify review-delta --affected` — equivalent to upstream's
+ * `graphify affected` but hosted on the existing review-delta extension
+ * point (per user decision 2026-05-23: do not ship a new top-level verb).
+ */
+export function computeAffectedFiles(
+  G: Graph,
+  changedFilesInput: string[],
+  options: ComputeAffectedFilesOptions = {},
+): string[] {
+  const depth = clampDepth(options.depth);
+  const maxNodes = Math.max(1, options.maxNodes ?? 1024);
+  const changedFiles = uniqueSorted(changedFilesInput);
+  if (changedFiles.length === 0) return [];
+  const initialChangedIds = changedNodeIds(G, changedFiles);
+  if (initialChangedIds.length === 0) return [];
+  const changedIds = expandChangedIdsViaBarrels(G, initialChangedIds);
+  const impactedIds = impactedNodeIds(G, changedIds, maxNodes, depth);
+  const files = new Set<string>();
+  for (const id of impactedIds) {
+    const file = sourceFileOf(G, id);
+    if (file) files.add(file);
+  }
+  return [...files].sort(compareStrings);
+}
+
+/** Newline-separated rendering of an affected-files list (no header). */
+export function affectedFilesToText(files: string[]): string {
+  return files.join("\n");
+}

--- a/tests/affected-flows-barrel-reexports.test.ts
+++ b/tests/affected-flows-barrel-reexports.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { buildReviewDelta } from "../src/review.js";
+
+// Layout:
+//   src/utils/index.ts  imports  src/utils/foo.ts
+//   src/utils/index.ts  imports  src/utils/bar.ts
+//   src/consumer.ts     imports  src/utils/index.ts
+//
+// A change to src/utils/foo.ts must surface src/consumer.ts as affected
+// (through the index.ts barrel re-export) even at depth 1.
+function makeBarrelGraph(): Graph {
+  const G = new Graph({ type: "directed" });
+  const files = [
+    "src/utils/foo.ts",
+    "src/utils/bar.ts",
+    "src/utils/index.ts",
+    "src/consumer.ts",
+    "src/unrelated.ts",
+  ];
+  for (const f of files) {
+    G.addNode(f, { label: f, source_file: f, kind: "File" });
+  }
+  // barrel index re-exports foo and bar
+  G.addDirectedEdge("src/utils/index.ts", "src/utils/foo.ts", {
+    relation: "imports_from",
+    confidence: "EXTRACTED",
+  });
+  G.addDirectedEdge("src/utils/index.ts", "src/utils/bar.ts", {
+    relation: "imports_from",
+    confidence: "EXTRACTED",
+  });
+  // consumer imports the barrel
+  G.addDirectedEdge("src/consumer.ts", "src/utils/index.ts", {
+    relation: "imports",
+    confidence: "EXTRACTED",
+  });
+  // unrelated file imports nothing relevant
+  G.addDirectedEdge("src/unrelated.ts", "src/utils/bar.ts", {
+    relation: "imports",
+    confidence: "EXTRACTED",
+  });
+  return G;
+}
+
+describe("affected-flows barrel re-exports", () => {
+  it("barrel index re-export pulls consumers into the affected set at depth 1", () => {
+    const delta = buildReviewDelta(makeBarrelGraph(), ["src/utils/foo.ts"], {
+      maxNodes: 50,
+      depth: 1,
+    });
+    expect(delta.impacted_files).toContain("src/utils/foo.ts");
+    expect(delta.impacted_files).toContain("src/utils/index.ts");
+    expect(delta.impacted_files).toContain("src/consumer.ts");
+  });
+
+  it("does not pull unrelated consumers via the barrel", () => {
+    const delta = buildReviewDelta(makeBarrelGraph(), ["src/utils/foo.ts"], {
+      maxNodes: 50,
+      depth: 1,
+    });
+    expect(delta.impacted_files).not.toContain("src/unrelated.ts");
+  });
+
+  it("__init__.py barrel pulls Python consumers", () => {
+    const G = new Graph({ type: "directed" });
+    G.addNode("pkg/foo.py", { label: "foo.py", source_file: "pkg/foo.py", kind: "File" });
+    G.addNode("pkg/__init__.py", {
+      label: "__init__.py",
+      source_file: "pkg/__init__.py",
+      kind: "File",
+    });
+    G.addNode("app.py", { label: "app.py", source_file: "app.py", kind: "File" });
+    G.addDirectedEdge("pkg/__init__.py", "pkg/foo.py", {
+      relation: "imports_from",
+      confidence: "EXTRACTED",
+    });
+    G.addDirectedEdge("app.py", "pkg/__init__.py", {
+      relation: "imports_from",
+      confidence: "EXTRACTED",
+    });
+    const delta = buildReviewDelta(G, ["pkg/foo.py"], { maxNodes: 50, depth: 1 });
+    expect(delta.impacted_files).toContain("pkg/foo.py");
+    expect(delta.impacted_files).toContain("pkg/__init__.py");
+    expect(delta.impacted_files).toContain("app.py");
+  });
+});

--- a/tests/review-delta-affected-flag.test.ts
+++ b/tests/review-delta-affected-flag.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { computeAffectedFiles, affectedFilesToText } from "../src/review.js";
+
+function makeGraph(): Graph {
+  const G = new Graph({ type: "directed" });
+  G.addNode("src/a.ts", { label: "a.ts", source_file: "src/a.ts", kind: "File" });
+  G.addNode("src/b.ts", { label: "b.ts", source_file: "src/b.ts", kind: "File" });
+  G.addNode("src/c.ts", { label: "src/c.ts", source_file: "src/c.ts", kind: "File" });
+  G.addDirectedEdge("src/a.ts", "src/b.ts", {
+    relation: "imports",
+    confidence: "EXTRACTED",
+  });
+  G.addDirectedEdge("src/b.ts", "src/c.ts", {
+    relation: "imports",
+    confidence: "EXTRACTED",
+  });
+  return G;
+}
+
+describe("review-delta --affected flag", () => {
+  it("computeAffectedFiles returns sorted unique file list at depth 1", () => {
+    const result = computeAffectedFiles(makeGraph(), ["src/a.ts"]);
+    expect(result).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("computeAffectedFiles respects depth=2", () => {
+    const result = computeAffectedFiles(makeGraph(), ["src/a.ts"], { depth: 2 });
+    expect(result).toEqual(["src/a.ts", "src/b.ts", "src/c.ts"]);
+  });
+
+  it("computeAffectedFiles returns empty array when no nodes match", () => {
+    const result = computeAffectedFiles(makeGraph(), ["missing.ts"]);
+    expect(result).toEqual([]);
+  });
+
+  it("affectedFilesToText emits newline-separated paths", () => {
+    const text = affectedFilesToText(["src/a.ts", "src/b.ts"]);
+    expect(text).toBe("src/a.ts\nsrc/b.ts");
+  });
+
+  it("affectedFilesToText returns empty string on empty array", () => {
+    expect(affectedFilesToText([])).toBe("");
+  });
+});

--- a/tests/review-delta-depth.test.ts
+++ b/tests/review-delta-depth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { buildReviewDelta } from "../src/review.js";
+
+// Build a 4-hop directed import chain:
+//   a.ts --imports--> b.ts --imports--> c.ts --imports--> d.ts --imports--> e.ts
+// Reviewing a change in a.ts at depth N should reach exactly N+1 files
+// (a + first N hops). Default depth (1) preserves prior behavior.
+function makeChainGraph(): Graph {
+  const G = new Graph({ type: "directed" });
+  const files = ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"];
+  for (const f of files) {
+    G.addNode(f, { label: f, source_file: f, kind: "File" });
+  }
+  for (let i = 0; i < files.length - 1; i += 1) {
+    G.addDirectedEdge(files[i]!, files[i + 1]!, {
+      relation: "imports",
+      confidence: "EXTRACTED",
+    });
+  }
+  return G;
+}
+
+describe("review-delta --depth", () => {
+  it("default depth 1 reaches first-hop neighbors only", () => {
+    const delta = buildReviewDelta(makeChainGraph(), ["a.ts"], { maxNodes: 50 });
+    expect(delta.impacted_files).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("depth 3 reaches three import hops", () => {
+    const delta = buildReviewDelta(makeChainGraph(), ["a.ts"], {
+      maxNodes: 50,
+      depth: 3,
+    });
+    expect(delta.impacted_files).toEqual(["a.ts", "b.ts", "c.ts", "d.ts"]);
+  });
+
+  it("depth 5 reaches the whole chain (cap at end)", () => {
+    const delta = buildReviewDelta(makeChainGraph(), ["a.ts"], {
+      maxNodes: 50,
+      depth: 5,
+    });
+    expect(delta.impacted_files).toEqual(["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"]);
+  });
+
+  it("clamps depth above 5 to 5", () => {
+    const delta = buildReviewDelta(makeChainGraph(), ["a.ts"], {
+      maxNodes: 50,
+      depth: 99,
+    });
+    expect(delta.impacted_files).toEqual(["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"]);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the existing `graphify review-delta` surface with the deeper
cross-language import-resolution patches from upstream safishamsi
`e44e6e9` (`feat: add v8 affected and import-resolution support`).

**Why this is *not* a new `affected` CLI verb** — per the cadrage
decision recorded in `spec/SPEC_TRACK_F_0816_BILAN.md > F-Opt scope
re-evaluation` (user directive 2026-05-23, Q1 of the structured
decision session): two parallel "which files are impacted by a diff"
verbs would split user muscle memory and add review surface debt
for no functional gain. The capabilities upstream ships under
`graphify affected` are instead exposed on the existing review-*
surface so users keep their existing commands and gain `--depth` /
`--affected` as additive flags.

### S-1 — Deeper import-resolution depth (commit `00aa40b`)
- New `depth?: number` field on `ReviewDeltaOptions` (default `1`, clamped to `[1, 5]`).
- `impactedNodeIds` rewritten as bounded BFS over the outbound import graph; default behavior unchanged at depth 1.
- New `--depth <n>` CLI flag on `review-delta`.
- Test: `tests/review-delta-depth.test.ts` (4 cases).

### S-2 — Barrel re-export propagation (commit `f6366af`)
- Detect barrel/re-export files by basename convention (`index.{ts,tsx,js,jsx,mjs,cjs}`, `__init__.py`, `mod.rs`, `lib.rs`) at affected-flows time, **without** adding a new edge kind to the extractor (least-invasive option per the cadrage hint).
- When a changed file's directory contains a barrel that imports from the changed file, the barrel and its inbound consumers fold into the seed set — so consumers of the barrel surface as affected at depth 1, matching upstream's explicit `re_exports` edge semantics.
- Test: `tests/affected-flows-barrel-reexports.test.ts` (TS index, Python `__init__.py`, isolation of unrelated consumers).

### S-3 — `review-delta --affected` convenience flag (commit `a5ae8e3`)
- New public API in `src/review.ts`: `computeAffectedFiles`, `affectedFilesToText`, `ComputeAffectedFilesOptions`. Re-exported from `src/index.ts`.
- New CLI flag `graphify review-delta --affected` emits only the affected-files list (one path per line, sorted). Honors `--depth` and `--max-nodes`. Equivalent to upstream `graphify affected` but on the review-delta surface.
- Test: `tests/review-delta-affected-flag.test.ts`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 905 passed / 7 skipped (was 889 + pre-existing flaky detect test; +11 new tests for this lot, no regression)
- [x] `npm run build` succeeds
- [x] `npx graphify hook-rebuild` — 4553 nodes / 7284 edges / 248 communities
- [ ] Spot-check on real diff: `graphify review-delta --depth 3 --affected --staged` against a small barrel-shaped change

## Source lock

Upstream: `safishamsi/graphify` @ `e44e6e9` (`feat: add v8 affected and import-resolution support`, 2026-05-20).

## Out of scope (intentional)

- Top-level `graphify affected` verb — explicitly rejected per cadrage decision.
- Adding a `re_exports` edge kind to `src/extract.ts` — option (b) of the spec hint chosen (detect at affected-time via filename convention) — keeps the schema delta zero.
- The upstream extract.py +1279 LOC symbol-resolution post-pass — covered already by our existing TS extractor's per-language import resolvers; we only port the *consumer-side* import-graph traversal depth.