### PR TITLE
feat(track-g): studio SPA — graph viewer + selection rework + reconciliation (DS ForceGraph 0.13.0)

### DIFF
--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -8,7 +8,7 @@
       "name": "graphify-ontology-studio-app",
       "version": "0.1.0",
       "dependencies": {
-        "@sentropic/design-system-svelte": "^0.10.5",
+        "@sentropic/design-system-svelte": "^0.13.0",
         "@sentropic/design-system-themes": "^0.10.3",
         "@sentropic/design-system-tokens": "^0.10.3"
       },
@@ -1035,9 +1035,9 @@
       ]
     },
     "node_modules/@sentropic/design-system-svelte": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.10.5.tgz",
-      "integrity": "sha512-ipewwzHz50DMm0B/oS4nAb3hKGmqA+xKS39AKI/FX7dHRHagG/5qMJJQDRM1N3DfJ+27ZwPbYWm07saw8AX74A==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.13.0.tgz",
+      "integrity": "sha512-F94Bw21VexAhwL5ebJCT5jff1tgIvVLyieqJ4XtDVTUdl+QuH944TKbZF2XCe+5IE3b8R+Ze2fCO5Bk34BZzhQ==",
       "dependencies": {
         "@lucide/svelte": "^0.562.0",
         "@sentropic/design-system-themes": "0.10.3"

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -8,7 +8,7 @@
       "name": "graphify-ontology-studio-app",
       "version": "0.1.0",
       "dependencies": {
-        "@sentropic/design-system-svelte": "^0.10.4",
+        "@sentropic/design-system-svelte": "^0.10.5",
         "@sentropic/design-system-themes": "^0.10.3",
         "@sentropic/design-system-tokens": "^0.10.3"
       },
@@ -1035,9 +1035,9 @@
       ]
     },
     "node_modules/@sentropic/design-system-svelte": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.10.4.tgz",
-      "integrity": "sha512-HheVOgVBdC+GO+ElwKEaSh49BjYFw/RcStMD6Xklwv7VsAp9lZ1nU4BqYMy192VELqq1PSIFU5t1DApw7zaPDw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.10.5.tgz",
+      "integrity": "sha512-ipewwzHz50DMm0B/oS4nAb3hKGmqA+xKS39AKI/FX7dHRHagG/5qMJJQDRM1N3DfJ+27ZwPbYWm07saw8AX74A==",
       "dependencies": {
         "@lucide/svelte": "^0.562.0",
         "@sentropic/design-system-themes": "0.10.3"

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -8,7 +8,7 @@
       "name": "graphify-ontology-studio-app",
       "version": "0.1.0",
       "dependencies": {
-        "@sentropic/design-system-svelte": "^0.13.0",
+        "@sentropic/design-system-svelte": "^0.16.0",
         "@sentropic/design-system-themes": "^0.10.3",
         "@sentropic/design-system-tokens": "^0.10.3"
       },
@@ -1035,9 +1035,9 @@
       ]
     },
     "node_modules/@sentropic/design-system-svelte": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.13.0.tgz",
-      "integrity": "sha512-F94Bw21VexAhwL5ebJCT5jff1tgIvVLyieqJ4XtDVTUdl+QuH944TKbZF2XCe+5IE3b8R+Ze2fCO5Bk34BZzhQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.16.0.tgz",
+      "integrity": "sha512-Pc9MsZK3QKTi+8iGfBMYsk/VpJapukWMX+uBVM04D6wEOMgRKnUqYWanVk9E0UEhETJHjnIPRhd/MZPXWLBMJA==",
       "dependencies": {
         "@lucide/svelte": "^0.562.0",
         "@sentropic/design-system-themes": "0.10.3"

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,7 +18,7 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@sentropic/design-system-svelte": "^0.10.5",
+    "@sentropic/design-system-svelte": "^0.13.0",
     "@sentropic/design-system-themes": "^0.10.3",
     "@sentropic/design-system-tokens": "^0.10.3"
   }

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,7 +18,7 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@sentropic/design-system-svelte": "^0.10.4",
+    "@sentropic/design-system-svelte": "^0.10.5",
     "@sentropic/design-system-themes": "^0.10.3",
     "@sentropic/design-system-tokens": "^0.10.3"
   }

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,7 +18,7 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@sentropic/design-system-svelte": "^0.13.0",
+    "@sentropic/design-system-svelte": "^0.16.0",
     "@sentropic/design-system-themes": "^0.10.3",
     "@sentropic/design-system-tokens": "^0.10.3"
   }

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -33,7 +33,9 @@
 
   const EMPTY_GRAPH = { nodes: [], links: [] };
 
-  let graph = $state(EMPTY_GRAPH);
+  // $state.raw: `graph` (1193 nodes) is only ever REASSIGNED in bulk, never
+  // mutated in place — raw skips deep proxying (perf: less memory + hydration).
+  let graph = $state.raw(EMPTY_GRAPH);
   let loaded = $state(false);
   let loadError = $state(null);
   let viewerState = $state(createDefaultViewerState());

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -9,6 +9,7 @@
    * re-laying-out the graph. Mirrors the aclp-am viewer architecture.
    */
   import { onMount } from "svelte";
+  import { Header, Button, Badge } from "@sentropic/design-system-svelte";
 
   import EntityPanel from "./components/EntityPanel.svelte";
   import GraphCanvas from "./components/GraphCanvas.svelte";
@@ -90,31 +91,32 @@
 </script>
 
 <div class="app" data-st-theme="entropic">
