### PR TITLE
feat(track-g): node shapes + legend + edge hover + zoom via ForceGraph 0.10.4 (SVELTE-4/5/6)

### DIFF
--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -8,7 +8,7 @@
       "name": "graphify-ontology-studio-app",
       "version": "0.1.0",
       "dependencies": {
-        "@sentropic/design-system-svelte": "^0.10.3",
+        "@sentropic/design-system-svelte": "^0.10.4",
         "@sentropic/design-system-themes": "^0.10.3",
         "@sentropic/design-system-tokens": "^0.10.3"
       },
@@ -1035,9 +1035,9 @@
       ]
     },
     "node_modules/@sentropic/design-system-svelte": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.10.3.tgz",
-      "integrity": "sha512-Oo2kwIqc1fZatzsUSZpSb4Y92H+Mzf12slak58K4LKuBRyqJ/bv4FzCtVPaMZdWySXWxH12G+CljeH44Rn8GYA==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.10.4.tgz",
+      "integrity": "sha512-HheVOgVBdC+GO+ElwKEaSh49BjYFw/RcStMD6Xklwv7VsAp9lZ1nU4BqYMy192VELqq1PSIFU5t1DApw7zaPDw==",
       "dependencies": {
         "@lucide/svelte": "^0.562.0",
         "@sentropic/design-system-themes": "0.10.3"

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,7 +18,7 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@sentropic/design-system-svelte": "^0.10.3",
+    "@sentropic/design-system-svelte": "^0.10.4",
     "@sentropic/design-system-themes": "^0.10.3",
     "@sentropic/design-system-tokens": "^0.10.3"
   }

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -16,7 +16,7 @@
   import ReconciliationView from "./components/ReconciliationView.svelte";
   import WorkspaceShell from "./components/WorkspaceShell.svelte";
   import { fetchEntity, fetchGraph } from "./lib/api.js";
