### PR TITLE
Track F-0818-P1: case-sensitive call resolution (upstream 4dce16f)

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -169,17 +169,26 @@ function qualifiedFileStem(filePath: string, rootDir: string = dirname(resolve(f
   return `${parent}.${stem}`;
 }
 
-function buildResolvableLabelIndex(nodes: GraphNode[]): Map<string, string> {
-  const candidates = new Map<string, Set<string>>();
-  for (const node of nodes) {
-    const raw = String(node.label ?? "");
-    const normalized = raw.replace(/\(?\)$/g, "").replace(/^\./, "").toLowerCase();
-    if (!normalized) continue;
-    const ids = candidates.get(normalized) ?? new Set<string>();
-    ids.add(node.id);
-    candidates.set(normalized, ids);
-  }
+interface ResolvableLabelIndex {
+  /** Keyed by the normalised label preserving original case (Ruby, C#, Java, Kotlin, …). */
+  caseSensitive: Map<string, string>;
+  /** Keyed by the lower-cased normalised label (PHP functions/classes). */
+  caseInsensitive: Map<string, string>;
+}
 
+/** Languages whose call/identifier resolution is case-insensitive. Everything
+ *  else resolves case-sensitively so e.g. a `render()` call does not phantom-link
+ *  to a `Render` class/function that merely differs by case (upstream 4dce16f). */
+const CASE_INSENSITIVE_CALL_MODULES = new Set<string>(["tree_sitter_php"]);
+
+function addLabelCandidate(map: Map<string, Set<string>>, key: string, id: string): void {
+  if (!key) return;
+  const ids = map.get(key) ?? new Set<string>();
+  ids.add(id);
+  map.set(key, ids);
+}
+
+function resolveUniqueLabels(candidates: Map<string, Set<string>>): Map<string, string> {
   const resolved = new Map<string, string>();
   for (const [label, ids] of candidates) {
     if (ids.size === 1) {
@@ -187,6 +196,34 @@ function buildResolvableLabelIndex(nodes: GraphNode[]): Map<string, string> {
     }
   }
   return resolved;
+}
+
+function buildResolvableLabelIndex(nodes: GraphNode[]): ResolvableLabelIndex {
+  const csCandidates = new Map<string, Set<string>>();
+  const ciCandidates = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    const raw = String(node.label ?? "");
+    const base = raw.replace(/\(?\)$/g, "").replace(/^\./, "");
+    if (!base) continue;
+    addLabelCandidate(csCandidates, base, node.id);
+    addLabelCandidate(ciCandidates, base.toLowerCase(), node.id);
+  }
+  return {
+    caseSensitive: resolveUniqueLabels(csCandidates),
+    caseInsensitive: resolveUniqueLabels(ciCandidates),
+  };
+}
+
+/** Resolve a callee name to a node id, honouring the language's case sensitivity. */
+function resolveCalleeNid(
+  index: ResolvableLabelIndex,
+  calleeName: string,
+  tsModule: string,
+): string | undefined {
+  if (CASE_INSENSITIVE_CALL_MODULES.has(tsModule)) {
+    return index.caseInsensitive.get(calleeName.toLowerCase());
+  }
+  return index.caseSensitive.get(calleeName);
 }
 
 type TsconfigAliasEntry = {
@@ -1771,7 +1808,7 @@ async function _extractGeneric(
 
   function emitCallByName(calleeName: string | null, node: SyntaxNode, callerNid: string): void {
     if (!calleeName) return;
-    const tgtNid = labelToNid.get(calleeName.toLowerCase());
+    const tgtNid = resolveCalleeNid(labelToNid, calleeName, config.tsModule);
     if (tgtNid && tgtNid !== callerNid) {
       const pair = `${callerNid}|${tgtNid}`;
       if (!seenCallPairs.has(pair)) {
@@ -3247,7 +3284,7 @@ export async function extractGo(filePath: string, rootDir?: string): Promise<Ext
         }
       }
       if (calleeName) {
-        const tgtNid = labelToNid.get(calleeName.toLowerCase());
+        const tgtNid = labelToNid.caseInsensitive.get(calleeName.toLowerCase());
         if (tgtNid && tgtNid !== callerNid) {
           const pair = `${callerNid}|${tgtNid}`;
           if (!seenCallPairs.has(pair)) {
@@ -3448,7 +3485,7 @@ export async function extractRust(filePath: string, rootDir?: string): Promise<E
         }
       }
       if (!targetNid && calleeName) {
-        targetNid = labelToNid.get(calleeName.toLowerCase()) ?? null;
+        targetNid = labelToNid.caseInsensitive.get(calleeName.toLowerCase()) ?? null;
       }
       if (targetNid && targetNid !== callerNid) {
         const pair = `${callerNid}|${targetNid}`;
@@ -3829,7 +3866,7 @@ export async function extractPowershell(filePath: string, rootDir?: string): Pro
       if (cmdNameNode) {
         const cmdText = _readText(cmdNameNode, source);
         if (!_PS_SKIP.has(cmdText.toLowerCase())) {
-          const tgtNid = labelToNid.get(cmdText.toLowerCase());
+          const tgtNid = labelToNid.caseInsensitive.get(cmdText.toLowerCase());
           if (tgtNid && tgtNid !== callerNid) {
             const pair = `${callerNid}|${tgtNid}`;
             if (!seenCallPairs.has(pair)) {
@@ -4259,7 +4296,7 @@ export async function extractElixir(filePath: string, rootDir?: string): Promise
       }
     }
     if (calleeName) {
-      const tgtNid = labelToNid.get(calleeName.toLowerCase());
+      const tgtNid = labelToNid.caseInsensitive.get(calleeName.toLowerCase());
       if (tgtNid && tgtNid !== callerNid) {
         const pair = `${callerNid}|${tgtNid}`;
         if (!seenCallPairs.has(pair)) {

--- a/tests/extract-call-confidence.test.ts
+++ b/tests/extract-call-confidence.test.ts
@@ -3,7 +3,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { extract, extractGo, extractJs } from "../src/extract.js";
+import { extract, extractGo, extractJs, extractPhp } from "../src/extract.js";
+
+function strip(label: string | undefined): string {
+  return String(label ?? "").replace(/\(?\)$/g, "").replace(/^\./, "");
+}
 
 const cleanupDirs: string[] = [];
 
@@ -35,6 +39,55 @@ describe("AST call edge confidence", () => {
     expect(calls.length).toBeGreaterThan(0);
     expect(calls.every((edge) => edge.confidence === "EXTRACTED")).toBe(true);
     expect(calls.every((edge) => edge.weight === 1.0)).toBe(true);
+  });
+
+  it("does not phantom-link a lowercase call to a different-case definition in case-sensitive languages", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-extract-case-"));
+    cleanupDirs.push(dir);
+
+    const filePath = join(dir, "sample.js");
+    writeFileSync(
+      filePath,
+      [
+        "function Render() { return 1; }",
+        "function caller() { return render(); }",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await extractJs(filePath);
+    const renderNode = result.nodes.find((n) => strip(n.label) === "Render");
+    const calls = result.edges.filter((edge) => edge.relation === "calls");
+
+    // `render()` (lowercase) must NOT resolve to the `Render` definition: JS is case-sensitive.
+    expect(renderNode).toBeDefined();
+    expect(calls.some((edge) => edge.target === renderNode!.id)).toBe(false);
+  });
+
+  it("resolves calls case-insensitively in PHP", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-extract-php-case-"));
+    cleanupDirs.push(dir);
+
+    const filePath = join(dir, "sample.php");
+    writeFileSync(
+      filePath,
+      [
+        "<?php",
+        "function Render() { return 1; }",
+        "function caller() { return render(); }",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await extractPhp(filePath);
+    const renderNode = result.nodes.find((n) => strip(n.label) === "Render");
+    const calls = result.edges.filter((edge) => edge.relation === "calls");
+
+    // PHP function names are case-insensitive: `render()` resolves to `Render`.
+    expect(renderNode).toBeDefined();
+    expect(calls.some((edge) => edge.target === renderNode!.id)).toBe(true);
   });
 
   it("uses namespaced Go package import IDs to avoid local file collisions", async () => {


### PR DESCRIPTION
## F-0818-P1 — case-sensitive call resolution

Ports the call-resolution half of upstream `4dce16f` / `v0.8.17` (`#993`/`#991`).

**Bug:** `_extractGeneric` resolved every callee through a single lower-cased label index, so a lowercase `render()` call would phantom-link to a `Render` class/function that only differs by case.

**Fix:** `buildResolvableLabelIndex` now returns both a case-sensitive and a case-insensitive index. `resolveCalleeNid` picks per language — **case-insensitive only for PHP** (function/class names are case-insensitive there), case-sensitive for everything else. Go/Rust/PowerShell/Elixir keep their existing resolution (no behaviour change).

**Tests** (`tests/extract-call-confidence.test.ts`, TDD red→green):
- a JS lowercase `render()` call no longer links to a `Render` definition;
- PHP still resolves `render()` → `Render` case-insensitively.

**Scope note:** the cross-language phantom-edge *drop* (the `build.py` half of `4dce16f`) is tracked separately — `analyze.ts` already de-scores cross-language INFERRED calls in surprise ranking; a full edge-drop is deferred pending edge-origin confirmation.

Gate: `npm run lint` clean · `npm run build` success · `npm test` 1015 passed / 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)