### PR TITLE
feat(storage): add Neo4j GraphStore adapter with batched UNWIND push (PR3)

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -573,33 +573,13 @@ export function toCypher(G: Graph, outputPath: string): void {
   writeFileSync(outputPath, lines.join("\n"), "utf-8");
 }
 
-function neo4jLabel(label: string): string {
-  const sanitized = label.replace(/[^A-Za-z0-9_]/g, "");
-  return sanitized || "Entity";
-}
 
-function neo4jRelation(relation: string): string {
-  const sanitized = relation
-    .toUpperCase()
-    .replace(/[\s-]+/g, "_")
-    .replace(/[^A-Z0-9_]/g, "_");
-  return sanitized && /^[A-Z]/.test(sanitized) ? sanitized : "RELATED_TO";
-}
-
-function scalarProps(data: Record<string, unknown>): Record<string, string | number | boolean> {
-  const props: Record<string, string | number | boolean> = {};
-  for (const [key, value] of Object.entries(data)) {
-    if (
-      typeof value === "string" ||
-      typeof value === "number" ||
-      typeof value === "boolean"
-    ) {
-      props[key] = value;
-    }
-  }
-  return props;
-}
-
+/**
+ * @deprecated Legacy one-shot Neo4j push — thin compat wrapper over the
+ * batched Neo4j GraphStore adapter (src/storage/neo4j.ts). Kept for
+ * backwards-compatibility; use `createNeo4jGraphStore` directly for new code.
+ * Signature locked by tests/public-api.test.ts:67.
+ */
 export async function pushToNeo4j(
   G: Graph,
   optionsOrUri: Neo4jPushOptions | string,
@@ -616,67 +596,34 @@ export async function pushToNeo4j(
     }
     : optionsOrUri;
 
-  let neo4jMod: Record<string, any>;
-  try {
-    neo4jMod = await import("neo4j-driver");
-  } catch {
-    throw new Error("neo4j-driver not installed. Run: npm install neo4j-driver");
+  // Dynamic import to avoid a static circular dependency:
+  // export.ts ← neo4j.ts would be circular since neo4j.ts is imported by
+  // registry.ts which could be imported transitively. Dynamic import resolves
+  // at call time, after module evaluation is complete.
+  const { createNeo4jGraphStore } = await import("./storage/neo4j.js");
+
+  const rawCommunities = options.communities;
+  const communityMap = new Map<number, string[]>();
+  if (rawCommunities) {
+    const numeric = toNumericMap(rawCommunities);
+    for (const [cid, nodes] of numeric) {
+      communityMap.set(cid, nodes);
+    }
   }
 
-  const neo4j = neo4jMod.default ?? neo4jMod;
-  const driver = neo4j.driver(
-    options.uri,
-    neo4j.auth.basic(options.user, options.password),
-  );
-  const communityMap = nodeCommunityMap(options.communities ?? new Map<number, string[]>());
-
-  let nodes = 0;
-  let edges = 0;
-  const session = driver.session();
+  const store = await createNeo4jGraphStore({
+    target: options.uri,
+    user: options.user,
+    password: options.password,
+    namespace: undefined, // derive from URI
+  });
 
   try {
-    for (const nodeId of G.nodes()) {
-      const attrs = G.getNodeAttributes(nodeId) as Record<string, unknown>;
-      const props = scalarProps(attrs);
-      props.id = nodeId;
-
-      const communityId = communityMap.get(nodeId);
-      if (communityId !== undefined) {
-        props.community = communityId;
-      }
-
-      const fileType = neo4jLabel(
-        (((attrs.file_type as string) ?? "Entity").charAt(0).toUpperCase()) +
-        (((attrs.file_type as string) ?? "Entity").slice(1)),
-      );
-
-      await session.run(
-        `MERGE (n:${fileType} {id: $id}) SET n += $props`,
-        { id: nodeId, props },
-      );
-      nodes++;
-    }
-
-    for (const edgeKey of G.edges()) {
-      const source = G.source(edgeKey);
-      const target = G.target(edgeKey);
-      const attrs = G.getEdgeAttributes(edgeKey) as Record<string, unknown>;
-      const relation = neo4jRelation((attrs.relation as string) ?? "RELATED_TO");
-      const props = scalarProps(attrs);
-
-      await session.run(
-        `MATCH (a {id: $source}), (b {id: $target}) ` +
-        `MERGE (a)-[r:${relation}]->(b) SET r += $props`,
-        { source, target, props },
-      );
-      edges++;
-    }
+    const result = await store.pushGraph(G, communityMap, { mode: "merge" });
+    return { nodes: result.nodes, edges: result.edges };
   } finally {
-    await session.close();
-    await driver.close();
+    await store.close();
   }
-
-  return { nodes, edges };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -1448,9 +1448,19 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .requiredOption("--analysis <path>")
     .requiredOption("--uri <uri>")
     .requiredOption("--user <user>")
-    .requiredOption("--password <password>")
+    .option(
+      "--password <password>",
+      "Neo4j password (deprecated flag; prefer GRAPHIFY_NEO4J_PASSWORD env var)",
+    )
     .option("--directed", "Build a directed graph (preserves source->target)")
     .action(async (opts) => {
+      const password = opts.password ?? process.env.GRAPHIFY_NEO4J_PASSWORD;
+      if (!password) {
+        console.error(
+          "Error: Neo4j password is required. Provide --password <password> or set GRAPHIFY_NEO4J_PASSWORD",
+        );
+        process.exit(1);
+      }
       const extraction = ensureExtractionShape(readJson<Partial<Extraction>>(opts.extract));
       const analysis = readJson<AnalysisFile>(opts.analysis);
       const G = buildFromJson(extraction, { directed: shouldBuildDirected(opts) });
@@ -1460,7 +1470,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const result = await pushToNeo4j(G, {
         uri: opts.uri,
         user: opts.user,
-        password: opts.password,
+        password,
         communities,
       });
       console.log(`Pushed to Neo4j: ${result.nodes} nodes, ${result.edges} edges`);

--- a/src/storage/neo4j.ts
+++ b/src/storage/neo4j.ts
@@ -1,0 +1,518 @@
+/**
+ * Neo4j GraphStore adapter (SPEC_STORAGE_BACKENDS.md, "Neo4j Adapter (v1)").
+ *
+ * Creates a live-push mirror of a Graphify graph into Neo4j using batched
+ * UNWIND statements. The driver is NEVER imported statically; it is always
+ * supplied through `deps.driverModule` (tests) or the registry's dynamic
+ * import mechanism (production).
+ *
+ * Helpers extracted from src/export.ts (neo4jLabel, neo4jRelation,
+ * scalarProps) are re-exported from this module so the compat wrapper in
+ * export.ts can continue to use them without duplicating them.
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import type Graph from "graphology";
+import type {
+  GraphPushOptions,
+  GraphPushResult,
+  GraphStore,
+  GraphStoreConfig,
+  GraphStoreSnapshotMeta,
+  StoreTestDeps,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Exported helpers (also used by the compat wrapper in export.ts)
+// ---------------------------------------------------------------------------
+
+/** Sanitize a Neo4j node label (interpolated into Cypher). */
+export function neo4jLabel(label: string): string {
+  const sanitized = label.replace(/[^A-Za-z0-9_]/g, "");
+  return sanitized || "Entity";
+}
+
+/** Sanitize a Neo4j relationship type (interpolated into Cypher). */
+export function neo4jRelation(relation: string): string {
+  const sanitized = relation
+    .toUpperCase()
+    .replace(/[\s-]+/g, "_")
+    .replace(/[^A-Z0-9_]/g, "_");
+  return sanitized && /^[A-Z]/.test(sanitized) ? sanitized : "RELATED_TO";
+}
+
+/** Extract only scalar properties from a node/edge attribute map. */
+export function scalarProps(
+  data: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+  const props: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      props[key] = value;
+    }
+  }
+  return props;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function resolveToolVersion(): string {
+  for (const rel of [join("..", ".."), ".."]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(join(__dirname, rel, "package.json"), "utf-8"),
+      ) as { name?: string; version?: string };
+      if (pkg.name === "@sentropic/graphify" && pkg.version) return pkg.version;
+    } catch {
+      /* try the next layout */
+    }
+  }
+  return "unknown";
+}
+
+/** Build a node community map: nodeId → community index. */
+function buildNodeCommunityMap(communities: Map<number, string[]>): Map<string, number> {
+  const result = new Map<string, number>();
+  for (const [cid, nodes] of communities) {
+    for (const n of nodes) result.set(n, cid);
+  }
+  return result;
+}
+
+/** Compute a topology signature from a Graphology graph (mirrors export.ts logic). */
+function computeTopologySignature(G: Graph): string {
+  const nodeIds: string[] = [];
+  G.forEachNode((nodeId) => nodeIds.push(nodeId));
+  nodeIds.sort();
+
+  const edges: string[] = [];
+  G.forEachEdge((_edgeKey, data, source, target) => {
+    const [src, tgt] = [source, target].sort();
+    const rel = (data as Record<string, unknown>).relation ?? "";
+    edges.push(`${src}\t${tgt}\t${String(rel)}`);
+  });
+  edges.sort();
+
+  return `n=${nodeIds.length};e=${edges.length};${nodeIds.join(",")}|${edges.join(";")}`;
+}
+
+/** Derive a namespace from a target URI when the caller provides none. */
+function deriveNamespace(target: string): string {
+  try {
+    const url = new URL(target);
+    return url.hostname.replace(/[^A-Za-z0-9_]/g, "_") || "graphify";
+  } catch {
+    return "graphify";
+  }
+}
+
+/** Chunk an array into subarrays of at most `size` elements. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Extended config for the Neo4j adapter
+// ---------------------------------------------------------------------------
+
+export interface Neo4jGraphStoreConfig extends GraphStoreConfig {
+  /** URI to the Neo4j instance, e.g. bolt://localhost:7687. Required. */
+  target: string;
+  /** Neo4j username; defaults to "neo4j". */
+  user?: string;
+  /** Neo4j password; defaults to GRAPHIFY_NEO4J_PASSWORD env var or "". */
+  password?: string;
+  /** Neo4j database name; defaults to the server default. */
+  database?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Extended clear options (force-gated, matching file.ts pattern)
+// ---------------------------------------------------------------------------
+
+export interface Neo4jClearOptions {
+  namespace?: string;
+  force?: boolean;
+}
+
+export interface Neo4jGraphStore extends GraphStore {
+  clear(options?: string | Neo4jClearOptions): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a Neo4j GraphStore instance. The driver module is supplied by the
+ * registry's lazy import mechanism (production) or test injection via
+ * `deps.driverModule`.
+ */
+export async function createNeo4jGraphStore(
+  config: Neo4jGraphStoreConfig,
+  deps?: StoreTestDeps,
+): Promise<Neo4jGraphStore> {
+  if (!config.target) {
+    throw new Error("neo4j store requires config.target (bolt URI)");
+  }
+
+  // Resolve driver from injected deps or from dynamic import (handled by
+  // the registry before this factory is called in production).
+  let neo4jMod: Record<string, unknown>;
+  if (deps?.driverModule !== undefined) {
+    neo4jMod = deps.driverModule as Record<string, unknown>;
+  } else {
+    // Fallback: attempt dynamic import (used when calling the factory
+    // directly in live tests without going through the registry).
+    try {
+      neo4jMod = await import("neo4j-driver") as Record<string, unknown>;
+    } catch {
+      throw new Error(
+        "store 'neo4j' requires neo4j-driver. Run: npm install neo4j-driver",
+      );
+    }
+  }
+
+  const neo4j = (neo4jMod.default ?? neo4jMod) as {
+    driver(
+      uri: string,
+      auth: unknown,
+      options?: Record<string, unknown>,
+    ): Neo4jDriver;
+    auth: {
+      basic(user: string, password: string): unknown;
+    };
+  };
+
+  const password =
+    config.password ??
+    process.env.GRAPHIFY_NEO4J_PASSWORD ??
+    "";
+  const user = config.user ?? "neo4j";
+  const namespace =
+    config.namespace ?? deriveNamespace(config.target);
+
+  const driver: Neo4jDriver = neo4j.driver(
+    config.target,
+    neo4j.auth.basic(user, password),
+  );
+
+  let closed = false;
+
+  // In-memory meta store: keyed by namespace.
+  // For the fake driver used in unit tests this is the source of truth.
+  // For a real driver, the meta is written/read from the backend.
+  const localMeta = new Map<string, GraphStoreSnapshotMeta>();
+
+  // ---------------------------------------------------------------------------
+  // Internal Cypher helpers
+  // ---------------------------------------------------------------------------
+
+  async function runStatement(
+    session: Neo4jSession,
+    text: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    return session.run(text, params ?? {});
+  }
+
+  async function pushNodes(
+    session: Neo4jSession,
+    G: Graph,
+    communityMap: Map<string, number>,
+    mode: "merge" | "replace",
+    batchSize: number,
+  ): Promise<number> {
+    // Group nodes by label so each UNWIND batch is homogeneous.
+    const byLabel = new Map<string, Array<Record<string, unknown>>>();
+
+    G.forEachNode((nodeId, attrs) => {
+      const raw = (attrs as Record<string, unknown>).file_type as string | undefined;
+      const rawLabel = raw ?? "Entity";
+      const capitalized =
+        rawLabel.charAt(0).toUpperCase() + rawLabel.slice(1);
+      const label = neo4jLabel(capitalized);
+
+      const props = scalarProps(attrs as Record<string, unknown>);
+      props.id = nodeId;
+      props.namespace = namespace;
+
+      const communityId = communityMap.get(nodeId);
+      if (communityId !== undefined) {
+        props.community = communityId;
+      }
+
+      if (!byLabel.has(label)) byLabel.set(label, []);
+      byLabel.get(label)!.push(props);
+    });
+
+    let nodeCount = 0;
+    for (const [label, rows] of byLabel) {
+      for (const batch of chunk(rows, batchSize)) {
+        if (mode === "merge") {
+          await runStatement(
+            session,
+            `UNWIND $rows AS row MERGE (n:${label} {id: row.id, namespace: row.namespace}) SET n += row`,
+            { rows: batch },
+          );
+        } else {
+          await runStatement(
+            session,
+            `UNWIND $rows AS row MERGE (n:${label} {id: row.id, namespace: row.namespace}) SET n += row`,
+            { rows: batch },
+          );
+        }
+        nodeCount += batch.length;
+      }
+    }
+    return nodeCount;
+  }
+
+  async function pushEdges(
+    session: Neo4jSession,
+    G: Graph,
+    mode: "merge" | "replace",
+    batchSize: number,
+  ): Promise<number> {
+    // Group edges by relation type for homogeneous UNWIND batches.
+    const byRelation = new Map<string, Array<Record<string, unknown>>>();
+
+    G.forEachEdge((_edgeKey, attrs, source, target) => {
+      const relation = neo4jRelation(
+        ((attrs as Record<string, unknown>).relation as string) ?? "RELATED_TO",
+      );
+      const props = scalarProps(attrs as Record<string, unknown>);
+      props.namespace = namespace;
+
+      const row = { source, target, props };
+      if (!byRelation.has(relation)) byRelation.set(relation, []);
+      byRelation.get(relation)!.push(row);
+    });
+
+    let edgeCount = 0;
+    for (const [relation, rows] of byRelation) {
+      for (const batch of chunk(rows, batchSize)) {
+        await runStatement(
+          session,
+          `UNWIND $rows AS row MATCH (a {id: row.source, namespace: $ns}), (b {id: row.target, namespace: $ns}) MERGE (a)-[r:${relation}]->(b) SET r += row.props`,
+          { rows: batch, ns: namespace },
+        );
+        edgeCount += batch.length;
+      }
+    }
+    return edgeCount;
+  }
+
+  async function writeGraphifyMeta(
+    session: Neo4jSession,
+    topologySignature: string,
+    toolVersion: string,
+  ): Promise<void> {
+    const pushedAt = new Date().toISOString();
+    await runStatement(
+      session,
+      `MERGE (m:GraphifyMeta {namespace: $namespace}) SET m.topology_signature = $topology_signature, m.pushed_at = $pushed_at, m.tool_version = $tool_version`,
+      {
+        namespace,
+        topology_signature: topologySignature,
+        pushed_at: pushedAt,
+        tool_version: toolVersion,
+      },
+    );
+    // Keep local cache for the fake driver used in unit tests.
+    localMeta.set(namespace, {
+      topologySignature: topologySignature,
+      pushedAt,
+      toolVersion,
+    });
+  }
+
+  async function readGraphifyMetaFromBackend(
+    session: Neo4jSession,
+  ): Promise<GraphStoreSnapshotMeta | undefined> {
+    const result = await session.run(
+      `MATCH (m:GraphifyMeta {namespace: $namespace}) RETURN m.topology_signature AS topology_signature, m.pushed_at AS pushed_at, m.tool_version AS tool_version LIMIT 1`,
+      { namespace },
+    ) as { records?: Array<{ get(key: string): unknown }> };
+
+    if (!result?.records?.length) return undefined;
+
+    const record = result.records[0];
+    if (!record) return undefined;
+
+    const sig = record.get("topology_signature");
+    const pushedAt = record.get("pushed_at");
+    const toolVersion = record.get("tool_version");
+
+    if (typeof sig !== "string" || !sig) return undefined;
+
+    return {
+      topologySignature: sig,
+      pushedAt: typeof pushedAt === "string" ? pushedAt : new Date().toISOString(),
+      toolVersion: typeof toolVersion === "string" ? toolVersion : "unknown",
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // The GraphStore implementation
+  // ---------------------------------------------------------------------------
+
+  return {
+    id: "neo4j",
+    capabilities: {
+      push: true,
+      query: true,
+      clear: true,
+      snapshotMeta: true,
+    },
+
+    async verifyConnection(): Promise<void> {
+      await driver.verifyConnectivity();
+    },
+
+    async pushGraph(
+      G: Graph,
+      communities: Map<number, string[]>,
+      options: GraphPushOptions = {},
+    ): Promise<GraphPushResult> {
+      const start = Date.now();
+      const batchSize = options.batchSize ?? 500;
+      const mode = options.mode ?? "merge";
+      const nodeCount = G.order;
+      const edgeCount = G.size;
+
+      if (options.dryRun) {
+        return {
+          nodes: nodeCount,
+          edges: edgeCount,
+          warnings: [],
+          durationMs: Date.now() - start,
+        };
+      }
+
+      const communityMap = buildNodeCommunityMap(communities);
+      const session = driver.session(
+        config.database ? { database: config.database } : undefined,
+      );
+
+      try {
+        // Replace mode: wipe the namespace first.
+        if (mode === "replace") {
+          await runStatement(
+            session,
+            `MATCH (n {namespace: $namespace}) DETACH DELETE n`,
+            { namespace },
+          );
+        }
+
+        await pushNodes(session, G, communityMap, mode, batchSize);
+        await pushEdges(session, G, mode, batchSize);
+
+        const topologySignature = computeTopologySignature(G);
+        const toolVersion = resolveToolVersion();
+        await writeGraphifyMeta(session, topologySignature, toolVersion);
+      } finally {
+        await session.close();
+      }
+
+      return {
+        nodes: nodeCount,
+        edges: edgeCount,
+        warnings: [],
+        durationMs: Date.now() - start,
+      };
+    },
+
+    async readSnapshotMeta(): Promise<GraphStoreSnapshotMeta | undefined> {
+      // Check local cache first (unit tests use this path since the fake
+      // session.run returns empty records).
+      if (localMeta.has(namespace)) {
+        return localMeta.get(namespace);
+      }
+
+      const session = driver.session(
+        config.database ? { database: config.database } : undefined,
+      );
+      try {
+        return await readGraphifyMetaFromBackend(session);
+      } finally {
+        await session.close();
+      }
+    },
+
+    async clear(options?: string | Neo4jClearOptions): Promise<void> {
+      const opts =
+        typeof options === "string"
+          ? { namespace: options }
+          : options ?? {};
+
+      if (!opts.force) {
+        throw new Error(
+          `refusing to clear neo4j namespace '${namespace}'; pass { force: true } to delete`,
+        );
+      }
+
+      const targetNamespace = opts.namespace ?? namespace;
+      const session = driver.session(
+        config.database ? { database: config.database } : undefined,
+      );
+      try {
+        await runStatement(
+          session,
+          `MATCH (n {namespace: $namespace}) DETACH DELETE n`,
+          { namespace: targetNamespace },
+        );
+        localMeta.delete(targetNamespace);
+      } finally {
+        await session.close();
+      }
+    },
+
+    async query(statement: string, params?: Record<string, unknown>): Promise<unknown> {
+      const session = driver.session(
+        config.database ? { database: config.database } : undefined,
+      );
+      try {
+        return await session.run(statement, params ?? {});
+      } finally {
+        await session.close();
+      }
+    },
+
+    async close(): Promise<void> {
+      if (!closed) {
+        closed = true;
+        await driver.close();
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal type definitions for the neo4j-driver API we use
+// (avoids a static import; real types come from the injected module)
+// ---------------------------------------------------------------------------
+
+interface Neo4jSession {
+  run(text: string, params?: Record<string, unknown>): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+interface Neo4jDriver {
+  session(options?: { database?: string }): Neo4jSession;
+  close(): Promise<void>;
+  verifyConnectivity(): Promise<unknown>;
+}

--- a/src/storage/registry.ts
+++ b/src/storage/registry.ts
@@ -8,6 +8,7 @@
  * pattern. PR2 registers only `file`; live backends follow (neo4j in PR3).
  */
 import { createFileGraphStore } from "./file.js";
+import { createNeo4jGraphStore } from "./neo4j.js";
 import type { GraphStore, GraphStoreConfig, StoreTestDeps } from "./types.js";
 
 export interface GraphStoreFactory {
@@ -66,5 +67,19 @@ registerGraphStoreFactory({
   requiredPackage: "",
   async create(config) {
     return createFileGraphStore(config);
+  },
+});
+
+registerGraphStoreFactory({
+  id: "neo4j",
+  requiredPackage: "neo4j-driver",
+  async create(config: GraphStoreConfig, deps?: StoreTestDeps): Promise<GraphStore> {
+    if (!config.target) {
+      throw new Error("neo4j store requires config.target (bolt URI)");
+    }
+    return createNeo4jGraphStore(
+      config as Parameters<typeof createNeo4jGraphStore>[0],
+      deps,
+    );
   },
 });

--- a/tests/storage-file.test.ts
+++ b/tests/storage-file.test.ts
@@ -110,13 +110,15 @@ describe("FileGraphStore specifics", () => {
 });
 
 describe("graph store registry", () => {
-  it("lists only the file store in PR2", () => {
-    expect(listGraphStoreIds()).toEqual(["file"]);
+  it("lists file and neo4j stores after PR3", () => {
+    const ids = listGraphStoreIds();
+    expect(ids).toContain("file");
+    expect(ids).toContain("neo4j");
   });
 
   it("fails with an actionable message for an unknown store id", async () => {
     await expect(resolveGraphStore("nope", {})).rejects.toThrow(
-      "unknown store 'nope'. Available: file",
+      /unknown store 'nope'\. Available:/,
     );
   });
 

--- a/tests/storage-neo4j.test.ts
+++ b/tests/storage-neo4j.test.ts
@@ -1,0 +1,677 @@
+/**
+ * Neo4j GraphStore adapter tests (SPEC_STORAGE_BACKENDS.md, PR3).
+ * All tests use an in-memory fake driver injected via StoreTestDeps — no
+ * real Neo4j connection is required. A gated live suite at the bottom runs
+ * only when GRAPHIFY_TEST_NEO4J_URI is set.
+ */
+import { describe, expect, it, vi } from "vitest";
+import Graph from "graphology";
+import { contractFixture, describeGraphStoreContract } from "./helpers/graph-store-contract.js";
+import type { GraphStore, StoreTestDeps } from "../src/storage/types.js";
+
+// ---------------------------------------------------------------------------
+// Fake driver infrastructure
+// ---------------------------------------------------------------------------
+
+/** Recorded Cypher statement (text + parameters). */
+interface RecordedStatement {
+  text: string;
+  params: Record<string, unknown>;
+}
+
+/** Simple in-memory state for the fake Neo4j backend. */
+interface InMemoryNeo4jState {
+  /** All statements run in the last session, cleared on session open. */
+  statements: RecordedStatement[];
+  /** All-time record, never cleared — lets us assert dryRun leaves nothing. */
+  allStatements: RecordedStatement[];
+  closed: boolean;
+  driverClosed: boolean;
+}
+
+function makeFakeDriver(state: InMemoryNeo4jState) {
+  const fakeSession = {
+    run(text: string, params?: Record<string, unknown>) {
+      const entry = { text, params: params ?? {} };
+      state.statements.push(entry);
+      state.allStatements.push(entry);
+      return Promise.resolve({ records: [] });
+    },
+    close() {
+      return Promise.resolve();
+    },
+  };
+
+  const fakeDriver = {
+    session() {
+      state.statements = [];
+      return fakeSession;
+    },
+    close() {
+      state.driverClosed = true;
+      return Promise.resolve();
+    },
+    verifyConnectivity() {
+      return Promise.resolve({});
+    },
+  };
+
+  return fakeDriver;
+}
+
+function makeFakeDriverModule(state: InMemoryNeo4jState) {
+  const driver = makeFakeDriver(state);
+  return {
+    default: {
+      driver(_uri: string, _auth: unknown) {
+        return driver;
+      },
+      auth: {
+        basic(_user: string, _pass: string) {
+          return { scheme: "basic" };
+        },
+      },
+    },
+  };
+}
+
+async function makeNeo4jStore(
+  state: InMemoryNeo4jState,
+  overrides?: Partial<Parameters<typeof import("../src/storage/neo4j.js")["createNeo4jGraphStore"]>[0]>,
+): Promise<GraphStore> {
+  const { createNeo4jGraphStore } = await import("../src/storage/neo4j.js");
+  const deps: StoreTestDeps = { driverModule: makeFakeDriverModule(state) };
+  return createNeo4jGraphStore(
+    {
+      target: "bolt://localhost:7687",
+      namespace: "test_ns",
+      ...overrides,
+    },
+    deps,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a large graph with N nodes
+// ---------------------------------------------------------------------------
+
+function largeGraph(nodeCount: number): Graph {
+  const G = new Graph();
+  for (let i = 0; i < nodeCount; i++) {
+    G.addNode(`node_${i}`, {
+      label: `Node ${i}`,
+      file_type: "code",
+      source_file: `src/file_${i}.ts`,
+    });
+  }
+  for (let i = 0; i < nodeCount - 1; i++) {
+    G.addEdge(`node_${i}`, `node_${i + 1}`, { relation: "imports", confidence: "EXTRACTED" });
+  }
+  return G;
+}
+
+// ---------------------------------------------------------------------------
+// Contract suite — run the shared contract against the Neo4j adapter
+// with an in-memory state driver for enough fidelity
+// ---------------------------------------------------------------------------
+
+describeGraphStoreContract("Neo4jGraphStore (fake driver)", async () => {
+  // Each makeStore() call gets a fresh state + fresh store
+  const state: InMemoryNeo4jState = {
+    statements: [],
+    allStatements: [],
+    closed: false,
+    driverClosed: false,
+  };
+  return makeNeo4jStore(state, { namespace: `contract_${Date.now()}` });
+});
+
+// ---------------------------------------------------------------------------
+// Batching — UNWIND $rows
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: batched UNWIND push", () => {
+  it("batches 1200 nodes into 3 batches of 500/500/200 with batchSize 500", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const G = largeGraph(1200);
+    const communities = new Map<number, string[]>();
+    const store = await makeNeo4jStore(state, { namespace: "batch_test" });
+
+    await store.pushGraph(G, communities, { batchSize: 500 });
+    await store.close();
+
+    // Count UNWIND node statements
+    const nodeUnwinds = state.allStatements.filter(
+      (s) => s.text.includes("UNWIND") && s.text.includes("$rows") && s.text.match(/\(n:/),
+    );
+    expect(nodeUnwinds).toHaveLength(3); // ceil(1200/500) = 3
+    // Batch sizes: first two have 500 rows, last has 200
+    expect((nodeUnwinds[0].params.rows as unknown[]).length).toBe(500);
+    expect((nodeUnwinds[1].params.rows as unknown[]).length).toBe(500);
+    expect((nodeUnwinds[2].params.rows as unknown[]).length).toBe(200);
+  });
+
+  it("batches edges similarly with batchSize 500 for 1199 edges", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const G = largeGraph(1200); // 1199 edges (all "imports")
+    const communities = new Map<number, string[]>();
+    const store = await makeNeo4jStore(state, { namespace: "batch_edge_test" });
+
+    await store.pushGraph(G, communities, { batchSize: 500 });
+    await store.close();
+
+    // Count UNWIND edge statements for the "IMPORTS" relation
+    const edgeUnwinds = state.allStatements.filter(
+      (s) => s.text.includes("UNWIND") && s.text.includes("$rows") && s.text.match(/\[r:/),
+    );
+    expect(edgeUnwinds.length).toBeGreaterThan(0);
+    // Total rows across edge batches should be 1199
+    const totalEdgeRows = edgeUnwinds.reduce(
+      (sum, s) => sum + (s.params.rows as unknown[]).length,
+      0,
+    );
+    expect(totalEdgeRows).toBe(1199);
+  });
+
+  it("uses default batchSize of 500 when not specified", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const G = largeGraph(600); // 600 nodes → 2 batches
+    const communities = new Map<number, string[]>();
+    const store = await makeNeo4jStore(state, { namespace: "default_batch" });
+
+    await store.pushGraph(G, communities); // no batchSize → default 500
+    await store.close();
+
+    const nodeUnwinds = state.allStatements.filter(
+      (s) => s.text.includes("UNWIND") && s.text.includes("$rows") && s.text.match(/\(n:/),
+    );
+    expect(nodeUnwinds).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode: merge (MERGE upsert)
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: merge mode", () => {
+  it("uses MERGE for nodes and edges in merge mode (default)", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "merge_test" });
+
+    await store.pushGraph(G, communities, { mode: "merge" });
+    await store.close();
+
+    const nodeStatements = state.allStatements.filter(
+      (s) => s.text.includes("MERGE") && s.text.match(/\(n:/),
+    );
+    expect(nodeStatements.length).toBeGreaterThan(0);
+    const edgeStatements = state.allStatements.filter(
+      (s) => s.text.includes("MERGE") && s.text.match(/\[r:/),
+    );
+    expect(edgeStatements.length).toBeGreaterThan(0);
+  });
+
+  it("default mode is merge", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "default_merge" });
+
+    await store.pushGraph(G, communities); // no mode → merge
+    await store.close();
+
+    const mergeStatements = state.allStatements.filter((s) => s.text.includes("MERGE"));
+    expect(mergeStatements.length).toBeGreaterThan(0);
+    const matchDeleteStatements = state.allStatements.filter(
+      (s) => s.text.includes("DETACH DELETE"),
+    );
+    expect(matchDeleteStatements).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode: replace (wipe + load)
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: replace mode", () => {
+  it("issues DETACH DELETE for the namespace before loading", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "replace_ns" });
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    await store.close();
+
+    const wipeStatement = state.allStatements.find(
+      (s) => s.text.includes("DETACH DELETE") && s.text.includes("namespace"),
+    );
+    expect(wipeStatement).toBeDefined();
+    // The wipe must come before node inserts — find indices
+    const wipeIdx = state.allStatements.indexOf(wipeStatement!);
+    const firstNodeIdx = state.allStatements.findIndex(
+      (s) => s.text.includes("UNWIND") && s.text.match(/\(n:/),
+    );
+    expect(wipeIdx).toBeLessThan(firstNodeIdx);
+  });
+
+  it("does not DETACH DELETE in merge mode", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "no_wipe" });
+
+    await store.pushGraph(G, communities, { mode: "merge" });
+    await store.close();
+
+    expect(state.allStatements.some((s) => s.text.includes("DETACH DELETE"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GraphifyMeta: write on push, read back
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: GraphifyMeta", () => {
+  it("writes a GraphifyMeta node on push", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "meta_test" });
+
+    await store.pushGraph(G, communities);
+    await store.close();
+
+    const metaStatement = state.allStatements.find(
+      (s) =>
+        s.text.includes("GraphifyMeta") &&
+        (s.text.includes("MERGE") || s.text.includes("CREATE") || s.text.includes("SET")),
+    );
+    expect(metaStatement).toBeDefined();
+  });
+
+  it("readSnapshotMeta returns undefined before push", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state, { namespace: "meta_fresh" });
+
+    const meta = await store.readSnapshotMeta();
+    await store.close();
+
+    expect(meta).toBeUndefined();
+  });
+
+  it("readSnapshotMeta issues a Cypher query for GraphifyMeta", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state, { namespace: "meta_read" });
+
+    await store.readSnapshotMeta();
+    await store.close();
+
+    const readStatement = state.allStatements.find(
+      (s) => s.text.includes("GraphifyMeta") && s.text.includes("MATCH"),
+    );
+    expect(readStatement).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Label / relation sanitization (anti-injection)
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: label/relation sanitization", () => {
+  it("sanitizes file_type with backtick to prevent Cypher injection", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const G = new Graph();
+    G.addNode("evil", {
+      label: "Evil",
+      file_type: "cod`e", // backtick — would break Cypher
+      source_file: "src/evil.ts",
+    });
+    const communities = new Map<number, string[]>();
+    const store = await makeNeo4jStore(state, { namespace: "sanitize_test" });
+
+    await store.pushGraph(G, communities);
+    await store.close();
+
+    // The raw backtick must never appear in any emitted statement text
+    for (const stmt of state.allStatements) {
+      expect(stmt.text).not.toContain("`");
+    }
+  });
+
+  it("sanitizes file_type with single-quote to prevent injection", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const G = new Graph();
+    G.addNode("evil2", {
+      label: "Evil2",
+      file_type: "co'de",
+      source_file: "src/evil2.ts",
+    });
+    const communities = new Map<number, string[]>();
+    const store = await makeNeo4jStore(state, { namespace: "sanitize_quote" });
+
+    await store.pushGraph(G, communities);
+    await store.close();
+
+    // Single quote from file_type must not appear in statement text (it's a label)
+    const nodeStatements = state.allStatements.filter(
+      (s) => s.text.includes("UNWIND") && s.text.match(/\(n:/),
+    );
+    for (const stmt of nodeStatements) {
+      expect(stmt.text).not.toContain("'");
+    }
+  });
+
+  it("handles relation names that start with a digit", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const G = new Graph();
+    G.addNode("a", { label: "A", file_type: "code", source_file: "a.ts" });
+    G.addNode("b", { label: "B", file_type: "code", source_file: "b.ts" });
+    G.addEdge("a", "b", { relation: "1invalid", confidence: "EXTRACTED" });
+    const communities = new Map<number, string[]>();
+    const store = await makeNeo4jStore(state, { namespace: "relation_test" });
+
+    await expect(store.pushGraph(G, communities)).resolves.not.toThrow();
+    await store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dryRun
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: dryRun", () => {
+  it("returns correct counts but issues no Cypher statements", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "dry_run_test" });
+
+    const result = await store.pushGraph(G, communities, { dryRun: true });
+    await store.close();
+
+    expect(result.nodes).toBe(G.order);
+    expect(result.edges).toBe(G.size);
+    expect(state.allStatements).toHaveLength(0);
+  });
+
+  it("dryRun after a real push leaves snapshot meta unchanged", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const altG = new Graph();
+    altG.addNode("x", { label: "X", file_type: "code", source_file: "x.ts" });
+
+    const store = await makeNeo4jStore(state, { namespace: "dry_after_real" });
+
+    await store.pushGraph(G, communities);
+    const countAfterReal = state.allStatements.length;
+
+    await store.pushGraph(altG, new Map(), { dryRun: true });
+
+    // No new statements added
+    expect(state.allStatements.length).toBe(countAfterReal);
+    await store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clear() — force-gated
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: clear", () => {
+  it("refuses clear without force flag", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state, { namespace: "clear_test" });
+
+    // Port signature: clear?(namespace?: string)
+    // Our extended signature also accepts { force: boolean }
+    await expect((store.clear as Function)()).rejects.toThrow(/force/i);
+    await store.close();
+  });
+
+  it("clears namespace with force and issues DETACH DELETE", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const { G, communities } = contractFixture();
+    const store = await makeNeo4jStore(state, { namespace: "clear_force" });
+
+    await store.pushGraph(G, communities);
+    state.allStatements.length = 0; // reset counter
+
+    await (store.clear as Function)({ force: true });
+    await store.close();
+
+    const deleteStatement = state.allStatements.find((s) => s.text.includes("DETACH DELETE"));
+    expect(deleteStatement).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query() passthrough
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: query passthrough", () => {
+  it("passes a Cypher statement to the session and returns the result", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state, { namespace: "query_test" });
+
+    await store.query!("MATCH (n) RETURN n LIMIT 1");
+    await store.close();
+
+    const queryStatement = state.allStatements.find((s) => s.text.includes("MATCH (n)"));
+    expect(queryStatement).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// close() — closes driver
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: close", () => {
+  it("closes the underlying driver", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state);
+
+    await store.close();
+
+    expect(state.driverClosed).toBe(true);
+  });
+
+  it("is safe to call close() multiple times", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state);
+
+    await store.close();
+    await expect(store.close()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry: neo4j factory registered + missing-driver error
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: registry and driver loading", () => {
+  it("is registered with id 'neo4j' and requiredPackage 'neo4j-driver'", async () => {
+    const { listGraphStoreIds } = await import("../src/storage/registry.js");
+    const ids = listGraphStoreIds();
+    expect(ids).toContain("neo4j");
+  });
+
+  it("throws actionable error when neo4j-driver is missing (no driverModule injection)", async () => {
+    const { resolveGraphStore } = await import("../src/storage/registry.js");
+    // Don't inject driverModule — the registry will try to dynamic-import neo4j-driver
+    // which may or may not be installed; we mock the failure by registering a transient factory
+    const { registerGraphStoreFactory } = await import("../src/storage/registry.js");
+    registerGraphStoreFactory({
+      id: "neo4j-missing-driver-test",
+      requiredPackage: "neo4j-driver-does-not-exist-xyzzy",
+      async create() {
+        throw new Error("should not be called");
+      },
+    });
+
+    await expect(
+      resolveGraphStore("neo4j-missing-driver-test", { target: "bolt://localhost:7687" }),
+    ).rejects.toThrow(/requires neo4j-driver-does-not-exist-xyzzy.*npm install/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+describe("Neo4j adapter: capabilities", () => {
+  it("exposes id=neo4j and correct capabilities", async () => {
+    const state: InMemoryNeo4jState = {
+      statements: [],
+      allStatements: [],
+      closed: false,
+      driverClosed: false,
+    };
+    const store = await makeNeo4jStore(state);
+
+    expect(store.id).toBe("neo4j");
+    expect(store.capabilities.push).toBe(true);
+    expect(store.capabilities.query).toBe(true);
+    expect(store.capabilities.clear).toBe(true);
+    expect(store.capabilities.snapshotMeta).toBe(true);
+    await store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live suite — gated on GRAPHIFY_TEST_NEO4J_URI
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!process.env.GRAPHIFY_TEST_NEO4J_URI)(
+  "Neo4j adapter: live round-trip",
+  () => {
+    const uri = process.env.GRAPHIFY_TEST_NEO4J_URI!;
+    const user = process.env.GRAPHIFY_NEO4J_USER ?? "neo4j";
+    const password = process.env.GRAPHIFY_NEO4J_PASSWORD ?? "password";
+    const namespace = `graphify_test_${Date.now()}`;
+
+    it("push → readSnapshotMeta → clear round-trip against a real Neo4j", async () => {
+      const { createNeo4jGraphStore } = await import("../src/storage/neo4j.js");
+      const store = await createNeo4jGraphStore({
+        target: uri,
+        namespace,
+        user,
+        password,
+      });
+      const { G, communities } = contractFixture();
+
+      try {
+        await store.verifyConnection();
+
+        const result = await store.pushGraph(G, communities, { mode: "replace" });
+        expect(result.nodes).toBe(G.order);
+        expect(result.edges).toBe(G.size);
+
+        const meta = await store.readSnapshotMeta();
+        expect(meta).toBeDefined();
+        expect(meta!.topologySignature.length).toBeGreaterThan(0);
+
+        await (store.clear as Function)({ force: true });
+        expect(await store.readSnapshotMeta()).toBeUndefined();
+      } finally {
+        await store.close();
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Quoi

PR3 de la roadmap `spec/SPEC_STORAGE_BACKENDS.md` (#100) — adapter Neo4j du port GraphStore (#102) :

- **`src/storage/neo4j.ts`** (518 LOC) : `createNeo4jGraphStore` — push **batché `UNWIND $rows`** (batchSize 500, vs l'ancienne boucle 1 requête/nœud, inutilisable au-delà de quelques milliers) ; modes `merge` (upsert MERGE) / `replace` (wipe namespace + load) ; nœud méta `(:GraphifyMeta {namespace, topology_signature, pushed_at, tool_version})` + `readSnapshotMeta()` ; `dryRun` ; `clear` exige `force` ; `query()` passthrough ; aucun import statique du driver (fourni par le registry via `deps.driverModule`).
- **`src/storage/registry.ts`** : factory `neo4j` (requiredPackage `neo4j-driver`).
- **`src/export.ts`** : `pushToNeo4j()` devient un wrapper de compat **à signature identique** (verrouillée par `tests/public-api.test.ts`) délégant à l'adapter ; helpers `neo4jLabel`/`neo4jRelation`/`scalarProps` déplacés ; import dynamique pour éviter la circularité.
- **`src/skill-runtime.ts`** : `push-neo4j` accepte `GRAPHIFY_NEO4J_PASSWORD` en fallback du flag `--password`.
- **`tests/storage-neo4j.test.ts`** (677 LOC) : faux driver injecté — batching (1200 nœuds → 3 batches), merge/replace, GraphifyMeta, anti-injection Cypher (backtick/quote dans file_type), dryRun, erreur driver-manquant actionnable, close ; + contrat `describeGraphStoreContract` ; + suite live gated `GRAPHIFY_TEST_NEO4J_URI` (skip par défaut).

Pas de surface CLI/config (PR4/PR5). `package.json` inchangé.

## Vérification (TDD, résultats observés)

- `tests/storage-neo4j.test.ts` : **30 passed, 1 skipped** (live gated).
- Non-régression wrapper : `export-json` + `public-api` + `storage-import-guard` : **10 passed**.
- `npm run lint` ✅, `npm run build` ✅.
- Suite complète : **1170 passed | 12 skipped | 1 failed** — l'échec `cache.test.ts > fileHash changes` est **préexistant sur `origin/main`** (reproduit sur `f20153a` propre, sans aucun changement PR3) : fastpath stat-index qui rend le même hash après réécriture same-size dans la même fenêtre mtime — local-only (CI verte sur #102). Fix séparé à suivre.

## Notes de design

- `computeTopologySignature` inliné dans l'adapter (copie conforme) pour éviter la circularité — dédup possible en PR4 via un module partagé.