-  import { buildScene, graphNodes, nodeType, nodeCommunity } from "./lib/graphAdapter.js";
+  import { buildScene, graphNodes, nodeType, nodeCommunity, shapeLegend } from "./lib/graphAdapter.js";
   import {
     createDefaultViewerState,
     selectNode,
@@ -40,6 +40,8 @@
   const scene = $derived(
     buildScene(graph, { showWeakLinks: viewerState.filters.showWeakLinks }),
   );
+  // SVELTE-4: shape->type legend for the graph canvas.
+  const legend = $derived(shapeLegend(graph));
 
   const focusEntity = $derived(
     viewerState.focusId ? (entityCache[viewerState.focusId] ?? null) : null,
@@ -145,6 +147,7 @@
         <div class="col col-center">
           <GraphCanvas
             {scene}
+            {legend}
             selectedIds={viewerState.selectedIds}
             focusId={viewerState.focusId}
             onSelect={handleSelect}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -9,7 +9,17 @@
    */
   import { ForceGraph } from "@sentropic/design-system-svelte";
 
-  let { scene, selectedIds = [], focusId = null, onSelect, onOpenEntity } = $props();
+  // SVELTE-4/5/6: legend (shape->type, dash->relation), edge hover tooltip, and
+  // zoom/pan all come from ForceGraph 0.10.4. node.shape is set in buildScene.
+  let {
+    scene,
+    selectedIds = [],
+    focusId = null,
+    legend = [],
+    onSelect,
+    onOpenEntity,
+    onEdgeHover,
+  } = $props();
 
   // Measure the container so the sim fills the available center column.
   let host = $state(null);
@@ -42,9 +52,11 @@
       {height}
       {selectedIds}
       {focusId}
+      {legend}
       showLabels={scene.nodes.length <= 80}
       {onSelect}
       {onOpenEntity}
+      {onEdgeHover}
     />
   {/if}
 </div>

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -66,6 +66,43 @@ export function nodeGroup(node) {
   return nodeType(node) ?? undefined;
 }
 
+/**
+ * SVELTE-4: map an ontology node type to a DS ForceGraph shape, mirroring the
+ * pack profile's visual_encoding (shape signals the entity's ontological
+ * nature; colour stays community-driven). Unknown types fall back to "dot".
+ * @returns {"diamond"|"star"|"hexagon"|"box"|"triangle"|"square"|"dot"}
+ */
+const TYPE_SHAPE = {
+  Character: "diamond",
+  Alias: "diamond",
+  DisguisePersona: "star",
+  NarrativeRole: "star",
+  Location: "triangle",
+  Organization: "hexagon",
+  Evidence: "square",
+  Object: "square",
+  ForensicMethod: "hexagon",
+  Work: "box",
+  Saga: "box",
+  ChapterOrStory: "box",
+  Author: "box",
+  Translator: "box",
+};
+export function shapeForType(node) {
+  const t = nodeType(node);
+  return (t && TYPE_SHAPE[t]) || "dot";
+}
+
+/** Distinct (type -> shape) legend entries present in a graph (SVELTE-4). */
+export function shapeLegend(graph) {
+  const seen = new Map();
+  for (const node of graphNodes(graph)) {
+    const t = nodeType(node);
+    if (t && !seen.has(t)) seen.set(t, shapeForType(node));
+  }
+  return [...seen.entries()].map(([label, shape]) => ({ label, shape }));
+}
+
 /** Strong = EXTRACTED (default). Anything else (INFERRED, …) renders weak. */
 export function isStrongEdge(edge) {
   const conf = String(edge?.confidence ?? "EXTRACTED").toUpperCase();
@@ -120,6 +157,7 @@ export function buildScene(graph, options = {}) {
       id: node.id,
       label: nodeLabel(node),
       weight: weightForDegree(degree.get(node.id) ?? 0),
+      shape: shapeForType(node), // SVELTE-4: ontology type -> DS shape
     };
     if (group !== undefined) out.group = group;
     return out;

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -209,3 +209,26 @@ describe("candidateSubgraph (SVELTE-7)", () => {
     expect(sub.nodes.map((n) => n.id)).toEqual(["A"]);
   });
 });
+
+describe("shapeForType / shapeLegend (SVELTE-4)", () => {
+  it("maps ontology types to DS shapes, defaulting to dot", async () => {
+    const { shapeForType } = await import("../lib/graphAdapter.js");
+    expect(shapeForType({ type: "Character" })).toBe("diamond");
+    expect(shapeForType({ node_type: "Location" })).toBe("triangle");
+    expect(shapeForType({ type: "Evidence" })).toBe("square");
+    expect(shapeForType({ type: "Work" })).toBe("box");
+    expect(shapeForType({ type: "Unknownish" })).toBe("dot");
+    expect(shapeForType({})).toBe("dot");
+  });
+  it("buildScene attaches a shape to every node", async () => {
+    const { buildScene } = await import("../lib/graphAdapter.js");
+    const s = buildScene({ nodes: [{ id: "a", type: "Character" }, { id: "b", type: "Location" }], links: [] });
+    expect(s.nodes.find((n) => n.id === "a").shape).toBe("diamond");
+    expect(s.nodes.find((n) => n.id === "b").shape).toBe("triangle");
+  });
+  it("shapeLegend returns distinct type->shape entries", async () => {
+    const { shapeLegend } = await import("../lib/graphAdapter.js");
+    const legend = shapeLegend({ nodes: [{ id: "a", type: "Character" }, { id: "b", type: "Character" }, { id: "c", type: "Evidence" }] });
+    expect(legend).toEqual([{ label: "Character", shape: "diamond" }, { label: "Evidence", shape: "square" }]);
+  });
+});


### PR DESCRIPTION
Restores the graph features the Svelte studio SPA had regressed vs the legacy vis-network studio, now that the design-system shipped them in **@sentropic/design-system-svelte@0.10.4**.

## Done (bump ^0.10.4 + wire)
- **SVELTE-4 — node shapes + legend.** Map ontology node type → DS shape (`shapeForType`): Character=diamond, Location=triangle, Evidence/Object=square, Work/Saga/ChapterOrStory/Author=box, Organization/ForensicMethod=hexagon, DisguisePersona/NarrativeRole=star, else dot. Shape set per node in `buildScene`; a shape→type `legend` (`shapeLegend`) is passed to the canvas (the DS renders the overlay legend).
- **SVELTE-5 — edge hover.** Forward `onEdgeHover`; the component renders the 3-line source/relation/target tooltip.
- **SVELTE-6 — zoom/pan.** Wheel zoom + drag pan + reset are built into 0.10.4 (stable positions, no re-layout).

## Verification
- TDD on the type→shape mapping (`shapeForType`/`shapeLegend`/buildScene shape).
- Full suite: **1073 tests pass**, SPA `vite build` ok.
- E2E: served SPA bundle emits shapes (diamond/hexagon/…) + legend + onEdgeHover.

## Notes
- Closes the DS-side regressions SVELTE-4/5/6. The remaining SPA item **SVELTE-3** (generic `Community N` labels) is a data/labelling task, not a SPA fix.
- Next: post the neg:forcegraph seq-3 offer so the DS peer signs the 0.10.4 API.