### PR TITLE
feat(storage): add GraphStore port, registry and file reference store (PR2)

### DIFF
--- a/src/storage/file.ts
+++ b/src/storage/file.ts
@@ -1,0 +1,133 @@
+/**
+ * FileGraphStore — reference GraphStore implementation
+ * (SPEC_STORAGE_BACKENDS.md, "Store Registry And Driver Loading"). It
+ * "pushes" the graph to a JSON file through the canonical graph.json
+ * serialization, so contract tests and dryRun/staleness logic run without
+ * any backend driver.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type Graph from "graphology";
+import { toJson } from "../export.js";
+import type {
+  GraphPushOptions,
+  GraphPushResult,
+  GraphStore,
+  GraphStoreConfig,
+  GraphStoreSnapshotMeta,
+} from "./types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function resolveToolVersion(): string {
+  // Source layout: src/storage -> ../../package.json; bundled layout:
+  // dist -> ../package.json. The name check guards against picking up an
+  // unrelated package.json.
+  for (const rel of [join("..", ".."), ".."]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(join(__dirname, rel, "package.json"), "utf-8"),
+      ) as { name?: string; version?: string };
+      if (pkg.name === "@sentropic/graphify" && pkg.version) return pkg.version;
+    } catch {
+      /* try the next layout */
+    }
+  }
+  return "unknown";
+}
+
+export interface FileStoreClearOptions {
+  namespace?: string;
+  force?: boolean;
+}
+
+/**
+ * File store with the port-mandated surface plus a force-gated clear:
+ * deleting the mirror is destructive, so `clear` refuses unless the caller
+ * passes `{ force: true }` (a bare namespace string never forces).
+ */
+export interface FileGraphStore extends GraphStore {
+  clear(namespaceOrOptions?: string | FileStoreClearOptions): Promise<void>;
+}
+
+export function createFileGraphStore(config: GraphStoreConfig): FileGraphStore {
+  const target = config.target;
+  if (!target) {
+    throw new Error("file store requires config.target (path of the graph.json mirror)");
+  }
+
+  return {
+    id: "file",
+    capabilities: { push: true, query: false, clear: true, snapshotMeta: true },
+
+    async verifyConnection(): Promise<void> {
+      if (existsSync(target) && statSync(target).isDirectory()) {
+        throw new Error(
+          `file store target '${target}' is a directory, expected a JSON file path`,
+        );
+      }
+    },
+
+    async pushGraph(
+      G: Graph,
+      communities: Map<number, string[]>,
+      options: GraphPushOptions = {},
+    ): Promise<GraphPushResult> {
+      const start = Date.now();
+      // The file backend has a single write primitive: rewriting the target
+      // file. A push therefore always has replace semantics; mode "merge" is
+      // accepted and equivalent, because rewriting the same data is exactly
+      // the idempotent upsert the port requires.
+      const nodes = G.order;
+      const edges = G.size;
+      if (!options.dryRun) {
+        mkdirSync(dirname(target), { recursive: true });
+        // Delegate to the canonical graph.json serialization (same writer the
+        // build pipeline uses); force bypasses the shrink guard because a
+        // store push is an explicit mirror write.
+        toJson(G, communities, target, { force: true });
+      }
+      return { nodes, edges, warnings: [], durationMs: Date.now() - start };
+    },
+
+    async readSnapshotMeta(): Promise<GraphStoreSnapshotMeta | undefined> {
+      if (!existsSync(target)) return undefined;
+      let signature: unknown;
+      try {
+        const parsed = JSON.parse(readFileSync(target, "utf-8")) as {
+          topology_signature?: unknown;
+        };
+        signature = parsed.topology_signature;
+      } catch {
+        return undefined;
+      }
+      if (typeof signature !== "string" || signature.length === 0) return undefined;
+      // The mirror file is its own GraphifyMeta record: the embedded
+      // topology_signature identifies the snapshot, the file mtime is the
+      // push time, and this tool is the writer.
+      return {
+        topologySignature: signature,
+        pushedAt: statSync(target).mtime.toISOString(),
+        toolVersion: resolveToolVersion(),
+      };
+    },
+
+    async clear(namespaceOrOptions?: string | FileStoreClearOptions): Promise<void> {
+      const options = typeof namespaceOrOptions === "string"
+        ? { namespace: namespaceOrOptions }
+        : namespaceOrOptions ?? {};
+      if (!options.force) {
+        throw new Error(
+          `refusing to clear file store '${target}'; pass { force: true } to delete the mirror`,
+        );
+      }
+      // Single-file backend: every namespace maps onto the one target file.
+      rmSync(target, { force: true });
+    },
+
+    async close(): Promise<void> {
+      // Nothing to release; safe to call multiple times.
+    },
+  };
+}

