### PR TITLE
Track F F-0816-M2: JS/TS barrel re-exports as explicit graph edges (port safishamsi 1494874)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,24 +1,25 @@
 # Graph Report - .  (2026-05-24)
 
 ## Corpus Check
-- 306 files · ~391 943 words
+- 308 files · ~394 658 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4590 nodes · 7330 edges · 251 communities detected
-- Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
+- 4603 nodes · 8946 edges · 182 communities detected
+- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
+- Edge kinds: contains: 3908 · calls: 1907 · imports: 1021 · imports_from: 604 · re_exports: 516 · uses: 466 · method: 232 · rationale_for: 208 · inherits: 68 · defines: 16
 
 
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 306 · Candidates: 328
-- Excluded: 0 untracked · 15521 ignored · 5 sensitive · 0 missing committed
+- Included files: 308 · Candidates: 330
+- Excluded: 0 untracked · 15765 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `1ec74b8`
+- Built from Git commit: `5a34400`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -55,8 +56,8 @@ Cohesion: 0.02
 Nodes (79): analysis, analysisPath, analysisValues, article, artifact, cacheKey, captionsDir, configOut (+71 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (82): BenchmarkResult, Confidence, DetectionResult, Extraction, FileType, GodNodeEntry, GraphDiffResult, GraphEdge (+74 more)
+Cohesion: 0.05
+Nodes (72): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), asRecord(), bucketMatches() (+64 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.04
@@ -67,1046 +68,742 @@ Cohesion: 0.07
 Nodes (19): Auth, BasicAuth, AsyncClient, BaseClient, Client, Limits, The main Client and AsyncClient classes. BaseClient holds all shared logic. Clie, Asynchronous HTTP client. (+11 more)
 
 ### Community 5 - "Community 5"
+Cohesion: 0.05
+Nodes (66): ASSET_DIR_MARKERS, canonicalFilePath(), classifyFile(), convertOfficeFile(), countWords(), detect(), detectIncremental(), DetectOptions (+58 more)
+
+### Community 6 - "Community 6"
 Cohesion: 0.03
 Nodes (58): alphaNeighbors, audit, beforeAudit, beforeDecisions, betaNeighbors, candidate, candidateResponse, candidates (+50 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
+Cohesion: 0.04
+Nodes (55): AssistantLlmClientOptions, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult, BatchVisionImportInput, BatchVisionImportResult, BatchVisionJsonClient (+47 more)
+
+### Community 8 - "Community 8"
+Cohesion: 0.04
+Nodes (58): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+50 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.04
+Nodes (45): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), addNode(), qn(), uniqueSorted(), analyzeChanges() (+37 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.07
 Nodes (33): BearerAuth, DigestAuth, NetRCAuth, Load credentials from ~/.netrc based on the request host., Base class for all authentication handlers., Modify the request. May yield to inspect the response., HTTP Basic Authentication., Bearer token authentication. (+25 more)
 
-### Community 7 - "Community 7"
+### Community 11 - "Community 11"
 Cohesion: 0.05
-Nodes (48): buildFlowArtifact(), computeFlowCriticality(), decoratorsOf(), detectEntryPoints(), flowIdFor(), flowListToText(), flowToSteps(), getFlowById() (+40 more)
+Nodes (53): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+45 more)
 
-### Community 8 - "Community 8"
-Cohesion: 0.05
-Nodes (52): buildReviewContext(), buildReviewGuidance(), buildSourceSnippets(), changedFunctionsWithoutTests(), extractRelevantLines(), formatLines(), isInside(), isSensitivePath() (+44 more)
-
-### Community 9 - "Community 9"
+### Community 12 - "Community 12"
 Cohesion: 0.06
-Nodes (49): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+41 more)
+Nodes (46): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), artifactId(), buildImageDataprepManifest(), existingImages(), fileHash() (+38 more)
 
