### PR TITLE
fix: restore README content asserted by tests (broken by #95 rewrite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ graphify builds on the foundational work of Safi Shamsi's [graphify](https://git
 
 `graphify install` writes assistant integrations. Pass `--platform <name>` for non-Claude clients: `codex`, `gemini`, `copilot`, `vscode`, `aider`, `opencode`, `claw`, `droid`, `trae`, `trae-cn`, `cursor`, `hermes`, `kimi`, `kiro`, `antigravity`, `windows`.
 
-To make an assistant always prefer the graph, run the matching `graphify <platform> install` (e.g. `graphify claude install` writes a `CLAUDE.md` section plus a PreToolUse hook; `graphify gemini install` writes `GEMINI.md` and registers the MCP server). Platforms without PreToolUse hooks (Gemini, Aider, OpenCode, Trae, Droid, and others) use **`AGENTS.md`** as the always-on mechanism instead. Uninstall with the matching `uninstall`, or `graphify uninstall` to remove all detected integrations.
+To make an assistant always prefer the graph, run the matching `graphify <platform> install` (e.g. `graphify claude install` writes a `CLAUDE.md` section plus a PreToolUse hook; `graphify gemini install` (or `graphify install --platform gemini`) writes `GEMINI.md` and registers the MCP server; `graphify copilot install` (or `graphify install --platform copilot`) installs the global skill for **GitHub Copilot CLI**). Platforms without PreToolUse hooks (Gemini, Aider, OpenCode, Trae, Droid, and others) use **`AGENTS.md`** as the always-on mechanism instead. Uninstall with the matching `uninstall`, or `graphify uninstall` to remove all detected integrations.
+
+Invocation differs per client: `/graphify .` in Claude Code, Gemini CLI, Copilot, and most others, but `$graphify` in Codex. Codex can also register the read-only graph as an MCP server with `codex mcp add graphify -- graphify serve /absolute/path/to/.graphify/graph.json`.
 
 ### Input scope
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Code is a first-class case of the same pipeline. Code files go through a determi
 
 - **~20 languages** via tree-sitter AST: Python, JS, TS, Go, Rust, Java, C, C++, Ruby, PHP, Lua — plus C#, Kotlin, Scala, Swift, Zig, PowerShell, Elixir, Objective-C, and Julia whose grammars are optional dependencies that degrade gracefully when absent. Vue, Svelte, Blade, Dart, Verilog/SystemVerilog, and EJS use regex fallback extraction.
 - **Call graphs and flows**: build a directed graph and derive execution flows from `CALLS` edges (`graphify flows build`).
-- **Review surfaces**: `graphify review-delta`, `graphify review-analysis`, and `graphify recommend-commits` (advisory-only) give blast radius, bridge nodes, test-gap hints, and impacted communities for changed files. Review impact favors **recall over precision — false positives are reported, not hidden.**
+- **Review surfaces**: `graphify review-delta`, `graphify review-analysis`, and `graphify recommend-commits` (advisory-only) give blast radius, bridge nodes, test-gap hints, and impacted communities for changed files. Review impact rules intentionally **favor recall over precision** — false positives are reported, not hidden. Review benchmarks (`graphify review-eval`) are deterministic local fixtures, not a universal quality guarantee. Token metrics are estimates unless backed by actual model calls.
 - **Git lifecycle**: `graphify hook install` wires post-commit/checkout/merge/rewrite hooks plus a `graphify-json` merge driver that **union-merges graph nodes** when branches build the graph concurrently, so `.graphify/graph.json` survives merges instead of conflicting.
 
 ## Multimodal ingestion


### PR DESCRIPTION
PR #95 rewrite dropped real, still-supported info asserted by tests. Restored concisely in README (Reference / Supported assistants + Review surfaces): GitHub Copilot CLI + install, gemini/codex install + $graphify + codex mcp add graphify, review benchmarks + recall-over-precision/token-estimate disclaimers. All verified against src/cli.ts & src/skills/. npm test: 1107 passed, 0 failed (was 4 failed).