### PR TITLE
Track F-0818-M1: Husky 9 hook path + skill INPUT_PATH literal (upstream 71b4e57)

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 /** Git repository resolution helpers shared by hooks and lifecycle metadata. */
 import { execFileSync } from "node:child_process";
-import { isAbsolute, resolve } from "node:path";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
 
 export interface GitContext {
   worktreeRoot: string;
@@ -57,6 +57,17 @@ function isSafeGitPath(value: string): boolean {
   return value.length > 0 && !/[\n\r\0]/.test(value);
 }
 
+/**
+ * Return the user-editable hooks directory. Husky 9 sets `core.hooksPath` to
+ * `.husky/_` (auto-generated wrapper scripts), while user-editable hooks live
+ * in the parent `.husky/`. Targeting `.husky/_` would put our hooks in the
+ * directory Husky regenerates, so step up to the parent in that case
+ * (port of upstream `_user_hooks_dir`, #987).
+ */
+export function userEditableHooksDir(hooksDir: string): string {
+  return basename(hooksDir) === "_" ? dirname(hooksDir) : hooksDir;
+}
+
 export function resolveGitContext(path: string = "."): GitContext | null {
   const cwd = resolve(path);
   try {
@@ -71,7 +82,7 @@ export function resolveGitContext(path: string = "."): GitContext | null {
     const worktreeRoot = resolve(topLevel);
     const gitDir = resolve(absoluteGitDir);
     const commonGitDir = resolveFromGitCwd(cwd, commonGitDirRaw);
-    const hooksDir = resolveFromGitCwd(cwd, hooksDirRaw);
+    const hooksDir = userEditableHooksDir(resolveFromGitCwd(cwd, hooksDirRaw));
     return { worktreeRoot, gitDir, commonGitDir, hooksDir };
   } catch {
     return null;

--- a/src/skills/skill-claw.md
+++ b/src/skills/skill-claw.md
@@ -104,7 +104,7 @@ const labels = LABELS_DICT;
 
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 fs.writeFileSync('.graphify/.graphify_labels.json', JSON.stringify(Object.fromEntries(Object.entries(labels).map(([k, v]) => [String(k), v]))));
 console.log('Report updated with community labels');

--- a/src/skills/skill-droid.md
+++ b/src/skills/skill-droid.md
@@ -403,7 +403,7 @@ const surprises = surprisingConnections(G, communities);
 const labels = new Map(Array.from(communities.keys(), cid => [cid, 'Community ' + cid]));
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 toJson(G, communities, '.graphify/graph.json');
 
@@ -456,7 +456,7 @@ const labels = LABELS_DICT;
 
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 fs.writeFileSync('.graphify/.graphify_labels.json', JSON.stringify(Object.fromEntries(Object.entries(labels).map(([k, v]) => [String(k), v]))));
 console.log('Report updated with community labels');

--- a/src/skills/skill-opencode.md
+++ b/src/skills/skill-opencode.md
@@ -402,7 +402,7 @@ const surprises = surprisingConnections(G, communities);
 const labels = new Map(Array.from(communities.keys(), cid => [cid, 'Community ' + cid]));
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 toJson(G, communities, '.graphify/graph.json');
 
@@ -455,7 +455,7 @@ const labels = LABELS_DICT;
 
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 fs.writeFileSync('.graphify/.graphify_labels.json', JSON.stringify(Object.fromEntries(Object.entries(labels).map(([k, v]) => [String(k), v]))));
 console.log('Report updated with community labels');

--- a/src/skills/skill-trae.md
+++ b/src/skills/skill-trae.md
@@ -104,7 +104,7 @@ const labels = LABELS_DICT;
 
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 fs.writeFileSync('.graphify/.graphify_labels.json', JSON.stringify(Object.fromEntries(Object.entries(labels).map(([k, v]) => [String(k), v]))));
 console.log('Report updated with community labels');

--- a/src/skills/skill-windows.md
+++ b/src/skills/skill-windows.md
@@ -403,7 +403,7 @@ const surprises = surprisingConnections(G, communities);
 const labels = new Map(Array.from(communities.keys(), cid => [cid, 'Community ' + cid]));
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 toJson(G, communities, '.graphify/graph.json');
 
@@ -456,7 +456,7 @@ const labels = LABELS_DICT;
 
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 fs.writeFileSync('.graphify/.graphify_labels.json', JSON.stringify(Object.fromEntries(Object.entries(labels).map(([k, v]) => [String(k), v]))));
 console.log('Report updated with community labels');

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -433,7 +433,7 @@ const surprises = surprisingConnections(G, communities);
 const labels = new Map(Array.from(communities.keys(), cid => [cid, 'Community ' + cid]));
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, gods, surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 toJson(G, communities, '.graphify/graph.json');
 
@@ -486,7 +486,7 @@ const labels = LABELS_DICT;
 
 const questions = suggestQuestions(G, communities, labels);
 
-const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, 'INPUT_PATH', {suggestedQuestions: questions});
+const report = generateReport(G, communities, cohesion, labels, analysis.gods, analysis.surprises, detection, tokens, '.', {suggestedQuestions: questions});
 fs.writeFileSync('.graphify/GRAPH_REPORT.md', report);
 fs.writeFileSync('.graphify/.graphify_labels.json', JSON.stringify(Object.fromEntries(Object.entries(labels).map(([k, v]) => [String(k), v]))));
 console.log('Report updated with community labels');

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -32,6 +32,16 @@ describe("hooks", () => {
     return join(isAbsolute(hooksDir) ? hooksDir : resolve(cwd, hooksDir), name);
   }
 
+  it("targets the user-editable .husky dir on Husky 9 repos (core.hooksPath=.husky/_)", () => {
+    git(tmpDir, ["config", "core.hooksPath", ".husky/_"]);
+
+    install(tmpDir);
+
+    // Husky 9 auto-generates wrappers under .husky/_; user hooks live in .husky/.
+    expect(existsSync(join(tmpDir, ".husky", "post-commit"))).toBe(true);
+    expect(existsSync(join(tmpDir, ".husky", "_", "post-commit"))).toBe(false);
+  });
+
   it("installs all lifecycle hooks", () => {
     const result = install(tmpDir);
 

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -38,6 +38,15 @@ const TRIGGER_DESCRIPTION_DOCS = [
 ];
 
 describe("skill cache examples", () => {
+  it("does not pass the unsubstituted INPUT_PATH literal to generateReport", () => {
+    for (const relativePath of DISTRIBUTED_SKILL_DOCS) {
+      const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");
+      // The report path arg must be a real path ('.'), not the unsubstituted
+      // placeholder, otherwise GRAPH_REPORT.md is titled literally "INPUT_PATH".
+      expect(content).not.toContain("'INPUT_PATH', {suggestedQuestions");
+    }
+  });
+
   it("uses trigger-oriented skill descriptions", () => {
     for (const relativePath of TRIGGER_DESCRIPTION_DOCS) {
       const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");


### PR DESCRIPTION
## F-0818-M1 — hook/skill hygiene

Ports two of three fixes from upstream `71b4e57` / `v0.8.17`.

- **Husky 9 hook path** (`#987`): `resolveGitContext` now steps up from `.husky/_` (Husky 9's auto-generated wrapper dir) to the user-editable parent `.husky/` via `userEditableHooksDir`, so `graphify hook install` no longer writes into the directory Husky regenerates.
- **skill `INPUT_PATH` literal** (`#986`): the `generateReport(..., 'INPUT_PATH', ...)` snippets in the bundled skills passed the unsubstituted placeholder as the report path, titling `GRAPH_REPORT.md` literally `"INPUT_PATH"`. Replaced with `'.'` across all 6 skill docs. The `detect`/`watch` `INPUT_PATH` placeholders (which the assistant substitutes) are intentionally left intact.

**Already-covered (not ported):** per-worker exception isolation (`#943`) — `src/direct-llm-extract.ts` already try/catches each chunk, logs a warning, and continues; no full sequential re-extraction on a single worker failure.

**Tests** (TDD red→green): `hooks.test.ts` asserts install targets `.husky/` on a `core.hooksPath=.husky/_` repo; `skills.test.ts` asserts no bundled skill passes the `INPUT_PATH` literal to `generateReport`.

Gate: `npm run lint` clean · `npm run build` success · `npm test` 1017 passed / 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)