-  <header class="app-header">
-    <div class="app-brand">
+  <Header class="app-header" title="Graphify Ontology Studio" label="Graphify Ontology Studio">
+    {#snippet logo()}
       <span class="app-logo" aria-hidden="true">◇</span>
-      <span class="app-name">Graphify Ontology Studio</span>
-    </div>
-    <nav class="app-nav" aria-label="Views">
-      <button
-        class="app-tab"
-        class:active={viewerState.activeView === "workspace"}
-        onclick={() => handleSetView("workspace")}>Workspace</button
+    {/snippet}
+    {#snippet navigation()}
+      <Button
+        size="sm"
+        variant={viewerState.activeView === "workspace" ? "primary" : "ghost"}
+        onclick={() => handleSetView("workspace")}>Workspace</Button
       >
-      <button
-        class="app-tab"
-        class:active={viewerState.activeView === "reconciliation"}
-        onclick={() => handleSetView("reconciliation")}>Reconciliation</button
+      <Button
+        size="sm"
+        variant={viewerState.activeView === "reconciliation" ? "primary" : "ghost"}
+        onclick={() => handleSetView("reconciliation")}>Reconciliation</Button
       >
-    </nav>
-    <div class="app-stats">
+    {/snippet}
+    {#snippet actions()}
       {#if loaded && !loadError}
-        <span>{scene.stats.nodeCount} nodes</span>
-        <span>{scene.stats.edgeCount} edges</span>
-        <span>{scene.stats.communityCount} groups</span>
+        <span class="app-stats">
+          <Badge tone="neutral">{scene.stats.nodeCount} nodes</Badge>
+          <Badge tone="neutral">{scene.stats.edgeCount} edges</Badge>
+          <Badge tone="info">{scene.stats.communityCount} groups</Badge>
+        </span>
       {/if}
-    </div>
-  </header>
+    {/snippet}
+  </Header>
 
   <main class="app-body">
     {#if !loaded}
@@ -174,53 +176,16 @@
     height: 100%;
     min-height: 0;
   }
-  .app-header {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    padding: 0.55rem 1.1rem;
-    background: var(--st-semantic-surface-default, #fff);
-    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-  }
-  .app-brand {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-weight: 700;
-  }
+  /* DS Header owns layout/surface/border. We only style the logo glyph it
+     renders via the `logo` snippet and the stats cluster in `actions`. */
   .app-logo {
     color: var(--st-semantic-action-primary, #2563eb);
     font-size: 1.1rem;
   }
-  .app-name {
-    color: var(--st-semantic-text-primary, #0f172a);
-  }
-  .app-nav {
-    display: flex;
-    gap: 0.25rem;
-  }
-  .app-tab {
-    border: 1px solid transparent;
-    background: transparent;
-    border-radius: var(--st-radius-sm, 4px);
-    padding: 0.3rem 0.7rem;
-    cursor: pointer;
-    color: var(--st-semantic-text-secondary, #475569);
-    font-size: 0.85rem;
-  }
-  .app-tab:hover {
-    background: var(--st-semantic-surface-subtle, #f8fafc);
-  }
-  .app-tab.active {
-    color: var(--st-semantic-action-primaryText, #fff);
-    background: var(--st-semantic-action-primary, #2563eb);
-  }
   .app-stats {
-    margin-left: auto;
-    display: flex;
-    gap: 0.85rem;
-    color: var(--st-semantic-text-muted, #64748b);
-    font-size: 0.78rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
     font-variant-numeric: tabular-nums;
   }
   .app-body {

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -24,6 +24,7 @@
     toggleCommunity,
     toggleEntity,
     focusEntity as focusEntityAction,
+    setFocus,
     clearSelection,
     setActiveView,
     setQuery,
@@ -49,11 +50,6 @@
   // Graph highlight = every entity of every selected type/community + the
   // directly-selected entities (R8-3.B).
   const selectedIds = $derived(resolveSelectedIds(graph, viewerState.selection));
-  // Focused entity detail (the leaf of the right-column drill-down).
-  const focusEntity = $derived(
-    viewerState.focusId ? (entityCache[viewerState.focusId] ?? null) : null,
-  );
-
   function handleToggleType(type) {
     viewerState = toggleType(viewerState, type);
   }
@@ -67,6 +63,11 @@
   function handleFocusEntity(id) {
     viewerState = focusEntityAction(viewerState, id);
     void ensureEntity(id);
+  }
+  function handleSetFocus(id) {
+    // Expand/collapse the right-column entity detail (null = collapse).
+    viewerState = setFocus(viewerState, id);
+    if (id) void ensureEntity(id);
   }
   function handleClear() {
     viewerState = clearSelection(viewerState);
@@ -171,7 +172,8 @@
             {graph}
             selection={viewerState.selection}
             focusId={viewerState.focusId}
-            {focusEntity}
+            {entityCache}
+            onSetFocus={handleSetFocus}
             onFocusEntity={handleFocusEntity}
             onToggleType={handleToggleType}
             onToggleCommunity={handleToggleCommunity}

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -11,18 +11,22 @@
   import { onMount } from "svelte";
   import { Header, Button, Badge } from "@sentropic/design-system-svelte";
 
-  import EntityPanel from "./components/EntityPanel.svelte";
   import GraphCanvas from "./components/GraphCanvas.svelte";
   import LeftRail from "./components/LeftRail.svelte";
   import ReconciliationView from "./components/ReconciliationView.svelte";
+  import SelectionPanel from "./components/SelectionPanel.svelte";
   import WorkspaceShell from "./components/WorkspaceShell.svelte";
   import { fetchEntity, fetchGraph } from "./lib/api.js";
-  import { buildScene, graphNodes, nodeType, nodeCommunity, shapeLegend } from "./lib/graphAdapter.js";
+  import { buildScene, shapeLegend, resolveSelectedIds } from "./lib/graphAdapter.js";
   import {
     createDefaultViewerState,
-    selectNode,
+    toggleType,
+    toggleCommunity,
+    toggleEntity,
+    focusEntity as focusEntityAction,
+    clearSelection,
     setActiveView,
-    setGroupFilter,
+    setQuery,
     setShowWeakLinks,
   } from "./lib/viewerState.js";
 
@@ -34,48 +38,53 @@
   let viewerState = $state(createDefaultViewerState());
   let entityCache = $state({});
 
-  // ----- derived scene ------------------------------------------------------
-  // The scene is rebuilt only when the GRAPH or the weak-link filter changes —
+  // ----- derived ------------------------------------------------------------
+  // The scene is rebuilt only when the GRAPH or the weak-link option changes —
   // NOT when selection changes. Selection flows through selectedIds/focusId,
   // which the DS applies without re-layout.
   const scene = $derived(
-    buildScene(graph, { showWeakLinks: viewerState.filters.showWeakLinks }),
+    buildScene(graph, { showWeakLinks: viewerState.options.showWeakLinks }),
   );
-  // SVELTE-4: shape->type legend for the graph canvas.
   const legend = $derived(shapeLegend(graph));
-
+  // Graph highlight = every entity of every selected type/community + the
+  // directly-selected entities (R8-3.B).
+  const selectedIds = $derived(resolveSelectedIds(graph, viewerState.selection));
+  // Focused entity detail (the leaf of the right-column drill-down).
   const focusEntity = $derived(
     viewerState.focusId ? (entityCache[viewerState.focusId] ?? null) : null,
   );
 
-  function handleSelect(id) {
-    // Highlight + focus. No graph reload, no re-layout.
-    viewerState = selectNode(viewerState, id);
+  function handleToggleType(type) {
+    viewerState = toggleType(viewerState, type);
+  }
+  function handleToggleCommunity(community) {
+    viewerState = toggleCommunity(viewerState, community);
+  }
+  function handleToggleEntity(id) {
+    viewerState = toggleEntity(viewerState, id);
+    if (viewerState.focusId) void ensureEntity(viewerState.focusId);
+  }
+  function handleFocusEntity(id) {
+    viewerState = focusEntityAction(viewerState, id);
     void ensureEntity(id);
   }
-
-  function handleOpenEntity(id) {
-    // dblclick / Enter — same target, the panel is already the detail surface.
-    viewerState = selectNode(viewerState, id);
-    void ensureEntity(id);
+  function handleClear() {
+    viewerState = clearSelection(viewerState);
   }
-
-  async function ensureEntity(id) {
-    if (entityCache[id]) return;
-    const data = await fetchEntity(id);
-    if (data) entityCache = { ...entityCache, [id]: data };
+  function handleSetQuery(q) {
+    viewerState = setQuery(viewerState, q);
   }
-
-  function handleSetGroup(group) {
-    viewerState = setGroupFilter(viewerState, group);
-  }
-
   function handleToggleWeak(value) {
     viewerState = setShowWeakLinks(viewerState, value);
   }
-
   function handleSetView(view) {
     viewerState = setActiveView(viewerState, view);
+  }
+
+  async function ensureEntity(id) {
+    if (!id || entityCache[id]) return;
+    const data = await fetchEntity(id);
+    if (data) entityCache = { ...entityCache, [id]: data };
   }
 
   onMount(async () => {
@@ -131,18 +140,19 @@
         <p class="app-error-detail">{loadError}</p>
       </section>
     {:else if viewerState.activeView === "reconciliation"}
-      <ReconciliationView {graph} onOpenEntity={handleOpenEntity} />
+      <ReconciliationView {graph} onOpenEntity={handleFocusEntity} />
     {:else}
       <WorkspaceShell>
         <div class="col col-left">
           <LeftRail
             {graph}
-            activeGroup={viewerState.filters.group}
-            showWeakLinks={viewerState.filters.showWeakLinks}
-            selectedIds={viewerState.selectedIds}
-            focusId={viewerState.focusId}
-            onSelectEntity={handleSelect}
-            onSetGroup={handleSetGroup}
+            query={viewerState.query}
+            selection={viewerState.selection}
+            showWeakLinks={viewerState.options.showWeakLinks}
+            onToggleType={handleToggleType}
+            onToggleCommunity={handleToggleCommunity}
+            onToggleEntity={handleToggleEntity}
+            onSetQuery={handleSetQuery}
             onToggleWeak={handleToggleWeak}
           />
         </div>
@@ -150,18 +160,23 @@
           <GraphCanvas
             {scene}
             {legend}
-            selectedIds={viewerState.selectedIds}
+            {selectedIds}
             focusId={viewerState.focusId}
-            onSelect={handleSelect}
-            onOpenEntity={handleOpenEntity}
+            onSelect={handleToggleEntity}
+            onOpenEntity={handleFocusEntity}
           />
         </div>
         <div class="col col-right">
-          <EntityPanel
+          <SelectionPanel
             {graph}
+            selection={viewerState.selection}
             focusId={viewerState.focusId}
-            entity={focusEntity}
-            onOpenEntity={handleOpenEntity}
+            {focusEntity}
+            onFocusEntity={handleFocusEntity}
+            onToggleType={handleToggleType}
+            onToggleCommunity={handleToggleCommunity}
+            onToggleEntity={handleToggleEntity}
+            onClear={handleClear}
           />
         </div>
       </WorkspaceShell>

--- a/studio/src/components/Accordion.svelte
+++ b/studio/src/components/Accordion.svelte
@@ -1,9 +1,13 @@
 <script>
-  /** Collapsed-by-default disclosure section for the left rail. */
-  let { title, count = null, open = false, children } = $props();
+  /**
+   * Collapsed-by-default disclosure section for the left rail.
+   * `compact` = a nested (second-level) accordion: smaller, lighter summary so
+   * the hierarchy reads (level 2 < level 1).
+   */
+  let { title, count = null, open = false, compact = false, children } = $props();
 </script>
 
-<details class="ws-acc" {open}>
+<details class="ws-acc" class:ws-acc--compact={compact} {open}>
   <summary class="ws-acc-summary">
     <span class="ws-acc-title">{title}</span>
     {#if count !== null}
@@ -44,8 +48,25 @@
     color: var(--st-semantic-text-muted, #64748b);
     transition: transform 0.12s ease;
   }
-  .ws-acc[open] .ws-acc-summary::before {
+  /* Child combinator (>) so an open accordion only rotates ITS OWN marker, not
+     the markers of nested (collapsed) child accordions. */
+  .ws-acc[open] > .ws-acc-summary::before {
     transform: rotate(90deg);
+  }
+  /* Second-level (nested) accordion: smaller, lighter, no uppercase. */
+  .ws-acc--compact > .ws-acc-summary {
+    padding: 0.32rem 0.6rem;
+    font-size: 0.74rem;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .ws-acc--compact > .ws-acc-summary::before {
+    font-size: 0.6rem;
+  }
+  .ws-acc--compact > .ws-acc-body {
+    padding: 0.15rem 0.5rem 0.5rem 1rem;
   }
   .ws-acc-title {
     flex: 1;

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -203,10 +203,6 @@
     letter-spacing: 0.05em;
     color: var(--st-semantic-text-secondary, #475569);
   }
-  .entity-counter {
-    color: var(--st-semantic-text-muted, #64748b);
-    font-variant-numeric: tabular-nums;
-  }
   .entity-description {
     line-height: 1.5;
     color: var(--st-semantic-text-primary, #0f172a);

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -17,7 +17,7 @@
   } from "../lib/graphAdapter.js";
   import { renderInlineMarkdown } from "../lib/markdown.js";
 
-  let { graph, focusId = null, entity = null, onOpenEntity } = $props();
+  let { graph, focusId = null, entity = null, onOpenEntity, hideTitle = false } = $props();
 
   const node = $derived(focusId ? (indexNodes(graph).get(focusId) ?? null) : null);
   const relations = $derived(focusId ? relationRowsFor(focusId, graph) : []);
@@ -42,8 +42,10 @@
   {:else}
     <header class="entity-head">
       <p class="entity-kicker">{nodeType(node) ?? "Entity"}</p>
-      <h2 class="entity-title">{nodeLabel(node)}</h2>
-      <p class="entity-id">{node.id}</p>
+      {#if !hideTitle}
+        <h2 class="entity-title">{nodeLabel(node)}</h2>
+        <p class="entity-id">{node.id}</p>
+      {/if}
     </header>
 
     <dl class="entity-meta">

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -110,7 +110,7 @@
           <ul class="entity-cite-files">
             {#each citationFiles as cf (cf.file)}
               <li>
-                <Accordion title={cf.file} count={cf.count} open={false}>
+                <Accordion title={cf.file} count={cf.count} open={false} compact>
                   <ul class="entity-cite-passages">
                     {#each cf.passages as p, i (cf.file + i)}
                       <li class="entity-cite-passage">

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -74,9 +74,9 @@
       </section>
     {/if}
 
-    <!-- SVELTE-1: relations collapsed into an accordion (open when few). -->
+    <!-- SVELTE-1: relations in an accordion, collapsed by default (like citations). -->
     <div class="entity-acc">
-      <Accordion title="Relations" count={relations.length} open={relations.length > 0 && relations.length <= 8}>
+      <Accordion title="Relations" count={relations.length} open={false}>
         {#if relations.length === 0}
           <p class="entity-empty-inline">No relations.</p>
         {:else}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -54,6 +54,7 @@
       {focusId}
       {legend}
       nodeRadius={3}
+      repulsion={1.6}
       showLabels={scene.nodes.length <= 80}
       {onSelect}
       {onOpenEntity}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -53,7 +53,7 @@
       {selectedIds}
       {focusId}
       {legend}
-      nodeRadius={4}
+      nodeRadius={3}
       showLabels={scene.nodes.length <= 80}
       {onSelect}
       {onOpenEntity}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -26,6 +26,13 @@
   let width = $state(720);
   let height = $state(560);
 
+  // UAT-4: the DS clamps nodes to the full w×h box, so a wide/short column
+  // spreads the graph into a band glued to the edges (clipped, not round).
+  // Feed the sim a SQUARE area (min side); the SVG's preserveAspectRatio="meet"
+  // then scales that square to fit the column and centres it — the graph stays
+  // round and is never cropped. (A true fit-to-content is a DS request.)
+  const side = $derived(Math.max(320, Math.min(width, height)));
+
   $effect(() => {
     if (!host) return;
     const ro = new ResizeObserver((entries) => {
@@ -48,8 +55,8 @@
       nodes={scene.nodes}
       edges={scene.edges}
       label="Ontology knowledge graph"
-      {width}
-      {height}
+      width={side}
+      height={side}
       {selectedIds}
       {focusId}
       {legend}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -19,6 +19,8 @@
     onSelect,
     onOpenEntity,
     onEdgeHover,
+    mergePair = null,
+    onMergeComplete,
   } = $props();
 
   // Measure the container so the sim fills the available center column.
@@ -59,6 +61,8 @@
       {onSelect}
       {onOpenEntity}
       {onEdgeHover}
+      {mergePair}
+      {onMergeComplete}
     />
   {/if}
 </div>

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -53,7 +53,7 @@
       {selectedIds}
       {focusId}
       {legend}
-      nodeRadius={5}
+      nodeRadius={4}
       showLabels={scene.nodes.length <= 80}
       {onSelect}
       {onOpenEntity}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -26,13 +26,6 @@
   let width = $state(720);
   let height = $state(560);
 
-  // UAT-4: the DS clamps nodes to the full w×h box, so a wide/short column
-  // spreads the graph into a band glued to the edges (clipped, not round).
-  // Feed the sim a SQUARE area (min side); the SVG's preserveAspectRatio="meet"
-  // then scales that square to fit the column and centres it — the graph stays
-  // round and is never cropped. (A true fit-to-content is a DS request.)
-  const side = $derived(Math.max(320, Math.min(width, height)));
-
   $effect(() => {
     if (!host) return;
     const ro = new ResizeObserver((entries) => {
@@ -55,8 +48,8 @@
       nodes={scene.nodes}
       edges={scene.edges}
       label="Ontology knowledge graph"
-      width={side}
-      height={side}
+      {width}
+      {height}
       {selectedIds}
       {focusId}
       {legend}

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -53,6 +53,7 @@
       {selectedIds}
       {focusId}
       {legend}
+      nodeRadius={5}
       showLabels={scene.nodes.length <= 80}
       {onSelect}
       {onOpenEntity}

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -155,6 +155,11 @@
               class:active={activeGroup === c.key}
               onclick={() => onSetGroup?.(activeGroup === c.key ? null : c.key)}
             >
+              <span
+                class="rail-swatch"
+                style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
+                aria-hidden="true"
+              ></span>
               <span class="rail-row-label">{c.key}</span>
               <span class="rail-row-count">{c.count}</span>
             </button>
@@ -229,9 +234,21 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .rail-swatch {
+    flex-shrink: 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+  }
   .rail-row-count {
+    flex-shrink: 0;
     font-variant-numeric: tabular-nums;
     color: var(--st-semantic-text-muted, #64748b);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-pill, 999px);
+    padding: 0.02rem 0.45rem;
     font-size: 0.72rem;
   }
   .rail-type-groups {

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -113,14 +113,14 @@
     {/if}
   </Accordion>
 
-  <Accordion title="Results" count={resultsTotal} open={true}>
+  <Accordion title="Results" count={resultsTotal} open={false}>
     {#if resultsTotal === 0}
       <p class="rail-empty">No matching entities.</p>
     {:else}
       <ul class="rail-type-groups">
         {#each resultsByType as grp (grp.type)}
           <li>
-            <Accordion title={grp.type} count={grp.count} open={false}>
+            <Accordion title={grp.type} count={grp.count} open={false} compact>
               <ul class="rail-list">
                 {#each grp.items as r (r.id)}
                   <li>

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -5,6 +5,7 @@
    * the selection (click = add/remove); selected rows are marked. The selection
    * itself is shown in the right column (SelectionPanel).
    */
+  import { SelectableRow } from "@sentropic/design-system-svelte";
   import Accordion from "./Accordion.svelte";
   import {
     graphNodes,
@@ -84,16 +85,12 @@
       <ul class="rail-list">
         {#each typeList as t (t.key)}
           <li>
-            <button
-              class="rail-row"
-              class:selected={typeSet.has(t.key)}
-              aria-pressed={typeSet.has(t.key)}
-              onclick={() => onToggleType?.(t.key)}
-            >
-              <span class="rail-check" aria-hidden="true">{typeSet.has(t.key) ? "✓" : ""}</span>
-              <span class="rail-row-label">{t.key}</span>
-              <span class="rail-row-count">{t.count}</span>
-            </button>
+            <SelectableRow value={t.key} selected={typeSet.has(t.key)} onselect={() => onToggleType?.(t.key)}>
+              <span class="rail-row-content">
+                <span class="rail-row-label">{t.key}</span>
+                <span class="rail-row-count">{t.count}</span>
+              </span>
+            </SelectableRow>
           </li>
         {/each}
       </ul>
@@ -107,20 +104,17 @@
       <ul class="rail-list">
         {#each communityInfo.live as c (c.key)}
           <li>
-            <button
-              class="rail-row"
-              class:selected={commSet.has(c.key)}
-              aria-pressed={commSet.has(c.key)}
-              onclick={() => onToggleCommunity?.(c.key)}
-            >
-              <span
-                class="rail-swatch"
-                style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
-                aria-hidden="true"
-              ></span>
-              <span class="rail-row-label">{c.key}</span>
-              <span class="rail-row-count">{c.count}</span>
-            </button>
+            <SelectableRow value={c.key} selected={commSet.has(c.key)} onselect={() => onToggleCommunity?.(c.key)}>
+              <span class="rail-row-content">
+                <span
+                  class="rail-swatch"
+                  style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
+                  aria-hidden="true"
+                ></span>
+                <span class="rail-row-label">{c.key}</span>
+                <span class="rail-row-count">{c.count}</span>
+              </span>
+            </SelectableRow>
           </li>
         {/each}
       </ul>
@@ -144,16 +138,11 @@
               <ul class="rail-list">
                 {#each grp.items as r (r.id)}
                   <li>
-                    <button
-                      class="rail-row"
-                      class:selected={entSet.has(r.id)}
-                      aria-pressed={entSet.has(r.id)}
-                      onclick={() => onToggleEntity?.(r.id)}
-                      title={r.id}
-                    >
-                      <span class="rail-check" aria-hidden="true">{entSet.has(r.id) ? "✓" : ""}</span>
-                      <span class="rail-row-label">{r.label}</span>
-                    </button>
+                    <SelectableRow value={r.id} selected={entSet.has(r.id)} onselect={() => onToggleEntity?.(r.id)}>
+                      <span class="rail-row-content" title={r.id}>
+                        <span class="rail-row-label">{r.label}</span>
+                      </span>
+                    </SelectableRow>
                   </li>
                 {/each}
               </ul>
@@ -214,36 +203,15 @@
     display: grid;
     gap: 1px;
   }
-  .rail-row {
+  /* SelectableRow (DS, R8-5) owns the row wrapper + selected styling; this is
+     just the inner layout (swatch | label | count). */
+  .rail-row-content {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     width: 100%;
-    text-align: left;
-    border: 1px solid transparent;
-    background: transparent;
-    border-radius: var(--st-radius-sm, 4px);
-    padding: 0.35rem 0.5rem;
-    cursor: pointer;
-    color: var(--st-semantic-text-primary, #0f172a);
+    min-width: 0;
     font-size: 0.85rem;
-  }
-  .rail-row:hover {
-    background: var(--st-semantic-surface-subtle, #f8fafc);
-  }
-  /* Selected = a clean themed state (no inset "boudin" bar). Pending the DS
-     selectable-row pattern (R8-5). */
-  .rail-row.selected {
-    background: var(--st-semantic-surface-selected, #eff6ff);
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-weight: 600;
-  }
-  .rail-check {
-    flex-shrink: 0;
-    width: 0.8rem;
-    text-align: center;
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-size: 0.75rem;
   }
   .rail-row-label {
     flex: 1;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -62,17 +62,10 @@
   const entSet = $derived(new Set(selection.entities));
 </script>
 
-<aside class="rail" aria-label="Workspace navigation">
-  <Accordion title="Options" open={false}>
-    <label class="rail-facet">
-      <input
-        type="checkbox"
-        checked={showWeakLinks}
-        onchange={(e) => onToggleWeak?.(e.currentTarget.checked)}
-      />
-      Show weak (inferred) links
-    </label>
-  </Accordion>
+<aside class="rail" aria-label="Search">
+  <header class="rail-head">
+    <span class="rail-kicker">Search</span>
+  </header>
 
   <div class="rail-search">
     <input
@@ -84,7 +77,7 @@
     />
   </div>
 
-  <Accordion title="Types" count={typeList.length} open={true}>
+  <Accordion title="Types" count={typeList.length} open={false}>
     {#if typeList.length === 0}
       <p class="rail-empty">No types.</p>
     {:else}
@@ -170,6 +163,17 @@
       </ul>
     {/if}
   </Accordion>
+
+  <Accordion title="Options" open={false}>
+    <label class="rail-facet">
+      <input
+        type="checkbox"
+        checked={showWeakLinks}
+        onchange={(e) => onToggleWeak?.(e.currentTarget.checked)}
+      />
+      Show weak (inferred) links
+    </label>
+  </Accordion>
 </aside>
 
 <style>
@@ -180,8 +184,19 @@
     display: flex;
     flex-direction: column;
   }
+  .rail-head {
+    padding: 0.6rem 0.85rem 0;
+  }
+  .rail-kicker {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
   .rail-search {
-    padding: 0.7rem 0.85rem;
+    padding: 0.5rem 0.85rem 0.7rem;
     border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
   }
   .rail-search input {

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -6,7 +6,14 @@
    * entity (highlight, no graph reload). Clicking a type/community filters.
    */
   import Accordion from "./Accordion.svelte";
-  import { graphNodes, nodeType, nodeLabel, groupCounts, nodeCommunity } from "../lib/graphAdapter.js";
+  import {
+    graphNodes,
+    nodeType,
+    nodeLabel,
+    groupCounts,
+    nodeCommunity,
+    communityStats,
+  } from "../lib/graphAdapter.js";
 
   let {
     graph,
@@ -22,7 +29,8 @@
   let query = $state("");
 
   const typeList = $derived(groupCounts(graph, nodeType));
-  const communityList = $derived(groupCounts(graph, nodeCommunity));
+  // Communities excluding degree-0 singletons (folded into `isolatedCount`).
+  const communityInfo = $derived(communityStats(graph));
 
   // SVELTE-3: results grouped by type (count) -> entities, like the legacy rail.
   // No cap: every matching entity is reachable (the per-type accordions stay
@@ -135,12 +143,12 @@
     {/if}
   </Accordion>
 
-  <Accordion title="Communities" count={communityList.length}>
-    {#if communityList.length === 0}
+  <Accordion title="Communities" count={communityInfo.liveCount}>
+    {#if communityInfo.liveCount === 0}
       <p class="rail-empty">No communities.</p>
     {:else}
       <ul class="rail-list">
-        {#each communityList as c (c.key)}
+        {#each communityInfo.live as c (c.key)}
           <li>
             <button
               class="rail-row"
@@ -153,6 +161,12 @@
           </li>
         {/each}
       </ul>
+      {#if communityInfo.isolatedCount > 0}
+        <p class="rail-isolated">
+          Isolated · {communityInfo.isolatedCount}
+          <span class="rail-isolated-note">degree-0, excluded from the count</span>
+        </p>
+      {/if}
     {/if}
   </Accordion>
 </aside>
@@ -231,6 +245,20 @@
     margin: 0.25rem 0;
     color: var(--st-semantic-text-muted, #64748b);
     font-size: 0.82rem;
+    font-style: italic;
+  }
+  .rail-isolated {
+    margin: 0.35rem 0 0;
+    padding: 0.3rem 0.5rem;
+    border-top: 1px dotted var(--st-semantic-border-subtle, #e2e8f0);
+    color: var(--st-semantic-text-secondary, #475569);
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .rail-isolated-note {
+    display: block;
+    color: var(--st-semantic-text-muted, #64748b);
+    font-size: 0.68rem;
     font-style: italic;
   }
   .rail-facet {

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -24,7 +24,10 @@
   const typeList = $derived(groupCounts(graph, nodeType));
   const communityList = $derived(groupCounts(graph, nodeCommunity));
 
-  const results = $derived.by(() => {
+  // SVELTE-3: results grouped by type (count) -> entities, like the legacy rail.
+  // No cap: every matching entity is reachable (the per-type accordions stay
+  // collapsed, so only an opened type renders its rows).
+  const resultsByType = $derived.by(() => {
     const q = query.trim().toLowerCase();
     let nodes = graphNodes(graph);
     if (activeGroup) {
@@ -38,11 +41,21 @@
           nodeLabel(n).toLowerCase().includes(q) || String(n.id).toLowerCase().includes(q),
       );
     }
-    return nodes
-      .map((n) => ({ id: n.id, label: nodeLabel(n), type: nodeType(n) }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-      .slice(0, 200);
+    const byType = new Map();
+    for (const n of nodes) {
+      const t = nodeType(n) ?? "—";
+      if (!byType.has(t)) byType.set(t, []);
+      byType.get(t).push({ id: n.id, label: nodeLabel(n) });
+    }
+    return [...byType.entries()]
+      .map(([type, items]) => ({
+        type,
+        count: items.length,
+        items: items.sort((a, b) => a.label.localeCompare(b.label)),
+      }))
+      .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
   });
+  const resultsTotal = $derived(resultsByType.reduce((n, g) => n + g.count, 0));
 </script>
 
 <aside class="rail" aria-label="Workspace navigation">
@@ -92,23 +105,30 @@
     {/if}
   </Accordion>
 
-  <Accordion title="Results" count={results.length} open={true}>
-    {#if results.length === 0}
+  <Accordion title="Results" count={resultsTotal} open={true}>
+    {#if resultsTotal === 0}
       <p class="rail-empty">No matching entities.</p>
     {:else}
-      <ul class="rail-list">
-        {#each results as r (r.id)}
+      <ul class="rail-type-groups">
+        {#each resultsByType as grp (grp.type)}
           <li>
-            <button
-              class="rail-row"
-              class:active={focusId === r.id}
-              class:selected={selectedIds.includes(r.id)}
-              onclick={() => onSelectEntity?.(r.id)}
-              title={r.id}
-            >
-              <span class="rail-row-label">{r.label}</span>
-              {#if r.type}<span class="rail-row-type">{r.type}</span>{/if}
-            </button>
+            <Accordion title={grp.type} count={grp.count} open={false}>
+              <ul class="rail-list">
+                {#each grp.items as r (r.id)}
+                  <li>
+                    <button
+                      class="rail-row"
+                      class:active={focusId === r.id}
+                      class:selected={selectedIds.includes(r.id)}
+                      onclick={() => onSelectEntity?.(r.id)}
+                      title={r.id}
+                    >
+                      <span class="rail-row-label">{r.label}</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </Accordion>
           </li>
         {/each}
       </ul>
@@ -200,11 +220,12 @@
     color: var(--st-semantic-text-muted, #64748b);
     font-size: 0.72rem;
   }
-  .rail-row-type {
-    color: var(--st-semantic-text-muted, #64748b);
-    font-size: 0.68rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+  .rail-type-groups {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.15rem;
   }
   .rail-empty {
     margin: 0.25rem 0;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -230,6 +230,9 @@
   }
   .rail-row-label {
     flex: 1;
+    /* min-width:0 lets the flex item shrink below its content so the ellipsis
+       kicks in (and the count to its right stays in view) instead of overflowing. */
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -1,9 +1,9 @@
 <script>
   /**
-   * Left rail: Types / Facets / Results / Communities accordions (collapsed).
-   * Pure presentational — derives its lists from the loaded graph and reports
-   * intent up via the on* callbacks. Clicking a result row selects+opens the
-   * entity (highlight, no graph reload). Clicking a type/community filters.
+   * Left rail = navigation (R8-3). Order: Options (top) → Search → Types →
+   * Communities → Entities. Each Type/Community/Entity row TOGGLES into/out of
+   * the selection (click = add/remove); selected rows are marked. The selection
+   * itself is shown in the right column (SelectionPanel).
    */
   import Accordion from "./Accordion.svelte";
   import {
@@ -11,38 +11,30 @@
     nodeType,
     nodeLabel,
     groupCounts,
-    nodeCommunity,
     communityStats,
   } from "../lib/graphAdapter.js";
 
   let {
     graph,
-    activeGroup = null,
+    query = "",
+    selection = { types: [], communities: [], entities: [] },
     showWeakLinks = true,
-    selectedIds = [],
-    focusId = null,
-    onSelectEntity,
-    onSetGroup,
+    onToggleType,
+    onToggleCommunity,
+    onToggleEntity,
+    onSetQuery,
     onToggleWeak,
   } = $props();
-
-  let query = $state("");
 
   const typeList = $derived(groupCounts(graph, nodeType));
   // Communities excluding degree-0 singletons (folded into `isolatedCount`).
   const communityInfo = $derived(communityStats(graph));
 
-  // SVELTE-3: results grouped by type (count) -> entities, like the legacy rail.
-  // No cap: every matching entity is reachable (the per-type accordions stay
-  // collapsed, so only an opened type renders its rows).
-  const resultsByType = $derived.by(() => {
+  // Entities grouped by type (count) -> rows, filtered by the search query.
+  // No cap: per-type accordions stay collapsed so all entities are reachable.
+  const entitiesByType = $derived.by(() => {
     const q = query.trim().toLowerCase();
     let nodes = graphNodes(graph);
-    if (activeGroup) {
-      nodes = nodes.filter(
-        (n) => nodeType(n) === activeGroup || nodeCommunity(n) === activeGroup,
-      );
-    }
     if (q) {
       nodes = nodes.filter(
         (n) =>
@@ -63,41 +55,15 @@
       }))
       .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
   });
-  const resultsTotal = $derived(resultsByType.reduce((n, g) => n + g.count, 0));
+  const entityTotal = $derived(entitiesByType.reduce((n, g) => n + g.count, 0));
+
+  const typeSet = $derived(new Set(selection.types));
+  const commSet = $derived(new Set(selection.communities));
+  const entSet = $derived(new Set(selection.entities));
 </script>
 
 <aside class="rail" aria-label="Workspace navigation">
-  <div class="rail-search">
-    <input
-      type="search"
-      placeholder="Search entities…"
-      bind:value={query}
-      aria-label="Search entities"
-    />
-  </div>
-
-  <Accordion title="Types" count={typeList.length}>
-    {#if typeList.length === 0}
-      <p class="rail-empty">No types.</p>
-    {:else}
-      <ul class="rail-list">
-        {#each typeList as t (t.key)}
-          <li>
-            <button
-              class="rail-row"
-              class:active={activeGroup === t.key}
-              onclick={() => onSetGroup?.(activeGroup === t.key ? null : t.key)}
-            >
-              <span class="rail-row-label">{t.key}</span>
-              <span class="rail-row-count">{t.count}</span>
-            </button>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-  </Accordion>
-
-  <Accordion title="Facets">
+  <Accordion title="Options" open={false}>
     <label class="rail-facet">
       <input
         type="checkbox"
@@ -106,37 +72,35 @@
       />
       Show weak (inferred) links
     </label>
-    {#if activeGroup}
-      <button class="rail-clear" onclick={() => onSetGroup?.(null)}>
-        Clear group filter: {activeGroup}
-      </button>
-    {/if}
   </Accordion>
 
-  <Accordion title="Results" count={resultsTotal} open={false}>
-    {#if resultsTotal === 0}
-      <p class="rail-empty">No matching entities.</p>
+  <div class="rail-search">
+    <input
+      type="search"
+      placeholder="Search entities…"
+      value={query}
+      oninput={(e) => onSetQuery?.(e.currentTarget.value)}
+      aria-label="Search entities"
+    />
+  </div>
+
+  <Accordion title="Types" count={typeList.length} open={true}>
+    {#if typeList.length === 0}
+      <p class="rail-empty">No types.</p>
     {:else}
-      <ul class="rail-type-groups">
-        {#each resultsByType as grp (grp.type)}
+      <ul class="rail-list">
+        {#each typeList as t (t.key)}
           <li>
-            <Accordion title={grp.type} count={grp.count} open={false} compact>
-              <ul class="rail-list">
-                {#each grp.items as r (r.id)}
-                  <li>
-                    <button
-                      class="rail-row"
-                      class:active={focusId === r.id}
-                      class:selected={selectedIds.includes(r.id)}
-                      onclick={() => onSelectEntity?.(r.id)}
-                      title={r.id}
-                    >
-                      <span class="rail-row-label">{r.label}</span>
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            </Accordion>
+            <button
+              class="rail-row"
+              class:selected={typeSet.has(t.key)}
+              aria-pressed={typeSet.has(t.key)}
+              onclick={() => onToggleType?.(t.key)}
+            >
+              <span class="rail-check" aria-hidden="true">{typeSet.has(t.key) ? "✓" : ""}</span>
+              <span class="rail-row-label">{t.key}</span>
+              <span class="rail-row-count">{t.count}</span>
+            </button>
           </li>
         {/each}
       </ul>
@@ -152,8 +116,9 @@
           <li>
             <button
               class="rail-row"
-              class:active={activeGroup === c.key}
-              onclick={() => onSetGroup?.(activeGroup === c.key ? null : c.key)}
+              class:selected={commSet.has(c.key)}
+              aria-pressed={commSet.has(c.key)}
+              onclick={() => onToggleCommunity?.(c.key)}
             >
               <span
                 class="rail-swatch"
@@ -172,6 +137,37 @@
           <span class="rail-isolated-note">degree-0, excluded from the count</span>
         </p>
       {/if}
+    {/if}
+  </Accordion>
+
+  <Accordion title="Entities" count={entityTotal} open={false}>
+    {#if entityTotal === 0}
+      <p class="rail-empty">No matching entities.</p>
+    {:else}
+      <ul class="rail-type-groups">
+        {#each entitiesByType as grp (grp.type)}
+          <li>
+            <Accordion title={grp.type} count={grp.count} open={false} compact>
+              <ul class="rail-list">
+                {#each grp.items as r (r.id)}
+                  <li>
+                    <button
+                      class="rail-row"
+                      class:selected={entSet.has(r.id)}
+                      aria-pressed={entSet.has(r.id)}
+                      onclick={() => onToggleEntity?.(r.id)}
+                      title={r.id}
+                    >
+                      <span class="rail-check" aria-hidden="true">{entSet.has(r.id) ? "✓" : ""}</span>
+                      <span class="rail-row-label">{r.label}</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </Accordion>
+          </li>
+        {/each}
+      </ul>
     {/if}
   </Accordion>
 </aside>
@@ -206,7 +202,6 @@
   .rail-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 0.5rem;
     width: 100%;
     text-align: left;
@@ -221,12 +216,19 @@
   .rail-row:hover {
     background: var(--st-semantic-surface-subtle, #f8fafc);
   }
-  .rail-row.active {
-    border-color: var(--st-semantic-action-primary, #2563eb);
-    box-shadow: inset 3px 0 0 var(--st-semantic-action-primary, #2563eb);
-  }
-  .rail-row.selected .rail-row-label {
+  /* Selected = a clean themed state (no inset "boudin" bar). Pending the DS
+     selectable-row pattern (R8-5). */
+  .rail-row.selected {
+    background: var(--st-semantic-surface-selected, #eff6ff);
+    color: var(--st-semantic-action-primary, #2563eb);
     font-weight: 600;
+  }
+  .rail-check {
+    flex-shrink: 0;
+    width: 0.8rem;
+    text-align: center;
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-size: 0.75rem;
   }
   .rail-row-label {
     flex: 1;
@@ -288,16 +290,5 @@
     font-size: 0.82rem;
     color: var(--st-semantic-text-secondary, #475569);
     cursor: pointer;
-  }
-  .rail-clear {
-    margin-top: 0.5rem;
-    width: 100%;
-    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    background: var(--st-semantic-surface-subtle, #f8fafc);
-    border-radius: var(--st-radius-sm, 4px);
-    padding: 0.3rem 0.5rem;
-    cursor: pointer;
-    font-size: 0.78rem;
-    color: var(--st-semantic-text-secondary, #475569);
   }
 </style>

--- a/studio/src/components/ReconciliationView.svelte
+++ b/studio/src/components/ReconciliationView.svelte
@@ -36,6 +36,9 @@
   let activeId = $state(null);
   let busy = $state(false);
   let actionResult = $state(null);
+  // UAT R8-4: drives the DS ForceGraph merge animation on accept.
+  let mergePair = $state(null);
+  let pendingDecision = $state(null);
 
   const idx = $derived(indexNodes(graph));
   const active = $derived(activeId ? (candidates.find((c) => c.id === activeId) ?? null) : null);
@@ -95,15 +98,34 @@
 
   async function decide(decision) {
     if (!active || busy) return;
+    // R8-4: on ACCEPT, play the merge animation first (candidate slides into
+    // canonical), then apply the patch in handleMergeComplete. Reject applies now.
+    if (decision === "accept") {
+      pendingDecision = { decision, candidate: active };
+      mergePair = { id: active.id, from: active.candidate_id, into: active.canonical_id };
+      return;
+    }
+    await applyDecision(decision, active);
+  }
+
+  function handleMergeComplete() {
+    const pending = pendingDecision;
+    pendingDecision = null;
+    mergePair = null;
+    if (pending) void applyDecision(pending.decision, pending.candidate);
+  }
+
+  async function applyDecision(decision, cand) {
+    if (!cand || busy) return;
     busy = true;
     actionResult = null;
     try {
-      const patch = buildPatchFromCandidate(active, decision, { graphHash, profileHash });
+      const patch = buildPatchFromCandidate(cand, decision, { graphHash, profileHash });
       const res = await postPatchApply(patch);
       if (res.ok && res.valid !== false) {
         actionResult = { ok: true, msg: `${decision === "accept" ? "Accepted" : "Rejected"} — patch applied.` };
         // Drop the decided candidate from the queue and advance.
-        const decidedId = active.id;
+        const decidedId = cand.id;
         candidates = candidates.filter((c) => c.id !== decidedId);
         total = Math.max(0, total - 1);
         activeId = candidates[0]?.id ?? null;
@@ -167,6 +189,8 @@
         focusId={active.candidate_id}
         onSelect={(id) => onOpenEntity?.(id)}
         onOpenEntity={(id) => onOpenEntity?.(id)}
+        {mergePair}
+        onMergeComplete={handleMergeComplete}
       />
     {:else}
       <p class="recon-center-empty">Select a candidate to see the two entities in context.</p>

--- a/studio/src/components/ReconciliationView.svelte
+++ b/studio/src/components/ReconciliationView.svelte
@@ -17,6 +17,7 @@
   import {
     candidateSubgraph,
     buildScene,
+    withReconcileEdge,
     indexNodes,
     nodeLabel,
     nodeType,
@@ -51,10 +52,21 @@
   });
 
   // Center graph: subgraph around the two candidate entities (focused context).
+  // The twins usually have no direct edge, so we (a) pin them side by side and
+  // (b) add a bold synthetic "reconcile" edge so they read as a pair.
   const scene = $derived.by(() => {
     if (!active) return buildScene({ nodes: [], links: [] });
     const sub = candidateSubgraph(graph, active.candidate_id, active.canonical_id, 1);
-    return buildScene(sub, { showWeakLinks: true });
+    const base = buildScene(sub, { showWeakLinks: true });
+    const linked = withReconcileEdge(base, active.candidate_id, active.canonical_id);
+    // Pin the two twins symmetrically near the centre so both stay in view.
+    const cx = 360, cy = 280, dx = 130;
+    const nodes = linked.nodes.map((n) => {
+      if (n.id === active.candidate_id) return { ...n, fx: cx - dx, fy: cy };
+      if (n.id === active.canonical_id) return { ...n, fx: cx + dx, fy: cy };
+      return n;
+    });
+    return { ...linked, nodes };
   });
   const selectedIds = $derived(active ? [active.candidate_id, active.canonical_id] : []);
 

--- a/studio/src/components/SelectionPanel.svelte
+++ b/studio/src/components/SelectionPanel.svelte
@@ -85,7 +85,7 @@
       see its detail.
     </p>
   {:else}
-    <Accordion title="Types" count={selection.types.length} open={true}>
+    <Accordion title="Types" count={selection.types.length} open={selection.types.length > 0}>
       {#if selection.types.length === 0}
         <p class="sel-muted">No type selected.</p>
       {:else}
@@ -108,7 +108,7 @@
       {/if}
     </Accordion>
 
-    <Accordion title="Communities" count={selection.communities.length} open={true}>
+    <Accordion title="Communities" count={selection.communities.length} open={selection.communities.length > 0}>
       {#if selection.communities.length === 0}
         <p class="sel-muted">No community selected.</p>
       {:else}
@@ -131,7 +131,7 @@
       {/if}
     </Accordion>
 
-    <Accordion title="Entities" count={selection.entities.length} open={true}>
+    <Accordion title="Entities" count={selection.entities.length} open={selection.entities.length > 0}>
       {#if directEntities.length === 0}
         <p class="sel-muted">No entity selected.</p>
       {:else}

--- a/studio/src/components/SelectionPanel.svelte
+++ b/studio/src/components/SelectionPanel.svelte
@@ -1,9 +1,11 @@
 <script>
   /**
-   * Right column = the current SELECTION (R8-3.A/F). Lists the selected buckets
-   * (types, communities) and directly-selected entities; each bucket drills down
-   * to its entities. Clicking an entity FOCUSES it (double emphasis in the graph
-   * + its detail shown here). A ✕ removes a bucket/entity from the selection.
+   * Right column = the current SELECTION (R8-3, mirror of the left rail but
+   * filtered to what's selected). Top-level accordions Types / Communities /
+   * Entities. A selected Type/Community drills down to its entities; every
+   * entity row EXPANDS to its detail (description / relations / citations) —
+   * the detail also opens when the entity is picked in the graph (focusId).
+   * ✕ removes a bucket or entity from the selection.
    */
   import Accordion from "./Accordion.svelte";
   import EntityPanel from "./EntityPanel.svelte";
@@ -18,7 +20,8 @@
     graph,
     selection = { types: [], communities: [], entities: [] },
     focusId = null,
-    focusEntity = null,
+    entityCache = {},
+    onSetFocus,
     onFocusEntity,
     onToggleType,
     onToggleCommunity,
@@ -31,102 +34,112 @@
   );
   const nodeIndex = $derived(indexNodes(graph));
   const directEntities = $derived(
-    selection.entities.map((id) => ({ id, label: nodeLabel(nodeIndex.get(id) ?? { id }) })),
+    selection.entities
+      .map((id) => ({ id, label: nodeLabel(nodeIndex.get(id) ?? { id }) }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
   );
 </script>
 
-<aside class="sel" aria-label="Selection">
-  {#if total === 0}
-    <div class="sel-empty">
-      <p class="sel-empty-kicker">Selection</p>
-      <p>Pick types, communities or entities on the left. They appear here and
-        are highlighted in the graph. Click an entity to focus it.</p>
-    </div>
-  {:else}
-    <header class="sel-head">
-      <span class="sel-kicker">Selection · {total}</span>
-      <button class="sel-clear" onclick={() => onClear?.()}>Clear all</button>
-    </header>
-
-    {#if focusId}
-      <section class="sel-detail" aria-label="Focused entity">
-        <EntityPanel {graph} {focusId} entity={focusEntity} onOpenEntity={onFocusEntity} />
-      </section>
-    {/if}
-
-    <div class="sel-buckets">
-      {#each selection.types as type (type)}
-        {@const items = entitiesByType(graph, type)}
-        <div class="sel-bucket">
-          <div class="sel-bucket-head">
-            <span class="sel-bucket-kind">Type</span>
-            <span class="sel-bucket-name">{type}</span>
-            <button class="sel-remove" title="Remove" onclick={() => onToggleType?.(type)}>✕</button>
-          </div>
-          <Accordion title="Entities" count={items.length} open={false} compact>
-            <ul class="sel-list">
-              {#each items as e (e.id)}
-                <li>
-                  <button
-                    class="sel-row"
-                    class:focused={focusId === e.id}
-                    onclick={() => onFocusEntity?.(e.id)}
-                    title={e.id}
-                  >{e.label}</button>
-                </li>
-              {/each}
-            </ul>
-          </Accordion>
-        </div>
-      {/each}
-
-      {#each selection.communities as community (community)}
-        {@const items = entitiesByCommunity(graph, community)}
-        <div class="sel-bucket">
-          <div class="sel-bucket-head">
-            <span class="sel-bucket-kind">Community</span>
-            <span class="sel-bucket-name">{community}</span>
-            <button class="sel-remove" title="Remove" onclick={() => onToggleCommunity?.(community)}>✕</button>
-          </div>
-          <Accordion title="Entities" count={items.length} open={false} compact>
-            <ul class="sel-list">
-              {#each items as e (e.id)}
-                <li>
-                  <button
-                    class="sel-row"
-                    class:focused={focusId === e.id}
-                    onclick={() => onFocusEntity?.(e.id)}
-                    title={e.id}
-                  >{e.label}</button>
-                </li>
-              {/each}
-            </ul>
-          </Accordion>
-        </div>
-      {/each}
-
-      {#if directEntities.length > 0}
-        <div class="sel-bucket">
-          <div class="sel-bucket-head">
-            <span class="sel-bucket-kind">Entities</span>
-            <span class="sel-bucket-name">{directEntities.length} picked</span>
-          </div>
-          <ul class="sel-list">
-            {#each directEntities as e (e.id)}
-              <li class="sel-row-wrap">
-                <button
-                  class="sel-row"
-                  class:focused={focusId === e.id}
-                  onclick={() => onFocusEntity?.(e.id)}
-                  title={e.id}
-                >{e.label}</button>
-                <button class="sel-remove" title="Remove" onclick={() => onToggleEntity?.(e.id)}>✕</button>
-              </li>
-            {/each}
-          </ul>
-        </div>
+{#snippet entityRow(e, removable)}
+  <div class="sel-entity" class:open={focusId === e.id}>
+    <div class="sel-entity-bar">
+      <button
+        class="sel-entity-head"
+        aria-expanded={focusId === e.id}
+        onclick={() => onSetFocus?.(focusId === e.id ? null : e.id)}
+        title={e.id}
+      >
+        <span class="sel-chevron" aria-hidden="true">{focusId === e.id ? "▾" : "▸"}</span>
+        <span class="sel-entity-label">{e.label}</span>
+      </button>
+      {#if removable}
+        <button class="sel-remove" title="Remove" onclick={() => onToggleEntity?.(e.id)}>✕</button>
       {/if}
     </div>
+    {#if focusId === e.id}
+      <div class="sel-entity-detail">
+        <EntityPanel
+          {graph}
+          focusId={e.id}
+          entity={entityCache[e.id] ?? null}
+          hideTitle
+          onOpenEntity={onFocusEntity}
+        />
+      </div>
+    {/if}
+  </div>
+{/snippet}
+
+<aside class="sel" aria-label="Selection">
+  <header class="sel-head">
+    <span class="sel-kicker">Selection · {total}</span>
+    {#if total > 0}
+      <button class="sel-clear" onclick={() => onClear?.()}>Clear all</button>
+    {/if}
+  </header>
+
+  {#if total === 0}
+    <p class="sel-empty">
+      Pick types, communities or entities on the left. They appear here and are
+      highlighted in the graph. Expand an entity (or click it in the graph) to
+      see its detail.
+    </p>
+  {:else}
+    <Accordion title="Types" count={selection.types.length} open={true}>
+      {#if selection.types.length === 0}
+        <p class="sel-muted">No type selected.</p>
+      {:else}
+        <div class="sel-buckets">
+          {#each selection.types as type (type)}
+            {@const items = entitiesByType(graph, type)}
+            <div class="sel-bucket">
+              <div class="sel-bucket-head">
+                <span class="sel-bucket-name">{type}</span>
+                <button class="sel-remove" title="Remove" onclick={() => onToggleType?.(type)}>✕</button>
+              </div>
+              <Accordion title="Entities" count={items.length} open={false} compact>
+                <div class="sel-entities">
+                  {#each items as e (e.id)}{@render entityRow(e, false)}{/each}
+                </div>
+              </Accordion>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </Accordion>
+
+    <Accordion title="Communities" count={selection.communities.length} open={true}>
+      {#if selection.communities.length === 0}
+        <p class="sel-muted">No community selected.</p>
+      {:else}
+        <div class="sel-buckets">
+          {#each selection.communities as community (community)}
+            {@const items = entitiesByCommunity(graph, community)}
+            <div class="sel-bucket">
+              <div class="sel-bucket-head">
+                <span class="sel-bucket-name">{community}</span>
+                <button class="sel-remove" title="Remove" onclick={() => onToggleCommunity?.(community)}>✕</button>
+              </div>
+              <Accordion title="Entities" count={items.length} open={false} compact>
+                <div class="sel-entities">
+                  {#each items as e (e.id)}{@render entityRow(e, false)}{/each}
+                </div>
+              </Accordion>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </Accordion>
+
+    <Accordion title="Entities" count={selection.entities.length} open={true}>
+      {#if directEntities.length === 0}
+        <p class="sel-muted">No entity selected.</p>
+      {:else}
+        <div class="sel-entities">
+          {#each directEntities as e (e.id)}{@render entityRow(e, true)}{/each}
+        </div>
+      {/if}
+    </Accordion>
   {/if}
 </aside>
 
@@ -138,19 +151,6 @@
     display: flex;
     flex-direction: column;
   }
-  .sel-empty {
-    padding: 1rem 1.1rem;
-    color: var(--st-semantic-text-muted, #64748b);
-  }
-  .sel-empty-kicker,
-  .sel-kicker {
-    margin: 0;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    font-size: 0.7rem;
-    font-weight: 700;
-    color: var(--st-semantic-text-muted, #64748b);
-  }
   .sel-head {
     display: flex;
     align-items: center;
@@ -158,6 +158,13 @@
     gap: 0.5rem;
     padding: 0.6rem 0.85rem;
     border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .sel-kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--st-semantic-text-muted, #64748b);
   }
   .sel-clear {
     border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
@@ -168,13 +175,20 @@
     font-size: 0.74rem;
     color: var(--st-semantic-text-secondary, #475569);
   }
-  .sel-detail {
-    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  .sel-empty,
+  .sel-muted {
+    margin: 0;
+    padding: 0.6rem 0.85rem;
+    color: var(--st-semantic-text-muted, #64748b);
+    font-size: 0.84rem;
+  }
+  .sel-muted {
+    font-style: italic;
+    padding: 0.3rem 0.5rem;
   }
   .sel-buckets {
     display: grid;
     gap: 0.4rem;
-    padding: 0.5rem 0.6rem 1.5rem;
   }
   .sel-bucket {
     border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
@@ -184,16 +198,9 @@
     display: flex;
     align-items: center;
     gap: 0.45rem;
-    padding: 0.4rem 0.55rem;
+    padding: 0.35rem 0.55rem;
     background: var(--st-semantic-surface-subtle, #f8fafc);
     border-radius: var(--st-radius-sm, 4px) var(--st-radius-sm, 4px) 0 0;
-  }
-  .sel-bucket-kind {
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    font-size: 0.62rem;
-    font-weight: 700;
-    color: var(--st-semantic-text-muted, #64748b);
   }
   .sel-bucket-name {
     flex: 1;
@@ -202,8 +209,57 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-weight: 600;
-    font-size: 0.84rem;
+    font-size: 0.82rem;
     color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .sel-entities {
+    display: grid;
+    gap: 1px;
+  }
+  .sel-entity-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+  }
+  .sel-entity-head {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    text-align: left;
+    border: 1px solid transparent;
+    background: transparent;
+    border-radius: var(--st-radius-sm, 4px);
+    padding: 0.3rem 0.45rem;
+    cursor: pointer;
+    color: var(--st-semantic-text-primary, #0f172a);
+    font-size: 0.82rem;
+  }
+  .sel-entity-head:hover {
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+  }
+  .sel-entity.open > .sel-entity-bar > .sel-entity-head {
+    background: var(--st-semantic-surface-selected, #eff6ff);
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-weight: 600;
+  }
+  .sel-chevron {
+    flex-shrink: 0;
+    width: 0.7rem;
+    font-size: 0.6rem;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .sel-entity-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sel-entity-detail {
+    border-left: 2px solid var(--st-semantic-border-subtle, #e2e8f0);
+    margin: 0.1rem 0 0.3rem 0.6rem;
   }
   .sel-remove {
     flex-shrink: 0;
@@ -213,46 +269,11 @@
     color: var(--st-semantic-text-muted, #64748b);
     font-size: 0.8rem;
     line-height: 1;
-    padding: 0.1rem 0.25rem;
+    padding: 0.1rem 0.3rem;
     border-radius: var(--st-radius-sm, 4px);
   }
   .sel-remove:hover {
     color: var(--st-semantic-feedback-error, #dc2626);
     background: var(--st-semantic-surface-subtle, #f1f5f9);
-  }
-  .sel-list {
-    list-style: none;
-    margin: 0;
-    padding: 0.2rem;
-    display: grid;
-    gap: 1px;
-  }
-  .sel-row-wrap {
-    display: flex;
-    align-items: center;
-    gap: 0.2rem;
-  }
-  .sel-row {
-    flex: 1;
-    min-width: 0;
-    text-align: left;
-    border: 1px solid transparent;
-    background: transparent;
-    border-radius: var(--st-radius-sm, 4px);
-    padding: 0.3rem 0.45rem;
-    cursor: pointer;
-    color: var(--st-semantic-text-primary, #0f172a);
-    font-size: 0.82rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .sel-row:hover {
-    background: var(--st-semantic-surface-subtle, #f8fafc);
-  }
-  .sel-row.focused {
-    background: var(--st-semantic-surface-selected, #eff6ff);
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-weight: 600;
   }
 </style>

--- a/studio/src/components/SelectionPanel.svelte
+++ b/studio/src/components/SelectionPanel.svelte
@@ -1,0 +1,258 @@
+<script>
+  /**
+   * Right column = the current SELECTION (R8-3.A/F). Lists the selected buckets
+   * (types, communities) and directly-selected entities; each bucket drills down
+   * to its entities. Clicking an entity FOCUSES it (double emphasis in the graph
+   * + its detail shown here). A ✕ removes a bucket/entity from the selection.
+   */
+  import Accordion from "./Accordion.svelte";
+  import EntityPanel from "./EntityPanel.svelte";
+  import {
+    entitiesByType,
+    entitiesByCommunity,
+    indexNodes,
+    nodeLabel,
+  } from "../lib/graphAdapter.js";
+
+  let {
+    graph,
+    selection = { types: [], communities: [], entities: [] },
+    focusId = null,
+    focusEntity = null,
+    onFocusEntity,
+    onToggleType,
+    onToggleCommunity,
+    onToggleEntity,
+    onClear,
+  } = $props();
+
+  const total = $derived(
+    selection.types.length + selection.communities.length + selection.entities.length,
+  );
+  const nodeIndex = $derived(indexNodes(graph));
+  const directEntities = $derived(
+    selection.entities.map((id) => ({ id, label: nodeLabel(nodeIndex.get(id) ?? { id }) })),
+  );
+</script>
+
+<aside class="sel" aria-label="Selection">
+  {#if total === 0}
+    <div class="sel-empty">
+      <p class="sel-empty-kicker">Selection</p>
+      <p>Pick types, communities or entities on the left. They appear here and
+        are highlighted in the graph. Click an entity to focus it.</p>
+    </div>
+  {:else}
+    <header class="sel-head">
+      <span class="sel-kicker">Selection · {total}</span>
+      <button class="sel-clear" onclick={() => onClear?.()}>Clear all</button>
+    </header>
+
+    {#if focusId}
+      <section class="sel-detail" aria-label="Focused entity">
+        <EntityPanel {graph} {focusId} entity={focusEntity} onOpenEntity={onFocusEntity} />
+      </section>
+    {/if}
+
+    <div class="sel-buckets">
+      {#each selection.types as type (type)}
+        {@const items = entitiesByType(graph, type)}
+        <div class="sel-bucket">
+          <div class="sel-bucket-head">
+            <span class="sel-bucket-kind">Type</span>
+            <span class="sel-bucket-name">{type}</span>
+            <button class="sel-remove" title="Remove" onclick={() => onToggleType?.(type)}>✕</button>
+          </div>
+          <Accordion title="Entities" count={items.length} open={false} compact>
+            <ul class="sel-list">
+              {#each items as e (e.id)}
+                <li>
+                  <button
+                    class="sel-row"
+                    class:focused={focusId === e.id}
+                    onclick={() => onFocusEntity?.(e.id)}
+                    title={e.id}
+                  >{e.label}</button>
+                </li>
+              {/each}
+            </ul>
+          </Accordion>
+        </div>
+      {/each}
+
+      {#each selection.communities as community (community)}
+        {@const items = entitiesByCommunity(graph, community)}
+        <div class="sel-bucket">
+          <div class="sel-bucket-head">
+            <span class="sel-bucket-kind">Community</span>
+            <span class="sel-bucket-name">{community}</span>
+            <button class="sel-remove" title="Remove" onclick={() => onToggleCommunity?.(community)}>✕</button>
+          </div>
+          <Accordion title="Entities" count={items.length} open={false} compact>
+            <ul class="sel-list">
+              {#each items as e (e.id)}
+                <li>
+                  <button
+                    class="sel-row"
+                    class:focused={focusId === e.id}
+                    onclick={() => onFocusEntity?.(e.id)}
+                    title={e.id}
+                  >{e.label}</button>
+                </li>
+              {/each}
+            </ul>
+          </Accordion>
+        </div>
+      {/each}
+
+      {#if directEntities.length > 0}
+        <div class="sel-bucket">
+          <div class="sel-bucket-head">
+            <span class="sel-bucket-kind">Entities</span>
+            <span class="sel-bucket-name">{directEntities.length} picked</span>
+          </div>
+          <ul class="sel-list">
+            {#each directEntities as e (e.id)}
+              <li class="sel-row-wrap">
+                <button
+                  class="sel-row"
+                  class:focused={focusId === e.id}
+                  onclick={() => onFocusEntity?.(e.id)}
+                  title={e.id}
+                >{e.label}</button>
+                <button class="sel-remove" title="Remove" onclick={() => onToggleEntity?.(e.id)}>✕</button>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</aside>
+
+<style>
+  .sel {
+    background: var(--st-semantic-surface-default, #fff);
+    overflow-y: auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .sel-empty {
+    padding: 1rem 1.1rem;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .sel-empty-kicker,
+  .sel-kicker {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .sel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.6rem 0.85rem;
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .sel-clear {
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border-radius: var(--st-radius-sm, 4px);
+    padding: 0.2rem 0.55rem;
+    cursor: pointer;
+    font-size: 0.74rem;
+    color: var(--st-semantic-text-secondary, #475569);
+  }
+  .sel-detail {
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .sel-buckets {
+    display: grid;
+    gap: 0.4rem;
+    padding: 0.5rem 0.6rem 1.5rem;
+  }
+  .sel-bucket {
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-sm, 4px);
+  }
+  .sel-bucket-head {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.55rem;
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border-radius: var(--st-radius-sm, 4px) var(--st-radius-sm, 4px) 0 0;
+  }
+  .sel-bucket-kind {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.62rem;
+    font-weight: 700;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .sel-bucket-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: 0.84rem;
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .sel-remove {
+    flex-shrink: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--st-semantic-text-muted, #64748b);
+    font-size: 0.8rem;
+    line-height: 1;
+    padding: 0.1rem 0.25rem;
+    border-radius: var(--st-radius-sm, 4px);
+  }
+  .sel-remove:hover {
+    color: var(--st-semantic-feedback-error, #dc2626);
+    background: var(--st-semantic-surface-subtle, #f1f5f9);
+  }
+  .sel-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.2rem;
+    display: grid;
+    gap: 1px;
+  }
+  .sel-row-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+  }
+  .sel-row {
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    border: 1px solid transparent;
+    background: transparent;
+    border-radius: var(--st-radius-sm, 4px);
+    padding: 0.3rem 0.45rem;
+    cursor: pointer;
+    color: var(--st-semantic-text-primary, #0f172a);
+    font-size: 0.82rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sel-row:hover {
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+  }
+  .sel-row.focused {
+    background: var(--st-semantic-surface-selected, #eff6ff);
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-weight: 600;
+  }
+</style>

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -172,13 +172,18 @@ export function computeDegrees(nodes, edges) {
  * Map degree -> ForceGraph `weight` (relative node radius multiplier).
  * Clamped to a gentle range so hubs read bigger without dwarfing leaves.
  */
-function weightForDegree(degree) {
-  if (!Number.isFinite(degree) || degree <= 0) return 1;
-  // Sized to the legacy graph: small leaves, clearly bigger hubs. With base
-  // radius 4px (GraphCanvas), r = 4*sqrt(weight): leaf 1 -> r=4, deg5 ->
-  // ~2.4 -> r~6.2, deg20 -> ~3.3 -> r~7.3, hub capped 4 -> r=8. Restores the
-  // 4..8px spread (legacy was r=4+12*(deg/maxDeg)) instead of the flat ~7px.
-  return Math.min(4, 1 + Math.log1p(degree) / 1.3);
+// Legacy autosizing: node radius is LINEAR in degree, NORMALISED by the graph's
+// max degree — r = rmin + (rmax - rmin) * (deg / maxDeg) (legacy used
+// r = 4 + 12*(deg/maxDeg), i.e. an rmax/rmin ratio of 4). The DS renders
+// r = nodeRadius * sqrt(weight), so to get that linear r we pass
+// weight = (r_target / nodeRadius)^2 with nodeRadius = rmin (3px in GraphCanvas).
+const RADIUS_RATIO = 4; // rmax / rmin, matches the legacy 4->16 spread
+function weightForDegree(degree, maxDegree) {
+  const max = Number.isFinite(maxDegree) && maxDegree > 0 ? maxDegree : 1;
+  const ratio = Math.min(1, Math.max(0, (Number.isFinite(degree) ? degree : 0) / max));
+  // r_target/rmin = 1 + (RADIUS_RATIO - 1) * ratio ; weight = (r_target/rmin)^2.
+  const rOverRmin = 1 + (RADIUS_RATIO - 1) * ratio;
+  return rOverRmin * rOverRmin;
 }
 
 /**
@@ -201,13 +206,16 @@ export function buildScene(graph, options = {}) {
   if (!showWeakLinks) edges = edges.filter(isStrongEdge);
 
   const degree = computeDegrees(rawNodes, edges);
+  // Autosizing is normalised by the graph's max degree (legacy method), so the
+  // largest hub is rmax and a leaf is rmin regardless of the absolute degrees.
+  const maxDegree = degree.size > 0 ? Math.max(...degree.values()) : 1;
 
   const nodes = rawNodes.map((node) => {
     const group = nodeGroup(node);
     const out = {
       id: node.id,
       label: nodeLabel(node),
-      weight: weightForDegree(degree.get(node.id) ?? 0),
+      weight: weightForDegree(degree.get(node.id) ?? 0, maxDegree),
       shape: shapeForType(node), // SVELTE-4: ontology type -> DS shape
     };
     if (group !== undefined) out.group = group;

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -181,7 +181,8 @@ export function buildScene(graph, options = {}) {
       nodeCount: nodes.length,
       edgeCount: sceneEdges.length,
       weakEdgeCount: sceneEdges.filter((e) => e.weak).length,
-      communityCount: new Set(nodes.map((n) => n.group).filter((g) => g !== undefined)).size,
+      // Isolated singletons (degree-0) are excluded from the community count.
+      communityCount: communityStats(graph).liveCount,
     },
   };
 }
@@ -256,6 +257,46 @@ export function groupCounts(graph, keyFn) {
   return [...counts.entries()]
     .map(([key, count]) => ({ key: String(key), count }))
     .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+}
+
+/**
+ * Community breakdown that EXCLUDES isolated singletons from the count.
+ * A community is "live" when at least one member has a relation (degree > 0
+ * over ALL links, strong + weak, so the set is stable regardless of the weak
+ * filter). Communities whose members are all degree-0 — the D9 isolated nodes
+ * that each form their own singleton — are not counted; their members fold into
+ * a single `isolatedCount`. This drops the public-pack count 141 -> 100.
+ */
+export function communityStats(graph) {
+  const nodes = graphNodes(graph);
+  const ids = new Set(nodes.map((n) => n.id));
+  const deg = new Map();
+  for (const e of graphEdges(graph)) {
+    if (!ids.has(e.source) || !ids.has(e.target)) continue;
+    deg.set(e.source, (deg.get(e.source) ?? 0) + 1);
+    deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
+  }
+  const byComm = new Map();
+  let isolatedCount = 0;
+  for (const node of nodes) {
+    const key = nodeCommunity(node);
+    const live = (deg.get(node.id) ?? 0) > 0;
+    if (key === undefined || key === null || key === "") {
+      if (!live) isolatedCount += 1;
+      continue;
+    }
+    const rec = byComm.get(key) ?? { count: 0, live: false };
+    rec.count += 1;
+    if (live) rec.live = true;
+    byComm.set(key, rec);
+  }
+  const liveList = [];
+  for (const [key, rec] of byComm) {
+    if (rec.live) liveList.push({ key: String(key), count: rec.count });
+    else isolatedCount += rec.count;
+  }
+  liveList.sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+  return { live: liveList, isolatedCount, liveCount: liveList.length };
 }
 
 /**

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -329,6 +329,20 @@ export function communityStats(graph) {
     deg.set(e.source, (deg.get(e.source) ?? 0) + 1);
     deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
   }
+  // Reproduce the DS tone assignment: it walks scene nodes and assigns
+  // category1..8 to each new `group` in first-seen order. We mirror that here
+  // (same node order, same nodeGroup key) so the rail swatch matches the graph.
+  const TONES = [
+    "category1", "category2", "category3", "category4",
+    "category5", "category6", "category7", "category8",
+  ];
+  const toneByGroup = new Map();
+  for (const node of nodes) {
+    const g = nodeGroup(node);
+    if (g === undefined || g === null || toneByGroup.has(g)) continue;
+    toneByGroup.set(g, TONES[toneByGroup.size % TONES.length]);
+  }
+
   const byComm = new Map();
   let isolatedCount = 0;
   for (const node of nodes) {
@@ -345,8 +359,11 @@ export function communityStats(graph) {
   }
   const liveList = [];
   for (const [key, rec] of byComm) {
-    if (rec.live) liveList.push({ key: String(key), count: rec.count });
-    else isolatedCount += rec.count;
+    if (rec.live) {
+      liveList.push({ key: String(key), count: rec.count, tone: toneByGroup.get(key) ?? "category1" });
+    } else {
+      isolatedCount += rec.count;
+    }
   }
   liveList.sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
   return { live: liveList, isolatedCount, liveCount: liveList.length };

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -463,3 +463,37 @@ export function withReconcileEdge(scene, idA, idB) {
     ],
   };
 }
+
+// ---- Selection resolution (R8-3) -----------------------------------------
+
+/** Entities of a given ontology type: [{ id, label }], sorted by label. */
+export function entitiesByType(graph, type) {
+  return graphNodes(graph)
+    .filter((n) => nodeType(n) === type)
+    .map((n) => ({ id: n.id, label: nodeLabel(n) }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/** Entities of a given community: [{ id, label }], sorted by label. */
+export function entitiesByCommunity(graph, community) {
+  return graphNodes(graph)
+    .filter((n) => nodeCommunity(n) === community)
+    .map((n) => ({ id: n.id, label: nodeLabel(n) }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/**
+ * Graph `selectedIds` derived from a selection: every entity of every selected
+ * type/community, plus the directly-selected entities. One pass over the nodes.
+ */
+export function resolveSelectedIds(graph, selection) {
+  const ids = new Set(selection?.entities ?? []);
+  const types = new Set(selection?.types ?? []);
+  const comms = new Set(selection?.communities ?? []);
+  if (types.size > 0 || comms.size > 0) {
+    for (const n of graphNodes(graph)) {
+      if (types.has(nodeType(n)) || comms.has(nodeCommunity(n))) ids.add(n.id);
+    }
+  }
+  return [...ids];
+}

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -82,25 +82,73 @@ const TYPE_SHAPE = {
   Evidence: "square",
   Object: "square",
   ForensicMethod: "hexagon",
-  Work: "box",
-  Saga: "box",
-  ChapterOrStory: "box",
-  Author: "box",
-  Translator: "box",
+  Work: "roundedbox",
+  Saga: "roundedbox",
+  ChapterOrStory: "roundedbox",
+  Author: "roundedbox",
+  Translator: "roundedbox",
 };
+
+/**
+ * Map an ontology relation to a typed dash style (ForceGraph 0.10.5).
+ * Four families: solid = belonging/structure, dashed = agency/interaction
+ * between characters, dotted = spatial/factual anchoring, long-dash =
+ * method/usage. Unmapped relations fall back to solid.
+ */
+const REL_DASH = {
+  // structure / belonging (the skeleton)
+  appears_in: "solid",
+  part_of: "solid",
+  belongs_to_saga: "solid",
+  contains_evidence: "solid",
+  written_by: "solid",
+  narrates: "solid",
+  alias_of: "solid",
+  same_as: "solid",
+  // agency / interaction
+  commits: "dashed",
+  investigates: "dashed",
+  assists: "dashed",
+  opposes: "dashed",
+  targets: "dashed",
+  suspected_of: "dashed",
+  disguises_as: "dashed",
+  motivates: "dashed",
+  // spatial / factual anchoring
+  occurs_at: "dotted",
+  located_in: "dotted",
+  establishes_fact: "dotted",
+  mentions: "dotted",
+  // method / usage
+  used_in: "long-dash",
+  uses_method: "long-dash",
+  involves: "long-dash",
+};
+export function dashForRelation(relation) {
+  if (!relation) return undefined;
+  return REL_DASH[String(relation)] ?? "solid";
+}
 export function shapeForType(node) {
   const t = nodeType(node);
   return (t && TYPE_SHAPE[t]) || "dot";
 }
 
 /** Distinct (type -> shape) legend entries present in a graph (SVELTE-4). */
+/** Edge legend (dash family -> relation kind), appended after the node shapes. */
+const RELATION_LEGEND = [
+  { label: "belonging / structure", dash: "solid" },
+  { label: "agency / interaction", dash: "dashed" },
+  { label: "spatial / factual", dash: "dotted" },
+  { label: "method / usage", dash: "long-dash" },
+];
 export function shapeLegend(graph) {
   const seen = new Map();
   for (const node of graphNodes(graph)) {
     const t = nodeType(node);
     if (t && !seen.has(t)) seen.set(t, shapeForType(node));
   }
-  return [...seen.entries()].map(([label, shape]) => ({ label, shape }));
+  const shapeEntries = [...seen.entries()].map(([label, shape]) => ({ label, shape }));
+  return [...shapeEntries, ...RELATION_LEGEND];
 }
 
 /** Strong = EXTRACTED (default). Anything else (INFERRED, …) renders weak. */
@@ -169,7 +217,12 @@ export function buildScene(graph, options = {}) {
   const sceneEdges = edges.map((edge) => {
     const out = { source: edge.source, target: edge.target };
     const relation = displayValue(edge.relation);
-    if (relation) out.relation = relation;
+    if (relation) {
+      out.relation = relation;
+      // SVELTE/UAT R3-8: typed dash per relation family (ForceGraph 0.10.5).
+      const dash = dashForRelation(edge.relation);
+      if (dash) out.dash = dash;
+    }
     if (!isStrongEdge(edge)) out.weak = true;
     return out;
   });
@@ -371,7 +424,17 @@ export function withReconcileEdge(scene, idA, idB) {
     ...scene,
     edges: [
       ...(scene.edges ?? []),
-      { source: idA, target: idB, relation: "≈ reconcile", reconcile: true },
+      // UAT R2-7: bold reconcile edge (ForceGraph 0.10.5). `width` takes
+      // precedence over `emphasis` per the DS API, so set both for a clear bold.
+      {
+        source: idA,
+        target: idB,
+        relation: "≈ reconcile",
+        reconcile: true,
+        emphasis: true,
+        width: 3,
+        dash: "solid",
+      },
     ],
   };
 }

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -126,8 +126,10 @@ export function computeDegrees(nodes, edges) {
  */
 function weightForDegree(degree) {
   if (!Number.isFinite(degree) || degree <= 0) return 1;
-  // 0->1, 5->~1.6, 20->~2.3; log keeps the spread readable.
-  return Math.min(2.6, 1 + Math.log1p(degree) / 2.2);
+  // Tightened to match the legacy graph's smaller nodes (base radius 5px in
+  // GraphCanvas): leaf weight 1 -> r=5, 5->~1.75 -> r~6.6, hub capped 2.2 ->
+  // r~7.4. Keeps the degree spread legible without the old 7–11px footprint.
+  return Math.min(2.2, 1 + Math.log1p(degree) / 2.4);
 }
 
 /**

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -307,3 +307,27 @@ export function candidateSubgraph(graph, idA, idB, hops = 1) {
   const links = edges.filter((e) => keep.has(e?.source) && keep.has(e?.target));
   return { nodes, links };
 }
+
+/**
+ * SVELTE-7: add a synthetic "reconciliation" edge between the two candidate
+ * entities so the force layout pulls them side by side and the link is visible
+ * (the twins usually have no direct edge). Marked `reconcile: true` and given a
+ * relation label so the DS edge tooltip reads it; consumers render it bold.
+ */
+export function withReconcileEdge(scene, idA, idB) {
+  if (!scene || !idA || !idB) return scene;
+  const ids = new Set((scene.nodes ?? []).map((n) => n.id));
+  if (!ids.has(idA) || !ids.has(idB)) return scene;
+  const exists = (scene.edges ?? []).some(
+    (e) =>
+      (e.source === idA && e.target === idB) || (e.source === idB && e.target === idA),
+  );
+  if (exists) return scene;
+  return {
+    ...scene,
+    edges: [
+      ...(scene.edges ?? []),
+      { source: idA, target: idB, relation: "≈ reconcile", reconcile: true },
+    ],
+  };
+}

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -126,10 +126,11 @@ export function computeDegrees(nodes, edges) {
  */
 function weightForDegree(degree) {
   if (!Number.isFinite(degree) || degree <= 0) return 1;
-  // Tightened to match the legacy graph's smaller nodes (base radius 5px in
-  // GraphCanvas): leaf weight 1 -> r=5, 5->~1.75 -> r~6.6, hub capped 2.2 ->
-  // r~7.4. Keeps the degree spread legible without the old 7–11px footprint.
-  return Math.min(2.2, 1 + Math.log1p(degree) / 2.4);
+  // Sized to the legacy graph: small leaves, clearly bigger hubs. With base
+  // radius 4px (GraphCanvas), r = 4*sqrt(weight): leaf 1 -> r=4, deg5 ->
+  // ~2.4 -> r~6.2, deg20 -> ~3.3 -> r~7.3, hub capped 4 -> r=8. Restores the
+  // 4..8px spread (legacy was r=4+12*(deg/maxDeg)) instead of the flat ~7px.
+  return Math.min(4, 1 + Math.log1p(degree) / 1.3);
 }
 
 /**

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -105,6 +105,16 @@ export function focusEntity(state, id) {
   });
 }
 
+/**
+ * Set (or clear with null) the focused entity — used to expand/collapse the
+ * entity detail in the right column. A non-null id is also added to the
+ * selection (focusing implies selecting).
+ */
+export function setFocus(state, id) {
+  if (!id) return normalizeViewerState({ ...state, focusId: null });
+  return focusEntity(state, id);
+}
+
 export function clearSelection(state) {
   return normalizeViewerState({
     ...state,

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -1,27 +1,28 @@
 /**
- * Single client viewer state for the ontology studio SPA.
+ * Single client viewer state for the ontology studio SPA (selection rework R8-3).
  *
- * Mirrors the aclp-am viewer pattern: one plain object that App.svelte holds in
- * a single `let viewerState`, mutated only by returning a fresh normalized
- * object. `$:` derived scenes downstream recompute from it. Kept intentionally
- * small for the first vertical slice.
+ * The LEFT column is navigation (search + Types / Communities / Entities lists);
+ * the RIGHT column shows the current SELECTION and drills down to an entity.
  *
- *   selectedIds  : node ids highlighted in the ForceGraph (NO re-layout).
- *   focusId      : node id with the accent ring + open in the entity panel.
- *   activeView   : "workspace" | "reconciliation".
- *   filters      : { group: string|null, showWeakLinks: boolean }.
+ *   selection : { types:[], communities:[], entities:[] } — what the user picked
+ *               on the left. Each list toggles independently (click = add/remove).
+ *   focusId   : the last individually-picked entity → gets the "double" emphasis
+ *               (selection highlight + focus shadow) and opens its detail.
+ *   options   : { showWeakLinks } — graph options (ex-"Facets").
+ *   query     : free-text filter for the Entities list.
+ *   activeView: "workspace" | "reconciliation".
+ *
+ * The graph's `selectedIds` is DERIVED in App from `selection` + the graph
+ * (a selected type/community contributes all its member entity ids).
  */
 
 export function createDefaultViewerState() {
   return {
     activeView: "workspace",
-    selectedIds: [],
+    query: "",
+    selection: { types: [], communities: [], entities: [] },
     focusId: null,
-    filters: {
-      // When set, the rail/scene focus on a single group (community or type).
-      group: null,
-      showWeakLinks: true,
-    },
+    options: { showWeakLinks: true },
   };
 }
 
@@ -31,57 +32,98 @@ function uniqueStrings(values = []) {
 
 export function normalizeViewerState(partial = {}) {
   const base = createDefaultViewerState();
+  const sel = partial.selection ?? {};
   const next = {
     ...base,
     ...partial,
-    filters: { ...base.filters, ...(partial.filters ?? {}) },
+    selection: {
+      types: uniqueStrings(sel.types ?? base.selection.types),
+      communities: uniqueStrings(sel.communities ?? base.selection.communities),
+      entities: uniqueStrings(sel.entities ?? base.selection.entities),
+    },
+    options: { ...base.options, ...(partial.options ?? {}) },
   };
-  next.selectedIds = uniqueStrings(next.selectedIds);
+  next.query = typeof next.query === "string" ? next.query : "";
   next.focusId = typeof next.focusId === "string" && next.focusId ? next.focusId : null;
   if (next.activeView !== "reconciliation") next.activeView = "workspace";
-  next.filters.showWeakLinks = Boolean(next.filters.showWeakLinks);
-  next.filters.group =
-    typeof next.filters.group === "string" && next.filters.group ? next.filters.group : null;
+  next.options.showWeakLinks = Boolean(next.options.showWeakLinks);
+  // The focus must be a selected entity; drop it if it was deselected.
+  if (next.focusId && !next.selection.entities.includes(next.focusId)) next.focusId = null;
   return next;
 }
 
-/** Toggle a node into/out of the highlight set (does NOT change focus). */
-export function toggleSelected(state, id) {
-  const set = new Set(state.selectedIds);
-  if (set.has(id)) set.delete(id);
-  else set.add(id);
-  return normalizeViewerState({ ...state, selectedIds: [...set] });
+function toggleIn(list, value) {
+  const set = new Set(list);
+  if (set.has(value)) set.delete(value);
+  else set.add(value);
+  return [...set];
 }
 
-/** Select a node: highlight it AND make it the focus (entity panel target). */
-export function selectNode(state, id) {
+/** Toggle a TYPE bucket in/out of the selection. */
+export function toggleType(state, type) {
   return normalizeViewerState({
     ...state,
-    selectedIds: state.selectedIds.includes(id) ? state.selectedIds : [...state.selectedIds, id],
+    selection: { ...state.selection, types: toggleIn(state.selection.types, type) },
+  });
+}
+
+/** Toggle a COMMUNITY bucket in/out of the selection. */
+export function toggleCommunity(state, community) {
+  return normalizeViewerState({
+    ...state,
+    selection: { ...state.selection, communities: toggleIn(state.selection.communities, community) },
+  });
+}
+
+/**
+ * Toggle a single ENTITY in/out of the selection. Adding makes it the focus
+ * (double emphasis); removing the focused one clears the focus.
+ */
+export function toggleEntity(state, id) {
+  const has = state.selection.entities.includes(id);
+  const entities = toggleIn(state.selection.entities, id);
+  const focusId = has ? (state.focusId === id ? null : state.focusId) : id;
+  return normalizeViewerState({
+    ...state,
+    selection: { ...state.selection, entities },
+    focusId,
+  });
+}
+
+/**
+ * Focus an entity (right-column drill-down or graph dblclick): ensure it is
+ * selected AND make it the focus, without touching the other buckets.
+ */
+export function focusEntity(state, id) {
+  const entities = state.selection.entities.includes(id)
+    ? state.selection.entities
+    : [...state.selection.entities, id];
+  return normalizeViewerState({
+    ...state,
+    selection: { ...state.selection, entities },
     focusId: id,
   });
 }
 
-/** Open an entity in the panel (focus) without clearing other highlights. */
-export function openEntity(state, id) {
-  return selectNode(state, id);
-}
-
 export function clearSelection(state) {
-  return normalizeViewerState({ ...state, selectedIds: [], focusId: null });
+  return normalizeViewerState({
+    ...state,
+    selection: { types: [], communities: [], entities: [] },
+    focusId: null,
+  });
 }
 
 export function setActiveView(state, view) {
   return normalizeViewerState({ ...state, activeView: view });
 }
 
-export function setGroupFilter(state, group) {
-  return normalizeViewerState({ ...state, filters: { ...state.filters, group } });
+export function setQuery(state, query) {
+  return normalizeViewerState({ ...state, query });
 }
 
 export function setShowWeakLinks(state, value) {
   return normalizeViewerState({
     ...state,
-    filters: { ...state.filters, showWeakLinks: Boolean(value) },
+    options: { ...state.options, showWeakLinks: Boolean(value) },
   });
 }

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -232,3 +232,20 @@ describe("shapeForType / shapeLegend (SVELTE-4)", () => {
     expect(legend).toEqual([{ label: "Character", shape: "diamond" }, { label: "Evidence", shape: "square" }]);
   });
 });
+
+describe("withReconcileEdge (SVELTE-7)", () => {
+  it("adds a bold reconcile edge between the two twins", async () => {
+    const { withReconcileEdge } = await import("../lib/graphAdapter.js");
+    const scene = { nodes: [{ id: "A" }, { id: "B" }], edges: [] };
+    const out = withReconcileEdge(scene, "A", "B");
+    expect(out.edges.length).toBe(1);
+    expect(out.edges[0]).toMatchObject({ source: "A", target: "B", relation: "≈ reconcile", reconcile: true });
+  });
+  it("does not duplicate when a direct edge already exists, and no-ops on missing nodes", async () => {
+    const { withReconcileEdge } = await import("../lib/graphAdapter.js");
+    const withEdge = { nodes: [{ id: "A" }, { id: "B" }], edges: [{ source: "B", target: "A", relation: "x" }] };
+    expect(withReconcileEdge(withEdge, "A", "B").edges.length).toBe(1);
+    const missing = { nodes: [{ id: "A" }], edges: [] };
+    expect(withReconcileEdge(missing, "A", "ZZ").edges.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Studio Svelte SPA (served at \`/studio/\` by \`graphify ontology studio\`) — the DS-aligned successor to the legacy server-rendered \`graph.html\`.

## What's in
- **Graph**: DS \`@sentropic/design-system-svelte\` ForceGraph **0.13.0** — typed shapes (ontology type → shape, incl. roundedbox), typed edge dashes (23 relations → 4 families), curves, equal-area shapes, **fit-to-content** (round, never cropped), legacy **autosizing** (r linear in degree / maxDeg), **repulsion** for breathing room, **hover-connected** dim, bold reconcile edge.
- **Header**: DS \`Header\` component (logo/nav/stats).
- **Left = Search**: search → Types / Communities / Entities (toggle + mark), Options at the bottom. Community rows carry the graph colour swatch + member count.
- **Right = Selection**: mirror of the left filtered to the selection; drill bucket → entities → **per-entity detail on expand** (or on graph click). Multi-select, ✕ to remove.
- **Communities**: degree-0 singletons excluded from the count (141 → 100 + Isolated·N).
- **Reconciliation**: twins side-by-side with a bold reconcile edge.
- **h2a**: \`neg:forcegraph-0104\` stabilized (DS ForceGraph surface sealed).

## Not done yet (tracked)
- DS requests pending: #4 merge animation, #5 themed selected-item pattern (\`env uat8\`).
- Chantiers (\`.graphify/uat/STUDIO_CHANTIERS.md\`): **standalone file:// export** (replace legacy graph.html), **data-model / reactivity perf** (graph.json is 2.6 MB for 1193 nodes; adversarial analysis in progress).

## Status
UAT is **iterative** (user-driven, verdict pending). Build green (3928 modules). Tracker: \`.graphify/uat/SPA_UAT_TRACKER.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)