-### Community 10 - "Community 10"
+### Community 13 - "Community 13"
+Cohesion: 0.07
+Nodes (52): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+44 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.07
+Nodes (45): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+37 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.04
+Nodes (52): collectFiles(), astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode (+44 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.06
 Nodes (50): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+42 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.04
-Nodes (51): astroNode, baseNode, buildNode, cardNode, classNode, cleanNode, codeNode, constructorCall (+43 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.07
-Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.05
-Nodes (35): AssistantLlmClientOptions, BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, BatchTextJsonImportInput, BatchTextJsonImportResult, BatchVisionExportInput, BatchVisionExportResult (+27 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.06
-Nodes (39): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+31 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (42): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, extract(), ExtractionDiagnostic, ExtractionResult (+34 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.09
-Nodes (32): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+24 more)
-
 ### Community 17 - "Community 17"
-Cohesion: 0.07
-Nodes (43): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+35 more)
+Cohesion: 0.05
+Nodes (48): _C_CONFIG, _CPP_CONFIG, _CSHARP_CONFIG, _DISPATCH, _EXTENSIONS, extractC(), extractCpp(), extractCsharp() (+40 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.07
-Nodes (40): asRecord(), bucketMatches(), calibrateImageRouting(), countArray(), imageRoutingSampleFromCaption(), loadImageRoutingLabels(), loadImageRoutingRules(), normalizeBucket() (+32 more)
+Nodes (48): _cross_community_surprises(), _cross_file_surprises(), _file_category(), god_nodes(), graph_diff(), _is_concept_node(), _is_file_node(), _node_community_map() (+40 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.06
-Nodes (33): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+25 more)
+Nodes (33): average(), buildBlastRadius(), buildReviewAnalysis(), communityRisk(), evaluateReviewAnalysis(), formatMetric(), impactedCommunities(), multimodalSafety() (+25 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.10
-Nodes (43): asRecord(), asStringArray(), bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), normalizeCitationPolicy(), normalizeHardeningPolicy(), normalizeOntologyProfile() (+35 more)
+Cohesion: 0.07
+Nodes (43): BACKUP_ARTIFACTS, backupIfProtected(), buildFreshnessMetadata(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, computeTopologySignature() (+35 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (26): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+18 more)
+Cohesion: 0.07
+Nodes (44): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+36 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.06
-Nodes (23): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea() (+15 more)
+Nodes (40): average(), countHits(), evaluateReviewBenchmarks(), flowIdentifiers(), formatMetric(), identifiers(), normalize(), ratio() (+32 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.10
-Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
+Cohesion: 0.06
+Nodes (31): ANTIGRAVITY_RULE_PATH, ANTIGRAVITY_WORKFLOW_PATH, changedFilesFromGit(), checkSkillVersion(), __dirname, ensureCliExtractionShape(), __filename, GEMINI_MCP_SERVER (+23 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.05
-Nodes (34): addFunction(), qn(), addFunction(), allNames, api, artifact, callee, caller (+26 more)
+Cohesion: 0.06
+Nodes (34): buildReviewDelta(), changedNodeIds(), compareNodes(), compareStrings(), highRiskChains(), impactedNodeIds(), isTestPath(), likelyTestGaps() (+26 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.08
-Nodes (38): addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus(), decisionLogTarget() (+30 more)
+Cohesion: 0.07
+Nodes (44): bodyContent(), cachedFiles(), cacheDir(), cacheKind(), cacheNamespace(), CacheOptions, checkSemanticCache(), clearCache() (+36 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.08
-Nodes (31): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+23 more)
+Cohesion: 0.09
+Nodes (42): collectJsonIssues(), collectStringIssues(), collectTextIssues(), hasSchemePrefix(), isIgnoredLocalArtifact(), isWindowsAbsolutePath(), makeDetectionPortable(), normalizeFileMap() (+34 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.09
-Nodes (36): buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext(), collectSourceRefs() (+28 more)
+Nodes (44): addError(), addWarning(), appendJsonLine(), applyOntologyPatch(), auditPath(), changedFiles(), decisionLogOperation(), decisionLogStatus() (+36 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.09
-Nodes (32): authorLogin(), CommandRunner, defaultRunner, formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest(), ghRepoArgs() (+24 more)
+Cohesion: 0.04
+Nodes (44): GraphifyDataprepPolicy, GraphifyImageAnalysisBatchPolicy, GraphifyImageAnalysisCalibrationPolicy, GraphifyImageAnalysisPolicy, GraphifyImageArtifactSource, GraphifyLlmExecutionBatchPolicy, GraphifyLlmExecutionMeshPolicy, GraphifyLlmExecutionMode (+36 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.09
-Nodes (35): augmentDetectionWithTranscripts(), buildWhisperPrompt(), CACHED_AUDIO_EXTENSIONS, cloneDetection(), defaultWhisperCacheDir(), downloadAudio(), downloadFile(), ensureWhisperArtifacts() (+27 more)
+Cohesion: 0.08
+Nodes (41): appendMemoryFiles(), buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), isInputScopeMode(), makeScope() (+33 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.09
-Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
+Nodes (41): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), loadProjectConfig(), normalizeProjectConfig() (+33 more)
 
 ### Community 31 - "Community 31"
-Cohesion: 0.10
-Nodes (33): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+25 more)
+Cohesion: 0.09
+Nodes (37): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), buildProfileState(), dataprepReport(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections() (+29 more)
 
 ### Community 32 - "Community 32"
+Cohesion: 0.10
+Nodes (40): buildNodeFacts(), CompactDescriptionContext, computeCounters(), CountersValues, DEFAULT_INLINE_FACTS, DEFAULT_SECTIONS, displayValue(), escapeHtml() (+32 more)
+
+### Community 33 - "Community 33"
+Cohesion: 0.05
+Nodes (36): addFunction(), qn(), readFlowArtifact(), writeFlowArtifact(), addFunction(), allNames, api, artifact (+28 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.07
+Nodes (29): bfs(), communitiesFromGraph(), communityName(), dfs(), findNode(), getVersion(), loadGraph(), scoreNodes() (+21 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.07
+Nodes (36): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+28 more)
+
+### Community 36 - "Community 36"
+Cohesion: 0.10
+Nodes (35): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+27 more)
+
+### Community 37 - "Community 37"
+Cohesion: 0.10
+Nodes (33): authorLogin(), CommandRunner, defaultRunner, formatPrWorktrees(), formatPullRequestConflicts(), formatPullRequestDetails(), formatPullRequestList(), getPullRequest() (+25 more)
+
+### Community 38 - "Community 38"
+Cohesion: 0.09
+Nodes (15): Config, HttpClient, HttpClientFactory, main(), NewServer(), process(), validate(), Server (+7 more)
+
+### Community 39 - "Community 39"
+Cohesion: 0.10
+Nodes (34): LlmExecutionMode, buildFallbackSidecar(), buildWikiDescriptionPrompt(), BuildWikiDescriptionPromptOptions, collectCommunityTargetContext(), collectInferredCommunityMap(), collectNodeNeighbors(), collectNodeTargetContext() (+26 more)
+
+### Community 40 - "Community 40"
 Cohesion: 0.14
 Nodes (34): buildModel(), CompactMetaInline, displayText(), escapeHtml(), graphHtmlUrl(), graphNodeById(), graphNodeCommunity(), graphNodeConfidence() (+26 more)
 
-### Community 33 - "Community 33"
-Cohesion: 0.10
-Nodes (30): applyConfiguredExcludes(), buildConfiguredDetectionInputs(), emptyDetection(), fullPageScreenshotExcludes(), mergeDetections(), mergeScopeInspections(), recomputeDetection(), uniqueResolved() (+22 more)
-
-### Community 34 - "Community 34"
+### Community 41 - "Community 41"
 Cohesion: 0.06
 Nodes (34): build_url_with_params(), flatten_queryparams(), is_known_encoding(), normalize_header_key(), obfuscate_sensitive_headers(), parse_content_type(), primitive_value_to_str(), Utility functions shared across the library. Small helpers that don't belong in (+26 more)
 
-### Community 35 - "Community 35"
-Cohesion: 0.11
-Nodes (30): crossCommunitySurprises(), crossFileSurprises(), edgeBetweennessSurprises(), fileCategory(), godNodes(), isConceptNode(), isFileNode(), nodeCommunityMap() (+22 more)
+### Community 42 - "Community 42"
+Cohesion: 0.08
+Nodes (27): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels(), ExtractionDiagnostic, buildProject(), BuildProjectArtifacts (+19 more)
 
-### Community 36 - "Community 36"
+### Community 43 - "Community 43"
 Cohesion: 0.11
-Nodes (30): appendMemoryFiles(), buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), isInputScopeMode(), makeScope() (+22 more)
+Nodes (31): buildProfileChunkPrompt(), buildProfileExtractionPrompt(), buildProfileValidationPrompt(), chunkGuidance(), citationSection(), genericSafetySection(), hardeningSection(), inputHintsSection() (+23 more)
 
-### Community 37 - "Community 37"
+### Community 44 - "Community 44"
+Cohesion: 0.08
+Nodes (31): BatchTextJsonClient, BatchTextJsonExportInput, BatchTextJsonExportResult, buildTargetKindsMap(), buildWikiDescriptionBatchExport(), BuildWikiDescriptionBatchOptions, exportWikiDescriptionBatchToJsonl(), ParseWikiDescriptionBatchOptions (+23 more)
+
+### Community 45 - "Community 45"
+Cohesion: 0.09
+Nodes (27): addCall(), addFunction(), makeFlowStore(), qn(), getAffectedFlows(), asNumber(), asString(), createReviewGraphStore() (+19 more)
+
+### Community 46 - "Community 46"
+Cohesion: 0.09
+Nodes (26): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+18 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.09
+Nodes (28): buildMinimalContext(), riskFromScore(), suggestionsForTask(), addCall(), addFunction(), makeStore(), qn(), topCommunities() (+20 more)
+
+### Community 48 - "Community 48"
 Cohesion: 0.11
 Nodes (32): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+24 more)
 
-### Community 38 - "Community 38"
-Cohesion: 0.08
-Nodes (32): buildWikiDescriptionCacheKey(), checkWikiDescriptionFreshness(), createInsufficientEvidenceRecord(), CreateInsufficientEvidenceRecordInput, isNonEmptyString(), isRecord(), isStringArray(), isStringOrNull() (+24 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.06
-Nodes (9): AnalyzeChangesOptions, ChangedRange, ChangedRangesByFile, ComputeRiskScoreOptions, DetectChangesMinimalResult, DetectChangesNodeRisk, DetectChangesResult, DetectChangesTestGap (+1 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.09
-Nodes (30): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryContext, OntologyDiscoveryProposal, OntologyDiscoveryProposalAction (+22 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.08
-Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.12
-Nodes (30): currentBranch(), currentHead(), lifecyclePaths(), markLifecycleAnalyzed(), markLifecycleStale(), mergeBase(), planLifecyclePrune(), readJson() (+22 more)
-
-### Community 43 - "Community 43"
-Cohesion: 0.14
-Nodes (31): antigravityInstall(), canonicalPlatformName(), claudeInstall(), cursorInstall(), emptyPreview(), findSkillFile(), geminiInstall(), getInvocationExample() (+23 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.10
-Nodes (28): escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes(), installHook() (+20 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.10
-Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.12
-Nodes (26): artifactId(), buildImageDataprepManifest(), existingImages(), fileHash(), mimeType(), pdfArtifactByImage(), runImageDataprep(), sha256() (+18 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.08
-Nodes (15): compareNodes(), compareStrings(), neighborCommunities(), riskFor(), BARREL_BASENAMES, compareNodes(), compareStrings(), ComputeAffectedFilesOptions (+7 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.12
-Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
-
 ### Community 49 - "Community 49"
 Cohesion: 0.07
-Nodes (11): MULTIMODAL_EXTENSIONS, ReviewAnalysis, ReviewAnalysisOptions, ReviewBlastRadius, ReviewEvaluationCase, ReviewEvaluationCaseResult, ReviewEvaluationOptions, ReviewEvaluationResult (+3 more)
+Nodes (29): agentsInstall(), getAgentsMdSection(), getInvocationExample(), installCodexHook(), agents, dir, home, section (+21 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.09
-Nodes (16): communitiesFromGraph(), communityName(), findNode(), getVersion(), loadGraph(), serve(), toolGetCommunity(), toolGetNeighbors() (+8 more)
+Cohesion: 0.10
+Nodes (30): OntologyPatchContext, candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, loadOntologyReconciliationCandidates() (+22 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.09
-Nodes (26): ASSET_DIR_MARKERS, classifyFile(), CODE_EXTENSIONS, DetectOptions, DOC_EXTENSIONS, envCommandArgs(), GOOGLE_WORKSPACE_EXTENSIONS, GraphifyIgnoreRule (+18 more)
+Nodes (23): compileNodes(), compileOntologyOutputs(), compileRelations(), ontologyNodeType(), safeFilename(), sha256(), stringValue(), writeJson() (+15 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.07
-Nodes (24): cacheKey, communities, communityKey, godNodesData, graph, labels, mesh, meshClient (+16 more)
+Cohesion: 0.09
+Nodes (26): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+18 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.10
-Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+Cohesion: 0.08
+Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.13
-Nodes (26): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+18 more)
+Cohesion: 0.09
+Nodes (26): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistries() (+18 more)
 
 ### Community 55 - "Community 55"
 Cohesion: 0.10
-Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
+Nodes (29): GitContext, escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes() (+21 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.13
-Nodes (21): activeViewFromQuery(), candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult() (+13 more)
+Cohesion: 0.11
+Nodes (29): CACHED_AUDIO_EXTENSIONS, defaultWhisperCacheDir(), downloadFile(), ensureWhisperArtifacts(), envBoolean(), envNumber(), extractTranscriptText(), FasterWhisperModel (+21 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.07
-Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
+Nodes (27): CONFIDENCE_VALUES, loadHyperedges(), mergeHyperedges(), validateHyperedge(), Confidence, Hyperedge, a, aFlow (+19 more)
 
 ### Community 58 - "Community 58"
-Cohesion: 0.14
-Nodes (23): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), buildRegistrySources(), CONFIG_CANDIDATES, loadProjectConfig() (+15 more)
+Cohesion: 0.10
+Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.10
-Nodes (20): BACKUP_ARTIFACTS, backupIfProtected(), CanvasOptions, COMMUNITY_COLORS, CommunityLabelOptions, CommunityLabelsInput, CONFIDENCE_SCORE_DEFAULTS, HtmlOptions (+12 more)
+Cohesion: 0.11
+Nodes (26): buildFirstHopSummary(), buildNextBestAction(), communityLabels(), communityMembership(), compareHubs(), compareStrings(), FirstHopCommunity, FirstHopHub (+18 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.09
-Nodes (21): addNode(), qn(), addNode(), caller, fallback, flows, funcA, funcB (+13 more)
+Cohesion: 0.15
+Nodes (29): antigravityInstall(), canonicalPlatformName(), claudeInstall(), emptyPreview(), findSkillFile(), geminiInstall(), globalSkillInstallPreview(), installClaudeHook() (+21 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.13
-Nodes (21): applyEntry(), collectEntries(), gitAdvice(), migrateGraphifyOut(), normalizeGitPath(), planGraphifyOutMigration(), shellQuote(), applyEntry() (+13 more)
+Cohesion: 0.10
+Nodes (23): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+15 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.13
-Nodes (20): candidateId(), candidateScore(), chooseCanonicalPair(), filterOntologyReconciliationCandidates(), generateOntologyReconciliationCandidates(), GenerateOntologyReconciliationCandidatesOptions, nodeTerms(), normalizeTerm() (+12 more)
+Cohesion: 0.07
+Nodes (25): GenerateWikiDescriptionSidecarsClients, cacheKey, communities, communityKey, godNodesData, graph, labels, mesh (+17 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.09
-Nodes (21): a, aFlow, aSnapshot, b, bFlow, bSnapshot, cFlow, { confidence_score: _ignored, ...rest } (+13 more)
+Cohesion: 0.11
+Nodes (27): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryProposal, OntologyDiscoveryProposalAction, OntologyDiscoveryProposalKind (+19 more)
 
 ### Community 64 - "Community 64"
+Cohesion: 0.10
+Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+
+### Community 65 - "Community 65"
+Cohesion: 0.10
+Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.11
+Nodes (20): AllChunksFailedError, createDirectSemanticExtractionClient(), DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens() (+12 more)
+
+### Community 67 - "Community 67"
+Cohesion: 0.13
+Nodes (21): activeViewFromQuery(), candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult() (+13 more)
+
+### Community 68 - "Community 68"
+Cohesion: 0.07
+Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.08
+Nodes (16): OntologyWriteFixture, writeOntologyWriteFixture(), OntologyPatch, boxes, central, dir, fixture, headingMatches (+8 more)
+
+### Community 70 - "Community 70"
+Cohesion: 0.14
+Nodes (25): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+17 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.14
+Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.09
+Nodes (21): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), communities, extraction (+13 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.08
+Nodes (8): CommitRecommendation, CommitRecommendationConfidence, CommitRecommendationGroup, CommitRecommendationOptions, CommitRecommendationStaleness, FileGraphInfo, GroupDraft, ReviewDelta
+
+### Community 74 - "Community 74"
+Cohesion: 0.10
+Nodes (22): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity(), allAssigned (+14 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.15
+Nodes (22): html, tokens, buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue() (+14 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.11
+Nodes (19): NumericMapLike, StringMapLike, toNumericMap(), toStringMap(), ReviewFlow, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections() (+11 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.16
+Nodes (22): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+14 more)
+
+### Community 78 - "Community 78"
+Cohesion: 0.18
+Nodes (18): addIssue(), buildEvidenceIds(), buildRegistryRecords(), citations(), isProfileEdge(), isRegistrySeed(), ProfileValidationContext, ProfileValidationIssue (+10 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.11
+Nodes (19): CODE_EXTENSIONS, DOC_EXTENSIONS, IMAGE_EXTENSIONS, PAPER_EXTENSIONS, makeGraphPortable(), acquireRebuildLock(), builtFromCommit(), checkUpdate() (+11 more)
+
+### Community 80 - "Community 80"
+Cohesion: 0.14
+Nodes (18): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), serializeGraph(), toUndirectedGraph(), traversalNeighbors(), mergedGraphType() (+10 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.09
+Nodes (19): ONTOLOGY_RECONCILIATION_DECISION_LOG_SCHEMA, auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath (+11 more)
+
+### Community 82 - "Community 82"
+Cohesion: 0.15
+Nodes (20): ALLOWED_SCHEMES, BLOCKED_HOSTS, embeddedIPv4(), escapeHtml(), expandIPv6(), isPrivateIp(), isRedirectStatus(), safeFetch() (+12 more)
+
+### Community 83 - "Community 83"
+Cohesion: 0.15
+Nodes (19): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+11 more)
+
+### Community 84 - "Community 84"
 Cohesion: 0.09
 Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
 
-### Community 65 - "Community 65"
-Cohesion: 0.15
-Nodes (21): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+13 more)
+### Community 85 - "Community 85"
+Cohesion: 0.10
+Nodes (15): bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), parseOntologyProfile(), stableForHash(), bound, cleanupDirs, config (+7 more)
 
-### Community 66 - "Community 66"
+### Community 86 - "Community 86"
 Cohesion: 0.15
 Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
 
-### Community 67 - "Community 67"
-Cohesion: 0.09
-Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
-
-### Community 68 - "Community 68"
-Cohesion: 0.16
-Nodes (21): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+13 more)
-
-### Community 69 - "Community 69"
+### Community 87 - "Community 87"
 Cohesion: 0.09
 Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
 
-### Community 70 - "Community 70"
-Cohesion: 0.09
-Nodes (18): auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath, escaped (+10 more)
-
-### Community 71 - "Community 71"
+### Community 88 - "Community 88"
 Cohesion: 0.11
 Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
 
-### Community 72 - "Community 72"
-Cohesion: 0.14
-Nodes (16): artifactHasDeepRoute(), asRecord(), existingValidSidecarErrors(), importImageDataprepBatchResults(), readCaption(), readJsonl(), artifactHasDeepRoute(), asRecord() (+8 more)
+### Community 89 - "Community 89"
+Cohesion: 0.10
+Nodes (16): inferEdgeDashes(), HtmlWriter, safeToHtml(), SafeToHtmlOptions, ToHtmlOptions, communities, dir, edgeLine (+8 more)
 
-### Community 73 - "Community 73"
+### Community 90 - "Community 90"
 Cohesion: 0.10
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
-### Community 74 - "Community 74"
-Cohesion: 0.13
-Nodes (16): asNumber(), asString(), createReviewGraphStore(), isTestPath(), KNOWN_KINDS, normalizeKind(), normalizePath(), parseLineRange() (+8 more)
+### Community 91 - "Community 91"
+Cohesion: 0.10
+Nodes (18): WIKI_DESCRIPTION_PROMPT_VERSION, WIKI_DESCRIPTION_SCHEMA, WikiDescriptionSidecarIndex, article, descriptions, G, generator, communities (+10 more)
 
-### Community 75 - "Community 75"
-Cohesion: 0.12
+### Community 92 - "Community 92"
+Cohesion: 0.14
 Nodes (19): aliasHit, hit, hits, i18nRecords, ids, index, lower, minimal (+11 more)
 
-### Community 76 - "Community 76"
-Cohesion: 0.13
-Nodes (13): NumericMapLike, StringMapLike, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections(), formatFlow(), generate(), GenerateReportOptions (+5 more)
+### Community 93 - "Community 93"
+Cohesion: 0.17
+Nodes (20): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+12 more)
 
-### Community 77 - "Community 77"
-Cohesion: 0.15
-Nodes (15): buildMinimalContext(), riskFromScore(), suggestionsForTask(), topCommunities(), topFlowNames(), uniqueSorted(), buildMinimalContext(), BuildMinimalContextOptions (+7 more)
+### Community 94 - "Community 94"
+Cohesion: 0.10
+Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
 
-### Community 78 - "Community 78"
+### Community 95 - "Community 95"
+Cohesion: 0.11
+Nodes (17): extract(), ExtractionResult, extractWithDiagnostics(), inferCommonRoot(), _mergeSwiftExtensions(), GraphEdge, GraphNode, allEdges (+9 more)
+
+### Community 96 - "Community 96"
 Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
-### Community 79 - "Community 79"
-Cohesion: 0.13
-Nodes (15): buildProject(), BuildProjectArtifacts, BuildProjectOptions, BuildProjectResult, BuildProjectWarning, countNonCodeFiles(), defaultLabels(), fileList() (+7 more)
-
-### Community 80 - "Community 80"
+### Community 97 - "Community 97"
 Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
 
-### Community 81 - "Community 81"
-Cohesion: 0.22
-Nodes (18): projectConfigSection(), rel(), buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection() (+10 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.17
-Nodes (14): ALLOWED_SCHEMES, BLOCKED_HOSTS, embeddedIPv4(), escapeHtml(), expandIPv6(), isPrivateIp(), isRedirectStatus(), safeFetch() (+6 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.14
-Nodes (2): ApiClient, ApiClient
-
-### Community 84 - "Community 84"
-Cohesion: 0.15
-Nodes (14): AllChunksFailedError, DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens(), extractionShape() (+6 more)
-
-### Community 85 - "Community 85"
-Cohesion: 0.14
-Nodes (11): CleanupStaleNodesOptions, CleanupStaleNodesResult, acquireRebuildLock(), builtFromCommit(), checkUpdate(), CheckUpdateResult, mergeHyperedges(), rebuildCode() (+3 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.11
-Nodes (17): after, aPath, bPath, bumped, codeExts, filePath, initial, initialManifest (+9 more)
-
-### Community 87 - "Community 87"
-Cohesion: 0.11
-Nodes (15): agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined, logs (+7 more)
-
-### Community 88 - "Community 88"
-Cohesion: 0.21
-Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
-
-### Community 89 - "Community 89"
-Cohesion: 0.12
-Nodes (10): bound, cleanupDirs, config, errors, first, profile, profilePath, raw (+2 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.12
-Nodes (14): communities, extraction, fixtureRoot, graph, graphJson, graphPath, processNode, profileValidation (+6 more)
-
-### Community 91 - "Community 91"
-Cohesion: 0.20
-Nodes (14): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+6 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.12
-Nodes (15): allAssigned, allNodes, communities, first, G, louvainMock, multiNodeCommunities, nodes (+7 more)
-
-### Community 93 - "Community 93"
-Cohesion: 0.13
-Nodes (15): client, communities, dir, exportInput, first, graph, { index, dropped }, lines (+7 more)
-
-### Community 94 - "Community 94"
-Cohesion: 0.13
-Nodes (11): cleanupDirs, config, cropDir, cropImage, directImage, image, manifest, markdown (+3 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.13
-Nodes (13): anthropicMock, cleanupDirs, client, cohereMock, config, generateTextMock, googleMock, mistralMock (+5 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.20
-Nodes (16): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), projectUninstallAll() (+8 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.18
-Nodes (13): convertGoogleWorkspaceFile(), ConvertGoogleWorkspaceOptions, createDefaultGoogleWorkspaceFetcher(), EXPORT_MIME_TYPE_BY_EXTENSION, extractFileIdFromUrl(), extractResourceKey(), frontmatterWrap(), GOOGLE_WORKSPACE_EXTENSIONS (+5 more)
-
 ### Community 98 - "Community 98"
-Cohesion: 0.23
-Nodes (14): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+6 more)
+Cohesion: 0.11
+Nodes (14): cursorInstall(), replaceOrAppendSection(), dir, original, rule, rulePath, tempDirs, bannedReportFirstPatterns (+6 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.15
-Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
+Cohesion: 0.11
+Nodes (16): projectUninstallAll(), agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined (+8 more)
 
 ### Community 100 - "Community 100"
 Cohesion: 0.13
-Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
+Nodes (15): SerializedGraphData, setHyperedges(), hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph(), ancestor (+7 more)
 
 ### Community 101 - "Community 101"
-Cohesion: 0.13
-Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
+Cohesion: 0.14
+Nodes (2): ApiClient, ApiClient
 
 ### Community 102 - "Community 102"
-Cohesion: 0.13
-Nodes (10): cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths, root (+2 more)
+Cohesion: 0.15
+Nodes (14): buildReviewDelta(), changedNodeIds(), clampDepth(), computeAffectedFiles(), dirname(), expandChangedIdsViaBarrels(), highRiskChains(), impactedNodeIds() (+6 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.24
-Nodes (14): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), GitContext (+6 more)
+Cohesion: 0.21
+Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.13
-Nodes (12): ambiguous, captionsDir, cleanupDirs, labelsPath, manifest, missing, outDir, result (+4 more)
+Cohesion: 0.18
+Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
 
 ### Community 105 - "Community 105"
-Cohesion: 0.19
-Nodes (12): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistry() (+4 more)
+Cohesion: 0.13
+Nodes (13): cleanupStaleNodes(), CleanupStaleNodesOptions, CleanupStaleNodesResult, cleanupDirs, dir, formatted, G, graph (+5 more)
 
 ### Community 106 - "Community 106"
 Cohesion: 0.13
-Nodes (12): cleanupDirs, components, config, csvPath, extraction, jsonPath, profile, record (+4 more)
+Nodes (14): augmentDetectionWithTranscripts(), buildWhisperPrompt(), cloneDetection(), transcribeAll(), cached, hash, modelDir, outDir (+6 more)
 
 ### Community 107 - "Community 107"
-Cohesion: 0.16
-Nodes (15): asBoolean(), asNumber(), asRecord(), asString(), asStringArray(), loadProjectConfig(), normalizeProjectConfig(), parseCitationMinimum() (+7 more)
+Cohesion: 0.13
+Nodes (11): SemanticPreparationResult, cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths (+3 more)
 
 ### Community 108 - "Community 108"
+Cohesion: 0.22
+Nodes (15): OntologyReconciliationDecisionLogOptions, OntologyReconciliationDecisionLogResponse, getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath() (+7 more)
+
+### Community 109 - "Community 109"
+Cohesion: 0.23
+Nodes (15): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+7 more)
+
+### Community 110 - "Community 110"
+Cohesion: 0.15
+Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
+
+### Community 111 - "Community 111"
+Cohesion: 0.13
+Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
+
+### Community 112 - "Community 112"
+Cohesion: 0.13
+Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
+
+### Community 113 - "Community 113"
+Cohesion: 0.13
+Nodes (10): discoverProjectConfig(), cleanupDirs, configDir, configPath, errors, loaded, normalized, raw (+2 more)
+
+### Community 114 - "Community 114"
+Cohesion: 0.22
+Nodes (15): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), removeProjectClaudeMdRegistration() (+7 more)
+
+### Community 115 - "Community 115"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 109 - "Community 109"
-Cohesion: 0.14
-Nodes (9): cleanupDirs, configDir, configPath, errors, loaded, normalized, raw, result (+1 more)
-
-### Community 110 - "Community 110"
-Cohesion: 0.33
-Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
-
-### Community 111 - "Community 111"
-Cohesion: 0.27
-Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.14
-Nodes (12): communities, diff, first, G, G1, G2, godIds, gods (+4 more)
-
-### Community 113 - "Community 113"
-Cohesion: 0.14
-Nodes (9): boxes, central, dir, fixture, headingMatches, pills, result, sections (+1 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.23
-Nodes (10): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), querySubgraphTokens() (+2 more)
-
-### Community 115 - "Community 115"
-Cohesion: 0.15
-Nodes (13): extractC(), extractCpp(), extractCsharp(), _extractGeneric(), extractJava(), extractJs(), extractKotlin(), extractLua() (+5 more)
-
 ### Community 116 - "Community 116"
-Cohesion: 0.19
-Nodes (6): CONFIDENCE_VALUES, hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph()
+Cohesion: 0.15
+Nodes (11): TextJsonGenerationClient, TextJsonGenerationInput, TextJsonGenerationResult, createGraphifyMesh(), CreateGraphifyMeshOptions, meshTextJsonClient(), MeshTextJsonClientOptions, client (+3 more)
 
 ### Community 117 - "Community 117"
 Cohesion: 0.21
-Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
+Nodes (12): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), printBenchmark() (+4 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.15
-Nodes (10): allEdges, allNodes, edges, fooNodes, merged, methodEdges, methodTargets, nodes (+2 more)
+Cohesion: 0.26
+Nodes (13): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), gitRevParse() (+5 more)
 
 ### Community 119 - "Community 119"
-Cohesion: 0.15
-Nodes (9): calls, dir, fetcher, googleEnvKeys, previousEnv, rendered, shortcut, stub (+1 more)
+Cohesion: 0.14
+Nodes (11): NormalizedOntologyProfile, ambiguous, cleanupDirs, extraction, nodes, outputDir, page, profile (+3 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.15
-Nodes (10): communities, dir, G, html, htmlPath, noProfile, profile, result (+2 more)
+Cohesion: 0.14
+Nodes (11): OntologyDiscoverySample, buildProfileChunkPrompt(), chunkGuidance(), documentPrompt, extraction, fixtureRoot, imagePrompt, profile (+3 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.15
-Nodes (10): cached, hash, modelDir, outDir, spawnSyncMock, tempDirs, video, videoA (+2 more)
+Cohesion: 0.16
+Nodes (11): PdfPreparationArtifact, parsePdfOcrMode(), PdfOcrMode, prepareSemanticDetection(), SemanticPreparationOptions, imagePath, outputDir, packageJson (+3 more)
 
 ### Community 122 - "Community 122"
-Cohesion: 0.26
-Nodes (11): addCall(), addFunction(), makeFlowStore(), qn(), addCall(), addFunction(), { artifact, store }, { artifact, store, ids } (+3 more)
+Cohesion: 0.33
+Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
 ### Community 123 - "Community 123"
-Cohesion: 0.26
-Nodes (11): addCall(), addFunction(), makeStore(), qn(), addCall(), addFunction(), makeStore(), qn() (+3 more)
+Cohesion: 0.20
+Nodes (14): loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), optionalInteger(), optionalNumber(), optionalString(), readableStatePath() (+6 more)
 
 ### Community 124 - "Community 124"
-Cohesion: 0.17
-Nodes (8): SemanticPreparationOptions, SemanticPreparationResult, imagePath, outputDir, packageJson, packageLock, tempDirs, { unpdfExtractTextMock, unpdfGetDocMock, convertPdfMock, spawnSyncMock }
+Cohesion: 0.27
+Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.21
-Nodes (12): canonicalFilePath(), countWords(), detect(), findVcsRoot(), isIgnored(), isNoiseDir(), isSensitive(), loadGraphifyignore() (+4 more)
+Cohesion: 0.17
+Nodes (12): OntologyDiscoveryContext, ontologyDiscoveryDiffToMarkdown(), OntologyDiscoveryProposalsFile, context, diff, discoveryContext(), fixtureRoot, proposals (+4 more)
 
 ### Community 126 - "Community 126"
-Cohesion: 0.17
-Nodes (6): CreateGraphifyMeshOptions, MeshTextJsonClientOptions, client, dir, mesh, tempDirs
+Cohesion: 0.21
+Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
 ### Community 127 - "Community 127"
-Cohesion: 0.33
-Nodes (11): getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), OntologyRebuildStatusResponse, ontologyReconciliationCandidatesPath() (+3 more)
+Cohesion: 0.17
+Nodes (6): profileValidationResultToJson(), profileValidationResultToMarkdown(), extraction, fixtureRoot, registryExtraction, result
 
 ### Community 128 - "Community 128"
 Cohesion: 0.17
-Nodes (7): bannedReportFirstPatterns, claudeSettings, dir, old, paths, tempDirs, updated
+Nodes (10): toCypher(), cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted (+2 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.21
-Nodes (9): bfsNeighbours(), buildAdjacency(), computeFocusSubgraph(), computeMetrics(), FocusSubgraph, FocusSubgraphMetrics, GraphEdgeLike, GraphLike (+1 more)
+Cohesion: 0.17
+Nodes (11): extractJs(), calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge (+3 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.17
-Nodes (10): cleanupDirs, dir, formatted, G, graph, graphPath, result, root (+2 more)
-
-### Community 131 - "Community 131"
-Cohesion: 0.17
-Nodes (10): base, cache_key, community, communityBase, fresh, generator, index, result (+2 more)
-
-### Community 132 - "Community 132"
-Cohesion: 0.17
-Nodes (11): communities, communityArticle, count, descriptions, files, flows, G, generator (+3 more)
-
-### Community 133 - "Community 133"
 Cohesion: 0.18
 Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
-### Community 134 - "Community 134"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (4): build_graph(), Graph, build_graph(), Graph
 
-### Community 135 - "Community 135"
+### Community 132 - "Community 132"
 Cohesion: 0.18
-Nodes (5): OntologyWriteFixture, dir, fixture, result, tempDirs
+Nodes (9): makeExtractionPortable(), DetectionResult, detection, extraction, graphifyDir, portable, result, root (+1 more)
 
-### Community 136 - "Community 136"
-Cohesion: 0.33
-Nodes (10): isRecord(), isStringArray(), validateImageCaption(), validateImageRouting(), isRecord(), isStringArray(), VALID_DENSITY, VALID_ROUTING_SIGNAL (+2 more)
-
-### Community 137 - "Community 137"
-Cohesion: 0.18
-Nodes (8): documentPrompt, extraction, fixtureRoot, imagePrompt, profile, prompt, sample, state
-
-### Community 138 - "Community 138"
-Cohesion: 0.29
-Nodes (11): buildProfileReport(), graphLinks(), graphNodes(), highDegreeSection(), humanReviewSection(), invalidRelationsSection(), lowEvidenceSection(), pdfOcrSection() (+3 more)
-
-### Community 139 - "Community 139"
-Cohesion: 0.29
-Nodes (11): buildReviewDelta(), changedNodeIds(), clampDepth(), computeAffectedFiles(), dirname(), expandChangedIdsViaBarrels(), highRiskChains(), impactedNodeIds() (+3 more)
-
-### Community 140 - "Community 140"
-Cohesion: 0.24
-Nodes (9): buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue(), WorkspaceFacet, WorkspaceFacetRecord (+1 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.29
-Nodes (10): countMatchingRecords(), groupRecordsByType(), GroupRecordsOptions, matchesActiveType(), matchesQuery(), recordSearchHaystack(), resolveTypeId(), WorkspaceResultEntry (+2 more)
-
-### Community 142 - "Community 142"
-Cohesion: 0.18
-Nodes (9): audit, client, credential, output, outputPath, PROVIDERS, providerSelection, tempDir (+1 more)
-
-### Community 143 - "Community 143"
-Cohesion: 0.18
-Nodes (9): cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted, warnings (+1 more)
-
-### Community 144 - "Community 144"
-Cohesion: 0.18
-Nodes (10): calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge, parseNode (+2 more)
-
-### Community 145 - "Community 145"
-Cohesion: 0.18
-Nodes (9): dir, filters, first, loaded, path, profile, queue, response (+1 more)
-
-### Community 146 - "Community 146"
+### Community 133 - "Community 133"
 Cohesion: 0.20
 Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
-### Community 147 - "Community 147"
-Cohesion: 0.18
-Nodes (10): affectedFlows, cohesion, communities, detection, flows, G, gods, labels (+2 more)
-
-### Community 148 - "Community 148"
+### Community 134 - "Community 134"
 Cohesion: 0.18
 Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
 
-### Community 149 - "Community 149"
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
 
-### Community 150 - "Community 150"
+### Community 136 - "Community 136"
 Cohesion: 0.18
 Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
 
-### Community 151 - "Community 151"
-Cohesion: 0.20
-Nodes (5): fixtureRoot, profile, projectConfig, registries, report
-
-### Community 152 - "Community 152"
+### Community 137 - "Community 137"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 153 - "Community 153"
-Cohesion: 0.24
-Nodes (10): htmlScript(), htmlStyles(), hyperedgeScript(), isCanvasOptions(), isCommunityLabelOptions(), normalizeCommunityLabels(), normalizeMemberCounts(), normalizeProfile() (+2 more)
-
-### Community 154 - "Community 154"
+### Community 138 - "Community 138"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 155 - "Community 155"
-Cohesion: 0.42
-Nodes (10): addError(), nodeById(), nodeType(), nonEmptyString(), relationById(), statusTransitionAllowed(), validateAcceptMatch(), validateAddRelation() (+2 more)
+### Community 139 - "Community 139"
+Cohesion: 0.33
+Nodes (7): normalizeSearchText(), queryTerms(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 156 - "Community 156"
-Cohesion: 0.24
-Nodes (6): normalizeSearchText(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
-
-### Community 157 - "Community 157"
-Cohesion: 0.38
-Nodes (9): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+1 more)
-
-### Community 158 - "Community 158"
-Cohesion: 0.20
-Nodes (9): attrs, edge, ext, ext1, ext2, G, hyper, hyperedges (+1 more)
-
-### Community 159 - "Community 159"
-Cohesion: 0.20
-Nodes (8): ancestor, current, dir, merged, other, result, tempDirs, tooManyNodes
-
-### Community 160 - "Community 160"
-Cohesion: 0.22
-Nodes (9): context, diff, discoveryContext(), fixtureRoot, proposals, repeat, sample, semanticDetection() (+1 more)
-
-### Community 161 - "Community 161"
+### Community 140 - "Community 140"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 162 - "Community 162"
+### Community 141 - "Community 141"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 163 - "Community 163"
+### Community 142 - "Community 142"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 164 - "Community 164"
-Cohesion: 0.22
-Nodes (4): cleanupDirs, result, root, text
+### Community 143 - "Community 143"
+Cohesion: 0.47
+Nodes (9): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+1 more)
 
-### Community 165 - "Community 165"
+### Community 144 - "Community 144"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 166 - "Community 166"
-Cohesion: 0.39
-Nodes (7): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity()
+### Community 145 - "Community 145"
+Cohesion: 0.22
+Nodes (6): formatMetric(), reviewAnalysisToText(), reviewEvaluationToText(), analysis, evaluation, text
 
-### Community 167 - "Community 167"
-Cohesion: 0.39
-Nodes (8): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), SerializedGraphData, serializeGraph(), toUndirectedGraph(), traversalNeighbors()
-
-### Community 168 - "Community 168"
-Cohesion: 0.25
+### Community 146 - "Community 146"
+Cohesion: 0.31
 Nodes (7): assertGraphJsonFileSize(), assertGraphJsonSize(), GraphSizeMode, dir, message, missing, path
 
-### Community 169 - "Community 169"
-Cohesion: 0.31
-Nodes (9): buildGitInventory(), countGitPaths(), fallbackAllScope(), gitInventory(), inspectInputScope(), makeScope(), pathspecForPrefix(), resolveGitScopeContext() (+1 more)
-
-### Community 170 - "Community 170"
-Cohesion: 0.42
-Nodes (7): evidenceRefsFromSources(), loadOntologyPatchContext(), loadProfilePatchRuntimeContext(), optionalJson(), ProfilePatchRuntimeContext, readJson(), stringValue()
-
-### Community 171 - "Community 171"
-Cohesion: 0.42
-Nodes (8): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl()
-
-### Community 172 - "Community 172"
+### Community 147 - "Community 147"
 Cohesion: 0.25
 Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
 
-### Community 173 - "Community 173"
+### Community 148 - "Community 148"
 Cohesion: 0.25
-Nodes (7): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), errors
+Nodes (8): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea()
 
-### Community 174 - "Community 174"
-Cohesion: 0.22
-Nodes (4): BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WIKI_DESCRIPTION_BATCH_SCHEMA, WikiDescriptionBatchResultRecord
-
-### Community 175 - "Community 175"
+### Community 149 - "Community 149"
 Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
+Nodes (3): LifecycleMetadata, commitRecommendationToText(), recommendation
 
-### Community 176 - "Community 176"
-Cohesion: 0.32
-Nodes (8): agentsInstall(), getAgentsMdSection(), installCodexHook(), installOpenCodePlugin(), legacyOpencodeConfigPath(), loadOpenCodeConfig(), opencodeConfigPath(), uninstallOpenCodePlugin()
-
-### Community 177 - "Community 177"
-Cohesion: 0.25
-Nodes (8): buildFreshnessMetadata(), computeTopologySignature(), computeTopologySignatureFromLinks(), isSvgOptions(), nodeCommunityMap(), toGraphml(), toJson(), toSvg()
-
-### Community 178 - "Community 178"
-Cohesion: 0.39
+### Community 150 - "Community 150"
+Cohesion: 0.43
 Nodes (8): _importJs(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds(), resolveJsImportTarget(), resolveJsImportTargetInfo(), toPortablePath()
 
-### Community 179 - "Community 179"
-Cohesion: 0.36
-Nodes (6): mergedGraphType(), mergeGraphsFromFiles(), MergeGraphsOptions, MergeGraphsResult, mergeHyperedges(), mergeHyperedgesFromGraphs()
-
-### Community 180 - "Community 180"
+### Community 151 - "Community 151"
 Cohesion: 0.25
-Nodes (8): buildBlastRadius(), buildReviewAnalysis(), communityRisk(), impactedCommunities(), multimodalSafety(), nodeCommunities(), riskLevel(), uniqueSorted()
+Nodes (8): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea()
 
-### Community 181 - "Community 181"
+### Community 152 - "Community 152"
+Cohesion: 0.29
+Nodes (6): firstHopSummaryToText(), graph, makeGraph(), summary, textA, textB
+
+### Community 153 - "Community 153"
 Cohesion: 0.25
-Nodes (8): basename(), isBarrelPath(), isTestPath(), maybeCommunity(), nodeInfo(), normalizePath(), sourceMatches(), stem()
+Nodes (7): downloadAudio(), runCommand(), cleanupDirs, dir, downloadAudioMock, expected, rendered
 
-### Community 182 - "Community 182"
-Cohesion: 0.25
-Nodes (5): html, tokens, html, state, tokens
-
-### Community 183 - "Community 183"
-Cohesion: 0.25
-Nodes (7): agents, dir, home, section, skill, skillPath, tempDirs
-
-### Community 184 - "Community 184"
+### Community 154 - "Community 154"
 Cohesion: 0.25
 Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
-### Community 185 - "Community 185"
+### Community 155 - "Community 155"
 Cohesion: 0.25
-Nodes (7): commands, dir, hooks, readme, section, skill, tempDirs
+Nodes (6): importsFromBarrel, importsFromTargets, labels, reExports, reExportTagged, targets
 
-### Community 186 - "Community 186"
-Cohesion: 0.25
-Nodes (5): cacheRoot, cleanupDirs, destination, result, source
-
-### Community 187 - "Community 187"
+### Community 156 - "Community 156"
 Cohesion: 0.25
 Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
 
-### Community 188 - "Community 188"
+### Community 157 - "Community 157"
 Cohesion: 0.25
 Nodes (7): dataset, dirty, facets, keys, slices, state, status
 
-### Community 189 - "Community 189"
+### Community 158 - "Community 158"
 Cohesion: 0.25
 Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
 
-### Community 190 - "Community 190"
+### Community 159 - "Community 159"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 191 - "Community 191"
-Cohesion: 0.38
-Nodes (7): buildProfileState(), dataprepReport(), resolveConfigPath(), runConfiguredDataprep(), writeJson(), writeProfileState(), writeRegistries()
-
-### Community 192 - "Community 192"
+### Community 160 - "Community 160"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 193 - "Community 193"
-Cohesion: 0.29
-Nodes (7): communityLabelsFromGraph(), readMcpResource(), resourceConfidenceAudit(), resourceQuestions(), resourceSurprises(), toolGodNodes(), toolGraphStats()
-
-### Community 194 - "Community 194"
-Cohesion: 0.43
-Nodes (7): loadReadonlyReconciliationCandidates(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), readableStatePath(), reconciliationQueueIsStale(), toolListReconciliationCandidates(), toolOntologyRebuildStatus()
-
-### Community 195 - "Community 195"
-Cohesion: 0.33
-Nodes (7): ontologyAppliedPatchesPath(), optionalInteger(), optionalNumber(), optionalString(), reconciliationCandidateFilters(), toolGetReconciliationCandidate(), toolPreviewOntologyDecisionLog()
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (4): nodeLabel(), renderTree(), RenderTreeOptions, TreeNeighbor
-
-### Community 197 - "Community 197"
+### Community 161 - "Community 161"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 198 - "Community 198"
-Cohesion: 0.29
-Nodes (6): dir, geminiMd, readme, settings, skill, tempDirs
-
-### Community 199 - "Community 199"
-Cohesion: 0.29
-Nodes (6): analyzed, head, metadata, plan, stale, worktreeDir
-
-### Community 200 - "Community 200"
+### Community 162 - "Community 162"
 Cohesion: 0.29
 Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
-### Community 201 - "Community 201"
+### Community 163 - "Community 163"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 202 - "Community 202"
+### Community 164 - "Community 164"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
 
-### Community 203 - "Community 203"
-Cohesion: 0.33
-Nodes (3): HtmlWriter, SafeToHtmlOptions, ToHtmlOptions
-
-### Community 204 - "Community 204"
+### Community 165 - "Community 165"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 205 - "Community 205"
+### Community 166 - "Community 166"
 Cohesion: 0.33
-Nodes (1): recommendation
+Nodes (3): reviewDeltaToText(), delta, text
 
-### Community 206 - "Community 206"
-Cohesion: 0.33
-Nodes (3): analysis, evaluation, text
-
-### Community 207 - "Community 207"
-Cohesion: 0.33
-Nodes (6): buildReviewDelta(), changedNodeIds(), highRiskChains(), impactedNodeIds(), likelyTestGaps(), uniqueSorted()
-
-### Community 208 - "Community 208"
-Cohesion: 0.33
-Nodes (6): isTestPath(), maybeCommunity(), nodeInfo(), normalizePath(), sourceMatches(), stem()
-
-### Community 209 - "Community 209"
-Cohesion: 0.33
-Nodes (6): bfs(), dfs(), scoreNodes(), subgraphToText(), toolQueryGraph(), toolShortestPath()
-
-### Community 210 - "Community 210"
-Cohesion: 0.67
-Nodes (5): normalizeCommunityLabel(), persistCommunityLabels(), readGraphAttributeLabels(), readLabelsJson(), resolveCommunityLabels()
-
-### Community 211 - "Community 211"
+### Community 167 - "Community 167"
 Cohesion: 0.47
 Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
-### Community 212 - "Community 212"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (5): commands, dir, matchers, settings, tempDirs
 
-### Community 213 - "Community 213"
-Cohesion: 0.33
-Nodes (4): cleanupDirs, dir, labelsPath, resolved
-
-### Community 214 - "Community 214"
-Cohesion: 0.33
-Nodes (5): dir, original, rule, rulePath, tempDirs
-
-### Community 215 - "Community 215"
-Cohesion: 0.33
-Nodes (5): cleanupDirs, dir, downloadAudioMock, expected, rendered
-
-### Community 216 - "Community 216"
+### Community 169 - "Community 169"
 Cohesion: 0.33
 Nodes (4): dir, logs, preview, tempDirs
 
-### Community 217 - "Community 217"
+### Community 170 - "Community 170"
 Cohesion: 0.33
 Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
-### Community 218 - "Community 218"
-Cohesion: 0.33
-Nodes (5): config, dir, plugin, previousCwd, tempDirs
-
-### Community 219 - "Community 219"
-Cohesion: 0.33
-Nodes (4): contents, dir, lockPath, tempDirs
-
-### Community 220 - "Community 220"
-Cohesion: 0.33
-Nodes (4): article, descriptions, G, generator
-
-### Community 221 - "Community 221"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
-
-### Community 222 - "Community 222"
+### Community 171 - "Community 171"
 Cohesion: 0.40
-Nodes (2): delta, text
+Nodes (3): affectedFilesToText(), result, text
 
-### Community 223 - "Community 223"
-Cohesion: 0.60
-Nodes (5): analyzeChanges(), changedNodesFromFiles(), mapChangesToNodes(), sortNodesByLocation(), uniqueSorted()
-
-### Community 224 - "Community 224"
-Cohesion: 0.50
-Nodes (5): detectIncremental(), loadManifest(), md5File(), normaliseManifestEntry(), saveManifest()
-
-### Community 225 - "Community 225"
-Cohesion: 0.40
-Nodes (4): r1, r2, r3, result
-
-### Community 226 - "Community 226"
-Cohesion: 0.40
-Nodes (4): chunks, client, files, root
-
-### Community 227 - "Community 227"
+### Community 172 - "Community 172"
 Cohesion: 0.40
 Nodes (4): changelog, lock, pkg, workflow
 
-### Community 228 - "Community 228"
-Cohesion: 0.40
-Nodes (4): graphifyOut, long, result, tmpDir
-
-### Community 229 - "Community 229"
+### Community 173 - "Community 173"
 Cohesion: 0.40
 Nodes (4): candidateGraph, graph, html, tokens
 
-### Community 230 - "Community 230"
+### Community 174 - "Community 174"
 Cohesion: 0.40
 Nodes (4): character, dataset, groups, total
 
-### Community 231 - "Community 231"
-Cohesion: 0.67
-Nodes (4): convertOfficeFile(), docxToMarkdown(), officeParseToText(), xlsxToMarkdown()
-
-### Community 232 - "Community 232"
+### Community 175 - "Community 175"
 Cohesion: 0.50
 Nodes (2): delta, G
 
-### Community 233 - "Community 233"
+### Community 176 - "Community 176"
 Cohesion: 0.50
-Nodes (3): b1, b2, backup
+Nodes (3): html, state, tokens
 
-### Community 234 - "Community 234"
-Cohesion: 0.50
-Nodes (2): extraction, out
-
-### Community 235 - "Community 235"
-Cohesion: 0.50
-Nodes (1): { root, files, cleanup }
-
-### Community 236 - "Community 236"
-Cohesion: 0.50
-Nodes (2): result, text
-
-### Community 237 - "Community 237"
+### Community 177 - "Community 177"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 238 - "Community 238"
-Cohesion: 0.67
-Nodes (1): html
-
-### Community 239 - "Community 239"
-Cohesion: 0.67
-Nodes (2): paths, root
-
-### Community 240 - "Community 240"
-Cohesion: 0.67
-Nodes (1): delta
-
-### Community 241 - "Community 241"
+### Community 178 - "Community 178"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 242 - "Community 242"
-Cohesion: 1.00
-Nodes (2): buildRegistrySources(), registrySourceName()
-
-### Community 243 - "Community 243"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 244 - "Community 244"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 245 - "Community 245"
-Cohesion: 1.00
-Nodes (2): average(), evaluateReviewAnalysis()
-
-### Community 246 - "Community 246"
-Cohesion: 1.00
-Nodes (2): formatMetric(), reviewEvaluationToText()
-
-### Community 247 - "Community 247"
+### Community 179 - "Community 179"
 Cohesion: 1.00
 Nodes (1): UnpdfTextResult
 
-### Community 248 - "Community 248"
+### Community 180 - "Community 180"
 Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 249 - "Community 249"
-Cohesion: 1.00
-Nodes (1): result
-
-### Community 250 - "Community 250"
+### Community 181 - "Community 181"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1831 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1826 more)
+- **1509 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1504 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 83`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 101`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 142`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 144`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 160`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (1 nodes): `recommendation`
+- **Thin community `Community 175`** (2 nodes): `delta`, `G`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `delta`, `text`
+- **Thin community `Community 179`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `delta`, `G`
+- **Thin community `Community 180`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `extraction`, `out`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (1 nodes): `{ root, files, cleanup }`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `result`, `text`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (1 nodes): `html`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `paths`, `root`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (1 nodes): `delta`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `buildRegistrySources()`, `registrySourceName()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `average()`, `evaluateReviewAnalysis()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `formatMetric()`, `reviewEvaluationToText()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (1 nodes): `UnpdfTextResult`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `tempProfileProject()`, `tempProject()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (1 nodes): `result`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 181`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Cookies` connect `Community 4` to `Community 80`, `Community 34`?**
-  _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `Cookies` connect `Community 0` to `Community 80`, `Community 34`?**
-  _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `InvalidURL` connect `Community 0` to `Community 3`?**
-  _High betweenness centrality (0.001) - this node is a cross-community bridge._
+- **Why does `OntologyReconciliationCandidate` connect `Community 50` to `Community 2`, `Community 108`, `Community 40`?**
+  _High betweenness centrality (0.007) - this node is a cross-community bridge._
+- **Why does `OntologyReconciliationDecisionLogResponse` connect `Community 108` to `Community 2`, `Community 27`, `Community 40`?**
+  _High betweenness centrality (0.007) - this node is a cross-community bridge._
+- **Why does `OntologyReconciliationCandidatesResponse` connect `Community 108` to `Community 2`, `Community 50`, `Community 40`?**
+  _High betweenness centrality (0.007) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -227,7 +227,7 @@ function crossFileSurprises(G: Graph, communities: Map<number, string[]>, topN: 
 
   G.forEachEdge((edge, data, source, target) => {
     const relation = (data.relation as string) ?? "";
-    if (["imports", "imports_from", "contains", "method"].includes(relation)) return;
+    if (["imports", "imports_from", "re_exports", "contains", "method"].includes(relation)) return;
     if (isConceptNode(G, source) || isConceptNode(G, target)) return;
     if (isFileNode(G, source) || isFileNode(G, target)) return;
 
@@ -280,7 +280,7 @@ function crossCommunitySurprises(
     if (cidU === undefined || cidV === undefined || cidU === cidV) return;
     if (isFileNode(G, u) || isFileNode(G, v)) return;
     const relation = (data.relation as string) ?? "";
-    if (["imports", "imports_from", "contains", "method"].includes(relation)) return;
+    if (["imports", "imports_from", "re_exports", "contains", "method"].includes(relation)) return;
 
     const srcId = (data._src as string) ?? u;
     const tgtId = (data._tgt as string) ?? v;

--- a/src/export.ts
+++ b/src/export.ts
@@ -157,7 +157,10 @@ export function inferNodeShape(fileType: string, sourceFile: string): string {
  */
 export function inferEdgeDashes(relation: string, confidenceTier: string): boolean | number[] {
   const r = (relation || "").toLowerCase();
-  if (r === "imports_from" || r === "imports") return [6, 4];
+  // Port of upstream safishamsi 1494874 — `re_exports` rides the same
+  // import-family dash so a barrel re-export edge is visually consistent
+  // with the plain `imports` / `imports_from` arrows that frame it.
+  if (r === "imports_from" || r === "imports" || r === "re_exports") return [6, 4];
   if (r === "tested_by" || r === "validated_by") return [2, 4];
   if (r === "inherits" || r === "extends" || r === "implements") return [10, 4];
   // Confidence fallback: solid for EXTRACTED, dashed for INFERRED/AMBIGUOUS.
@@ -1209,7 +1212,7 @@ ${htmlStyles()}
     <h3 id="relations-heading" style="margin-top:14px">Edges</h3>
     <ul id="relation-legend" aria-labelledby="relations-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:var(--ws-text-muted)">
       <li>━━━━ solid &mdash; calls / strong (EXTRACTED)</li>
-      <li>┄┄┄┄ dashed &mdash; imports_from</li>
+      <li>┄┄┄┄ dashed &mdash; imports_from / imports / re_exports</li>
       <li>┈┈┈┈ dotted &mdash; tested_by / validated_by</li>
       <li>━ ━ ━ long-dash &mdash; inherits / implements</li>
       <li style="opacity:0.6">··· faded &mdash; INFERRED / AMBIGUOUS</li>

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -638,24 +638,83 @@ function _importJs(
 
   const raw = readStringSpecifier(node);
   if (!raw) return;
-  const tgtNid = resolveJsImportTarget(raw, strPath);
-  if (tgtNid) {
-    const importEdge: GraphEdge = {
-      source: fileNid, target: tgtNid, relation: "imports_from",
-      confidence: "EXTRACTED", source_file: strPath,
-      source_location: `L${node.startPosition.row + 1}`, weight: 1.0,
-    };
-    if (isReExport) {
-      // Tag the file-level edge so consumers (review-delta barrel detection,
-      // wiki audit, etc.) can distinguish a regular `import` from an
-      // `export { X } from './m'` re-export. Symbol-level `re_exports` edges
-      // are introduced in S-2.
-      (importEdge as GraphEdge & { context?: string }).context = "re-export";
-    }
-    edges.push(importEdge);
+  const targetInfo = resolveJsImportTargetInfo(raw, strPath);
+  if (!targetInfo) return;
+  const line = node.startPosition.row + 1;
+
+  const importEdge: GraphEdge = {
+    source: fileNid, target: targetInfo.targetId, relation: "imports_from",
+    confidence: "EXTRACTED", source_file: strPath,
+    source_location: `L${line}`, weight: 1.0,
+  };
+  if (isReExport) {
+    // Tag the file-level edge so consumers (review-delta barrel detection,
+    // wiki audit, etc.) can distinguish a regular `import` from an
+    // `export { X } from './m'` re-export.
+    (importEdge as GraphEdge & { context?: string }).context = "re-export";
   }
-  // rootDir is reserved for symbol-level edge resolution (introduced in S-2).
-  void rootDir;
+  edges.push(importEdge);
+
+  // Symbol-level edges: each named specifier becomes a file→symbol edge.
+  //   `import { Foo } from './bar'`         → file -imports->        bar.Foo
+  //   `export { Foo } from './bar'`         → file -re_exports->     bar.Foo
+  //   `export { default as Alias } from .`  → skipped (matches upstream)
+  //   `export * from './bar'`               → no symbol-level edge (no clause)
+  // The target id reuses _makeId(targetStem, sym) so it resolves to the same
+  // node _extract_generic emits when defining the symbol in `./bar`. The
+  // re_exports edge target lives in another file's seenIds — the cleanEdges
+  // allowlist below permits this cross-file landing.
+  if (!targetInfo.resolvedPath) return;
+  const targetStem = qualifiedFileStem(
+    targetInfo.resolvedPath,
+    rootDir ?? dirname(resolve(strPath)),
+  );
+
+  const pushSymbolEdge = (sym: string, relation: "imports" | "re_exports"): void => {
+    if (!sym || sym === "default") return;
+    const edge: GraphEdge = {
+      source: fileNid,
+      target: _makeId(targetStem, sym),
+      relation,
+      confidence: "EXTRACTED",
+      source_file: strPath,
+      source_location: `L${line}`,
+      weight: 1.0,
+    };
+    if (relation === "re_exports") {
+      (edge as GraphEdge & { context?: string }).context = "re-export";
+    }
+    edges.push(edge);
+  };
+
+  if (isReExport) {
+    // tree-sitter `export_statement` carries an `export_clause` listing the
+    // re-exported specifiers. `export * from './m'` has no `export_clause`
+    // (only a wildcard `*`), so it produces no symbol-level edges — only the
+    // file-level imports_from already pushed above.
+    for (const child of node.children) {
+      if (child.type !== "export_clause") continue;
+      for (const spec of child.children) {
+        if (spec.type !== "export_specifier") continue;
+        const nameNode = spec.childForFieldName("name");
+        if (!nameNode) continue;
+        pushSymbolEdge(_readText(nameNode, source), "re_exports");
+      }
+    }
+  } else if (node.type === "import_statement") {
+    for (const child of node.children) {
+      if (child.type !== "import_clause") continue;
+      for (const sub of child.children) {
+        if (sub.type !== "named_imports") continue;
+        for (const spec of sub.children) {
+          if (spec.type !== "import_specifier") continue;
+          const nameNode = spec.childForFieldName("name");
+          if (!nameNode) continue;
+          pushSymbolEdge(_readText(nameNode, source), "imports");
+        }
+      }
+    }
+  }
 }
 
 function _importJava(

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -465,6 +465,7 @@ type ImportHandler = (
   stem: string,
   edges: GraphEdge[],
   strPath: string,
+  rootDir?: string,
 ) => void;
 
 type ResolveFunctionNameFn = (node: SyntaxNode, source: string) => string | null;
@@ -603,7 +604,7 @@ function _importPython(
 
 function _importJs(
   node: SyntaxNode, source: string, fileNid: string, _stem: string,
-  edges: GraphEdge[], strPath: string,
+  edges: GraphEdge[], strPath: string, rootDir?: string,
 ): void {
   const readStringSpecifier = (current: SyntaxNode): string | null => {
     if (current.type === "string") {
@@ -622,16 +623,39 @@ function _importJs(
       return;
     }
   }
+
+  // Port of upstream safishamsi 1494874 — barrel re-exports as explicit
+  // graph edges. tree-sitter parses `export { X } from './mod'` as an
+  // `export_statement` carrying a `string` child (the source module). Pure
+  // exports without a `from` clause (`export const x = 1`, `export { local }`)
+  // have no string child and must be ignored here so the walker keeps walking
+  // children for the local declarations / specifiers.
+  const isReExport = node.type === "export_statement";
+  if (isReExport) {
+    const hasStringChild = node.children.some((c) => c.type === "string");
+    if (!hasStringChild) return;
+  }
+
   const raw = readStringSpecifier(node);
   if (!raw) return;
   const tgtNid = resolveJsImportTarget(raw, strPath);
   if (tgtNid) {
-    edges.push({
+    const importEdge: GraphEdge = {
       source: fileNid, target: tgtNid, relation: "imports_from",
       confidence: "EXTRACTED", source_file: strPath,
       source_location: `L${node.startPosition.row + 1}`, weight: 1.0,
-    });
+    };
+    if (isReExport) {
+      // Tag the file-level edge so consumers (review-delta barrel detection,
+      // wiki audit, etc.) can distinguish a regular `import` from an
+      // `export { X } from './m'` re-export. Symbol-level `re_exports` edges
+      // are introduced in S-2.
+      (importEdge as GraphEdge & { context?: string }).context = "re-export";
+    }
+    edges.push(importEdge);
   }
+  // rootDir is reserved for symbol-level edge resolution (introduced in S-2).
+  void rootDir;
 }
 
 function _importJava(
@@ -1119,7 +1143,11 @@ const _JS_CONFIG: LanguageConfig = defaultConfig({
   tsModule: "tree_sitter_javascript",
   classTypes: new Set(["class_declaration"]),
   functionTypes: new Set(["function_declaration", "method_definition"]),
-  importTypes: new Set(["import_statement"]),
+  // export_statement is included so the walker hands re-exports
+  // (`export { X } from './m'`) to _importJs. Pure exports (no `from`)
+  // fall through to walk children in _extract_generic. Port of upstream
+  // safishamsi 1494874.
+  importTypes: new Set(["import_statement", "export_statement"]),
   callTypes: new Set(["call_expression", "new_expression"]),
   callFunctionField: "function",
   callAccessorNodeTypes: new Set(["member_expression"]),
@@ -1133,7 +1161,11 @@ const _TS_CONFIG: LanguageConfig = defaultConfig({
   tsModule: "tree_sitter_typescript",
   classTypes: new Set(["class_declaration", "interface_declaration", "enum_declaration", "type_alias_declaration"]),
   functionTypes: new Set(["function_declaration", "method_definition"]),
-  importTypes: new Set(["import_statement"]),
+  // export_statement is included so the walker hands re-exports
+  // (`export { X } from './m'`) to _importJs. Pure exports (no `from`)
+  // fall through to walk children in _extract_generic. Port of upstream
+  // safishamsi 1494874.
+  importTypes: new Set(["import_statement", "export_statement"]),
   callTypes: new Set(["call_expression", "new_expression"]),
   callFunctionField: "function",
   callAccessorNodeTypes: new Set(["member_expression"]),
@@ -1384,7 +1416,19 @@ async function _extractGeneric(
     // Import types
     if (config.importTypes.has(t)) {
       if (config.importHandler) {
-        config.importHandler(node, source, fileNid, stem, edges, strPath);
+        config.importHandler(node, source, fileNid, stem, edges, strPath, rootDir);
+      }
+      // Port of upstream safishamsi 1494874: an `export_statement` without a
+      // `from` clause (`export const x = 1`, `export function foo() {}`,
+      // `export { localVar }`) is NOT a re-export — fall through and walk
+      // children so the local declaration / specifier still becomes a node.
+      if (t === "export_statement") {
+        const hasSource = node.children.some((c) => c.type === "string");
+        if (!hasSource) {
+          for (const child of node.children) {
+            walk(child, parentClassNid);
+          }
+        }
       }
       return;
     }
@@ -1834,7 +1878,16 @@ async function _extractGeneric(
   const cleanEdges = edges.filter((edge) => {
     const src = edge.source;
     const tgt = edge.target;
-    return validIds.has(src) && (validIds.has(tgt) || edge.relation === "imports" || edge.relation === "imports_from");
+    // `re_exports` is allow-listed alongside `imports`/`imports_from` so a
+    // barrel re-export edge can land on a symbol that lives in another file
+    // (i.e. the target id won't be in this file's seenIds). Port of upstream
+    // safishamsi 1494874.
+    return validIds.has(src) && (
+      validIds.has(tgt)
+      || edge.relation === "imports"
+      || edge.relation === "imports_from"
+      || edge.relation === "re_exports"
+    );
   });
 
   const result: ExtractionResult = { nodes, edges: cleanEdges };

--- a/src/report.ts
+++ b/src/report.ts
@@ -166,8 +166,15 @@ export function generate(
   const today = new Date().toISOString().slice(0, 10);
 
   const confidences: string[] = [];
+  // Track edge-kind counts (port of upstream safishamsi 1494874 — a new
+  // `re_exports` edge kind warrants surface counts so audit-trail consumers
+  // can read the barrel-aware delta). Generic: every relation seen on the
+  // graph gets a row, not just re_exports.
+  const edgeKindCounts = new Map<string, number>();
   G.forEachEdge((_, data) => {
     confidences.push((data.confidence as string) ?? "EXTRACTED");
+    const relation = (data.relation as string) ?? "related_to";
+    edgeKindCounts.set(relation, (edgeKindCounts.get(relation) ?? 0) + 1);
   });
   const total = confidences.length || 1;
   const extPct = Math.round((confidences.filter((c) => c === "EXTRACTED").length / total) * 100);
@@ -211,8 +218,20 @@ export function generate(
     `- Extraction: ${extPct}% EXTRACTED · ${infPct}% INFERRED · ${ambPct}% AMBIGUOUS` +
       (infAvg !== null ? ` · INFERRED: ${infEdges.length} edges (avg confidence: ${infAvg})` : ""),
     `- Token cost: ${tokenCost.input.toLocaleString()} input · ${tokenCost.output.toLocaleString()} output`,
-    "",
   );
+
+  // Per-kind edge breakdown: sorted by count desc, ties by relation name asc.
+  // Surfaces the new `re_exports` edge kind (port of upstream safishamsi
+  // 1494874) without singling it out — every relation is listed so the
+  // report stays generic.
+  if (edgeKindCounts.size > 0) {
+    const breakdown = [...edgeKindCounts.entries()]
+      .sort(([ra, ca], [rb, cb]) => (cb - ca) || ra.localeCompare(rb))
+      .map(([rel, count]) => `${rel}: ${count}`)
+      .join(" · ");
+    lines.push(`- Edge kinds: ${breakdown}`);
+  }
+  lines.push("");
 
   appendInputScopeSection(lines, detectionResult);
   appendFreshnessSection(lines, freshnessOptions);

--- a/src/review.ts
+++ b/src/review.ts
@@ -149,14 +149,32 @@ function changedNodeIds(G: Graph, changedFiles: string[]): string[] {
   return result.sort(compareStrings);
 }
 
+const REEXPORT_RELATION = "re_exports";
+
 /**
- * For each changed node whose source file is in a directory that contains
- * a barrel / re-export file (index.ts, __init__.py, mod.rs, lib.rs, ...),
- * also include the barrel file's nodes and the barrel's inbound consumers
- * as "changed" if the barrel imports from the changed file (i.e. is acting
- * as a re-export). This makes consumers of the barrel surface as affected
- * at depth 1, matching upstream safishamsi e44e6e9 `re_exports` edge
- * semantics without requiring a new edge kind in the TS extractor.
+ * For each changed node, include any file that re-exports symbols from it
+ * (the "barrel") and the barrel's inbound consumers in the affected set.
+ *
+ * Two detection paths, in order of preference:
+ *
+ *   1. Explicit edges (Track F F-0816-M2 / port safishamsi 1494874): any
+ *      node that emits a `re_exports` edge pointing at the changed file is
+ *      a barrel, regardless of its basename.
+ *   2. Filename + edge heuristic (Track F F-0816-Opt-Affected S-2): a node
+ *      whose basename matches BARREL_BASENAMES (`index.ts`, `__init__.py`,
+ *      `mod.rs`, `lib.rs`, ...) sitting in the same directory as a changed
+ *      file *and* importing from it. Kept as a fallback for graphs built
+ *      before the M2 port.
+ *
+ * The fallback never overrides explicit edges — when re_exports edges exist
+ * for a barrel they short-circuit the directory/basename gate, so a
+ * deliberately non-conventional barrel name (`entry.ts`, `surface.ts`, ...)
+ * still propagates.
+ *
+ * Once barrel nodes are identified, the barrel itself and its inbound
+ * consumers (anyone importing the barrel) are added to the changed set so
+ * downstream review-delta surfaces them as affected at depth 1, matching
+ * upstream safishamsi e44e6e9 `graphify affected` semantics.
  */
 function expandChangedIdsViaBarrels(G: Graph, changedIds: string[]): string[] {
   if (changedIds.length === 0) return changedIds;
@@ -164,6 +182,7 @@ function expandChangedIdsViaBarrels(G: Graph, changedIds: string[]): string[] {
   const directed = isDirectedGraph(G);
 
   const changedFileSet = new Set<string>();
+  const changedIdSet = new Set(changedIds);
   for (const id of changedIds) {
     const file = sourceFileOf(G, id);
     if (file) changedFileSet.add(file);
@@ -173,10 +192,29 @@ function expandChangedIdsViaBarrels(G: Graph, changedIds: string[]): string[] {
   const candidateDirs = new Set<string>();
   for (const file of changedFileSet) candidateDirs.add(dirname(file));
 
-  // Identify barrels in the same directory as any changed file that re-export
-  // (import_from) the changed file.
-  const barrelNodes: string[] = [];
+  const barrelNodes = new Set<string>();
+
+  // Path 1: explicit re_exports edges. Iterate over every edge once — when
+  // the edge target is a changed node (or its source_file is a changed
+  // file), the edge source is a barrel pointing at the change.
+  G.forEachEdge((_edge, edgeAttrs, source, target) => {
+    const relation = typeof edgeAttrs.relation === "string" ? edgeAttrs.relation : "";
+    if (relation !== REEXPORT_RELATION) return;
+    const barrelId = directed ? source : source;
+    const tgtId = directed ? target : target;
+    // Match either on node id (when the changed entity is a symbol) or on
+    // source_file (when the changed entity is a file node).
+    const targetFile = sourceFileOf(G, tgtId);
+    const targetChanged = changedIdSet.has(tgtId)
+      || (targetFile !== null && changedFileSet.has(targetFile));
+    if (!targetChanged) return;
+    barrelNodes.add(barrelId);
+  });
+
+  // Path 2: filename + edge fallback. Skipped per barrel that the explicit
+  // path already accepted — explicit edges win.
   G.forEachNode((nodeId, attrs) => {
+    if (barrelNodes.has(nodeId)) return;
     const source = typeof attrs.source_file === "string" ? attrs.source_file : null;
     if (!isBarrelPath(source)) return;
     const normalized = source ? normalizePath(source) : "";
@@ -201,7 +239,7 @@ function expandChangedIdsViaBarrels(G: Graph, changedIds: string[]): string[] {
         if (otherFile && changedFileSet.has(otherFile)) importsChanged = true;
       });
     }
-    if (importsChanged) barrelNodes.push(nodeId);
+    if (importsChanged) barrelNodes.add(nodeId);
   });
 
   // Add barrels and their inbound consumers (re-export propagation) to the

--- a/tests/affected-flows-prefers-explicit-reexports.test.ts
+++ b/tests/affected-flows-prefers-explicit-reexports.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+
+import { buildReviewDelta } from "../src/review.js";
+
+// Port of upstream safishamsi 1494874 — when the extractor emits explicit
+// `re_exports` edges (Track F F-0816-M2 S-2), review-delta barrel propagation
+// must follow those edges *regardless* of the file's basename. The
+// pre-existing filename-convention heuristic (index.ts, __init__.py,
+// mod.rs, lib.rs, ...) remains a fallback for graphs built before this port
+// (Track F F-0816-Opt-Affected S-2).
+function nonBarrelNameGraph(): Graph {
+  const G = new Graph({ type: "directed" });
+  for (const f of [
+    "src/utils/foo.ts",
+    "src/utils/bar.ts",
+    // NOT named index.ts / __init__.py / mod.rs / lib.rs — the filename
+    // heuristic would reject this as a barrel candidate.
+    "src/utils/entry.ts",
+    "src/consumer.ts",
+  ]) {
+    G.addNode(f, { label: f, source_file: f, kind: "File" });
+  }
+  // entry.ts explicitly re-exports symbols from foo.ts and bar.ts.
+  G.addDirectedEdge("src/utils/entry.ts", "src/utils/foo.ts", {
+    relation: "re_exports",
+    confidence: "EXTRACTED",
+    context: "re-export",
+  });
+  G.addDirectedEdge("src/utils/entry.ts", "src/utils/bar.ts", {
+    relation: "re_exports",
+    confidence: "EXTRACTED",
+    context: "re-export",
+  });
+  // consumer imports entry.ts (the barrel).
+  G.addDirectedEdge("src/consumer.ts", "src/utils/entry.ts", {
+    relation: "imports",
+    confidence: "EXTRACTED",
+  });
+  return G;
+}
+
+describe("affected-flows prefers explicit re_exports edges over filename heuristic", () => {
+  it("non-conventional barrel name still propagates when re_exports edges exist", () => {
+    const delta = buildReviewDelta(nonBarrelNameGraph(), ["src/utils/foo.ts"], {
+      maxNodes: 50,
+      depth: 1,
+    });
+    // foo is the changed file; entry.ts is the explicit re-exporter; consumer
+    // imports entry.ts. All three must surface at depth 1.
+    expect(delta.impacted_files).toContain("src/utils/foo.ts");
+    expect(delta.impacted_files).toContain("src/utils/entry.ts");
+    expect(delta.impacted_files).toContain("src/consumer.ts");
+  });
+
+  it("re_exports edge alone (no filename match) does not pull unrelated files", () => {
+    const G = nonBarrelNameGraph();
+    G.addNode("src/other.ts", { label: "other.ts", source_file: "src/other.ts", kind: "File" });
+    // unrelated import path
+    G.addDirectedEdge("src/other.ts", "src/utils/bar.ts", {
+      relation: "imports",
+      confidence: "EXTRACTED",
+    });
+
+    const delta = buildReviewDelta(G, ["src/utils/foo.ts"], {
+      maxNodes: 50,
+      depth: 1,
+    });
+    expect(delta.impacted_files).not.toContain("src/other.ts");
+  });
+
+  it("graphs built before the port (no re_exports edges) still propagate via filename fallback", () => {
+    // Same shape, but using the legacy imports_from edges and an
+    // index.ts-named barrel — the fallback path must still fire.
+    const G = new Graph({ type: "directed" });
+    for (const f of [
+      "src/utils/foo.ts",
+      "src/utils/index.ts",
+      "src/consumer.ts",
+    ]) {
+      G.addNode(f, { label: f, source_file: f, kind: "File" });
+    }
+    G.addDirectedEdge("src/utils/index.ts", "src/utils/foo.ts", {
+      relation: "imports_from",
+      confidence: "EXTRACTED",
+    });
+    G.addDirectedEdge("src/consumer.ts", "src/utils/index.ts", {
+      relation: "imports",
+      confidence: "EXTRACTED",
+    });
+
+    const delta = buildReviewDelta(G, ["src/utils/foo.ts"], {
+      maxNodes: 50,
+      depth: 1,
+    });
+    expect(delta.impacted_files).toContain("src/utils/index.ts");
+    expect(delta.impacted_files).toContain("src/consumer.ts");
+  });
+});

--- a/tests/extract-barrel-reexports.test.ts
+++ b/tests/extract-barrel-reexports.test.ts
@@ -165,4 +165,77 @@ describe("JS/TS barrel re-exports (port upstream safishamsi 1494874)", () => {
       .map((e) => e.target.toLowerCase());
     expect(importsFromTargets.some((t) => t.includes("storagehelpers"))).toBe(true);
   });
+
+  // ── S-2: re_exports edge kind ─────────────────────────────────────────────
+
+  it("S-2 emits symbol-level re_exports edges for `export { X } from './mod'`", async () => {
+    writeBarrel();
+    const result = await extract([
+      join(dir, "src", "index.ts"),
+      join(dir, "src", "cookieHelpers.ts"),
+      join(dir, "src", "storageHelpers.ts"),
+      join(dir, "src", "urlHelpers.ts"),
+      join(dir, "src", "namespacedHelpers.ts"),
+    ]);
+
+    const reExports = result.edges.filter((e) => e.relation === "re_exports");
+    // 4 named specifiers: readCookie, writeCookie, basePathRewrite, getFullUrl.
+    expect(reExports.length).toBeGreaterThanOrEqual(4);
+    const targets = reExports.map((e) => e.target).join(" ");
+    expect(targets).toMatch(/readCookie/i);
+    expect(targets).toMatch(/writeCookie/i);
+    expect(targets).toMatch(/basePathRewrite/i);
+    expect(targets).toMatch(/getFullUrl/i);
+  });
+
+  it("S-2 tags re_exports edges with confidence=EXTRACTED and context='re-export'", async () => {
+    writeBarrel();
+    const result = await extract([join(dir, "src", "index.ts"), join(dir, "src", "cookieHelpers.ts")]);
+
+    const reExports = result.edges.filter((e) => e.relation === "re_exports");
+    expect(reExports.length).toBeGreaterThan(0);
+    for (const edge of reExports) {
+      expect(edge.confidence).toBe("EXTRACTED");
+      expect((edge as { context?: string }).context).toBe("re-export");
+    }
+  });
+
+  it("S-2 does NOT emit re_exports for pure `export const x = 1` (no `from` clause)", async () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "pure.ts"),
+      [
+        "const x = 1;",
+        "export { x };",
+        "export const y = 2;",
+        "export function z() { return 3; }",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await extract([join(dir, "src", "pure.ts")]);
+    const reExports = result.edges.filter((e) => e.relation === "re_exports");
+    expect(reExports).toEqual([]);
+  });
+
+  it("S-2 ignores `default` specifier in re-export symbol matching", async () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "mod.ts"),
+      "export default function defFn() { return 1; }\n",
+    );
+    writeFileSync(
+      join(dir, "src", "index.ts"),
+      "export { default as DefAlias } from './mod';\n",
+    );
+
+    const result = await extract([
+      join(dir, "src", "index.ts"),
+      join(dir, "src", "mod.ts"),
+    ]);
+
+    const reExports = result.edges.filter((e) => e.relation === "re_exports");
+    // No re_exports edge for the default specifier itself.
+    expect(reExports.every((e) => !e.target.toLowerCase().endsWith("_default"))).toBe(true);
+  });
 });

--- a/tests/extract-barrel-reexports.test.ts
+++ b/tests/extract-barrel-reexports.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extract } from "../src/extract.js";
+
+// Port of upstream safishamsi 1494874 — track JS/TS barrel re-exports as
+// explicit graph edges. This file pins both S-1 (detection of the
+// `export_statement` with a `from` clause and tagging of the file-level
+// `imports_from` edge with `context: "re-export"`) and S-2 (symbol-level
+// `re_exports` edges). The combined file lets the suite remain green at
+// every checkpoint while the S-2 implementation lands.
+describe("JS/TS barrel re-exports (port upstream safishamsi 1494874)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "graphify-barrel-reexports-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeBarrel = (): void => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "cookieHelpers.ts"),
+      [
+        "export function readCookie(name: string): string {",
+        "  return '';",
+        "}",
+        "export function writeCookie(name: string, value: string): void {}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dir, "src", "storageHelpers.ts"),
+      [
+        "export function getFromStorage(key: string): string | null {",
+        "  return null;",
+        "}",
+        "export function setInStorage(key: string, value: string): void {}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dir, "src", "urlHelpers.ts"),
+      [
+        "export function getFullUrl(path: string): string {",
+        "  return 'https://example.com' + path;",
+        "}",
+        "export function basePathRewrite(url: string): string {",
+        "  return url;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dir, "src", "namespacedHelpers.ts"),
+      [
+        "export function withNamespace(): number { return 1; }",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dir, "src", "index.ts"),
+      [
+        "// Barrel file that re-exports from submodules",
+        "export { readCookie, writeCookie } from './cookieHelpers';",
+        "export * from './storageHelpers';",
+        "export { basePathRewrite, getFullUrl as fullUrl } from './urlHelpers';",
+        "export * as Ns from './namespacedHelpers';",
+        "",
+        "// Also has local exports (should still be extracted as nodes)",
+        "export function localHelper() {",
+        "  return 'local';",
+        "}",
+        "",
+        "export const LOCAL_CONST = 42;",
+        "",
+      ].join("\n"),
+    );
+  };
+
+  // ── S-1: detection ────────────────────────────────────────────────────────
+
+  it("S-1 emits file-level imports_from edges from a barrel to each source module", async () => {
+    writeBarrel();
+    const result = await extract([
+      join(dir, "src", "index.ts"),
+      join(dir, "src", "cookieHelpers.ts"),
+      join(dir, "src", "storageHelpers.ts"),
+      join(dir, "src", "urlHelpers.ts"),
+      join(dir, "src", "namespacedHelpers.ts"),
+    ]);
+
+    const importsFromTargets = result.edges
+      .filter((e) => e.relation === "imports_from")
+      .map((e) => e.target.toLowerCase());
+
+    expect(importsFromTargets.some((t) => t.includes("cookiehelpers"))).toBe(true);
+    expect(importsFromTargets.some((t) => t.includes("storagehelpers"))).toBe(true);
+    expect(importsFromTargets.some((t) => t.includes("urlhelpers"))).toBe(true);
+    expect(importsFromTargets.some((t) => t.includes("namespacedhelpers"))).toBe(true);
+  });
+
+  it("S-1 tags re-export file edges with context='re-export' (vs plain import edges)", async () => {
+    writeBarrel();
+    const result = await extract([join(dir, "src", "index.ts"), join(dir, "src", "cookieHelpers.ts")]);
+    const importsFromBarrel = result.edges.filter(
+      (e) => e.relation === "imports_from" && (e.source_file ?? "").endsWith("index.ts"),
+    );
+    expect(importsFromBarrel.length).toBeGreaterThan(0);
+    for (const edge of importsFromBarrel) {
+      expect((edge as { context?: string }).context).toBe("re-export");
+    }
+  });
+
+  it("S-1 keeps walking children so `export function/const` in a barrel still emit nodes", async () => {
+    writeBarrel();
+    const result = await extract([join(dir, "src", "index.ts")]);
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels.some((l) => l === "localHelper" || l === "localHelper()")).toBe(true);
+    expect(labels.some((l) => l === "index.ts")).toBe(true);
+  });
+
+  it("S-1 does NOT tag pure `export const/function/{ local }` edges (no `from` clause)", async () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "pure.ts"),
+      [
+        "const x = 1;",
+        "export { x };",
+        "export const y = 2;",
+        "export function z() { return 3; }",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await extract([join(dir, "src", "pure.ts")]);
+    const reExportTagged = result.edges.filter(
+      (e) => (e as { context?: string }).context === "re-export",
+    );
+    expect(reExportTagged).toEqual([]);
+  });
+
+  it("S-1 handles `export * from './mod'` with a target on the source module", async () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "storageHelpers.ts"),
+      "export function getFromStorage(k: string): string { return ''; }\n",
+    );
+    writeFileSync(
+      join(dir, "src", "index.ts"),
+      "export * from './storageHelpers';\n",
+    );
+
+    const result = await extract([
+      join(dir, "src", "index.ts"),
+      join(dir, "src", "storageHelpers.ts"),
+    ]);
+
+    const importsFromTargets = result.edges
+      .filter((e) => e.relation === "imports_from")
+      .map((e) => e.target.toLowerCase());
+    expect(importsFromTargets.some((t) => t.includes("storagehelpers"))).toBe(true);
+  });
+});

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -190,6 +190,10 @@ describe("toHtml visual encoding (Track C3)", () => {
     expect(inferEdgeDashes("calls", "EXTRACTED")).toBe(false);
     expect(inferEdgeDashes("imports_from", "EXTRACTED")).toEqual([6, 4]);
     expect(inferEdgeDashes("imports", "EXTRACTED")).toEqual([6, 4]);
+    // Port of upstream safishamsi 1494874 — `re_exports` rides the same
+    // import-family dash style so barrel-aware viewers render barrel
+    // re-exports identically to plain imports.
+    expect(inferEdgeDashes("re_exports", "EXTRACTED")).toEqual([6, 4]);
     expect(inferEdgeDashes("tested_by", "EXTRACTED")).toEqual([2, 4]);
     expect(inferEdgeDashes("validated_by", "EXTRACTED")).toEqual([2, 4]);
     expect(inferEdgeDashes("inherits", "EXTRACTED")).toEqual([10, 4]);
@@ -198,6 +202,31 @@ describe("toHtml visual encoding (Track C3)", () => {
     expect(inferEdgeDashes("uses", "EXTRACTED")).toBe(false);
     expect(inferEdgeDashes("uses", "INFERRED")).toBe(true);
     expect(inferEdgeDashes("", "AMBIGUOUS")).toBe(true);
+  });
+
+  it("HTML legend mentions re_exports alongside imports_from (port safishamsi 1494874)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-reexports-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    G.addNode("barrel", { label: "barrel", source_file: "src/index.ts", file_type: "code" });
+    G.addNode("foo", { label: "foo", source_file: "src/foo.ts", file_type: "code" });
+    G.addUndirectedEdge("barrel", "foo", {
+      relation: "re_exports",
+      confidence: "EXTRACTED",
+      context: "re-export",
+    });
+    const communities = new Map([[0, ["barrel", "foo"]]]);
+    toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
+    const html = readFileSync(htmlPath, "utf-8");
+    // Edge legend must surface re_exports as a documented relation kind so
+    // the viewer can attribute barrel arrows to the new edge type.
+    expect(html).toContain("re_exports");
+    // The dash pattern for re_exports rides the imports family. Match dashes
+    // and relation on the same JSON-serialised edge entry (line-based).
+    const edgeLine = html.split("\n").find((line) => line.includes('"relation":"re_exports"'));
+    expect(edgeLine).toBeDefined();
+    expect(edgeLine).toMatch(/"dashes":\[6,4\]/);
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("emits per-node shape, shape legend, and edge legend in the rendered HTML", () => {

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -224,4 +224,60 @@ describe("generate report", () => {
     expect(report).not.toContain("### Community 1 - \"Empty\"");
     expect(report).not.toContain("Thin community `Empty`");
   });
+
+  it("reports a re_exports edge-kind count line when re_exports edges exist (port safishamsi 1494874)", () => {
+    const G = new Graph({ type: "directed" });
+    G.mergeNode("barrel", { label: "barrel", source_file: "src/index.ts", file_type: "code" });
+    G.mergeNode("foo", { label: "foo", source_file: "src/foo.ts", file_type: "code" });
+    G.mergeNode("bar", { label: "bar", source_file: "src/bar.ts", file_type: "code" });
+    G.mergeNode("baz", { label: "baz", source_file: "src/baz.ts", file_type: "code" });
+    G.mergeEdge("barrel", "foo", {
+      relation: "re_exports",
+      confidence: "EXTRACTED",
+      source_file: "src/index.ts",
+    });
+    G.mergeEdge("barrel", "bar", {
+      relation: "re_exports",
+      confidence: "EXTRACTED",
+      source_file: "src/index.ts",
+    });
+    G.mergeEdge("barrel", "baz", {
+      relation: "imports_from",
+      confidence: "EXTRACTED",
+      source_file: "src/index.ts",
+    });
+
+    const report = generate(
+      G,
+      new Map([[0, ["barrel", "foo", "bar", "baz"]]]),
+      new Map([[0, 1.0]]),
+      new Map([[0, "Core"]]),
+      [{ id: "barrel", label: "barrel", edges: 3 }],
+      [],
+      {
+        files: {
+          code: ["src/index.ts", "src/foo.ts", "src/bar.ts", "src/baz.ts"],
+          document: [],
+          paper: [],
+          image: [],
+        },
+        total_files: 4,
+        total_words: 1000,
+        needs_graph: true,
+        warning: null,
+        skipped_sensitive: [],
+        graphifyignore_patterns: 0,
+      },
+      { input: 0, output: 0 },
+      ".",
+    );
+
+    // 2 re_exports + 1 imports_from = the new line must record the
+    // re_exports count so audit-trail consumers can compare to upstream's
+    // 162-edges signal on a Next.js codebase. Sorted by count desc, ties by
+    // relation name asc.
+    expect(report).toContain("Edge kinds:");
+    expect(report).toMatch(/re_exports: 2/);
+    expect(report).toMatch(/imports_from: 1/);
+  });
 });


### PR DESCRIPTION
## Summary

Port of upstream `safishamsi/graphify` commit `1494874` (row 9 of F-0816 cadrage). Adds explicit `re_exports` graph edges for JS/TS barrel patterns.

- **S-1** detect JS/TS re-export statements (`export { X } from './mod'`, `export * from`, `export * as Ns from`, etc.) in the extractor.
- **S-2** emit `re_exports` edge kind + clean_edges allowlist for cross-file edges.
- **S-3** `affected-flows` prefers explicit `re_exports` edges over the filename-convention fallback shipped in F-0816-Opt-Affected (#66).
- **S-4** surface `re_exports` in graph.html legend (import-family dash), GRAPH_REPORT edge-kind counts.

## Impact

On our own codebase the graph went from ~7274 → **8920 edges** after rebuild — the previously-invisible barrel re-export structure (`src/index.ts`, `src/workspace/index.ts`, etc.) is now explicit. Upstream measured 162 re_exports + 5760 symbol-level imports on a 976-file Next.js repo.

## Notes

- Complementary to Opt-Affected S-2 (#66): that detected barrels at runtime by filename convention for affected-flows only; this emits persistent graph edges visible to graph.html / GRAPH_REPORT / wiki / any downstream consumer.
- Local full-suite run had 1 flaky fs failure (cluster-only temp-dir race) that passes in isolation (2/2); unrelated to this lot.