### PR TITLE
ci(publish): revert to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -203,12 +203,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-        env:
-          # Bootstrap publish of the new @sentropic/graphify package uses a scoped
-          # granular token (NPM_TOKEN secret). Revert to OIDC Trusted Publishing
-          # (remove this env) once the package exists and a trusted publisher is
-          # configured on npmjs.com.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Post-publish validation: install from npm and verify
   post-publish-check:


### PR DESCRIPTION
Removes the one-time `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish job. The bootstrap token (used once to create `@sentropic/graphify`) is revoked; a GitHub Actions **Trusted Publisher** is now configured on npmjs.com for `rhanka/graphify` / `typescript-ci.yml`, so publishing uses OIDC (`id-token: write`). Unblocks future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)