### PR TITLE
Track F-0818-M3: constrained query expansion skill guidance (upstream 238702b + a4a615d)

### DIFF
--- a/src/skills/skill-claw.md
+++ b/src/skills/skill-claw.md
@@ -529,6 +529,35 @@ if (!fs.existsSync('.graphify/graph.json')) {
 ```
 If it fails, stop and tell the user to run `/graphify <path>` first.
 
+### Step 0 - Constrained query expansion (before traversal)
+
+`graphify query` matches nodes by case-folded substring + IDF - **no stemming, no synonyms, no cross-language match**. When the question uses different vocabulary than the graph labels (user says "обработчик" / graph says "handler"; "authentication" / "Guardian"), the literal matcher returns 0 hits. Expand the query against the **actual graph vocabulary** first - never invent tokens:
+
+```bash
+node -e "
+const fs = require('fs');
+const g = JSON.parse(fs.readFileSync('.graphify/graph.json','utf-8'));
+const vocab = new Set();
+for (const n of (g.nodes || [])) {
+  for (const c of String(n.label || '').match(/[^\W\d_]+/gu) || []) {
+    for (const p of (c.match(/[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+/g) || [c])) {
+      if (p.length > 1) vocab.add(p.toLowerCase());
+    }
+  }
+}
+fs.writeFileSync('.graphify/.vocab.txt', [...vocab].sort().join('\n'));
+console.log('vocab: ' + vocab.size + ' tokens');
+"
+```
+
+Read `.graphify/.vocab.txt`, then pick **up to 12 tokens from that exact list** that match the query intent. Hard constraints:
+- Use only tokens present in `.vocab.txt` - do **not** invent tokens.
+- A concept with no plausible vocab token: skip it, no near-synonym from memory.
+- No vocab token matches at all: output an empty list and tell the user the corpus has no relevant vocabulary; do not fabricate a search.
+- Cross-language: e.g. Russian "аутентификация" - look for `auth`, `credential`, `token`, `security` **iff present** in the vocab.
+
+Print the selection before querying (`Query expanded to (from graph vocab, N tokens): [...]`), then run `graphify query` with the joined expanded tokens (keep the original question only for `save-result`).
+
 Before deep traversal, run the compact first-hop summary and use it to choose the right graph action:
 
 ```bash

--- a/src/skills/skill-droid.md
+++ b/src/skills/skill-droid.md
@@ -914,6 +914,35 @@ if (!fs.existsSync('.graphify/graph.json')) {
 ```
 If it fails, stop and tell the user to run `/graphify <path>` first.
 
+### Step 0 - Constrained query expansion (before traversal)
+
+`graphify query` matches nodes by case-folded substring + IDF - **no stemming, no synonyms, no cross-language match**. When the question uses different vocabulary than the graph labels (user says "обработчик" / graph says "handler"; "authentication" / "Guardian"), the literal matcher returns 0 hits. Expand the query against the **actual graph vocabulary** first - never invent tokens:
+
+```bash
+node -e "
+const fs = require('fs');
+const g = JSON.parse(fs.readFileSync('.graphify/graph.json','utf-8'));
+const vocab = new Set();
+for (const n of (g.nodes || [])) {
+  for (const c of String(n.label || '').match(/[^\W\d_]+/gu) || []) {
+    for (const p of (c.match(/[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+/g) || [c])) {
+      if (p.length > 1) vocab.add(p.toLowerCase());
+    }
+  }
+}
+fs.writeFileSync('.graphify/.vocab.txt', [...vocab].sort().join('\n'));
+console.log('vocab: ' + vocab.size + ' tokens');
+"
+```
+
+Read `.graphify/.vocab.txt`, then pick **up to 12 tokens from that exact list** that match the query intent. Hard constraints:
+- Use only tokens present in `.vocab.txt` - do **not** invent tokens.
+- A concept with no plausible vocab token: skip it, no near-synonym from memory.
+- No vocab token matches at all: output an empty list and tell the user the corpus has no relevant vocabulary; do not fabricate a search.
+- Cross-language: e.g. Russian "аутентификация" - look for `auth`, `credential`, `token`, `security` **iff present** in the vocab.
+
+Print the selection before querying (`Query expanded to (from graph vocab, N tokens): [...]`), then run `graphify query` with the joined expanded tokens (keep the original question only for `save-result`).
+
 Before deep traversal, run the compact first-hop summary and use it to choose the right graph action:
 
 ```bash

--- a/src/skills/skill-opencode.md
+++ b/src/skills/skill-opencode.md
@@ -913,6 +913,35 @@ if (!fs.existsSync('.graphify/graph.json')) {
 ```
 If it fails, stop and tell the user to run `/graphify <path>` first.
 
+### Step 0 - Constrained query expansion (before traversal)
+
+`graphify query` matches nodes by case-folded substring + IDF - **no stemming, no synonyms, no cross-language match**. When the question uses different vocabulary than the graph labels (user says "обработчик" / graph says "handler"; "authentication" / "Guardian"), the literal matcher returns 0 hits. Expand the query against the **actual graph vocabulary** first - never invent tokens:
+
+```bash
+node -e "
+const fs = require('fs');
+const g = JSON.parse(fs.readFileSync('.graphify/graph.json','utf-8'));
+const vocab = new Set();
+for (const n of (g.nodes || [])) {
+  for (const c of String(n.label || '').match(/[^\W\d_]+/gu) || []) {
+    for (const p of (c.match(/[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+/g) || [c])) {
+      if (p.length > 1) vocab.add(p.toLowerCase());
+    }
+  }
+}
+fs.writeFileSync('.graphify/.vocab.txt', [...vocab].sort().join('\n'));
+console.log('vocab: ' + vocab.size + ' tokens');
+"
+```
+
+Read `.graphify/.vocab.txt`, then pick **up to 12 tokens from that exact list** that match the query intent. Hard constraints:
+- Use only tokens present in `.vocab.txt` - do **not** invent tokens.
+- A concept with no plausible vocab token: skip it, no near-synonym from memory.
+- No vocab token matches at all: output an empty list and tell the user the corpus has no relevant vocabulary; do not fabricate a search.
+- Cross-language: e.g. Russian "аутентификация" - look for `auth`, `credential`, `token`, `security` **iff present** in the vocab.
+
+Print the selection before querying (`Query expanded to (from graph vocab, N tokens): [...]`), then run `graphify query` with the joined expanded tokens (keep the original question only for `save-result`).
+
 Before deep traversal, run the compact first-hop summary and use it to choose the right graph action:
 
 ```bash

--- a/src/skills/skill-trae.md
+++ b/src/skills/skill-trae.md
@@ -514,6 +514,35 @@ if (!fs.existsSync('.graphify/graph.json')) {
 ```
 If it fails, stop and tell the user to run `/graphify <path>` first.
 
+### Step 0 - Constrained query expansion (before traversal)
+
+`graphify query` matches nodes by case-folded substring + IDF - **no stemming, no synonyms, no cross-language match**. When the question uses different vocabulary than the graph labels (user says "обработчик" / graph says "handler"; "authentication" / "Guardian"), the literal matcher returns 0 hits. Expand the query against the **actual graph vocabulary** first - never invent tokens:
+
+```bash
+node -e "
+const fs = require('fs');
+const g = JSON.parse(fs.readFileSync('.graphify/graph.json','utf-8'));
+const vocab = new Set();
+for (const n of (g.nodes || [])) {
+  for (const c of String(n.label || '').match(/[^\W\d_]+/gu) || []) {
+    for (const p of (c.match(/[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+/g) || [c])) {
+      if (p.length > 1) vocab.add(p.toLowerCase());
+    }
+  }
+}
+fs.writeFileSync('.graphify/.vocab.txt', [...vocab].sort().join('\n'));
+console.log('vocab: ' + vocab.size + ' tokens');
+"
+```
+
+Read `.graphify/.vocab.txt`, then pick **up to 12 tokens from that exact list** that match the query intent. Hard constraints:
+- Use only tokens present in `.vocab.txt` - do **not** invent tokens.
+- A concept with no plausible vocab token: skip it, no near-synonym from memory.
+- No vocab token matches at all: output an empty list and tell the user the corpus has no relevant vocabulary; do not fabricate a search.
+- Cross-language: e.g. Russian "аутентификация" - look for `auth`, `credential`, `token`, `security` **iff present** in the vocab.
+
+Print the selection before querying (`Query expanded to (from graph vocab, N tokens): [...]`), then run `graphify query` with the joined expanded tokens (keep the original question only for `save-result`).
+
 Before deep traversal, run the compact first-hop summary and use it to choose the right graph action:
 
 ```bash

--- a/src/skills/skill-windows.md
+++ b/src/skills/skill-windows.md
@@ -918,6 +918,35 @@ if (!fs.existsSync('.graphify/graph.json')) {
 ```
 If it fails, stop and tell the user to run `/graphify <path>` first.
 
+### Step 0 - Constrained query expansion (before traversal)
+
+`graphify query` matches nodes by case-folded substring + IDF - **no stemming, no synonyms, no cross-language match**. When the question uses different vocabulary than the graph labels (user says "обработчик" / graph says "handler"; "authentication" / "Guardian"), the literal matcher returns 0 hits. Expand the query against the **actual graph vocabulary** first - never invent tokens:
+
+```bash
+node -e "
+const fs = require('fs');
+const g = JSON.parse(fs.readFileSync('.graphify/graph.json','utf-8'));
+const vocab = new Set();
+for (const n of (g.nodes || [])) {
+  for (const c of String(n.label || '').match(/[^\W\d_]+/gu) || []) {
+    for (const p of (c.match(/[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+/g) || [c])) {
+      if (p.length > 1) vocab.add(p.toLowerCase());
+    }
+  }
+}
+fs.writeFileSync('.graphify/.vocab.txt', [...vocab].sort().join('\n'));
+console.log('vocab: ' + vocab.size + ' tokens');
+"
+```
+
+Read `.graphify/.vocab.txt`, then pick **up to 12 tokens from that exact list** that match the query intent. Hard constraints:
+- Use only tokens present in `.vocab.txt` - do **not** invent tokens.
+- A concept with no plausible vocab token: skip it, no near-synonym from memory.
+- No vocab token matches at all: output an empty list and tell the user the corpus has no relevant vocabulary; do not fabricate a search.
+- Cross-language: e.g. Russian "аутентификация" - look for `auth`, `credential`, `token`, `security` **iff present** in the vocab.
+
+Print the selection before querying (`Query expanded to (from graph vocab, N tokens): [...]`), then run `graphify query` with the joined expanded tokens (keep the original question only for `save-result`).
+
 Before deep traversal, run the compact first-hop summary and use it to choose the right graph action:
 
 ```powershell

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -962,6 +962,35 @@ if (!fs.existsSync('.graphify/graph.json')) {
 ```
 If it fails, stop and tell the user to run `/graphify <path>` first.
 
+### Step 0 - Constrained query expansion (before traversal)
+
+`graphify query` matches nodes by case-folded substring + IDF - **no stemming, no synonyms, no cross-language match**. When the question uses different vocabulary than the graph labels (user says "обработчик" / graph says "handler"; "authentication" / "Guardian"), the literal matcher returns 0 hits. Expand the query against the **actual graph vocabulary** first - never invent tokens:
+
+```bash
+node -e "
+const fs = require('fs');
+const g = JSON.parse(fs.readFileSync('.graphify/graph.json','utf-8'));
+const vocab = new Set();
+for (const n of (g.nodes || [])) {
+  for (const c of String(n.label || '').match(/[^\W\d_]+/gu) || []) {
+    for (const p of (c.match(/[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+/g) || [c])) {
+      if (p.length > 1) vocab.add(p.toLowerCase());
+    }
+  }
+}
+fs.writeFileSync('.graphify/.vocab.txt', [...vocab].sort().join('\n'));
+console.log('vocab: ' + vocab.size + ' tokens');
+"
+```
+
+Read `.graphify/.vocab.txt`, then pick **up to 12 tokens from that exact list** that match the query intent. Hard constraints:
+- Use only tokens present in `.vocab.txt` - do **not** invent tokens.
+- A concept with no plausible vocab token: skip it, no near-synonym from memory.
+- No vocab token matches at all: output an empty list and tell the user the corpus has no relevant vocabulary; do not fabricate a search.
+- Cross-language: e.g. Russian "аутентификация" - look for `auth`, `credential`, `token`, `security` **iff present** in the vocab.
+
+Print the selection before querying (`Query expanded to (from graph vocab, N tokens): [...]`), then run `graphify query` with the joined expanded tokens (keep the original question only for `save-result`).
+
 Before deep traversal, run the compact first-hop summary and use it to choose the right graph action:
 
 ```bash

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -47,6 +47,25 @@ describe("skill cache examples", () => {
     }
   });
 
+  it("teaches constrained query expansion against the actual graph vocabulary", () => {
+    // The detailed /graphify query workflow (with the first-hop summary step)
+    // lives in these docs; the condensed codex/gemini variants point to it.
+    const QUERY_WORKFLOW_DOCS = [
+      "../src/skills/skill.md",
+      "../src/skills/skill-droid.md",
+      "../src/skills/skill-opencode.md",
+      "../src/skills/skill-windows.md",
+      "../src/skills/skill-claw.md",
+      "../src/skills/skill-trae.md",
+    ];
+    for (const relativePath of QUERY_WORKFLOW_DOCS) {
+      const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");
+      // Expand the query against the real graph vocab before traversal; never invent tokens.
+      expect(content).toContain("Constrained query expansion");
+      expect(content).toContain(".vocab.txt");
+    }
+  });
+
   it("uses trigger-oriented skill descriptions", () => {
     for (const relativePath of TRIGGER_DESCRIPTION_DOCS) {
       const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");


### PR DESCRIPTION
## F-0818-M3 — constrained query expansion (skill guidance)

Ports the skill-content fix `238702b` / `v0.8.18` (`#998`) + the Unicode vocab regex from `a4a615d`.

**Why:** `graphify query` matches by case-folded substring + IDF — no stemming, synonyms, or cross-language match. A question phrased in different vocabulary than the graph labels ("обработчик" vs "handler", "authentication" vs "Guardian") returns 0 hits, and an LLM consumer then improvises ungrounded keywords.

**Fix:** a new **"Step 0 — Constrained query expansion"** in the detailed `/graphify query` workflow. The assistant extracts the actual node-label vocabulary into `.graphify/.vocab.txt` and picks **up to 12 expansion tokens only from that set** — never inventing tokens or pulling synonyms from training memory. The vocab tokenizer uses the Unicode regex `[^\W\d_]+` (per `a4a615d`) so Cyrillic/CJK labels are captured, not just ASCII.

Added to the six skill docs that host the full query workflow (`skill.md`, `droid`, `opencode`, `windows`, `claw`, `trae`). The condensed `codex`/`gemini` variants point to that workflow rather than duplicating the Node snippet.

**Test** (TDD red→green): `skills.test.ts` asserts those docs teach constrained query expansion and reference `.graphify/.vocab.txt`.

Gate: `npm run lint` clean · `npm run build` success · `npm test` 1019 passed / 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)