### PR TITLE
Track F-0831-P1: security cluster — zip-bomb cap (F2) + ollama SSRF guard (F3)

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -14,6 +14,7 @@ import {
 } from "./paths.js";
 import { FileType } from "./types.js";
 import { googleWorkspaceEnabled } from "./google-workspace.js";
+import { fileWithinSizeCap, zipWithinCaps } from "./office-guard.js";
 import type { DetectionResult, InputScopeInspection } from "./types.js";
 
 export const CODE_EXTENSIONS = new Set([
@@ -349,6 +350,9 @@ export function classifyFile(filePath: string): FileType | null {
  * bundles its own pdfjs runtime; no peer pdfjs-dist install required).
  */
 export async function extractPdfText(filePath: string): Promise<string> {
+  // F-0831-P1 (F2): screen the on-disk size before unpdf decompresses the PDF
+  // streams, so an oversized untrusted paper cannot OOM the scan.
+  if (!fileWithinSizeCap(filePath)) return "";
   try {
     const { extractText, getDocumentProxy } = await import("unpdf");
     const buf = readFileSync(filePath);
@@ -381,11 +385,16 @@ async function officeParseToText(filePath: string): Promise<string> {
 
 /** Convert a .docx file to plain text via officeparser. */
 export async function docxToMarkdown(filePath: string): Promise<string> {
+  // F-0831-P1 (F2): .docx is a zip+XML container; cap it before officeparser
+  // decompresses it, treating a zip-bomb as empty rather than parsing it.
+  if (!zipWithinCaps(filePath)) return "";
   return (await officeParseToText(filePath)).trim();
 }
 
 /** Convert an .xlsx file to plain text via officeparser. */
 export async function xlsxToMarkdown(filePath: string): Promise<string> {
+  // F-0831-P1 (F2): same zip-bomb cap as .docx before openpyxl-style parsing.
+  if (!zipWithinCaps(filePath)) return "";
   return (await officeParseToText(filePath)).trim();
 }
 

--- a/src/llm-execution.ts
+++ b/src/llm-execution.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+import { validateOllamaBaseUrl } from "./security.js";
 import type { NormalizedLlmExecutionPolicy } from "./types.js";
 
 export type LlmExecutionCapability = "text_json" | "vision_json" | "batch_vision_json";
@@ -272,6 +273,9 @@ async function resolveDirectModel(provider: DirectLlmProvider, model: string): P
     case "ollama": {
       const { createOllama } = await import("ollama-ai-provider");
       const baseURL = process.env.OLLAMA_BASE_URL?.trim();
+      // F-0831-P1 (F3): block a link-local/metadata OLLAMA_BASE_URL (SSRF)
+      // before the corpus leaves; warn-and-allow a trusted LAN host.
+      if (baseURL) await validateOllamaBaseUrl(baseURL, { warn: true });
       const factory = baseURL ? createOllama({ baseURL }) : createOllama();
       return factory(model);
     }

--- a/src/office-guard.ts
+++ b/src/office-guard.ts
@@ -1,0 +1,161 @@
+/**
+ * Resource caps for parsing untrusted office/PDF files (Track F-0831-P1, F2).
+ *
+ * A corpus is attacker-controllable (graphify runs on cloned/shared folders),
+ * and .docx/.xlsx are zip+XML containers: a few-KB zip-bomb can decompress to
+ * gigabytes and OOM-kill the process at parse time. We screen every office/PDF
+ * file before officeparser / unpdf touch it.
+ *
+ * Two layers for zip-based office files, because the zip central-directory
+ * sizes are attacker-controlled:
+ *   1. A cheap pre-filter on the declared sizes (on-disk cap, summed-uncompressed
+ *      cap, compression ratio) that rejects an honest bomb without decompressing.
+ *   2. An authoritative pass that inflates every member with a hard byte ceiling
+ *      (`zlib.inflateRawSync({ maxOutputLength })`), so a member that
+ *      under-declares its size in the central directory cannot expand past the
+ *      cap undetected.
+ *
+ * Port of upstream safishamsi/graphify commits c50ffc2 + 763b673 (Python
+ * `_file_within_size_cap` / `_zip_within_caps` in graphify/detect.py). The
+ * Python uses zipfile's chunked streaming read; Node's zlib gives the same
+ * hard ceiling via `maxOutputLength`.
+ */
+import { statSync, readFileSync } from "node:fs";
+import { inflateRawSync } from "node:zlib";
+
+export const OFFICE_MAX_RAW_BYTES = 50 * 1024 * 1024; // 50 MiB on-disk
+export const OFFICE_MAX_DECOMPRESSED_BYTES = 512 * 1024 * 1024; // 512 MiB total uncompressed
+export const OFFICE_MAX_COMPRESSION_RATIO = 200; // uncompressed : compressed
+
+/** True if `path` exists and its on-disk size is within `cap`. */
+export function fileWithinSizeCap(path: string, cap: number = OFFICE_MAX_RAW_BYTES): boolean {
+  try {
+    return statSync(path).size <= cap;
+  } catch {
+    return false;
+  }
+}
+
+// --- Minimal ZIP central-directory parser (PKZIP APPNOTE) -------------------
+// We only read the central directory, never trusting the local file headers.
+// Each central-directory entry record starts with the signature 0x02014b50 and
+// stores the compression method, compressed size, uncompressed size and the
+// local-header offset we need to locate the deflate stream.
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CDH_SIGNATURE = 0x02014b50;
+const LFH_SIGNATURE = 0x04034b50;
+const MAX_EOCD_COMMENT = 0xffff;
+
+interface CentralEntry {
+  method: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}
+
+function findEocdOffset(buf: Buffer): number {
+  // The End Of Central Directory record lives at the tail, possibly followed by
+  // a comment of up to 0xffff bytes. Scan backwards for its signature.
+  const minOffset = Math.max(0, buf.length - (MAX_EOCD_COMMENT + 22));
+  for (let i = buf.length - 22; i >= minOffset; i--) {
+    if (buf.readUInt32LE(i) === EOCD_SIGNATURE) return i;
+  }
+  return -1;
+}
+
+function parseCentralDirectory(buf: Buffer): CentralEntry[] | null {
+  const eocd = findEocdOffset(buf);
+  if (eocd < 0) return null;
+  const entryCount = buf.readUInt16LE(eocd + 10);
+  const cdOffset = buf.readUInt32LE(eocd + 16);
+  const entries: CentralEntry[] = [];
+  let pos = cdOffset;
+  for (let i = 0; i < entryCount; i++) {
+    if (pos + 46 > buf.length || buf.readUInt32LE(pos) !== CDH_SIGNATURE) return null;
+    const method = buf.readUInt16LE(pos + 10);
+    const compressedSize = buf.readUInt32LE(pos + 20);
+    const uncompressedSize = buf.readUInt32LE(pos + 24);
+    const nameLen = buf.readUInt16LE(pos + 28);
+    const extraLen = buf.readUInt16LE(pos + 30);
+    const commentLen = buf.readUInt16LE(pos + 32);
+    const localHeaderOffset = buf.readUInt32LE(pos + 42);
+    entries.push({ method, compressedSize, uncompressedSize, localHeaderOffset });
+    pos += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+/** Locate the start of a member's compressed data from its local file header. */
+function memberDataRange(buf: Buffer, entry: CentralEntry): { start: number; end: number } | null {
+  const lfh = entry.localHeaderOffset;
+  if (lfh + 30 > buf.length || buf.readUInt32LE(lfh) !== LFH_SIGNATURE) return null;
+  const nameLen = buf.readUInt16LE(lfh + 26);
+  const extraLen = buf.readUInt16LE(lfh + 28);
+  const start = lfh + 30 + nameLen + extraLen;
+  const end = start + entry.compressedSize;
+  if (end > buf.length) return null;
+  return { start, end };
+}
+
+/**
+ * Reject a zip-based office file that is a likely zip/XML bomb.
+ *
+ * Returns true only when the file is safe to hand to a parser. On any parse
+ * error, oversize, or ratio breach it returns false so the caller treats the
+ * file as empty rather than decompressing it.
+ */
+export function zipWithinCaps(path: string): boolean {
+  if (!fileWithinSizeCap(path)) return false;
+  let buf: Buffer;
+  try {
+    buf = readFileSync(path);
+  } catch {
+    return false;
+  }
+  const entries = parseCentralDirectory(buf);
+  if (entries === null) return false;
+
+  // Layer 1: cheap pre-filter on declared sizes (fast reject for honest bombs).
+  let compressed = 0;
+  let declared = 0;
+  for (const e of entries) {
+    compressed += e.compressedSize;
+    declared += e.uncompressedSize;
+  }
+  compressed = compressed || 1;
+  if (declared > OFFICE_MAX_DECOMPRESSED_BYTES) return false;
+  if (declared / compressed > OFFICE_MAX_COMPRESSION_RATIO) return false;
+
+  // Layer 2: authoritative bounded decompression. The declared sizes above are
+  // attacker-controlled, so actually inflate every deflated member with a hard
+  // ceiling; a member that under-declares its size cannot expand past the cap.
+  let total = 0;
+  for (const e of entries) {
+    const range = memberDataRange(buf, e);
+    if (range === null) return false;
+    if (e.method === 0) {
+      // Stored (uncompressed): the on-disk bytes are the output bytes.
+      total += range.end - range.start;
+    } else if (e.method === 8) {
+      // Deflate: inflate with a ceiling so a runaway member throws instead of
+      // materializing gigabytes.
+      const remaining = OFFICE_MAX_DECOMPRESSED_BYTES - total;
+      if (remaining <= 0) return false;
+      try {
+        const out = inflateRawSync(buf.subarray(range.start, range.end), {
+          maxOutputLength: remaining + 1,
+        });
+        total += out.length;
+      } catch {
+        // ERR_BUFFER_TOO_LARGE (cap breach) or corrupt stream: refuse.
+        return false;
+      }
+    } else {
+      // Unknown compression method: refuse rather than guess.
+      return false;
+    }
+    if (total > OFFICE_MAX_DECOMPRESSED_BYTES) return false;
+  }
+  return true;
+}

--- a/src/security.ts
+++ b/src/security.ts
@@ -66,6 +66,106 @@ export function validateUrlSync(url: string): string {
   return url;
 }
 
+// ---------------------------------------------------------------------------
+// Ollama base URL validation (Track F-0831-P1, F3)
+// ---------------------------------------------------------------------------
+
+const OLLAMA_METADATA_HOSTS = new Set([
+  "metadata.google.internal",
+  "metadata.google.com",
+  "0.0.0.0",
+  "::",
+  "[::]",
+]);
+
+/** True if a literal IP is link-local (169.254/16, fe80::/10) — includes the
+ * 169.254.169.254 cloud-metadata address. */
+function isLinkLocalIp(addr: string): boolean {
+  if (net.isIPv4(addr)) {
+    const [a, b] = addr.split(".").map(Number) as [number, number, ...number[]];
+    return a === 169 && b === 254;
+  }
+  if (net.isIPv6(addr)) {
+    const embedded = embeddedIPv4(addr);
+    if (embedded !== null) return isLinkLocalIp(embedded);
+    return addr.toLowerCase().startsWith("fe80:");
+  }
+  return false;
+}
+
+/**
+ * True if `host` is, or resolves to, a link-local / cloud-metadata address.
+ * Resolves the name so an alias pointing at 169.254.169.254 is caught too, not
+ * just a literal IP. General private/LAN addresses are deliberately NOT treated
+ * as metadata: people do run Ollama on trusted LAN boxes, so those only warn.
+ */
+async function ollamaHostIsLinkLocalOrMetadata(host: string): Promise<boolean> {
+  const normalized = host.toLowerCase();
+  if (OLLAMA_METADATA_HOSTS.has(normalized)) return true;
+  if (normalized.startsWith("169.254.")) return true; // link-local literal incl. metadata IP
+  const literal = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  if (net.isIP(literal)) return isLinkLocalIp(literal);
+  try {
+    const results = await dns.lookup(host, { all: true, verbatim: true });
+    return results.some((r) => isLinkLocalIp(r.address));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate OLLAMA_BASE_URL before the corpus is sent there (F3).
+ *
+ * Sending an entire corpus to a non-loopback http:// endpoint silently leaks
+ * proprietary code, but some users genuinely run Ollama on a LAN host they
+ * trust, so a general non-loopback target only warns. A link-local or cloud
+ * metadata address (169.254.x, metadata.google.*, 0.0.0.0, or any host that
+ * resolves to one) is never a legitimate Ollama host and is a classic SSRF
+ * target, so we throw there regardless of `warn`.
+ *
+ * Pass `warn: false` for an early gate that should hard-block but leave the
+ * single user-facing LAN warning to the later in-flow call.
+ */
+export async function validateOllamaBaseUrl(
+  url: string,
+  { warn = true }: { warn?: boolean } = {},
+): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    if (warn) {
+      console.warn(`[graphify] WARNING: OLLAMA_BASE_URL=${JSON.stringify(url)} is not a parseable URL.`);
+    }
+    return;
+  }
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    if (warn) {
+      console.warn(
+        `[graphify] WARNING: OLLAMA_BASE_URL has unexpected scheme '${parsed.protocol}'; expected http or https.`,
+      );
+    }
+    return;
+  }
+  const host = (parsed.hostname || "").toLowerCase();
+  if (await ollamaHostIsLinkLocalOrMetadata(host)) {
+    throw new Error(
+      `OLLAMA_BASE_URL points at a link-local/metadata address (${JSON.stringify(host)}); refusing to ` +
+        "send the corpus there. Set it to a real Ollama host.",
+    );
+  }
+  const literal = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  const isLoopback =
+    host === "localhost" || host === "127.0.0.1" || host === "::1" || literal === "::1" || literal.startsWith("127.");
+  if (warn && !isLoopback) {
+    const schemeNote = parsed.protocol === "http:" ? " (UNENCRYPTED)" : "";
+    console.warn(
+      `[graphify] WARNING: OLLAMA_BASE_URL points to non-loopback host ${JSON.stringify(host)}${schemeNote}. ` +
+        "Your corpus will be sent there.",
+    );
+  }
+}
+
 /**
  * Expand an IPv6 string to its canonical 8-group form so prefix checks can
  * inspect the high bits without parsing every shorthand.

--- a/tests/fortran-cpp-path.test.ts
+++ b/tests/fortran-cpp-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extract } from "../src/extract.js";
+
+/**
+ * Track F-0831-P1 (F5). Upstream safishamsi/graphify 46a1d4c hardens a Python
+ * C-preprocessor call (`cpp ... <path>`) by passing an absolute path, because
+ * cpp has no `--` end-of-options terminator and an attacker-named corpus file
+ * like `-I/etc/x.F90` could be parsed as a cpp option.
+ *
+ * The TS fork has NO equivalent surface: Fortran is regex-backed and read with
+ * readFileSync inside extractRegexBackedCode — no `cpp`/subprocess is ever
+ * invoked. This test is a non-regression guard proving a hostile filename still
+ * extracts cleanly (and never shells out).
+ */
+describe("Fortran extraction has no cpp/subprocess surface (F5)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = join(tmpdir(), `fortran-f5-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("extracts a Fortran file whose name looks like a cpp option", async () => {
+    // A filename an attacker could craft to be parsed as a `cpp` option if it
+    // were ever passed unquoted to a preprocessor.
+    const hostile = join(dir, "-I-etc-evil.f90");
+    writeFileSync(
+      hostile,
+      [
+        "module geometry",
+        "contains",
+        "  subroutine area(r)",
+        "    real :: r",
+        "  end subroutine area",
+        "  function perimeter(r)",
+        "    real :: r, perimeter",
+        "  end function perimeter",
+        "end module geometry",
+      ].join("\n"),
+    );
+
+    const result = await extract([hostile]);
+    const labels = result.nodes.map((n) => n.label);
+    // Regex extractor must have read the file and produced its symbols.
+    expect(labels).toContain("area()");
+    expect(labels).toContain("perimeter()");
+  });
+});

--- a/tests/office-guard.test.ts
+++ b/tests/office-guard.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { deflateRawSync } from "node:zlib";
+import {
+  fileWithinSizeCap,
+  zipWithinCaps,
+  OFFICE_MAX_RAW_BYTES,
+  OFFICE_MAX_DECOMPRESSED_BYTES,
+} from "../src/office-guard.js";
+import { extractPdfText, docxToMarkdown, xlsxToMarkdown } from "../src/detect.js";
+
+// Minimal in-memory ZIP writer so we can build a legitimate archive and a
+// zip-bomb without pulling a zip dependency into the test. Single entry,
+// deflate or stored, no data descriptor.
+function buildZip(entries: { name: string; data: Buffer; store?: boolean }[]): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const e of entries) {
+    const nameBuf = Buffer.from(e.name, "utf-8");
+    const method = e.store ? 0 : 8;
+    const body = e.store ? e.data : deflateRawSync(e.data);
+    const crc = 0; // not validated by our guard
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4);
+    lfh.writeUInt16LE(0, 6);
+    lfh.writeUInt16LE(method, 8);
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(body.length, 18);
+    lfh.writeUInt32LE(e.data.length, 22);
+    lfh.writeUInt16LE(nameBuf.length, 26);
+    lfh.writeUInt16LE(0, 28);
+    const localOffset = offset;
+    locals.push(lfh, nameBuf, body);
+    offset += lfh.length + nameBuf.length + body.length;
+
+    const cdh = Buffer.alloc(46);
+    cdh.writeUInt32LE(0x02014b50, 0);
+    cdh.writeUInt16LE(20, 4);
+    cdh.writeUInt16LE(20, 6);
+    cdh.writeUInt16LE(0, 8);
+    cdh.writeUInt16LE(method, 10);
+    cdh.writeUInt32LE(crc, 16);
+    cdh.writeUInt32LE(body.length, 20);
+    cdh.writeUInt32LE(e.data.length, 24);
+    cdh.writeUInt16LE(nameBuf.length, 28);
+    cdh.writeUInt32LE(localOffset, 42);
+    centrals.push(cdh, nameBuf);
+  }
+  const cdStart = offset;
+  const cdBuf = Buffer.concat(centrals);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cdBuf.length, 12);
+  eocd.writeUInt32LE(cdStart, 16);
+  return Buffer.concat([...locals, cdBuf, eocd]);
+}
+
+describe("office-guard (F-0831-P1 / F2 zip-bomb)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = join(tmpdir(), `office-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("accepts a small legitimate office-style zip", () => {
+    const p = join(dir, "ok.docx");
+    writeFileSync(p, buildZip([{ name: "word/document.xml", data: Buffer.from("<x>hello world</x>") }]));
+    expect(zipWithinCaps(p)).toBe(true);
+  });
+
+  it("rejects a zip-bomb whose member decompresses past the cap", () => {
+    // A single member that inflates well past the 512 MiB ceiling from a tiny
+    // highly-compressible payload (classic zip-bomb shape).
+    const p = join(dir, "bomb.xlsx");
+    const huge = Buffer.alloc(OFFICE_MAX_DECOMPRESSED_BYTES + 1024 * 1024, 0);
+    writeFileSync(p, buildZip([{ name: "xl/sheet.xml", data: huge }]));
+    expect(zipWithinCaps(p)).toBe(false);
+  });
+
+  it("rejects a member that under-declares its size (header lies)", () => {
+    // Build a real zip-bomb, then corrupt the central-directory uncompressed
+    // size to look tiny. The authoritative inflate pass must still catch it.
+    const p = join(dir, "liar.docx");
+    const huge = Buffer.alloc(OFFICE_MAX_DECOMPRESSED_BYTES + 1024 * 1024, 0);
+    const zip = buildZip([{ name: "word/document.xml", data: huge }]);
+    // Falsify both local + central uncompressed-size fields to 10 bytes.
+    // Find the EOCD to locate the central directory.
+    const eocd = zip.length - 22;
+    const cdStart = zip.readUInt32LE(eocd + 16);
+    zip.writeUInt32LE(10, cdStart + 24); // central uncompressed size
+    zip.writeUInt32LE(10, 22); // local header uncompressed size
+    writeFileSync(p, zip);
+    expect(zipWithinCaps(p)).toBe(false);
+  });
+
+  it("rejects a file over the on-disk raw byte cap before parsing", () => {
+    const p = join(dir, "fat.xlsx");
+    writeFileSync(p, Buffer.alloc(OFFICE_MAX_RAW_BYTES + 1, 0x50));
+    expect(zipWithinCaps(p)).toBe(false);
+    expect(fileWithinSizeCap(p)).toBe(false);
+  });
+
+  it("rejects a non-zip / corrupt file", () => {
+    const p = join(dir, "garbage.docx");
+    writeFileSync(p, Buffer.from("not a zip at all"));
+    expect(zipWithinCaps(p)).toBe(false);
+  });
+
+  it("fileWithinSizeCap returns false for a missing file", () => {
+    expect(fileWithinSizeCap(join(dir, "nope.pdf"))).toBe(false);
+  });
+
+  it("fileWithinSizeCap accepts a small file", () => {
+    const p = join(dir, "small.pdf");
+    writeFileSync(p, Buffer.from("%PDF-1.4 tiny"));
+    expect(fileWithinSizeCap(p)).toBe(true);
+  });
+
+  // Wiring guard: detect.ts must short-circuit oversized / bomb files to ""
+  // before unpdf / officeparser ever decompress them.
+  it("extractPdfText returns '' for a PDF over the on-disk cap", async () => {
+    const p = join(dir, "huge.pdf");
+    writeFileSync(p, Buffer.alloc(OFFICE_MAX_RAW_BYTES + 1, 0x50));
+    expect(await extractPdfText(p)).toBe("");
+  });
+
+  it("docxToMarkdown returns '' for a non-zip / bomb .docx", async () => {
+    const p = join(dir, "garbage.docx");
+    writeFileSync(p, Buffer.from("not a zip"));
+    expect(await docxToMarkdown(p)).toBe("");
+  });
+
+  it("xlsxToMarkdown returns '' for a non-zip / bomb .xlsx", async () => {
+    const p = join(dir, "garbage.xlsx");
+    writeFileSync(p, Buffer.from("not a zip"));
+    expect(await xlsxToMarkdown(p)).toBe("");
+  });
+});