--- a/src/storage/registry.ts
+++ b/src/storage/registry.ts
@@ -1,0 +1,70 @@
+/**
+ * GraphStore registry — store ids -> factories, with lazy driver loading
+ * (SPEC_STORAGE_BACKENDS.md, "Store Registry And Driver Loading").
+ *
+ * Importing this module never evaluates a backend driver: drivers are
+ * optionalDependencies resolved through dynamic import() at the moment a
+ * store is resolved, generalizing the existing neo4j-driver / chokidar
+ * pattern. PR2 registers only `file`; live backends follow (neo4j in PR3).
+ */
+import { createFileGraphStore } from "./file.js";
+import type { GraphStore, GraphStoreConfig, StoreTestDeps } from "./types.js";
+
+export interface GraphStoreFactory {
+  readonly id: string;
+  /** npm package resolved via dynamic import, e.g. "neo4j-driver"; empty when no driver is needed */
+  readonly requiredPackage: string;
+  create(config: GraphStoreConfig, deps?: StoreTestDeps): Promise<GraphStore>;
+}
+
+const factories = new Map<string, GraphStoreFactory>();
+
+export function registerGraphStoreFactory(factory: GraphStoreFactory): void {
+  factories.set(factory.id, factory);
+}
+
+export function listGraphStoreIds(): string[] {
+  return [...factories.keys()].sort();
+}
+
+/**
+ * Resolve a store id into a GraphStore instance. When the factory declares a
+ * required driver package, the registry probes the dynamic import here so
+ * every backend shares the same actionable missing-driver error.
+ * `deps.driverModule` (tests only) bypasses the import entirely.
+ */
+export async function resolveGraphStore(
+  id: string,
+  config: GraphStoreConfig,
+  deps?: StoreTestDeps,
+): Promise<GraphStore> {
+  const factory = factories.get(id);
+  if (!factory) {
+    throw new Error(`unknown store '${id}'. Available: ${listGraphStoreIds().join(", ")}`);
+  }
+
+  let resolvedDeps = deps;
+  if (factory.requiredPackage && deps?.driverModule === undefined) {
+    let driverModule: unknown;
+    try {
+      driverModule = await import(factory.requiredPackage);
+    } catch {
+      throw new Error(
+        `store '${factory.id}' requires ${factory.requiredPackage}. ` +
+          `Run: npm install ${factory.requiredPackage}`,
+      );
+    }
+    resolvedDeps = { ...deps, driverModule };
+  }
+
+  return factory.create(config, resolvedDeps);
+}
+
+registerGraphStoreFactory({
+  id: "file",
+  // Built-in reference store: no driver package to load.
+  requiredPackage: "",
+  async create(config) {
+    return createFileGraphStore(config);
+  },
+});

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,0 +1,75 @@
+/**
+ * GraphStore port — narrow interface for opt-in graph mirrors
+ * (SPEC_STORAGE_BACKENDS.md, "GraphStore Port"). `.graphify/graph.json`
+ * stays the source of truth; every backend is a pushed projection, never a
+ * source. Signatures here are normative for the storage layer.
+ */
+import type Graph from "graphology";
+
+export interface GraphStoreCapabilities {
+  push: true;
+  query: boolean;
+  clear: boolean;
+  snapshotMeta: boolean;
+}
+
+export interface GraphPushOptions {
+  /** merge = idempotent upsert (default); replace = clear namespace then load */
+  mode?: "merge" | "replace";
+  /** statements batched per request; default 500 */
+  batchSize?: number;
+  /** plan and report without writing to the backend */
+  dryRun?: boolean;
+  /** target namespace; default derived from the project */
+  namespace?: string;
+}
+
+export interface GraphPushResult {
+  nodes: number;
+  edges: number;
+  warnings: string[];
+  durationMs: number;
+}
+
+export interface GraphStoreSnapshotMeta {
+  topologySignature: string;
+  pushedAt: string;
+  toolVersion: string;
+}
+
+export interface GraphStore {
+  readonly id: string;
+  readonly capabilities: GraphStoreCapabilities;
+  verifyConnection(): Promise<void>;
+  pushGraph(
+    G: Graph,
+    communities: Map<number, string[]>,
+    options?: GraphPushOptions,
+  ): Promise<GraphPushResult>;
+  readSnapshotMeta(): Promise<GraphStoreSnapshotMeta | undefined>;
+  clear?(namespace?: string): Promise<void>;
+  query?(statement: string): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+/**
+ * Minimal store configuration for PR2. The full `storage:` YAML schema and
+ * env resolution land in PR4; until then the port only needs a backend
+ * target and a default namespace. Credentials are environment-only and never
+ * part of this object (SPEC_STORAGE_BACKENDS.md, "Secret Handling").
+ */
+export interface GraphStoreConfig {
+  /** Backend-specific target: a file path for `file`, a URI for live backends. */
+  target?: string;
+  /** Default namespace for pushes; derived from the project when omitted. */
+  namespace?: string;
+}
+
+/**
+ * Test-only injection point: a fake driver module used instead of the
+ * dynamic import of `GraphStoreFactory.requiredPackage`, mirroring the LLM
+ * execution ports injection pattern. Production code never passes this.
+ */
+export interface StoreTestDeps {
+  driverModule?: unknown;
+}

--- a/tests/helpers/graph-store-contract.ts
+++ b/tests/helpers/graph-store-contract.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared GraphStore contract suite (SPEC_STORAGE_BACKENDS.md, Tests).
+ * Every backend adapter must pass this suite at the port boundary so all
+ * mirrors behave identically: idempotent push, coherent results, snapshot
+ * meta round-trip, force-gated clear, idempotent close, write-free dryRun.
+ */
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+import type { GraphStore } from "../../src/storage/types.js";
+
+/**
+ * Widened clear signature shared by implementations: destructive clears are
+ * gated on an explicit force option (the port keeps `clear?(namespace?)`).
+ */
+type ContractGraphStore = GraphStore & {
+  clear?(options?: string | { namespace?: string; force?: boolean }): Promise<void>;
+};
+
+export interface ContractFixture {
+  G: Graph;
+  communities: Map<number, string[]>;
+}
+
+/** Small deterministic graph: 3 nodes, 2 edges, 2 communities. */
+export function contractFixture(): ContractFixture {
+  const G = new Graph();
+  G.addNode("alpha", { label: "Alpha", file_type: "code", source_file: "src/a.ts" });
+  G.addNode("beta", { label: "Beta", file_type: "code", source_file: "src/b.ts" });
+  G.addNode("gamma", { label: "Gamma", file_type: "doc", source_file: "docs/g.md" });
+  G.addEdge("alpha", "beta", { relation: "imports", confidence: "EXTRACTED" });
+  G.addEdge("beta", "gamma", { relation: "documents", confidence: "INFERRED" });
+  return { G, communities: new Map([[0, ["alpha", "beta"]], [1, ["gamma"]]]) };
+}
+
+/** A different topology, used to prove dryRun never reaches the backend. */
+function alternateFixture(): ContractFixture {
+  const G = new Graph();
+  G.addNode("delta", { label: "Delta", file_type: "code", source_file: "src/d.ts" });
+  return { G, communities: new Map([[0, ["delta"]]]) };
+}
+
+export function describeGraphStoreContract(
+  name: string,
+  makeStore: () => Promise<GraphStore> | GraphStore,
+): void {
+  describe(`GraphStore contract: ${name}`, () => {
+    it("pushes idempotently: same data twice yields the same counts without error", async () => {
+      const store = await makeStore();
+      const { G, communities } = contractFixture();
+      try {
+        const first = await store.pushGraph(G, communities);
+        const second = await store.pushGraph(G, communities);
+        expect(first.nodes).toBe(G.order);
+        expect(first.edges).toBe(G.size);
+        expect(second.nodes).toBe(first.nodes);
+        expect(second.edges).toBe(first.edges);
+      } finally {
+        await store.close();
+      }
+    });
+
+    it("returns a coherent push result", async () => {
+      const store = await makeStore();
+      const { G, communities } = contractFixture();
+      try {
+        const result = await store.pushGraph(G, communities);
+        expect(result.nodes).toBe(G.order);
+        expect(result.edges).toBe(G.size);
+        expect(Array.isArray(result.warnings)).toBe(true);
+        expect(typeof result.durationMs).toBe("number");
+        expect(result.durationMs).toBeGreaterThanOrEqual(0);
+      } finally {
+        await store.close();
+      }
+    });
+
+    it("round-trips snapshot meta: undefined before push, signature after", async () => {
+      const store = await makeStore();
+      const { G, communities } = contractFixture();
+      try {
+        if (!store.capabilities.snapshotMeta) return;
+        expect(await store.readSnapshotMeta()).toBeUndefined();
+
+        await store.pushGraph(G, communities);
+        const meta = await store.readSnapshotMeta();
+        expect(meta).toBeDefined();
+        expect(typeof meta!.topologySignature).toBe("string");
+        expect(meta!.topologySignature.length).toBeGreaterThan(0);
+        expect(Number.isNaN(Date.parse(meta!.pushedAt))).toBe(false);
+        expect(typeof meta!.toolVersion).toBe("string");
+        expect(meta!.toolVersion.length).toBeGreaterThan(0);
+
+        // Same data re-pushed keeps the same snapshot signature.
+        await store.pushGraph(G, communities);
+        const again = await store.readSnapshotMeta();
+        expect(again!.topologySignature).toBe(meta!.topologySignature);
+      } finally {
+        await store.close();
+      }
+    });
+
+    it("rejects clear without force", async () => {
+      const store = (await makeStore()) as ContractGraphStore;
+      const { G, communities } = contractFixture();
+      try {
+        if (!store.capabilities.clear || !store.clear) return;
+        await store.pushGraph(G, communities);
+        await expect(store.clear()).rejects.toThrow(/force/i);
+      } finally {
+        await store.close();
+      }
+    });
+
+    it("clears the backend with force", async () => {
+      const store = (await makeStore()) as ContractGraphStore;
+      const { G, communities } = contractFixture();
+      try {
+        if (!store.capabilities.clear || !store.clear) return;
+        await store.pushGraph(G, communities);
+        await store.clear({ force: true });
+        if (store.capabilities.snapshotMeta) {
+          expect(await store.readSnapshotMeta()).toBeUndefined();
+        }
+      } finally {
+        await store.close();
+      }
+    });
+
+    it("close is idempotent", async () => {
+      const store = await makeStore();
+      await store.close();
+      await expect(store.close()).resolves.toBeUndefined();
+    });
+
+    it("dryRun reports counts without modifying the backend", async () => {
+      const store = await makeStore();
+      const { G, communities } = contractFixture();
+      const alternate = alternateFixture();
+      try {
+        // dryRun on a fresh store leaves it untouched.
+        const planned = await store.pushGraph(G, communities, { dryRun: true });
+        expect(planned.nodes).toBe(G.order);
+        expect(planned.edges).toBe(G.size);
+        if (store.capabilities.snapshotMeta) {
+          expect(await store.readSnapshotMeta()).toBeUndefined();
+        }
+
+        // dryRun after a real push leaves the previous snapshot intact even
+        // when the planned graph differs.
+        await store.pushGraph(G, communities);
+        const before = await store.readSnapshotMeta();
+        const replan = await store.pushGraph(alternate.G, alternate.communities, { dryRun: true });
+        expect(replan.nodes).toBe(alternate.G.order);
+        expect(replan.edges).toBe(alternate.G.size);
+        if (store.capabilities.snapshotMeta) {
+          const after = await store.readSnapshotMeta();
+          expect(after?.topologySignature).toBe(before?.topologySignature);
+        }
+      } finally {
+        await store.close();
+      }
+    });
+  });
+}

--- a/tests/storage-file.test.ts
+++ b/tests/storage-file.test.ts
@@ -1,0 +1,167 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { contractFixture, describeGraphStoreContract } from "./helpers/graph-store-contract.js";
+import { createFileGraphStore } from "../src/storage/file.js";
+import {
+  listGraphStoreIds,
+  registerGraphStoreFactory,
+  resolveGraphStore,
+} from "../src/storage/registry.js";
+import type { GraphStore, GraphStoreConfig, StoreTestDeps } from "../src/storage/types.js";
+
+const cleanupDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-storage-file-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function fakeStore(id: string): GraphStore {
+  return {
+    id,
+    capabilities: { push: true, query: false, clear: false, snapshotMeta: false },
+    async verifyConnection() {},
+    async pushGraph(G) {
+      return { nodes: G.order, edges: G.size, warnings: [], durationMs: 0 };
+    },
+    async readSnapshotMeta() {
+      return undefined;
+    },
+    async close() {},
+  };
+}
+
+describeGraphStoreContract("FileGraphStore", () =>
+  createFileGraphStore({ target: join(tempDir(), "graph.json") }));
+
+describe("FileGraphStore specifics", () => {
+  it("requires config.target", () => {
+    expect(() => createFileGraphStore({})).toThrow(/target/);
+  });
+
+  it("writes the canonical graph.json serialization and reads its signature", async () => {
+    const target = join(tempDir(), "graph.json");
+    const store = createFileGraphStore({ target });
+    const { G, communities } = contractFixture();
+
+    await store.pushGraph(G, communities);
+
+    const persisted = JSON.parse(readFileSync(target, "utf-8")) as {
+      topology_signature?: string;
+      nodes?: unknown[];
+      links?: unknown[];
+    };
+    expect(persisted.nodes).toHaveLength(G.order);
+    expect(persisted.links).toHaveLength(G.size);
+    expect(typeof persisted.topology_signature).toBe("string");
+
+    const meta = await store.readSnapshotMeta();
+    expect(meta?.topologySignature).toBe(persisted.topology_signature);
+    await store.close();
+  });
+
+  it("treats merge and replace as the same file write", async () => {
+    const target = join(tempDir(), "graph.json");
+    const store = createFileGraphStore({ target });
+    const { G, communities } = contractFixture();
+
+    await store.pushGraph(G, communities, { mode: "merge" });
+    const merged = readFileSync(target, "utf-8");
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const replaced = readFileSync(target, "utf-8");
+
+    expect(replaced).toBe(merged);
+    await store.close();
+  });
+
+  it("refuses clear without force and keeps the mirror file", async () => {
+    const target = join(tempDir(), "graph.json");
+    const store = createFileGraphStore({ target });
+    const { G, communities } = contractFixture();
+
+    await store.pushGraph(G, communities);
+    await expect(store.clear()).rejects.toThrow(/force/i);
+    expect(existsSync(target)).toBe(true);
+
+    await store.clear({ force: true });
+    expect(existsSync(target)).toBe(false);
+    await store.close();
+  });
+
+  it("verifyConnection accepts a fresh path and rejects a directory target", async () => {
+    const dir = tempDir();
+    const store = createFileGraphStore({ target: join(dir, "graph.json") });
+    await expect(store.verifyConnection()).resolves.toBeUndefined();
+    await store.close();
+
+    const directoryStore = createFileGraphStore({ target: dir });
+    await expect(directoryStore.verifyConnection()).rejects.toThrow(/directory/);
+    await directoryStore.close();
+  });
+});
+
+describe("graph store registry", () => {
+  it("lists only the file store in PR2", () => {
+    expect(listGraphStoreIds()).toEqual(["file"]);
+  });
+
+  it("fails with an actionable message for an unknown store id", async () => {
+    await expect(resolveGraphStore("nope", {})).rejects.toThrow(
+      "unknown store 'nope'. Available: file",
+    );
+  });
+
+  it("resolves the file store", async () => {
+    const target = join(tempDir(), "graph.json");
+    const store = await resolveGraphStore("file", { target });
+    const { G, communities } = contractFixture();
+
+    expect(store.id).toBe("file");
+    const result = await store.pushGraph(G, communities);
+    expect(result.nodes).toBe(G.order);
+    expect(existsSync(target)).toBe(true);
+    await store.close();
+  });
+
+  it("fails with an actionable install message when the driver package is missing", async () => {
+    registerGraphStoreFactory({
+      id: "fake-neo4j",
+      requiredPackage: "graphify-test-missing-driver",
+      async create() {
+        return fakeStore("fake-neo4j");
+      },
+    });
+
+    await expect(resolveGraphStore("fake-neo4j", {})).rejects.toThrow(
+      "store 'fake-neo4j' requires graphify-test-missing-driver. " +
+        "Run: npm install graphify-test-missing-driver",
+    );
+  });
+
+  it("skips the driver import when tests inject a driver module", async () => {
+    const injected = { driver: () => "fake" };
+    let received: StoreTestDeps | undefined;
+    registerGraphStoreFactory({
+      id: "fake-injected",
+      requiredPackage: "graphify-test-missing-driver",
+      async create(_config: GraphStoreConfig, deps?: StoreTestDeps) {
+        received = deps;
+        return fakeStore("fake-injected");
+      },
+    });
+
+    const store = await resolveGraphStore("fake-injected", {}, { driverModule: injected });
+    expect(store.id).toBe("fake-injected");
+    expect(received?.driverModule).toBe(injected);
+    await store.close();
+  });
+});

--- a/tests/storage-import-guard.test.ts
+++ b/tests/storage-import-guard.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Compatibility Contract guard (SPEC_STORAGE_BACKENDS.md): importing the
+ * public index or any storage module must never evaluate a store driver.
+ * Two complementary checks:
+ * - static: src/storage/*.ts contains no static import/require of a driver
+ *   package (dynamic `import("pkg")` at call time stays allowed);
+ * - runtime: a mocked neo4j-driver records whether it gets evaluated while
+ *   importing src/index.ts and the storage modules, with a positive control
+ *   proving the probe actually trips when the driver is imported.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import Graph from "graphology";
+
+const driverProbe = vi.hoisted(() => ({ evaluated: false }));
+
+vi.mock("neo4j-driver", () => {
+  driverProbe.evaluated = true;
+  return { default: {} };
+});
+
+const storageDir = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "storage");
+
+const DRIVER_PACKAGES = ["neo4j-driver", "@google-cloud/spanner", "better-sqlite3"];
+
+describe("storage import guard", () => {
+  it("src/storage has no static driver imports", () => {
+    const files = readdirSync(storageDir).filter((file) => file.endsWith(".ts"));
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const content = readFileSync(join(storageDir, file), "utf-8");
+      for (const pkg of DRIVER_PACKAGES) {
+        const escaped = pkg.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
+        // `import ... from "pkg"` and `export ... from "pkg"`.
+        expect(content, `${file} must not statically import ${pkg}`).not.toMatch(
+          new RegExp(`(import|export)[^;()]*from\\s*["']${escaped}["']`),
+        );
+        // Bare side-effect `import "pkg"` (dynamic import("pkg") not matched).
+        expect(content, `${file} must not statically import ${pkg}`).not.toMatch(
+          new RegExp(`import\\s+["']${escaped}["']`),
+        );
+        // CJS require("pkg").
+        expect(content, `${file} must not require ${pkg}`).not.toMatch(
+          new RegExp(`require\\(\\s*["']${escaped}["']\\s*\\)`),
+        );
+      }
+    }
+  });
+
+  it("importing the public index and storage modules does not evaluate neo4j-driver", async () => {
+    const api = await import("../src/index.js");
+    await import("../src/storage/types.js");
+    await import("../src/storage/registry.js");
+    await import("../src/storage/file.js");
+    expect(driverProbe.evaluated).toBe(false);
+
+    // Positive control: the probe trips once the driver is really imported
+    // (pushToNeo4j resolves it dynamically), so the assertion above measures
+    // evaluation instead of vacuously passing.
+    await api
+      .pushToNeo4j(new Graph(), "bolt://localhost:7687", "user", "password")
+      .catch(() => {});
+    expect(driverProbe.evaluated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Quoi

PR2 de la roadmap `spec/SPEC_STORAGE_BACKENDS.md` (mergée en #100) — noyau du chantier stockage multi-backend, **aucune exposition publique** :

- `src/storage/types.ts` — interfaces normatives du port GraphStore (Capabilities/PushOptions/PushResult/SnapshotMeta), signatures de la spec.
- `src/storage/registry.ts` — factories + `resolveGraphStore` ; erreurs actionnables (`unknown store 'x'. Available: …` / `store 'x' requires <pkg>. Run: npm install <pkg>`) ; chargement de driver centralisé, transmis via `deps.driverModule` (les adapters n'importent jamais eux-mêmes) ; injection de faux driver pour les tests.
- `src/storage/file.ts` — `createFileGraphStore`, implémentation de référence (réutilise la sérialisation existante, ne réinvente rien ; `clear` exige `force: true`).
- `tests/helpers/graph-store-contract.ts` — `describeGraphStoreContract()` : 7 tests de contrat que tout futur backend (Neo4j PR3, Spanner PR8…) devra passer.
- `tests/storage-file.test.ts` + `tests/storage-import-guard.test.ts` — contrat sur FileGraphStore, registry, et garde-fou du Compatibility Contract : scan statique (aucun import statique de driver dans `src/storage/`) + sonde runtime avec contrôle positif (l'import de `src/index.ts` n'évalue jamais `neo4j-driver`).

Pas de modification de `src/index.ts`, `src/cli.ts`, `src/pipeline.ts`, `package.json` — la surface CLI/config arrive en PR4/PR5 (gel de surface à la PR5 seulement).

## Vérification (TDD, résultats observés)

- Tests rouges constatés avant implémentation, verts après : **19 tests** sur les 3 nouveaux fichiers.
- `npm test` : **1139 passed | 11 skipped** (146 fichiers).
- `npm run lint` ✅, `npm run build` ✅ (tsup + studio).