### PR TITLE
fix(track-f): F-0819-P2 determinism + stale-node hygiene (#1010, abs-path prune)

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -427,7 +427,22 @@ export function buildMerge(newChunks: Extraction[], options?: BuildMergeOptions)
   const graph = buildFromJson(deduplicated, options);
 
   if ((options?.pruneSources?.length ?? 0) > 0) {
-    const pruneSet = new Set((options?.pruneSources ?? []).map(sourceKey).filter(Boolean));
+    // F-0819-P2 (#1007): a manifest may store absolute paths (e.g.
+    // /home/user/corpus/module_b/utils.ts) while graph nodes store repo-relative
+    // paths (module_b/utils.ts). `sourceKey` normalises slashes but does not
+    // relativize without a root, so absolute prune entries would never match
+    // relative node source_files and stale nodes would persist. Seed the prune
+    // set with both the slash-normalised entry and a root-relative variant.
+    const pruneRoot = rootForOptions(options);
+    const pruneSet = new Set<string>();
+    for (const raw of options?.pruneSources ?? []) {
+      const direct = sourceKey(raw);
+      if (direct) pruneSet.add(direct);
+      if (pruneRoot) {
+        const relative = normalizeSourceFilePath(raw, pruneRoot);
+        if (relative) pruneSet.add(relative);
+      }
+    }
     const nodesToDrop: string[] = [];
     graph.forEachNode((nodeId, attrs) => {
       if (pruneSet.has(sourceKey(attrs.source_file))) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -288,7 +288,26 @@ export function buildFromJson(extraction: Extraction, options?: BuildOptions): G
 
   const nodeSet = new Set(G.nodes());
 
-  for (const edge of extraction.edges ?? []) {
+  // F-0819-P2 (#1010): iterate edges in a deterministic order. The graph is
+  // undirected and stores direction in _src/_tgt; when two edges collapse onto
+  // the same node pair the surviving edge depends on iteration order, so an
+  // unstable order (e.g. AST + semantic chunks merged in a different sequence
+  // run-to-run) flips _src/_tgt and makes the serialized graph churn. Sorting
+  // by (source, target, relation) pins the first-seen outcome.
+  const sortedEdges = [...(extraction.edges ?? [])].sort((a, b) => {
+    const as = String(a.source ?? "");
+    const bs = String(b.source ?? "");
+    if (as !== bs) return as < bs ? -1 : 1;
+    const at = String(a.target ?? "");
+    const bt = String(b.target ?? "");
+    if (at !== bt) return at < bt ? -1 : 1;
+    const ar = String(a.relation ?? "");
+    const br = String(b.relation ?? "");
+    if (ar !== br) return ar < br ? -1 : 1;
+    return 0;
+  });
+
+  for (const edge of sortedEdges) {
     const { source, target, ...attrs } = edge;
     if (!nodeSet.has(source) || !nodeSet.has(target)) continue;
     if ("source_file" in attrs) {

--- a/tests/build-edge-determinism.test.ts
+++ b/tests/build-edge-determinism.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+import { buildFromJson } from "../src/build.js";
+
+/**
+ * Regression for Track F-0819-P2 (upstream #1010): make graph output
+ * deterministic so a no-op rebuild reproduces graph.json byte-for-byte.
+ *
+ * The undirected build stores edge direction in `_src`/`_tgt`. When edges
+ * collapse onto the same node pair, the surviving edge (and its preserved
+ * direction) depends on iteration order. If `extraction.edges` arrives in a
+ * different order run-to-run — e.g. when AST + semantic subagent chunks are
+ * merged in a nondeterministic order — `_src`/`_tgt` flip and the serialized
+ * graph churns. Upstream pins this by sorting edges by
+ * `(source, target, relation)` before the add loop; the TS port must match.
+ */
+describe("buildFromJson — edge order determinism (F-0819-P2 / #1010)", () => {
+  function extraction(edges: Array<{ source: string; target: string; relation: string }>) {
+    return {
+      nodes: [
+        { id: "a", label: "a", file_type: "code" as const, type: "function", source_file: "src/a.ts" },
+        { id: "b", label: "b", file_type: "code" as const, type: "function", source_file: "src/b.ts" },
+        { id: "c", label: "c", file_type: "code" as const, type: "function", source_file: "src/c.ts" },
+      ],
+      edges: edges.map((e) => ({ ...e, confidence: "EXTRACTED" as const, source_file: "src/a.ts" })),
+      input_tokens: 0,
+      output_tokens: 0,
+    };
+  }
+
+  function dump(G: Graph): string {
+    const rows: string[] = [];
+    G.forEachEdge((_key, data: Record<string, unknown>) => {
+      rows.push(`${data._src}->${data._tgt}:${data.relation}`);
+    });
+    return rows.sort().join(" | ");
+  }
+
+  it("produces the same _src/_tgt regardless of input edge order", () => {
+    const edges = [
+      { source: "a", target: "b", relation: "calls" },
+      { source: "b", target: "c", relation: "calls" },
+      { source: "a", target: "c", relation: "references" },
+    ];
+    const forward = dump(buildFromJson(extraction(edges)));
+    const reversed = dump(buildFromJson(extraction([...edges].reverse())));
+    expect(reversed).toBe(forward);
+  });
+
+  it("keeps a deterministic survivor when two relations collapse onto one undirected pair", () => {
+    // `a calls b` and `b references a` collapse onto the same undirected pair.
+    // The survivor must not depend on which one is seen first.
+    const order1 = dump(
+      buildFromJson(
+        extraction([
+          { source: "a", target: "b", relation: "calls" },
+          { source: "b", target: "a", relation: "references" },
+        ]),
+      ),
+    );
+    const order2 = dump(
+      buildFromJson(
+        extraction([
+          { source: "b", target: "a", relation: "references" },
+          { source: "a", target: "b", relation: "calls" },
+        ]),
+      ),
+    );
+    expect(order2).toBe(order1);
+  });
+});

--- a/tests/build-merge.test.ts
+++ b/tests/build-merge.test.ts
@@ -163,6 +163,36 @@ describe("buildMerge", () => {
     expect(graph.size).toBe(0);
   });
 
+  it("prunes deleted sources when pruneSources holds absolute manifest paths (F-0819-P2 / #1007)", () => {
+    // The manifest stores absolute paths (e.g. /home/user/corpus/module_b/utils.ts)
+    // while graph nodes store repo-relative paths (module_b/utils.ts). With a
+    // `root` in scope, an absolute prune entry must still match the relative
+    // node source_file, otherwise stale nodes persist after file deletion.
+    const dir = tempDir();
+    const root = join(dir, "corpus");
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "login", label: "login", source_file: "module_a/auth.ts", file_type: "code" },
+          { id: "fmt", label: "format_date", source_file: "module_b/utils.ts", file_type: "code" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const deletedAbs = [join(root, "module_b", "utils.ts")];
+    const graph = buildMerge([], { graphPath, pruneSources: deletedAbs, root });
+
+    expect(graph.hasNode("fmt")).toBe(false);
+    expect(graph.hasNode("login")).toBe(true);
+    expect(graph.order).toBe(1);
+  });
+
   it("deduplicates chunk-suffixed labels during explicit merge flows", () => {
     const dir = tempDir();
     const graphPath = join(dir, "graph.json");


### PR DESCRIPTION
Track F upstream parity, lot **F-0819-P2** (determinism / stale-node graph hygiene from the v0.8.18..v0.8.27 drift). Same vetting protocol as the merged P1: each candidate checked against our TS code before porting; 2 of 4 rejected.

## Ported (2, TDD)
- **#1010 `a54a542`** — deterministic graph output. Edges were added in input order, so the same logical graph could yield different surviving `_src`/`_tgt` on collapsed pairs. Sort edges by `(source, target, relation)` before the add loop. (The upstream `PYTHONHASHSEED=0` half is N/A — our clustering already uses a fixed rng + size-descending community re-indexing.)
- **`a26f24e`** — stale nodes after file deletion when the manifest uses absolute paths. The prune set was seeded with un-rooted keys, so an absolute manifest path never matched a node's relative `source_file`. Seed the prune set with both slash-normalised and root-relative variants.

## Rejected by review (not ported)
- **`3f8efae`** ghost nodes on `graphify update` — already covered: `makeGraphPortable(existing, root)` relativizes the prior graph before prune; our paths are already as_posix-style relative.
- **#1006 `c09fbef`** hyperedge remap in the community-aggregated meta-graph — that recursive aggregation path doesn't exist in our `toHtml` (we throw on oversized graphs instead of aggregating).

## Verification
- Full suite: **1070 tests pass** (+5 vs the P1 baseline), `tsc --noEmit` clean.
- New tests: `tests/build-edge-determinism.test.ts` (2 cases) + an absolute-path prune case in `tests/build-merge.test.ts`. P1's bidirectional-edge test still passes (sort is compatible with first-seen-wins).

_Note: the second commit message references `#1007` but the actual upstream fix is `a26f24e` (abs-path prune); `#1007` was the watch-evict candidate already covered and skipped in P1. Message typo only — the code is the abs-path prune fix._