### PR TITLE
Track F F-0816-M4: semantic-fragment validation at skill merge (port safishamsi b6127aa / #825)

### DIFF
--- a/.graphify/GRAPH_REPORT.md
+++ b/.graphify/GRAPH_REPORT.md
@@ -1,25 +1,25 @@
 # Graph Report - .  (2026-05-24)
 
 ## Corpus Check
-- 308 files · ~394 658 words
+- 311 files · ~399,330 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4603 nodes · 8946 edges · 182 communities detected
+- 4647 nodes · 8998 edges · 184 communities detected
 - Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 466 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
-- Edge kinds: contains: 3908 · calls: 1907 · imports: 1021 · imports_from: 604 · re_exports: 516 · uses: 466 · method: 232 · rationale_for: 208 · inherits: 68 · defines: 16
+- Edge kinds: contains: 3949 · calls: 1915 · imports: 1021 · imports_from: 607 · re_exports: 516 · uses: 466 · method: 232 · rationale_for: 208 · inherits: 68 · defines: 16
 
 
 ## Input Scope
 - Requested: auto
 - Resolved: committed (source: default-auto)
-- Included files: 308 · Candidates: 330
-- Excluded: 0 untracked · 15765 ignored · 5 sensitive · 0 missing committed
+- Included files: 311 · Candidates: 333
+- Excluded: 0 untracked · 15770 ignored · 5 sensitive · 0 missing committed
 - Recommendation: Use --scope all or graphify.yaml inputs.corpus for a knowledge-base folder.
 
 ## Graph Freshness
-- Built from Git commit: `5a34400`
+- Built from Git commit: `6747bde`
 - Compare this hash to `git rev-parse HEAD` before trusting freshness-sensitive graph output.
 ## God Nodes (most connected - your core abstractions)
 1. `Response` - 45 edges
@@ -260,28 +260,28 @@ Cohesion: 0.09
 Nodes (26): asRecord(), asString(), build(), buildFromJson(), buildMerge(), BuildMergeOptions, BuildOptions, dedupLabelKey() (+18 more)
 
 ### Community 53 - "Community 53"
+Cohesion: 0.09
+Nodes (23): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+15 more)
+
+### Community 54 - "Community 54"
 Cohesion: 0.08
 Nodes (12): DataProcessor, Get-Data(), GraphifyDemo, IProcessor, Process-Items(), Processor, DataProcessor, Get-Data() (+4 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.09
 Nodes (26): field(), loadProfileRegistry(), normalizeRegistryRecord(), readRegistryRows(), registryRecordsToExtraction(), safeIdPart(), field(), loadProfileRegistries() (+18 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.10
 Nodes (29): GitContext, escapeRegExp(), GRAPH_GITATTR_LINES, hookBlockRegex(), HookDefinition, HOOKS, install(), installGraphAttributes() (+21 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.11
 Nodes (29): CACHED_AUDIO_EXTENSIONS, defaultWhisperCacheDir(), downloadFile(), ensureWhisperArtifacts(), envBoolean(), envNumber(), extractTranscriptText(), FasterWhisperModel (+21 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.07
 Nodes (27): CONFIDENCE_VALUES, loadHyperedges(), mergeHyperedges(), validateHyperedge(), Confidence, Hyperedge, a, aFlow (+19 more)
-
-### Community 58 - "Community 58"
-Cohesion: 0.10
-Nodes (22): AnalysisFile, analyzeGraph(), cacheOptionsFromRuntime(), defaultLabels(), __dirname, ensureExtractionShape(), __filename, getVersion() (+14 more)
 
 ### Community 59 - "Community 59"
 Cohesion: 0.11
@@ -304,416 +304,416 @@ Cohesion: 0.11
 Nodes (27): allowedPathFor(), buildOntologyDiscoveryDiff(), buildOntologyDiscoverySample(), knownEvidenceRefs(), loadOntologyDiscoveryContext(), OntologyDiscoveryProposal, OntologyDiscoveryProposalAction, OntologyDiscoveryProposalKind (+19 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.10
-Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
+Cohesion: 0.09
+Nodes (25): appendRationaleAttr(), INVALID_FILE_TYPES_FOR_SANITIZE, isPlainObject(), isSentenceLikeRationaleLabel(), LoadValidatedResult, loadValidatedSemanticFragment(), sanitizeSemanticFragment(), SemanticFragment (+17 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.10
-Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
+Nodes (26): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+18 more)
 
 ### Community 66 - "Community 66"
+Cohesion: 0.10
+Nodes (26): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+18 more)
+
+### Community 67 - "Community 67"
 Cohesion: 0.11
 Nodes (20): AllChunksFailedError, createDirectSemanticExtractionClient(), DirectSemanticChunk, DirectSemanticClientOptions, DirectSemanticExtractionClient, DirectSemanticExtractionOptions, DirectSemanticFile, estimateFileTokens() (+12 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.13
 Nodes (21): activeViewFromQuery(), candidateFilters(), createOntologyStudioRequestHandler(), decisionLogOptions(), generateOntologyStudioToken(), graphHtmlArtifactResult(), handleOntologyStudioRequest(), htmlResult() (+13 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.07
 Nodes (22): apply, audit, auditLine, authoritative, { body, headers }, decision, decisionLine, dir (+14 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.08
 Nodes (16): OntologyWriteFixture, writeOntologyWriteFixture(), OntologyPatch, boxes, central, dir, fixture, headingMatches (+8 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.14
 Nodes (25): augmentDetectionWithPdfPreflight(), cloneDetection(), countWords(), dedupe(), listImageArtifacts(), loadMistralOcrModule(), metadataPath(), preparePdf() (+17 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.14
 Nodes (23): countImageMarkers(), countWords(), extractPdfTextLayer(), extractWithPdfParse(), extractWithPdftotext(), normalizeText(), preflightPdf(), sha256() (+15 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.09
 Nodes (21): assertValid(), REQUIRED_EDGE_FIELDS, REQUIRED_NODE_FIELDS, VALID_CONFIDENCES, VALID_FILE_TYPES, validateExtraction(), communities, extraction (+13 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.08
 Nodes (8): CommitRecommendation, CommitRecommendationConfidence, CommitRecommendationGroup, CommitRecommendationOptions, CommitRecommendationStaleness, FileGraphInfo, GroupDraft, ReviewDelta
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.10
 Nodes (22): canonicalizeForPartition(), cluster(), ClusterOptions, cohesionScore(), partition(), scoreAll(), splitCommunity(), allAssigned (+14 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.15
 Nodes (22): html, tokens, buildFacetValues(), collectFieldNames(), DENYLIST, DiscoverFacetsOptions, discoverWorkspaceFacets(), isFacetableValue() (+14 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.11
 Nodes (19): NumericMapLike, StringMapLike, toNumericMap(), toStringMap(), ReviewFlow, appendFreshnessSection(), appendInputScopeSection(), appendReviewSections() (+11 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.16
 Nodes (22): defaultGraphPath(), defaultManifestPath(), defaultTranscriptsDir(), legacyGraphPath(), resolveGraphifyPaths(), resolveGraphInputPath(), statePath(), defaultGraphPath() (+14 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.18
 Nodes (18): addIssue(), buildEvidenceIds(), buildRegistryRecords(), citations(), isProfileEdge(), isRegistrySeed(), ProfileValidationContext, ProfileValidationIssue (+10 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.11
 Nodes (19): CODE_EXTENSIONS, DOC_EXTENSIONS, IMAGE_EXTENSIONS, PAPER_EXTENSIONS, makeGraphPortable(), acquireRebuildLock(), builtFromCommit(), checkUpdate() (+11 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.14
 Nodes (18): createGraph(), forEachTraversalNeighbor(), isDirectedGraph(), loadGraphFromData(), serializeGraph(), toUndirectedGraph(), traversalNeighbors(), mergedGraphType() (+10 more)
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.09
 Nodes (19): ONTOLOGY_RECONCILIATION_DECISION_LOG_SCHEMA, auditPath, authoritativePath, badRelation, badStatus, cleanupDirs, context, decisionsPath (+11 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.15
 Nodes (20): ALLOWED_SCHEMES, BLOCKED_HOSTS, embeddedIPv4(), escapeHtml(), expandIPv6(), isPrivateIp(), isRedirectStatus(), safeFetch() (+12 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.15
 Nodes (19): escapeHtml(), escapeUrl(), HTML_ESCAPE_MAP, modeLabel(), renderGraphPanel(), RenderGraphPanelOptions, renderLiveGraphScript(), renderMetricsCard() (+11 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.09
 Nodes (22): allClustered, count, cypher, data, errors, exts, FIXTURES_DIR, G2 (+14 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.10
 Nodes (15): bindOntologyProfile(), hashOntologyProfile(), loadOntologyProfile(), parseOntologyProfile(), stableForHash(), bound, cleanupDirs, config (+7 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.15
 Nodes (22): _csharpExtraWalk(), extractMarkdown(), _findRequireCall(), _getCFuncName(), _getCppFuncName(), _importC(), _importCsharp(), _importJava() (+14 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.09
 Nodes (18): configOut, dir, discoveryDiffPath, discoveryDir, discoveryPromptPath, discoveryProposalsPath, discoveryReportPath, discoverySample (+10 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.11
 Nodes (20): build_graph(), cluster(), cohesion_score(), Leiden community detection on NetworkX graphs. Splits oversized communities. Ret, Run Leiden community detection. Returns {community_id: [node_ids]}.      Communi, Build a NetworkX graph from graphify node/edge dicts.      Preserves original ed, Run a second Leiden pass on a community subgraph to split it further., Ratio of actual intra-community edges to maximum possible. (+12 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.10
 Nodes (16): inferEdgeDashes(), HtmlWriter, safeToHtml(), SafeToHtmlOptions, ToHtmlOptions, communities, dir, edgeLine (+8 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.10
 Nodes (16): blocked, captionPath, captionsDir, cleanupDirs, dense, forced, graphifyManifest, input (+8 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.10
 Nodes (18): WIKI_DESCRIPTION_PROMPT_VERSION, WIKI_DESCRIPTION_SCHEMA, WikiDescriptionSidecarIndex, article, descriptions, G, generator, communities (+10 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.14
 Nodes (19): aliasHit, hit, hits, i18nRecords, ids, index, lower, minimal (+11 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.17
 Nodes (20): createDefaultViewerState(), DEFAULT_EVIDENCE_PANEL_STATE, DEFAULT_FACET_STATE, DEFAULT_GRAPH_PANEL_STATE, DEFAULT_SELECTION_STATE, isEvidenceMode(), isFiniteNonNegativeInt(), isGraphAggregation() (+12 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.10
 Nodes (18): benchmark, canvas, cleanupDirs, cohesion, communities, detection, dir, G (+10 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.11
 Nodes (17): extract(), ExtractionResult, extractWithDiagnostics(), inferCommonRoot(), _mergeSwiftExtensions(), GraphEdge, GraphNode, allEdges (+9 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.15
 Nodes (14): Base, area(), Circle, describe(), Geometry, Point, Shape, LinearAlgebra (+6 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.11
 Nodes (10): DecodingError, HTTPError, HTTPStatusError, An error occurred while issuing a request., Decoding of the response failed., A 4xx or 5xx response was received., Base class for all httpx exceptions., RequestError (+2 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.11
 Nodes (14): cursorInstall(), replaceOrAppendSection(), dir, original, rule, rulePath, tempDirs, bannedReportFirstPatterns (+6 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.11
 Nodes (16): projectUninstallAll(), agentsMd, claudeMd, cwd, hasFiles, hooks, hooksPath, joined (+8 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.13
 Nodes (15): SerializedGraphData, setHyperedges(), hyperedgeSortKey(), mergeGraphAttributes(), mergeGraphJsonFiles(), MergeGraphJsonResult, readGraph(), ancestor (+7 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.14
 Nodes (2): ApiClient, ApiClient
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.15
 Nodes (14): buildReviewDelta(), changedNodeIds(), clampDepth(), computeAffectedFiles(), dirname(), expandChangedIdsViaBarrels(), highRiskChains(), impactedNodeIds() (+6 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.21
 Nodes (10): Analyzer, compute_score(), normalize(), Fixture: functions and methods that call each other - for call-graph extraction, run_analysis(), Analyzer, compute_score(), normalize() (+2 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.18
 Nodes (13): cloneRepo(), CloneRepoOptions, CloneRepoResult, defaultCloneDestination(), execGit(), GithubRepoRef, maybeGithubRepo(), repoNameFromUrl() (+5 more)
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.13
 Nodes (13): cleanupStaleNodes(), CleanupStaleNodesOptions, CleanupStaleNodesResult, cleanupDirs, dir, formatted, G, graph (+5 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.13
 Nodes (14): augmentDetectionWithTranscripts(), buildWhisperPrompt(), cloneDetection(), transcribeAll(), cached, hash, modelDir, outDir (+6 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.13
 Nodes (11): SemanticPreparationResult, cleanupDirs, config, detection, filtered, fixtureRoot, inputs, paths (+3 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (15): OntologyReconciliationDecisionLogOptions, OntologyReconciliationDecisionLogResponse, getOntologyRebuildStatus(), getOntologyReconciliationCandidate(), listOntologyReconciliationCandidates(), loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath() (+7 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.23
 Nodes (15): buildTypeRows(), escapeHtml(), HTML_ESCAPE_MAP, nodeType(), recordsFromGraph(), renderFacets(), RenderRailOptions, renderResults() (+7 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.15
 Nodes (15): auditPath, beforeAudit, beforeDecisions, cliOut, cliPreview, fixtureRoot, prepareProject(), queue (+7 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.13
 Nodes (15): candidateHtml, empty, graph, headerIndex, html, populated, readOnlyHtml, skipIndex (+7 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.13
 Nodes (14): a, after, b, before, cleared, initial, q, query (+6 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.13
 Nodes (10): discoverProjectConfig(), cleanupDirs, configDir, configPath, errors, loaded, normalized, raw (+2 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (15): agentsUninstall(), antigravityUninstall(), claudeUninstall(), cursorUninstall(), geminiUninstall(), kiroUninstall(), projectUninstall(), removeProjectClaudeMdRegistration() (+7 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.39
 Nodes (15): buildResolvableLabelIndex(), ensureParserInit(), extractElixir(), extractGo(), extractJulia(), extractObjc(), extractPowershell(), _extractPythonRationale() (+7 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (11): TextJsonGenerationClient, TextJsonGenerationInput, TextJsonGenerationResult, createGraphifyMesh(), CreateGraphifyMeshOptions, meshTextJsonClient(), MeshTextJsonClientOptions, client (+3 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.21
 Nodes (12): estimateTokens(), loadGraph(), querySubgraphTokens(), runBenchmark(), BenchmarkOptions, estimateTokens(), loadGraph(), printBenchmark() (+4 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.26
 Nodes (13): execGit(), gitRevParse(), resolveFromGitCwd(), resolveGitContext(), safeExecGit(), safeGitRevParse(), execGit(), gitRevParse() (+5 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.14
 Nodes (11): NormalizedOntologyProfile, ambiguous, cleanupDirs, extraction, nodes, outputDir, page, profile (+3 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.14
 Nodes (11): OntologyDiscoverySample, buildProfileChunkPrompt(), chunkGuidance(), documentPrompt, extraction, fixtureRoot, imagePrompt, profile (+3 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.16
 Nodes (11): PdfPreparationArtifact, parsePdfOcrMode(), PdfOcrMode, prepareSemanticDetection(), SemanticPreparationOptions, imagePath, outputDir, packageJson (+3 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.33
 Nodes (13): detectUrlType(), downloadBinary(), fetchArxiv(), fetchTweet(), fetchWebpage(), htmlToMarkdown(), ingest(), IngestOptions (+5 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.20
 Nodes (14): loadReadonlyReconciliationCandidates(), ontologyAppliedPatchesPath(), ontologyNeedsUpdatePath(), ontologyReconciliationCandidatesPath(), optionalInteger(), optionalNumber(), optionalString(), readableStatePath() (+6 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.27
 Nodes (12): communityArticle(), crossCommunityLinks(), flowArticle(), flowsThroughNodes(), godNodeArticle(), indexMd(), normalizeFlows(), renderDescription() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (12): OntologyDiscoveryContext, ontologyDiscoveryDiffToMarkdown(), OntologyDiscoveryProposalsFile, context, diff, discoveryContext(), fixtureRoot, proposals (+4 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.21
 Nodes (13): bfs(), communityName(), dfs(), findNode(), mcpField(), nodeDisplayLabel(), scoreNodes(), subgraphToText() (+5 more)
 
-### Community 127 - "Community 127"
-Cohesion: 0.17
-Nodes (6): profileValidationResultToJson(), profileValidationResultToMarkdown(), extraction, fixtureRoot, registryExtraction, result
-
 ### Community 128 - "Community 128"
 Cohesion: 0.17
-Nodes (10): toCypher(), cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted (+2 more)
+Nodes (11): ast, cached, dir, fresh, input, merged, outPath, runMain() (+3 more)
 
 ### Community 129 - "Community 129"
 Cohesion: 0.17
-Nodes (11): extractJs(), calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge (+3 more)
+Nodes (6): profileValidationResultToJson(), profileValidationResultToMarkdown(), extraction, fixtureRoot, registryExtraction, result
 
 ### Community 130 - "Community 130"
-Cohesion: 0.18
-Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
+Cohesion: 0.17
+Nodes (10): toCypher(), cleanupDirs, cypher, dir, graph, graphPath, outputPath, persisted (+2 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.25
-Nodes (4): build_graph(), Graph, build_graph(), Graph
+Cohesion: 0.17
+Nodes (11): extractJs(), calls, callTargets, cleanupDirs, demoNode, dir, filePath, importEdge (+3 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.18
-Nodes (9): makeExtractionPortable(), DetectionResult, detection, extraction, graphifyDir, portable, result, root (+1 more)
+Nodes (10): Animal, -initWithName, -speak, Dog, -fetch, Animal, -initWithName, -speak (+2 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.20
-Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
+Cohesion: 0.25
+Nodes (4): build_graph(), Graph, build_graph(), Graph
 
 ### Community 134 - "Community 134"
 Cohesion: 0.18
-Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
+Nodes (9): makeExtractionPortable(), DetectionResult, detection, extraction, graphifyDir, portable, result, root (+1 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.18
-Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
+Cohesion: 0.20
+Nodes (9): home, project, rule, runCliInTemp(), runCliWithEnvironment(), skill, skillPath, tempDirs (+1 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.18
-Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
+Nodes (10): communities, communityLabels, dir, G, list, long, outPath, result (+2 more)
 
 ### Community 137 - "Community 137"
+Cohesion: 0.18
+Nodes (9): allStale, article, communities, count, formatted, G, LABELS, stale (+1 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.18
+Nodes (9): focused, graph, graphJsonShape, html, state, strongOnly, subgraph, tokens (+1 more)
+
+### Community 139 - "Community 139"
 Cohesion: 0.20
 Nodes (7): batch, G, impact, node, out, store, targets
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
 Cohesion: 0.20
 Nodes (10): braceDelta(), extractAstro(), extractGroovy(), extractRegexBackedCode(), extractSql(), extractSvelte(), lineForIndex(), normalizeSqlObjectName() (+2 more)
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (7): normalizeSearchText(), queryTerms(), scoreSearchText(), textMatchesQuery(), exact, substring, terms
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
 Cohesion: 0.20
 Nodes (9): centralEnd, centralIdx, graph, graphIdx, html, ids, state, subgraph (+1 more)
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
 Cohesion: 0.28
 Nodes (6): MyApp.Accounts.User, create(), validate(), MyApp.Accounts.User, create(), validate()
 
-### Community 142 - "Community 142"
+### Community 144 - "Community 144"
 Cohesion: 0.22
 Nodes (2): ignoredDir, inventory
 
-### Community 143 - "Community 143"
+### Community 145 - "Community 145"
 Cohesion: 0.47
 Nodes (9): addIssue(), citations(), isProfileEdge(), isRegistrySeed(), stringValue(), validateCitations(), validateEdge(), validateNode() (+1 more)
 
-### Community 144 - "Community 144"
+### Community 146 - "Community 146"
 Cohesion: 0.31
 Nodes (1): ConnectionPool
 
-### Community 145 - "Community 145"
+### Community 147 - "Community 147"
 Cohesion: 0.22
 Nodes (6): formatMetric(), reviewAnalysisToText(), reviewEvaluationToText(), analysis, evaluation, text
 
-### Community 146 - "Community 146"
+### Community 148 - "Community 148"
 Cohesion: 0.31
 Nodes (7): assertGraphJsonFileSize(), assertGraphJsonSize(), GraphSizeMode, dir, message, missing, path
 
-### Community 147 - "Community 147"
+### Community 149 - "Community 149"
 Cohesion: 0.25
 Nodes (9): communitiesFromGraph(), createReloadingGraphStore(), getVersion(), GraphFileSignature, loadGraph(), loadGraphSnapshot(), readGraphData(), serve() (+1 more)
 
-### Community 148 - "Community 148"
+### Community 150 - "Community 150"
 Cohesion: 0.25
 Nodes (8): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea()
-
-### Community 149 - "Community 149"
-Cohesion: 0.25
-Nodes (3): LifecycleMetadata, commitRecommendationToText(), recommendation
-
-### Community 150 - "Community 150"
-Cohesion: 0.43
-Nodes (8): _importJs(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds(), resolveJsImportTarget(), resolveJsImportTargetInfo(), toPortablePath()
 
 ### Community 151 - "Community 151"
 Cohesion: 0.25
-Nodes (8): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea()
+Nodes (3): LifecycleMetadata, commitRecommendationToText(), recommendation
 
 ### Community 152 - "Community 152"
-Cohesion: 0.29
-Nodes (6): firstHopSummaryToText(), graph, makeGraph(), summary, textA, textB
+Cohesion: 0.43
+Nodes (8): _importJs(), loadTsconfigAliases(), normalizeJsImportTarget(), projectRelativeFilePath(), remapFileNodeIds(), resolveJsImportTarget(), resolveJsImportTargetInfo(), toPortablePath()
 
 ### Community 153 - "Community 153"
 Cohesion: 0.25
-Nodes (7): downloadAudio(), runCommand(), cleanupDirs, dir, downloadAudioMock, expected, rendered
+Nodes (8): commitPrefixForArea(), communityLabel(), dominantCommunity(), groupDraftForFile(), isGraphifyStatePath(), normalizePath(), sourceMatches(), topLevelArea()
 
 ### Community 154 - "Community 154"
-Cohesion: 0.25
-Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
+Cohesion: 0.29
+Nodes (6): firstHopSummaryToText(), graph, makeGraph(), summary, textA, textB
 
 ### Community 155 - "Community 155"
 Cohesion: 0.25
-Nodes (6): importsFromBarrel, importsFromTargets, labels, reExports, reExportTagged, targets
+Nodes (7): downloadAudio(), runCommand(), cleanupDirs, dir, downloadAudioMock, expected, rendered
 
 ### Community 156 - "Community 156"
 Cohesion: 0.25
-Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+Nodes (6): attrs, cleanupDirs, dir, edge, graph, graphPath
 
 ### Community 157 - "Community 157"
 Cohesion: 0.25
-Nodes (7): dataset, dirty, facets, keys, slices, state, status
+Nodes (6): importsFromBarrel, importsFromTargets, labels, reExports, reExportTagged, targets
 
 ### Community 158 - "Community 158"
 Cohesion: 0.25
-Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+Nodes (7): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, INLINE_MERGE_SKILLS, SKILLS, TRIGGER_DESCRIPTION_DOCS
 
 ### Community 159 - "Community 159"
+Cohesion: 0.25
+Nodes (7): graph, html, idxControls, idxCounters, idxGraphPanel, state, tokens
+
+### Community 160 - "Community 160"
+Cohesion: 0.25
+Nodes (7): dataset, dirty, facets, keys, slices, state, status
+
+### Community 161 - "Community 161"
+Cohesion: 0.25
+Nodes (7): graph, html, idxChar, idxLoc, idxWork, state, tokens
+
+### Community 162 - "Community 162"
 Cohesion: 0.38
 Nodes (6): build(), build_from_json(), Merge multiple extraction results into one graph., build(), build_from_json(), Merge multiple extraction results into one graph.
 
-### Community 160 - "Community 160"
+### Community 163 - "Community 163"
 Cohesion: 0.29
 Nodes (2): Transformer, Transformer
 
-### Community 161 - "Community 161"
+### Community 164 - "Community 164"
 Cohesion: 0.29
 Nodes (6): home, previousCwd, readme, skillPath, tempDirs, versionPath
 
-### Community 162 - "Community 162"
-Cohesion: 0.29
-Nodes (6): ALL_SKILL_DOCS, content, DISTRIBUTED_SKILL_DOCS, EXTRACTION_PROMPT_DOCS, SKILLS, TRIGGER_DESCRIPTION_DOCS
-
-### Community 163 - "Community 163"
+### Community 165 - "Community 165"
 Cohesion: 0.29
 Nodes (6): evidenceQuery, html, reconHtml, reconQuery, tokens, workspaceHtml
 
-### Community 164 - "Community 164"
+### Community 166 - "Community 166"
 Cohesion: 0.29
 Nodes (6): query, restored, state, state0, state1, state2
-
-### Community 165 - "Community 165"
-Cohesion: 0.47
-Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
-
-### Community 166 - "Community 166"
-Cohesion: 0.33
-Nodes (3): reviewDeltaToText(), delta, text
 
 ### Community 167 - "Community 167"
 Cohesion: 0.47
@@ -721,88 +721,96 @@ Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minCon
 
 ### Community 168 - "Community 168"
 Cohesion: 0.33
-Nodes (5): commands, dir, matchers, settings, tempDirs
+Nodes (3): reviewDeltaToText(), delta, text
 
 ### Community 169 - "Community 169"
-Cohesion: 0.33
-Nodes (4): dir, logs, preview, tempDirs
+Cohesion: 0.47
+Nodes (6): buildCommitRecommendation(), groupConfidence(), mergeDrafts(), minConfidence(), stalenessFrom(), uniqueSorted()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.33
-Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
+Nodes (5): commands, dir, matchers, settings, tempDirs
 
 ### Community 171 - "Community 171"
-Cohesion: 0.40
-Nodes (3): affectedFilesToText(), result, text
+Cohesion: 0.33
+Nodes (4): dir, logs, preview, tempDirs
 
 ### Community 172 - "Community 172"
-Cohesion: 0.40
-Nodes (4): changelog, lock, pkg, workflow
+Cohesion: 0.33
+Nodes (5): markdown, outputDir, pdfPath, tempDirs, tmpDir
 
 ### Community 173 - "Community 173"
 Cohesion: 0.40
-Nodes (4): candidateGraph, graph, html, tokens
+Nodes (3): affectedFilesToText(), result, text
 
 ### Community 174 - "Community 174"
 Cohesion: 0.40
-Nodes (4): character, dataset, groups, total
+Nodes (4): changelog, lock, pkg, workflow
 
 ### Community 175 - "Community 175"
+Cohesion: 0.40
+Nodes (4): candidateGraph, graph, html, tokens
+
+### Community 176 - "Community 176"
+Cohesion: 0.40
+Nodes (4): character, dataset, groups, total
+
+### Community 177 - "Community 177"
 Cohesion: 0.50
 Nodes (2): delta, G
 
-### Community 176 - "Community 176"
+### Community 178 - "Community 178"
 Cohesion: 0.50
 Nodes (3): html, state, tokens
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.67
 Nodes (3): runCli(), runMain(), runSkillRuntime()
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 0.67
 Nodes (3): writeFixtureGraph(), writeOntologyPatchFixture(), writeOntologyReconciliationFixture()
 
-### Community 179 - "Community 179"
+### Community 181 - "Community 181"
 Cohesion: 1.00
 Nodes (1): UnpdfTextResult
 
-### Community 180 - "Community 180"
+### Community 182 - "Community 182"
 Cohesion: 1.00
 Nodes (2): tempProfileProject(), tempProject()
 
-### Community 181 - "Community 181"
+### Community 183 - "Community 183"
 Cohesion: 1.00
 Nodes (1): optionalRuntimeDeps
 
 ## Knowledge Gaps
-- **1509 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1504 more)
+- **1537 isolated node(s):** `GraphInstance`, `JSON_NOISE_LABELS`, `SAMPLE_QUESTIONS`, `BenchmarkOptions`, `BuildOptions` (+1532 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 101`** (2 nodes): `ApiClient`, `ApiClient`
+- **Thin community `Community 102`** (2 nodes): `ApiClient`, `ApiClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (2 nodes): `ignoredDir`, `inventory`
+- **Thin community `Community 144`** (2 nodes): `ignoredDir`, `inventory`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (1 nodes): `ConnectionPool`
+- **Thin community `Community 146`** (1 nodes): `ConnectionPool`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (2 nodes): `Transformer`, `Transformer`
+- **Thin community `Community 163`** (2 nodes): `Transformer`, `Transformer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (2 nodes): `delta`, `G`
+- **Thin community `Community 177`** (2 nodes): `delta`, `G`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (1 nodes): `UnpdfTextResult`
+- **Thin community `Community 181`** (1 nodes): `UnpdfTextResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (2 nodes): `tempProfileProject()`, `tempProject()`
+- **Thin community `Community 182`** (2 nodes): `tempProfileProject()`, `tempProject()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (1 nodes): `optionalRuntimeDeps`
+- **Thin community `Community 183`** (1 nodes): `optionalRuntimeDeps`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `OntologyReconciliationCandidate` connect `Community 50` to `Community 2`, `Community 108`, `Community 40`?**
+- **Why does `OntologyReconciliationCandidate` connect `Community 50` to `Community 2`, `Community 109`, `Community 40`?**
   _High betweenness centrality (0.007) - this node is a cross-community bridge._
-- **Why does `OntologyReconciliationDecisionLogResponse` connect `Community 108` to `Community 2`, `Community 27`, `Community 40`?**
+- **Why does `OntologyReconciliationDecisionLogResponse` connect `Community 109` to `Community 27`, `Community 2`, `Community 40`?**
   _High betweenness centrality (0.007) - this node is a cross-community bridge._
-- **Why does `OntologyReconciliationCandidatesResponse` connect `Community 108` to `Community 2`, `Community 50`, `Community 40`?**
+- **Why does `OntologyReconciliationCandidatesResponse` connect `Community 109` to `Community 50`, `Community 2`, `Community 40`?**
   _High betweenness centrality (0.007) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `Response` (e.g. with `Auth` and `BasicAuth`) actually correct?**
   _`Response` has 39 INFERRED edges - model-reasoned connections that need verification._

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,19 @@ export type { BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions
 export { detect, classifyFile, detectIncremental, saveManifest } from "./detect.js";
 export { extract, collectFiles } from "./extract.js";
 export { fileHash, loadCached, saveCached, checkSemanticCache, saveSemanticCache } from "./cache.js";
+export {
+  MAX_SEMANTIC_FRAGMENT_BYTES,
+  MAX_SEMANTIC_FRAGMENT_EDGES,
+  MAX_SEMANTIC_FRAGMENT_HYPEREDGES,
+  MAX_SEMANTIC_FRAGMENT_NODES,
+  MAX_SEMANTIC_HYPEREDGE_NODES,
+  MAX_SEMANTIC_ID_LENGTH,
+  VALID_SEMANTIC_FILE_TYPES,
+  loadValidatedSemanticFragment,
+  sanitizeSemanticFragment,
+  validateSemanticFragment,
+} from "./semantic-fragment-validation.js";
+export type { LoadValidatedResult, SemanticFragment } from "./semantic-fragment-validation.js";
 export { validateUrl, safeFetch, safeFetchText, validateGraphPath, sanitizeLabel } from "./security.js";
 export { DEFAULT_GRAPHIFY_STATE_DIR, LEGACY_GRAPHIFY_STATE_DIR, NEXT_GRAPHIFY_STATE_DIR, resolveGraphifyPaths, defaultGraphPath, legacyGraphPath, resolveGraphInputPath, defaultManifestPath, defaultTranscriptsDir } from "./paths.js";
 export { createGraph, isDirectedGraph, loadGraphFromData, serializeGraph } from "./graph.js";

--- a/src/semantic-fragment-validation.ts
+++ b/src/semantic-fragment-validation.ts
@@ -1,0 +1,428 @@
+// Semantic-fragment validator + sanitizer for untrusted JSON chunks emitted
+// by LLM agents (OpenCode, Codex, and other skill-driven extractors).
+//
+// Ported from upstream Python `graphify.semantic_cleanup` (PR #825 /
+// commit `b6127aa` on `safishamsi/graphify`). The validator enforces hard
+// boundaries on payload shape so a malicious or runaway agent response
+// cannot:
+//
+//   * exhaust memory with a multi-GB payload (25 MiB byte cap)
+//   * escape the chunk directory via crafted node/edge/hyperedge IDs
+//     (charset + length validation across all three)
+//   * inject sentence-like rationale text as standalone graph nodes
+//     (detected via file_type in {rationale, concept} OR via a
+//     rationale_for edge with a sentence-like label, regardless of
+//     declared file_type)
+//   * inject unknown file_type values
+//   * leave dangling hyperedges referencing removed nodes
+//   * corrupt unrelated nodes by propagating rationale text through
+//     non-rationale_for edges (only rationale_for edges propagate)
+//
+// The sanitizer is *destructive*: it mutates the fragment in place and
+// returns the same reference for callers that prefer chaining.
+
+import { readFileSync, statSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/** Maximum on-disk + in-memory payload size before validation rejects the fragment. */
+export const MAX_SEMANTIC_FRAGMENT_BYTES = 25 * 1024 * 1024;
+/** Maximum number of top-level nodes in a single fragment. */
+export const MAX_SEMANTIC_FRAGMENT_NODES = 10_000;
+/** Maximum number of top-level edges in a single fragment. */
+export const MAX_SEMANTIC_FRAGMENT_EDGES = 100_000;
+/** Maximum number of hyperedges in a single fragment. */
+export const MAX_SEMANTIC_FRAGMENT_HYPEREDGES = 10_000;
+/** Maximum number of node references in a single hyperedge. */
+export const MAX_SEMANTIC_HYPEREDGE_NODES = 256;
+/** Maximum character length for any node/edge/hyperedge ID. */
+export const MAX_SEMANTIC_ID_LENGTH = 256;
+
+/**
+ * Closed set of accepted `file_type` values. Matches upstream
+ * `VALID_SEMANTIC_FILE_TYPES` (PR #825 + the "review #6" follow-up that
+ * re-admitted `rationale` and `concept` so the sanitizer can clean them up
+ * instead of the validator rejecting the whole chunk).
+ */
+export const VALID_SEMANTIC_FILE_TYPES = Object.freeze(
+  new Set<string>(["code", "document", "paper", "image", "rationale", "concept"]),
+);
+
+const SEMANTIC_ID_RE = /^[A-Za-z0-9._:\-]+$/;
+
+// Sentence-like rationale heuristic thresholds (must match upstream).
+const RATIONALE_MIN_CHARS = 80;
+const RATIONALE_MIN_WORDS = 8;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Loose shape for a semantic fragment — keys are optional and tolerated. */
+export interface SemanticFragment {
+  nodes?: unknown[];
+  edges?: unknown[];
+  hyperedges?: unknown[] | null;
+  input_tokens?: number;
+  output_tokens?: number;
+  [key: string]: unknown;
+}
+
+export interface LoadValidatedResult {
+  fragment: SemanticFragment | null;
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+/**
+ * Return validation errors for an untrusted semantic-extraction fragment.
+ *
+ * An empty array means the fragment passed validation. The parameter type is
+ * `unknown` (not `SemanticFragment`) because the validator is the first
+ * line of defense against arbitrary deserialized JSON — the first check
+ * rejects anything that isn't a plain object.
+ */
+export function validateSemanticFragment(fragment: unknown): string[] {
+  if (!isPlainObject(fragment)) {
+    return ["fragment must be a JSON object"];
+  }
+
+  const errors: string[] = [];
+  let payloadSize = 0;
+  try {
+    payloadSize = Buffer.byteLength(JSON.stringify(fragment), "utf-8");
+  } catch (exc) {
+    return [`fragment is not JSON-serializable: ${(exc as Error).message}`];
+  }
+  if (payloadSize > MAX_SEMANTIC_FRAGMENT_BYTES) {
+    errors.push(`payload is ${payloadSize} bytes; max is ${MAX_SEMANTIC_FRAGMENT_BYTES}`);
+  }
+
+  const rawNodes = (fragment as SemanticFragment).nodes;
+  const rawEdges = (fragment as SemanticFragment).edges;
+  const rawHyperedges = (fragment as SemanticFragment).hyperedges;
+
+  let nodes: unknown[] = [];
+  if (rawNodes === undefined) {
+    // optional
+  } else if (!Array.isArray(rawNodes)) {
+    errors.push("nodes must be a list");
+  } else if (rawNodes.length > MAX_SEMANTIC_FRAGMENT_NODES) {
+    errors.push(`nodes has ${rawNodes.length} entries; max is ${MAX_SEMANTIC_FRAGMENT_NODES}`);
+    nodes = rawNodes;
+  } else {
+    nodes = rawNodes;
+  }
+
+  let edges: unknown[] = [];
+  if (rawEdges === undefined) {
+    // optional
+  } else if (!Array.isArray(rawEdges)) {
+    errors.push("edges must be a list");
+  } else if (rawEdges.length > MAX_SEMANTIC_FRAGMENT_EDGES) {
+    errors.push(`edges has ${rawEdges.length} entries; max is ${MAX_SEMANTIC_FRAGMENT_EDGES}`);
+    edges = rawEdges;
+  } else {
+    edges = rawEdges;
+  }
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (!isPlainObject(node)) {
+      errors.push(`nodes[${i}] must be an object`);
+      continue;
+    }
+    validateSemanticId(errors, `nodes[${i}].id`, (node as Record<string, unknown>).id);
+    const fileType = (node as Record<string, unknown>).file_type;
+    if (fileType !== null && fileType !== undefined && !VALID_SEMANTIC_FILE_TYPES.has(fileType as string)) {
+      const sortedTypes = [...VALID_SEMANTIC_FILE_TYPES].sort();
+      errors.push(
+        `nodes[${i}].file_type ${JSON.stringify(fileType)} is not one of ${JSON.stringify(sortedTypes)}`,
+      );
+    }
+  }
+
+  for (let i = 0; i < edges.length; i++) {
+    const edge = edges[i];
+    if (!isPlainObject(edge)) {
+      errors.push(`edges[${i}] must be an object`);
+      continue;
+    }
+    validateSemanticId(errors, `edges[${i}].source`, (edge as Record<string, unknown>).source);
+    validateSemanticId(errors, `edges[${i}].target`, (edge as Record<string, unknown>).target);
+  }
+
+  let hyperedges: unknown[] = [];
+  if (rawHyperedges === undefined || rawHyperedges === null) {
+    // optional / nullable
+  } else if (!Array.isArray(rawHyperedges)) {
+    errors.push("hyperedges must be a list");
+  } else {
+    hyperedges = rawHyperedges;
+    if (hyperedges.length > MAX_SEMANTIC_FRAGMENT_HYPEREDGES) {
+      errors.push(
+        `hyperedges has ${hyperedges.length} entries; max is ${MAX_SEMANTIC_FRAGMENT_HYPEREDGES}`,
+      );
+    }
+    for (let i = 0; i < hyperedges.length; i++) {
+      const he = hyperedges[i];
+      if (!isPlainObject(he)) {
+        errors.push(`hyperedges[${i}] must be an object`);
+        continue;
+      }
+      const heRec = he as Record<string, unknown>;
+      validateSemanticId(errors, `hyperedges[${i}].id`, heRec.id);
+      const heNodes = heRec.nodes;
+      if (!Array.isArray(heNodes)) {
+        errors.push(`hyperedges[${i}].nodes must be a list`);
+        continue;
+      }
+      if (heNodes.length > MAX_SEMANTIC_HYPEREDGE_NODES) {
+        errors.push(
+          `hyperedges[${i}].nodes has ${heNodes.length} entries; max is ${MAX_SEMANTIC_HYPEREDGE_NODES}`,
+        );
+      }
+      for (let j = 0; j < heNodes.length; j++) {
+        validateSemanticId(errors, `hyperedges[${i}].nodes[${j}]`, heNodes[j]);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function validateSemanticId(errors: string[], field: string, value: unknown): void {
+  if (typeof value !== "string") {
+    errors.push(`${field} must be a string`);
+    return;
+  }
+  if (value.length === 0) {
+    errors.push(`${field} must not be empty`);
+    return;
+  }
+  if (value.length > MAX_SEMANTIC_ID_LENGTH) {
+    errors.push(`${field} is ${value.length} chars; max is ${MAX_SEMANTIC_ID_LENGTH}`);
+  }
+  if (value.includes("/") || value.includes("\\") || value.includes("..")) {
+    errors.push(`${field} must not contain path separators or '..'`);
+  }
+  if (!SEMANTIC_ID_RE.test(value)) {
+    errors.push(`${field} contains unsupported characters`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and validate a semantic chunk file, rejecting oversize payloads
+ * before parsing. JSON decode errors are reported as validation errors
+ * instead of being raised, so callers can skip past bad chunks without
+ * a try/catch.
+ */
+export function loadValidatedSemanticFragment(filePath: string): LoadValidatedResult {
+  let size = 0;
+  try {
+    size = statSync(filePath).size;
+  } catch (exc) {
+    return { fragment: null, errors: [`could not stat ${filePath}: ${(exc as Error).message}`] };
+  }
+  if (size > MAX_SEMANTIC_FRAGMENT_BYTES) {
+    return {
+      fragment: null,
+      errors: [`payload is ${size} bytes; max is ${MAX_SEMANTIC_FRAGMENT_BYTES}`],
+    };
+  }
+  let fragment: unknown;
+  try {
+    const text = readFileSync(filePath, "utf-8");
+    fragment = JSON.parse(text);
+  } catch (exc) {
+    const message = (exc as Error).message;
+    if (message.includes("ENOENT") || message.includes("EISDIR")) {
+      return { fragment: null, errors: [`could not read ${filePath}: ${message}`] };
+    }
+    return { fragment: null, errors: [`invalid JSON: ${message}`] };
+  }
+  const errors = validateSemanticFragment(fragment);
+  if (errors.length > 0) {
+    return { fragment: null, errors };
+  }
+  return { fragment: fragment as SemanticFragment, errors: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Sanitizer
+// ---------------------------------------------------------------------------
+
+const INVALID_FILE_TYPES_FOR_SANITIZE = new Set<string>(["rationale", "concept"]);
+
+/**
+ * Clean up a semantic-extraction fragment in place. Returns the same object
+ * reference for chaining.
+ *
+ * Operations:
+ *   1. Remove nodes with `file_type: 'rationale'` or `file_type: 'concept'`
+ *      (these are not graph-entity types — they were emitted by an LLM
+ *      that ignored the schema).
+ *   2. Detect nodes whose label reads like a sentence / rationale paragraph
+ *      AND that participate in a `rationale_for` edge, then convert the
+ *      label into a `rationale` attribute on the target node and drop the
+ *      source node + its edges. The `rationale_for` edge signal applies
+ *      regardless of the source node's `file_type` — sentence-like nodes
+ *      with allowed types (`document`, `code`) are still cleaned up when
+ *      they're explicitly marked as rationale.
+ *   3. Strip nodes whose only distinguishing field is the label (empty id —
+ *      likely LLM hallucination).
+ *   4. Filter hyperedges so they cannot reference removed or unknown node
+ *      IDs after the cleanup passes above. A hyperedge with fewer than two
+ *      surviving members is dropped.
+ *
+ * Only `rationale_for` edges propagate rationale text. Other outgoing edges
+ * (e.g. `references`, `conceptually_related_to`) are not used as
+ * attribute-propagation paths — that would corrupt unrelated nodes by
+ * attaching rationale meant for a different target.
+ */
+export function sanitizeSemanticFragment(fragment: SemanticFragment): SemanticFragment {
+  const nodes = Array.isArray(fragment.nodes) ? (fragment.nodes as Array<Record<string, unknown>>) : [];
+  const edges = Array.isArray(fragment.edges) ? (fragment.edges as Array<Record<string, unknown>>) : [];
+  const hyperedgesRaw = Array.isArray(fragment.hyperedges) ? (fragment.hyperedges as unknown[]) : [];
+
+  // ---- build lookup maps --------------------------------------------------
+  const nodeById = new Map<string, Record<string, unknown>>();
+  for (const n of nodes) {
+    const nid = (n.id as string) ?? "";
+    if (nid) nodeById.set(nid, n);
+  }
+
+  // Pre-collect node IDs that source a `rationale_for` edge — these are
+  // candidates for sentence-like cleanup even when file_type is allowed.
+  const rationaleForSources = new Set<string>();
+  for (const e of edges) {
+    if (e.relation === "rationale_for") {
+      const src = (e.source as string) ?? "";
+      if (src) rationaleForSources.add(src);
+    }
+  }
+
+  // ---- pass 1: identify nodes to remove + rationale candidates -----------
+  const rationaleCandidates: Array<Record<string, unknown>> = [];
+  const removeIds = new Set<string>();
+  const keepNodes: Array<Record<string, unknown>> = [];
+  for (const n of nodes) {
+    const nid = (n.id as string) ?? "";
+    if (!nid) {
+      // node without an id cannot be referenced — discard
+      continue;
+    }
+    const ft = (n.file_type as string) ?? "";
+    const label = (n.label as string) ?? "";
+    if (INVALID_FILE_TYPES_FOR_SANITIZE.has(ft)) {
+      // Invalid file_type ("rationale" / "concept"): if the label looks
+      // like a sentence we may convert it to an attribute on its target.
+      if (isSentenceLikeRationaleLabel(label)) {
+        rationaleCandidates.push(n);
+      }
+      removeIds.add(nid);
+      continue;
+    }
+    if (rationaleForSources.has(nid) && isSentenceLikeRationaleLabel(label)) {
+      // Allowed file_type, but the node sources a `rationale_for` edge AND
+      // its label is sentence-like prose. Treat it as rationale cleanup
+      // material rather than a real graph entity.
+      rationaleCandidates.push(n);
+      removeIds.add(nid);
+      continue;
+    }
+    keepNodes.push(n);
+  }
+
+  // ---- pass 2: convert sentence-nodes → rationale attributes -------------
+  const rationaleAttrs = new Map<string, string[]>();
+  for (const rn of rationaleCandidates) {
+    const rnId = (rn.id as string) ?? "";
+    const text = ((rn.label as string) ?? "").trim();
+    for (const e of edges) {
+      if (e.relation !== "rationale_for") continue;
+      if (e.source !== rnId) continue;
+      const targetId = e.target as string | undefined;
+      if (!targetId || !nodeById.has(targetId) || removeIds.has(targetId)) continue;
+      const list = rationaleAttrs.get(targetId) ?? [];
+      list.push(text);
+      rationaleAttrs.set(targetId, list);
+    }
+  }
+  for (const [targetId, texts] of rationaleAttrs) {
+    if (nodeById.has(targetId) && !removeIds.has(targetId)) {
+      appendRationaleAttr(nodeById.get(targetId)!, texts);
+    }
+  }
+
+  // ---- pass 3: strip edges referencing removed nodes ---------------------
+  const keepEdges: Array<Record<string, unknown>> = [];
+  for (const e of edges) {
+    const src = (e.source as string) ?? "";
+    const tgt = (e.target as string) ?? "";
+    if (removeIds.has(src) || removeIds.has(tgt)) continue;
+    keepEdges.push(e);
+  }
+
+  // ---- pass 4: filter hyperedges to surviving node IDs -------------------
+  const survivingIds = new Set<string>();
+  for (const n of keepNodes) {
+    const nid = (n.id as string) ?? "";
+    if (nid) survivingIds.add(nid);
+  }
+  const keepHyperedges: Array<Record<string, unknown>> = [];
+  for (const he of hyperedgesRaw) {
+    if (!isPlainObject(he)) continue;
+    const heRec = he as Record<string, unknown>;
+    const heNodes = heRec.nodes;
+    if (!Array.isArray(heNodes)) continue;
+    const filtered = heNodes.filter((ref) => typeof ref === "string" && survivingIds.has(ref));
+    if (filtered.length < 2) {
+      // A hyperedge needs at least two surviving members to be meaningful.
+      continue;
+    }
+    if (filtered.length !== heNodes.length) {
+      keepHyperedges.push({ ...heRec, nodes: filtered });
+    } else {
+      keepHyperedges.push(heRec);
+    }
+  }
+
+  fragment.nodes = keepNodes;
+  fragment.edges = keepEdges;
+  fragment.hyperedges = keepHyperedges;
+  return fragment;
+}
+
+function appendRationaleAttr(node: Record<string, unknown>, texts: string[]): void {
+  const existing = (node.rationale as string) ?? "";
+  const newText = texts.join("\n\n").trim();
+  if (existing) {
+    node.rationale = `${existing}\n\n${newText}`;
+  } else {
+    node.rationale = newText;
+  }
+}
+
+function isSentenceLikeRationaleLabel(label: string): boolean {
+  if (!label) return false;
+  const trimmed = label.trim();
+  if (trimmed.length < RATIONALE_MIN_CHARS) {
+    const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
+    if (wordCount < RATIONALE_MIN_WORDS) return false;
+  }
+  return /[.!?:]/.test(trimmed);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -14,6 +14,12 @@ import { fileURLToPath } from "node:url";
 import { graphDiff, godNodes, surprisingConnections, suggestQuestions } from "./analyze.js";
 import { runBenchmark, printBenchmark } from "./benchmark.js";
 import { saveSemanticCache, checkSemanticCache, type CacheOptions } from "./cache.js";
+import {
+  loadValidatedSemanticFragment,
+  sanitizeSemanticFragment,
+  validateSemanticFragment,
+  type SemanticFragment,
+} from "./semantic-fragment-validation.js";
 import { buildFromJson } from "./build.js";
 import { cluster, scoreAll } from "./cluster.js";
 import { detect, detectIncremental, saveManifest } from "./detect.js";
@@ -225,6 +231,60 @@ function ensureExtractionShape(value?: Partial<Extraction> | null): Extraction {
     input_tokens: value?.input_tokens ?? 0,
     output_tokens: value?.output_tokens ?? 0,
   };
+}
+
+/**
+ * Load + validate + sanitize an untrusted semantic-fragment file.
+ *
+ * Ported from upstream `safishamsi/graphify` PR #825 (commit `b6127aa`) —
+ * the upstream skill markdown templates inline `load_validated_semantic_fragment`
+ * + `sanitize_semantic_fragment` around every chunk + cached + merge JSON read.
+ * In the TS fork the skill markdown templates call into `skill-runtime.ts`
+ * subcommands, so the validation lives here at the merge boundary.
+ *
+ * Behaviour:
+ *   - File missing -> `{ extraction: empty, skipped: false, errors: [...] }`
+ *     (the caller decides whether missing is fatal — `merge-semantic`
+ *     treats it as empty cached, `save-semantic-cache` treats it as fatal).
+ *   - File present + valid -> sanitized fragment wrapped in `Extraction` shape.
+ *   - File present + invalid -> empty extraction, `skipped=true`, errors set.
+ */
+function loadAndSanitizeFragment(
+  path: string,
+  label: string,
+): { extraction: Extraction; skipped: boolean; errors: string[] } {
+  const resolved = resolve(path);
+  if (!existsSync(resolved)) {
+    return { extraction: ensureExtractionShape(null), skipped: false, errors: [] };
+  }
+  const { fragment, errors } = loadValidatedSemanticFragment(resolved);
+  if (!fragment) {
+    console.warn(
+      `Skipping invalid ${label} fragment ${resolved}: ${errors.slice(0, 3).join("; ")}`,
+    );
+    return { extraction: ensureExtractionShape(null), skipped: true, errors };
+  }
+  const sanitized = sanitizeSemanticFragment(fragment) as SemanticFragment;
+  return {
+    extraction: ensureExtractionShape(sanitized as unknown as Partial<Extraction>),
+    skipped: false,
+    errors: [],
+  };
+}
+
+/**
+ * Validate (without sanitizing) an in-memory extraction object. Throws when
+ * the payload is structurally unsound — used by `save-semantic-cache` where
+ * the caller has only one input and a failure mode that loudly halts is
+ * the safer default.
+ */
+function assertValidSemanticFragment(value: unknown, label: string): void {
+  const errors = validateSemanticFragment(value);
+  if (errors.length > 0) {
+    throw new Error(
+      `${label} is not a valid semantic fragment: ${errors.slice(0, 3).join("; ")}`,
+    );
+  }
 }
 
 function loadGraph(graphPath: string): Graph {
@@ -980,7 +1040,13 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .option("--cache-namespace <value>", "Optional semantic cache namespace")
     .option("--profile-state <path>", "Optional profile-state.json used to derive a profile cache namespace")
     .action((opts) => {
-      const extraction = ensureExtractionShape(readJson<Partial<Extraction>>(opts.input));
+      // Validate before caching — a malformed agent response should not be
+      // persisted into the per-file semantic cache (ported from upstream
+      // PR #825 semantic-fragment validation).
+      const raw = readJson<Partial<Extraction>>(opts.input);
+      assertValidSemanticFragment(raw, `save-semantic-cache --input ${resolve(opts.input)}`);
+      const sanitized = sanitizeSemanticFragment(raw as unknown as SemanticFragment);
+      const extraction = ensureExtractionShape(sanitized as unknown as Partial<Extraction>);
       const saved = saveSemanticCache(
         extraction.nodes as Array<Record<string, unknown>>,
         extraction.edges as Array<Record<string, unknown>>,
@@ -997,8 +1063,13 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .requiredOption("--new <path>")
     .requiredOption("--out <path>")
     .action((opts) => {
-      const cached = ensureExtractionShape(readJson<Partial<Extraction>>(opts.cached));
-      const fresh = ensureExtractionShape(readJson<Partial<Extraction>>(opts.new));
+      // Validate + sanitize each fragment independently. A malformed cached
+      // or fresh fragment is skipped with a warning so a single bad chunk
+      // cannot crash the whole pipeline (ported from upstream PR #825).
+      const cachedLoad = loadAndSanitizeFragment(opts.cached, "cached");
+      const freshLoad = loadAndSanitizeFragment(opts.new, "new");
+      const cached = cachedLoad.extraction;
+      const fresh = freshLoad.extraction;
 
       const dedupedNodes: Extraction["nodes"] = [];
       const seen = new Set<string>();
@@ -1028,7 +1099,10 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .requiredOption("--out <path>")
     .action((opts) => {
       const ast = ensureExtractionShape(readJson<Partial<Extraction>>(opts.ast));
-      const semantic = ensureExtractionShape(readJson<Partial<Extraction>>(opts.semantic));
+      // The AST side is produced by Tree-sitter and trusted as-is. The
+      // semantic side is LLM-generated and must be validated + sanitized
+      // (ported from upstream PR #825).
+      const semantic = loadAndSanitizeFragment(opts.semantic, "semantic").extraction;
 
       const mergedNodes: Extraction["nodes"] = [...ast.nodes];
       const seen = new Set(ast.nodes.map((node) => node.id));
@@ -1068,11 +1142,14 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const root = resolve(opts.root);
       const detection = readJson<DetectionResult>(opts.detect);
       const ast = ensureExtractionShape(readJson<Partial<Extraction>>(opts.ast));
-      const cached = opts.cached && existsSync(resolve(opts.cached))
-        ? readJson<Partial<Extraction>>(opts.cached)
+      // Validate + sanitize untrusted semantic fragments (port of upstream
+      // PR #825). Invalid chunks are dropped with a warning rather than
+      // crashing the whole finalize-build pipeline.
+      const cached = opts.cached
+        ? (loadAndSanitizeFragment(opts.cached, "cached").extraction as Partial<Extraction>)
         : null;
-      const semanticNew = opts.semanticNew && existsSync(resolve(opts.semanticNew))
-        ? readJson<Partial<Extraction>>(opts.semanticNew)
+      const semanticNew = opts.semanticNew
+        ? (loadAndSanitizeFragment(opts.semanticNew, "semantic-new").extraction as Partial<Extraction>)
         : null;
 
       if (semanticNew) {
@@ -1140,11 +1217,14 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const root = resolve(opts.root);
       const detection = readJson<DetectionResult>(opts.detect);
       const ast = ensureExtractionShape(readJson<Partial<Extraction>>(opts.ast));
-      const cached = opts.cached && existsSync(resolve(opts.cached))
-        ? readJson<Partial<Extraction>>(opts.cached)
+      // Validate + sanitize untrusted semantic fragments (port of upstream
+      // PR #825). Invalid chunks are dropped with a warning rather than
+      // crashing the whole finalize-update pipeline.
+      const cached = opts.cached
+        ? (loadAndSanitizeFragment(opts.cached, "cached").extraction as Partial<Extraction>)
         : null;
-      const semanticNew = opts.semanticNew && existsSync(resolve(opts.semanticNew))
-        ? readJson<Partial<Extraction>>(opts.semanticNew)
+      const semanticNew = opts.semanticNew
+        ? (loadAndSanitizeFragment(opts.semanticNew, "semantic-new").extraction as Partial<Extraction>)
         : null;
 
       if (semanticNew) {

--- a/src/skills/skill-droid.md
+++ b/src/skills/skill-droid.md
@@ -293,28 +293,45 @@ Wait for all subagents. For each result:
 
 If more than half the chunks failed, stop and tell the user.
 
-Save new results to cache:
+Save new results to cache. The `saveSemanticCache` call is wrapped in `validateSemanticFragment` + `sanitizeSemanticFragment` so a malformed agent response cannot poison the per-file semantic cache:
 ```bash
 node -e "
 const fs = require('fs');
-const { saveSemanticCache } = require('graphifyy');
+const { saveSemanticCache, validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
 const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const saved = saveSemanticCache(raw.nodes || [], raw.edges || [], raw.hyperedges || []);
+const errors = validateSemanticFragment(raw);
+if (errors.length > 0) {
+  console.error('Refusing to cache invalid semantic fragment: ' + errors.slice(0, 3).join('; '));
+  process.exit(1);
+}
+const clean = sanitizeSemanticFragment(raw);
+const saved = saveSemanticCache(clean.nodes || [], clean.edges || [], clean.hyperedges || []);
 console.log(\`Cached ${saved} files\`);
 "
 ```
 
-Merge cached + new results into `.graphify/.graphify_semantic.json`:
+Merge cached + new results into `.graphify/.graphify_semantic.json`. Each chunk is independently validated; invalid chunks are skipped with a warning rather than crashing the merge (mirrors upstream PR #825):
 ```bash
 node -e "
 const fs = require('fs');
+const { validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
-const cached = fs.existsSync('.graphify/.graphify_cached.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_cached.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
+function loadAndClean(path, label) {
+  if (!fs.existsSync(path)) return {nodes:[],edges:[],hyperedges:[]};
+  let raw;
+  try { raw = JSON.parse(fs.readFileSync(path, 'utf-8')); }
+  catch (e) { console.warn(\`Skipping invalid \${label} fragment \${path}: \${e.message}\`); return {nodes:[],edges:[],hyperedges:[]}; }
+  const errs = validateSemanticFragment(raw);
+  if (errs.length > 0) { console.warn(\`Skipping invalid \${label} fragment \${path}: \` + errs.slice(0, 3).join('; ')); return {nodes:[],edges:[],hyperedges:[]}; }
+  return sanitizeSemanticFragment(raw);
+}
 
-const allNodes = cached.nodes.concat(raw.nodes || []);
-const allEdges = cached.edges.concat(raw.edges || []);
+const cached = loadAndClean('.graphify/.graphify_cached.json', 'cached');
+const raw = loadAndClean('.graphify/.graphify_semantic_new.json', 'new');
+
+const allNodes = (cached.nodes || []).concat(raw.nodes || []);
+const allEdges = (cached.edges || []).concat(raw.edges || []);
 const allHyperedges = (cached.hyperedges || []).concat(raw.hyperedges || []);
 const seen = new Set();
 const deduped = [];
@@ -328,19 +345,21 @@ const merged = {
     output_tokens: raw.output_tokens || 0,
 };
 fs.writeFileSync('.graphify/.graphify_semantic.json', JSON.stringify(merged, null, 2));
-console.log(\`Extraction complete - ${deduped.length} nodes, ${allEdges.length} edges (${cached.nodes.length} from cache, ${(raw.nodes||[]).length} new)\`);
+console.log(\`Extraction complete - ${deduped.length} nodes, ${allEdges.length} edges (${(cached.nodes||[]).length} from cache, ${(raw.nodes||[]).length} new)\`);
 "
 ```
 Clean up temp files: `rm -f .graphify/.graphify_cached.json .graphify/.graphify_uncached.txt .graphify/.graphify_semantic_new.json .graphify/.graphify_detect_semantic.json .graphify/.graphify_transcripts.json .graphify/.graphify_pdf_ocr.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
+The AST side comes from Tree-sitter and is trusted as-is. The semantic side is LLM-generated and must be sanitized one more time before the final merge:
 ```bash
 node -e "
 const fs = require('fs');
+const { sanitizeSemanticFragment } = require('graphifyy');
 
 const ast = JSON.parse(fs.readFileSync('.graphify/.graphify_ast.json', 'utf-8'));
-const sem = JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8'));
+const sem = sanitizeSemanticFragment(JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8')));
 
 const seen = new Set(ast.nodes.map(n => n.id));
 const mergedNodes = [...ast.nodes];

--- a/src/skills/skill-opencode.md
+++ b/src/skills/skill-opencode.md
@@ -292,28 +292,45 @@ Wait for all subagents. For each result:
 
 If more than half the chunks failed, stop and tell the user.
 
-Save new results to cache:
+Save new results to cache. The `saveSemanticCache` call is wrapped in `validateSemanticFragment` + `sanitizeSemanticFragment` so a malformed agent response cannot poison the per-file semantic cache:
 ```bash
 node -e "
 const fs = require('fs');
-const { saveSemanticCache } = require('graphifyy');
+const { saveSemanticCache, validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
 const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const saved = saveSemanticCache(raw.nodes || [], raw.edges || [], raw.hyperedges || []);
+const errors = validateSemanticFragment(raw);
+if (errors.length > 0) {
+  console.error('Refusing to cache invalid semantic fragment: ' + errors.slice(0, 3).join('; '));
+  process.exit(1);
+}
+const clean = sanitizeSemanticFragment(raw);
+const saved = saveSemanticCache(clean.nodes || [], clean.edges || [], clean.hyperedges || []);
 console.log(\`Cached ${saved} files\`);
 "
 ```
 
-Merge cached + new results into `.graphify/.graphify_semantic.json`:
+Merge cached + new results into `.graphify/.graphify_semantic.json`. Each chunk is independently validated; invalid chunks are skipped with a warning rather than crashing the merge (mirrors upstream PR #825):
 ```bash
 node -e "
 const fs = require('fs');
+const { validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
-const cached = fs.existsSync('.graphify/.graphify_cached.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_cached.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
+function loadAndClean(path, label) {
+  if (!fs.existsSync(path)) return {nodes:[],edges:[],hyperedges:[]};
+  let raw;
+  try { raw = JSON.parse(fs.readFileSync(path, 'utf-8')); }
+  catch (e) { console.warn(\`Skipping invalid \${label} fragment \${path}: \${e.message}\`); return {nodes:[],edges:[],hyperedges:[]}; }
+  const errs = validateSemanticFragment(raw);
+  if (errs.length > 0) { console.warn(\`Skipping invalid \${label} fragment \${path}: \` + errs.slice(0, 3).join('; ')); return {nodes:[],edges:[],hyperedges:[]}; }
+  return sanitizeSemanticFragment(raw);
+}
 
-const allNodes = cached.nodes.concat(raw.nodes || []);
-const allEdges = cached.edges.concat(raw.edges || []);
+const cached = loadAndClean('.graphify/.graphify_cached.json', 'cached');
+const raw = loadAndClean('.graphify/.graphify_semantic_new.json', 'new');
+
+const allNodes = (cached.nodes || []).concat(raw.nodes || []);
+const allEdges = (cached.edges || []).concat(raw.edges || []);
 const allHyperedges = (cached.hyperedges || []).concat(raw.hyperedges || []);
 const seen = new Set();
 const deduped = [];
@@ -327,19 +344,21 @@ const merged = {
     output_tokens: raw.output_tokens || 0,
 };
 fs.writeFileSync('.graphify/.graphify_semantic.json', JSON.stringify(merged, null, 2));
-console.log(\`Extraction complete - ${deduped.length} nodes, ${allEdges.length} edges (${cached.nodes.length} from cache, ${(raw.nodes||[]).length} new)\`);
+console.log(\`Extraction complete - ${deduped.length} nodes, ${allEdges.length} edges (${(cached.nodes||[]).length} from cache, ${(raw.nodes||[]).length} new)\`);
 "
 ```
 Clean up temp files: `rm -f .graphify/.graphify_cached.json .graphify/.graphify_uncached.txt .graphify/.graphify_semantic_new.json .graphify/.graphify_detect_semantic.json .graphify/.graphify_transcripts.json .graphify/.graphify_pdf_ocr.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
+The AST side comes from Tree-sitter and is trusted as-is. The semantic side is LLM-generated and must be sanitized one more time before the final merge:
 ```bash
 node -e "
 const fs = require('fs');
+const { sanitizeSemanticFragment } = require('graphifyy');
 
 const ast = JSON.parse(fs.readFileSync('.graphify/.graphify_ast.json', 'utf-8'));
-const sem = JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8'));
+const sem = sanitizeSemanticFragment(JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8')));
 
 const seen = new Set(ast.nodes.map(n => n.id));
 const mergedNodes = [...ast.nodes];

--- a/src/skills/skill-windows.md
+++ b/src/skills/skill-windows.md
@@ -293,28 +293,45 @@ Wait for all subagents. For each result:
 
 If more than half the chunks failed, stop and tell the user.
 
-Save new results to cache:
+Save new results to cache. The `saveSemanticCache` call is wrapped in `validateSemanticFragment` + `sanitizeSemanticFragment` so a malformed agent response cannot poison the per-file semantic cache:
 ```powershell
 node -e "
 const fs = require('fs');
-const { saveSemanticCache } = require('graphifyy');
+const { saveSemanticCache, validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
 const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const saved = saveSemanticCache(raw.nodes || [], raw.edges || [], raw.hyperedges || []);
+const errors = validateSemanticFragment(raw);
+if (errors.length > 0) {
+  console.error('Refusing to cache invalid semantic fragment: ' + errors.slice(0, 3).join('; '));
+  process.exit(1);
+}
+const clean = sanitizeSemanticFragment(raw);
+const saved = saveSemanticCache(clean.nodes || [], clean.edges || [], clean.hyperedges || []);
 console.log(\`Cached ${saved} files\`);
 "
 ```
 
-Merge cached + new results into `.graphify/.graphify_semantic.json`:
+Merge cached + new results into `.graphify/.graphify_semantic.json`. Each chunk is independently validated; invalid chunks are skipped with a warning rather than crashing the merge (mirrors upstream PR #825):
 ```powershell
 node -e "
 const fs = require('fs');
+const { validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
-const cached = fs.existsSync('.graphify/.graphify_cached.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_cached.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
+function loadAndClean(path, label) {
+  if (!fs.existsSync(path)) return {nodes:[],edges:[],hyperedges:[]};
+  let raw;
+  try { raw = JSON.parse(fs.readFileSync(path, 'utf-8')); }
+  catch (e) { console.warn(\`Skipping invalid \${label} fragment \${path}: \${e.message}\`); return {nodes:[],edges:[],hyperedges:[]}; }
+  const errs = validateSemanticFragment(raw);
+  if (errs.length > 0) { console.warn(\`Skipping invalid \${label} fragment \${path}: \` + errs.slice(0, 3).join('; ')); return {nodes:[],edges:[],hyperedges:[]}; }
+  return sanitizeSemanticFragment(raw);
+}
 
-const allNodes = cached.nodes.concat(raw.nodes || []);
-const allEdges = cached.edges.concat(raw.edges || []);
+const cached = loadAndClean('.graphify/.graphify_cached.json', 'cached');
+const raw = loadAndClean('.graphify/.graphify_semantic_new.json', 'new');
+
+const allNodes = (cached.nodes || []).concat(raw.nodes || []);
+const allEdges = (cached.edges || []).concat(raw.edges || []);
 const allHyperedges = (cached.hyperedges || []).concat(raw.hyperedges || []);
 const seen = new Set();
 const deduped = [];
@@ -328,19 +345,21 @@ const merged = {
     output_tokens: raw.output_tokens || 0,
 };
 fs.writeFileSync('.graphify/.graphify_semantic.json', JSON.stringify(merged, null, 2));
-console.log(\`Extraction complete - ${deduped.length} nodes, ${allEdges.length} edges (${cached.nodes.length} from cache, ${(raw.nodes||[]).length} new)\`);
+console.log(\`Extraction complete - ${deduped.length} nodes, ${allEdges.length} edges (${(cached.nodes||[]).length} from cache, ${(raw.nodes||[]).length} new)\`);
 "
 ```
 Clean up temp files: `Remove-Item -ErrorAction SilentlyContinue .graphify/.graphify_cached.json, .graphify/.graphify_uncached.txt, .graphify/.graphify_semantic_new.json, .graphify/.graphify_detect_semantic.json, .graphify/.graphify_transcripts.json, .graphify/.graphify_pdf_ocr.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
+The AST side comes from Tree-sitter and is trusted as-is. The semantic side is LLM-generated and must be sanitized one more time before the final merge:
 ```powershell
 node -e "
 const fs = require('fs');
+const { sanitizeSemanticFragment } = require('graphifyy');
 
 const ast = JSON.parse(fs.readFileSync('.graphify/.graphify_ast.json', 'utf-8'));
-const sem = JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8'));
+const sem = sanitizeSemanticFragment(JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8')));
 
 const seen = new Set(ast.nodes.map(n => n.id));
 const mergedNodes = [...ast.nodes];

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -321,28 +321,45 @@ Wait for all subagents. For each result:
 
 If more than half the chunks failed, stop and tell the user.
 
-Save new results to cache:
+Save new results to cache. The `saveSemanticCache` call is wrapped in `validateSemanticFragment` + `sanitizeSemanticFragment` so a malformed agent response cannot poison the per-file semantic cache:
 ```bash
 node -e "
 const fs = require('fs');
-const { saveSemanticCache } = require('graphifyy');
+const { saveSemanticCache, validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
 const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const saved = saveSemanticCache(raw.nodes || [], raw.edges || [], raw.hyperedges || []);
+const errors = validateSemanticFragment(raw);
+if (errors.length > 0) {
+  console.error('Refusing to cache invalid semantic fragment: ' + errors.slice(0, 3).join('; '));
+  process.exit(1);
+}
+const clean = sanitizeSemanticFragment(raw);
+const saved = saveSemanticCache(clean.nodes || [], clean.edges || [], clean.hyperedges || []);
 console.log(\`Cached \${saved} files\`);
 "
 ```
 
-Merge cached + new results into `.graphify/.graphify_semantic.json`:
+Merge cached + new results into `.graphify/.graphify_semantic.json`. Each chunk is independently validated; invalid chunks are skipped with a warning rather than crashing the merge (mirrors upstream PR #825):
 ```bash
 node -e "
 const fs = require('fs');
+const { validateSemanticFragment, sanitizeSemanticFragment } = require('graphifyy');
 
-const cached = fs.existsSync('.graphify/.graphify_cached.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_cached.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
-const raw = fs.existsSync('.graphify/.graphify_semantic_new.json') ? JSON.parse(fs.readFileSync('.graphify/.graphify_semantic_new.json', 'utf-8')) : {nodes:[],edges:[],hyperedges:[]};
+function loadAndClean(path, label) {
+  if (!fs.existsSync(path)) return {nodes:[],edges:[],hyperedges:[]};
+  let raw;
+  try { raw = JSON.parse(fs.readFileSync(path, 'utf-8')); }
+  catch (e) { console.warn(\`Skipping invalid \${label} fragment \${path}: \${e.message}\`); return {nodes:[],edges:[],hyperedges:[]}; }
+  const errs = validateSemanticFragment(raw);
+  if (errs.length > 0) { console.warn(\`Skipping invalid \${label} fragment \${path}: \` + errs.slice(0, 3).join('; ')); return {nodes:[],edges:[],hyperedges:[]}; }
+  return sanitizeSemanticFragment(raw);
+}
 
-const allNodes = cached.nodes.concat(raw.nodes || []);
-const allEdges = cached.edges.concat(raw.edges || []);
+const cached = loadAndClean('.graphify/.graphify_cached.json', 'cached');
+const raw = loadAndClean('.graphify/.graphify_semantic_new.json', 'new');
+
+const allNodes = (cached.nodes || []).concat(raw.nodes || []);
+const allEdges = (cached.edges || []).concat(raw.edges || []);
 const allHyperedges = (cached.hyperedges || []).concat(raw.hyperedges || []);
 const seen = new Set();
 const deduped = [];
@@ -356,19 +373,21 @@ const merged = {
     output_tokens: raw.output_tokens || 0,
 };
 fs.writeFileSync('.graphify/.graphify_semantic.json', JSON.stringify(merged, null, 2));
-console.log(\`Extraction complete - \${deduped.length} nodes, \${allEdges.length} edges (\${cached.nodes.length} from cache, \${(raw.nodes||[]).length} new)\`);
+console.log(\`Extraction complete - \${deduped.length} nodes, \${allEdges.length} edges (\${(cached.nodes||[]).length} from cache, \${(raw.nodes||[]).length} new)\`);
 "
 ```
 Clean up temp files: `rm -f .graphify/.graphify_cached.json .graphify/.graphify_uncached.txt .graphify/.graphify_semantic_new.json .graphify/.graphify_detect_semantic.json .graphify/.graphify_transcripts.json .graphify/.graphify_pdf_ocr.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
+The AST side comes from Tree-sitter and is trusted as-is. The semantic side is LLM-generated and must be sanitized one more time before the final merge:
 ```bash
 node -e "
 const fs = require('fs');
+const { sanitizeSemanticFragment } = require('graphifyy');
 
 const ast = JSON.parse(fs.readFileSync('.graphify/.graphify_ast.json', 'utf-8'));
-const sem = JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8'));
+const sem = sanitizeSemanticFragment(JSON.parse(fs.readFileSync('.graphify/.graphify_semantic.json', 'utf-8')));
 
 const seen = new Set(ast.nodes.map(n => n.id));
 const mergedNodes = [...ast.nodes];

--- a/tests/semantic-fragment-validation.test.ts
+++ b/tests/semantic-fragment-validation.test.ts
@@ -1,0 +1,434 @@
+// Tests for the semantic-fragment validator + sanitizer.
+//
+// Ports the upstream Python `semantic_cleanup.py` module's behavior contract
+// (PR #825 / commit b6127aa on safishamsi/graphify) into TypeScript. Used by
+// the OpenCode + Codex skill markdown templates when merging untrusted
+// JSON chunks emitted by the LLM agent.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  MAX_SEMANTIC_FRAGMENT_BYTES,
+  MAX_SEMANTIC_FRAGMENT_NODES,
+  MAX_SEMANTIC_FRAGMENT_EDGES,
+  MAX_SEMANTIC_FRAGMENT_HYPEREDGES,
+  MAX_SEMANTIC_HYPEREDGE_NODES,
+  MAX_SEMANTIC_ID_LENGTH,
+  VALID_SEMANTIC_FILE_TYPES,
+  validateSemanticFragment,
+  sanitizeSemanticFragment,
+  loadValidatedSemanticFragment,
+} from "../src/semantic-fragment-validation.js";
+
+describe("validateSemanticFragment - structural rejection", () => {
+  it("rejects non-object input", () => {
+    expect(validateSemanticFragment(null)).toEqual(["fragment must be a JSON object"]);
+    expect(validateSemanticFragment("not an object")).toEqual(["fragment must be a JSON object"]);
+    expect(validateSemanticFragment(42)).toEqual(["fragment must be a JSON object"]);
+    expect(validateSemanticFragment([])).toEqual(["fragment must be a JSON object"]);
+  });
+
+  it("accepts an empty object as a valid (empty) fragment", () => {
+    expect(validateSemanticFragment({})).toEqual([]);
+  });
+
+  it("rejects when nodes is not a list", () => {
+    const errs = validateSemanticFragment({ nodes: "not a list" });
+    expect(errs).toContain("nodes must be a list");
+  });
+
+  it("rejects when edges is not a list", () => {
+    const errs = validateSemanticFragment({ edges: { not: "a list" } });
+    expect(errs).toContain("edges must be a list");
+  });
+
+  it("rejects when hyperedges is not a list", () => {
+    const errs = validateSemanticFragment({ hyperedges: 42 });
+    expect(errs).toContain("hyperedges must be a list");
+  });
+
+  it("rejects non-object node entries", () => {
+    const errs = validateSemanticFragment({ nodes: ["bare string"] });
+    expect(errs).toContain("nodes[0] must be an object");
+  });
+});
+
+describe("validateSemanticFragment - id charset and length", () => {
+  it("rejects ids containing path separators", () => {
+    const errs = validateSemanticFragment({
+      nodes: [{ id: "../etc/passwd" }],
+    });
+    expect(errs.some((e) => e.includes("nodes[0].id") && e.includes("path separators"))).toBe(true);
+  });
+
+  it("rejects ids containing backslash separators", () => {
+    const errs = validateSemanticFragment({
+      nodes: [{ id: "a\\b" }],
+    });
+    expect(errs.some((e) => e.includes("nodes[0].id") && e.includes("path separators"))).toBe(true);
+  });
+
+  it("rejects empty string ids", () => {
+    const errs = validateSemanticFragment({ nodes: [{ id: "" }] });
+    expect(errs).toContain("nodes[0].id must not be empty");
+  });
+
+  it("rejects non-string ids", () => {
+    const errs = validateSemanticFragment({ nodes: [{ id: 42 }] });
+    expect(errs).toContain("nodes[0].id must be a string");
+  });
+
+  it("rejects ids containing unsupported chars", () => {
+    const errs = validateSemanticFragment({
+      nodes: [{ id: "weird id with space" }],
+    });
+    expect(errs.some((e) => e.includes("nodes[0].id") && e.includes("unsupported characters"))).toBe(true);
+  });
+
+  it("rejects ids longer than the cap", () => {
+    const longId = "a".repeat(MAX_SEMANTIC_ID_LENGTH + 1);
+    const errs = validateSemanticFragment({ nodes: [{ id: longId }] });
+    expect(errs.some((e) => e.includes("nodes[0].id") && e.includes("max is"))).toBe(true);
+  });
+
+  it("validates edge source and target ids", () => {
+    const errs = validateSemanticFragment({
+      edges: [{ source: "../boom", target: "ok" }],
+    });
+    expect(errs.some((e) => e.includes("edges[0].source"))).toBe(true);
+  });
+
+  it("validates hyperedge id and node refs", () => {
+    const errs = validateSemanticFragment({
+      hyperedges: [{ id: "../escape", nodes: ["bad/ref"] }],
+    });
+    expect(errs.some((e) => e.includes("hyperedges[0].id"))).toBe(true);
+    expect(errs.some((e) => e.includes("hyperedges[0].nodes[0]"))).toBe(true);
+  });
+
+  it("rejects when hyperedge.nodes is not a list", () => {
+    const errs = validateSemanticFragment({
+      hyperedges: [{ id: "ok", nodes: "not-a-list" }],
+    });
+    expect(errs).toContain("hyperedges[0].nodes must be a list");
+  });
+});
+
+describe("validateSemanticFragment - file_type", () => {
+  it("accepts valid file_type values", () => {
+    for (const ft of VALID_SEMANTIC_FILE_TYPES) {
+      const errs = validateSemanticFragment({
+        nodes: [{ id: "ok", file_type: ft }],
+      });
+      expect(errs).toEqual([]);
+    }
+  });
+
+  it("rejects unknown file_type values", () => {
+    const errs = validateSemanticFragment({
+      nodes: [{ id: "ok", file_type: "not-real" }],
+    });
+    expect(errs.some((e) => e.includes("nodes[0].file_type") && e.includes("not-real"))).toBe(true);
+  });
+
+  it("treats null file_type as absent (allowed)", () => {
+    const errs = validateSemanticFragment({
+      nodes: [{ id: "ok", file_type: null }],
+    });
+    expect(errs).toEqual([]);
+  });
+});
+
+describe("validateSemanticFragment - counts", () => {
+  it("accepts up to the node cap", () => {
+    const nodes = Array.from({ length: 5 }, (_, i) => ({ id: `n${i}` }));
+    expect(validateSemanticFragment({ nodes })).toEqual([]);
+  });
+
+  it("rejects when too many nodes", () => {
+    const nodes = Array.from({ length: MAX_SEMANTIC_FRAGMENT_NODES + 1 }, (_, i) => ({ id: `n${i}` }));
+    const errs = validateSemanticFragment({ nodes });
+    expect(errs.some((e) => e.includes("nodes has"))).toBe(true);
+  });
+
+  it("rejects when too many edges", () => {
+    const edges = Array.from({ length: MAX_SEMANTIC_FRAGMENT_EDGES + 1 }, (_, i) => ({
+      source: `s${i}`,
+      target: `t${i}`,
+    }));
+    const errs = validateSemanticFragment({ edges });
+    expect(errs.some((e) => e.includes("edges has"))).toBe(true);
+  });
+
+  it("rejects when too many hyperedges", () => {
+    const hyperedges = Array.from({ length: MAX_SEMANTIC_FRAGMENT_HYPEREDGES + 1 }, (_, i) => ({
+      id: `h${i}`,
+      nodes: ["a", "b"],
+    }));
+    const errs = validateSemanticFragment({ hyperedges });
+    expect(errs.some((e) => e.includes("hyperedges has"))).toBe(true);
+  });
+
+  it("rejects hyperedges that exceed the per-hyperedge member cap", () => {
+    const tooMany = Array.from({ length: MAX_SEMANTIC_HYPEREDGE_NODES + 1 }, (_, i) => `m${i}`);
+    const errs = validateSemanticFragment({
+      hyperedges: [{ id: "huge", nodes: tooMany }],
+    });
+    expect(errs.some((e) => e.includes("hyperedges[0].nodes has"))).toBe(true);
+  });
+});
+
+describe("validateSemanticFragment - happy path", () => {
+  it("returns no errors for a minimal well-formed fragment", () => {
+    expect(
+      validateSemanticFragment({
+        nodes: [{ id: "n1", file_type: "code" }, { id: "n2", file_type: "document" }],
+        edges: [{ source: "n1", target: "n2" }],
+        hyperedges: [{ id: "h1", nodes: ["n1", "n2"] }],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("sanitizeSemanticFragment", () => {
+  it("returns the same object reference (in-place semantics)", () => {
+    const fragment = { nodes: [], edges: [], hyperedges: [] };
+    const out = sanitizeSemanticFragment(fragment);
+    expect(out).toBe(fragment);
+  });
+
+  it("removes nodes whose file_type is 'rationale' or 'concept'", () => {
+    const fragment = {
+      nodes: [
+        { id: "good", file_type: "code", label: "Good" },
+        { id: "rat", file_type: "rationale", label: "Some long rationale text explaining why decisions were made." },
+        { id: "con", file_type: "concept", label: "Short" },
+      ],
+      edges: [],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment);
+    expect(out.nodes.map((n: { id: string }) => n.id)).toEqual(["good"]);
+  });
+
+  it("converts sentence-like rationale nodes into rationale attributes via rationale_for edges", () => {
+    const longSentence = "This is a long rationale that explains the design choice for the component.";
+    const fragment = {
+      nodes: [
+        { id: "target", file_type: "code", label: "Target" },
+        { id: "rat", file_type: "rationale", label: longSentence },
+      ],
+      edges: [{ source: "rat", target: "target", relation: "rationale_for" }],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+      edges: unknown[];
+    };
+    expect(out.nodes.map((n) => n.id)).toEqual(["target"]);
+    const target = out.nodes.find((n) => n.id === "target");
+    expect(target?.rationale).toBe(longSentence);
+    expect(out.edges).toEqual([]); // rationale_for edge removed because source was dropped
+  });
+
+  it("does NOT propagate rationale via non-rationale_for edges", () => {
+    const longSentence = "This explains the whole design rationale at length and with detail.";
+    const fragment = {
+      nodes: [
+        { id: "target", file_type: "code", label: "Target" },
+        { id: "rat", file_type: "rationale", label: longSentence },
+      ],
+      // 'references' edge: should NOT propagate rationale
+      edges: [{ source: "rat", target: "target", relation: "references" }],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+    };
+    const target = out.nodes.find((n) => n.id === "target");
+    expect(target?.rationale).toBeUndefined();
+  });
+
+  it("converts sentence-like nodes with ALLOWED file_type when they source rationale_for", () => {
+    const longSentence = "Document-level rationale explaining a strategic architectural choice in detail.";
+    const fragment = {
+      nodes: [
+        { id: "target", file_type: "code", label: "Target" },
+        // allowed file_type but sentence-like + sources rationale_for
+        { id: "doc", file_type: "document", label: longSentence },
+      ],
+      edges: [{ source: "doc", target: "target", relation: "rationale_for" }],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+    };
+    expect(out.nodes.map((n) => n.id)).toEqual(["target"]);
+    const target = out.nodes.find((n) => n.id === "target");
+    expect(target?.rationale).toBe(longSentence);
+  });
+
+  it("does NOT treat short labels as sentence-like rationale (false-positive guard)", () => {
+    const fragment = {
+      nodes: [
+        { id: "target", file_type: "code", label: "Target" },
+        // file_type rationale, but label is a short concept name
+        { id: "rat", file_type: "rationale", label: "ShortName" },
+      ],
+      edges: [{ source: "rat", target: "target", relation: "rationale_for" }],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+    };
+    // node still removed because file_type is invalid, BUT no rationale text propagated
+    expect(out.nodes.map((n) => n.id)).toEqual(["target"]);
+    expect(out.nodes.find((n) => n.id === "target")?.rationale).toBeUndefined();
+  });
+
+  it("filters hyperedges referencing removed or unknown nodes", () => {
+    const longSentence = "Long rationale text explaining the whole reason for this design choice at depth.";
+    const fragment = {
+      nodes: [
+        { id: "a", file_type: "code", label: "A" },
+        { id: "b", file_type: "code", label: "B" },
+        { id: "rat", file_type: "rationale", label: longSentence },
+      ],
+      edges: [{ source: "rat", target: "a", relation: "rationale_for" }],
+      hyperedges: [
+        { id: "h1", nodes: ["a", "b", "rat"] }, // 'rat' removed -> filter to ['a', 'b']
+        { id: "h2", nodes: ["a", "unknown"] }, // only one surviving -> drop
+        { id: "h3", nodes: ["a", "b"] }, // both survive
+      ],
+    };
+    const out = sanitizeSemanticFragment(fragment) as {
+      hyperedges: Array<{ id: string; nodes: string[] }>;
+    };
+    expect(out.hyperedges.map((h) => h.id)).toEqual(["h1", "h3"]);
+    expect(out.hyperedges.find((h) => h.id === "h1")?.nodes).toEqual(["a", "b"]);
+  });
+
+  it("strips edges that reference removed nodes", () => {
+    const longSentence = "Removed rationale that propagates nothing, but had non-rationale_for edges.";
+    const fragment = {
+      nodes: [
+        { id: "a", file_type: "code", label: "A" },
+        { id: "rat", file_type: "rationale", label: longSentence },
+      ],
+      edges: [{ source: "rat", target: "a", relation: "references" }],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment);
+    expect(out.edges).toEqual([]);
+  });
+
+  it("drops nodes with empty ids", () => {
+    const fragment = {
+      nodes: [
+        { id: "", file_type: "code", label: "Anon" },
+        { id: "good", file_type: "code", label: "Good" },
+      ],
+      edges: [],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment) as { nodes: Array<{ id: string }> };
+    expect(out.nodes.map((n) => n.id)).toEqual(["good"]);
+  });
+
+  it("appends multiple rationale texts onto a single target", () => {
+    const r1 = "First reason explaining the rationale at significant length and with detail.";
+    const r2 = "Second reason explaining the rationale at significant length and with detail.";
+    const fragment = {
+      nodes: [
+        { id: "target", file_type: "code", label: "T" },
+        { id: "r1", file_type: "rationale", label: r1 },
+        { id: "r2", file_type: "rationale", label: r2 },
+      ],
+      edges: [
+        { source: "r1", target: "target", relation: "rationale_for" },
+        { source: "r2", target: "target", relation: "rationale_for" },
+      ],
+      hyperedges: [],
+    };
+    const out = sanitizeSemanticFragment(fragment) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+    };
+    const target = out.nodes.find((n) => n.id === "target");
+    expect(target?.rationale).toContain(r1);
+    expect(target?.rationale).toContain(r2);
+  });
+});
+
+describe("loadValidatedSemanticFragment", () => {
+  const tmps: string[] = [];
+  afterEach(() => {
+    while (tmps.length > 0) {
+      rmSync(tmps.pop()!, { recursive: true, force: true });
+    }
+  });
+  function makeDir(): string {
+    const d = mkdtempSync(join(tmpdir(), "graphify-semcleanup-"));
+    tmps.push(d);
+    return d;
+  }
+
+  it("loads a valid JSON fragment", () => {
+    const dir = makeDir();
+    const file = join(dir, "chunk.json");
+    writeFileSync(
+      file,
+      JSON.stringify({ nodes: [{ id: "a" }], edges: [], hyperedges: [] }),
+      "utf-8",
+    );
+    const { fragment, errors } = loadValidatedSemanticFragment(file);
+    expect(errors).toEqual([]);
+    expect(fragment).not.toBeNull();
+    expect(fragment?.nodes).toHaveLength(1);
+  });
+
+  it("returns errors for invalid JSON", () => {
+    const dir = makeDir();
+    const file = join(dir, "bad.json");
+    writeFileSync(file, "{not json", "utf-8");
+    const { fragment, errors } = loadValidatedSemanticFragment(file);
+    expect(fragment).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toMatch(/invalid JSON/i);
+  });
+
+  it("returns errors for missing files (stat failure)", () => {
+    const dir = makeDir();
+    const file = join(dir, "missing.json");
+    const { fragment, errors } = loadValidatedSemanticFragment(file);
+    expect(fragment).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toMatch(/could not stat/i);
+  });
+
+  it("rejects files larger than the byte cap before parsing", () => {
+    const dir = makeDir();
+    const file = join(dir, "huge.json");
+    // Write a payload that exceeds MAX_SEMANTIC_FRAGMENT_BYTES
+    const huge = "a".repeat(MAX_SEMANTIC_FRAGMENT_BYTES + 64);
+    writeFileSync(file, huge, "utf-8");
+    const { fragment, errors } = loadValidatedSemanticFragment(file);
+    expect(fragment).toBeNull();
+    expect(errors.some((e) => e.includes("max is"))).toBe(true);
+  });
+
+  it("propagates validation errors when JSON parses but content is malformed", () => {
+    const dir = makeDir();
+    const file = join(dir, "malformed.json");
+    writeFileSync(
+      file,
+      JSON.stringify({ nodes: [{ id: "../escape" }] }),
+      "utf-8",
+    );
+    const { fragment, errors } = loadValidatedSemanticFragment(file);
+    expect(fragment).toBeNull();
+    expect(errors.some((e) => e.includes("path separators"))).toBe(true);
+  });
+});

--- a/tests/skill-fragment-validation.test.ts
+++ b/tests/skill-fragment-validation.test.ts
@@ -1,0 +1,314 @@
+// Integration tests for semantic fragment validation in the skill merge pipeline.
+//
+// Ports the upstream PR #825 contract (`safishamsi/graphify` commit b6127aa)
+// into the TypeScript fork. The TS skill markdown templates invoke
+// `skill-runtime.ts` subcommands (`save-semantic-cache`, `merge-semantic`,
+// `merge-extraction`, `finalize-build`) which now validate + sanitize untrusted
+// semantic-fragment JSON before merging it into the graph.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function makeDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "graphify-frag-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+async function runSkillRuntime(args: string[], cwd: string): Promise<{
+  logs: string[];
+  errors: string[];
+  warnings: string[];
+  exitCode: number;
+}> {
+  const { main } = await import("../src/skill-runtime.js");
+  return runMain(
+    () => main(["node", "skill-runtime", ...args]),
+    ["node", "skill-runtime", ...args],
+    cwd,
+  );
+}
+
+async function runMain(
+  call: () => Promise<void>,
+  argv: string[],
+  cwd: string,
+): Promise<{ logs: string[]; errors: string[]; warnings: string[]; exitCode: number }> {
+  const previousArgv = process.argv;
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  console.log = (...args: unknown[]) => { logs.push(args.join(" ")); };
+  console.error = (...args: unknown[]) => { errors.push(args.join(" ")); };
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+
+  process.argv = argv;
+  process.chdir(cwd);
+  try {
+    await call();
+    return { logs, errors, warnings, exitCode: 0 };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { logs, errors: [...errors, message], warnings, exitCode: 1 };
+  } finally {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+  }
+}
+
+describe("skill-runtime merge-semantic - fragment validation", () => {
+  it("merges a valid cached + new fragment without warnings", async () => {
+    const dir = makeDir();
+    const cached = join(dir, "cached.json");
+    const fresh = join(dir, "new.json");
+    const outPath = join(dir, "merged.json");
+    writeFileSync(
+      cached,
+      JSON.stringify({
+        nodes: [{ id: "a", file_type: "code", source_file: "a.ts" }],
+        edges: [],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      fresh,
+      JSON.stringify({
+        nodes: [{ id: "b", file_type: "code", source_file: "b.ts" }],
+        edges: [],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await runSkillRuntime(
+      [
+        "merge-semantic",
+        "--cached", cached,
+        "--new", fresh,
+        "--out", outPath,
+      ],
+      dir,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.logs.join("\n")).toContain("Extraction complete");
+    expect(result.warnings).toEqual([]);
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string }>;
+    };
+    expect(merged.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("drops invalid 'rationale' file_type nodes when sanitizing the new fragment", async () => {
+    const dir = makeDir();
+    const cached = join(dir, "cached.json");
+    const fresh = join(dir, "new.json");
+    const outPath = join(dir, "merged.json");
+    writeFileSync(
+      cached,
+      JSON.stringify({ nodes: [], edges: [], hyperedges: [] }),
+      "utf-8",
+    );
+    const longSentence = "A long rationale sentence explaining why the target was built the way it was.";
+    writeFileSync(
+      fresh,
+      JSON.stringify({
+        nodes: [
+          { id: "target", file_type: "code", source_file: "t.ts", label: "Target" },
+          { id: "rat", file_type: "rationale", source_file: "t.ts", label: longSentence },
+        ],
+        edges: [{ source: "rat", target: "target", relation: "rationale_for" }],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await runSkillRuntime(
+      [
+        "merge-semantic",
+        "--cached", cached,
+        "--new", fresh,
+        "--out", outPath,
+      ],
+      dir,
+    );
+    expect(result.exitCode).toBe(0);
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+      edges: unknown[];
+    };
+    expect(merged.nodes.map((n) => n.id)).toEqual(["target"]);
+    expect(merged.nodes.find((n) => n.id === "target")?.rationale).toBe(longSentence);
+    expect(merged.edges).toEqual([]);
+  });
+
+  it("skips a malformed cached fragment instead of crashing the pipeline", async () => {
+    const dir = makeDir();
+    const cached = join(dir, "cached.json");
+    const fresh = join(dir, "new.json");
+    const outPath = join(dir, "merged.json");
+    // Cached fragment has an id with path separators -> validation rejects it
+    writeFileSync(
+      cached,
+      JSON.stringify({
+        nodes: [{ id: "../escape", source_file: "x.ts" }],
+        edges: [],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      fresh,
+      JSON.stringify({
+        nodes: [{ id: "ok", file_type: "code", source_file: "o.ts" }],
+        edges: [],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await runSkillRuntime(
+      [
+        "merge-semantic",
+        "--cached", cached,
+        "--new", fresh,
+        "--out", outPath,
+      ],
+      dir,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.warnings.join("\n")).toMatch(/Skipping invalid cached/i);
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string }>;
+    };
+    expect(merged.nodes.map((n) => n.id)).toEqual(["ok"]);
+  });
+
+  it("skips a malformed fresh fragment instead of crashing the pipeline", async () => {
+    const dir = makeDir();
+    const cached = join(dir, "cached.json");
+    const fresh = join(dir, "new.json");
+    const outPath = join(dir, "merged.json");
+    writeFileSync(
+      cached,
+      JSON.stringify({
+        nodes: [{ id: "ok", file_type: "code", source_file: "o.ts" }],
+        edges: [],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+    // Fresh fragment has nodes that's not a list -> structural error
+    writeFileSync(fresh, JSON.stringify({ nodes: "not a list" }), "utf-8");
+
+    const result = await runSkillRuntime(
+      [
+        "merge-semantic",
+        "--cached", cached,
+        "--new", fresh,
+        "--out", outPath,
+      ],
+      dir,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.warnings.join("\n")).toMatch(/Skipping invalid new/i);
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string }>;
+    };
+    expect(merged.nodes.map((n) => n.id)).toEqual(["ok"]);
+  });
+});
+
+describe("skill-runtime merge-extraction - fragment validation", () => {
+  it("sanitizes invalid file_types before AST+semantic merge", async () => {
+    const dir = makeDir();
+    const ast = join(dir, "ast.json");
+    const semantic = join(dir, "semantic.json");
+    const outPath = join(dir, "extract.json");
+    writeFileSync(
+      ast,
+      JSON.stringify({
+        nodes: [{ id: "a_func", file_type: "code", source_file: "a.ts", label: "a" }],
+        edges: [],
+      }),
+      "utf-8",
+    );
+    const longSentence = "Concept-like rationale prose that must not become a standalone node in the merged graph.";
+    writeFileSync(
+      semantic,
+      JSON.stringify({
+        nodes: [
+          { id: "good", file_type: "code", source_file: "b.ts", label: "Good" },
+          { id: "bad", file_type: "concept", source_file: "b.ts", label: longSentence },
+        ],
+        edges: [{ source: "bad", target: "good", relation: "rationale_for" }],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await runSkillRuntime(
+      [
+        "merge-extraction",
+        "--ast", ast,
+        "--semantic", semantic,
+        "--out", outPath,
+      ],
+      dir,
+    );
+    expect(result.exitCode).toBe(0);
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string; rationale?: string }>;
+    };
+    expect(merged.nodes.map((n) => n.id).sort()).toEqual(["a_func", "good"]);
+    expect(merged.nodes.find((n) => n.id === "good")?.rationale).toBe(longSentence);
+  });
+});
+
+describe("skill-runtime save-semantic-cache - fragment validation", () => {
+  it("rejects a structurally invalid extraction file with a clear error", async () => {
+    const dir = makeDir();
+    const input = join(dir, "input.json");
+    writeFileSync(
+      input,
+      JSON.stringify({
+        nodes: [{ id: "../boom", source_file: "x.ts" }],
+        edges: [],
+        hyperedges: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await runSkillRuntime(
+      [
+        "save-semantic-cache",
+        "--input", input,
+        "--root", dir,
+      ],
+      dir,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.errors.join("\n")).toMatch(/(invalid semantic fragment|path separators)/i);
+  });
+});

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -240,6 +240,26 @@ describe("skill cache examples", () => {
     }
   });
 
+  it("guards inline semantic merges with validateSemanticFragment + sanitizeSemanticFragment (port of upstream PR #825)", () => {
+    // Skill templates that inline a `node -e "..."` saveSemanticCache / merge
+    // block must validate the untrusted agent JSON before merging. Codex and
+    // Gemini route through the central `skill-runtime` (which already
+    // validates), so they're exempt from this regex check.
+    const INLINE_MERGE_SKILLS = [
+      "../src/skills/skill.md",
+      "../src/skills/skill-droid.md",
+      "../src/skills/skill-opencode.md",
+      "../src/skills/skill-windows.md",
+    ];
+    for (const relativePath of INLINE_MERGE_SKILLS) {
+      const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");
+      expect(content).toContain("validateSemanticFragment");
+      expect(content).toContain("sanitizeSemanticFragment");
+      // saveSemanticCache must not be called on a raw, unvalidated fragment.
+      expect(content).toMatch(/sanitizeSemanticFragment\([\s\S]{0,200}\)[\s\S]{0,200}saveSemanticCache/);
+    }
+  });
+
   it("keeps the Windows skill usage lines aligned with upstream v0.3.28", () => {
     const content = readFileSync(new URL("../src/skills/skill-windows.md", import.meta.url), "utf-8");
 


### PR DESCRIPTION
## Summary

Ports the real upstream `semantic_cleanup.py` behavior from `safishamsi/graphify` PR #825 / commit `b6127aa` into the TypeScript fork as semantic-fragment validation for untrusted skill merge JSON.

- Adds `src/semantic-fragment-validation.ts` with `validateSemanticFragment`, `sanitizeSemanticFragment`, and `loadValidatedSemanticFragment`.
- Wires `src/skill-runtime.ts` merge paths (`merge-semantic`, `merge-extraction`, `save-semantic-cache`, finalize paths) to validate/sanitize fragments and skip malformed inputs with warnings instead of crashing.
- Updates skill markdown merge recipes to call the validation/sanitization helpers around untrusted chunk reads.
- Refreshes `.graphify` on top of #68 / M2.

## Naming note

Upstream's Python file is named `semantic_cleanup.py`, but in this fork `src/semantic-cleanup.ts` is already taken by F-0816-M5's merged stale-node pruner. This PR intentionally uses `semantic-fragment-validation.ts` so it does not clobber M5. The F-0816 bilan row 11h mis-described upstream as stale-node pruning; a doc correction remains pending for the release cleanup.

## Verification

- `npm install` clean, no dependency changes.
- `npm run lint` clean.
- Targeted M4 tests: `npm test -- tests/semantic-fragment-validation.test.ts tests/skill-fragment-validation.test.ts tests/skills.test.ts` -> 66 passed / 3 files.
- Full suite: first sandbox run failed only on `listen EPERM 127.0.0.1`; rerun outside sandbox passed: 1013 passed / 7 skipped / 1020 tests.
- `npm run build` clean.
- `npx graphify hook-rebuild` clean: 4647 nodes, 8998 edges, 185 communities.

## Safety checks

- `src/semantic-cleanup.ts` is not modified.
- No `Co-Authored-By` trailers in the three M4 commits.