### PR TITLE
feat(storage): add storage config block and env/flag resolution (PR4)

### DIFF
--- a/src/portable-artifacts.ts
+++ b/src/portable-artifacts.ts
@@ -26,6 +26,7 @@ const LOCAL_LIFECYCLE_FILES = new Set([
   "branch.json",
   "worktree.json",
   "needs_update",
+  "store-state.json",
 ]);
 
 const LOCAL_LIFECYCLE_PREFIXES = [

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { listGraphStoreIds } from "./storage/registry.js";
 
 import type {
   GraphifyDataprepPolicy,
@@ -13,9 +14,32 @@ import type {
   GraphifyProjectConfig,
   GraphifyProjectInputs,
   GraphifyProjectConfigProfile,
+  GraphifyStorageMirrorConfig,
   NormalizedProjectConfig,
+  NormalizedStorageConfig,
+  NormalizedStorageMirrorConfig,
   ProjectConfigDiscoveryResult,
 } from "./types.js";
+
+/**
+ * Keys that look like secrets and are forbidden inside the storage: YAML block.
+ * Credentials must be supplied via environment variables only.
+ * (SPEC_STORAGE_BACKENDS.md, "Secret Handling")
+ */
+const SECRET_KEY_PATTERNS = [
+  "password",
+  "pass",
+  "secret",
+  "token",
+  "credential",
+  "credentials",
+  "key",
+  "apikey",
+  "api_key",
+  "private_key",
+];
+
+const VALID_MIRROR_MODES = new Set(["merge", "replace"]);
 
 const CONFIG_CANDIDATES = [
   "graphify.yaml",
@@ -56,6 +80,72 @@ function asNumber(value: unknown, fallback: number): number {
 
 function resolvePath(configDir: string, value: string): string {
   return resolve(configDir, value);
+}
+
+function isSecretKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SECRET_KEY_PATTERNS.some((pattern) => lower === pattern || lower.includes(pattern));
+}
+
+function validateStorageMirror(mirror: Record<string, unknown>, index: number): string[] {
+  const errors: string[] = [];
+
+  // Check for secret keys — must use env vars instead
+  for (const key of Object.keys(mirror)) {
+    if (isSecretKey(key)) {
+      errors.push(
+        `storage.mirrors[${index}]: key "${key}" looks like a secret and is not allowed in YAML config. ` +
+          `Use environment variables instead: GRAPHIFY_NEO4J_PASSWORD, GRAPHIFY_NEO4J_USER, ` +
+          `GRAPHIFY_NEO4J_URI, GRAPHIFY_NEO4J_DATABASE, GRAPHIFY_SPANNER_PROJECT, ` +
+          `GRAPHIFY_SPANNER_INSTANCE, GRAPHIFY_SPANNER_DATABASE`,
+      );
+    }
+  }
+
+  // Validate backend id against known registry
+  if (typeof mirror.backend === "string" && mirror.backend.trim().length > 0) {
+    const knownIds = listGraphStoreIds();
+    if (!knownIds.includes(mirror.backend.trim())) {
+      errors.push(
+        `storage.mirrors[${index}]: unknown backend "${mirror.backend}". ` +
+          `Available: ${knownIds.join(", ")}`,
+      );
+    }
+  } else {
+    errors.push(`storage.mirrors[${index}]: backend is required and must be a string`);
+  }
+
+  // Validate mode if present
+  if (mirror.mode !== undefined && !VALID_MIRROR_MODES.has(String(mirror.mode))) {
+    errors.push(`storage.mirrors[${index}]: mode must be "merge" or "replace"`);
+  }
+
+  return errors;
+}
+
+function validateStorage(storage: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  const mirrors = storage.mirrors;
+
+  if (mirrors === undefined || mirrors === null) {
+    return errors;
+  }
+
+  if (!Array.isArray(mirrors)) {
+    errors.push("storage.mirrors must be a list of mirror entries");
+    return errors;
+  }
+
+  for (let i = 0; i < mirrors.length; i++) {
+    const mirror = mirrors[i];
+    if (typeof mirror !== "object" || mirror === null || Array.isArray(mirror)) {
+      errors.push(`storage.mirrors[${i}] must be an object`);
+      continue;
+    }
+    errors.push(...validateStorageMirror(mirror as Record<string, unknown>, i));
+  }
+
+  return errors;
 }
 
 function registrySourceName(path: string): string {
@@ -198,6 +288,13 @@ export function validateProjectConfig(config: GraphifyProjectConfig): string[] {
   if (reconciliation.patches_path !== undefined && typeof reconciliation.patches_path !== "string") {
     errors.push("outputs.ontology.reconciliation.patches_path must be a path string");
   }
+
+  // Validate storage block if present
+  if (config.storage !== undefined) {
+    const storage = asRecord(config.storage);
+    errors.push(...validateStorage(storage));
+  }
+
   return errors;
 }
 
@@ -310,7 +407,40 @@ export function normalizeProjectConfig(
         },
       },
     },
+    storage: normalizeStorageConfig(config.storage),
   };
+}
+
+function normalizeStorageConfig(
+  storage: GraphifyProjectConfig["storage"],
+): NormalizedStorageConfig | undefined {
+  if (storage === undefined || storage === null) return undefined;
+  const rec = asRecord(storage);
+  const mirrorsRaw = rec.mirrors;
+  if (!Array.isArray(mirrorsRaw) || mirrorsRaw.length === 0) {
+    // Empty mirrors array — no storage block in normalized output
+    if (Array.isArray(mirrorsRaw) && mirrorsRaw.length === 0) {
+      return { mirrors: [] };
+    }
+    return undefined;
+  }
+
+  const mirrors: NormalizedStorageMirrorConfig[] = mirrorsRaw.map((m) => {
+    const mirror = asRecord(m) as unknown as GraphifyStorageMirrorConfig;
+    return {
+      backend: String(mirror.backend ?? ""),
+      uri: typeof mirror.uri === "string" ? mirror.uri : undefined,
+      user: typeof mirror.user === "string" ? mirror.user : undefined,
+      database: typeof mirror.database === "string" ? mirror.database : undefined,
+      project: typeof mirror.project === "string" ? mirror.project : undefined,
+      instance: typeof mirror.instance === "string" ? mirror.instance : undefined,
+      mode: mirror.mode === "replace" ? "replace" : "merge",
+      namespace: typeof mirror.namespace === "string" ? mirror.namespace : undefined,
+      autoPush: typeof mirror.autoPush === "boolean" ? mirror.autoPush : false,
+    };
+  });
+
+  return { mirrors };
 }
 
 export function loadProjectConfig(configPath: string): NormalizedProjectConfig {

--- a/src/storage/config.ts
+++ b/src/storage/config.ts
@@ -1,0 +1,163 @@
+/**
+ * Storage config resolution for PR4.
+ *
+ * resolveStoreConfig() merges CLI flags > environment variables > YAML config
+ * into a GraphStoreConfig ready for resolveGraphStore().
+ *
+ * Secrets (passwords) come exclusively from environment variables.
+ * The YAML `storage:` block is never consulted for secrets.
+ * (SPEC_STORAGE_BACKENDS.md, "Secret Handling", "CLI And Config Surface")
+ */
+
+import type { GraphStoreConfig } from "./types.js";
+import type { NormalizedProjectConfig } from "../types.js";
+
+/**
+ * CLI flags that can override env / yaml values. These are the non-secret
+ * connection parameters a user may supply on the command line.
+ */
+export interface StorageCliFlags {
+  /** Backend Bolt URI (neo4j) or file path (file). */
+  uri?: string;
+  /** Target namespace for pushes. */
+  namespace?: string;
+  /** Database name. */
+  database?: string;
+  /** User name (non-secret; password must come from env). */
+  user?: string;
+  /** Spanner project id. */
+  project?: string;
+  /** Spanner instance id. */
+  instance?: string;
+}
+
+/**
+ * Inputs for config resolution. All fields are optional so call sites only
+ * pass what they have.
+ */
+export interface ResolveStoreConfigInput {
+  /** CLI flags — highest precedence. */
+  cliFlags?: StorageCliFlags;
+  /**
+   * Environment variable map. Defaults to `process.env` when omitted.
+   * Accepting an explicit map makes tests fully hermetic.
+   */
+  env?: NodeJS.ProcessEnv;
+  /** Normalized project config (from graphify.yaml). Lowest precedence. */
+  projectConfig?: Pick<NormalizedProjectConfig, "storage">;
+}
+
+/**
+ * Resolve a GraphStoreConfig for the given backend id from the three-layer
+ * precedence chain: CLI flags > env vars > YAML config.
+ *
+ * @param backendId - The store id (e.g. "neo4j", "file"). When undefined,
+ *   GRAPHIFY_STORE is consulted; if that is also absent the returned config
+ *   has no backend-specific values.
+ * @param input - Sources to merge.
+ * @returns A GraphStoreConfig ready for resolveGraphStore().
+ */
+export function resolveStoreConfig(
+  backendId: string | undefined,
+  input: ResolveStoreConfigInput,
+): GraphStoreConfig {
+  const { cliFlags = {}, env = process.env, projectConfig } = input;
+
+  // Determine effective backend id
+  const effectiveId = backendId ?? env["GRAPHIFY_STORE"] ?? undefined;
+
+  // Pull yaml mirror for the effective backend (lowest precedence)
+  const yamlMirror = findMirror(projectConfig, effectiveId);
+
+  // Build resolved config by merging layers: yaml < env < cli
+  const config: GraphStoreConfig = {};
+
+  if (effectiveId === "neo4j" || (!effectiveId && env["GRAPHIFY_NEO4J_URI"])) {
+    config.target =
+      cliFlags.uri ??
+      env["GRAPHIFY_NEO4J_URI"] ??
+      yamlMirror?.uri;
+
+    const user = cliFlags.user ?? env["GRAPHIFY_NEO4J_USER"] ?? yamlMirror?.user;
+    // Password comes from env only — never from yaml or cliFlags object
+    const password = env["GRAPHIFY_NEO4J_PASSWORD"];
+
+    if (user !== undefined || password !== undefined) {
+      config.auth = {};
+      if (user !== undefined) config.auth.user = user;
+      if (password !== undefined) config.auth.password = password;
+    }
+
+    config.database =
+      cliFlags.database ??
+      env["GRAPHIFY_NEO4J_DATABASE"] ??
+      yamlMirror?.database;
+  } else if (effectiveId === "spanner") {
+    // Spanner authenticates through Application Default Credentials (ADC).
+    // No password variable by design.
+    config.project =
+      cliFlags.project ??
+      env["GRAPHIFY_SPANNER_PROJECT"] ??
+      yamlMirror?.project;
+
+    config.instance =
+      cliFlags.instance ??
+      env["GRAPHIFY_SPANNER_INSTANCE"] ??
+      yamlMirror?.instance;
+
+    config.database =
+      cliFlags.database ??
+      env["GRAPHIFY_SPANNER_DATABASE"] ??
+      yamlMirror?.database;
+  } else if (effectiveId === "file" || effectiveId === undefined) {
+    // file store or generic: uri becomes target if provided
+    if (cliFlags.uri !== undefined) config.target = cliFlags.uri;
+  } else {
+    // Unknown / future backend — passthrough from yaml and env what we can
+    if (cliFlags.uri !== undefined) {
+      config.target = cliFlags.uri;
+    } else if (yamlMirror?.uri !== undefined) {
+      config.target = yamlMirror.uri;
+    }
+  }
+
+  // Namespace: cli > yaml
+  const namespace = cliFlags.namespace ?? yamlMirror?.namespace;
+  if (namespace !== undefined) config.namespace = namespace;
+
+  // autoPush from yaml mirror (CLI does not expose autoPush as a flag)
+  if (yamlMirror !== undefined) {
+    config.autoPush = yamlMirror.autoPush ?? false;
+  }
+
+  // mode from yaml mirror
+  if (yamlMirror?.mode !== undefined) {
+    config.mode = yamlMirror.mode;
+  }
+
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function findMirror(
+  projectConfig: Pick<NormalizedProjectConfig, "storage"> | undefined,
+  backendId: string | undefined,
+): {
+  uri?: string;
+  user?: string;
+  database?: string;
+  project?: string;
+  instance?: string;
+  namespace?: string;
+  autoPush?: boolean;
+  mode?: "merge" | "replace";
+} | undefined {
+  if (!projectConfig?.storage?.mirrors) return undefined;
+  if (backendId === undefined) {
+    return projectConfig.storage.mirrors[0];
+  }
+  return projectConfig.storage.mirrors.find((m) => m.backend === backendId);
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -53,16 +53,31 @@ export interface GraphStore {
 }
 
 /**
- * Minimal store configuration for PR2. The full `storage:` YAML schema and
- * env resolution land in PR4; until then the port only needs a backend
- * target and a default namespace. Credentials are environment-only and never
- * part of this object (SPEC_STORAGE_BACKENDS.md, "Secret Handling").
+ * Resolved store configuration (PR4). Produced by resolveStoreConfig() from
+ * the precedence chain: CLI flags > env vars > YAML config.
+ * Credentials are environment-only and never read from YAML
+ * (SPEC_STORAGE_BACKENDS.md, "Secret Handling").
  */
 export interface GraphStoreConfig {
-  /** Backend-specific target: a file path for `file`, a URI for live backends. */
+  /** Backend-specific target: a file path for `file`, a Bolt URI for neo4j. */
   target?: string;
   /** Default namespace for pushes; derived from the project when omitted. */
   namespace?: string;
+  /** Authentication credentials — populated from env only, never from YAML. */
+  auth?: {
+    user?: string;
+    password?: string;
+  };
+  /** Target database name (neo4j/spanner). */
+  database?: string;
+  /** Spanner project id (ADC-authenticated; no password). */
+  project?: string;
+  /** Spanner instance id. */
+  instance?: string;
+  /** Whether to push automatically after a successful build. Default false. */
+  autoPush?: boolean;
+  /** Resolved push mode for the mirror. */
+  mode?: "merge" | "replace";
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,6 +275,22 @@ export interface GraphifyProjectOntologyReconciliationPolicy {
   patches_path?: string;
 }
 
+export interface GraphifyStorageMirrorConfig {
+  backend: string;
+  uri?: string;
+  user?: string;
+  database?: string;
+  project?: string;
+  instance?: string;
+  mode?: "merge" | "replace";
+  namespace?: string;
+  autoPush?: boolean;
+}
+
+export interface GraphifyStorageConfig {
+  mirrors?: GraphifyStorageMirrorConfig[];
+}
+
 export interface GraphifyProjectConfig {
   version?: number;
   profile?: GraphifyProjectConfigProfile;
@@ -282,6 +298,23 @@ export interface GraphifyProjectConfig {
   dataprep?: GraphifyDataprepPolicy;
   llm_execution?: GraphifyLlmExecutionPolicy;
   outputs?: GraphifyOutputPolicy;
+  storage?: GraphifyStorageConfig;
+}
+
+export interface NormalizedStorageMirrorConfig {
+  backend: string;
+  uri?: string;
+  user?: string;
+  database?: string;
+  project?: string;
+  instance?: string;
+  mode: "merge" | "replace";
+  namespace?: string;
+  autoPush: boolean;
+}
+
+export interface NormalizedStorageConfig {
+  mirrors: NormalizedStorageMirrorConfig[];
 }
 
 export interface NormalizedProjectProfile {
@@ -369,6 +402,7 @@ export interface NormalizedProjectConfig {
   dataprep: NormalizedDataprepPolicy;
   llm_execution: NormalizedLlmExecutionPolicy;
   outputs: NormalizedOutputPolicy;
+  storage?: NormalizedStorageConfig;
 }
 
 export interface ProjectConfigDiscoveryResult {

--- a/tests/storage-config.test.ts
+++ b/tests/storage-config.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Tests for PR4: storage: YAML block, env resolution, secret-in-YAML validation.
+ * TDD: these tests are written before the implementation.
+ */
+import { describe, expect, it, afterEach, beforeEach } from "vitest";
+
+import { validateProjectConfig, parseProjectConfig } from "../src/project-config.js";
+import { resolveStoreConfig } from "../src/storage/config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMinimalConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    profile: { path: "graphify/ontology-profile.yaml" },
+    inputs: { corpus: ["raw"] },
+    ...overrides,
+  };
+}
+
+// Env isolation helpers
+const savedEnv: Record<string, string | undefined> = {};
+const envKeys = [
+  "GRAPHIFY_STORE",
+  "GRAPHIFY_NEO4J_URI",
+  "GRAPHIFY_NEO4J_USER",
+  "GRAPHIFY_NEO4J_PASSWORD",
+  "GRAPHIFY_NEO4J_DATABASE",
+  "GRAPHIFY_SPANNER_PROJECT",
+  "GRAPHIFY_SPANNER_INSTANCE",
+  "GRAPHIFY_SPANNER_DATABASE",
+];
+
+beforeEach(() => {
+  for (const key of envKeys) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of envKeys) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Part 1: storage: block in project config validation
+// ---------------------------------------------------------------------------
+
+describe("validateProjectConfig – storage block", () => {
+  it("accepts a valid storage block with no secret keys", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      uri: bolt://localhost:7687",
+        "      user: neo4j",
+        "      database: graphs",
+        "      mode: merge",
+        "      autoPush: false",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.filter((e) => e.includes("storage"))).toHaveLength(0);
+  });
+
+  it("rejects a storage mirror with 'password' key — secret must be env", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      password: s3cr3t",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    const secretErrors = errors.filter((e) => e.toLowerCase().includes("secret") || e.toLowerCase().includes("password") || e.toLowerCase().includes("env"));
+    expect(secretErrors.length).toBeGreaterThan(0);
+    // Message must reference env variable
+    expect(secretErrors[0]).toMatch(/GRAPHIFY_/);
+  });
+
+  it("rejects a storage mirror with 'token' key", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      token: abc123",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.some((e) => e.toLowerCase().includes("token") || e.toLowerCase().includes("secret") || e.match(/GRAPHIFY_/))).toBe(true);
+  });
+
+  it("rejects a storage mirror with 'secret' key", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      secret: mysecret",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.some((e) => e.match(/GRAPHIFY_/))).toBe(true);
+  });
+
+  it("rejects a storage mirror with 'credential' key", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      credential: val",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.some((e) => e.match(/GRAPHIFY_/))).toBe(true);
+  });
+
+  it("rejects a storage mirror with 'pass' key", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      pass: pw",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.some((e) => e.match(/GRAPHIFY_/))).toBe(true);
+  });
+
+  it("rejects an unknown backend id, listing available ids", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: unknowndb",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    const backendErrors = errors.filter((e) => e.includes("backend") || e.includes("unknowndb"));
+    expect(backendErrors.length).toBeGreaterThan(0);
+    // Must list available ids
+    expect(backendErrors[0]).toMatch(/neo4j|file/);
+  });
+
+  it("accepts omitted storage block (no config = no error)", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.filter((e) => e.includes("storage"))).toHaveLength(0);
+  });
+
+  it("accepts mirrors array being absent under storage:", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage: {}",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.filter((e) => e.includes("storage"))).toHaveLength(0);
+  });
+
+  it("rejects a non-string mode value", () => {
+    const raw = parseProjectConfig(
+      [
+        "version: 1",
+        "profile:",
+        "  path: graphify/ontology-profile.yaml",
+        "inputs:",
+        "  corpus: [raw]",
+        "storage:",
+        "  mirrors:",
+        "    - backend: neo4j",
+        "      mode: overwrite",
+        "",
+      ].join("\n"),
+      "graphify.yaml",
+    );
+
+    const errors = validateProjectConfig(raw);
+    expect(errors.some((e) => e.includes("mode"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part 2: normalizeProjectConfig — storage field in normalized output
+// ---------------------------------------------------------------------------
+
+describe("normalizeProjectConfig – storage field", () => {
+  it("preserves autoPush defaulting to false when mirror has no autoPush", async () => {
+    const { normalizeProjectConfig } = await import("../src/project-config.js");
+    const normalized = normalizeProjectConfig(
+      {
+        version: 1,
+        profile: { path: "graphify/ontology-profile.yaml" },
+        inputs: { corpus: ["raw"] },
+        storage: {
+          mirrors: [{ backend: "neo4j", uri: "bolt://localhost:7687", user: "neo4j" }],
+        },
+      } as any,
+      "graphify.yaml",
+    );
+
+    expect(normalized.storage).toBeDefined();
+    expect(normalized.storage!.mirrors).toHaveLength(1);
+    expect(normalized.storage!.mirrors[0].autoPush).toBe(false);
+    expect(normalized.storage!.mirrors[0].backend).toBe("neo4j");
+  });
+
+  it("preserves autoPush: true when explicitly set", async () => {
+    const { normalizeProjectConfig } = await import("../src/project-config.js");
+    const normalized = normalizeProjectConfig(
+      {
+        version: 1,
+        profile: { path: "graphify/ontology-profile.yaml" },
+        inputs: { corpus: ["raw"] },
+        storage: {
+          mirrors: [{ backend: "neo4j", autoPush: true }],
+        },
+      } as any,
+      "graphify.yaml",
+    );
+
+    expect(normalized.storage!.mirrors[0].autoPush).toBe(true);
+  });
+
+  it("returns undefined storage when no storage block", async () => {
+    const { normalizeProjectConfig } = await import("../src/project-config.js");
+    const normalized = normalizeProjectConfig(
+      {
+        version: 1,
+        profile: { path: "graphify/ontology-profile.yaml" },
+        inputs: { corpus: ["raw"] },
+      },
+      "graphify.yaml",
+    );
+
+    expect(normalized.storage).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part 3: resolveStoreConfig — env/flag/yaml precedence + secret handling
+// ---------------------------------------------------------------------------
+
+describe("resolveStoreConfig – env variable mapping", () => {
+  it("reads neo4j URI, user, database from env when no yaml or flags", () => {
+    process.env.GRAPHIFY_NEO4J_URI = "bolt://envhost:7687";
+    process.env.GRAPHIFY_NEO4J_USER = "envuser";
+    process.env.GRAPHIFY_NEO4J_DATABASE = "envdb";
+
+    const config = resolveStoreConfig("neo4j", { env: process.env });
+
+    expect(config.target).toBe("bolt://envhost:7687");
+    expect(config.auth?.user).toBe("envuser");
+    expect(config.database).toBe("envdb");
+  });
+
+  it("reads neo4j password from env, never from yaml or flags object", () => {
+    process.env.GRAPHIFY_NEO4J_PASSWORD = "envpassword";
+
+    const config = resolveStoreConfig("neo4j", { env: process.env });
+
+    expect(config.auth?.password).toBe("envpassword");
+  });
+
+  it("CLI flags override env for neo4j URI", () => {
+    process.env.GRAPHIFY_NEO4J_URI = "bolt://envhost:7687";
+
+    const config = resolveStoreConfig("neo4j", {
+      env: process.env,
+      cliFlags: { uri: "bolt://clihost:7687" },
+    });
+
+    expect(config.target).toBe("bolt://clihost:7687");
+  });
+
+  it("CLI flags override env for namespace", () => {
+    process.env.GRAPHIFY_NEO4J_URI = "bolt://envhost:7687";
+
+    const config = resolveStoreConfig("neo4j", {
+      env: process.env,
+      cliFlags: { namespace: "cli-ns" },
+    });
+
+    expect(config.namespace).toBe("cli-ns");
+  });
+
+  it("YAML uri is used when no CLI flag and no env", () => {
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", uri: "bolt://yamlhost:7687", user: "yamluser" }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", { projectConfig: projectConfig as any });
+
+    expect(config.target).toBe("bolt://yamlhost:7687");
+    expect(config.auth?.user).toBe("yamluser");
+  });
+
+  it("env overrides yaml for URI", () => {
+    process.env.GRAPHIFY_NEO4J_URI = "bolt://envhost:7687";
+
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", uri: "bolt://yamlhost:7687", user: "yamluser" }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", {
+      env: process.env,
+      projectConfig: projectConfig as any,
+    });
+
+    expect(config.target).toBe("bolt://envhost:7687");
+  });
+
+  it("CLI flag overrides env which overrides yaml (full precedence chain)", () => {
+    process.env.GRAPHIFY_NEO4J_URI = "bolt://envhost:7687";
+
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", uri: "bolt://yamlhost:7687" }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", {
+      env: process.env,
+      cliFlags: { uri: "bolt://clihost:7687" },
+      projectConfig: projectConfig as any,
+    });
+
+    expect(config.target).toBe("bolt://clihost:7687");
+  });
+
+  it("spanner maps GRAPHIFY_SPANNER_PROJECT|INSTANCE|DATABASE env vars", () => {
+    process.env.GRAPHIFY_SPANNER_PROJECT = "my-project";
+    process.env.GRAPHIFY_SPANNER_INSTANCE = "my-instance";
+    process.env.GRAPHIFY_SPANNER_DATABASE = "my-database";
+
+    const config = resolveStoreConfig("spanner", { env: process.env });
+
+    expect(config.project).toBe("my-project");
+    expect(config.instance).toBe("my-instance");
+    expect(config.database).toBe("my-database");
+    // Spanner uses ADC — no password field
+    expect((config as any).auth?.password).toBeUndefined();
+  });
+
+  it("GRAPHIFY_STORE env selects the default backend when backendId is omitted", () => {
+    process.env.GRAPHIFY_STORE = "neo4j";
+    process.env.GRAPHIFY_NEO4J_URI = "bolt://envhost:7687";
+
+    // resolveStoreConfig without explicit backendId uses GRAPHIFY_STORE
+    const config = resolveStoreConfig(undefined, { env: process.env });
+
+    expect(config.target).toBe("bolt://envhost:7687");
+  });
+
+  it("autoPush is false by default from normalized mirror config", () => {
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", uri: "bolt://host:7687" }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", { projectConfig: projectConfig as any });
+
+    expect(config.autoPush).toBe(false);
+  });
+
+  it("autoPush is true when mirror sets it", () => {
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", uri: "bolt://host:7687", autoPush: true }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", { projectConfig: projectConfig as any });
+
+    expect(config.autoPush).toBe(true);
+  });
+
+  it("neo4j database from yaml when not in env", () => {
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", uri: "bolt://host:7687", database: "mydb" }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", { projectConfig: projectConfig as any });
+
+    expect(config.database).toBe("mydb");
+  });
+
+  it("namespace from yaml mirror", () => {
+    const projectConfig = {
+      storage: {
+        mirrors: [{ backend: "neo4j", namespace: "yaml-ns" }],
+      },
+    };
+
+    const config = resolveStoreConfig("neo4j", { projectConfig: projectConfig as any });
+
+    expect(config.namespace).toBe("yaml-ns");
+  });
+
+  it("returns empty config object for unknown backend when no env/flags", () => {
+    const config = resolveStoreConfig("file", {});
+    expect(config).toBeDefined();
+    expect(typeof config).toBe("object");
+  });
+});


### PR DESCRIPTION
## Quoi

PR4 de la roadmap `spec/SPEC_STORAGE_BACKENDS.md` — config sans surface CLI (PR5 séparée) :

- Bloc `storage: mirrors: [...]` dans `graphify.yaml` (`src/project-config.ts` + `src/types.ts`) : backend validé contre `listGraphStoreIds()` (erreur actionnable), `mode` merge|replace, `autoPush` défaut false.
- **Garde secrets** : toute clé évoquant un secret (`password`, `token`, `credential`, `*key`…) dans un mirror YAML = erreur de validation qui renvoie vers les env vars (`GRAPHIFY_NEO4J_PASSWORD`…) — le YAML reste committable.
- `src/storage/config.ts` : `resolveStoreConfig()` — précédence flags CLI > env > yaml ; mapping `GRAPHIFY_STORE`, `GRAPHIFY_NEO4J_URI|USER|PASSWORD|DATABASE`, `GRAPHIFY_SPANNER_PROJECT|INSTANCE|DATABASE` (Spanner = ADC, pas de password).
- `store-state.json` ajouté à `LOCAL_LIFECYCLE_FILES` (contrat commit-safe).

## Vérification (TDD, observée)

- `tests/storage-config.test.ts` : **27 passed** ; `project-config.test.ts` : **8 passed**.
- Suite complète : **1198 passed | 12 skipped | 0 failed** ; lint ✅ ; build ✅.