### PR TITLE
Track F-0818-M2: rate-limit backupIfProtected to one folder/day (upstream 3efae38)

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -2,6 +2,7 @@
  * Export graph to HTML, JSON, SVG, GraphML, Obsidian Canvas, and Neo4j Cypher.
  */
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { basename, dirname, join, resolve } from "node:path";
 import Graph from "graphology";
 import { sanitizeLabel, escapeHtml, sanitizeMetadata } from "./security.js";
@@ -77,11 +78,21 @@ export function backupIfProtected(outDir: string): string | null {
   ].filter(Boolean).join("+");
 
   const today = todayIso();
-  let backupDir = join(out, today);
-  let suffix = 2;
-  while (existsSync(backupDir)) {
-    backupDir = join(out, `${today}_${suffix}`);
-    suffix++;
+  const backupDir = join(out, today);
+
+  // One backup folder per day (port of upstream 3efae38). If today's backup
+  // already holds byte-identical graph.json content, skip the re-copy; if the
+  // graph changed since that backup, overwrite it in place so the dated folder
+  // always holds the latest pre-overwrite state instead of accumulating `_N`.
+  const backupGraph = join(backupDir, "graph.json");
+  if (existsSync(backupDir) && existsSync(backupGraph)) {
+    try {
+      const srcHash = createHash("sha256").update(readFileSync(join(out, "graph.json"))).digest("hex");
+      const bakHash = createHash("sha256").update(readFileSync(backupGraph)).digest("hex");
+      if (srcHash === bakHash) return backupDir;
+    } catch {
+      /* fall through and overwrite the backup */
+    }
   }
 
   try {

--- a/tests/backup-if-protected.test.ts
+++ b/tests/backup-if-protected.test.ts
@@ -5,7 +5,7 @@
  * graph cost real LLM tokens or has been human-curated.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { backupIfProtected } from "../src/export.js";
@@ -44,6 +44,33 @@ describe("backupIfProtected (upstream 6939494 #834)", () => {
     expect(existsSync(join(backup!, ".graphify_semantic_marker"))).toBe(true);
   });
 
+  it("keeps a single dated backup folder per day for identical content (no _N accumulation)", () => {
+    writeFileSync(join(tmpDir, "graph.json"), '{"nodes":[],"edges":[]}');
+    writeFileSync(join(tmpDir, ".graphify_semantic_marker"), "{}");
+
+    const b1 = backupIfProtected(tmpDir);
+    const b2 = backupIfProtected(tmpDir);
+
+    expect(b1).not.toBeNull();
+    expect(b2).toBe(b1);
+    const dated = readdirSync(tmpDir).filter((n) => /^\d{4}-\d{2}-\d{2}/.test(n));
+    expect(dated).toHaveLength(1);
+  });
+
+  it("overwrites today's backup in place when graph.json content changed", () => {
+    writeFileSync(join(tmpDir, "graph.json"), '{"nodes":[],"edges":[]}');
+    writeFileSync(join(tmpDir, ".graphify_semantic_marker"), "{}");
+    const b1 = backupIfProtected(tmpDir);
+
+    writeFileSync(join(tmpDir, "graph.json"), '{"nodes":[{"id":"x"}],"edges":[]}');
+    const b2 = backupIfProtected(tmpDir);
+
+    expect(b2).toBe(b1);
+    expect(readFileSync(join(b2!, "graph.json"), "utf-8")).toContain('"id":"x"');
+    const dated = readdirSync(tmpDir).filter((n) => /^\d{4}-\d{2}-\d{2}/.test(n));
+    expect(dated).toHaveLength(1);
+  });
+
   it("creates a backup when .graphify_labels.json has at least one non-default label", () => {
     writeFileSync(join(tmpDir, "graph.json"), '{"nodes":[],"edges":[]}');
     writeFileSync(
@@ -63,16 +90,6 @@ describe("backupIfProtected (upstream 6939494 #834)", () => {
     expect(backupIfProtected(tmpDir)).toBeNull();
   });
 
-  it("uses a _2 suffix on the second backup taken the same day", () => {
-    writeFileSync(join(tmpDir, "graph.json"), '{"nodes":[],"edges":[]}');
-    writeFileSync(join(tmpDir, ".graphify_semantic_marker"), "{}");
-    const b1 = backupIfProtected(tmpDir);
-    const b2 = backupIfProtected(tmpDir);
-    expect(b1).not.toBeNull();
-    expect(b2).not.toBeNull();
-    expect(b1).not.toBe(b2);
-    expect(b2!.endsWith("_2")).toBe(true);
-  });
 
   it("is disabled by the GRAPHIFY_NO_BACKUP env var", () => {
     process.env.GRAPHIFY_NO_BACKUP = "1";


### PR DESCRIPTION
## F-0818-M2 — backup daily rate-limit

Ports upstream `3efae38` / `v0.8.18`.

**Before:** `backupIfProtected` created a fresh `{today}_2`, `{today}_3`, … folder on every call — one backup per rebuild, unbounded accumulation.

**Now:** a single dated folder per day —
- identical `graph.json` (sha256) → skip re-copy, return the existing folder;
- changed `graph.json` → overwrite the dated folder in place (latest pre-overwrite state).

**Already-covered (not ported):** community-reconstruction fallback (`#1001`, upstream `d778e2c`). `communitiesFromCliGraph` already rebuilds the community map directly from each node's `community` attribute in `graph.json`, so the TS export path never depended on a `.graphify_analysis.json` sidecar that could go missing.

**Tests** (TDD): single dated folder per day for identical content; in-place overwrite on changed content. The obsolete `_2`-accumulation test (which encoded the now-fixed behaviour) is removed.

Gate: `npm run lint` clean · `npm run build` success · `npm test` 1018 passed / 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)