### PR TITLE
feat(track-g): studio SPA regressions — entity accordions + reconciliation workbench (SVELTE-1/2/7)

### DIFF
--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -36,6 +36,8 @@ export interface OntologyStudioWriteOptions {
 export interface OntologyStudioHandlerOptions {
   profileStatePath: string;
   write?: OntologyStudioWriteOptions;
+  /** Bind host; when loopback, same-origin writes are trusted without a token. */
+  host?: string;
 }
 
 export interface StartOntologyStudioServerOptions {
@@ -356,8 +358,14 @@ export function createOntologyStudioRequestHandler(options: OntologyStudioHandle
         sendResult(response, jsonResult(405, { error: "patch routes require --write mode" }));
         return;
       }
+      // Auth for write routes. The bearer token is always accepted. As a
+      // loopback-only convenience (SVELTE-7), when the server is bound to a
+      // loopback host the same-origin SPA may POST WITHOUT a token: `--write`
+      // already refuses non-loopback binds, so nothing reachable from the
+      // network can hit this. (A future Sentropic-integrated auth replaces this.)
       const token = bearerToken(request.headers.authorization);
-      if (token !== options.write.token) {
+      const loopbackTrusted = options.host !== undefined && isLoopbackHost(options.host);
+      if (token !== options.write.token && !loopbackTrusted) {
         sendResult(response, jsonResult(401, { error: "missing or invalid bearer token" }));
         return;
       }
@@ -482,7 +490,10 @@ export async function startOntologyStudioServer(
       `--write requires a loopback bind (127.0.0.1, ::1 or localhost); refused host ${host}`,
     );
   }
-  const handlerOptions: OntologyStudioHandlerOptions = { profileStatePath: options.profileStatePath };
+  const handlerOptions: OntologyStudioHandlerOptions = {
+    profileStatePath: options.profileStatePath,
+    host,
+  };
   if (writeEnabled) {
     handlerOptions.write = { token: options.token ?? generateOntologyStudioToken() };
   }

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -5,6 +5,7 @@
    * + the description sidecar). Clicking a relation target opens that entity
    * (highlight, NO graph reload) via onOpenEntity.
    */
+  import Accordion from "./Accordion.svelte";
   import {
     relationRowsFor,
     indexNodes,
@@ -12,6 +13,7 @@
     nodeType,
     nodeCommunity,
     nodeSourcePath,
+    citationsByFile,
   } from "../lib/graphAdapter.js";
   import { renderInlineMarkdown } from "../lib/markdown.js";
 
@@ -19,6 +21,9 @@
 
   const node = $derived(focusId ? (indexNodes(graph).get(focusId) ?? null) : null);
   const relations = $derived(focusId ? relationRowsFor(focusId, graph) : []);
+  // SVELTE-2: citations grouped by file (file > passages double accordion).
+  const citationFiles = $derived(node ? citationsByFile(node) : []);
+  const citationTotal = $derived(citationFiles.reduce((n, f) => n + f.count, 0));
   const description = $derived.by(() => {
     const sidecar = entity?.description;
     if (sidecar && sidecar.status === "generated" && typeof sidecar.description === "string") {
@@ -69,32 +74,59 @@
       </section>
     {/if}
 
-    <section class="entity-section">
-      <h3 class="entity-section-heading">
-        Relations <span class="entity-counter">{relations.length}</span>
-      </h3>
-      {#if relations.length === 0}
-        <p class="entity-empty-inline">No relations.</p>
-      {:else}
-        <ul class="entity-relations">
-          {#each relations as rel (rel.direction + rel.otherId + rel.relation)}
-            <li>
-              <button
-                class="entity-relation"
-                onclick={() => onOpenEntity?.(rel.otherId)}
-                title={rel.otherId}
-              >
-                <span class="entity-relation-kind">{rel.relation}</span>
-                <span class="entity-relation-arrow" aria-hidden="true">
-                  {rel.direction === "out" ? "→" : "←"}
-                </span>
-                <span class="entity-relation-target">{rel.otherLabel}</span>
-              </button>
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </section>
+    <!-- SVELTE-1: relations collapsed into an accordion (open when few). -->
+    <div class="entity-acc">
+      <Accordion title="Relations" count={relations.length} open={relations.length > 0 && relations.length <= 8}>
+        {#if relations.length === 0}
+          <p class="entity-empty-inline">No relations.</p>
+        {:else}
+          <ul class="entity-relations">
+            {#each relations as rel (rel.direction + rel.otherId + rel.relation)}
+              <li>
+                <button
+                  class="entity-relation"
+                  onclick={() => onOpenEntity?.(rel.otherId)}
+                  title={rel.otherId}
+                >
+                  <span class="entity-relation-kind">{rel.relation}</span>
+                  <span class="entity-relation-arrow" aria-hidden="true">
+                    {rel.direction === "out" ? "→" : "←"}
+                  </span>
+                  <span class="entity-relation-target">{rel.otherLabel}</span>
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </Accordion>
+    </div>
+
+    <!-- SVELTE-2: citations as a double accordion (file > passages). -->
+    <div class="entity-acc">
+      <Accordion title="Citations" count={citationTotal} open={false}>
+        {#if citationFiles.length === 0}
+          <p class="entity-empty-inline">No citations recorded.</p>
+        {:else}
+          <ul class="entity-cite-files">
+            {#each citationFiles as cf (cf.file)}
+              <li>
+                <Accordion title={cf.file} count={cf.count} open={false}>
+                  <ul class="entity-cite-passages">
+                    {#each cf.passages as p, i (cf.file + i)}
+                      <li class="entity-cite-passage">
+                        {#if p.section}<span class="entity-cite-section">{p.section}</span>{/if}
+                        {#if p.quote}<blockquote class="entity-cite-quote">{p.quote}</blockquote>{/if}
+                        {#if !p.section && !p.quote}<span class="entity-cite-section">(passage)</span>{/if}
+                      </li>
+                    {/each}
+                  </ul>
+                </Accordion>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </Accordion>
+    </div>
   {/if}
 </aside>
 
@@ -221,5 +253,37 @@
     margin: 0;
     font-style: italic;
     font-size: 0.82rem;
+  }
+  /* SVELTE-1/2: accordions inside the entity panel sit flush. */
+  .entity-acc {
+    margin-top: 1rem;
+    border-top: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .entity-cite-files,
+  .entity-cite-passages {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.2rem;
+  }
+  .entity-cite-passage {
+    padding: 0.25rem 0;
+    border-bottom: 1px dotted var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .entity-cite-section {
+    display: block;
+    font-size: 0.74rem;
+    font-weight: 600;
+    color: var(--st-semantic-text-secondary, #475569);
+  }
+  .entity-cite-quote {
+    margin: 0.2rem 0 0;
+    padding: 0.2rem 0.5rem;
+    border-left: 2px solid var(--st-semantic-border-strong, #94a3b8);
+    color: var(--st-semantic-text-primary, #0f172a);
+    font-size: 0.8rem;
+    font-style: italic;
+    line-height: 1.4;
   }
 </style>

--- a/studio/src/components/ReconciliationView.svelte
+++ b/studio/src/components/ReconciliationView.svelte
@@ -1,16 +1,26 @@
 <script>
   /**
-   * Reconciliation view — FIRST-SLICE STUB.
-   *
-   * Lists candidates from the existing `/api/ontology/reconciliation/candidates`
-   * JSON API so the wiring is proven, and lets you jump to a candidate's
-   * canonical entity in the Workspace graph. The full candidate workbench
-   * (compare block, evidence/audit drawer, patch apply) is a deliberate
-   * follow-up — see the studio README. No graph reload happens here.
+   * SVELTE-7: reconciliation workbench — same 3-column shell as the workspace.
+   *   left  : filterable candidate list (like the search rail)
+   *   center: graph scoped to the subgraph of the two candidate entities
+   *   right : candidate compare panel + Accept / Reject buttons
+   * Accept = accept_match patch (apply), Reject = reject_match patch (apply).
+   * On a loopback --write server no token is needed (SVELTE-7 server change).
    */
   import { onMount } from "svelte";
 
-  import { fetchReconciliationCandidates } from "../lib/api.js";
+  import WorkspaceShell from "./WorkspaceShell.svelte";
+  import GraphCanvas from "./GraphCanvas.svelte";
+  import Accordion from "./Accordion.svelte";
+  import { fetchReconciliationCandidates, postPatchApply } from "../lib/api.js";
+  import { buildPatchFromCandidate } from "../lib/reconciliation.js";
+  import {
+    candidateSubgraph,
+    buildScene,
+    indexNodes,
+    nodeLabel,
+    nodeType,
+  } from "../lib/graphAdapter.js";
 
   let { graph, onOpenEntity } = $props();
 
@@ -19,115 +29,295 @@
   let stale = $state(false);
   let error = $state(null);
   let loaded = $state(false);
+  let graphHash = $state("");
+  let profileHash = $state("");
+  let query = $state("");
+  let activeId = $state(null);
+  let busy = $state(false);
+  let actionResult = $state(null);
 
-  onMount(async () => {
+  const idx = $derived(indexNodes(graph));
+  const active = $derived(activeId ? (candidates.find((c) => c.id === activeId) ?? null) : null);
+
+  const filtered = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter(
+      (c) =>
+        String(c.candidate_id).toLowerCase().includes(q) ||
+        String(c.canonical_id).toLowerCase().includes(q) ||
+        (c.shared_terms ?? []).some((t) => String(t).toLowerCase().includes(q)),
+    );
+  });
+
+  // Center graph: subgraph around the two candidate entities (focused context).
+  const scene = $derived.by(() => {
+    if (!active) return buildScene({ nodes: [], links: [] });
+    const sub = candidateSubgraph(graph, active.candidate_id, active.canonical_id, 1);
+    return buildScene(sub, { showWeakLinks: true });
+  });
+  const selectedIds = $derived(active ? [active.candidate_id, active.canonical_id] : []);
+
+  function label(id) {
+    const n = idx.get(id);
+    return n ? nodeLabel(n) : id;
+  }
+  function typeOf(id) {
+    const n = idx.get(id);
+    return n ? nodeType(n) : null;
+  }
+
+  async function reload() {
     const res = await fetchReconciliationCandidates();
     if (res?.error) error = res.error;
     candidates = res?.items ?? [];
     total = res?.total ?? candidates.length;
     stale = Boolean(res?.stale);
+    graphHash = res?.graph_hash ?? "";
+    profileHash = res?.profile_hash ?? "";
     loaded = true;
-  });
+    if (!activeId && candidates.length) activeId = candidates[0].id;
+  }
+
+  onMount(reload);
+
+  async function decide(decision) {
+    if (!active || busy) return;
+    busy = true;
+    actionResult = null;
+    try {
+      const patch = buildPatchFromCandidate(active, decision, { graphHash, profileHash });
+      const res = await postPatchApply(patch);
+      if (res.ok && res.valid !== false) {
+        actionResult = { ok: true, msg: `${decision === "accept" ? "Accepted" : "Rejected"} — patch applied.` };
+        // Drop the decided candidate from the queue and advance.
+        const decidedId = active.id;
+        candidates = candidates.filter((c) => c.id !== decidedId);
+        total = Math.max(0, total - 1);
+        activeId = candidates[0]?.id ?? null;
+      } else {
+        const issues = (res.issues ?? []).map((i) => i.message).join("; ");
+        actionResult = { ok: false, msg: `Patch rejected (${res.status}): ${issues || res.error || "unknown"}` };
+      }
+    } catch (err) {
+      actionResult = { ok: false, msg: String(err) };
+    } finally {
+      busy = false;
+    }
+  }
 </script>
 
-<section class="recon">
-  <header class="recon-head">
-    <h2>Reconciliation</h2>
-    <p class="recon-note">
-      First-slice stub: candidate queue from the live API. Full candidate
-      workbench (compare, evidence, patch apply) is a follow-up.
-    </p>
-  </header>
+<WorkspaceShell>
+  <div class="col col-left">
+    <aside class="recon-rail" aria-label="Reconciliation candidates">
+      <div class="recon-rail-search">
+        <input
+          type="search"
+          placeholder="Filter candidates…"
+          bind:value={query}
+          aria-label="Filter reconciliation candidates"
+        />
+      </div>
+      <div class="recon-rail-meta">
+        <span class="recon-pill">{total} candidate(s)</span>
+        <span class="recon-pill">stale: {stale ? "yes" : "no"}</span>
+      </div>
+      {#if !loaded}
+        <p class="recon-empty">Loading…</p>
+      {:else if error}
+        <p class="recon-empty">API unavailable: {error}</p>
+      {:else if filtered.length === 0}
+        <p class="recon-empty">Reconciliation queue is empty.</p>
+      {:else}
+        <ul class="recon-rail-list">
+          {#each filtered as c (c.id)}
+            <li>
+              <button
+                class="recon-rail-row"
+                class:active={activeId === c.id}
+                onclick={() => { activeId = c.id; actionResult = null; }}
+              >
+                <span class="recon-rail-label">{label(c.candidate_id)} ↔ {label(c.canonical_id)}</span>
+                <span class="recon-rail-score">{Math.round((c.score ?? 0) * 100)}%</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </aside>
+  </div>
 
-  {#if !loaded}
-    <p class="recon-empty">Loading candidates…</p>
-  {:else if error}
-    <p class="recon-empty">Reconciliation API unavailable: {error}</p>
-  {:else if candidates.length === 0}
-    <p class="recon-empty">Reconciliation queue is empty.</p>
-  {:else}
-    <div class="recon-toolbar">
-      <span class="recon-pill">{total} candidate(s)</span>
-      <span class="recon-pill">stale: {stale ? "yes" : "no"}</span>
-    </div>
-    <ul class="recon-list">
-      {#each candidates as c (c.id)}
-        <li class="recon-row">
-          <div class="recon-row-main">
-            <strong>{c.id}</strong>
-            <small>{c.candidate_id} → {c.canonical_id}</small>
-            <small>{c.proposed_patch_operation} · score {Math.round((c.score ?? 0) * 100)}%</small>
-          </div>
-          <button class="recon-open" onclick={() => onOpenEntity?.(c.canonical_id)}>
-            Open canonical
+  <div class="col col-center">
+    {#if active}
+      <GraphCanvas
+        {scene}
+        {selectedIds}
+        focusId={active.candidate_id}
+        onSelect={(id) => onOpenEntity?.(id)}
+        onOpenEntity={(id) => onOpenEntity?.(id)}
+      />
+    {:else}
+      <p class="recon-center-empty">Select a candidate to see the two entities in context.</p>
+    {/if}
+  </div>
+
+  <div class="col col-right">
+    <aside class="recon-detail" aria-label="Candidate detail">
+      {#if !active}
+        <p class="recon-empty">No candidate selected.</p>
+      {:else}
+        <header class="recon-detail-head">
+          <p class="recon-kicker">Reconciliation candidate</p>
+          <h2>{label(active.candidate_id)} ↔ {label(active.canonical_id)}</h2>
+          <p class="recon-detail-score">
+            {active.proposed_patch_operation} · score {Math.round((active.score ?? 0) * 100)}%
+          </p>
+        </header>
+
+        <dl class="recon-compare">
+          <div><dt>Candidate</dt><dd>{label(active.candidate_id)} <small>{typeOf(active.candidate_id) ?? ""}</small></dd></div>
+          <div><dt>Canonical</dt><dd>{label(active.canonical_id)} <small>{typeOf(active.canonical_id) ?? ""}</small></dd></div>
+          {#if active.shared_terms?.length}
+            <div><dt>Shared</dt><dd>{active.shared_terms.join(", ")}</dd></div>
+          {/if}
+        </dl>
+
+        {#if active.reasons?.length}
+          <Accordion title="Reasons" count={active.reasons.length} open={true}>
+            <ul class="recon-reasons">
+              {#each active.reasons as r (r)}<li>{r}</li>{/each}
+            </ul>
+          </Accordion>
+        {/if}
+
+        <!-- Evidence collapsed by default (user request). -->
+        <Accordion title="Evidence" count={(active.evidence_refs ?? []).length} open={false}>
+          {#if (active.evidence_refs ?? []).length === 0}
+            <p class="recon-empty">No evidence refs.</p>
+          {:else}
+            <ul class="recon-evidence">
+              {#each active.evidence_refs as ref (ref)}<li>{ref}</li>{/each}
+            </ul>
+          {/if}
+        </Accordion>
+
+        <div class="recon-actions">
+          <button class="recon-accept" disabled={busy} onclick={() => decide("accept")}>
+            {busy ? "Applying…" : "Accept match"}
           </button>
-        </li>
-      {/each}
-    </ul>
-  {/if}
-</section>
+          <button class="recon-reject" disabled={busy} onclick={() => decide("reject")}>
+            Reject match
+          </button>
+        </div>
+        {#if actionResult}
+          <p class="recon-result" class:ok={actionResult.ok} class:err={!actionResult.ok}>
+            {actionResult.msg}
+          </p>
+        {/if}
+      {/if}
+    </aside>
+  </div>
+</WorkspaceShell>
 
 <style>
-  .recon {
-    padding: 1.5rem 2rem;
-    max-width: 60rem;
-    margin: 0 auto;
-    height: 100%;
+  .col { min-height: 0; height: 100%; }
+  .recon-rail,
+  .recon-detail {
+    background: var(--st-semantic-surface-default, #fff);
     overflow-y: auto;
-  }
-  .recon-head h2 {
-    margin: 0;
-  }
-  .recon-note {
-    margin: 0.25rem 0 1rem;
-    color: var(--st-semantic-text-muted, #64748b);
-    font-size: 0.85rem;
-  }
-  .recon-toolbar {
+    min-height: 0;
+    height: 100%;
     display: flex;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
+    flex-direction: column;
+  }
+  .recon-rail-search {
+    padding: 0.7rem 0.85rem;
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .recon-rail-search input {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--st-semantic-border-strong, #94a3b8);
+    border-radius: var(--st-radius-sm, 4px);
+  }
+  .recon-rail-meta {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.5rem 0.85rem;
   }
   .recon-pill {
     border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
     border-radius: var(--st-radius-pill, 999px);
-    padding: 0.1rem 0.6rem;
-    font-size: 0.78rem;
+    padding: 0.05rem 0.55rem;
+    font-size: 0.74rem;
     color: var(--st-semantic-text-secondary, #475569);
     background: var(--st-semantic-surface-subtle, #f8fafc);
   }
-  .recon-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 0.5rem;
-  }
-  .recon-row {
+  .recon-rail-list { list-style: none; margin: 0; padding: 0 0.5rem; display: grid; gap: 2px; }
+  .recon-rail-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
-    padding: 0.6rem 0.75rem;
-    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    border-radius: var(--st-radius-md, 8px);
-    background: var(--st-semantic-surface-default, #fff);
-  }
-  .recon-row-main {
-    display: grid;
-    gap: 2px;
-  }
-  .recon-row-main small {
-    color: var(--st-semantic-text-muted, #64748b);
-    font-size: 0.78rem;
-  }
-  .recon-open {
-    border: 1px solid var(--st-semantic-border-strong, #94a3b8);
-    background: var(--st-semantic-surface-subtle, #f8fafc);
+    gap: 0.5rem;
+    width: 100%;
+    text-align: left;
+    border: 1px solid transparent;
+    background: transparent;
     border-radius: var(--st-radius-sm, 4px);
-    padding: 0.35rem 0.7rem;
+    padding: 0.4rem 0.5rem;
     cursor: pointer;
     font-size: 0.82rem;
-    white-space: nowrap;
+    color: var(--st-semantic-text-primary, #0f172a);
   }
+  .recon-rail-row:hover { background: var(--st-semantic-surface-subtle, #f8fafc); }
+  .recon-rail-row.active {
+    border-color: var(--st-semantic-action-primary, #2563eb);
+    box-shadow: inset 3px 0 0 var(--st-semantic-action-primary, #2563eb);
+  }
+  .recon-rail-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .recon-rail-score { font-variant-numeric: tabular-nums; color: var(--st-semantic-text-muted, #64748b); font-size: 0.74rem; }
+  .recon-detail { padding: 1rem 1.1rem 2rem; }
+  .recon-kicker {
+    margin: 0; text-transform: uppercase; letter-spacing: 0.06em;
+    font-size: 0.7rem; font-weight: 700; color: var(--st-semantic-text-muted, #64748b);
+  }
+  .recon-detail-head h2 { margin: 0.15rem 0 0.2rem; font-size: 1.05rem; line-height: 1.25; }
+  .recon-detail-score { margin: 0; font-size: 0.8rem; color: var(--st-semantic-text-muted, #64748b); }
+  .recon-compare { margin: 0.9rem 0 0; display: grid; gap: 0.3rem; font-size: 0.84rem; }
+  .recon-compare > div { display: grid; grid-template-columns: 6rem 1fr; gap: 0.5rem; }
+  .recon-compare dt {
+    margin: 0; color: var(--st-semantic-text-muted, #64748b);
+    text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.68rem; font-weight: 600;
+  }
+  .recon-compare dd { margin: 0; }
+  .recon-compare small { color: var(--st-semantic-text-muted, #64748b); }
+  .recon-reasons, .recon-evidence {
+    list-style: none; margin: 0; padding: 0; display: grid; gap: 0.2rem;
+    font-size: 0.8rem; color: var(--st-semantic-text-secondary, #475569);
+  }
+  .recon-evidence li { overflow-wrap: anywhere; }
+  .recon-actions { margin-top: 1.2rem; display: flex; gap: 0.5rem; }
+  .recon-accept, .recon-reject {
+    flex: 1; border-radius: var(--st-radius-sm, 4px); padding: 0.5rem 0.7rem;
+    cursor: pointer; font-size: 0.85rem; font-weight: 600;
+  }
+  .recon-accept {
+    border: 1px solid var(--st-semantic-action-primary, #2563eb);
+    background: var(--st-semantic-action-primary, #2563eb);
+    color: var(--st-semantic-action-primaryText, #fff);
+  }
+  .recon-accept:disabled { opacity: 0.6; cursor: progress; }
+  .recon-reject {
+    border: 1px solid var(--st-semantic-border-strong, #94a3b8);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .recon-result { margin-top: 0.6rem; font-size: 0.82rem; }
+  .recon-result.ok { color: var(--st-semantic-feedback-success, #16a34a); }
+  .recon-result.err { color: var(--st-semantic-feedback-error, #dc2626); }
+  .recon-empty, .recon-center-empty {
+    color: var(--st-semantic-text-muted, #64748b); font-size: 0.85rem; font-style: italic;
+    padding: 1rem;
+  }
+  .recon-center-empty { display: grid; place-items: center; height: 100%; }
 </style>

--- a/studio/src/lib/api.js
+++ b/studio/src/lib/api.js
@@ -47,3 +47,23 @@ export async function fetchReconciliationCandidates() {
     return { items: [], total: 0, error: String(err) };
   }
 }
+
+/**
+ * POST a patch to one of the write routes. On a loopback --write server no
+ * bearer token is required (SVELTE-7); the server applies/validates the patch.
+ * @param {"validate"|"dry-run"|"apply"} route
+ * @param {object} patch  a graphify_ontology_patch_v1 document
+ */
+export async function postPatch(route, patch) {
+  const res = await fetch(`/api/ontology/patch/${route}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify(patch),
+  });
+  const data = await res.json().catch(() => ({}));
+  return { ok: res.ok, status: res.status, ...data };
+}
+
+export const postPatchValidate = (patch) => postPatch("validate", patch);
+export const postPatchDryRun = (patch) => postPatch("dry-run", patch);
+export const postPatchApply = (patch) => postPatch("apply", patch);

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -239,3 +239,33 @@ export function citationsByFile(node) {
     .map(([file, passages]) => ({ file, count: passages.length, passages }))
     .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
 }
+
+/**
+ * SVELTE-7: build a focused subgraph around two reconciliation-candidate
+ * entities. Includes both anchors + their neighbours up to `hops` (default 1),
+ * and every edge whose endpoints are both in the kept set. Returns a graph
+ * shaped like the full one ({ nodes, links }) so buildScene can consume it.
+ */
+export function candidateSubgraph(graph, idA, idB, hops = 1) {
+  const idx = indexNodes(graph);
+  const edges = graphEdges(graph);
+  const keep = new Set();
+  for (const a of [idA, idB]) {
+    if (a != null && idx.has(a)) keep.add(a);
+  }
+  let frontier = new Set(keep);
+  for (let h = 0; h < Math.max(0, hops); h++) {
+    const next = new Set();
+    for (const e of edges) {
+      const s = e?.source, t = e?.target;
+      if (frontier.has(s) && t != null && idx.has(t) && !keep.has(t)) next.add(t);
+      if (frontier.has(t) && s != null && idx.has(s) && !keep.has(s)) next.add(s);
+    }
+    for (const n of next) keep.add(n);
+    frontier = next;
+    if (next.size === 0) break;
+  }
+  const nodes = [...keep].map((id) => idx.get(id)).filter(Boolean);
+  const links = edges.filter((e) => keep.has(e?.source) && keep.has(e?.target));
+  return { nodes, links };
+}

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -216,3 +216,26 @@ export function groupCounts(graph, keyFn) {
     .map(([key, count]) => ({ key: String(key), count }))
     .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
 }
+
+/**
+ * SVELTE-2: group a node's citations by source file, with their passages.
+ * Each citation is `{ source_file, section?, quote? }`. Returns one entry per
+ * distinct file, with its passages (section + optional verbatim quote). Used by
+ * the entity panel's double accordion (file > passages) for full traceability.
+ * @returns {{ file: string, count: number, passages: { section: string|null, quote: string|null }[] }[]}
+ */
+export function citationsByFile(node) {
+  const cites = Array.isArray(node?.citations) ? node.citations : [];
+  const byFile = new Map();
+  for (const c of cites) {
+    const file = displayValue(c?.source_file) ?? displayValue(node?.source_file) ?? "(unknown source)";
+    if (!byFile.has(file)) byFile.set(file, []);
+    byFile.get(file).push({
+      section: displayValue(c?.section) ?? null,
+      quote: displayValue(c?.quote) ?? null,
+    });
+  }
+  return [...byFile.entries()]
+    .map(([file, passages]) => ({ file, count: passages.length, passages }))
+    .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+}

--- a/studio/src/lib/reconciliation.js
+++ b/studio/src/lib/reconciliation.js
@@ -1,0 +1,41 @@
+/**
+ * SVELTE-7: build an ontology patch payload from a reconciliation candidate.
+ *
+ * The studio server's POST /api/ontology/patch/{validate,dry-run,apply} expects
+ * a `graphify_ontology_patch_v1` document. Accept = accept_match, reject =
+ * reject_match. graph_hash/profile_hash come from the candidate queue response
+ * so the server can detect drift.
+ */
+const PATCH_SCHEMA = "graphify_ontology_patch_v1";
+
+/**
+ * @param {object} candidate  one queue item ({ id, candidate_id, canonical_id, evidence_refs, ... })
+ * @param {"accept"|"reject"} decision
+ * @param {{ graphHash?: string, profileHash?: string, author?: string, createdAt?: string }} ctx
+ * @returns {object} the patch document
+ */
+export function buildPatchFromCandidate(candidate, decision, ctx = {}) {
+  if (!candidate || !candidate.candidate_id || !candidate.canonical_id) {
+    throw new Error("candidate must have candidate_id and canonical_id");
+  }
+  const operation = decision === "reject" ? "reject_match" : "accept_match";
+  return {
+    schema: PATCH_SCHEMA,
+    id: `patch-${candidate.id ?? candidate.candidate_id}-${operation}`,
+    operation,
+    status: "proposed",
+    profile_hash: ctx.profileHash ?? "",
+    graph_hash: ctx.graphHash ?? "",
+    target: {
+      candidate_id: candidate.candidate_id,
+      canonical_id: candidate.canonical_id,
+    },
+    evidence_refs: Array.isArray(candidate.evidence_refs) ? candidate.evidence_refs : [],
+    reason:
+      decision === "reject"
+        ? `Rejected via studio reconciliation (${candidate.id ?? candidate.candidate_id}).`
+        : `Accepted via studio reconciliation (${candidate.id ?? candidate.candidate_id}; score ${candidate.score ?? "?"}).`,
+    author: ctx.author ?? "studio-reconciliation",
+    created_at: ctx.createdAt ?? "1970-01-01T00:00:00.000Z",
+  };
+}

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -156,3 +156,34 @@ describe("graphAdapter helpers", () => {
     expect(byComm).toContainEqual({ key: "Sherlock Holmes anthology", count: 2 });
   });
 });
+
+describe("citationsByFile (SVELTE-2)", () => {
+  it("groups citations by source file with passages", async () => {
+    const { citationsByFile } = await import("../lib/graphAdapter.js");
+    const node = {
+      id: "n1",
+      source_file: "a.txt",
+      citations: [
+        { source_file: "a.txt", section: "ch1", quote: "alpha" },
+        { source_file: "a.txt", section: "ch2" },
+        { source_file: "b.txt", section: "intro", quote: "beta" },
+      ],
+    };
+    const groups = citationsByFile(node);
+    expect(groups.length).toBe(2);
+    const a = groups.find((g) => g.file === "a.txt");
+    expect(a.count).toBe(2);
+    expect(a.passages[0].quote).toBe("alpha");
+    expect(a.passages[1].section).toBe("ch2");
+    expect(a.passages[1].quote).toBe(null);
+    const b = groups.find((g) => g.file === "b.txt");
+    expect(b.count).toBe(1);
+  });
+
+  it("falls back to node.source_file when a citation has none, and handles empty", async () => {
+    const { citationsByFile } = await import("../lib/graphAdapter.js");
+    expect(citationsByFile({ citations: [] })).toEqual([]);
+    const g = citationsByFile({ source_file: "x.txt", citations: [{ section: "s" }] });
+    expect(g[0].file).toBe("x.txt");
+  });
+});

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -187,3 +187,25 @@ describe("citationsByFile (SVELTE-2)", () => {
     expect(g[0].file).toBe("x.txt");
   });
 });
+
+describe("candidateSubgraph (SVELTE-7)", () => {
+  it("keeps both anchors + 1-hop neighbours and their internal edges", async () => {
+    const { candidateSubgraph } = await import("../lib/graphAdapter.js");
+    const graph = {
+      nodes: [{ id: "A" }, { id: "B" }, { id: "n1" }, { id: "n2" }, { id: "far" }],
+      links: [
+        { source: "A", target: "n1", relation: "r" },
+        { source: "B", target: "n2", relation: "r" },
+        { source: "n1", target: "far", relation: "r" },
+      ],
+    };
+    const sub = candidateSubgraph(graph, "A", "B", 1);
+    expect(sub.nodes.map((n) => n.id).sort()).toEqual(["A", "B", "n1", "n2"]);
+    expect(sub.links.length).toBe(2);
+  });
+  it("handles missing anchors gracefully", async () => {
+    const { candidateSubgraph } = await import("../lib/graphAdapter.js");
+    const sub = candidateSubgraph({ nodes: [{ id: "A" }], links: [] }, "A", "ZZZ", 1);
+    expect(sub.nodes.map((n) => n.id)).toEqual(["A"]);
+  });
+});

--- a/studio/src/tests/reconciliation.test.js
+++ b/studio/src/tests/reconciliation.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildPatchFromCandidate } from "../lib/reconciliation.js";
+
+const cand = {
+  id: "reconcile:abc",
+  candidate_id: "character_king_of_bohemia",
+  canonical_id: "character_king_bohemia",
+  score: 0.95,
+  evidence_refs: ["corpus/x/text.txt#A Scandal in Bohemia"],
+};
+
+describe("buildPatchFromCandidate (SVELTE-7)", () => {
+  it("builds an accept_match patch with target + evidence + hashes", () => {
+    const p = buildPatchFromCandidate(cand, "accept", { graphHash: "gh", profileHash: "ph", createdAt: "2026-01-01T00:00:00.000Z" });
+    expect(p.schema).toBe("graphify_ontology_patch_v1");
+    expect(p.operation).toBe("accept_match");
+    expect(p.target).toEqual({ candidate_id: "character_king_of_bohemia", canonical_id: "character_king_bohemia" });
+    expect(p.evidence_refs.length).toBe(1);
+    expect(p.graph_hash).toBe("gh");
+    expect(p.profile_hash).toBe("ph");
+    expect(p.created_at).toBe("2026-01-01T00:00:00.000Z");
+  });
+  it("builds a reject_match patch", () => {
+    const p = buildPatchFromCandidate(cand, "reject", {});
+    expect(p.operation).toBe("reject_match");
+  });
+  it("throws without candidate ids", () => {
+    expect(() => buildPatchFromCandidate({}, "accept")).toThrow();
+  });
+});

--- a/tests/ontology-studio-write.test.ts
+++ b/tests/ontology-studio-write.test.ts
@@ -207,7 +207,7 @@ describe("graphify ontology studio --write", () => {
     }
   });
 
-  it("requires a bearer token for write routes and never mutates without it", async () => {
+  it("accepts same-origin loopback writes without a token, and still accepts a valid token (SVELTE-7)", async () => {
     const dir = makeTempDir();
     const fixture = writeOntologyWriteFixture(dir);
     const started = await startOntologyStudioServer({
@@ -218,24 +218,24 @@ describe("graphify ontology studio --write", () => {
       expect(started.writeEnabled).toBe(true);
       expect(started.token).toMatch(/^[0-9a-f]{48}$/);
 
+      // Loopback bind (default 127.0.0.1): the SPA may dry-run/apply WITHOUT a
+      // bearer token. --write already refuses non-loopback binds (separate
+      // test), so nothing reachable from the network can hit this.
       const { body, headers } = postBody(fixture.patch);
-      const noAuth = await fetch(`${started.url}/api/ontology/patch/apply`, {
+      const noAuthDry = await fetch(`${started.url}/api/ontology/patch/dry-run`, {
         method: "POST",
         headers,
         body,
       });
-      expect(noAuth.status).toBe(401);
+      expect(noAuthDry.status).toBe(200);
 
-      const wrongAuth = await fetch(`${started.url}/api/ontology/patch/apply`, {
+      // A valid token is still accepted (back-compat).
+      const withToken = await fetch(`${started.url}/api/ontology/patch/dry-run`, {
         method: "POST",
-        headers: { ...headers, authorization: "Bearer not-the-token" },
+        headers: { ...headers, authorization: `Bearer ${started.token}` },
         body,
       });
-      expect(wrongAuth.status).toBe(401);
-
-      // No mutation should have happened.
-      expect(readFileSync(fixture.decisionsPath, "utf-8")).toBe("");
-      expect(existsSync(fixture.auditPath)).toBe(false);
+      expect(withToken.status).toBe(200);
     } finally {
       started.server.close();
     }


### PR DESCRIPTION
Fixes UAT regressions in the Svelte studio SPA vs the legacy server-rendered studio. From `.graphify/uat/STUDIO_DEFECTS.md` (SVELTE-1..7).

## Done
- **SVELTE-1** — entity relations now in a collapsible accordion (open when ≤8).
- **SVELTE-2** — citations restored as a **double accordion** (file > passages, with verbatim quotes), sourced from the node's `citations[]`. New `citationsByFile()` adapter (TDD).
- **SVELTE-7** — reconciliation rewritten from a stub into the **3-column workbench**: left = filterable candidate list, center = graph scoped to the **subgraph of the two candidate entities** (`candidateSubgraph`, TDD), right = compare panel (Reasons + collapsed Evidence) with **Accept match** / **Reject match**. Accept = `accept_match` apply, Reject = `reject_match`. New `buildPatchFromCandidate` (TDD) + `postPatch{Validate,DryRun,Apply}`.
- **Loopback write unblock** — the SPA can't know the write bearer token, so accept/reject couldn't authenticate. Since `--write` already refuses non-loopback binds, a same-origin POST on a loopback host is now trusted without a token (token still accepted). A future Sentropic-integrated auth replaces this. (User-approved.)

## Verification
- Full suite: **1073 tests pass**, `tsc --noEmit` clean, SPA `vite build` ok.
- E2E on the public pack: reconciliation dry-run returns `valid: true` (3 changed files) **without a token** via the loopback unblock.

## Out of scope (separate tracks)
- **SVELTE-3** = data: the regenerated graph's 141 communities are generic `Community N` (labels are assistant-authored, not auto-generated by clustering). Needs a labelling pass — not a SPA fix.
- **SVELTE-4/5/6** (node shapes, zoom/pan, edge hover, legend) = design-system `ForceGraph`; the DS just published **0.10.4** with all four — a follow-up PR will bump + wire them.