### PR TITLE
fix(track-g): studio defects D1–D8/D10/D11 — ontology graph, entity panel, DS audit clean

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ import {
   resolveConfiguredInputScopeSelection,
 } from "./input-scope.js";
 import { forEachTraversalNeighbor, loadGraphFromData } from "./graph.js";
+import { communitiesFromGraph, communityLabelsFromGraph } from "./graph-communities.js";
 import { safeExecGit } from "./git.js";
 import { safeGitRevParse } from "./git.js";
 import { discoverProjectConfig, loadProjectConfig } from "./project-config.js";
@@ -98,53 +99,14 @@ function loadCliGraph(graphPath: string): Graph {
 }
 
 function communitiesFromCliGraph(G: Graph): Map<number, string[]> {
-  const communities = new Map<number, string[]>();
-  G.forEachNode((nodeId, data) => {
-    const rawCommunity = data.community;
-    const community = typeof rawCommunity === "number"
-      ? rawCommunity
-      : typeof rawCommunity === "string" && rawCommunity.trim().length > 0
-        ? Number.parseInt(rawCommunity, 10)
-        : null;
-    if (community === null || Number.isNaN(community)) return;
-    const members = communities.get(community) ?? [];
-    members.push(nodeId);
-    communities.set(community, members);
-  });
-  return communities;
+  return communitiesFromGraph(G);
 }
 
 function communityLabelsFromCliGraph(
   G: Graph,
   communities: Map<number, string[]>,
 ): Map<number, string> {
-  const labels = new Map<number, string>();
-  const graphLabels = G.getAttribute("community_labels") as Record<string, unknown> | undefined;
-  if (graphLabels && typeof graphLabels === "object") {
-    for (const [key, value] of Object.entries(graphLabels)) {
-      const community = Number.parseInt(key, 10);
-      if (Number.isNaN(community)) continue;
-      if (typeof value === "string" && value.trim().length > 0) {
-        labels.set(community, value.trim());
-      }
-    }
-  }
-  G.forEachNode((_nodeId, data) => {
-    const rawCommunity = data.community;
-    const community = typeof rawCommunity === "number"
-      ? rawCommunity
-      : typeof rawCommunity === "string" && rawCommunity.trim().length > 0
-        ? Number.parseInt(rawCommunity, 10)
-        : null;
-    if (community === null || Number.isNaN(community) || labels.has(community)) return;
-    if (typeof data.community_name === "string" && data.community_name.trim().length > 0) {
-      labels.set(community, data.community_name.trim());
-    }
-  });
-  for (const community of communities.keys()) {
-    if (!labels.has(community)) labels.set(community, `Community ${community}`);
-  }
-  return labels;
+  return communityLabelsFromGraph(G, communities);
 }
 
 function resolvePortableCheckDir(inputPath: string = ".graphify"): string {

--- a/src/export.ts
+++ b/src/export.ts
@@ -1115,12 +1115,18 @@ announce(\`Graph loaded: \${RAW_NODES.length} node(s), \${RAW_EDGES.length} edge
 </script>`;
 }
 
-export function toHtml(
+/**
+ * Build the full graph HTML document as a string. Extracted from `toHtml` so
+ * the ontology studio can render a profile-aware, studio-mode graph as a
+ * sub-view of the workspace model (Track G D1/D2/D5/D8) without serving a
+ * stale on-disk `graph.html`. `outputPath` is used only for the page title.
+ */
+export function buildGraphHtml(
   G: Graph,
   communities: NumericMapLike<string[]>,
   outputPath: string,
   communityLabelsOrOptions?: CommunityLabelsInput | HtmlOptions,
-): void {
+): string {
   const communityMap = toNumericMap(communities);
   const communityLabels = normalizeCommunityLabels(communityLabelsOrOptions);
   const memberCounts = normalizeMemberCounts(communityLabelsOrOptions);
@@ -1349,7 +1355,25 @@ ${hyperedgeScript(hyperedgesJson)}
 </body>
 </html>`;
 
-  writeFileSync(outputPath, html, "utf-8");
+  return html;
+}
+
+/**
+ * Write the graph HTML produced by {@link buildGraphHtml} to disk. File-writing
+ * entry point for `graphify export html`; byte-stable with the previous
+ * behaviour.
+ */
+export function toHtml(
+  G: Graph,
+  communities: NumericMapLike<string[]>,
+  outputPath: string,
+  communityLabelsOrOptions?: CommunityLabelsInput | HtmlOptions,
+): void {
+  writeFileSync(
+    outputPath,
+    buildGraphHtml(G, communities, outputPath, communityLabelsOrOptions),
+    "utf-8",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/export.ts
+++ b/src/export.ts
@@ -955,6 +955,11 @@ network.on('click', params => {
     showInfo(params.nodes[0]);
     const n = nodesDS.get(params.nodes[0]);
     if (n) announce(\`Selected \${n.label}, in community \${n._community_name}, \${n._degree} connection(s).\`);
+    // Track G D4: when embedded in the studio shell, tell the parent which
+    // node was selected so it can open the right-column entity panel.
+    if (window.parent && window.parent !== window) {
+      try { window.parent.postMessage({ type: 'graphify:selectNode', nodeId: params.nodes[0] }, '*'); } catch (err) {}
+    }
   } else if (hoveredNodeId === null) {
     document.getElementById('info-content').innerHTML = '<span class="empty">Click a node to inspect it</span>';
   }

--- a/src/graph-communities.ts
+++ b/src/graph-communities.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared community extraction helpers for a loaded graphology graph.
+ *
+ * Previously private to `cli.ts`; lifted here so the ontology studio can
+ * regenerate a profile-aware graph HTML sub-view (Track G D1/D2/D5/D8) using
+ * the same community + label derivation as `graphify export html`.
+ */
+import type Graph from "graphology";
+
+function communityOf(rawCommunity: unknown): number | null {
+  if (typeof rawCommunity === "number") return rawCommunity;
+  if (typeof rawCommunity === "string" && rawCommunity.trim().length > 0) {
+    const parsed = Number.parseInt(rawCommunity, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+/** Group node ids by their `community` attribute. */
+export function communitiesFromGraph(G: Graph): Map<number, string[]> {
+  const communities = new Map<number, string[]>();
+  G.forEachNode((nodeId, data) => {
+    const community = communityOf(data.community);
+    if (community === null) return;
+    const members = communities.get(community) ?? [];
+    members.push(nodeId);
+    communities.set(community, members);
+  });
+  return communities;
+}
+
+/**
+ * Resolve a human label per community id. Precedence: graph-level
+ * `community_labels` attribute, then any node's `community_name`, then a
+ * `Community <id>` fallback so every community is labelled.
+ */
+export function communityLabelsFromGraph(
+  G: Graph,
+  communities: Map<number, string[]>,
+): Map<number, string> {
+  const labels = new Map<number, string>();
+  const graphLabels = G.getAttribute("community_labels") as Record<string, unknown> | undefined;
+  if (graphLabels && typeof graphLabels === "object") {
+    for (const [key, value] of Object.entries(graphLabels)) {
+      const community = Number.parseInt(key, 10);
+      if (Number.isNaN(community)) continue;
+      if (typeof value === "string" && value.trim().length > 0) {
+        labels.set(community, value.trim());
+      }
+    }
+  }
+  G.forEachNode((_nodeId, data) => {
+    const community = communityOf(data.community);
+    if (community === null || labels.has(community)) return;
+    if (typeof data.community_name === "string" && data.community_name.trim().length > 0) {
+      labels.set(community, data.community_name.trim());
+    }
+  });
+  for (const community of communities.keys()) {
+    if (!labels.has(community)) labels.set(community, `Community ${community}`);
+  }
+  return labels;
+}

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -8,6 +8,9 @@ import { URL } from "node:url";
 import { applyOntologyPatch, validateOntologyPatch } from "./ontology-patch.js";
 import { loadOntologyPatchContext } from "./ontology-patch-context.js";
 import { renderOntologyStudioWorkspace } from "./ontology-studio-workspace.js";
+import { buildGraphHtml } from "./export.js";
+import { loadGraphFromData } from "./graph.js";
+import { communitiesFromGraph, communityLabelsFromGraph } from "./graph-communities.js";
 import {
   getOntologyRebuildStatus,
   getOntologyReconciliationCandidate,
@@ -175,6 +178,27 @@ function graphHtmlArtifactResult(
   context: ReturnType<typeof loadOntologyPatchContext>,
   studioMode = false,
 ): OntologyStudioRouteResult {
+  // Track G D1/D2/D5/D8: render the graph as a generated sub-view of the studio
+  // model — built from graph.json with the project profile (ontology node-type
+  // shapes/colours) and the native studio variant — instead of serving a
+  // possibly-stale, profile-less on-disk graph.html. Falls back to the on-disk
+  // artifact when graph.json is unavailable or rendering fails (e.g. too large).
+  const graphJsonPath = join(context.stateDir, "graph.json");
+  if (existsSync(graphJsonPath)) {
+    try {
+      const graph = loadGraphFromData(JSON.parse(readFileSync(graphJsonPath, "utf-8")));
+      const communities = communitiesFromGraph(graph);
+      const communityLabels = communityLabelsFromGraph(graph, communities);
+      const html = buildGraphHtml(graph, communities, "graph.html", {
+        communityLabels,
+        ...(context.profile ? { profile: context.profile } : {}),
+        studioMode,
+      });
+      return { status: 200, contentType: "text/html; charset=utf-8", body: html };
+    } catch {
+      // Fall through to the pre-built artifact below.
+    }
+  }
   const graphHtmlPath = join(context.stateDir, "graph.html");
   if (!existsSync(graphHtmlPath)) {
     return jsonResult(404, { error: "graph.html not found" });

--- a/src/workspace/graph-panel.ts
+++ b/src/workspace/graph-panel.ts
@@ -174,6 +174,29 @@ function renderLiveGraphScript(enabled: boolean): string {
   ].join("\n");
 }
 
+/**
+ * Track G D4: parent-side bridge. The embedded graph posts
+ * `{ type: "graphify:selectNode", nodeId }` when a node is clicked; navigating
+ * to `?node=<id>` makes the server render the right-column entity panel (wiki
+ * description + relations). Only emitted when a graph surface is present.
+ */
+function renderSelectionBridgeScript(enabled: boolean): string {
+  if (!enabled) return "";
+  return [
+    "<script>",
+    "(() => {",
+    '  window.addEventListener("message", (event) => {',
+    "    const data = event.data;",
+    '    if (!data || data.type !== "graphify:selectNode" || !data.nodeId) return;',
+    "    const url = new URL(window.location.href);",
+    '    url.searchParams.set("node", String(data.nodeId));',
+    "    window.location.assign(url.toString());",
+    "  });",
+    "})();",
+    "</script>",
+  ].join("\n");
+}
+
 export function renderGraphPanel(opts: RenderGraphPanelOptions): string {
   const subgraph = computeFocusSubgraph(opts.graph, opts.state);
   const styles = [
@@ -189,5 +212,6 @@ export function renderGraphPanel(opts: RenderGraphPanelOptions): string {
     renderMetricsCard(subgraph, opts.state),
     renderViewerSurface(opts),
     renderLiveGraphScript(Boolean(opts.liveGraphHtmlUrl)),
+    renderSelectionBridgeScript(Boolean(opts.graphHtmlUrl)),
   ].filter(Boolean).join("\n");
 }

--- a/src/workspace/graph-panel.ts
+++ b/src/workspace/graph-panel.ts
@@ -99,7 +99,7 @@ function renderMetricsCard(subgraph: FocusSubgraph, state: WorkspaceViewerState)
   const m = subgraph.metrics;
   const hops = state.viewState.graph.focusHops;
   const weak = state.viewState.graph.showWeakLinks ? "yes" : "no";
-  const focus = state.focusEntityId ? escapeHtml(state.focusEntityId) : "—";
+  const focus = state.focusEntityId ? escapeHtml(state.focusEntityId) : "n/a";
   const fields = [
     `<span><b>Mode:</b> ${modeLabel(subgraph.appliedMode)}</span>`,
     `<span><b>Nodes:</b> ${m.nodes}</span>`,

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -556,7 +556,7 @@ function shellStyles(): string {
     "*:focus-visible { outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); }",
     ".ws-root { display: grid; grid-template-columns: 280px 1fr 320px; grid-template-rows: auto 1fr; min-height: 100vh; column-gap: 0; row-gap: 0; }",
     ".ws-header { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; gap: var(--ws-space-3); padding: var(--ws-space-3) var(--ws-space-4); border-bottom: 1px solid var(--ws-border); background: var(--ws-surface-2); }",
-    ".ws-header h1 { font-size: var(--ws-font-size-lg); margin: 0; }",
+    ".ws-header h1 { font-family: var(--ws-font-family-display); font-size: var(--ws-font-size-lg); margin: 0; }",
     ".ws-header-meta { font-size: var(--ws-font-size-sm); color: var(--ws-text-muted); display: flex; gap: var(--ws-space-3); align-items: center; }",
     // Top tabs (G6-3 S2.1).
     ".ws-tabs { display: inline-flex; gap: var(--ws-space-1); margin: 0; padding: 0; list-style: none; }",

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -551,7 +551,7 @@ function shellStyles(): string {
     "*, *::before, *::after { box-sizing: border-box; }",
     "html, body { margin: 0; padding: 0; height: 100%; }",
     "body { background: var(--ws-surface); color: var(--ws-text); font-family: var(--ws-font-family-sans); font-size: var(--ws-font-size-md); line-height: var(--ws-line-height-normal); }",
-    ".ws-skip-link { position: absolute; top: -40px; left: var(--ws-space-2); background: var(--ws-accent); color: #fff; padding: var(--ws-space-1) var(--ws-space-3); border-radius: 0 0 var(--ws-radius-sm) var(--ws-radius-sm); z-index: 1000; text-decoration: none; }",
+    ".ws-skip-link { position: absolute; top: -40px; left: var(--ws-space-2); background: var(--ws-accent); color: oklch(1 0 0); padding: var(--ws-space-1) var(--ws-space-3); border-radius: 0 0 var(--ws-radius-sm) var(--ws-radius-sm); z-index: 1000; text-decoration: none; }",
     ".ws-skip-link:focus-visible { top: var(--ws-space-1); outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); }",
     "*:focus-visible { outline: var(--ws-outline); outline-offset: var(--ws-outline-offset); outline-color: var(--ws-outline-color); }",
     ".ws-root { display: grid; grid-template-columns: 280px 1fr 320px; grid-template-rows: auto 1fr; min-height: 100vh; column-gap: 0; row-gap: 0; }",

--- a/src/workspace/shell.ts
+++ b/src/workspace/shell.ts
@@ -689,7 +689,7 @@ export function renderWorkspaceShell(opts: RenderWorkspaceShellOptions): string 
   const tokens = opts.tokens;
   const tokenSource = escapeHtml(opts.tokenSource ?? "fallback");
   const title = escapeHtml(opts.title);
-  const profileId = opts.profileId ? escapeHtml(opts.profileId) : "—";
+  const profileId = opts.profileId ? escapeHtml(opts.profileId) : "n/a";
   const lastRebuiltAt = opts.lastRebuiltAt ? escapeHtml(opts.lastRebuiltAt) : "";
   const writeFlag = opts.writeEnabled === true;
   const queueEmpty = opts.queueEmpty === true;

--- a/src/workspace/tokens-ds.ts
+++ b/src/workspace/tokens-ds.ts
@@ -38,6 +38,7 @@ const REQUIRED_KEYS: Record<WorkspaceTokenGroup, readonly string[]> = {
     "warning",
   ],
   typography: [
+    "font-family-display",
     "font-family-sans",
     "font-family-mono",
     "font-size-sm",

--- a/src/workspace/tokens-fallback.ts
+++ b/src/workspace/tokens-fallback.ts
@@ -19,6 +19,8 @@ import { DEFAULT_WORKSPACE_THEME } from "./tokens.js";
 import { tryGetDsTokens } from "./tokens-ds.js";
 
 const SHARED_TYPOGRAPHY = Object.freeze({
+  "font-family-display":
+    '"Segoe UI", system-ui, "Helvetica Neue", Arial, sans-serif',
   "font-family-sans":
     '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
   "font-family-mono":

--- a/src/workspace/tokens-fallback.ts
+++ b/src/workspace/tokens-fallback.ts
@@ -49,15 +49,15 @@ const SHARED_RADIUS = Object.freeze({
 
 const DARK_TOKENS: WorkspaceTokens = Object.freeze({
   colour: Object.freeze({
-    surface: "#0f111a",
-    "surface-2": "#1a1d2a",
-    border: "#2a2e3e",
-    text: "#e6e8ec",
-    "text-muted": "#9fa6b2",
-    accent: "#4E79A7",
-    danger: "#E15759",
-    success: "#59A14F",
-    warning: "#F28E2B",
+    surface: "oklch(0.18 0.0188 274.65)",
+    "surface-2": "oklch(0.2339 0.0255 274.22)",
+    border: "oklch(0.3044 0.0295 273.63)",
+    text: "oklch(0.9306 0.0058 264.53)",
+    "text-muted": "oklch(0.7233 0.0191 261.33)",
+    accent: "oklch(0.5645 0.0863 251.12)",
+    danger: "oklch(0.6383 0.1726 22.53)",
+    success: "oklch(0.6422 0.1371 141.33)",
+    warning: "oklch(0.7384 0.1595 59.42)",
   }),
   typography: SHARED_TYPOGRAPHY,
   spacing: SHARED_SPACING,
@@ -69,21 +69,21 @@ const DARK_TOKENS: WorkspaceTokens = Object.freeze({
   focusRing: Object.freeze({
     outline: "3px solid",
     "outline-offset": "2px",
-    "outline-color": "#ffd54f",
+    "outline-color": "oklch(0.8859 0.1539 91.23)",
   }),
 }) as WorkspaceTokens;
 
 const LIGHT_TOKENS: WorkspaceTokens = Object.freeze({
   colour: Object.freeze({
-    surface: "#ffffff",
-    "surface-2": "#f5f6f8",
-    border: "#d6d8df",
-    text: "#1a1d2a",
-    "text-muted": "#5b6271",
-    accent: "#2F5A8A",
-    danger: "#B2432D",
-    success: "#3F7A39",
-    warning: "#B9601E",
+    surface: "oklch(1 0 0)",
+    "surface-2": "oklch(0.9729 0.0029 264.54)",
+    border: "oklch(0.8827 0.0098 273.34)",
+    text: "oklch(0.2339 0.0255 274.22)",
+    "text-muted": "oklch(0.4955 0.0255 265.57)",
+    accent: "oklch(0.4601 0.0923 252.7)",
+    danger: "oklch(0.5319 0.1493 33.1)",
+    success: "oklch(0.5232 0.1151 141.93)",
+    warning: "oklch(0.5844 0.1367 51.89)",
   }),
   typography: SHARED_TYPOGRAPHY,
   spacing: SHARED_SPACING,
@@ -96,7 +96,7 @@ const LIGHT_TOKENS: WorkspaceTokens = Object.freeze({
   focusRing: Object.freeze({
     outline: "3px solid",
     "outline-offset": "2px",
-    "outline-color": "#A05E00",
+    "outline-color": "oklch(0.5448 0.1227 64.54)",
   }),
 }) as WorkspaceTokens;
 

--- a/src/workspace/tokens.ts
+++ b/src/workspace/tokens.ts
@@ -41,6 +41,9 @@ export interface WorkspaceColourTokens {
 }
 
 export interface WorkspaceTypographyTokens {
+  /** Display / heading family. Distinct from `font-family-sans` so the shell
+   *  carries a deliberate display + body hierarchy (DS convention). */
+  "font-family-display": string;
   "font-family-sans": string;
   "font-family-mono": string;
   "font-size-sm": string;

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -67,8 +67,8 @@ describe("safeToHtml", () => {
     toHtml(G, communities, htmlPath, { communityLabels: new Map([[0, "Core"]]) });
 
     const html = readFileSync(htmlPath, "utf-8");
-    expect(html).toContain("--ws-surface: #ffffff;");
-    expect(html).toContain("--ws-surface-2: #f5f6f8;");
+    expect(html).toContain("--ws-surface: oklch(1 0 0);");
+    expect(html).toContain("--ws-surface-2: oklch(0.9729 0.0029 264.54);");
     expect(html).toContain("body { background: var(--ws-surface); color: var(--ws-text);");
     // G-studio-lot1 #1: the canvas keeps an explicit light background that
     // does NOT follow the (themeable) --ws-surface.

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -305,6 +305,15 @@ describe("toHtml visual encoding (Track C3)", () => {
 
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it("graph HTML posts node selection to the embedding studio shell (D4)", () => {
+    const G = new Graph();
+    G.addNode("a", { label: "A", source_file: "src/a.ts", file_type: "code" });
+    const communities = new Map([[0, ["a"]]]);
+    const html = buildGraphHtml(G, communities, "graph.html", {});
+    expect(html).toContain("graphify:selectNode");
+    expect(html).toContain("window.parent.postMessage");
+  });
 });
 
 describe("toHtml visual encoding (Track C-3.5: profile-aware)", () => {

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "no
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Graph from "graphology";
-import { inferEdgeDashes, inferNodeShape, toHtml } from "../src/export.js";
+import { buildGraphHtml, inferEdgeDashes, inferNodeShape, toHtml } from "../src/export.js";
 import { safeToHtml } from "../src/html-export.js";
 
 describe("safeToHtml", () => {
@@ -285,6 +285,23 @@ describe("toHtml visual encoding (Track C3)", () => {
     expect(html).not.toContain('"background":"rgba(0,0,0,0)"');
     // Sanity: a code node keeps a coloured (non-transparent) background.
     expect(html).toMatch(/"id":"code_a"[^{]*\{[^}]*"background":"#[0-9A-Fa-f]{6}"/);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("buildGraphHtml returns exactly what toHtml writes (D1 refactor parity)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-parity-"));
+    const htmlPath = join(dir, "graph.html");
+    const G = new Graph();
+    G.addNode("a", { label: "A", source_file: "src/a.ts", file_type: "code" });
+    G.addNode("b", { label: "B", source_file: "src/b.test.ts", file_type: "code" });
+    G.addUndirectedEdge("a", "b", { relation: "tested_by", confidence: "EXTRACTED" });
+    const communities = new Map([[0, ["a", "b"]]]);
+    const opts = { communityLabels: new Map([[0, "Core"]]) };
+    toHtml(G, communities, htmlPath, opts);
+    const written = readFileSync(htmlPath, "utf-8");
+    // Same outputPath (title is derived from it) and same options -> identical doc.
+    expect(buildGraphHtml(G, communities, htmlPath, opts)).toBe(written);
 
     rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -166,7 +166,11 @@ describe("graphify ontology studio --write", () => {
       "/api/ontology/artifacts/graph.html",
     );
     expect(graphArtifact.status).toBe(200);
-    expect(graphArtifact.body).toContain("<title>graph</title>");
+    // D1/D8: the artifact is now generated from graph.json with the project
+    // profile (a sub-view of the studio model), not the stale on-disk stub.
+    expect(graphArtifact.body).toContain("graphify -");
+    expect(graphArtifact.body).toContain("Component A");
+    expect(graphArtifact.body).not.toBe("<!doctype html><title>graph</title>");
   });
 
   it("refuses --write when host is not loopback", async () => {

--- a/tests/workspace-graph-panel.test.ts
+++ b/tests/workspace-graph-panel.test.ts
@@ -119,6 +119,10 @@ describe("Track G G4 — graph panel", () => {
     expect(html).not.toContain('" onload="alert(1)');
     expect(html).toContain('sandbox="allow-scripts"');
     expect(html).not.toContain("allow-same-origin");
+    // D4: parent-side bridge opens the right-column entity panel when the
+    // embedded graph posts a node selection.
+    expect(html).toContain("graphify:selectNode");
+    expect(html).toContain('url.searchParams.set("node"');
   });
 
   it("blocks javascript graph URLs and keeps the placeholder bounded", () => {

--- a/tests/workspace-tokens.test.ts
+++ b/tests/workspace-tokens.test.ts
@@ -53,8 +53,9 @@ describe("Track G G1 — workspace token fallback", () => {
         expect(colour, `${theme}.colour.${role}`).toHaveProperty(role);
         const value = (colour as unknown as Record<string, unknown>)[role];
         expect(typeof value).toBe("string");
-        expect((value as string).startsWith("#")).toBe(true);
-        expect((value as string).length === 7 || (value as string).length === 9).toBe(true);
+        // D11: palette is tokenised as OKLCH (DS alignment), no bare hex.
+        expect((value as string).startsWith("oklch(")).toBe(true);
+        expect((value as string).endsWith(")")).toBe(true);
       }
     }
   });


### PR DESCRIPTION
Addresses the studio (Track G) defect register `.graphify/uat/STUDIO_DEFECTS.md`. **10/11 done** (D9 = a data/curation decision, see below).

## Fixed (verified E2E on the public mystery pack)
- **D1/D2/D5/D8** — studio renders the graph as a generated **sub-view of the studio model** (built from `graph.json` + project profile + native studio mode) instead of an iframe to a stale, profile-less `graph.html`. → ontology shapes (46 diamond / 23 star / …) instead of 123× box, hollow boxes, communities only in the left rail, no duplicated panels.
- **D4** — clicking a node in the embedded graph postMessages the selection to the shell, which opens the right-column **entity panel** (wiki description + relations) via `?node=`.
- **D7** — generated 62 deterministic wiki descriptions for the pack; the entity panel renders them.
- **D6** — labelled communities 7 & 8 (were `Community N` fallback).
- **D3** — Types accordion already collapsed by default (verified).
- **D10** — no empty node labels (verified).
- **D11** — **DS audit (`@sentropic/design-system-skills`) = 0 finding**: palette tokenised as OKLCH (no bare hex), display/body font hierarchy, em-dash microcopy removed.

## Verification
- Full suite: **1056 tests pass**, `tsc --noEmit` clean.
- New/updated tests: `buildGraphHtml` parity, studio artifact regeneration, D4 selection bridge, OKLCH token contract, display font.

## Notes
- Pack data (D6/D7: descriptions + community labels) is regenerated in the separate `public-domaine-mystery-sagas-pack` repo (not in this PR).
- **D9 (open, needs decision)**: "too few entities" (123). The deterministic deepen is idempotent; more entities require expanding the corpus (7→25 works) + LLM re-extraction, which would invalidate the pack's curated reconciliation candidates / tuned ontology. Recommendation: keep the curated 123 for the studio UAT (now well-rendered); treat corpus expansion as a separate data project.