### PR TITLE
Track F F-0816-M5: semantic_cleanup stale-node prune (port safishamsi b6127aa)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-24)
 
 ## Corpus Check
-- 304 files · ~389 521 words
+- 306 files · ~391 943 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4573 nodes · 7311 edges · 250 communities detected
+- 4590 nodes · 7330 edges · 251 communities detected
 - Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
@@ -13,12 +13,12 @@
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 304 · Candidates: 326
-- Excluded: 0 untracked · 15768 ignored · 5 sensitive · 0 missing committed
+- Included files: 306 · Candidates: 328
+- Excluded: 0 untracked · 15521 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `97e6244`
+- Built from Git commit: `1ec74b8`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -131,72 +131,72 @@ Cohesion: 0.10
 Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.10
-Nodes (41): assertGraphJsonFileSize(), assertGraphJsonSize(), GraphSizeMode, buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl() (+33 more)
-
-### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
 
-### Community 23 - "Community 23"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
 
-### Community 24 - "Community 24"
+### Community 23 - "Community 23"
 Cohesion: 0.10
 Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
 
-### Community 25 - "Community 25"
+### Community 24 - "Community 24"
 Cohesion: 0.05
 Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.08
 Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.08
 Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.09
 Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
 
-### Community 29 - "Community 29"
+### Community 28 - "Community 28"
 Cohesion: 0.09
 Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
 
-### Community 30 - "Community 30"
+### Community 29 - "Community 29"
 Cohesion: 0.09
 Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 0.09
 Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
 
+### Community 31 - "Community 31"
+Cohesion: 0.10
+Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
+
 ### Community 32 - "Community 32"
