### PR TITLE
fix(track-f): F-0819-P1 graph-correctness ports (#1061, #1017, #1077, #1075)

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -297,6 +297,21 @@ export function buildFromJson(extraction: Extraction, options?: BuildOptions): G
     // Preserve original edge direction
     attrs._src = source;
     attrs._tgt = target;
+    // F-0819-P1 (#1061): on an undirected graph a pair emitted in both
+    // directions with the same relation (a calls b AND b calls a) collapses to
+    // one edge; the reverse-direction duplicate would otherwise overwrite the
+    // first edge's _src/_tgt and silently flip caller/callee. First-seen wins:
+    // skip the redundant reverse duplicate.
+    if (!G.type.startsWith("directed") && G.hasEdge(source, target)) {
+      const existing = G.getEdgeAttributes(source, target) as Record<string, unknown>;
+      if (
+        existing.relation === attrs.relation &&
+        existing._src === target &&
+        existing._tgt === source
+      ) {
+        continue;
+      }
+    }
     // graphology mergeEdge prevents duplicates on same src/tgt pair
     try {
       G.mergeEdge(source, target, attrs);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -926,6 +926,48 @@ function _importPhp(
   }
 }
 
+/**
+ * Resolve a Lua require() module name to a node id (F-0819-P1 #1075).
+ *
+ * Lua module names use dots as path separators: `require("pkg.b")` looks for
+ * `pkg/b.lua` (or `.luau`) relative to a package root. Probe the importing
+ * file's directory and walk upward; when a matching file is found, return the
+ * id `_makeId(qualifiedFileStem(cand))` matching the file node id the extractor
+ * assigns, so the edge lands on a real node. When nothing matches on disk, fall
+ * back to `_makeId` of the full dotted module so the symbol-resolution pass can
+ * still complete the edge instead of dropping it (previously the bare last
+ * segment was used, which never matched any node id).
+ */
+function _resolveLuaImportTarget(rawModule: string, strPath: string): string {
+  if (!rawModule) return "";
+  const rel = rawModule.replace(/\./g, "/");
+  let probe: string | null = null;
+  try {
+    probe = dirname(resolve(strPath));
+  } catch {
+    probe = null;
+  }
+  // The dotted module name IS the qualified relative path of the target file
+  // (`pkg.b` -> `pkg/b.lua`), so the node id is `_makeId(rawModule)` in every
+  // case. Probing the disk only distinguishes a resolvable local module from an
+  // external one; either way the id is the dotted module (never the bare last
+  // segment, which was the #1075 bug). We keep the probe so future callers can
+  // branch on locality if needed.
+  if (probe) {
+    for (let i = 0; i < 6; i++) {
+      for (const suffix of [".lua", ".luau"]) {
+        if (existsSync(join(probe, `${rel}${suffix}`))) {
+          return _makeId(rawModule);
+        }
+      }
+      const parent = dirname(probe);
+      if (parent === probe) break;
+      probe = parent;
+    }
+  }
+  return _makeId(rawModule);
+}
+
 function _importLua(
   node: SyntaxNode, source: string, fileNid: string, _stem: string,
   edges: GraphEdge[], strPath: string,
@@ -933,10 +975,11 @@ function _importLua(
   const text = _readText(node, source);
   const m = text.match(/require\s*[('"]?\s*['"]?([^'")\s]+)/);
   if (m) {
-    const moduleName = m[1]!.split(".").pop()!;
-    if (moduleName) {
+    const rawModule = m[1]!;
+    const tgtNid = _resolveLuaImportTarget(rawModule, strPath);
+    if (tgtNid) {
       edges.push({
-        source: fileNid, target: moduleName, relation: "imports",
+        source: fileNid, target: tgtNid, relation: "imports",
         confidence: "EXTRACTED", source_file: strPath,
         source_location: String(node.startPosition.row + 1), weight: 1.0,
       });
@@ -4820,3 +4863,11 @@ export function collectFiles(target: string, options?: { followSymlinks?: boolea
   walkDir(resolved, new Set<string>());
   return results.sort();
 }
+
+/**
+ * Internal helpers exposed for unit tests only (F-0819-P1 #1075). Not part of
+ * the public API; do not import from application code.
+ */
+export const __testing = {
+  resolveLuaImportTarget: _resolveLuaImportTarget,
+};

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -233,7 +233,7 @@ type TsconfigAliasEntry = {
 
 const tsconfigAliasCache = new Map<string, TsconfigAliasEntry[]>();
 type TsconfigDocument = {
-  extends?: string;
+  extends?: string | string[];
   compilerOptions?: {
     baseUrl?: string;
     paths?: Record<string, string[]>;
@@ -315,13 +315,23 @@ function loadTsconfigAliasesFromPath(tsconfigPath: string, seen: Set<string> = n
   }
 
   const configDir = dirname(resolvedTsconfigPath);
-  const extendsPath = typeof parsed.extends === "string"
-    ? resolveTsconfigExtendsPath(parsed.extends, configDir)
-    : null;
-  const inherited = extendsPath ? loadTsconfigAliasesFromPath(extendsPath, seen) : [];
-  const merged = new Map<string, TsconfigAliasEntry>(
-    inherited.map((entry) => [entry.aliasPrefix, entry]),
-  );
+  // F-0819-P1 (#1017): TS 5.0 allows `extends` to be an array of base configs,
+  // merged left-to-right (later bases win). A bare-string check silently
+  // dropped the array form, losing inherited path aliases. Resolve each base in
+  // order and let later ones override earlier ones.
+  const extendsList = typeof parsed.extends === "string"
+    ? [parsed.extends]
+    : Array.isArray(parsed.extends)
+      ? parsed.extends.filter((e): e is string => typeof e === "string")
+      : [];
+  const merged = new Map<string, TsconfigAliasEntry>();
+  for (const ext of extendsList) {
+    const extendsPath = resolveTsconfigExtendsPath(ext, configDir);
+    if (!extendsPath) continue;
+    for (const entry of loadTsconfigAliasesFromPath(extendsPath, seen)) {
+      merged.set(entry.aliasPrefix, entry);
+    }
+  }
   const baseDir = resolve(configDir, parsed.compilerOptions?.baseUrl ?? ".");
   for (const [alias, targets] of Object.entries(parsed.compilerOptions?.paths ?? {})) {
     const firstTarget = targets[0];

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1127,7 +1127,21 @@ function _jsExtraWalk(
 
     let constFound = false;
 
-    if (node.type === "lexical_declaration") {
+    // Scope guard (F-0819-P1 #1077): only emit nodes for module-level
+    // declarations. A `const x = ...` inside an arrow callback (e.g. inside
+    // `describe(() => { const set = new Set(...) })`) would otherwise emit a
+    // bare-named node, and the same name colliding across unrelated files
+    // produces phantom god-nodes. Arrow-function bodies are walked separately
+    // via functionBodies, so locals never need a node here.
+    const parent = node.parent;
+    const isModuleLevel =
+      parent !== null &&
+      (parent.type === "program" ||
+        (parent.type === "export_statement" &&
+          parent.parent !== null &&
+          parent.parent.type === "program"));
+
+    if (node.type === "lexical_declaration" && isModuleLevel) {
       for (const child of node.children) {
         if (child.type === "variable_declarator") {
           const value = child.childForFieldName("value");
@@ -2970,9 +2984,6 @@ export async function extractMarkdown(filePath: string, rootDir?: string): Promi
 
   const headingStack: Array<{ level: number; id: string }> = [];
   let inCodeBlock = false;
-  let codeBlockLang: string | null = null;
-  let codeBlockStart = 0;
-  let codeBlockCount = 0;
   const codeBlockLines: string[] = [];
 
   const lines = source.split(/\r?\n/u);
@@ -2984,21 +2995,15 @@ export async function extractMarkdown(filePath: string, rootDir?: string): Promi
     if (stripped.startsWith("```")) {
       if (!inCodeBlock) {
         inCodeBlock = true;
-        codeBlockLang = stripped.slice(3).trim().split(/\s+/u)[0] || null;
-        codeBlockStart = lineNumber;
         codeBlockLines.length = 0;
         continue;
       }
 
+      // F-0819-P1 (#1077): close the fence WITHOUT emitting a node. Fenced
+      // code blocks were always orphans (a single `contains` edge to the
+      // parent doc) and inflated the disconnected-component count. We still
+      // track the block so its contents aren't mistaken for headings.
       inCodeBlock = false;
-      codeBlockCount += 1;
-      const firstLine = codeBlockLines.find((line) => line.trim())?.trim().slice(0, 60);
-      const baseLabel = codeBlockLang ? `code:${codeBlockLang}` : `code:block${codeBlockCount}`;
-      const label = firstLine ? `${baseLabel} (${firstLine})` : baseLabel;
-      const codeNid = _makeId(stem, `codeblock_${codeBlockCount}`);
-      addNode(codeNid, label, codeBlockStart, "document");
-      const parent = headingStack.at(-1)?.id ?? fileNid;
-      addEdge(parent, codeNid, "contains", codeBlockStart);
       continue;
     }
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -33,6 +33,19 @@ export function loadGraphFromData(raw: SerializedGraphData): Graph {
   for (const link of raw.links ?? raw.edges ?? []) {
     const { source, target, ...attrs } = link;
     if (!G.hasNode(source) || !G.hasNode(target)) continue;
+    // F-0819-P1 (#1061): same-relation reverse duplicate on an undirected graph
+    // collapses to one edge; don't let it overwrite the first edge's _src/_tgt
+    // (which would flip caller/callee). First-seen direction wins.
+    if (!G.type.startsWith("directed") && G.hasEdge(source, target)) {
+      const existing = G.getEdgeAttributes(source, target) as Record<string, unknown>;
+      if (
+        existing.relation === (attrs as Record<string, unknown>).relation &&
+        existing._src === target &&
+        existing._tgt === source
+      ) {
+        continue;
+      }
+    }
     try {
       G.mergeEdge(source, target, attrs);
     } catch {

--- a/tests/build-bidirectional-edge.test.ts
+++ b/tests/build-bidirectional-edge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildFromJson } from "../src/build.js";
+
+/**
+ * Regression for Track F-0819-P1 (upstream #1061): on an undirected build, a
+ * `calls` pair emitted in both directions (a calls b AND b calls a) collapses
+ * to one graphology edge. The second mergeEdge must NOT overwrite the first
+ * edge's preserved `_src`/`_tgt`, which would silently flip caller/callee.
+ * First-seen direction wins.
+ */
+describe("buildFromJson — bidirectional calls pair (F-0819-P1 / #1061)", () => {
+  function extraction(edges: Array<{ source: string; target: string; relation: string }>) {
+    return {
+      nodes: [
+        { id: "a", label: "a", type: "function", source_file: "src/a.ts" },
+        { id: "b", label: "b", type: "function", source_file: "src/b.ts" },
+      ],
+      edges: edges.map((e) => ({ ...e, confidence: "EXTRACTED", source_file: "src/a.ts" })),
+      input_tokens: 0,
+      output_tokens: 0,
+    };
+  }
+
+  it("preserves first-seen direction when the reverse duplicate arrives", () => {
+    const G = buildFromJson(
+      extraction([
+        { source: "a", target: "b", relation: "calls" },
+        { source: "b", target: "a", relation: "calls" },
+      ]),
+    );
+    // Undirected graph collapses the pair to a single edge.
+    expect(G.size).toBe(1);
+    const attrs = G.getEdgeAttributes("a", "b");
+    // First-seen direction (a -> b) must survive, not be flipped to b -> a.
+    expect(attrs._src).toBe("a");
+    expect(attrs._tgt).toBe("b");
+  });
+
+  it("only guards same-relation reverse duplicates (scoped to #1061)", () => {
+    // The guard is intentionally narrow: it skips a reverse duplicate ONLY when
+    // the relation matches (the `a calls b` / `b calls a` case). A different
+    // relation on the same pair is a distinct edge intent and is not dropped by
+    // this fix — same-relation guarding is exactly what #1061 specifies.
+    const G = buildFromJson(
+      extraction([
+        { source: "a", target: "b", relation: "calls" },
+        { source: "a", target: "b", relation: "calls" }, // exact duplicate, same direction
+      ]),
+    );
+    expect(G.size).toBe(1);
+    const attrs = G.getEdgeAttributes("a", "b");
+    expect(attrs._src).toBe("a");
+    expect(attrs._tgt).toBe("b");
+  });
+});

--- a/tests/extract-godnode-orphans.test.ts
+++ b/tests/extract-godnode-orphans.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extract } from "../src/extract.js";
+
+/**
+ * Track F-0819-P1 (upstream #1077): two phantom-node sources.
+ *  - JS/TS: a `const`/`let` inside an arrow-function callback must NOT emit a
+ *    bare-named node (it collides across files into a phantom god-node).
+ *  - Markdown: fenced code blocks must NOT emit orphan nodes.
+ */
+describe("F-0819-P1 #1077 — no phantom nodes from arrow-fn locals or md code blocks", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-f0819-1077-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("does not emit nodes for locals declared inside an arrow callback", async () => {
+    writeFileSync(
+      join(dir, "a.ts"),
+      [
+        "export function setup() {",
+        "  register(() => {",
+        "    const phantomLocal = new Set();", // local inside arrow callback
+        "    const helper = () => 42;",
+        "    return phantomLocal.size + helper();",
+        "  });",
+        "}",
+        "const moduleLevelConst = 7;", // module-level — this one MAY be a node
+        "",
+      ].join("\n"),
+    );
+    const result = await extract([join(dir, "a.ts")]);
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).not.toContain("phantomLocal");
+    expect(labels).not.toContain("helper");
+  });
+
+  it("does not emit orphan nodes for markdown fenced code blocks", async () => {
+    writeFileSync(
+      join(dir, "doc.md"),
+      [
+        "# Title",
+        "",
+        "Some prose.",
+        "",
+        "```ts",
+        "const x = 1;",
+        "console.log(x);",
+        "```",
+        "",
+        "## Section",
+        "",
+      ].join("\n"),
+    );
+    const result = await extract([join(dir, "doc.md")]);
+    // No node whose id/label marks a code block.
+    const codeBlockNodes = result.nodes.filter(
+      (n) => n.id.includes("codeblock_") || /^code:/.test(n.label ?? ""),
+    );
+    expect(codeBlockNodes).toEqual([]);
+    // The heading nodes still exist (code-block skipping must not eat headings).
+    expect(result.nodes.some((n) => (n.label ?? "").includes("Title"))).toBe(true);
+    expect(result.nodes.some((n) => (n.label ?? "").includes("Section"))).toBe(true);
+  });
+});

--- a/tests/extract-lua-require.test.ts
+++ b/tests/extract-lua-require.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { __testing } from "../src/extract.js";
+
+const { resolveLuaImportTarget } = __testing;
+
+/**
+ * Track F-0819-P1 (upstream #1075): a Lua require() target must resolve to the
+ * real file node id (so the import edge lands on a node), not the bare last
+ * dotted segment (which never matched any node and silently dropped the edge).
+ */
+describe("F-0819-P1 #1075 — Lua require() target resolution", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-lua-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("resolves a dotted module to the on-disk file node id", () => {
+    // require("pkg.b") from <dir>/main.lua should find <dir>/pkg/b.lua
+    mkdirSync(join(dir, "pkg"), { recursive: true });
+    writeFileSync(join(dir, "pkg", "b.lua"), "return {}\n");
+    const main = join(dir, "main.lua");
+    writeFileSync(main, 'local b = require("pkg.b")\n');
+
+    const target = resolveLuaImportTarget("pkg.b", main);
+    // qualifiedFileStem(pkg/b.lua) -> "pkg.b" -> _makeId -> "pkg_b"
+    expect(target).toBe("pkg_b");
+    // crucially NOT the bare last segment "b"
+    expect(target).not.toBe("b");
+  });
+
+  it("falls back to the full dotted module id when no file matches on disk", () => {
+    const main = join(dir, "main.lua");
+    writeFileSync(main, 'local x = require("third.party.lib")\n');
+    const target = resolveLuaImportTarget("third.party.lib", main);
+    // fallback: _makeId of the full dotted module (underscored), not bare "lib"
+    expect(target).toBe("third_party_lib");
+    expect(target).not.toBe("lib");
+  });
+});

--- a/tests/language-surface.test.ts
+++ b/tests/language-surface.test.ts
@@ -349,6 +349,45 @@ class PaymentService extends BaseService implements Billable {}
     expect(importEdge?.target).toBe("lib_helper_ts");
   });
 
+  it("resolves tsconfig path aliases through an array extends (TS 5.0, F-0819-P1 #1017)", async () => {
+    mkdirSync(join(dir, "src", "lib"), { recursive: true });
+    // First base defines an unrelated alias; the second (later) base defines
+    // @lib/* — array extends merges left-to-right, so the later base must win.
+    writeFileSync(
+      join(dir, "tsconfig.other.json"),
+      '{ "compilerOptions": { "baseUrl": ".", "paths": { "@other/*": ["vendor/*"] } } }\n',
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "tsconfig.base.json"),
+      '{ "compilerOptions": { "baseUrl": ".", "paths": { "@lib/*": ["src/lib/*"] } } }\n',
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      '{ "extends": ["./tsconfig.other.json", "./tsconfig.base.json"] }\n',
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "src", "entry.ts"),
+      "import { helper } from '@lib/helper';\nexport function alpha() { return helper(); }\n",
+    );
+    writeFileSync(
+      join(dir, "src", "lib", "helper.ts"),
+      "export function helper() { return 1; }\n",
+    );
+
+    const result = await extract([
+      join(dir, "src", "entry.ts"),
+      join(dir, "src", "lib", "helper.ts"),
+    ]);
+
+    const importEdge = result.edges.find(
+      (edge) => edge.source === "entry_ts" && edge.relation === "imports_from",
+    );
+    expect(importEdge?.target).toBe("lib_helper_ts");
+  });
+
   it("resolves local dynamic imports as imports_from edges", async () => {
     mkdirSync(join(dir, "src"), { recursive: true });
     writeFileSync(

--- a/tests/language-surface.test.ts
+++ b/tests/language-surface.test.ts
@@ -754,7 +754,7 @@ class PaymentService extends BaseService implements Billable {}
     expect(jsxCall).toBeDefined();
   });
 
-  it("extracts Markdown heading hierarchy and fenced code blocks", async () => {
+  it("extracts Markdown heading hierarchy (code blocks skipped, no orphan nodes)", async () => {
     const guidePath = join(dir, "guide.md");
     writeFileSync(
       guidePath,
@@ -779,18 +779,20 @@ class PaymentService extends BaseService implements Billable {}
     const guideNode = result.nodes.find((node) => node.label === "Guide");
     const installNode = result.nodes.find((node) => node.label === "Install");
     const verifyNode = result.nodes.find((node) => node.label === "Verify");
+    // F-0819-P1 (#1077): fenced code blocks no longer emit orphan nodes.
     const codeNode = result.nodes.find((node) => node.label.startsWith("code:ts"));
 
     expect(fileNode?.id).toBeTruthy();
     expect(guideNode?.id).toBeTruthy();
     expect(installNode?.id).toBeTruthy();
     expect(verifyNode?.id).toBeTruthy();
-    expect(codeNode?.id).toBeTruthy();
+    expect(codeNode).toBeUndefined();
+    // The heading hierarchy is preserved; the code block is skipped (not a
+    // heading) but emits no node, so no edge points at it.
     expect(result.edges).toEqual(expect.arrayContaining([
       expect.objectContaining({ source: fileNode?.id, target: guideNode?.id, relation: "contains" }),
       expect.objectContaining({ source: guideNode?.id, target: installNode?.id, relation: "contains" }),
       expect.objectContaining({ source: installNode?.id, target: verifyNode?.id, relation: "contains" }),
-      expect.objectContaining({ source: installNode?.id, target: codeNode?.id, relation: "contains" }),
     ]));
   });
 


### PR DESCRIPTION
Track F upstream parity, lot **F-0819-P1** (graph-correctness fixes from the v0.8.18..v0.8.27 drift). Each candidate was vetted by **two independent reviewers** before porting; 2 of the 6 P1 candidates were rejected (see below).

## Ported (4, TDD)
- **#1061** `66acfd8` — `calls` edge direction flip on bidirectional pairs. On an undirected build, `a calls b` + `b calls a` collapse to one graphology edge; the reverse duplicate overwrote `_src/_tgt`, flipping caller/callee. Guard both merge paths (`buildFromJson` + `loadGraphFromData`): first-seen same-relation direction wins.
- **#1017** `3366527` — TS 5.0 array form of tsconfig `extends`. The array form was silently dropped, losing inherited path aliases. Parse left-to-right (later bases win).
- **#1077** `925eb81` — phantom god-nodes. (a) JS/TS: a `const`/`let` inside an arrow callback emitted a bare-named node colliding across files into a god-node — guard to module-level declarations. (b) Markdown: fenced code blocks emitted orphan nodes — skip the fence, emit no node.
- **#1075** `5642c1b` — Lua `require()` target id. Used the bare last segment (`require("pkg.b")` → `"b"`), never matching the file node, dropping the edge. Resolve to `_makeId(module)`. (Latent: Lua grammar isn't packaged; resolver unit-tested directly.)

## Rejected by review (not ported)
- **#1007** watch stale-node eviction — **already covered** by our unconditional `cleanupStaleNodes` reconcile on every rebuild (the `changed_paths is None` gap can't occur here).
- **#961** circular-import detection — a **new feature**, not a correctness bug; reclassified to a P2 feature track (graphology has no `simpleCycles`).

## Verification
- Full suite: **1065 tests pass**, `tsc --noEmit` clean.
- New tests: bidirectional-edge direction, array-extends, arrow-fn/markdown phantom nodes, Lua require resolution.