--- a/tests/ollama-base-url.test.ts
+++ b/tests/ollama-base-url.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateOllamaBaseUrl } from "../src/security.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("validateOllamaBaseUrl (F-0831-P1 / F3 SSRF)", () => {
+  it("fails closed on the 169.254.169.254 cloud-metadata IP", async () => {
+    await expect(validateOllamaBaseUrl("http://169.254.169.254")).rejects.toThrow(
+      /link-local\/metadata/,
+    );
+  });
+
+  it("fails closed on any 169.254.x link-local host", async () => {
+    await expect(validateOllamaBaseUrl("http://169.254.0.1:11434")).rejects.toThrow(
+      /refusing to send the corpus/,
+    );
+  });
+
+  it("fails closed on metadata.google.internal", async () => {
+    await expect(validateOllamaBaseUrl("http://metadata.google.internal")).rejects.toThrow(
+      /link-local\/metadata/,
+    );
+  });
+
+  it("fails closed on 0.0.0.0", async () => {
+    await expect(validateOllamaBaseUrl("http://0.0.0.0:11434")).rejects.toThrow(
+      /link-local\/metadata/,
+    );
+  });
+
+  it("fails closed regardless of warn flag", async () => {
+    await expect(
+      validateOllamaBaseUrl("http://169.254.169.254", { warn: false }),
+    ).rejects.toThrow(/link-local\/metadata/);
+  });
+
+  it("accepts a loopback host without warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(validateOllamaBaseUrl("http://127.0.0.1:11434")).resolves.toBeUndefined();
+    await expect(validateOllamaBaseUrl("http://localhost:11434")).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns but allows a general LAN host (trusted on-prem Ollama)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(validateOllamaBaseUrl("http://10.0.0.5:11434")).resolves.toBeUndefined();
+    await expect(validateOllamaBaseUrl("http://192.168.1.20:11434")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("does not warn for a LAN host when warn:false (early gate)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      validateOllamaBaseUrl("http://192.168.1.20:11434", { warn: false }),
+    ).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns (does not throw) on an unparseable URL", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(validateOllamaBaseUrl("not a url")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("warns (does not throw) on a non-http(s) scheme", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(validateOllamaBaseUrl("ftp://example.com")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Upstream security cluster port (bilan `.graphify/scratch/F_BILAN_0831.md`, F-0831-P1). TDD, no new deps.

## Ported
- **F2 (zip-bomb, c50ffc2/763b673)** — `src/office-guard.ts`: on-disk cap 50 MiB (PDF + office) + bounded ZIP inflate (`inflateRawSync({maxOutputLength})`, 512 MiB / 200:1 ratio guard, header-independent). Wired into `extractPdfText`/`docxToMarkdown`/`xlsxToMarkdown`. +10 tests.
- **F3 (ollama SSRF, 763b673/46a1d4c)** — `validateOllamaBaseUrl` in `security.ts`: fail-closed on link-local/metadata (169.254.169.254, metadata.google.*, 0.0.0.0, DNS-alias resolution), warn-and-allow on private LAN, OK on loopback. Wired into `resolveDirectModel` (ollama) before any corpus egress. +10 tests.

## Not ported
- **F1 (e3993e4, custom-provider base_url registry)** — **n/a**: no repo-loaded provider/base_url surface exists in the TS line (providers are a fixed list + internal llm-mesh registry). Gated on **decision D-1** (adopt `providers.json` registry #9 or not). The one egress-controlling env (`OLLAMA_BASE_URL`) is covered by F3.
- **F5 (cpp Fortran path)** — **already covered**: Fortran is regex-backed (no `cpp` subprocess); added a non-regression guard.

## Verify
`npm test`: 1094 passed, 0 fail · `tsc --noEmit` clean · `tsup` ok. (`npm run build` prescript fails on a pre-existing env issue — design-system-themes not installed — unrelated.)

Owner decision needed: **D-1** (providers registry) gates whether F1 is ever ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)