### PR TITLE
fix(cache): bigint stats for the mtime fastpath + deterministic same-size edit test

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,7 +11,7 @@ import {
   renameSync,
   existsSync,
   statSync,
-  type Stats,
+  type BigIntStats,
 } from "node:fs";
 import { dirname, extname, join, resolve } from "node:path";
 import { resolveGraphifyPaths } from "./paths.js";
@@ -70,11 +70,12 @@ function flushStatIndex(): void {
   statIndexDirty = false;
 }
 
-function statMtimeNs(stat: Stats): number {
-  // mtimeNs available on Node 12+; fall back to mtimeMs * 1e6.
-  const ns = (stat as Stats & { mtimeNs?: bigint }).mtimeNs;
-  if (typeof ns === "bigint") return Number(ns);
-  return Math.floor(stat.mtimeMs * 1e6);
+function statMtimeNs(stat: BigIntStats): number {
+  // `mtimeNs` is only populated on BigIntStats (statSync with bigint: true);
+  // a plain Stats never carries it. Number() keeps the existing stat-index
+  // schema (mtime_ns: number) at ~hundreds-of-ns precision, far below kernel
+  // timestamp granularity.
+  return Number(stat.mtimeNs);
 }
 
 export interface CacheOptions {
@@ -103,9 +104,9 @@ function bodyContent(content: Buffer): Buffer {
  * changes do not invalidate semantic extraction cache entries.
  */
 export function fileHash(filePath: string, root: string = "."): string {
-  let stat: Stats;
+  let stat: BigIntStats;
   try {
-    stat = statSync(filePath);
+    stat = statSync(filePath, { bigint: true });
   } catch (error) {
     throw error;
   }
@@ -115,12 +116,15 @@ export function fileHash(filePath: string, root: string = "."): string {
 
   // Upstream d84f07c: stat fastpath — skip full SHA256 read when size and
   // mtime are unchanged. `touch` triggers a harmless re-hash; same-size edits
-  // within a 1 ns mtime window are the only blind spot (matches make(1)).
+  // within the same kernel timestamp tick are the only blind spot (matches
+  // make(1)). bigint stats are required: plain statSync has no mtimeNs and
+  // its mtimeMs*1e6 fallback degraded the window to ~milliseconds.
   ensureStatIndex(root);
   const absKey = resolve(filePath);
   const mtimeNs = statMtimeNs(stat);
+  const size = Number(stat.size);
   const cached = statIndex[absKey];
-  if (cached && cached.size === stat.size && cached.mtime_ns === mtimeNs) {
+  if (cached && cached.size === size && cached.mtime_ns === mtimeNs) {
     return cached.hash;
   }
 
@@ -137,7 +141,7 @@ export function fileHash(filePath: string, root: string = "."): string {
   h.update(relativePath);
   const digest = h.digest("hex");
 
-  statIndex[absKey] = { size: stat.size, mtime_ns: mtimeNs, hash: digest };
+  statIndex[absKey] = { size, mtime_ns: mtimeNs, hash: digest };
   statIndexDirty = true;
 
   return digest;

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -39,6 +39,11 @@ describe("cache", () => {
     writeFileSync(f, "v1");
     const h1 = fileHash(f);
     writeFileSync(f, "v2");
+    // Same-size rewrite within one kernel timestamp tick is the documented
+    // stat-fastpath blind spot (make(1) trade-off) — step the mtime explicitly
+    // so the test is deterministic on any filesystem, as a real edit would.
+    const later = Date.now() / 1000 + 1;
+    utimesSync(f, later, later);
     const h2 = fileHash(f);
     expect(h1).not.toBe(h2);
   });


### PR DESCRIPTION
## Quoi

Corrige le test flaky `cache.test.ts > fileHash changes when content changes` (échouait en local sur `origin/main` propre, reproduit sur `f20153a`) et le défaut produit sous-jacent :

- **`src/cache.ts`** : le fastpath stat (port upstream `d84f07c`) prétendait une fenêtre aveugle « 1 ns » mais `statSync` sans `{ bigint: true }` ne fournit **jamais** `mtimeNs` → le fallback `Math.floor(mtimeMs * 1e6)` dégradait la fenêtre à ~ms (avec perte de précision float). Passage à `statSync(filePath, { bigint: true })` : vraie précision ns du kernel, schéma du stat-index inchangé (`mtime_ns: number`).
- **`tests/cache.test.ts`** : une réécriture same-size dans le même tick d'horloge kernel reste le blind spot documenté (trade-off make(1)) — le test bump désormais le mtime explicitement (`utimesSync +1s`), comme le ferait un édit réel → déterministe sur tout filesystem.

## Vérification (observée)

- Avant fix : `1 failed | 15 passed` sur `origin/main` propre.
- Après fix : `tests/cache.test.ts` **16 passed** ; suite complète **1141 passed | 11 skipped (0 failed)** ; `npm run lint` ✅.