### PR TITLE
Track F bilan #3: 0.8.18 upstream drift intake (12 commits)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -209,7 +209,7 @@ Each lane carries six independent dimensions. "Infra" = library / CLI / MCP / AP
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | ---: |
 | **C** CRG `v2.3.3` | ✅ 2/2 | ✅ 3/3 (C1/C2/C3 lots landed) | 🟡 3/4 (C1 review-precision, C2 a11y, C3 visual encoding shipped; C4 review UAT outstanding) | 🟡 1/2 (HTML a11y shipped; review surface live-walk pending) | ❌ 0/1 (live user UAT pending) | ✅ 1/1 (C-3.5 visual encoding released in `graphifyy@0.9.6` CHANGELOG) | **10/13 = 77 %** |
 | **E** Install footprint | ✅ 1/1 | ✅ 6/6 (Lots 1/2/3/4-safe/5 + Lot 4-risky dep majors @0.9.3 + Lot 6 Node 24 CI @0.9.2 all landed) | ✅ 6/6 | n/a | ✅ 1/1 (smoke + portable-check green at each lot) | ✅ 1/1 (`graphifyy@0.9.0` minor for Lot 1; 0.9.2/0.9.3 patch follow-ups) | **15/15 = 100 % — DONE** |
-| **F** Upstream parity weekly | ✅ 1/1 | ✅ (0.8.16 cycle closed; M3 bash hardening parked, F-Opt-LLM-Triage deferred) | ✅ 4/4 (F-Install/P1/P2/M1 + F-0816 P1–P4/M1/M2/M4/M5/Opt-Affected merged via PRs #59/#62/#63/#64/#65/#66/#67/#68/#69) | n/a | ✅ 2/2 (per-lot Vitest regressions + release smoke/portable-check green through 0.9.7) | ✅ 1/1 (released through `graphifyy@0.9.7`; CHANGELOG + Version Alignment refreshed) | **closed @0.9.7 — next bilan on fresh upstream scan past `990ac70`** |
+| **F** Upstream parity weekly | ✅ 1/1 | ✅ (0.8.16 cycle closed; M3 bash hardening parked, F-Opt-LLM-Triage deferred) | ✅ 4/4 (F-Install/P1/P2/M1 + F-0816 P1–P4/M1/M2/M4/M5/Opt-Affected merged via PRs #59/#62/#63/#64/#65/#66/#67/#68/#69) | n/a | ✅ 2/2 (per-lot Vitest regressions + release smoke/portable-check green through 0.9.7) | ✅ 1/1 (released through `graphifyy@0.9.7`; CHANGELOG + Version Alignment refreshed) | **0.8.16 cycle closed @0.9.7; bilan #3 (2026-05-25) opened a 12-commit `0.8.18` drift → lots F-0818-P1/M1/M2/M3 pending go** |
 
 **Tracks A / B / D archived as DONE** — see git log and `CHANGELOG.md` for details (A bridge mesh `graphifyy@0.9.1`, B reconciliation through `0.7.19-rc.1`, D drift `0.7.11..0.7.19` at `0.7.19` stable). Removed from active reporting per user request 2026-05-16.
 
@@ -219,7 +219,7 @@ Each lane carries six independent dimensions. "Infra" = library / CLI / MCP / AP
 | --- | --- | --- |
 | **C** CRG `v2.3.3` | Live user UAT on regenerated `graph.html` (skip-link, F1/?, contrast toggle, keyboard nav, filtres communautés, dashes par relation). | **DECISION user** — verdict UAT live OK/KO. URL UAT : http://127.0.0.1:8765/graph.html. |
 | **E** Install footprint | Aucune — lane close (15/15). Lot 4-risky dep majors livrés en `0.9.3`, Lot 6 Node 24 CI en `0.9.2`. | Aucune. |
-| **F** Upstream parity weekly | Nouveau bilan : rescan upstream Python `safishamsi/graphify` au-delà de `upstream/v8` `990ac70` (`v0.8.16`), classer le drift, recommander le prochain numéro de version. | **DECISION user** — lancer le prochain bilan F ou laisser parqué jusqu'au prochain `/loop` hebdo. |
+| **F** Upstream parity weekly | Bilan #3 fait (2026-05-25, drift `0.8.18` = 12 commits, cf. `UPSTREAM_GAP.md > Active 0.8.18 Drift Intake`). Prochaine action : ouvrir les lots F-0818-P1 + M1/M2/M3 puis release patch `0.9.8`. | **DECISION user** — go pour les lots F-0818 (~3-4 j) + scope du `#8` semantic-contexts (defer par défaut). |
 
 ## Detailed Track Plans
 
@@ -317,6 +317,32 @@ M0..M5 lots all landed. `.astro` extractor (`6a7de56`), watch `.rebuild.lock` (`
 
 **Release / Docs (1/1)**
 - [x] `UPSTREAM_GAP.md` Version Alignment refreshed through `graphifyy@0.9.7`, advancing the closest audited parity point to the `0.8.16` drift train and recording the `0.9.5`/`0.9.6`/`0.9.7` rows. CHANGELOG carries the per-release notes through `0.9.7`.
+
+## Lot F-0818 drift (2026-05-25)
+
+**Source lock:** `upstream/v8` at `3efae38` (one commit past tag `v0.8.18` `98100f3`); new tags `v0.8.17` (`73c3c33`) and `v0.8.18` (`98100f3`) since the `0.8.16` lock (`990ac70`). Tag `v1.0.0` (`0a31c08`, "add git commit hook") is **not on the v8 line** (divergent, lightweight tag) → non-target, already-covered by our `hook-rebuild`. Local TS baseline: `main` at `2583f33` (`graphifyy@0.9.7`). Drift range `990ac70..upstream/v8` = **12 commits**. Companion intake: `UPSTREAM_GAP.md > Active 0.8.18 Drift Intake`.
+
+**Sub-lots in priority order** (P → M). Each lot one cohesive PR. Recommended release vehicle after P1 + M1/M2/M3: patch `graphifyy@0.9.8` advancing the closest audited parity point to `v0.8.18`.
+
+- [ ] **Lot F-0818-P1 — Call-resolution correctness** (~1 day). Target upstream commit:
+  - `4dce16f` — *Fix case-sensitive call resolution and cross-language phantom calls (#993, #991)* (`upstream/v8`).
+  We already suppress some cross-language structural bonuses (`src/analyze.ts:116 shouldSuppressCrossLanguageStructuralBonuses`) but have no case-sensitive call-resolution guard. Touches `src/extract.ts`, `src/analyze.ts`, `tests/extract-call-confidence.test.ts` / `tests/analyze.test.ts`. **Proposed PR title:** `Track F-0818-P1: case-sensitive call resolution + cross-language phantom-call suppression`.
+- [ ] **Lot F-0818-M1 — Hook/skill/worker hygiene** (~0.5-1 day). Target upstream commit:
+  - `71b4e57` — *Fix Husky 9 hook path, skill.md INPUT_PATH literal, per-worker exception isolation* (`upstream/v8`).
+  Touches `src/hooks.ts` (Husky-9 hook path), `src/skills/*` (`INPUT_PATH` literal), `src/llm-execution.ts` (per-worker exception isolation), `tests/hooks.test.ts` / `tests/skills.test.ts`. **Proposed PR title:** `Track F-0818-M1: Husky 9 hook path + skill INPUT_PATH literal + per-worker isolation`.
+- [ ] **Lot F-0818-M2 — Backup rate-limit + community sidecar fallback** (~1 day). Target upstream commits:
+  - `3efae38` — *Rate-limit backup_if_protected to one folder per day via content hash* (`upstream/v8`).
+  - `d778e2c` — *reconstruct communities from per-node attribute when sidecar missing (#1001)* (`upstream/v8`).
+  Both are robustness fixes on surfaces we already have. `backupIfProtected` exists (`src/export.ts`, wired `src/watch.ts:299`); add the daily content-hash rate-limit. Community-label reconstruction touches `src/community-labels.ts` / cluster load. **Proposed PR title:** `Track F-0818-M2: backup daily rate-limit + community reconstruction fallback`.
+- [ ] **Lot F-0818-M3 — Query expansion + Unicode vocab regex** (~1 day). Target upstream commits:
+  - `238702b` — *Constrained query expansion (#998)* (`upstream/v8`).
+  - `a4a615d` (subset) — *Unicode vocab regex* (`upstream/v8`).
+  No query expansion exists in `src/serve.ts` / `src/search.ts` today; port the constrained-expansion ranking + the Unicode vocab regex (pairs with the 0.8.16 Unicode lineage). Touches `src/serve.ts`, `src/search.ts`, `tests/serve.test.ts`. **Proposed PR title:** `Track F-0818-M3: constrained query expansion + Unicode vocab regex`.
+- [ ] **Lot F-0818-Opt — cross-language semantic contexts** (scope-decision, size TBD). Target upstream commit:
+  - `ab4e542` — *feat: add cross-language semantic contexts for Python, JS/TS, C#, and Java (#996)* (`upstream/v8`).
+  New capability with no TS counterpart. **Default `defer`** pending a mini-spec sizing it; reopen as a `must-port` only after owner ack on scope. A `0.10.0` minor would be the release vehicle if accepted.
+
+**Already-covered / non-target at this bilan:** Java `extends`→`inherits` (already canonicalized, `src/extract.ts:1541+`); upstream `v1.0.0` git-commit-hook (our `hook-rebuild`); Windows `cp1252` / `str.parent` crashes (`461e346`, Python-runtime specific, `n-a`). **Needs-audit:** watch shrink-guard bypass (`6fba4e4`) — we have no shrink-guard; verify the `.rebuild.lock` + deletion-aware path is equivalent before deciding port vs `n-a`. **Release-only:** `v0.8.17`/`v0.8.18` bumps, Ukrainian README (`#995` + typo).
 
 ## Lot F-0816 drift (2026-05-23)
 

--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -40,6 +40,39 @@ This document tracks the delta between this TypeScript port and upstream Python 
 - The `0.7.10` parity cycle is closed in the TypeScript release line; any newer upstream drift must start a new traceability pass.
 - Python `upstream/v8` was re-fetched on 2026-05-23 (Track F bilan #2) and advanced from the previous cadrage lock `4c95d02` (`v0.8.13`, bilan #1 baseline) to `990ac70` (`v0.8.16`); intermediate tag `v0.8.14` at `f4da176` was published, intermediate tag `v0.8.15` was **skipped upstream** (commit `ff14ad5` landed in-tree but no remote tag was pushed — do not record `v0.8.15` as a published Python release).
 - Local TS baseline for the `0.8.16` drift bilan is `main` at `751ddce935ba8baec26fe5225da12a7525da428b`, package `graphifyy@0.9.1`.
+- Python `upstream/v8` was re-fetched on 2026-05-25 (Track F bilan #3) and advanced from `990ac70` (`v0.8.16`) to `3efae38`; new remote tags `v0.8.17` at `73c3c33` and `v0.8.18` at `98100f3` were published. Tag `v1.0.0` at `0a31c08` ("add git commit hook") is **NOT an ancestor of `upstream/v8`** (it is a lightweight tag on a divergent commit, not a v8-line release) — it stays a **non-target**, confirming the bilan #1/#2 finding; the auto-rebuild-after-commit feature it carries is already-covered by our `graphify hook-rebuild` / git-hook install.
+
+## Active `0.8.18` Drift Intake
+
+Observed on 2026-05-25 (Track F bilan #3) after publishing `graphifyy@0.9.7` (closing the `0.8.16` intake):
+
+- Safi Python Graphify: `upstream/v8` at `3efae38` (`Rate-limit backup_if_protected ...`), one commit past tag `v0.8.18` (`98100f3`).
+- New remote tags since `v0.8.16`: `v0.8.17` at `73c3c33`, `v0.8.18` at `98100f3`. Tag `v1.0.0` at `0a31c08` is a non-target (see Source Lock Notes).
+- Drift commit range `990ac70..upstream/v8` is **12 commits**. Companion lot plan: `PLAN.md > Lot F-0818 drift (2026-05-25)`.
+- Local TS baseline: `main` at `2583f33` (`graphifyy@0.9.7`, post-PR #71 ledger).
+
+Grounding checks run against `main` at intake time: `backupIfProtected` already exists (`src/watch.ts:299`, `src/export.ts`); Java `extends`→`inherits` is already canonicalized (`src/extract.ts:1541+`); partial cross-language structural suppression exists (`src/analyze.ts:116`); **no** query-expansion, semantic-contexts, or watch shrink-guard exist yet.
+
+| # | Commit | Subject (issue) | Bucket | Initial TS status / action |
+| --- | --- | --- | --- | --- |
+| 1 | `461e346` | Windows cp1252 crash, `str.parent` crash, MCP error message, god_nodes relative import | `already-covered` / `n-a` | cp1252 + `str.parent` are Python-runtime specific (TS reads UTF-8, no `str.parent`). Audit only the MCP error-message wording + god-node import angle. |
+| 2 | `71b4e57` | Husky 9 hook path, `skill.md` `INPUT_PATH` literal, per-worker exception isolation | `must-port (M)` | F-0818-M1. Audit `src/hooks.ts` (Husky-9 path), `src/skills/*` (`INPUT_PATH` literal), `src/llm-execution.ts` (per-worker isolation). |
+| 3 | `4dce16f` | Case-sensitive call resolution + cross-language phantom calls (#993, #991) | `must-port (P)` | F-0818-P1. We have partial cross-lang suppression (`analyze.ts:116`) but no case-sensitive call resolution. Extend `src/extract.ts` / `src/analyze.ts` + regression. |
+| 4 | `73c3c33` | Bump 0.8.17 | `release-only` | Do not mirror (`MEMORY.md > Cautious semver bumps`). |
+| 5 | `6fba4e4` | watch: bypass shrink-guard on explicit deletions (#1000) | `needs-audit` → likely `n-a` / `intentional-delta` | No shrink-guard in `src/watch.ts`; verify our `.rebuild.lock` + deletion-aware update path is equivalent before porting. |
+| 6 | `d778e2c` | cli: reconstruct communities from per-node attribute when sidecar missing (#1001) | `must-port (M)` | F-0818-M2. Robustness for `src/community-labels.ts` / cluster when the label sidecar is absent. |
+| 7 | `32effb1` | docs: Ukrainian README to v8 (#995) | `intentional-delta` / `release-only` | The TS fork does not carry a Ukrainian README. |
+| 8 | `ab4e542` | feat: cross-language semantic contexts for Python, JS/TS, C#, Java (#996) | `feature — scope decision` | New capability we lack. Needs a mini-spec before a lot is opened; default `defer` pending scope (size unknown). |
+| 9 | `238702b` | Constrained query expansion (#998) | `must-port (M)` | F-0818-M3. No query expansion in `src/serve.ts` / `src/search.ts`; port the constrained-expansion ranking. |
+| 10 | `a4a615d` | Ukrainian typo + Unicode vocab regex + Java `extends`→`inherits` migration note | split | Unicode vocab regex → `must-port (M)` (F-0818-M3, pairs with #9 query hygiene); Java `inherits` → `already-covered` (`extract.ts:1541+`); README typo → `release-only`. |
+| 11 | `98100f3` | Bump 0.8.18 | `release-only` | Do not mirror. |
+| 12 | `3efae38` | Rate-limit `backup_if_protected` to one folder/day via content hash | `must-port (M)` | F-0818-M2. Enhancement to existing `backupIfProtected` (`watch.ts:299`); add the daily content-hash rate-limit. |
+
+**Bucket counts:** must-port-P = 1 (#3), must-port-M = 4 (#2, #6, #9+#10-regex, #12), feature/scope-decision = 1 (#8), needs-audit = 1 (#5), already-covered = 2 (#1, #10-Java), intentional-delta = 1 (#7), release-only = 3 (#4, #11, README bits).
+
+**Rolled-up effort:** ~3-4 days serialized for P1 + M1/M2/M3, excluding the `#8` semantic-contexts feature (scope TBD).
+
+**Version recommendation:** after porting P1 + M1/M2/M3, the next TS release is a **patch bump `graphifyy@0.9.8`** advancing the closest audited parity point to `v0.8.18`. Do **not** jump to `1.0.0`: upstream `v1.0.0` is a lightweight tag on a divergent git-hook commit, not a v8-line major. `#8` semantic-contexts, if accepted, would justify a **minor `0.10.0`** in a later cycle once scoped.
 
 ## Active `0.8.16` Drift Intake
 


### PR DESCRIPTION
## Bilan #3 — Track F weekly upstream parity

Rescan of upstream Python `safishamsi/graphify` after publishing `graphifyy@0.9.7`. `upstream/v8` advanced `990ac70` (`v0.8.16`) → `3efae38` (one commit past `v0.8.18`), a **12-commit drift**. Analysis only — no code ported in this PR.

### Findings
- New tags `v0.8.17` (`73c3c33`), `v0.8.18` (`98100f3`).
- `v1.0.0` (`0a31c08`, "add git commit hook") is **not on the v8 line** (divergent, lightweight tag) → **non-target**, already-covered by our `hook-rebuild`. Confirms the bilan #1/#2 finding.
- Grounding vs `main`: `backupIfProtected` exists; Java `extends`→`inherits` already canonicalized; partial cross-language suppression exists; **no** query-expansion / semantic-contexts / shrink-guard.

### Buckets
must-port-P = 1 · must-port-M = 4 · feature/scope = 1 (deferred) · needs-audit = 1 · already-covered = 2 · intentional-delta = 1 · release-only = 3.

### Recommendation
Open lots **F-0818-P1** (call resolution) + **M1** (hook/skill/worker) + **M2** (backup rate-limit + community fallback) + **M3** (query expansion + Unicode regex), ~3-4 days, then ship a **patch `graphifyy@0.9.8`** advancing the closest audited parity point to `v0.8.18`. **Do not** jump to `1.0.0`. The `#8` cross-language semantic-contexts feature stays **deferred** pending a sizing mini-spec.

Details: `UPSTREAM_GAP.md > Active 0.8.18 Drift Intake` and `PLAN.md > Lot F-0818 drift (2026-05-25)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)