### PR TITLE
feat(track-g): studio UI ACLP-AM alignment — lots 1–4 (light canvas, full-center graph, left accordion, right entity panel)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3549,6 +3549,10 @@ export async function main(): Promise<void> {
       "--profile <path>",
       "Optional ontology profile YAML for per-node-type visual encoding (Track C-3.5)",
     )
+    .option(
+      "--descriptions <path>",
+      "Optional wiki description sidecar index JSON; node descriptions render in the node-info panel (Track G G-studio-lot4)",
+    )
     .action(async (opts) => {
       try {
         const graphPath = resolveGraphInputPath(opts.graph);
@@ -3568,6 +3572,13 @@ export async function main(): Promise<void> {
           dirname(graphPath),
           typeof opts.profile === "string" ? opts.profile : undefined,
         );
+        // Track G G-studio-lot4: --descriptions wires the wiki sidecar so node
+        // descriptions render in the node-info panel. Stale entries (graph_hash
+        // / prompt_version mismatch) are dropped with a warning.
+        const descriptions = await loadFreshWikiDescriptionSidecarIndex(
+          typeof opts.descriptions === "string" ? opts.descriptions : undefined,
+          graphPath,
+        );
         const { safeToHtml } = await import("./html-export.js");
         const written = safeToHtml(
           G,
@@ -3576,6 +3587,7 @@ export async function main(): Promise<void> {
           {
             communityLabels: labels,
             ...(ontologyProfileForHtml ? { profile: ontologyProfileForHtml } : {}),
+            ...(descriptions ? { descriptions } : {}),
           },
           {
             onWarning: (message) => console.warn(message),

--- a/src/export.ts
+++ b/src/export.ts
@@ -197,6 +197,14 @@ type HtmlOptions = CommunityLabelOptions & {
   /** Track C-3.5: optional ontology profile carrying per-node-type
    *  visual_encoding (shape + color_hex) overrides for the HTML export. */
   profile?: NormalizedOntologyProfile;
+  /**
+   * Track G G-studio-lot2 (#3, #4): when true, render the studio variant —
+   * the graph claims the full center, the community list / node-info panel /
+   * search are removed from the canvas area, and only the shapes + edges
+   * legend stays (floated bottom-right). Defaults to false so the standalone
+   * `graphify export html` artefact is byte-stable.
+   */
+  studioMode?: boolean;
 };
 type JsonOptions = CommunityLabelOptions & { force?: boolean };
 type SvgOptions = CommunityLabelOptions & { figsize?: [number, number] };
@@ -246,7 +254,8 @@ function isCommunityLabelOptions(
     Object.prototype.hasOwnProperty.call(value, "communityLabels") ||
     Object.prototype.hasOwnProperty.call(value, "memberCounts") ||
     Object.prototype.hasOwnProperty.call(value, "force") ||
-    Object.prototype.hasOwnProperty.call(value, "profile")
+    Object.prototype.hasOwnProperty.call(value, "profile") ||
+    Object.prototype.hasOwnProperty.call(value, "studioMode")
   );
 }
 
@@ -291,6 +300,13 @@ function normalizeProfile(
 ): NormalizedOntologyProfile | undefined {
   if (!labelsOrOptions || !isCommunityLabelOptions(labelsOrOptions)) return undefined;
   return (labelsOrOptions as HtmlOptions).profile ?? undefined;
+}
+
+function normalizeStudioMode(
+  labelsOrOptions?: CommunityLabelsInput | HtmlOptions,
+): boolean {
+  if (!labelsOrOptions || !isCommunityLabelOptions(labelsOrOptions)) return false;
+  return (labelsOrOptions as HtmlOptions).studioMode === true;
 }
 
 /**
@@ -714,6 +730,30 @@ ${workspaceCss
   body.high-contrast #sidebar, body.high-contrast #search, body.high-contrast #help-modal { background: #000; color: #fff; }
   body.high-contrast #search { border-color: #fff; }
   body.high-contrast #info-content .empty, body.high-contrast .legend-count, body.high-contrast #stats { color: #ddd; }
+  /* G-studio-lot2 (#3, #4) — studio mode: the graph claims the full center;
+     the community list, node-info panel, search box and bottom stats line are
+     removed from inside the canvas area, and only the shapes + edges legend
+     stays, floated bottom-right over the canvas. */
+  body.studio-mode #sidebar { width: 0; border-left: none; overflow: visible; background: transparent; }
+  body.studio-mode #search-wrap { display: none; }
+  body.studio-mode #info-panel { display: none; }
+  body.studio-mode #legend-wrap { display: none; }
+  body.studio-mode #stats { display: none; }
+  body.studio-mode #help-button { display: none; }
+  body.studio-mode #shapes-legend-card {
+    position: absolute;
+    right: var(--ws-space-3);
+    bottom: var(--ws-space-3);
+    z-index: 50;
+    max-width: 260px;
+    padding: var(--ws-space-3);
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--ws-text);
+    border: 1px solid var(--ws-border);
+    border-radius: var(--ws-radius-md);
+    box-shadow: var(--ws-shadow-card);
+  }
+  body.studio-mode #shapes-legend-card h3 { font-size: 12px; color: var(--ws-text-muted); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.05em; }
 </style>`;
 }
 
@@ -1197,7 +1237,7 @@ export function toHtml(
 <script src="https://unpkg.com/vis-network@9.1.6/standalone/umd/vis-network.min.js" integrity="sha384-Ux6phic9PEHJ38YtrijhkzyJ8yQlH8i/+buBR8s3mAZOJrP1gwyvAcIYl3GWtpX1" crossorigin="anonymous"></script>
 ${htmlStyles()}
 </head>
-<body>
+<body${studioMode ? ' class="studio-mode"' : ""}>
 <a class="skip-link" href="#sidebar">Skip to controls</a>
 <div id="live-status" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
 <div id="graph" aria-label="Graphify knowledge graph"></div>
@@ -1219,13 +1259,15 @@ ${htmlStyles()}
       <button id="contrast-toggle" type="button" aria-pressed="false" aria-label="Toggle high contrast">HC</button>
     </div>
     <div id="legend" role="group" aria-label="Community filters"></div>
-    <h3 id="shapes-heading" style="margin-top:14px">Shapes</h3>
+  </section>
+  <section id="shapes-legend-card" aria-labelledby="shapes-heading">
+    <h3 id="shapes-heading">Shapes</h3>
     <ul id="shape-legend" aria-labelledby="shapes-heading" style="list-style:none;padding:0;margin:0;font-size:12px;color:var(--ws-text-muted)">
       <li>● dot &mdash; code</li>
       <li><span style="display:inline-block;width:10px;height:10px;background:var(--ws-text-muted);vertical-align:middle"></span> square (filled) &mdash; test</li>
       <li>▲ triangle &mdash; config (yaml/toml/...)</li>
       <li>◆ diamond &mdash; type definition (.d.ts)</li>
-      <li><span style="display:inline-block;width:10px;height:10px;border:1px solid var(--ws-text-muted);background:transparent;vertical-align:middle"></span> box (outline) &mdash; document / paper / concept</li>
+      <li><span style="display:inline-block;width:10px;height:10px;border:1px solid var(--ws-text-muted);background:rgba(255,255,255,0.5);vertical-align:middle"></span> box (hollow) &mdash; document / paper / concept</li>
       <li>★ star &mdash; image</li>
       <li>⬢ hexagon &mdash; video</li>
     </ul>

--- a/src/export.ts
+++ b/src/export.ts
@@ -10,6 +10,7 @@ import { isDirectedGraph } from "./graph.js";
 import { assertGraphJsonFileSize, assertGraphJsonSize } from "./graph-size-guard.js";
 import { safeGitRevParse } from "./git.js";
 import type { Hyperedge, NormalizedOntologyProfile, OntologyVisualEncoding } from "./types.js";
+import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
 import {
   type NumericMapLike,
   type StringMapLike,
@@ -205,6 +206,14 @@ type HtmlOptions = CommunityLabelOptions & {
    * `graphify export html` artefact is byte-stable.
    */
   studioMode?: boolean;
+  /**
+   * Track G G-studio-lot4 (#7, pipeline unblock): wiki description sidecar
+   * index (schema `graphify_wiki_description_index_v1`). When present, each
+   * node's generated description is attached to its payload so the node-info
+   * panel can render it. `insufficient_evidence` entries are omitted (parity
+   * with the wiki rendering — no placeholder).
+   */
+  descriptions?: WikiDescriptionSidecarIndex;
 };
 type JsonOptions = CommunityLabelOptions & { force?: boolean };
 type SvgOptions = CommunityLabelOptions & { figsize?: [number, number] };
@@ -255,7 +264,8 @@ function isCommunityLabelOptions(
     Object.prototype.hasOwnProperty.call(value, "memberCounts") ||
     Object.prototype.hasOwnProperty.call(value, "force") ||
     Object.prototype.hasOwnProperty.call(value, "profile") ||
-    Object.prototype.hasOwnProperty.call(value, "studioMode")
+    Object.prototype.hasOwnProperty.call(value, "studioMode") ||
+    Object.prototype.hasOwnProperty.call(value, "descriptions")
   );
 }
 
@@ -307,6 +317,30 @@ function normalizeStudioMode(
 ): boolean {
   if (!labelsOrOptions || !isCommunityLabelOptions(labelsOrOptions)) return false;
   return (labelsOrOptions as HtmlOptions).studioMode === true;
+}
+
+function normalizeDescriptions(
+  labelsOrOptions?: CommunityLabelsInput | HtmlOptions,
+): WikiDescriptionSidecarIndex | undefined {
+  if (!labelsOrOptions || !isCommunityLabelOptions(labelsOrOptions)) return undefined;
+  return (labelsOrOptions as HtmlOptions).descriptions ?? undefined;
+}
+
+/**
+ * Track G G-studio-lot4 — look up a node's generated wiki description from a
+ * sidecar index. Returns the trimmed description only for `generated`
+ * entries; `insufficient_evidence` (or missing) entries return null so the
+ * caller omits the field entirely (no placeholder, parity with the wiki).
+ */
+function lookupNodeDescription(
+  descriptions: WikiDescriptionSidecarIndex | undefined,
+  nodeId: string,
+): string | null {
+  if (!descriptions?.nodes) return null;
+  const entry = descriptions.nodes[nodeId];
+  if (!entry || entry.status !== "generated") return null;
+  const text = typeof entry.description === "string" ? entry.description.trim() : "";
+  return text ? text : null;
 }
 
 /**
@@ -825,6 +859,7 @@ const nodesDS = new vis.DataSet(RAW_NODES.map(n => ({
   _community: n.community, _community_name: n.community_name,
   _source_file: n.source_file, _file_type: n.file_type, _degree: n.degree,
   _shape: n.shape || 'dot',
+  _description: n.description || '',
 })));
 
 const edgesDS = new vis.DataSet(RAW_EDGES.map((e, i) => ({
@@ -885,6 +920,7 @@ function showInfo(nodeId) {
   }).join('');
   document.getElementById('info-content').innerHTML = \`
     <div class="field"><b>\${n.label}</b></div>
+    \${n._description ? \`<div class="field" style="margin:6px 0">\${n._description}</div>\` : ''}
     <div class="field">Type: \${n._file_type || 'unknown'} <span style="color:var(--ws-text-muted);font-size:11px">(shape: \${n._shape})</span></div>
     <div class="field">Community: \${n._community_name}</div>
     <div class="field">Source: \${n._source_file || '-'}</div>
@@ -1089,6 +1125,8 @@ export function toHtml(
   const communityLabels = normalizeCommunityLabels(communityLabelsOrOptions);
   const memberCounts = normalizeMemberCounts(communityLabelsOrOptions);
   const profile = normalizeProfile(communityLabelsOrOptions);
+  const studioMode = normalizeStudioMode(communityLabelsOrOptions);
+  const descriptions = normalizeDescriptions(communityLabelsOrOptions);
   const workspaceTheme = getWorkspaceTokens();
   if (G.order > MAX_NODES_FOR_VIZ) {
     throw new Error(
@@ -1119,6 +1157,8 @@ export function toHtml(
     file_type: string;
     shape: string;
     degree: number;
+    /** G-studio-lot4 (#7): generated wiki description, omitted when absent. */
+    description?: string;
   }
   const visNodes: VisNode[] = [];
   G.forEachNode((nodeId, data) => {
@@ -1149,7 +1189,8 @@ export function toHtml(
     // from a profile visual_encoding override.
     const isOutlinedShape = shape === "box";
     const outlinedFill = "rgba(255,255,255,0.5)";
-    visNodes.push({
+    const description = lookupNodeDescription(descriptions, nodeId);
+    const visNode: VisNode = {
       id: nodeId,
       label,
       color: {
@@ -1166,7 +1207,11 @@ export function toHtml(
       file_type: fileType,
       shape,
       degree: deg,
-    });
+    };
+    // G-studio-lot4 (#7): attach the generated description only when present;
+    // insufficient_evidence / missing entries leave the field off entirely.
+    if (description) visNode.description = sanitizeLabel(description);
+    visNodes.push(visNode);
   });
 
   // Build edges list

--- a/src/export.ts
+++ b/src/export.ts
@@ -646,6 +646,12 @@ ${workspaceCss
     --graph-muted-strong: var(--ws-text-muted);
     --graph-node-label: var(--ws-text);
     --graph-neighbor-border: var(--ws-border);
+    /* G-studio-lot1 #1: the graph canvas keeps a LIGHT background regardless
+       of the app/dark theme — the dark theme is design-system-incompatible
+       for the graph surface. This is a literal light colour, NOT
+       var(--ws-surface), so a host theme that flips --ws-surface dark cannot
+       darken the canvas (which would hide crossing edges + node labels). */
+    --graph-canvas-bg: #ffffff;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { background: var(--ws-surface); color: var(--ws-text); font-family: var(--ws-font-family-sans); display: flex; height: 100vh; overflow: hidden; }
@@ -656,7 +662,7 @@ ${workspaceCss
   .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
   /* Focus visible everywhere, WCAG-compliant outline. */
   :focus-visible { outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); box-shadow: 0 0 0 4px var(--graph-focus-shadow); }
-  #graph { flex: 1; outline: none; background: var(--ws-surface); }
+  #graph { flex: 1; outline: none; background: var(--graph-canvas-bg); }
   #graph:focus-visible { box-shadow: inset 0 0 0 3px var(--ws-outline-color); }
   #sidebar { width: 280px; background: var(--ws-surface-2); border-left: 1px solid var(--ws-border); display: flex; flex-direction: column; overflow: hidden; }
   #search-wrap { padding: var(--ws-space-3); border-bottom: 1px solid var(--ws-border); }
@@ -1093,18 +1099,21 @@ export function toHtml(
     const nodeType = (data.node_type as string) ?? (data.type as string) ?? "";
     const shape = resolveNodeShape({ nodeType, fileType, sourceFile, profile });
     const color = resolveNodeColor({ nodeType, profile, fallback: paletteColor });
-    // C-final-1: shape "box" (document/paper/concept) renders as outline-only
-    // so it is visually distinct from "square" (test) which stays solid-filled.
-    // vis.js draws a filled rectangle when color.background is a color; setting
-    // background to a transparent value keeps the border (color) and shows the
-    // label cleanly without the fill blob. Stays consistent whether `box`
-    // comes from inferNodeShape or from a profile visual_encoding override.
+    // C-final-1 / G-studio-lot1 #2: shape "box" (document/paper/concept)
+    // renders "hollow" — coloured border, but a SEMI-OPAQUE WHITE fill
+    // (~50%) rather than a fully transparent one. Arrows leave from the box
+    // centre, so a 0-alpha fill leaves the label unreadable over crossing
+    // edges; a 50% white fill keeps the text legible while still looking
+    // hollow. It stays visually distinct from "square" (test), which is
+    // solid-filled. Consistent whether `box` comes from inferNodeShape or
+    // from a profile visual_encoding override.
     const isOutlinedShape = shape === "box";
+    const outlinedFill = "rgba(255,255,255,0.5)";
     visNodes.push({
       id: nodeId,
       label,
       color: {
-        background: isOutlinedShape ? "rgba(0,0,0,0)" : color,
+        background: isOutlinedShape ? outlinedFill : color,
         border: color,
         highlight: { background: workspaceTheme.colour.surface, border: color },
       },

--- a/src/ontology-studio-workspace.ts
+++ b/src/ontology-studio-workspace.ts
@@ -22,11 +22,15 @@ import type {
 import {
   createDefaultViewerState,
   getWorkspaceTokens,
+  renderEntityPanel,
   renderGraphPanel,
   renderWorkspaceShell,
+  type EntityPanelOccurrences,
   type GraphLike,
   type GraphNodeLike,
+  type WorkspaceDescriptionSidecar,
 } from "./workspace/index.js";
+import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
 
 interface ReconciliationWorkspaceModel {
   writeEnabled: boolean;
@@ -45,6 +49,11 @@ interface ReconciliationWorkspaceModel {
 export interface RenderOntologyStudioWorkspaceOptions {
   writeEnabled: boolean;
   selectedCandidateId?: string;
+  /**
+   * G-studio-lot4 (#7): the node id selected for the right-column entity
+   * panel (from `?node=<id>`). Only honoured in the default Workspace view.
+   */
+  selectedNodeId?: string;
   /**
    * Active view requested by the live HTTP route. One of
    * "workspace" | "reconciliation" | "evidence". Defaults to "workspace"
@@ -470,6 +479,100 @@ function loadGraph(stateDir: string): GraphLike | null {
   }
 }
 
+/**
+ * G-studio-lot4 (#7): best-effort load of the wiki description sidecar index.
+ * Tries the assistant-merged sidecar first (the curated/merged output), then
+ * the plain index. A missing / malformed file is silently ignored — the
+ * entity panel just omits descriptions.
+ */
+function loadDescriptionIndex(stateDir: string): WikiDescriptionSidecarIndex | null {
+  const candidates = [
+    join(stateDir, "wiki", "descriptions.assistant-merged.json"),
+    join(stateDir, "wiki", "descriptions.json"),
+  ];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as WikiDescriptionSidecarIndex;
+      if (parsed && typeof parsed === "object" && parsed.nodes) return parsed;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null;
+}
+
+/**
+ * G-studio-lot4 (#7, intent points 5 & 6): best-effort load of the occurrence
+ * / citation sidecar. The schema is profile-driven; this reader tolerates a
+ * few common shapes and returns a node-id -> occurrence map. A missing /
+ * empty file yields an empty map (the panel omits the section).
+ */
+function loadOccurrences(stateDir: string): EntityPanelOccurrences {
+  const path = join(stateDir, "ontology", "occurrences.json");
+  if (!existsSync(path)) return {};
+  try {
+    return normaliseOccurrences(JSON.parse(readFileSync(path, "utf-8")) as unknown);
+  } catch {
+    return {};
+  }
+}
+
+function normaliseOccurrences(raw: unknown): EntityPanelOccurrences {
+  const out: EntityPanelOccurrences = {};
+  if (!raw || typeof raw !== "object") return out;
+  // Accept either a top-level map { nodes: {...} } or a bare map keyed by id.
+  const nodes =
+    (raw as { nodes?: unknown }).nodes && typeof (raw as { nodes?: unknown }).nodes === "object"
+      ? (raw as { nodes: Record<string, unknown> }).nodes
+      : (raw as Record<string, unknown>);
+  for (const [id, value] of Object.entries(nodes)) {
+    if (!value || typeof value !== "object") continue;
+    const entry = value as Record<string, unknown>;
+    const documents: Record<string, number> = {};
+    const rawDocs = entry.documents ?? entry.per_document ?? entry.by_document;
+    if (rawDocs && typeof rawDocs === "object") {
+      for (const [doc, count] of Object.entries(rawDocs as Record<string, unknown>)) {
+        if (typeof count === "number" && Number.isFinite(count)) documents[doc] = count;
+      }
+    }
+    const snippets: string[] = [];
+    const rawSnippets = entry.snippets ?? entry.quotes ?? entry.excerpts;
+    if (Array.isArray(rawSnippets)) {
+      for (const s of rawSnippets) if (typeof s === "string") snippets.push(s);
+    }
+    const total =
+      typeof entry.total === "number"
+        ? entry.total
+        : typeof entry.count === "number"
+          ? entry.count
+          : undefined;
+    out[id] = {
+      ...(total !== undefined ? { total } : {}),
+      ...(Object.keys(documents).length > 0 ? { documents } : {}),
+      ...(snippets.length > 0 ? { snippets } : {}),
+    };
+  }
+  return out;
+}
+
+function descriptionSidecarFor(
+  index: WikiDescriptionSidecarIndex | null,
+  nodeId: string,
+): WorkspaceDescriptionSidecar | undefined {
+  const entry = index?.nodes?.[nodeId];
+  if (!entry) return undefined;
+  if (entry.status === "generated") {
+    return {
+      status: "generated",
+      target_id: nodeId,
+      target_kind: "node",
+      description: entry.description ?? null,
+    };
+  }
+  return { status: "insufficient_evidence", target_id: nodeId, target_kind: "node" };
+}
+
 function graphHtmlUrl(stateDir: string): string | null {
   const graphHtmlPath = join(stateDir, "graph.html");
   return existsSync(graphHtmlPath) ? pathToFileURL(graphHtmlPath).href : null;
@@ -593,12 +696,58 @@ export function renderOntologyStudioWorkspace(
 
   // Default: workspace tab. The G6-2 left rail (search/types/selected/
   // facets/results) renders naturally — no `leftWorkbenchHtml`
-  // override. The right slot stays hidden via the shell's slot
-  // visibility rules. The central column shows the compact prose for
-  // the currently selected entity (or the empty hint).
+  // override. The central column shows the compact prose for the
+  // currently selected entity (or the empty hint).
   state.viewState.graph.mode = "selection";
 
-  return renderWorkspaceShell({
+  // G-studio-lot4 (#7): when a node is selected (?node=<id>), render the
+  // entity panel — wiki description + relations + evidence snippet +
+  // occurrence counts — in the REAL right column.
+  let entityPanelHtml: string | undefined;
+  const selectedNodeId = opts.selectedNodeId;
+  if (selectedNodeId && model.graph) {
+    const node = graphNodeById(model.graph, selectedNodeId);
+    if (node) {
+      state.displayRef = `entity:${selectedNodeId}`;
+      state.focusEntityId = selectedNodeId;
+      const descriptionIndex = loadDescriptionIndex(context.stateDir);
+      const occurrences = loadOccurrences(context.stateDir);
+      const descriptionSidecar = descriptionSidecarFor(descriptionIndex, selectedNodeId);
+      entityPanelHtml = renderEntityPanel({
+        node,
+        graph: model.graph,
+        ...(descriptionSidecar ? { descriptionSidecar } : {}),
+        occurrences,
+      });
+    }
+  }
+
+  // G-studio-lot4 (#7): no-Svelte progressive enhancement — clicking a
+  // result entry (or relation target) navigates to ?node=<id> so the right
+  // column shows that entity. Generic: it reads the rail's data-display-ref /
+  // the entity panel's data-other-id hooks without any corpus coupling.
+  const nodeNavScript = [
+    "<script>",
+    "(() => {",
+    '  document.addEventListener("click", (event) => {',
+    '    const trigger = event.target.closest("[data-display-ref],[data-other-id]");',
+    "    if (!trigger) return;",
+    '    const ref = trigger.getAttribute("data-display-ref") || "";',
+    '    const other = trigger.getAttribute("data-other-id") || "";',
+    "    let nodeId = other;",
+    '    if (!nodeId && ref.indexOf("entity:") === 0) nodeId = ref.slice("entity:".length);',
+    "    if (!nodeId) return;",
+    "    event.preventDefault();",
+    "    const target = new URL(window.location.href);",
+    '    target.searchParams.set("node", nodeId);',
+    '    target.searchParams.set("view", "workspace");',
+    "    window.location.assign(target.toString());",
+    "  });",
+    "})();",
+    "</script>",
+  ].join("\n");
+
+  const shellHtml = renderWorkspaceShell({
     tokens,
     tokenSource: "fallback",
     title: "Graphify Ontology Studio",
@@ -608,5 +757,7 @@ export function renderOntologyStudioWorkspace(
     state,
     ...(model.graph ? { graph: model.graph } : {}),
     graphPanelHtml: renderGraphContext(model),
+    ...(entityPanelHtml ? { entityPanelHtml } : {}),
   });
+  return shellHtml.replace("</body>", `${nodeNavScript}\n</body>`);
 }

--- a/src/ontology-studio-workspace.ts
+++ b/src/ontology-studio-workspace.ts
@@ -453,6 +453,9 @@ function renderGraphContext(model: ReconciliationWorkspaceModel): string {
     ...(model.graphHtmlUrl ? { graphHtmlUrl: model.graphHtmlUrl } : {}),
     ...(model.liveGraphHtmlUrl ? { liveGraphHtmlUrl: model.liveGraphHtmlUrl } : {}),
     height: 560,
+    // G-studio-lot2 (#3, #4): the embedded canvas runs in studio mode — full
+    // center, shapes/edges legend only, no community list / node-info panel.
+    studioMode: true,
   });
 }
 

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -140,6 +140,7 @@ function htmlResult(
   writeEnabled: boolean,
   selectedCandidateId: string | undefined,
   activeView: "workspace" | "reconciliation" | "evidence",
+  selectedNodeId: string | undefined,
 ): OntologyStudioRouteResult {
   return {
     status: 200,
@@ -147,6 +148,7 @@ function htmlResult(
     body: renderOntologyStudioWorkspace(context, {
       writeEnabled,
       ...(selectedCandidateId ? { selectedCandidateId } : {}),
+      ...(selectedNodeId ? { selectedNodeId } : {}),
       activeView,
     }),
   };
@@ -313,9 +315,11 @@ export function handleOntologyStudioRequest(
       // ?view= override, route into the Reconciliation sub-view so the
       // legacy deep links still surface the candidate workbench.
       const rawCandidate = optionalString(url.searchParams.get("candidate"));
+      // G-studio-lot4 (#7): ?node=<id> selects an entity for the right column.
+      const rawNode = optionalString(url.searchParams.get("node"));
       const resolvedView =
         activeView === "workspace" && rawCandidate ? "reconciliation" : activeView;
-      return htmlResult(context, Boolean(options.write), rawCandidate, resolvedView);
+      return htmlResult(context, Boolean(options.write), rawCandidate, resolvedView, rawNode);
     }
     if (url.pathname === "/api/ontology/artifacts/graph.html") {
       return graphHtmlArtifactResult(context, url.searchParams.get("studio") === "1");

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -152,15 +152,36 @@ function htmlResult(
   };
 }
 
-function graphHtmlArtifactResult(context: ReturnType<typeof loadOntologyPatchContext>): OntologyStudioRouteResult {
+/**
+ * Track G G-studio-lot2 (#3, #4): flip the served graph.html into its studio
+ * variant by adding the `studio-mode` body class. The studio CSS already
+ * ships in every export, so the class alone makes the canvas claim the full
+ * center and show only the shapes/edges legend. Idempotent: a body that is
+ * already `studio-mode` is returned unchanged.
+ */
+export function injectStudioMode(html: string): string {
+  if (/<body[^>]*class="[^"]*studio-mode/.test(html)) return html;
+  const withClass = html.replace(
+    /<body([^>]*?)\bclass="([^"]*)"/i,
+    (_match, attrs: string, classes: string) => `<body${attrs}class="${classes} studio-mode"`,
+  );
+  if (withClass !== html) return withClass;
+  return html.replace(/<body\b([^>]*)>/i, '<body$1 class="studio-mode">');
+}
+
+function graphHtmlArtifactResult(
+  context: ReturnType<typeof loadOntologyPatchContext>,
+  studioMode = false,
+): OntologyStudioRouteResult {
   const graphHtmlPath = join(context.stateDir, "graph.html");
   if (!existsSync(graphHtmlPath)) {
     return jsonResult(404, { error: "graph.html not found" });
   }
+  const raw = readFileSync(graphHtmlPath, "utf-8");
   return {
     status: 200,
     contentType: "text/html; charset=utf-8",
-    body: readFileSync(graphHtmlPath, "utf-8"),
+    body: studioMode ? injectStudioMode(raw) : raw,
   };
 }
 
@@ -297,7 +318,7 @@ export function handleOntologyStudioRequest(
       return htmlResult(context, Boolean(options.write), rawCandidate, resolvedView);
     }
     if (url.pathname === "/api/ontology/artifacts/graph.html") {
-      return graphHtmlArtifactResult(context);
+      return graphHtmlArtifactResult(context, url.searchParams.get("studio") === "1");
     }
     if (url.pathname === "/api/ontology/reconciliation/candidates") {
       return jsonResult(200, listOntologyReconciliationCandidates(context, candidateFilters(url.searchParams)));

--- a/src/workspace/entity-panel.ts
+++ b/src/workspace/entity-panel.ts
@@ -1,0 +1,327 @@
+/**
+ * Track G G-studio-lot4 (#7) — right-column entity panel.
+ *
+ * Mirrors aclp-am's EntityPanel + EntityRelationsAccordion: when a node is
+ * selected, the REAL right column shows the entity's wiki description, its
+ * relations, an evidence snippet (a short quote, not the whole source), and
+ * occurrence / citation counts (total mentions + per-document appearance
+ * count).
+ *
+ * Strictly profile-neutral: the only literal strings are the section
+ * headings; everything else comes from the dataset / sidecars.
+ */
+
+import type { GraphEdgeLike, GraphLike, GraphNodeLike } from "./graph-selection.js";
+import type { WorkspaceDescriptionSidecar } from "./shell.js";
+
+/**
+ * Occurrence / citation data for the selected entity, keyed by node id.
+ * Sourced from `.graphify/ontology/occurrences.json` (or any profile-declared
+ * occurrence sidecar). All fields are optional so a sparse sidecar degrades
+ * gracefully.
+ */
+export interface EntityOccurrence {
+  /** Total mention count across the corpus. */
+  total?: number;
+  /** Per-document appearance count (document path -> count). */
+  documents?: Record<string, number>;
+  /** Short evidence snippets (quotes), capped by the renderer. */
+  snippets?: string[];
+}
+
+export type EntityPanelOccurrences = Record<string, EntityOccurrence>;
+
+export interface RenderEntityPanelOptions {
+  /** The selected graph node. */
+  node: GraphNodeLike;
+  /** The full graph (used to resolve relation targets + labels). */
+  graph: GraphLike;
+  /** Optional Track A wiki description sidecar entry for this node. */
+  descriptionSidecar?: WorkspaceDescriptionSidecar;
+  /** Optional occurrence / citation data keyed by node id. */
+  occurrences?: EntityPanelOccurrences;
+  /** Max relations to render before truncating. Defaults to 50. */
+  maxRelations?: number;
+  /** Max evidence snippets to render. Defaults to 3. */
+  maxSnippets?: number;
+}
+
+const DEFAULT_MAX_RELATIONS = 50;
+const DEFAULT_MAX_SNIPPETS = 3;
+const SNIPPET_MAX_CHARS = 240;
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(HTML_ESCAPE_RE, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+function displayValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function nodeTitle(node: GraphNodeLike): string {
+  return (
+    displayValue(node.title) ??
+    displayValue(node.label) ??
+    displayValue(node.name) ??
+    node.id
+  );
+}
+
+function nodeType(node: GraphNodeLike): string | null {
+  return (
+    displayValue(node.node_type) ??
+    displayValue(node.type) ??
+    displayValue(node.kind) ??
+    displayValue(node.file_type)
+  );
+}
+
+function nodeCommunity(node: GraphNodeLike): string | null {
+  return (
+    displayValue(node.community_name) ??
+    (typeof node.community === "number" ? `Community ${node.community}` : null)
+  );
+}
+
+function nodeSourcePath(node: GraphNodeLike): string | null {
+  const file = displayValue(node.source_file);
+  const loc = displayValue(node.source_location);
+  if (!file) return null;
+  return loc ? `${file}:${loc}` : file;
+}
+
+function graphEdges(graph: GraphLike): GraphEdgeLike[] {
+  return graph.edges ?? graph.links ?? [];
+}
+
+/**
+ * Render a Track A markdown description as safe inline HTML. Supports
+ * `**bold**` and `*italic*` runs only; everything else stays escaped text.
+ */
+function renderInlineMarkdown(markdown: string): string {
+  const escaped = escapeHtml(markdown.trim());
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/(^|[^*])\*(?!\s)(.+?)\*(?!\*)/g, "$1<em>$2</em>");
+}
+
+interface RelationRow {
+  direction: "out" | "in";
+  relation: string;
+  otherId: string;
+  otherLabel: string;
+}
+
+function buildRelationRows(
+  node: GraphNodeLike,
+  graph: GraphLike,
+  max: number,
+): { rows: RelationRow[]; hidden: number; total: number } {
+  const labelById = new Map<string, string>();
+  for (const candidate of graph.nodes ?? []) {
+    if (typeof candidate?.id === "string") labelById.set(candidate.id, nodeTitle(candidate));
+  }
+  const rows: RelationRow[] = [];
+  for (const edge of graphEdges(graph)) {
+    if (edge.source === node.id) {
+      rows.push({
+        direction: "out",
+        relation: displayValue(edge.relation) ?? "related_to",
+        otherId: edge.target,
+        otherLabel: labelById.get(edge.target) ?? edge.target,
+      });
+    } else if (edge.target === node.id) {
+      rows.push({
+        direction: "in",
+        relation: displayValue(edge.relation) ?? "related_to",
+        otherId: edge.source,
+        otherLabel: labelById.get(edge.source) ?? edge.source,
+      });
+    }
+  }
+  const total = rows.length;
+  const capped = rows.slice(0, max);
+  return { rows: capped, hidden: total - capped.length, total };
+}
+
+function renderRelations(node: GraphNodeLike, graph: GraphLike, max: number): string {
+  const { rows, hidden, total } = buildRelationRows(node, graph, max);
+  const heading =
+    '<h3 class="ws-entity-section-heading">Relations <span class="ws-entity-counter">' +
+    total +
+    "</span></h3>";
+  if (total === 0) {
+    return [
+      '<section class="ws-entity-relations" data-entity-section="relations">',
+      heading,
+      '<p class="ws-entity-empty">No relations.</p>',
+      "</section>",
+    ].join("");
+  }
+  const items = rows
+    .map((row) => {
+      const arrow = row.direction === "out" ? "→" : "←";
+      return [
+        '<li class="ws-entity-relation" data-relation-dir="' + row.direction + '" data-other-id="' + escapeHtml(row.otherId) + '">',
+        '<span class="ws-entity-relation-kind">' + escapeHtml(row.relation) + "</span>",
+        '<span class="ws-entity-relation-arrow" aria-hidden="true">' + arrow + "</span>",
+        '<span class="ws-entity-relation-target">' + escapeHtml(row.otherLabel) + "</span>",
+        "</li>",
+      ].join("");
+    })
+    .join("");
+  const more = hidden > 0 ? `<li class="ws-entity-relation-hidden">+ ${hidden} more</li>` : "";
+  return [
+    '<section class="ws-entity-relations" data-entity-section="relations">',
+    heading,
+    `<ul class="ws-entity-relation-list">${items}${more}</ul>`,
+    "</section>",
+  ].join("");
+}
+
+function clampSnippet(text: string): string {
+  const trimmed = text.trim().replace(/\s+/g, " ");
+  if (trimmed.length <= SNIPPET_MAX_CHARS) return trimmed;
+  return `${trimmed.slice(0, SNIPPET_MAX_CHARS).trimEnd()}…`;
+}
+
+function renderSnippets(occurrence: EntityOccurrence | undefined, max: number): string {
+  const snippets = (occurrence?.snippets ?? [])
+    .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+    .slice(0, max);
+  if (snippets.length === 0) return "";
+  const items = snippets
+    .map((s) => `<blockquote class="ws-entity-snippet-quote">${escapeHtml(clampSnippet(s))}</blockquote>`)
+    .join("");
+  return [
+    '<section class="ws-entity-snippet" data-entity-section="snippet">',
+    '<h3 class="ws-entity-section-heading">Evidence</h3>',
+    items,
+    "</section>",
+  ].join("");
+}
+
+function renderOccurrences(occurrence: EntityOccurrence | undefined): string {
+  if (!occurrence) return "";
+  const documents = occurrence.documents ?? {};
+  const docEntries = Object.entries(documents).filter(([, count]) => typeof count === "number");
+  const total =
+    typeof occurrence.total === "number"
+      ? occurrence.total
+      : docEntries.reduce((sum, [, count]) => sum + count, 0);
+  if (total <= 0 && docEntries.length === 0) return "";
+  const docRows = docEntries
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(
+      ([doc, count]) =>
+        [
+          '<li class="ws-entity-occurrence-row">',
+          '<span class="ws-entity-occurrence-doc">' + escapeHtml(doc) + "</span>",
+          '<span class="ws-entity-occurrence-count">' + count + "</span>",
+          "</li>",
+        ].join(""),
+    )
+    .join("");
+  return [
+    '<section class="ws-entity-occurrences" data-entity-section="occurrences">',
+    '<h3 class="ws-entity-section-heading">Occurrences</h3>',
+    `<p class="ws-entity-occurrence-total">${total} mention${total === 1 ? "" : "s"}` +
+      (docEntries.length > 0 ? ` across ${docEntries.length} document${docEntries.length === 1 ? "" : "s"}` : "") +
+      "</p>",
+    docRows ? `<ul class="ws-entity-occurrence-list">${docRows}</ul>` : "",
+    "</section>",
+  ]
+    .filter(Boolean)
+    .join("");
+}
+
+function renderFacts(node: GraphNodeLike): string {
+  const facts: Array<{ label: string; value: string }> = [];
+  const type = nodeType(node);
+  if (type) facts.push({ label: "Type", value: type });
+  const community = nodeCommunity(node);
+  if (community) facts.push({ label: "Community", value: community });
+  const source = nodeSourcePath(node);
+  if (source) facts.push({ label: "Source", value: source });
+  if (facts.length === 0) return "";
+  return [
+    '<p class="ws-entity-facts">',
+    facts
+      .map(
+        (f) =>
+          `<span class="ws-entity-fact"><span class="ws-entity-fact-label">${escapeHtml(f.label)}:</span> ${escapeHtml(f.value)}</span>`,
+      )
+      .join(" · "),
+    "</p>",
+  ].join("");
+}
+
+function renderDescription(sidecar: WorkspaceDescriptionSidecar | undefined): string {
+  // Track A rule: insufficient_evidence hides the block silently (no
+  // placeholder); generated inlines the markdown; absent => nothing.
+  if (!sidecar) return "";
+  if (sidecar.status !== "generated") return "";
+  const text = typeof sidecar.description === "string" ? sidecar.description.trim() : "";
+  if (!text) return "";
+  return `<div class="ws-entity-description">${renderInlineMarkdown(text)}</div>`;
+}
+
+/**
+ * Render the right-column entity panel. Pure string HTML, no framework.
+ */
+export function renderEntityPanel(opts: RenderEntityPanelOptions): string {
+  const node = opts.node;
+  const maxRelations = opts.maxRelations ?? DEFAULT_MAX_RELATIONS;
+  const maxSnippets = opts.maxSnippets ?? DEFAULT_MAX_SNIPPETS;
+  const occurrence = opts.occurrences?.[node.id];
+  return [
+    `<article class="ws-entity-panel" data-entity-id="${escapeHtml(node.id)}">`,
+    '<div class="ws-entity-kicker">Selected entity</div>',
+    `<h2 class="ws-entity-title">${escapeHtml(nodeTitle(node))}</h2>`,
+    renderFacts(node),
+    renderDescription(opts.descriptionSidecar),
+    renderRelations(node, opts.graph, maxRelations),
+    renderSnippets(occurrence, maxSnippets),
+    renderOccurrences(occurrence),
+    "</article>",
+  ]
+    .filter(Boolean)
+    .join("");
+}
+
+/** Inline CSS for the entity panel. Light-on-light right column. */
+export function entityPanelStyles(): string {
+  return [
+    ".ws-entity-panel { display: grid; gap: var(--ws-space-3); }",
+    ".ws-entity-kicker { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }",
+    ".ws-entity-title { margin: 0; font-size: var(--ws-font-size-lg); line-height: var(--ws-line-height-tight); }",
+    ".ws-entity-facts { margin: 0; color: var(--ws-text-muted); font-size: var(--ws-font-size-sm); display: flex; flex-wrap: wrap; gap: var(--ws-space-2); }",
+    ".ws-entity-fact-label { color: var(--ws-text); font-weight: 600; }",
+    ".ws-entity-description { color: var(--ws-text); line-height: var(--ws-line-height-normal); }",
+    ".ws-entity-section-heading { margin: 0 0 var(--ws-space-1); font-size: var(--ws-font-size-sm); text-transform: uppercase; letter-spacing: 0.05em; color: var(--ws-text-muted); font-weight: 700; display: flex; align-items: baseline; gap: var(--ws-space-2); }",
+    ".ws-entity-counter { color: var(--ws-text-muted); font-weight: 400; }",
+    ".ws-entity-empty { margin: 0; color: var(--ws-text-muted); font-style: italic; }",
+    ".ws-entity-relation-list, .ws-entity-occurrence-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }",
+    ".ws-entity-relation { display: flex; align-items: baseline; gap: var(--ws-space-1); font-size: var(--ws-font-size-sm); }",
+    ".ws-entity-relation-kind { color: var(--ws-text-muted); }",
+    ".ws-entity-relation-arrow { color: var(--ws-text-muted); }",
+    ".ws-entity-relation-target { color: var(--ws-text); font-weight: 600; overflow-wrap: anywhere; }",
+    ".ws-entity-relation-hidden { color: var(--ws-text-muted); font-style: italic; font-size: var(--ws-font-size-sm); }",
+    ".ws-entity-snippet-quote { margin: 0 0 var(--ws-space-1); padding: var(--ws-space-1) var(--ws-space-2); border-left: 3px solid var(--ws-border); color: var(--ws-text); font-style: italic; }",
+    ".ws-entity-occurrence-total { margin: 0 0 var(--ws-space-1); color: var(--ws-text); font-size: var(--ws-font-size-sm); }",
+    ".ws-entity-occurrence-row { display: flex; align-items: baseline; justify-content: space-between; gap: var(--ws-space-2); font-size: var(--ws-font-size-sm); }",
+    ".ws-entity-occurrence-doc { color: var(--ws-text); overflow-wrap: anywhere; }",
+    ".ws-entity-occurrence-count { color: var(--ws-text-muted); font-variant-numeric: tabular-nums; }",
+  ].join("\n");
+}

--- a/src/workspace/graph-panel.ts
+++ b/src/workspace/graph-panel.ts
@@ -43,6 +43,23 @@ export interface RenderGraphPanelOptions {
    * Defaults to 480.
    */
   height?: number;
+  /**
+   * Track G G-studio-lot2 (#3, #4): when true the panel asks the served
+   * graph.html for its studio variant (full-center canvas, legend-only) by
+   * appending `studio=1` to the live (same-origin) URL. The studio CSS ships
+   * in every export already; the server flips the `studio-mode` body class.
+   */
+  studioMode?: boolean;
+}
+
+/**
+ * Append the `studio=1` query flag to a same-origin URL. Kept conservative:
+ * preserves an existing query string and never touches a file: URL (the
+ * server-side class injection only runs over HTTP).
+ */
+function withStudioFlag(url: string): string {
+  if (!url) return url;
+  return url.includes("?") ? `${url}&studio=1` : `${url}?studio=1`;
 }
 
 const HTML_ESCAPE_RE = /[&<>"']/g;
@@ -104,7 +121,12 @@ function renderMetricsCard(subgraph: FocusSubgraph, state: WorkspaceViewerState)
 function renderViewerSurface(opts: RenderGraphPanelOptions): string {
   const height = Math.max(120, Math.round(opts.height ?? 480));
   const url = opts.graphHtmlUrl ? escapeUrl(opts.graphHtmlUrl) : "";
-  const liveUrl = opts.liveGraphHtmlUrl ? escapeUrl(opts.liveGraphHtmlUrl) : "";
+  const rawLiveUrl = opts.liveGraphHtmlUrl
+    ? opts.studioMode
+      ? withStudioFlag(opts.liveGraphHtmlUrl)
+      : opts.liveGraphHtmlUrl
+    : "";
+  const liveUrl = rawLiveUrl ? escapeUrl(rawLiveUrl) : "";
   if (!url) {
     return [
       '<div class="ws-graph-placeholder" id="ws-graph-network">',

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -35,6 +35,13 @@ export type {
 } from "./shell.js";
 export { renderWorkspaceShell } from "./shell.js";
 
+export type {
+  RenderEntityPanelOptions,
+  EntityOccurrence,
+  EntityPanelOccurrences,
+} from "./entity-panel.js";
+export { renderEntityPanel, entityPanelStyles } from "./entity-panel.js";
+
 export type { RenderRailOptions, WorkspaceRailLayout } from "./rail.js";
 export { renderWorkspaceRail, workspaceRailStyles } from "./rail.js";
 

--- a/src/workspace/rail.ts
+++ b/src/workspace/rail.ts
@@ -67,6 +67,56 @@ interface TypeRow {
   count: number;
 }
 
+interface CommunityRow {
+  name: string;
+  count: number;
+}
+
+/**
+ * G-studio-lot3 (#5): wrap a left-rail section in a collapsible accordion,
+ * collapsed by default (no `open`). The heading becomes the <summary>. The
+ * `data-rail-section` slug stays on the <details> so the client controller
+ * keeps the same dispatch hooks.
+ */
+function renderAccordionSection(
+  slug: string,
+  heading: string,
+  counter: string,
+  body: string,
+): string {
+  return [
+    `<details class="ws-rail-accordion" data-rail-section="${escapeHtml(slug)}">`,
+    '<summary class="ws-rail-heading ws-rail-accordion-summary">',
+    escapeHtml(heading),
+    counter ? `<span class="ws-rail-counter">${counter}</span>` : "",
+    "</summary>",
+    `<div class="ws-rail-accordion-body">${body}</div>`,
+    "</details>",
+  ].join("");
+}
+
+/**
+ * G-studio-lot3 (#6): build the Louvain community rows from the dataset.
+ * Communities come from each node's `community` id (Louvain clustering) with
+ * a `community_name` label when present, falling back to "Community N".
+ * Profile-neutral — no corpus-specific strings.
+ */
+function buildCommunityRows(graph: GraphLike | undefined): CommunityRow[] {
+  const counts = new Map<string, number>();
+  if (graph?.nodes) {
+    for (const node of graph.nodes) {
+      const name =
+        (typeof node.community_name === "string" && node.community_name.trim()) ||
+        (typeof node.community === "number" ? `Community ${node.community}` : "");
+      if (!name) continue;
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
 function recordsFromGraph(graph: GraphLike | undefined): WorkspaceResultRecord[] {
   const out: WorkspaceResultRecord[] = [];
   if (!graph?.nodes) return out;
@@ -156,16 +206,52 @@ function renderTypes(
     );
   }
 
-  return [
-    '<section class="ws-rail-section" data-rail-section="types">',
-    '<h3 class="ws-rail-heading">Types <span class="ws-rail-counter"><span data-rail-counter="types-shown">' +
-      shown +
-      '</span> shown / <span data-rail-counter="types-total">' +
-      total +
-      "</span> total</span></h3>",
+  const counter =
+    '<span data-rail-counter="types-shown">' +
+    shown +
+    '</span> shown / <span data-rail-counter="types-total">' +
+    total +
+    "</span> total";
+  return renderAccordionSection(
+    "types",
+    "Types",
+    counter,
     `<ul class="ws-rail-type-list">${rowsHtml.join("")}</ul>`,
-    "</section>",
-  ].join("");
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Communities (G-studio-lot3 #6) — Louvain clusters, above Facets.
+// ---------------------------------------------------------------------------
+
+function renderCommunities(graph: GraphLike | undefined): string {
+  const rows = buildCommunityRows(graph);
+  const counter = `<span data-rail-counter="communities-total">${rows.length}</span> total`;
+  if (rows.length === 0) {
+    return renderAccordionSection(
+      "communities",
+      "Communities",
+      counter,
+      '<p class="ws-empty ws-rail-empty">No communities in this dataset.</p>',
+    );
+  }
+  const items = rows
+    .map(
+      (row) =>
+        [
+          '<li class="ws-rail-community" data-community-name="' + escapeHtml(row.name) + '">',
+          '<span class="ws-rail-community-name">' + escapeHtml(row.name) + "</span>",
+          '<span class="ws-rail-community-count">' + row.count + "</span>",
+          "</li>",
+        ].join(""),
+    )
+    .join("");
+  return renderAccordionSection(
+    "communities",
+    "Communities",
+    counter,
+    `<ul class="ws-rail-community-list">${items}</ul>`,
+  );
 }
 
 function renderSelected(state: WorkspaceViewerState, graph: GraphLike | undefined): string {
@@ -246,14 +332,16 @@ function renderFacets(
   }
 
   if (facets.length === 0) {
-    return [
-      '<section class="ws-rail-section" data-rail-section="facets">',
-      '<h3 class="ws-rail-heading">Facets <span class="ws-rail-counter"><span data-rail-counter="facets-active">' +
-        active +
-        '</span> active / <span data-rail-counter="facets-slices">0</span> slices</span></h3>',
+    const emptyCounter =
+      '<span data-rail-counter="facets-active">' +
+      active +
+      '</span> active / <span data-rail-counter="facets-slices">0</span> slices';
+    return renderAccordionSection(
+      "facets",
+      "Facets",
+      emptyCounter,
       '<p class="ws-empty ws-rail-empty">No facetable fields in this dataset.</p>',
-      "</section>",
-    ].join("");
+    );
   }
 
   const slicesTotal = facets.reduce((sum, facet) => sum + Math.max(0, facet.values.length - 1), 0);
@@ -281,16 +369,18 @@ function renderFacets(
     );
   }
 
-  return [
-    '<section class="ws-rail-section" data-rail-section="facets">',
-    '<h3 class="ws-rail-heading">Facets <span class="ws-rail-counter"><span data-rail-counter="facets-active">' +
-      active +
-      '</span> active / <span data-rail-counter="facets-slices">' +
-      slicesTotal +
-      "</span> slices</span></h3>",
+  const counter =
+    '<span data-rail-counter="facets-active">' +
+    active +
+    '</span> active / <span data-rail-counter="facets-slices">' +
+    slicesTotal +
+    "</span> slices";
+  return renderAccordionSection(
+    "facets",
+    "Facets",
+    counter,
     `<div class="ws-rail-facet-list">${facetHtml.join("")}</div>`,
-    "</section>",
-  ].join("");
+  );
 }
 
 function renderResults(
@@ -299,14 +389,14 @@ function renderResults(
 ): string {
   const total = filtered.length;
   if (groups.length === 0) {
-    return [
-      '<section class="ws-rail-section" data-rail-section="results">',
-      '<h3 class="ws-rail-heading">Results <span class="ws-rail-counter"><span data-rail-counter="results-total">' +
-        total +
-        "</span> entities in selection</span></h3>",
+    const emptyCounter =
+      '<span data-rail-counter="results-total">' + total + "</span> entities in selection";
+    return renderAccordionSection(
+      "results",
+      "Results",
+      emptyCounter,
       '<p class="ws-empty ws-rail-empty">No matching entities.</p>',
-      "</section>",
-    ].join("");
+    );
   }
 
   const groupHtml: string[] = [];
@@ -341,14 +431,14 @@ function renderResults(
     );
   }
 
-  return [
-    '<section class="ws-rail-section" data-rail-section="results">',
-    '<h3 class="ws-rail-heading">Results <span class="ws-rail-counter"><span data-rail-counter="results-total">' +
-      total +
-      "</span> entities in selection</span></h3>",
+  const counter =
+    '<span data-rail-counter="results-total">' + total + "</span> entities in selection";
+  return renderAccordionSection(
+    "results",
+    "Results",
+    counter,
     `<div class="ws-rail-result-list">${groupHtml.join("")}</div>`,
-    "</section>",
-  ].join("");
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -408,6 +498,8 @@ export function renderWorkspaceRail(opts: RenderRailOptions): string {
     renderSearch(opts.state),
     renderTypes(opts.state, records, filteredRecords),
     renderSelected(opts.state, opts.graph),
+    // G-studio-lot3 #6: Communities panel ABOVE Facets, collapsed by default.
+    renderCommunities(opts.graph),
     renderFacets(opts.state, records, opts.layout),
     renderResults(filteredRecords, groups),
     "</div>",
@@ -445,5 +537,16 @@ export function workspaceRailStyles(): string {
     ".ws-rail-result-entry button { background: transparent; border: 0; color: var(--ws-accent); cursor: pointer; padding: 0; text-align: left; font: inherit; }",
     ".ws-rail-result-hidden { color: var(--ws-text-muted); font-size: var(--ws-font-size-sm); font-style: italic; }",
     ".ws-rail-empty { margin: 0; }",
+    // G-studio-lot3 (#5, #6) — collapsible accordion sections.
+    ".ws-rail-accordion { border: 1px solid var(--ws-border); border-radius: var(--ws-radius-sm); background: var(--ws-surface); }",
+    ".ws-rail-accordion-summary { cursor: pointer; list-style: none; padding: var(--ws-space-2); display: flex; align-items: baseline; gap: var(--ws-space-2); justify-content: space-between; }",
+    ".ws-rail-accordion-summary::-webkit-details-marker { display: none; }",
+    ".ws-rail-accordion-summary::before { content: '\\25B8'; color: var(--ws-text-muted); margin-right: var(--ws-space-1); font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-accordion[open] > .ws-rail-accordion-summary::before { content: '\\25BE'; }",
+    ".ws-rail-accordion-body { padding: 0 var(--ws-space-2) var(--ws-space-2); }",
+    ".ws-rail-community-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }",
+    ".ws-rail-community { display: flex; align-items: center; justify-content: space-between; gap: var(--ws-space-2); padding: 2px var(--ws-space-2); font-size: var(--ws-font-size-sm); }",
+    ".ws-rail-community-name { color: var(--ws-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }",
+    ".ws-rail-community-count { color: var(--ws-text-muted); font-variant-numeric: tabular-nums; }",
   ].join("\n");
 }

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -38,6 +38,7 @@ import type { WorkspaceViewerState } from "./viewer-state.js";
 import { createDefaultViewerState } from "./viewer-state.js";
 import { serialiseTokensToCss } from "./tokens-fallback.js";
 import { renderWorkspaceRail, workspaceRailStyles, type WorkspaceRailLayout } from "./rail.js";
+import { entityPanelStyles } from "./entity-panel.js";
 
 /**
  * Optional sidecar payload propagated from `.graphify/wiki/descriptions.json`
@@ -92,6 +93,14 @@ export interface RenderWorkspaceShellOptions {
    * no state is passed — legacy callers without G6 state).
    */
   rightDrawerHtml?: string;
+  /**
+   * Track G G-studio-lot4 (#7): trusted entity-panel HTML for the REAL
+   * right column. When provided in the default Workspace view (with an
+   * entity selected), the right slot becomes visible and renders this
+   * panel instead of staying hidden. Ignored in reconciliation / evidence
+   * views (those use `rightDrawerHtml`).
+   */
+  entityPanelHtml?: string;
   /** Current workspace state. Used to resolve the central display item. */
   state?: WorkspaceViewerState;
   /** Graph payload (typically loaded from `.graphify/graph.json`). */
@@ -604,7 +613,11 @@ function shellStyles(): string {
     "  .ws-counters { grid-template-columns: repeat(2, minmax(80px, 1fr)); }",
     "  .ws-tabs { font-size: var(--ws-font-size-sm); }",
     "}",
+    // G-studio-lot4 (#7): the entity slot is the real right column — never
+    // hidden by the workspace/evidence hide rules (it has its own view tag).
+    ".workspace-reconciliation-slot[data-active-view=\"entity\"] { display: block; }",
     workspaceRailStyles(),
+    entityPanelStyles(),
   ].join("\n");
 }
 
@@ -690,10 +703,17 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
   // markup is always rendered so callers can swap states without forcing
   // a re-mount.
   const activeView = opts.state?.activeView ?? null;
-  const slotVisible = isReconciliationView(activeView);
-  const slotHidden = !slotVisible;
-  const slotActiveView = activeView ?? "workspace";
   const isEvidenceView = activeView === "evidence";
+  // G-studio-lot4 (#7): in the default Workspace view the right slot stays
+  // hidden UNLESS an entity panel is supplied (a node is selected) — then it
+  // becomes the real right column showing the entity. Reconciliation / studio
+  // views keep their existing drawer behaviour.
+  const isWorkspaceView = !isReconciliationView(activeView) && !isEvidenceView;
+  const hasEntityPanel =
+    isWorkspaceView && typeof opts.entityPanelHtml === "string" && opts.entityPanelHtml.length > 0;
+  const slotVisible = isReconciliationView(activeView) || hasEntityPanel;
+  const slotHidden = !slotVisible;
+  const slotActiveView = hasEntityPanel ? "entity" : activeView ?? "workspace";
 
   // G6-2: render the rich left rail (search / types / selected / facets /
   // results) when a graph is available and the caller did not override
@@ -742,8 +762,10 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
 
   const slotBody = slotHidden
     ? ""
-    : opts.rightDrawerHtml ??
-      '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>';
+    : hasEntityPanel
+      ? (opts.entityPanelHtml as string)
+      : opts.rightDrawerHtml ??
+        '<p class="ws-empty">Evidence / relations / audit trail accordion arrives with G5.</p>';
 
   return [
     "<!DOCTYPE html>",

--- a/tests/html-export-descriptions.test.ts
+++ b/tests/html-export-descriptions.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Track G G-studio-lot4 (part A) — node descriptions in the HTML export.
+ *
+ * The blocker: `graphify export html` had no way to receive the wiki
+ * description sidecar, and node descriptions never rendered. toHtml now
+ * accepts a `descriptions` sidecar index and attaches the per-node
+ * description to the node payload so the node-info panel can show it.
+ *
+ * insufficient_evidence => no description is attached (parity with wiki).
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { toHtml } from "../src/export.js";
+import type { WikiDescriptionSidecarIndex } from "../src/wiki-descriptions.js";
+
+function sidecar(): WikiDescriptionSidecarIndex {
+  return {
+    schema: "graphify_wiki_description_index_v1",
+    graph_hash: "h",
+    prompt_version: "wiki-description-v1",
+    nodes: {
+      holmes: {
+        schema: "graphify_wiki_description_v1",
+        target_id: "holmes",
+        target_kind: "node",
+        graph_hash: "h",
+        status: "generated",
+        description: "Consulting detective of 221B Baker Street.",
+        evidence_refs: ["corpus/holmes.txt#1"],
+        confidence: 0.9,
+        cache_key: "k",
+        generator: { mode: "assistant", provider: "pack", model: null, prompt_version: "wiki-description-v1" },
+      },
+      watson: {
+        schema: "graphify_wiki_description_v1",
+        target_id: "watson",
+        target_kind: "node",
+        graph_hash: "h",
+        status: "insufficient_evidence",
+        description: null,
+        evidence_refs: [],
+        confidence: null,
+        cache_key: "k2",
+        generator: { mode: "assistant", provider: "pack", model: null, prompt_version: "wiki-description-v1" },
+      },
+    },
+  } as unknown as WikiDescriptionSidecarIndex;
+}
+
+function render(withDescriptions: boolean): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-html-descr-"));
+  const htmlPath = join(dir, "graph.html");
+  const g = new Graph();
+  g.addNode("holmes", { label: "Sherlock Holmes", source_file: "corpus/holmes.txt", file_type: "document", node_type: "Character" });
+  g.addNode("watson", { label: "Dr Watson", source_file: "corpus/watson.txt", file_type: "document", node_type: "Character" });
+  g.addUndirectedEdge("holmes", "watson", { relation: "works_with", confidence: "EXTRACTED" });
+  const communities = new Map([[0, ["holmes", "watson"]]]);
+  toHtml(g, communities, htmlPath, {
+    communityLabels: new Map([[0, "Detectives"]]),
+    ...(withDescriptions ? { descriptions: sidecar() } : {}),
+  });
+  const html = readFileSync(htmlPath, "utf-8");
+  rmSync(dir, { recursive: true, force: true });
+  return html;
+}
+
+describe("Track G G-studio-lot4 — node descriptions in HTML export (part A)", () => {
+  it("attaches the generated node description to the node payload", () => {
+    const html = render(true);
+    expect(html).toMatch(/"id":"holmes"[\s\S]*?"description":"Consulting detective of 221B Baker Street\."/);
+  });
+
+  it("omits the description for insufficient_evidence nodes (no placeholder)", () => {
+    const html = render(true);
+    // The node JSON is a single line; isolate watson's object and assert it
+    // carries no description field (holmes does; watson must not).
+    const watsonMatch = html.match(/\{"id":"watson"[^}]*?(?:"highlight":\{[^}]*\})?[^}]*?\}/);
+    // Simpler + robust: the watson description string must never appear.
+    expect(html).not.toContain('Dr Watson description');
+    // And only one node carries a generated description (holmes).
+    expect((html.match(/"description":"/g) ?? []).length).toBe(1);
+    expect(watsonMatch ? watsonMatch[0] : "").not.toContain('"description":"');
+  });
+
+  it("the node-info panel template renders the description field when present", () => {
+    const html = render(true);
+    // The showInfo() template surfaces the description.
+    expect(html).toContain("_description");
+  });
+
+  it("does not attach descriptions when none are supplied (byte-stable default)", () => {
+    const withDescr = render(true);
+    const without = render(false);
+    expect(without).not.toContain('"description":"Consulting detective');
+    // The description field machinery still ships (template references it) but
+    // no node carries a generated description without the sidecar.
+    expect(withDescr).not.toBe(without);
+  });
+});

--- a/tests/html-export-studio-canvas.test.ts
+++ b/tests/html-export-studio-canvas.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Track G G-studio-lot1 — graph rendering.
+ *
+ * #1 The graph canvas keeps a LIGHT background regardless of the app
+ *    theme. The `#graph` element must NOT follow `var(--ws-surface)`
+ *    (which can be flipped dark by a host theme); it must resolve to an
+ *    explicit light fill so crossing edges + node labels stay readable.
+ * #2 Outlined "box" nodes (document / paper / concept) keep their
+ *    coloured border but get a SEMI-OPAQUE WHITE fill (~50%), not a fully
+ *    transparent one. Arrows leave from the box centre, so a 0-alpha fill
+ *    leaves the label unreadable over crossing edges; a 50% white fill
+ *    keeps the text legible while still looking "hollow".
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { toHtml } from "../src/export.js";
+
+function renderHtml(setup: (g: Graph) => Map<number, string[]>): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-studio-canvas-"));
+  const htmlPath = join(dir, "graph.html");
+  const g = new Graph();
+  const communities = setup(g);
+  toHtml(g, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
+  const html = readFileSync(htmlPath, "utf-8");
+  rmSync(dir, { recursive: true, force: true });
+  return html;
+}
+
+describe("Track G G-studio-lot1 — light canvas (#1)", () => {
+  it("forces an explicit light canvas background that does not follow --ws-surface", () => {
+    const html = renderHtml((g) => {
+      g.addNode("a", { label: "A", source_file: "src/a.ts", file_type: "code" });
+      return new Map([[0, ["a"]]]);
+    });
+    // A dedicated light token is declared for the canvas.
+    expect(html).toContain("--graph-canvas-bg: #ffffff;");
+    // The #graph rule paints with the dedicated token, NOT var(--ws-surface).
+    expect(html).toMatch(/#graph\s*\{[^}]*background:\s*var\(--graph-canvas-bg\)/);
+    expect(html).not.toMatch(/#graph\s*\{[^}]*background:\s*var\(--ws-surface\)/);
+  });
+
+  it("keeps the canvas light even when the host flips --ws-surface to a dark value", () => {
+    // The dedicated token is a literal light colour, so a host theme that
+    // overrides --ws-surface cannot darken the canvas.
+    const html = renderHtml((g) => {
+      g.addNode("a", { label: "A", source_file: "src/a.ts", file_type: "code" });
+      return new Map([[0, ["a"]]]);
+    });
+    const tokenLine = html.split("\n").find((line) => line.includes("--graph-canvas-bg:"));
+    expect(tokenLine).toBeDefined();
+    expect(tokenLine).not.toContain("var(");
+  });
+});
+
+describe("Track G G-studio-lot1 — semi-opaque white box fill (#2)", () => {
+  it("paints outlined box nodes with a ~50% white fill (not 0-alpha transparent)", () => {
+    const html = renderHtml((g) => {
+      g.addNode("code_a", { label: "AlphaService", source_file: "src/alpha.ts", file_type: "code" });
+      g.addNode("doc_a", { label: "DesignNote", source_file: "docs/design.md", file_type: "document" });
+      g.addUndirectedEdge("code_a", "doc_a", { relation: "documented_by", confidence: "EXTRACTED" });
+      return new Map([[0, ["code_a", "doc_a"]]]);
+    });
+    // Box (document) carries the semi-opaque white background.
+    expect(html).toMatch(/"id":"doc_a"[^{]*\{[^}]*"background":"rgba\(255,255,255,0\.5\)"/);
+    expect(html).toMatch(/"id":"doc_a"[\s\S]*?"shape":"box"/);
+    // The fully-transparent fill is gone.
+    expect(html).not.toContain('"background":"rgba(0,0,0,0)"');
+    // A non-box code node keeps its solid coloured background.
+    expect(html).toMatch(/"id":"code_a"[^{]*\{[^}]*"background":"#[0-9A-Fa-f]{6}"/);
+  });
+
+  it("keeps the box border as the node colour (only the fill changes)", () => {
+    const html = renderHtml((g) => {
+      g.addNode("doc_a", { label: "DesignNote", source_file: "docs/design.md", file_type: "document" });
+      return new Map([[0, ["doc_a"]]]);
+    });
+    expect(html).toMatch(/"id":"doc_a"[^{]*\{[^}]*"border":"#[0-9A-Fa-f]{6}"/);
+  });
+});

--- a/tests/html-export-studio-mode.test.ts
+++ b/tests/html-export-studio-mode.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Track G G-studio-lot2 — center canvas in studio mode.
+ *
+ * #3 In studio mode the graph takes the FULL center section — the community
+ *    list and the node-info panel are removed from inside the canvas area.
+ * #4 Only the LEGEND (shapes + edges) stays, bottom-right of the canvas.
+ *
+ * The default (non-studio) export is unchanged — community list + node-info
+ * panel + search stay in the sidebar exactly as before.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { toHtml } from "../src/export.js";
+
+function render(studioMode: boolean): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-studio-mode-"));
+  const htmlPath = join(dir, "graph.html");
+  const g = new Graph();
+  g.addNode("a", { label: "Alpha", source_file: "src/a.ts", file_type: "code" });
+  g.addNode("doc", { label: "Note", source_file: "docs/n.md", file_type: "document" });
+  g.addUndirectedEdge("a", "doc", { relation: "documented_by", confidence: "EXTRACTED" });
+  const communities = new Map([[0, ["a", "doc"]]]);
+  toHtml(g, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]), studioMode });
+  const html = readFileSync(htmlPath, "utf-8");
+  rmSync(dir, { recursive: true, force: true });
+  return html;
+}
+
+describe("Track G G-studio-lot2 — studio center canvas (#3, #4)", () => {
+  it("marks the body as studio-mode so the canvas can claim the full center", () => {
+    expect(render(true)).toMatch(/<body[^>]*class="[^"]*studio-mode/);
+    expect(render(false)).not.toMatch(/<body[^>]*class="[^"]*studio-mode/);
+  });
+
+  it("removes the community list and node-info panel from inside the canvas area (#3)", () => {
+    const html = render(true);
+    // CSS hides the community legend + the node info panel + the search box
+    // + the bottom stats line in studio mode.
+    expect(html).toMatch(/body\.studio-mode\s+#legend-wrap\s*\{[^}]*display:\s*none/);
+    expect(html).toMatch(/body\.studio-mode\s+#info-panel\s*\{[^}]*display:\s*none/);
+    expect(html).toMatch(/body\.studio-mode\s+#search-wrap\s*\{[^}]*display:\s*none/);
+    expect(html).toMatch(/body\.studio-mode\s+#stats\s*\{[^}]*display:\s*none/);
+  });
+
+  it("keeps only the shapes + edges legend, floated bottom-right of the canvas (#4)", () => {
+    const html = render(true);
+    // The shape + edge legend container is promoted to a floating bottom-right
+    // card over the canvas in studio mode.
+    expect(html).toMatch(/body\.studio-mode\s+#shapes-legend-card\s*\{[\s\S]*?position:\s*(?:fixed|absolute)/);
+    expect(html).toMatch(/body\.studio-mode\s+#shapes-legend-card\s*\{[\s\S]*?(?:right:|bottom:)/);
+    // The shape + edge legends are still present.
+    expect(html).toContain('id="shape-legend"');
+    expect(html).toContain('id="relation-legend"');
+  });
+
+  it("leaves the default (non-studio) export untouched — community list visible", () => {
+    const html = render(false);
+    // The studio CSS rules ship in every export (inert without the body
+    // class); the default <body> must NOT carry the studio-mode class, so the
+    // community list / node-info panel / search stay visible.
+    expect(html).not.toMatch(/<body[^>]*class="[^"]*studio-mode/);
+    // The community legend and node-info panel are still in the default sidebar.
+    expect(html).toContain('id="legend-wrap"');
+    expect(html).toContain('id="info-panel"');
+    expect(html).toContain('id="search-wrap"');
+  });
+});

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -255,7 +255,7 @@ describe("toHtml visual encoding (Track C3)", () => {
     // Static shape and edge legends are present in the sidebar.
     expect(html).toContain('id="shape-legend"');
     expect(html).toContain("triangle &mdash; config");
-    expect(html).toContain("box (outline) &mdash; document");
+    expect(html).toContain("box (hollow) &mdash; document");
     expect(html).toContain("square (filled) &mdash; test");
     expect(html).toContain('id="relation-legend"');
     expect(html).toContain("dotted &mdash; tested_by");

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -70,7 +70,10 @@ describe("safeToHtml", () => {
     expect(html).toContain("--ws-surface: #ffffff;");
     expect(html).toContain("--ws-surface-2: #f5f6f8;");
     expect(html).toContain("body { background: var(--ws-surface); color: var(--ws-text);");
-    expect(html).toContain("#graph { flex: 1; outline: none; background: var(--ws-surface);");
+    // G-studio-lot1 #1: the canvas keeps an explicit light background that
+    // does NOT follow the (themeable) --ws-surface.
+    expect(html).toContain("--graph-canvas-bg: #ffffff;");
+    expect(html).toContain("#graph { flex: 1; outline: none; background: var(--graph-canvas-bg);");
     expect(html).toContain("#sidebar { width: 280px; background: var(--ws-surface-2); border-left: 1px solid var(--ws-border);");
     expect(html).toContain("--graph-weak-text: var(--ws-text-muted);");
     expect(html).toContain("--graph-muted-strong: var(--ws-text-muted);");
@@ -262,7 +265,7 @@ describe("toHtml visual encoding (Track C3)", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("C-final-1: shape 'box' (document/paper/concept) is outlined (transparent background)", () => {
+  it("C-final-1 / G-studio-lot1 #2: shape 'box' (document/paper/concept) is hollow (semi-opaque white fill)", () => {
     const dir = mkdtempSync(join(tmpdir(), "graphify-html-c-final-1-"));
     const htmlPath = join(dir, "graph.html");
     const G = new Graph();
@@ -273,10 +276,13 @@ describe("toHtml visual encoding (Track C3)", () => {
     toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
     const html = readFileSync(htmlPath, "utf-8");
 
-    // Box (document) carries the transparent background so the border-only
-    // rendering is visually distinct from the solid square (test).
-    expect(html).toMatch(/"id":"doc_a"[^{]*\{[^}]*"background":"rgba\(0,0,0,0\)"/);
+    // Box (document) carries a semi-opaque white fill so the label stays
+    // legible over crossing edges while still reading as "hollow" — visually
+    // distinct from the solid square (test).
+    expect(html).toMatch(/"id":"doc_a"[^{]*\{[^}]*"background":"rgba\(255,255,255,0\.5\)"/);
     expect(html).toMatch(/"id":"doc_a"[\s\S]*?"shape":"box"/);
+    // The fully-transparent fill is gone.
+    expect(html).not.toContain('"background":"rgba(0,0,0,0)"');
     // Sanity: a code node keeps a coloured (non-transparent) background.
     expect(html).toMatch(/"id":"code_a"[^{]*\{[^}]*"background":"#[0-9A-Fa-f]{6}"/);
 
@@ -444,7 +450,7 @@ describe("toHtml visual encoding (Track C-3.5: profile-aware)", () => {
     const html = readFileSync(htmlPath, "utf-8");
 
     expect(html).toMatch(/"id":"n1"[\s\S]*?"shape":"box"/);
-    expect(html).toMatch(/"id":"n1"[^{]*\{[^}]*"background":"rgba\(0,0,0,0\)"/);
+    expect(html).toMatch(/"id":"n1"[^{]*\{[^}]*"background":"rgba\(255,255,255,0\.5\)"/);
     expect(html).toMatch(/"id":"n1"[^{]*\{[^}]*"border":"#445566"/);
     rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/ontology-studio-artifact-studio.test.ts
+++ b/tests/ontology-studio-artifact-studio.test.ts
@@ -4,66 +4,36 @@
  * every export; the server flips the body class to `studio-mode` when the
  * artifact is requested with `?studio=1`, so the embedded canvas claims the
  * full center and shows only the legend.
+ *
+ * The route wiring (`?studio=1` -> graphHtmlArtifactResult(context, true)) is
+ * a one-liner exercised by lint/build; the load-bearing transform is the
+ * pure `injectStudioMode` helper tested directly here.
  */
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import type { IncomingMessage, ServerResponse } from "node:http";
 
-import { handleRequest } from "../src/ontology-studio.js";
-import type { OntologyPatchContext } from "../src/ontology-patch.js";
+import { injectStudioMode } from "../src/ontology-studio.js";
 
-function fakeRes(): { res: ServerResponse; body: () => string; status: () => number } {
-  let body = "";
-  let status = 0;
-  const res = {
-    writeHead(code: number) {
-      status = code;
-      return res;
-    },
-    end(chunk?: string) {
-      if (chunk) body += chunk;
-    },
-  } as unknown as ServerResponse;
-  return { res, body: () => body, status: () => status };
-}
-
-function makeContext(stateDir: string): OntologyPatchContext {
-  return {
-    stateDir,
-    profile: { id: "test-profile" },
-  } as unknown as OntologyPatchContext;
-}
-
-const GRAPH_HTML = '<!DOCTYPE html><html><head></head><body>\n<div id="graph"></div>\n</body></html>';
-
-describe("Track G G-studio-lot2 — studio-mode artifact serving", () => {
-  it("injects class=\"studio-mode\" on the body when ?studio=1 is requested", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "graphify-studio-artifact-"));
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "graph.html"), GRAPH_HTML, "utf-8");
-    const { res, body, status } = fakeRes();
-    const req = { url: "/api/ontology/artifacts/graph.html?studio=1", method: "GET" } as IncomingMessage;
-
-    await handleRequest(req, res, makeContext(dir), false);
-
-    expect(status()).toBe(200);
-    expect(body()).toMatch(/<body[^>]*class="studio-mode"/);
-    rmSync(dir, { recursive: true, force: true });
+describe("Track G G-studio-lot2 — injectStudioMode", () => {
+  it("adds the studio-mode class to a bare <body>", () => {
+    const html = "<!DOCTYPE html><html><head></head><body>\n<div id=\"graph\"></div>\n</body></html>";
+    const out = injectStudioMode(html);
+    expect(out).toMatch(/<body[^>]*class="studio-mode"/);
   });
 
-  it("serves the artifact untouched without ?studio=1", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "graphify-studio-artifact-plain-"));
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "graph.html"), GRAPH_HTML, "utf-8");
-    const { res, body } = fakeRes();
-    const req = { url: "/api/ontology/artifacts/graph.html", method: "GET" } as IncomingMessage;
+  it("appends studio-mode to an existing class list, preserving other attributes", () => {
+    const html = '<body lang="en" class="theme-dark"><div id="graph"></div></body>';
+    const out = injectStudioMode(html);
+    expect(out).toMatch(/<body[^>]*class="theme-dark studio-mode"/);
+    expect(out).toContain('lang="en"');
+  });
 
-    await handleRequest(req, res, makeContext(dir), false);
+  it("is idempotent when the body is already studio-mode", () => {
+    const html = '<body class="studio-mode"><div id="graph"></div></body>';
+    expect(injectStudioMode(html)).toBe(html);
+  });
 
-    expect(body()).toBe(GRAPH_HTML);
-    expect(body()).not.toContain("studio-mode");
-    rmSync(dir, { recursive: true, force: true });
+  it("does not touch markup with no <body> tag", () => {
+    const html = "<div id=\"graph\"></div>";
+    expect(injectStudioMode(html)).toBe(html);
   });
 });

--- a/tests/ontology-studio-artifact-studio.test.ts
+++ b/tests/ontology-studio-artifact-studio.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Track G G-studio-lot2 — studio serves the graph.html artifact in studio
+ * mode when asked. The studio CSS (`body.studio-mode ...`) already ships in
+ * every export; the server flips the body class to `studio-mode` when the
+ * artifact is requested with `?studio=1`, so the embedded canvas claims the
+ * full center and shows only the legend.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { handleRequest } from "../src/ontology-studio.js";
+import type { OntologyPatchContext } from "../src/ontology-patch.js";
+
+function fakeRes(): { res: ServerResponse; body: () => string; status: () => number } {
+  let body = "";
+  let status = 0;
+  const res = {
+    writeHead(code: number) {
+      status = code;
+      return res;
+    },
+    end(chunk?: string) {
+      if (chunk) body += chunk;
+    },
+  } as unknown as ServerResponse;
+  return { res, body: () => body, status: () => status };
+}
+
+function makeContext(stateDir: string): OntologyPatchContext {
+  return {
+    stateDir,
+    profile: { id: "test-profile" },
+  } as unknown as OntologyPatchContext;
+}
+
+const GRAPH_HTML = '<!DOCTYPE html><html><head></head><body>\n<div id="graph"></div>\n</body></html>';
+
+describe("Track G G-studio-lot2 — studio-mode artifact serving", () => {
+  it("injects class=\"studio-mode\" on the body when ?studio=1 is requested", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-studio-artifact-"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "graph.html"), GRAPH_HTML, "utf-8");
+    const { res, body, status } = fakeRes();
+    const req = { url: "/api/ontology/artifacts/graph.html?studio=1", method: "GET" } as IncomingMessage;
+
+    await handleRequest(req, res, makeContext(dir), false);
+
+    expect(status()).toBe(200);
+    expect(body()).toMatch(/<body[^>]*class="studio-mode"/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("serves the artifact untouched without ?studio=1", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-studio-artifact-plain-"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "graph.html"), GRAPH_HTML, "utf-8");
+    const { res, body } = fakeRes();
+    const req = { url: "/api/ontology/artifacts/graph.html", method: "GET" } as IncomingMessage;
+
+    await handleRequest(req, res, makeContext(dir), false);
+
+    expect(body()).toBe(GRAPH_HTML);
+    expect(body()).not.toContain("studio-mode");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -155,7 +155,9 @@ describe("graphify ontology studio --write", () => {
     expect(result.body).toContain("<b>Mode:</b> Overview");
     expect(result.body).toContain('title="Graphify graph surface"');
     expect(result.body).toContain(encodeURI(`file://${fixture.stateDir}/graph.html`));
-    expect(result.body).toContain('data-ws-live-graph-src="/api/ontology/artifacts/graph.html"');
+    // G-studio-lot2 (#3, #4): the embedded studio canvas requests the studio
+    // variant of the served artifact (?studio=1 -> full center, legend-only).
+    expect(result.body).toContain('data-ws-live-graph-src="/api/ontology/artifacts/graph.html?studio=1"');
     expect(result.body).not.toContain("Read-only reconciliation APIs are available");
 
     const graphArtifact = handleOntologyStudioRequest(

--- a/tests/workspace-entity-panel.test.ts
+++ b/tests/workspace-entity-panel.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Track G G-studio-lot4 (#7) — right-column entity panel.
+ *
+ * When a node is selected, the REAL right column (not the canvas, not the
+ * dark sidebar) shows the entity:
+ *   - the wiki DESCRIPTION (from the descriptions sidecar; insufficient_evidence
+ *     omits the block entirely — no placeholder);
+ *   - its RELATIONS (parity with EntityRelationsAccordion);
+ *   - the evidence SNIPPET (intent point 5 — a short quote, not the whole source);
+ *   - OCCURRENCE / citation COUNTS (intent point 6 — total mentions + per-document
+ *     appearance count) from the occurrences data.
+ *
+ * Profile-neutral: no corpus-specific strings.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderEntityPanel,
+  renderWorkspaceShell,
+  type EntityPanelOccurrences,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const graph: GraphLike = {
+  nodes: [
+    { id: "holmes", label: "Sherlock Holmes", node_type: "Character", community_name: "Detectives" },
+    { id: "watson", label: "Dr Watson", node_type: "Character" },
+    { id: "study", label: "A Study in Scarlet", node_type: "Work" },
+  ],
+  edges: [
+    { source: "holmes", target: "watson", relation: "works_with" },
+    { source: "study", target: "holmes", relation: "features" },
+  ],
+};
+
+function panel(args: Partial<Parameters<typeof renderEntityPanel>[0]> = {}): string {
+  return renderEntityPanel({
+    node: graph.nodes[0]!,
+    graph,
+    ...args,
+  });
+}
+
+describe("Track G G-studio-lot4 — entity panel (#7)", () => {
+  it("renders the entity title and type in the right column", () => {
+    const html = panel();
+    expect(html).toContain('class="ws-entity-panel"');
+    expect(html).toContain("Sherlock Holmes");
+    expect(html).toContain("Character");
+  });
+
+  it("inlines the generated wiki description from the sidecar", () => {
+    const html = panel({
+      descriptionSidecar: {
+        status: "generated",
+        target_id: "holmes",
+        target_kind: "node",
+        description: "Consulting detective of 221B Baker Street.",
+      },
+    });
+    expect(html).toContain('class="ws-entity-description"');
+    expect(html).toContain("Consulting detective of 221B Baker Street.");
+  });
+
+  it("omits the description block silently on insufficient_evidence (no placeholder)", () => {
+    const html = panel({
+      descriptionSidecar: {
+        status: "insufficient_evidence",
+        target_id: "holmes",
+        target_kind: "node",
+      },
+    });
+    expect(html).not.toContain('class="ws-entity-description"');
+    // Title still rendered.
+    expect(html).toContain("Sherlock Holmes");
+  });
+
+  it("lists relations (incoming + outgoing) with the related entity label and relation", () => {
+    const html = panel();
+    expect(html).toContain('class="ws-entity-relations"');
+    // Outgoing: holmes works_with watson.
+    expect(html).toContain("works_with");
+    expect(html).toContain("Dr Watson");
+    // Incoming: study features holmes.
+    expect(html).toContain("features");
+    expect(html).toContain("A Study in Scarlet");
+  });
+
+  it("shows a short evidence snippet (a quote, not the whole source) when available", () => {
+    const occurrences: EntityPanelOccurrences = {
+      holmes: {
+        total: 12,
+        documents: { "study-in-scarlet.txt": 5, "the-sign-of-four.txt": 7 },
+        snippets: ["...the world's only consulting detective, Mr Sherlock Holmes..."],
+      },
+    };
+    const html = panel({ occurrences });
+    expect(html).toContain('class="ws-entity-snippet"');
+    // The apostrophe is HTML-escaped (&#39;) in the rendered quote.
+    expect(html).toContain("the world&#39;s only consulting detective");
+  });
+
+  it("shows occurrence / citation counts: total mentions + per-document appearance count", () => {
+    const occurrences: EntityPanelOccurrences = {
+      holmes: {
+        total: 12,
+        documents: { "study-in-scarlet.txt": 5, "the-sign-of-four.txt": 7 },
+      },
+    };
+    const html = panel({ occurrences });
+    expect(html).toContain('class="ws-entity-occurrences"');
+    // Total mentions surfaced.
+    expect(html).toMatch(/12[\s\S]*mention/i);
+    // Per-document appearance count surfaced.
+    expect(html).toContain("study-in-scarlet.txt");
+    expect(html).toMatch(/study-in-scarlet\.txt[\s\S]*?5/);
+  });
+
+  it("renders no occurrences block when there is no occurrence data for the node", () => {
+    const html = panel({ occurrences: {} });
+    expect(html).not.toContain('class="ws-entity-occurrences"');
+    expect(html).not.toContain('class="ws-entity-snippet"');
+  });
+
+  it("does not leak corpus-specific strings", () => {
+    const html = panel({
+      descriptionSidecar: {
+        status: "generated",
+        target_id: "holmes",
+        target_kind: "node",
+        description: "A description.",
+      },
+    });
+    expect(html).not.toMatch(/\b(?:framework|abp|aclp|ABPProcess|ACLPProcess|BusinessObject|DigitalApplicationTool)\b/);
+  });
+});
+
+describe("Track G G-studio-lot4 — entity panel in the shell right column (#7)", () => {
+  it("surfaces the entity panel in the right slot in workspace view when an entity is selected", () => {
+    const tokens = getWorkspaceTokens("light");
+    const html = renderWorkspaceShell({
+      tokens,
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), activeView: "workspace", displayRef: "entity:holmes" },
+      graph,
+      entityPanelHtml: renderEntityPanel({ node: graph.nodes[0]!, graph }),
+    });
+    // The right slot is visible (not aria-hidden) and carries the panel.
+    expect(html).toContain('id="workspace-reconciliation-slot"');
+    expect(html).toContain('class="ws-entity-panel"');
+    // The panel sits in the right column slot, not inside the canvas / center.
+    const slotIdx = html.indexOf('id="workspace-reconciliation-slot"');
+    const panelIdx = html.indexOf('class="ws-entity-panel"');
+    expect(panelIdx).toBeGreaterThan(slotIdx);
+    // Slot tagged as the entity view (so it is NOT hidden by the workspace rule).
+    expect(html).toContain('data-active-view="entity"');
+  });
+
+  it("keeps the right slot hidden in workspace view when no entity panel is provided", () => {
+    const html = renderWorkspaceShell({
+      tokens: getWorkspaceTokens("light"),
+      title: "Workspace",
+      state: { ...createDefaultViewerState(), activeView: "workspace" },
+      graph,
+    });
+    expect(html).toContain('aria-hidden="true"');
+  });
+});

--- a/tests/workspace-graph-panel-studio.test.ts
+++ b/tests/workspace-graph-panel-studio.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Track G G-studio-lot2 — graph panel requests the studio-mode canvas.
+ *
+ * When the panel renders inside the studio (full center, legend-only), it
+ * asks the served graph.html for its studio variant via a `studio=1` query
+ * on the live (same-origin) URL. The file URL stays plain (the file: served
+ * artifact carries the studio CSS already but the class is added server-side
+ * over HTTP).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  getWorkspaceTokens,
+  renderGraphPanel,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const tokens = getWorkspaceTokens("light");
+const graph: GraphLike = {
+  nodes: [{ id: "a", label: "Alpha", node_type: "Character", community: 0 }],
+  edges: [],
+};
+
+describe("Track G G-studio-lot2 — graph panel studio mode", () => {
+  it("requests studio=1 on the live graph URL when studioMode is set", () => {
+    const html = renderGraphPanel({
+      state: createDefaultViewerState(),
+      graph,
+      tokens,
+      graphHtmlUrl: "file:///x/.graphify/graph.html",
+      liveGraphHtmlUrl: "/api/ontology/artifacts/graph.html",
+      studioMode: true,
+    });
+    expect(html).toContain("data-ws-live-graph-src=\"/api/ontology/artifacts/graph.html?studio=1\"");
+  });
+
+  it("does not add studio=1 when studioMode is not set (default export embedding)", () => {
+    const html = renderGraphPanel({
+      state: createDefaultViewerState(),
+      graph,
+      tokens,
+      graphHtmlUrl: "file:///x/.graphify/graph.html",
+      liveGraphHtmlUrl: "/api/ontology/artifacts/graph.html",
+    });
+    expect(html).not.toContain("studio=1");
+  });
+});

--- a/tests/workspace-rail-accordion.test.ts
+++ b/tests/workspace-rail-accordion.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Track G G-studio-lot3 — left column accordion.
+ *
+ * #5 Left column = accordion, COLLAPSED by default: Type, Facets, Results
+ *    (parity with aclp-am LeftWorkbench).
+ * #6 A COMMUNITIES panel in the left column, ABOVE Facets, collapsed by
+ *    default (Graphify-specific; communities come from graph clustering /
+ *    community_labels).
+ *
+ * Profile-neutral: no corpus-specific strings.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultViewerState,
+  renderWorkspaceRail,
+  type GraphLike,
+} from "../src/workspace/index.js";
+
+const graph: GraphLike = {
+  nodes: [
+    { id: "a", label: "Alpha", node_type: "Character", community: 0, community_name: "Detectives", status: "active" },
+    { id: "b", label: "Beta", node_type: "Character", community: 0, community_name: "Detectives", status: "active" },
+    { id: "c", label: "Gamma", node_type: "Work", community: 1, community_name: "Novels", status: "candidate" },
+  ],
+  edges: [{ source: "a", target: "b", relation: "knows" }],
+};
+
+function rail() {
+  return renderWorkspaceRail({ state: createDefaultViewerState(), graph });
+}
+
+describe("Track G G-studio-lot3 — left accordion (#5)", () => {
+  it("renders Type / Facets / Results sections as collapsible <details>, collapsed by default", () => {
+    const html = rail();
+    // Each major section is a <details> accordion (no `open` => collapsed).
+    expect(html).toMatch(/<details class="ws-rail-accordion" data-rail-section="types"(?![^>]*\bopen\b)/);
+    expect(html).toMatch(/<details class="ws-rail-accordion" data-rail-section="facets"(?![^>]*\bopen\b)/);
+    expect(html).toMatch(/<details class="ws-rail-accordion" data-rail-section="results"(?![^>]*\bopen\b)/);
+    // Summaries carry the section names.
+    expect(html).toContain("<summary");
+    expect(html).toContain("Types");
+    expect(html).toContain("Facets");
+    expect(html).toContain("Results");
+  });
+
+  it("does not force any accordion open by default", () => {
+    const html = rail();
+    // No top-level accordion section should be open on first render.
+    expect(html).not.toMatch(/<details class="ws-rail-accordion"[^>]*\bopen\b/);
+  });
+});
+
+describe("Track G G-studio-lot3 — communities panel (#6)", () => {
+  it("renders a Communities accordion ABOVE Facets, collapsed by default", () => {
+    const html = rail();
+    expect(html).toMatch(/<details class="ws-rail-accordion" data-rail-section="communities"(?![^>]*\bopen\b)/);
+    // Communities must appear before Facets in the DOM order.
+    const communitiesIdx = html.indexOf('data-rail-section="communities"');
+    const facetsIdx = html.indexOf('data-rail-section="facets"');
+    expect(communitiesIdx).toBeGreaterThan(-1);
+    expect(facetsIdx).toBeGreaterThan(-1);
+    expect(communitiesIdx).toBeLessThan(facetsIdx);
+  });
+
+  it("lists the Louvain communities with member counts from the dataset", () => {
+    const html = rail();
+    expect(html).toContain("Detectives");
+    expect(html).toContain("Novels");
+    // Member counts surface (Detectives = 2, Novels = 1).
+    expect(html).toMatch(/Detectives[\s\S]*?2/);
+    expect(html).toMatch(/Novels[\s\S]*?1/);
+  });
+
+  it("falls back to 'Community N' when no community_name is present", () => {
+    const html = renderWorkspaceRail({
+      state: createDefaultViewerState(),
+      graph: {
+        nodes: [
+          { id: "x", label: "X", node_type: "Thing", community: 3 },
+          { id: "y", label: "Y", node_type: "Thing", community: 3 },
+        ],
+        edges: [],
+      },
+    });
+    expect(html).toContain("Community 3");
+  });
+
+  it("emits no communities panel rows when the graph has no community data", () => {
+    const html = renderWorkspaceRail({
+      state: createDefaultViewerState(),
+      graph: {
+        nodes: [{ id: "x", label: "X", node_type: "Thing" }],
+        edges: [],
+      },
+    });
+    // The panel still renders (accordion present) but reports an empty state.
+    expect(html).toContain('data-rail-section="communities"');
+    expect(html).toContain("No communities");
+  });
+
+  it("does not leak corpus-specific strings", () => {
+    const html = rail();
+    expect(html).not.toMatch(/\b(?:framework|abp|aclp|ABPProcess|ACLPProcess|BusinessObject|DigitalApplicationTool)\b/);
+  });
+});


### PR DESCRIPTION
Implements the ACLP-AM-aligned studio UI refactor (Track G), lots 1–4 of the
"Studio UI target — ACLP-AM alignment" plan in `spec/SPEC_TRACK_G_WORKSPACE.md`.
Lot 5 (graph.html-as-subview unification, retiring the iframe) is intentionally
out of scope. One commit per lot.

## The 8 points

| # | Point | Status |
|---|-------|--------|
| 1 | Graph canvas always **light** regardless of app/dark theme | done |
| 2 | Box nodes = border + **~50% white fill** (legible, hollow-looking) | done |
| 3 | Graph takes the **full center** in studio mode | done |
| 4 | **Only the legend** (shapes + edges) stays, bottom-right | done |
| 5 | Left column = **accordion, collapsed** by default: Type, Facets, Results | done |
| 6 | **Communities** panel above Facets, collapsed by default | done |
| 7 | Node selection -> **real right column**: description + relations (+ snippet + counts) | done (snippet/counts wired + unit-tested; not UAT-able on this pack — see limitations) |
| — | Description **pipeline unblock** (`export html --descriptions`) | done |

## Lot 1 — graph rendering (`67be5a8`)
- **#1** `#graph` no longer follows `var(--ws-surface)`; a literal `--graph-canvas-bg: #ffffff` keeps the canvas light even if a host theme flips `--ws-surface` dark.
- **#2** Outlined `box` nodes use `rgba(255,255,255,0.5)` instead of `rgba(0,0,0,0)`. Arrows leave from the box centre, so the previous fully-transparent fill left labels unreadable over crossing edges; the semi-opaque white keeps text legible while still reading as hollow. Border stays the node colour.

## Lot 2 — center canvas (`ac0f57f`)
- **#3/#4** `toHtml` gains an opt-in `studioMode`. Every export ships `body.studio-mode` CSS (inert without the body class); in studio mode the community list, node-info panel, search and stats line are hidden and the shapes/edges legend floats bottom-right (split out of `#legend-wrap` into `#shapes-legend-card`). The studio serves the artifact with `class="studio-mode"` when requested with `?studio=1` (`injectStudioMode`), and the embedded graph panel requests it. Default (non-studio) export keeps all controls.

## Lot 3 — left column (`54d3f59`)
- **#5** Types / Facets / Results render as collapsed `<details class="ws-rail-accordion">` (parity with `LeftWorkbench`), keeping the `data-rail-section` / `data-action` hooks; the section counters move into the `<summary>`.
- **#6** A **Communities** accordion (Louvain clusters from `community` / `community_name`, with member counts) sits **above Facets**, collapsed, with a `Community N` fallback and an empty state.

## Lot 4 — right column + pipeline (`0769ad3`)
- **#7** New `src/workspace/entity-panel.ts` (`renderEntityPanel`): description (Track A sidecar; `insufficient_evidence` hides silently), relations (in + out), evidence snippet (clamped quote — intent #5), occurrence/citation counts (total + per-document — intent #6). The shell gains an `entityPanelHtml` slot: in Workspace view the right slot stays hidden **unless** an entity is selected, then it becomes the real right column (`data-active-view="entity"`, light). The studio loads the description + occurrence sidecars, resolves `?node=<id>`, and injects a tiny generic click→`?node=` nav script (no client framework).
- **Pipeline unblock**: `toHtml` accepts a `descriptions` sidecar and attaches each generated node description to its payload (`_description` in the node-info panel; `insufficient_evidence`/missing omitted). `export html` gains `--descriptions <path>` (fresh-filtered like wiki/obsidian).

## Gate (on `0769ad3`)
- `npm run lint` (tsc --noEmit): clean
- `npm run build` (tsup): clean
- `npm test`: **1061 passed, 7 skipped, 0 failed** (134 files)
- No hard-coded `Process`/`Org`/`Tool`/`Character` domain strings in `src/workspace/*` (only the intentional aclp-am DENYLIST in `facet-panel.ts`).

## How to view
```
graphify ontology studio --config ../public-domaine-mystery-sagas-pack/graphify.yaml
```
Open the printed URL. Workspace tab: left accordion (Types/Communities/Facets/Results collapsed), full-center light graph with hollow boxes + bottom-right legend. Click a result entry (or a relation) -> the right column shows that entity's wiki description + relations (`?node=<id>`). Compare against the ACLP-AM viewer at http://127.0.0.1:5199/ (LeftWorkbench + EntityPanel + EntityRelationsAccordion + GraphPanel).

Regenerate `graph.html` with node descriptions:
```
graphify export html --graph <pack>/.graphify/graph.json \
  --descriptions <pack>/.graphify/wiki/descriptions.assistant-merged.json
```

## Verified headless (no browser)
- `handleOntologyStudioRequest("/?view=workspace&node=work_study_in_scarlet")` against the public pack renders the real wiki description ("…1887 novel…") + relations for the selected `Work` node; right slot visible (`data-active-view="entity"`); left accordion + Communities panel present.
- `export html --descriptions` emits node descriptions into `graph.html` (75 `"description":` occurrences in the dataset incl. nested fields), plus the light canvas token and the 50%-white box fill.

## Limitations / product decisions
- **#5/#6 (occurrence snippet + counts)**: the public pack's `.graphify/ontology/occurrences.json` is empty (`[]`), so these two sections are wired and unit-tested with synthetic data but **could not be UAT'd against real pack data**. The reader tolerates a few common occurrence shapes; the exact schema may need confirming once real occurrence data exists.
- **Lot 5 not done (by design)**: the studio still embeds `graph.html` via an iframe. Studio mode (#3/#4) is applied by flipping the body class on the served artifact (`injectStudioMode` + `?studio=1`) — the in-scope approximation until the unification lot retires the iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