+Cohesion: 0.14
+Nodes (34): buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeConfidence() (+26 more)
+
+### Community 33 - "Community 33"
 Cohesion: 0.10
 Nodes (30): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections(), recomputeDetection(), uniqueResolved() (+22 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.06
 Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (30): appendMemoryFiles(), buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), isInputScopeMode(), makeScope() (+22 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.09
-Nodes (28): BACKUP_ARTIFACTS, backupIfProtected(), buildFreshnessMetadata(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, computeTopologySignature() (+20 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.08
@@ -283,16 +283,16 @@ Cohesion: 0.14
 Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
 
 ### Community 59 - "Community 59"
+Cohesion: 0.10
+Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
+
+### Community 60 - "Community 60"
 Cohesion: 0.09
 Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.13
 Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.15
-Nodes (20): buildProfileChunkPrompt(), buildProfileDiscoveryPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), evidenceRequirementsSection(), genericSafetySection() (+12 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.13
@@ -363,20 +363,20 @@ Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
 ### Community 79 - "Community 79"
+Cohesion: 0.13
+Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
+
+### Community 80 - "Community 80"
 Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.22
 Nodes (18): projectConfigSection(), rel(), buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection() (+10 more)
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.17
 Nodes (14): ALLOWED_SCHEMES, BLOCKED_HOSTS, embeddedIPv4(), escapeHtml(), expandIPv6(), isPrivateIp(), isRedirectStatus(), safeFetch() (+6 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.13
-Nodes (13): acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode(), rebuildLockPath(), releaseRebuildLock() (+5 more)
 
 ### Community 83 - "Community 83"
 Cohesion: 0.14
@@ -387,312 +387,312 @@ Cohesion: 0.15
 Nodes (14): AllChunksFailedError, DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape() (+6 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.11
-Nodes (17): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+9 more)
+Cohesion: 0.14
+Nodes (11): CleanupStaleNodesOptions, CleanupStaleNodesResult, acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode() (+3 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.11
-Nodes (15): agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined, logs (+7 more)
+Nodes (17): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+9 more)
 
 ### Community 87 - "Community 87"
+Cohesion: 0.11
+Nodes (15): agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined, logs (+7 more)
+
+### Community 88 - "Community 88"
 Cohesion: 0.21
 Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.12
 Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.12
 Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.20
 Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.12
 Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.13
 Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.13
 Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.13
 Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.20
 Nodes (16): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), projectUninstallAll() (+8 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.18
 Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.23
 Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.15
 Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.13
 Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.13
 Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.24
 Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.13
 Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.19
 Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.13
 Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.16
 Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.14
 Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.27
 Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.14
 Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.14
 Nodes (9): boxes, central, dir, fixture, headingMatches, pills, result, sections (+1 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.23
 Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.15
-Nodes (13): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+5 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.15
 Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
 
 ### Community 116 - "Community 116"
+Cohesion: 0.19
+Nodes (6): CONFIDENCE_VALUES, hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
+
+### Community 117 - "Community 117"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.15
 Nodes (10): allEdges, allNodes, edges, fooNodes, merged, methodEdges, methodTargets, nodes (+2 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.15
 Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.15
 Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.15
 Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.26
 Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.17
 Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.21
 Nodes (12): canonicalFilePath(), countWords(), detect(), findVcsRoot(), isIgnored(), isNoiseDir(), isSensitive(), loadGraphifyignore() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.17
 Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.21
 Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
+Cohesion: 0.17
+Nodes (10): cleanupDirs, dir, formatted, G, graph, graphPath, result, root (+2 more)
+
+### Community 131 - "Community 131"
 Cohesion: 0.17
 Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.17
 Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.18
 Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (11): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+3 more)
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.29
 Nodes (11): buildReviewDelta(), changedNodeIds(), clampDepth(), computeAffectedFiles(), dirname(), expandChangedIdsViaBarrels(), highRiskChains(), impactedNodeIds() (+3 more)
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
 Cohesion: 0.24
 Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.29
 Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
 
-### Community 142 - "Community 142"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
 
-### Community 143 - "Community 143"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
 
-### Community 144 - "Community 144"
+### Community 146 - "Community 146"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 145 - "Community 145"
+### Community 147 - "Community 147"
 Cohesion: 0.18
 Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
 
-### Community 146 - "Community 146"
+### Community 148 - "Community 148"
 Cohesion: 0.18
 Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
 
-### Community 147 - "Community 147"
+### Community 149 - "Community 149"
 Cohesion: 0.18
 Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
 
-### Community 148 - "Community 148"
+### Community 150 - "Community 150"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 149 - "Community 149"
+### Community 151 - "Community 151"
 Cohesion: 0.20
 Nodes (5): fixtureRoot, profile, projectConfig, registries, report
 
-### Community 150 - "Community 150"
+### Community 152 - "Community 152"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 151 - "Community 151"
+### Community 153 - "Community 153"
 Cohesion: 0.24
 Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
 
-### Community 152 - "Community 152"
+### Community 154 - "Community 154"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 153 - "Community 153"
+### Community 155 - "Community 155"
 Cohesion: 0.42
 Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
 
-### Community 154 - "Community 154"
-Cohesion: 0.31
-Nodes (9): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+1 more)
-
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.24
 Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.38
 Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.20
 Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.20
 Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.22
 Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
-
-### Community 161 - "Community 161"
-Cohesion: 0.22
-Nodes (6): cleanupDirs, dir, graphText, labels, labelsPath, reportText
 
 ### Community 162 - "Community 162"
 Cohesion: 0.28
@@ -719,176 +719,176 @@ Cohesion: 0.39
 Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
 
 ### Community 168 - "Community 168"
+Cohesion: 0.25
+Nodes (7): assertGraphJsonFileSize(), assertGraphJsonSize(), GraphSizeMode, dir, message, missing, path
+
+### Community 169 - "Community 169"
 Cohesion: 0.31
 Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.42
 Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.42
 Nodes (8): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.22
 Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.32
 Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
+Cohesion: 0.25
+Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
+
+### Community 178 - "Community 178"
 Cohesion: 0.39
 Nodes (8): _importJs(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds(), resolveJsImportTarget(), resolveJsImportTargetInfo(), toPortablePath()
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.36
 Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 0.25
 Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
 
-### Community 179 - "Community 179"
+### Community 181 - "Community 181"
 Cohesion: 0.25
 Nodes (8): basename(), isBarrelPath(), isTestPath(), maybeCommunity(), nodeInfo(), normalizePath(), sourceMatches(), stem()
 
-### Community 180 - "Community 180"
+### Community 182 - "Community 182"
 Cohesion: 0.25
 Nodes (5): html, tokens, html, state, tokens
 
-### Community 181 - "Community 181"
+### Community 183 - "Community 183"
 Cohesion: 0.25
 Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
 
-### Community 182 - "Community 182"
+### Community 184 - "Community 184"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 183 - "Community 183"
+### Community 185 - "Community 185"
 Cohesion: 0.25
 Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
 
-### Community 184 - "Community 184"
+### Community 186 - "Community 186"
 Cohesion: 0.25
 Nodes (5): cacheRoot, cleanupDirs, destination, result, source
 
-### Community 185 - "Community 185"
+### Community 187 - "Community 187"
 Cohesion: 0.25
 Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
-### Community 186 - "Community 186"
+### Community 188 - "Community 188"
 Cohesion: 0.25
 Nodes (7): dataset, dirty, facets, keys, slices, state, status
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.25
 Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.38
 Nodes (7): buildProfileState(), dataprepReport(), resolveConfigPath(), runConfiguredDataprep(), writeJson(), writeProfileState(), writeRegistries()
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 191 - "Community 191"
-Cohesion: 0.43
-Nodes (5): hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
-
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.43
 Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.29
 Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.29
 Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (1): recommendation
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.33
 Nodes (3): analysis, evaluation, text
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.33
 Nodes (6): buildReviewDelta(), changedNodeIds(), highRiskChains(), impactedNodeIds(), likelyTestGaps(), uniqueSorted()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (6): isTestPath(), maybeCommunity(), nodeInfo(), normalizePath(), sourceMatches(), stem()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.33
 Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (5): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels()
-
-### Community 210 - "Community 210"
-Cohesion: 0.33
-Nodes (1): CONFIDENCE_VALUES
 
 ### Community 211 - "Community 211"
 Cohesion: 0.47
@@ -924,130 +924,134 @@ Nodes (5): config, dir, plugin, previousCwd, tempDirs
 
 ### Community 219 - "Community 219"
 Cohesion: 0.33
-Nodes (4): article, descriptions, G, generator
+Nodes (4): contents, dir, lockPath, tempDirs
 
 ### Community 220 - "Community 220"
+Cohesion: 0.33
+Nodes (4): article, descriptions, G, generator
+
+### Community 221 - "Community 221"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.40
 Nodes (2): delta, text
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.60
 Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.50
 Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.40
 Nodes (4): r1, r2, r3, result
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.40
 Nodes (4): chunks, client, files, root
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.40
 Nodes (4): graphifyOut, long, result, tmpDir
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.40
 Nodes (4): candidateGraph, graph, html, tokens
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.40
 Nodes (4): character, dataset, groups, total
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.67
 Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.50
 Nodes (2): delta, G
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.50
 Nodes (3): b1, b2, backup
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.50
 Nodes (2): extraction, out
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.50
 Nodes (1): { root, files, cleanup }
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.50
 Nodes (2): result, text
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.67
 Nodes (1): html
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (2): paths, root
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (1): delta
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 1.00
 Nodes (2): buildRegistrySources(), registrySourceName()
 
-### Community 242 - "Community 242"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
 ### Community 243 - "Community 243"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 244 - "Community 244"
 Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 245 - "Community 245"
 Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
+Nodes (2): average(), evaluateReviewAnalysis()
 
 ### Community 246 - "Community 246"
 Cohesion: 1.00
-Nodes (1): UnpdfTextResult
+Nodes (2): formatMetric(), reviewEvaluationToText()
 
 ### Community 247 - "Community 247"
 Cohesion: 1.00
-Nodes (2): tempProfileProject(), tempProject()
+Nodes (1): UnpdfTextResult
 
 ### Community 248 - "Community 248"
 Cohesion: 1.00
-Nodes (1): result
+Nodes (2): tempProfileProject(), tempProject()
 
 ### Community 249 - "Community 249"
+Cohesion: 1.00
+Nodes (1): result
+
+### Community 250 - "Community 250"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1819 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1814 more)
+- **1831 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1826 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1055,53 +1059,51 @@ Nodes (1): optionalRuntimeDeps
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 165`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 192`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (1 nodes): `recommendation`
+- **Thin community `Community 205`** (1 nodes): `recommendation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (1 nodes): `CONFIDENCE_VALUES`
+- **Thin community `Community 222`** (2 nodes): `delta`, `text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `delta`, `text`
+- **Thin community `Community 232`** (2 nodes): `delta`, `G`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `delta`, `G`
+- **Thin community `Community 234`** (2 nodes): `extraction`, `out`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `extraction`, `out`
+- **Thin community `Community 235`** (1 nodes): `{ root, files, cleanup }`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (1 nodes): `{ root, files, cleanup }`
+- **Thin community `Community 236`** (2 nodes): `result`, `text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `result`, `text`
+- **Thin community `Community 238`** (1 nodes): `html`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (1 nodes): `html`
+- **Thin community `Community 239`** (2 nodes): `paths`, `root`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `paths`, `root`
+- **Thin community `Community 240`** (1 nodes): `delta`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (1 nodes): `delta`
+- **Thin community `Community 242`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
+- **Thin community `Community 243`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 244`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 245`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
+- **Thin community `Community 246`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
+- **Thin community `Community 247`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 248`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 249`** (1 nodes): `result`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (1 nodes): `result`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 250`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 79`, `Community 33`?**
+- **Why does `Cookies` connect `Community 4` to `Community 80`, `Community 34`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 79`, `Community 33`?**
+- **Why does `Cookies` connect `Community 0` to `Community 80`, `Community 34`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
 - **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._

--- a/src/build.ts
+++ b/src/build.ts
@@ -14,6 +14,7 @@ import Graph from "graphology";
 import type { Extraction } from "./types.js";
 import { createGraph } from "./graph.js";
 import { assertGraphJsonFileSize } from "./graph-size-guard.js";
+import { cleanupStaleNodes } from "./semantic-cleanup.js";
 import { validateExtraction } from "./validate.js";
 
 export interface BuildOptions {
@@ -343,6 +344,23 @@ export function build(extractions: Extraction[], options?: BuildOptions): Graph 
 export interface BuildMergeOptions extends BuildOptions {
   graphPath?: string;
   pruneSources?: string[];
+  /**
+   * Automatic stale-node prune at finalize (F-0816-M5). When set, any
+   * node whose `source_file` no longer exists on disk under `root` (or
+   * is missing from `aliveSourceFiles` when provided) is dropped along
+   * with its adjacent edges before the shrink-guard fires.
+   *
+   * The wiki-level equivalent for the render path is the F-0816-P4
+   * stale-node filter in `src/wiki.ts > toWiki`. The two layers are
+   * deliberately overlapping (defence-in-depth): this pre-render cleanup
+   * keeps `.graphify/graph.json` itself dangling-reference-free; the
+   * wiki filter still defends the render path against any drift between
+   * graph.json and the analysis JSON.
+   */
+  pruneMissingSources?: {
+    root: string;
+    aliveSourceFiles?: Set<string>;
+  };
 }
 
 export function buildMerge(newChunks: Extraction[], options?: BuildMergeOptions): Graph {
@@ -387,7 +405,20 @@ export function buildMerge(newChunks: Extraction[], options?: BuildMergeOptions)
     }
   }
 
-  if (existingNodeCount > 0 && graph.order < existingNodeCount && (options?.pruneSources?.length ?? 0) === 0) {
+  // F-0816-M5: automatic stale-node prune. Ordered AFTER pruneSources so
+  // explicit caller intent always wins; the auto-prune catches whatever
+  // remains where source_file no longer exists on disk.
+  let autoPruned = 0;
+  if (options?.pruneMissingSources) {
+    const before = graph.order;
+    cleanupStaleNodes(graph, options.pruneMissingSources);
+    autoPruned = before - graph.order;
+  }
+
+  const explicitPruneRequested =
+    (options?.pruneSources?.length ?? 0) > 0 ||
+    (options?.pruneMissingSources !== undefined && autoPruned > 0);
+  if (existingNodeCount > 0 && graph.order < existingNodeCount && !explicitPruneRequested) {
     throw new Error(
       `graphify: buildMerge would shrink graph from ${existingNodeCount} to ${graph.order} nodes. ` +
       "Pass pruneSources explicitly if you intend to remove nodes.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,8 @@ export type {
 } from "./profile-report.js";
 export { validateExtraction, assertValid } from "./validate.js";
 export { buildFromJson, build, buildMerge, deduplicateByLabel } from "./build.js";
+export { cleanupStaleNodes } from "./semantic-cleanup.js";
+export type { CleanupStaleNodesOptions, CleanupStaleNodesResult } from "./semantic-cleanup.js";
 export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";
 export type { CloneRepoOptions, CloneRepoResult } from "./repo-clone.js";
 export { mergeGraphsFromFiles } from "./merge-graphs.js";

--- a/src/semantic-cleanup.ts
+++ b/src/semantic-cleanup.ts
@@ -1,0 +1,134 @@
+/**
+ * Stale-node pruning at the build/finalize step (F-0816-M5).
+ *
+ * Drop nodes whose `source_file` attribute no longer points at an existing
+ * file on disk, and any edges adjacent to those nodes. This is the
+ * graph-level pair of the wiki-level stale-node filter shipped in
+ * F-0816-P4 (`src/wiki.ts > toWiki`). Where the wiki filter rescues the
+ * render path from a drifted analysis JSON, this pre-render cleanup keeps
+ * `.graphify/graph.json` itself from carrying dangling references when a
+ * source file has been deleted between two builds.
+ *
+ * Ordering note vs. P4 wiki cleanup: this cleanup runs *before* the wiki
+ * render, so when called from the rebuild path the wiki filter becomes a
+ * no-op for these cases. When called only from `buildMerge` (without a
+ * wiki render in the same call), the wiki filter still does its defensive
+ * job downstream. The two layers are deliberately overlapping —
+ * defence-in-depth.
+ *
+ * Upstream reference: safishamsi/graphify commit `b6127aa` introduces a
+ * Python module named `semantic_cleanup.py`. Note: the upstream module is
+ * actually an agent-JSON sanitiser (rationale-text filtering for skill
+ * LLM responses) and does *not* implement file-deletion stale-node
+ * pruning. The TS port adopts the *name* + *bilan row 11h* framing
+ * ("delete-stale nodes after rebuild") and pairs naturally with P4 —
+ * see SPEC_TRACK_F_0816_BILAN.md row 11h.
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve as pathResolve } from "node:path";
+import type Graph from "graphology";
+
+export interface CleanupStaleNodesOptions {
+  /** Filesystem root used to resolve relative source_file paths. */
+  root: string;
+  /**
+   * Optional caller-supplied liveness set. When provided, the cleanup uses
+   * it as the source of truth and skips fs probing — useful when the
+   * caller already has the new detection's code-file list (e.g.
+   * `watch.ts > rebuildCode`). Paths in the set are compared after the
+   * same normalisation applied to stored `source_file` values.
+   */
+  aliveSourceFiles?: Set<string>;
+}
+
+export interface CleanupStaleNodesResult {
+  /** IDs of nodes removed from the graph. */
+  droppedNodes: string[];
+  /** Number of edges removed because at least one endpoint was dropped. */
+  droppedEdges: number;
+}
+
+function normaliseStoredSourcePath(value: unknown): string {
+  if (typeof value !== "string") return "";
+  // Stored values may use Windows backslashes (legacy graph.json on
+  // Windows runners). Normalise to forward slashes before any liveness
+  // probe so we don't double-bookkeep both forms.
+  return value.replace(/\\/g, "/").trim();
+}
+
+/**
+ * Prune nodes whose `source_file` no longer exists.
+ *
+ * @returns The list of dropped node IDs and the edge-drop count.
+ */
+export function cleanupStaleNodes(
+  graph: Graph,
+  options: CleanupStaleNodesOptions,
+): CleanupStaleNodesResult {
+  const rootAbs = pathResolve(options.root);
+  // Normalise the explicit-alive set the same way as stored source paths
+  // so backslash/forward-slash variants don't accidentally diverge.
+  const aliveSet = options.aliveSourceFiles
+    ? new Set(Array.from(options.aliveSourceFiles, (p) => normaliseStoredSourcePath(p)))
+    : undefined;
+
+  // Cache fs.existsSync probes per source_file so a 1000-node graph
+  // covering 200 source files doesn't run 1000 stat() calls.
+  const liveByPath = new Map<string, boolean>();
+  const isAlive = (sourceFile: string): boolean => {
+    if (!sourceFile) return true; // untracked entity; never prune
+    if (aliveSet) return aliveSet.has(sourceFile);
+    const cached = liveByPath.get(sourceFile);
+    if (cached !== undefined) return cached;
+    const absolute = isAbsolute(sourceFile) ? sourceFile : pathResolve(rootAbs, sourceFile);
+    const alive = existsSync(absolute);
+    liveByPath.set(sourceFile, alive);
+    return alive;
+  };
+
+  const toDrop: string[] = [];
+  graph.forEachNode((nodeId, attrs) => {
+    const stored = normaliseStoredSourcePath(attrs.source_file);
+    if (!stored) return; // untracked entity (concept, descriptor-only, etc.)
+    // Only prune `code` nodes by file-deletion. Document / paper / image /
+    // concept nodes can legitimately reference synthetic or external
+    // paths (semantic chunks, draft docs not yet committed, etc.) — the
+    // existing graph.json merge contract treats them as user-curated
+    // until an explicit `pruneSources` removes them.
+    const fileType = typeof attrs.file_type === "string" ? attrs.file_type : "";
+    if (fileType !== "" && fileType !== "code") return;
+    if (!isAlive(stored)) {
+      toDrop.push(nodeId);
+    }
+  });
+
+  let droppedEdges = 0;
+  if (toDrop.length > 0) {
+    const dropSet = new Set(toDrop);
+    // Count adjacent edges first — graphology drops them transparently
+    // when the node is dropped, but the diagnostic surface needs the
+    // count for the prune log line.
+    const seen = new Set<string>();
+    for (const nodeId of toDrop) {
+      graph.forEachEdge(nodeId, (edgeKey, _attrs, source, target) => {
+        // Don't double-count edges where both endpoints are stale.
+        if (seen.has(edgeKey)) return;
+        if (dropSet.has(source) || dropSet.has(target)) {
+          seen.add(edgeKey);
+          droppedEdges++;
+        }
+      });
+    }
+    for (const nodeId of toDrop) {
+      if (graph.hasNode(nodeId)) {
+        graph.dropNode(nodeId);
+      }
+    }
+    console.warn(
+      `[graphify] semantic_cleanup: dropped ${toDrop.length} stale node(s) ` +
+        `(${droppedEdges} edge(s) removed) — source file(s) no longer present.`,
+    );
+  }
+
+  return { droppedNodes: toDrop, droppedEdges };
+}

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -202,6 +202,19 @@ export async function rebuildCode(
         /* ignore unreadable prior graph snapshots */
       }
     }
+
+    // F-0816-M5: stale-node prune after the existing-graph merge step.
+    // When a code file has been deleted since the last build, its nodes
+    // survived the mergeNode-from-existing loop above because they did
+    // not appear in the new AST extraction. Drop them now — paired with
+    // the wiki-level stale-node filter from F-0816-P4 (defence-in-depth).
+    // Use the relative-code-files list as the explicit alive set so we
+    // don't run an `existsSync` probe per node.
+    const { cleanupStaleNodes } = await import("./semantic-cleanup.js");
+    cleanupStaleNodes(G, {
+      root,
+      aliveSourceFiles: new Set(relativeCodeFiles),
+    });
     // Topology short-circuit (upstream PR #824): if the new merged AST graph
     // has the exact same nodes + edges + relations as the previously
     // committed graph.json, reuse the existing community assignment instead

--- a/tests/build-semantic-cleanup.test.ts
+++ b/tests/build-semantic-cleanup.test.ts
@@ -128,6 +128,27 @@ describe("cleanupStaleNodes (F-0816-M5, build-time pair of wiki P4 stale-node fi
     expect(result.droppedNodes).toEqual([]);
   });
 
+  it("only prunes file_type=code nodes; document/paper/image/concept nodes survive missing source files", () => {
+    // Semantic / curated nodes often reference synthetic paths (draft docs,
+    // semantic chunks, external papers). The existing graph.json merge
+    // contract treats them as user-curated until an explicit pruneSources
+    // removes them — semantic_cleanup must respect that.
+    const root = tempDir("graphify-cleanup-root-");
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("code_dead", { label: "dead", source_file: "missing.ts", file_type: "code" });
+    G.mergeNode("doc_dead", { label: "doc", source_file: "missing.md", file_type: "document" });
+    G.mergeNode("paper_dead", { label: "paper", source_file: "missing.pdf", file_type: "paper" });
+    G.mergeNode("image_dead", { label: "image", source_file: "missing.png", file_type: "image" });
+
+    const result = cleanupStaleNodes(G, { root });
+
+    expect(G.hasNode("code_dead")).toBe(false);
+    expect(G.hasNode("doc_dead")).toBe(true);
+    expect(G.hasNode("paper_dead")).toBe(true);
+    expect(G.hasNode("image_dead")).toBe(true);
+    expect(result.droppedNodes).toEqual(["code_dead"]);
+  });
+
   it("emits a single log line with the dropped-node count when nodes were pruned", () => {
     const root = tempDir("graphify-cleanup-root-");
     const G = new Graph({ type: "undirected" });

--- a/tests/build-semantic-cleanup.test.ts
+++ b/tests/build-semantic-cleanup.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression tests for F-0816-M5.
+ *
+ * Stale-node pruning at the build/finalize step — the graph-level equivalent
+ * of P4's wiki-level stale-page cleanup. When a source file has been deleted
+ * between two builds (or its identity changes), the nodes/edges it produced
+ * must be pruned from the rebuilt graph.json before serialization.
+ *
+ * Upstream reference: safishamsi/graphify commit `b6127aa` introduces
+ * `semantic_cleanup.py`. Note: the *upstream* module is actually an
+ * agent-JSON sanitiser (rationale-text filtering for skill-merge LLM
+ * responses) and does not implement file-deletion stale-node pruning. The
+ * TS port adopts the *name* `semantic-cleanup` and the *spirit* of the row
+ * 11h bilan entry (`delete-stale nodes after rebuild`), but the actual
+ * semantics implemented here are deliberately scoped to file-deletion
+ * stale-node pruning — the graph-level pair of P4's wiki cleanup.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { buildMerge } from "../src/build.js";
+import { cleanupStaleNodes } from "../src/semantic-cleanup.js";
+
+const cleanupDirs: string[] = [];
+
+function tempDir(prefix: string = "graphify-semantic-cleanup-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+describe("cleanupStaleNodes (F-0816-M5, build-time pair of wiki P4 stale-node filter)", () => {
+  it("drops nodes whose source_file no longer exists on disk", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    // a.ts still exists; b.ts has been deleted.
+    writeFileSync(join(root, "a.ts"), "export const a = 1;\n", "utf-8");
+
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("a_sym", { label: "a", source_file: "a.ts", file_type: "code" });
+    G.mergeNode("b_sym", { label: "b", source_file: "b.ts", file_type: "code" });
+
+    const result = cleanupStaleNodes(G, { root });
+
+    expect(G.hasNode("a_sym")).toBe(true);
+    expect(G.hasNode("b_sym")).toBe(false);
+    expect(result.droppedNodes).toContain("b_sym");
+    expect(result.droppedNodes).not.toContain("a_sym");
+  });
+
+  it("also drops edges adjacent to a pruned node", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    writeFileSync(join(root, "a.ts"), "export const a = 1;\n", "utf-8");
+
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("a_sym", { label: "a", source_file: "a.ts", file_type: "code" });
+    G.mergeNode("b_sym", { label: "b", source_file: "b.ts", file_type: "code" });
+    G.mergeNode("c_sym", { label: "c", source_file: "c.ts", file_type: "code" });
+    // edges
+    G.mergeEdge("a_sym", "b_sym", { relation: "uses", confidence: "EXTRACTED" });
+    G.mergeEdge("a_sym", "c_sym", { relation: "uses", confidence: "EXTRACTED" });
+    G.mergeEdge("b_sym", "c_sym", { relation: "uses", confidence: "EXTRACTED" });
+
+    const result = cleanupStaleNodes(G, { root });
+
+    expect(G.hasNode("a_sym")).toBe(true);
+    expect(G.hasNode("b_sym")).toBe(false);
+    expect(G.hasNode("c_sym")).toBe(false);
+    // Only a_sym remains; no surviving edges (its peers are all gone).
+    expect(G.size).toBe(0);
+    expect(result.droppedNodes.sort()).toEqual(["b_sym", "c_sym"]);
+    // 3 edges adjacent to dropped nodes — graphology drops them when the
+    // node is dropped, but we still report the count.
+    expect(result.droppedEdges).toBeGreaterThanOrEqual(2);
+  });
+
+  it("accepts a caller-supplied aliveSourceFiles set and skips fs probing", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    // No files written. Liveness is decided entirely by the alive set.
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("keep", { label: "keep", source_file: "src/keep.ts", file_type: "code" });
+    G.mergeNode("drop", { label: "drop", source_file: "src/gone.ts", file_type: "code" });
+
+    const result = cleanupStaleNodes(G, {
+      root,
+      aliveSourceFiles: new Set(["src/keep.ts"]),
+    });
+
+    expect(G.hasNode("keep")).toBe(true);
+    expect(G.hasNode("drop")).toBe(false);
+    expect(result.droppedNodes).toEqual(["drop"]);
+  });
+
+  it("normalises Windows-style source paths before checking liveness", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "keep.ts"), "export {};\n", "utf-8");
+
+    const G = new Graph({ type: "undirected" });
+    // Windows-style backslashes in stored source_file.
+    G.mergeNode("keep", { label: "keep", source_file: "src\\keep.ts", file_type: "code" });
+    G.mergeNode("drop", { label: "drop", source_file: "src\\gone.ts", file_type: "code" });
+
+    cleanupStaleNodes(G, { root });
+
+    expect(G.hasNode("keep")).toBe(true);
+    expect(G.hasNode("drop")).toBe(false);
+  });
+
+  it("leaves nodes with empty/missing source_file alone (untracked entities)", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("untracked", { label: "Untracked", file_type: "concept" });
+    G.mergeNode("empty", { label: "empty", source_file: "", file_type: "concept" });
+
+    const result = cleanupStaleNodes(G, { root });
+
+    expect(G.hasNode("untracked")).toBe(true);
+    expect(G.hasNode("empty")).toBe(true);
+    expect(result.droppedNodes).toEqual([]);
+  });
+
+  it("emits a single log line with the dropped-node count when nodes were pruned", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("a", { label: "a", source_file: "a.ts", file_type: "code" });
+    G.mergeNode("b", { label: "b", source_file: "b.ts", file_type: "code" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    cleanupStaleNodes(G, { root });
+
+    expect(warn).toHaveBeenCalled();
+    const formatted = warn.mock.calls.map((args) => args.join(" ")).join("\n");
+    // F-0816-M5 marker so it shows up in CI logs.
+    expect(formatted).toMatch(/stale/i);
+    expect(formatted).toContain("2");
+  });
+
+  it("is silent when no nodes are stale", () => {
+    const root = tempDir("graphify-cleanup-root-");
+    writeFileSync(join(root, "a.ts"), "// alive\n", "utf-8");
+    writeFileSync(join(root, "b.ts"), "// alive\n", "utf-8");
+
+    const G = new Graph({ type: "undirected" });
+    G.mergeNode("a", { label: "a", source_file: "a.ts", file_type: "code" });
+    G.mergeNode("b", { label: "b", source_file: "b.ts", file_type: "code" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = cleanupStaleNodes(G, { root });
+
+    expect(result.droppedNodes).toEqual([]);
+    const stale = warn.mock.calls.filter((args) => /stale/i.test(args.join(" ")));
+    expect(stale).toHaveLength(0);
+  });
+});
+
+describe("buildMerge auto-prunes missing-source nodes (F-0816-M5)", () => {
+  it("prunes nodes whose source_file no longer exists when pruneMissingSources: { root }", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    // a.ts stays alive on disk; old.ts is the deleted file.
+    writeFileSync(join(dir, "a.ts"), "// alive\n", "utf-8");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "alive", label: "Alive", source_file: "a.ts", file_type: "code" },
+          { id: "ghost", label: "Ghost", source_file: "old.ts", file_type: "code" },
+        ],
+        links: [
+          { source: "alive", target: "ghost", relation: "uses", confidence: "EXTRACTED", source_file: "old.ts" },
+        ],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const graph = buildMerge([], { graphPath, pruneMissingSources: { root: dir } });
+
+    expect(graph.hasNode("alive")).toBe(true);
+    expect(graph.hasNode("ghost")).toBe(false);
+    // Edge adjacent to ghost is gone with the node.
+    expect(graph.size).toBe(0);
+  });
+
+  it("auto-prune satisfies the shrink-guard (no need for explicit pruneSources)", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    // Only b.ts exists; a.ts was deleted.
+    writeFileSync(join(dir, "b.ts"), "// alive\n", "utf-8");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "n_a", label: "A", source_file: "a.ts", file_type: "code" },
+          { id: "n_b", label: "B", source_file: "b.ts", file_type: "code" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    expect(() =>
+      buildMerge([], { graphPath, pruneMissingSources: { root: dir } }),
+    ).not.toThrow();
+  });
+
+  it("respects an explicit aliveSourceFiles set passed to buildMerge", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    // No files on disk — liveness is decided exclusively by the explicit set.
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "k", label: "K", source_file: "src/k.ts", file_type: "code" },
+          { id: "g", label: "G", source_file: "src/gone.ts", file_type: "code" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const graph = buildMerge([], {
+      graphPath,
+      pruneMissingSources: { root: dir, aliveSourceFiles: new Set(["src/k.ts"]) },
+    });
+
+    expect(graph.hasNode("k")).toBe(true);
+    expect(graph.hasNode("g")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the `semantic_cleanup` lot from upstream `safishamsi/graphify` commit `b6127aa` (row 11h of the F-0816 cadrage bilan) into TypeScript as **stale-node pruning at build/finalize**. This is the graph-level pair of the wiki-level stale-node filter shipped in F-0816-P4 (PR #65 / upstream PR #936).

- `src/semantic-cleanup.ts` — new module exporting `cleanupStaleNodes(graph, { root, aliveSourceFiles? })`. Drops nodes whose `source_file` no longer exists on disk (or is missing from a caller-supplied alive set), plus adjacent edges. Single-line diagnostic warn with the dropped-node + edge counts; silent on no-op.
- `src/build.ts` — `buildMerge` gains a `pruneMissingSources: { root, aliveSourceFiles? }` option. When set, the cleanup runs after the explicit `pruneSources` pass and before the shrink-guard. The shrink-guard accepts the auto-prune as 'intent expressed' so callers no longer need to enumerate deleted files manually.
- `src/watch.ts > rebuildCode` — invokes `cleanupStaleNodes` immediately after the existing-graph merge step, using the freshly detected `relativeCodeFiles` list as the alive set. `hook-rebuild` therefore prunes stale nodes automatically.
- Pruning is scoped to `file_type === 'code'` (or empty). Document / paper / image / concept nodes survive missing source files because the existing graph.json merge contract treats them as user-curated until an explicit `pruneSources` removes them.

## Upstream traceability

- **Bilan row**: `spec/SPEC_TRACK_F_0816_BILAN.md` row 11h.
- **Upstream SHA**: `b6127aa5a7cf289aba80051dcc94f00646853410` (PR #956 omnibus, semantic_cleanup sub-fragment).

**Upstream-semantics deviation (documented in module header + commit body)**: the upstream Python `semantic_cleanup.py` is actually an *agent-JSON sanitiser* (rationale-text filtering for skill LLM responses) and does NOT implement file-deletion stale-node pruning. The TS port adopts the bilan row 11h framing ('delete-stale nodes after rebuild') and the user-task pair note with F-0816-P4's wiki cleanup — it is the graph-level equivalent of `src/wiki.ts > toWiki`'s stale filter.

## Pair note with F-0816-P4

This module runs *before* the wiki render in the `rebuildCode` path, so the P4 wiki filter becomes a no-op for these cases (defence-in-depth, no regression). When `buildMerge` is called without a wiki render in scope, the P4 wiki filter still defends the render path against any drift between `graph.json` and the analysis JSON.

## Test plan

- [x] `tests/build-semantic-cleanup.test.ts` — 11 new tests covering: source-file-missing prune, edge cleanup, alive-set bypass, Windows path normalisation, untracked-entity preservation, file_type=code restriction, single-warn diagnostic, no-op silence, buildMerge auto-prune integration, shrink-guard interaction, explicit alive-set on buildMerge.
- [x] All existing tests pass: 950 / 950 (was 939 baseline = +11).
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [x] `npx graphify hook-rebuild` clean.