### PR TITLE
spec(ontology): hierarchies v1 schema — D1=1b/D2=2a approved

### DIFF
--- a/spec/SPEC_ONTOLOGY_HIERARCHIES.md
+++ b/spec/SPEC_ONTOLOGY_HIERARCHIES.md
@@ -4,7 +4,10 @@
 
 - Product: Graphify TypeScript port
 - Scope: profile-driven ontology hierarchy generation, sidecar artifacts, studio passthrough
-- Spec state: **Draft — decision surface, not yet approved**
+- Spec state: **Approved — D1=1b, D2=2a confirmed; declarative path implemented**
+- Decisions: Decision 1 = **1b** (declarative, rebuild-only) and Decision 2 = **2a**
+  (registry `id_column`) are both **Approved**. The aclp-am peer signed
+  `workspace-bundle-contract-v1` (artifactHash `sha256:5b08e19d…afaf`, stabilized 2/2).
 - State root: `.graphify/`
 - Activation: explicit ontology profile `hierarchies` block only
 - Default behavior: unchanged and artifact-free
@@ -28,35 +31,42 @@ project, regulated-domain, or proprietary ontology examples.
 Graphify already accepts a `hierarchies` block in its ontology profile YAML/JSON.
 The type system, normalizer, and validator for that block are fully implemented.
 
-**`OntologyHierarchySpec`** (`src/types.ts:581-588`) declares six fields:
+**`OntologyHierarchySpec`** (`src/types.ts:674-718`) declares six fields:
 `registry`, `parent_column`, `child_column`, `relation_type`,
-`parent_node_type`, `child_node_type`.
+`parent_node_type`, `child_node_type` (with `OntologyHierarchyArc` and its
+`status` / `confidence` lifecycle fields following in the same range).
 
 **`normalizeHierarchy`** (`src/ontology-profile.ts:160-169`) converts each entry
 to a `NormalizedOntologyHierarchySpec` and stores the result on
-`NormalizedOntologyProfile.hierarchies` (`src/types.ts:692`).
+`NormalizedOntologyProfile.hierarchies` (`src/types.ts:835`).
 
 **`validateOntologyProfile`** (`src/ontology-profile.ts:234, 331-358`) checks
 that every hierarchy entry references a valid registry, valid node types, and a
 valid relation type.
 
-Despite this, **`src/ontology-output.ts`** never reads `profile.hierarchies`.
-The compile step (`compileOntologyOutputs`, L220-268) writes six sidecar files —
-`manifest.json`, `nodes.json`, `aliases.json`, `relations.json`,
-`validation.json`, `index.json` — but produces no hierarchy artifacts. The
-declared structure is validated and then silently dropped.
+The **declarative compile path is now implemented**: `compileOntologyOutputs`
+(`src/ontology-output.ts`, L229+) reads `options.profile.hierarchies`
+(`src/ontology-output.ts:241,247`) and, when the profile declares hierarchies,
+emits `hierarchies.json` and `hierarchy-index.json` alongside the existing
+sidecar files (`manifest.json`, `nodes.json`, `aliases.json`, `relations.json`,
+`validation.json`, `index.json`). The earlier claim that
+`compileOntologyOutputs` "never reads `profile.hierarchies`" and silently drops
+the declared structure is **no longer true** — that gap is closed under D1=1b
+(declarative, rebuild-only).
 
 At the same time, the studio scene passthrough **is already in place** (commit
-`7bbba08`). `NODE_PROFILE_FIELDS` in `src/studio-scene.ts:139-159` lists
+`7bbba08`). `NODE_PROFILE_FIELDS` in `src/studio-scene.ts:164` lists
 `parent_id`, `child_ids`, `level`, `code`, `hierarchy_id`, `hierarchy_ids` for
-nodes, and `EDGE_PROFILE_FIELDS` (L161-171) lists `hierarchy_id`, `structural`
-for edges. These fields are copied verbatim from graph nodes when present
-(`copyOwnFields`, L374). The studio front-end will receive and render hierarchy
-fields as soon as the core emits them.
+nodes (L175-180), and `EDGE_PROFILE_FIELDS` (L185) lists `hierarchy_id`,
+`structural` for edges (L192-193). These fields are copied verbatim from graph
+nodes when present (`copyOwnFields`, L143). The studio front-end receives and
+renders hierarchy fields as soon as the core emits them.
 
-**The gap:** the profile declares hierarchies, validation passes, but no
-hierarchy artifact is generated and no node receives hierarchy fields during
-compile. The studio passthrough is ready; the core generation step is missing.
+**Status:** the profile declares hierarchies, validation passes, and the core
+compile step now generates the hierarchy sidecar (D1=1b declarative path). The
+studio passthrough consumes the emitted fields. The remaining out-of-scope-v1
+surface is the `source:"extracted"` lane and registry→canonical unification
+(see "v2 bridge" below).
 
 ---
 
@@ -142,9 +152,11 @@ and does not emit the cyclic hierarchy entry.
 
 ### Integration Point in `compileOntologyOutputs` (`src/ontology-output.ts`)
 
-The hierarchy compile step is inserted inside `compileOntologyOutputs`
-(currently L220-268), after `compileRelations` and before the manifest write.
-It reads `options.profile.hierarchies`, joins parent→child arcs to the
+The hierarchy compile step runs inside `compileOntologyOutputs`
+(`src/ontology-output.ts:229+`; hierarchy block at L239-269), after
+`compileRelations` and before the manifest write.
+It reads `options.profile.hierarchies` (`src/ontology-output.ts:241,247`), joins
+parent→child arcs to the
 already-compiled `nodes` array, runs BFS for level assignment and ancestor-path
 computation, detects cycles, and writes `hierarchies.json` +
 `hierarchy-index.json`. If no `hierarchies` entries are declared, both files
@@ -155,6 +167,12 @@ existing consumers are unaffected.
 ---
 
 ## Decision 1 — Hierarchy Lifecycle: Declarative vs. Reconciliation Cycle
+
+> **Resolved — Approved: D1 = Option 1b (declarative, rebuild-only).** Confirmed
+> by the product owner; the aclp-am peer signed `workspace-bundle-contract-v1`
+> (artifactHash `sha256:5b08e19d…afaf`, stabilized 2/2). The declarative path is
+> implemented in `compileOntologyOutputs`. The `source:"extracted"` candidate
+> lane is reserved for v2 (see "v2 bridge").
 
 **Context.** The existing patch model (`src/ontology-patch.ts`) supports a
 reviewed lifecycle for entity matches and relations (operations: `accept_match`,
@@ -208,12 +226,19 @@ are not uncertain. The `source` field is forward-compatible: `"profile"` /
 `"registry"` arcs stay declarative; `"extracted"` arcs (reserved) enter the
 queue. The decision log is not polluted with trivially accepted registry rows.
 
-**Product owner: confirm 1b, or escalate to 1a if hierarchy arcs require human
-sign-off even when registry-bound.**
+**Product owner decision: Approved — 1b confirmed.** Registry-bound arcs stay
+declarative; human sign-off is not required when registry-bound. (Signed via
+`workspace-bundle-contract-v1`, `sha256:5b08e19d…afaf`, stabilized 2/2.)
 
 ---
 
 ## Decision 2 — Canonical ID Scheme for Parent and Child
+
+> **Resolved — Approved: D2 = Option 2a (registry `id_column`).** Confirmed by
+> the product owner; signed via `workspace-bundle-contract-v1`
+> (`sha256:5b08e19d…afaf`, stabilized 2/2). `parent_id`/`child_id` reference the
+> registry `id_column`; the downstream bundle join key is `registry_record_id`
+> with no id_map. The 2b registry→canonical unification is reserved for v2.
 
 **Context.** When `compileOntologyOutputs` compiles `nodes.json`, each node
 receives an `id`. That id is used to link arcs in `hierarchies.json`. Two
@@ -255,8 +280,51 @@ directly reusable for cross-work reconciliation in the public-pack corpus. The
 sequencing dependency imposed by Option 2b is unjustified when registry bindings
 already attest the arc with confidence = 1.0.
 
-**Product owner: confirm 2a, or escalate to 2b if a unified id space with
-`relations.json` is a hard studio requirement.**
+**Product owner decision: Approved — 2a confirmed.** `parent_id`/`child_id` =
+registry `id_column`; cross-work reuse via stable registry ids; downstream join
+key `registry_record_id`, no id_map. (Signed via `workspace-bundle-contract-v1`,
+`sha256:5b08e19d…afaf`, stabilized 2/2.) A unified id space with `relations.json`
+(2b) is not a v1 requirement and is reserved for v2.
+
+---
+
+## Bundle relationship — core `hierarchies.json` → aclp-am `scene-hierarchies.json`
+
+The core `hierarchies.json` (schema `graphify_ontology_hierarchies_v1`, a flat
+list of directed arcs) is the **upstream** artifact. The WP4 G2 bundle emitter
+reshapes it into the aclp-am-facing `scene-hierarchies.json` (schema
+`graphify_scene_hierarchies_v1`); the bundle is the downstream consumption
+artifact, not a replacement for the core sidecar.
+
+Per the approved decisions:
+
+- **D1 = 1b** → every emitted arc carries `status: "reference"`,
+  `source: "profile"`, `confidence: 1.0` (registry-bound, declarative,
+  rebuild-only — no candidate queue, no patch).
+- **D2 = 2a** → `parent_id` / `child_id` are the registry `id_column` values.
+- **Join key** → the downstream join from `scene-hierarchies.json` back to the
+  registry / scene records is `registry_record_id`. There is **no id_map**: the
+  registry id is the canonical key on both sides of the bundle boundary.
+
+The bundle emitter is **additive and gated**: it activates only when
+`hierarchies.json` exists (no `hierarchies` block → no core sidecar → no bundle),
+so the default path is byte-identical to today.
+
+### v2 bridge (reserved — out of scope for v1)
+
+Two extensions are explicitly **deferred to v2 / increment-C** and are NOT
+produced in v1:
+
+- The **`source:"extracted"` arc lane** — LLM-extracted arcs with
+  `confidence < 1.0` that enter the candidate → patch review queue (Option 1a
+  applies to that lane only; registry-bound arcs stay declarative).
+- The **registry→canonical unification (Decision 2b)** — a unified id space
+  shared with `relations.json` via reconciliation `canonical_id`, replacing the
+  `registry_record_id` join key with an attested canonical id.
+
+Both are forward-compatible with the v1 schema: the `source` and `status`/
+`confidence` fields are already reserved, and the `registry_record_id` join can
+be superseded by a `canonical_id` join without breaking the v1 arc shape.
 
 ---
 
@@ -284,10 +352,11 @@ File: `src/ontology-output.ts`
 File: `src/studio-scene.ts`
 
 Commit `7bbba08` already added `parent_id`, `child_ids`, `level`, `code`,
-`hierarchy_id`, `hierarchy_ids` to `NODE_PROFILE_FIELDS` (L151-156) and
-`hierarchy_id`, `structural` to `EDGE_PROFILE_FIELDS` (L169-170). The studio
-will receive these fields as soon as graph nodes carry them. No further change
-to the passthrough is required for v1.
+`hierarchy_id`, `hierarchy_ids` to `NODE_PROFILE_FIELDS`
+(`src/studio-scene.ts:164`, fields at L175-180) and `hierarchy_id`, `structural`
+to `EDGE_PROFILE_FIELDS` (`src/studio-scene.ts:185`, fields at L192-193). The
+studio receives these fields as soon as graph nodes carry them. No further
+change to the passthrough is required for v1.
 
 ### Graph schema impact
 
@@ -330,17 +399,19 @@ scene passthrough already reads).
 
 ---
 
-## Open Decisions
+## Resolved & Open Decisions
 
-1. **Decision 1 (owner required)** — Hierarchy lifecycle: declarative rebuild-only
-   (Option 1b, recommended) vs. candidate→patch cycle (Option 1a). See
+1. **Decision 1 — RESOLVED (Approved: 1b).** Hierarchy lifecycle: declarative
+   rebuild-only. Confirmed by the product owner and signed via
+   `workspace-bundle-contract-v1` (`sha256:5b08e19d…afaf`, stabilized 2/2). See
    section "Decision 1" above.
 
-2. **Decision 2 (owner required)** — Canonical ID scheme: registry ids (Option 2a,
-   recommended) vs. reconciliation canonical ids (Option 2b). See section
-   "Decision 2" above.
+2. **Decision 2 — RESOLVED (Approved: 2a).** Canonical ID scheme: registry
+   `id_column`. Confirmed by the product owner and signed via
+   `workspace-bundle-contract-v1` (`sha256:5b08e19d…afaf`, stabilized 2/2). See
+   section "Decision 2" above.
 
-3. **guessed→validated policy** — The treatment of hierarchy arcs whose source
+3. **guessed→validated policy (open)** — The treatment of hierarchy arcs whose source
    node carries `status: "guessed"` (i.e., the extraction did not attest the
    registry match directly) is not specified here. This policy is shared with the
    broader entity status hardening work and is tracked separately under

--- a/spec/SPEC_ONTOLOGY_HIERARCHIES.md
+++ b/spec/SPEC_ONTOLOGY_HIERARCHIES.md
@@ -1,0 +1,347 @@
+# SPEC_ONTOLOGY_HIERARCHIES
+
+## Status
+
+- Product: Graphify TypeScript port
+- Scope: profile-driven ontology hierarchy generation, sidecar artifacts, studio passthrough
+- Spec state: **Draft — decision surface, not yet approved**
+- State root: `.graphify/`
+- Activation: explicit ontology profile `hierarchies` block only
+- Default behavior: unchanged and artifact-free
+
+This spec defines how Graphify should compile hierarchy artifacts from a declared
+`hierarchies` block in the ontology profile. It covers the `hierarchies.json` and
+`hierarchy-index.json` sidecar, integration with the existing compile step in
+`src/ontology-output.ts`, studio passthrough (already wired), and two product
+decisions the owner must resolve before implementation can begin.
+
+This spec complements `SPEC_ONTOLOGY_OUTPUT_ARTIFACTS.md` and
+`SPEC_ONTOLOGY_LIFECYCLE_RECONCILIATION.md`. It does not replace them.
+
+This spec must remain generic. It must not introduce real customer, partner,
+project, regulated-domain, or proprietary ontology examples.
+
+---
+
+## Problem
+
+Graphify already accepts a `hierarchies` block in its ontology profile YAML/JSON.
+The type system, normalizer, and validator for that block are fully implemented.
+
+**`OntologyHierarchySpec`** (`src/types.ts:581-588`) declares six fields:
+`registry`, `parent_column`, `child_column`, `relation_type`,
+`parent_node_type`, `child_node_type`.
+
+**`normalizeHierarchy`** (`src/ontology-profile.ts:160-169`) converts each entry
+to a `NormalizedOntologyHierarchySpec` and stores the result on
+`NormalizedOntologyProfile.hierarchies` (`src/types.ts:692`).
+
+**`validateOntologyProfile`** (`src/ontology-profile.ts:234, 331-358`) checks
+that every hierarchy entry references a valid registry, valid node types, and a
+valid relation type.
+
+Despite this, **`src/ontology-output.ts`** never reads `profile.hierarchies`.
+The compile step (`compileOntologyOutputs`, L220-268) writes six sidecar files —
+`manifest.json`, `nodes.json`, `aliases.json`, `relations.json`,
+`validation.json`, `index.json` — but produces no hierarchy artifacts. The
+declared structure is validated and then silently dropped.
+
+At the same time, the studio scene passthrough **is already in place** (commit
+`7bbba08`). `NODE_PROFILE_FIELDS` in `src/studio-scene.ts:139-159` lists
+`parent_id`, `child_ids`, `level`, `code`, `hierarchy_id`, `hierarchy_ids` for
+nodes, and `EDGE_PROFILE_FIELDS` (L161-171) lists `hierarchy_id`, `structural`
+for edges. These fields are copied verbatim from graph nodes when present
+(`copyOwnFields`, L374). The studio front-end will receive and render hierarchy
+fields as soon as the core emits them.
+
+**The gap:** the profile declares hierarchies, validation passes, but no
+hierarchy artifact is generated and no node receives hierarchy fields during
+compile. The studio passthrough is ready; the core generation step is missing.
+
+---
+
+## Goals
+
+- Generate `hierarchies.json` and `hierarchy-index.json` under
+  `.graphify/ontology/` from every declared `OntologyHierarchySpec` entry.
+- Make the compile step in `src/ontology-output.ts` the single callsite for
+  hierarchy generation (additive, profile-gated, no new command required).
+- Produce artifacts that the studio passthrough (`NODE_PROFILE_FIELDS`,
+  `EDGE_PROFILE_FIELDS`) can consume without further changes.
+- Detect and report cycles; reject cyclic hierarchies rather than silently
+  dropping them.
+- Keep hierarchy generation registry-bound in v1 (no LLM, no extraction guessing).
+- Leave `graph.json` schema unchanged (hierarchies remain a sidecar, not a
+  graph-level field).
+- Preserve the existing artifact-free default: if no `hierarchies` block is
+  declared, no file is written and behavior is byte-identical to today.
+
+## Non-Goals
+
+- Do not hardcode any domain-specific node type, taxonomy, or relation name.
+- Do not add real customer, partner, project, regulated-domain, or proprietary
+  examples.
+- Do not extract hierarchies from text via LLM in v1.
+- Do not change the `graph.json` schema.
+- Do not replace or conflict with existing `nodes.json`, `relations.json`,
+  or `index.json` sidecar files.
+- Do not implement a hierarchy reconciliation cycle in v1 (see Decision 1).
+- Do not implement cross-work-corpus hierarchy merging in v1 (see Decision 2).
+
+---
+
+## Proposed Artifact Schema `graphify_ontology_hierarchies_v1`
+
+### `hierarchies.json`
+
+Path: `.graphify/ontology/hierarchies.json`
+
+```json
+{
+  "schema": "graphify_ontology_hierarchies_v1",
+  "graph_hash": "<sha256>", "profile_hash": "<sha256>",
+  "generated_at": "<ISO-8601>", "hierarchy_count": 1, "entry_count": 42,
+  "entries": [
+    { "hierarchy_id": "genre_taxonomy", "parent_id": "fiction",
+      "child_id": "mystery", "level": 1, "type": "is_a",
+      "confidence": 1.0, "evidence_refs": ["registries/genre_taxonomy.csv"],
+      "source": "profile" }
+  ]
+}
+```
+
+Fields: `hierarchy_id` (spec key), `parent_id` / `child_id` (resolved node ids
+— see Decision 2), `level` (depth from root = 0), `type` (`is_a` | `part_of` |
+`broader` | `custom:<x>`), `confidence` (1.0 for registry-bound; reserved for
+`< 1.0` when extraction added), `evidence_refs`, `source` (`"profile"` /
+`"registry"` / `"extracted"` — last reserved for v2).
+
+### `hierarchy-index.json`
+
+Path: `.graphify/ontology/hierarchy-index.json`
+
+```json
+{
+  "schema": "graphify_ontology_hierarchies_v1", "generated_at": "<ISO-8601>",
+  "hierarchies": {
+    "genre_taxonomy": {
+      "root_ids": ["fiction", "non_fiction"], "depth": 3,
+      "node_count": 42, "arc_count": 41, "cycles_detected": false,
+      "paths": {
+        "mystery": ["fiction", "mystery"],
+        "cozy_mystery": ["fiction", "mystery", "cozy_mystery"]
+      }
+    }
+  }
+}
+```
+
+`paths` provides pre-computed ancestor chains (root→leaf) for O(1) breadcrumb
+lookup in the studio. The index builder records a cycle error in `validation.json`
+and does not emit the cyclic hierarchy entry.
+
+### Integration Point in `compileOntologyOutputs` (`src/ontology-output.ts`)
+
+The hierarchy compile step is inserted inside `compileOntologyOutputs`
+(currently L220-268), after `compileRelations` and before the manifest write.
+It reads `options.profile.hierarchies`, joins parent→child arcs to the
+already-compiled `nodes` array, runs BFS for level assignment and ancestor-path
+computation, detects cycles, and writes `hierarchies.json` +
+`hierarchy-index.json`. If no `hierarchies` entries are declared, both files
+are skipped (no empty-file footprint). The manifest gains two optional count
+fields (`hierarchy_count`, `hierarchy_entry_count`); absent when zero, so
+existing consumers are unaffected.
+
+---
+
+## Decision 1 — Hierarchy Lifecycle: Declarative vs. Reconciliation Cycle
+
+**Context.** The existing patch model (`src/ontology-patch.ts`) supports a
+reviewed lifecycle for entity matches and relations (operations: `accept_match`,
+`reject_match`, `create_canonical`, `merge_alias`, `set_status`, `add_relation`,
+`reject_relation`, `deprecate_entity`, `supersede_entity`). The reconciliation
+candidate queue (`src/ontology-reconciliation.ts`) always sets `status:
+"candidate"` and proposes `accept_match` patches.
+
+The question is whether hierarchy arcs should enter that same review pipeline,
+or whether they should remain purely declarative.
+
+---
+
+**Option 1a — Hierarchies follow the entity lifecycle (candidate → patch →
+decision log)**
+
+Arcs are generated as candidates (`kind: "hierarchy_arc"`, `status: "candidate"`),
+accepted or rejected via patches, and hardened to `hierarchies.json` only after
+an `accept_relation` patch. The studio gains a new candidate queue view. The
+decision log records every arc acceptance with registry evidence ref.
+
+Consequences: arcs become reviewable alongside entity matches; the reconciliation
+API needs a new `kind` filter; `OntologyReconciliationCandidateKind` is extended.
+The main cost: profile-declared arcs (confidence = 1.0, fully deterministic from
+the registry) go through a review queue that adds operational overhead with no
+epistemic benefit in v1. Value would materialize in v2 when LLM-extracted arcs
+(confidence < 1.0) require human arbitration. Timeline impact: medium.
+
+---
+
+**Option 1b — Hierarchies are frozen at profile (declarative, rebuild-only)**
+
+Registry-bound arcs are structural facts, not probabilistic matches. They are
+generated deterministically from the declared spec and registry data, written to
+`hierarchies.json`, and invalidated by a full rebuild when the profile or
+registry changes. No patch, no candidate queue, no decision log entry.
+`validation.json` is the only review surface (cycle detection blocks compile).
+
+When LLM-extracted arcs are introduced, the spec is revisited: extracted arcs
+would enter the candidate queue while registry-bound arcs remain declarative.
+Timeline impact: low — self-contained addition to `compileOntologyOutputs`,
+no new types, no new API routes.
+
+---
+
+**Recommendation: Option 1b in v1, with a reserved `source: "extracted"` lane
+for v2.**
+
+The patch model's value is in managing uncertain matches. Profile-declared arcs
+are not uncertain. The `source` field is forward-compatible: `"profile"` /
+`"registry"` arcs stay declarative; `"extracted"` arcs (reserved) enter the
+queue. The decision log is not polluted with trivially accepted registry rows.
+
+**Product owner: confirm 1b, or escalate to 1a if hierarchy arcs require human
+sign-off even when registry-bound.**
+
+---
+
+## Decision 2 — Canonical ID Scheme for Parent and Child
+
+**Context.** When `compileOntologyOutputs` compiles `nodes.json`, each node
+receives an `id`. That id is used to link arcs in `hierarchies.json`. Two
+schemes are available.
+
+---
+
+**Option 2a — Registry IDs (registry `id_column`, stable cross-works)**
+
+`parent_id` / `child_id` reference the registry's `id_column` value directly.
+These ids are stable by construction and independent of extraction runs.
+
+Consequences: ids are deterministic at profile-parse time; no dependency on the
+reconciliation cycle completing first. For cross-work reuse (public-pack corpus
+extension, 7→25 works), the same registry id is the same canonical concept in
+every work's build — no remapping needed. Risk: if a registry uses unstable
+auto-generated ids, cross-work reuse breaks; mitigation is the existing
+`validateOntologyProfile` check that requires an explicit `id_column`
+(L364, `src/ontology-profile.ts`).
+
+---
+
+**Option 2b — Reconciliation canonical IDs (patch-attested, graph-derived)**
+
+`parent_id` / `child_id` reference the `canonical_id` produced by
+`create_canonical` / `accept_match` patches in `src/ontology-patch.ts`.
+Benefit: unified id space across `relations.json`, `index.json`, and
+`hierarchies.json`. Cost: generation depends on the reconciliation cycle
+completing first (sequencing dependency); canonical ids may diverge across
+builds if the decision log is not exported; sharing ids across 25 works requires
+a versioned shared decision log.
+
+---
+
+**Recommendation: Option 2a in v1.**
+
+Registry ids are available at profile-parse time, stable across builds, and
+directly reusable for cross-work reconciliation in the public-pack corpus. The
+sequencing dependency imposed by Option 2b is unjustified when registry bindings
+already attest the arc with confidence = 1.0.
+
+**Product owner: confirm 2a, or escalate to 2b if a unified id space with
+`relations.json` is a hard studio requirement.**
+
+---
+
+## Integration Summary
+
+### Compile step (core)
+
+File: `src/ontology-output.ts`
+
+- New internal function `compileHierarchies(nodes, profile, outputDir)` called
+  from `compileOntologyOutputs` after `compileRelations` and before the manifest
+  write.
+- Iterates `profile.hierarchies` entries, reads the bound registry (already
+  resolved in `NormalizedOntologyRegistrySpec.bound_source_path`), joins
+  parent→child arcs to compiled `nodes` by registry id, runs BFS for level
+  assignment and ancestor-path computation, detects cycles, writes
+  `hierarchies.json` and `hierarchy-index.json`.
+- Cycle errors are appended to `validationIssues` (same list as alias issues)
+  and also written to `validation.json`.
+- If no hierarchies are declared: both files are skipped, manifest fields are
+  `0`.
+
+### Studio scene passthrough (already complete)
+
+File: `src/studio-scene.ts`
+
+Commit `7bbba08` already added `parent_id`, `child_ids`, `level`, `code`,
+`hierarchy_id`, `hierarchy_ids` to `NODE_PROFILE_FIELDS` (L151-156) and
+`hierarchy_id`, `structural` to `EDGE_PROFILE_FIELDS` (L169-170). The studio
+will receive these fields as soon as graph nodes carry them. No further change
+to the passthrough is required for v1.
+
+### Graph schema impact
+
+None. `graph.json` is unaffected. The hierarchy sidecar lives under
+`.graphify/ontology/hierarchies.json` and `.graphify/ontology/hierarchy-index.json`.
+These paths follow the existing `.graphify/ontology/` artifact pattern
+(`nodes.json`, `aliases.json`, `relations.json`, `manifest.json`, `index.json`,
+`validation.json`) established by `compileOntologyOutputs`.
+
+The graph schema remains at its current version. If graph nodes need to carry
+`parent_id`/`child_ids` for the studio passthrough, these fields are populated
+at graph-build time from the registry binding, not from `hierarchies.json`
+(the sidecar is a compiled view; the graph node fields are the source that the
+scene passthrough already reads).
+
+### Artifact paths
+
+```text
+.graphify/ontology/
+  hierarchies.json        # arc list (graphify_ontology_hierarchies_v1)
+  hierarchy-index.json    # root_ids, depth, ancestor paths per hierarchy
+  manifest.json           # extended with hierarchy_count, hierarchy_entry_count
+  validation.json         # extended with cycle detection errors
+```
+
+---
+
+## Planned Tests
+
+- Valid `hierarchies` block: `hierarchies.json` written, all ids resolve to
+  compiled nodes, levels correct, index paths consistent.
+- No `hierarchies` block: neither sidecar file is written.
+- Cycle in registry data: cycle error in `validation.json`, cyclic arc excluded
+  from `hierarchies.json`.
+- `manifest.json` carries correct count fields (0 when no hierarchies declared).
+- Studio passthrough: graph node with `parent_id` / `hierarchy_ids` passes
+  those fields through `copyOwnFields` in `src/studio-scene.ts` (already tested
+  since commit `7bbba08`; coverage extends once core emits the fields).
+- Registry id stability: same registry + profile → same ids across two builds.
+
+---
+
+## Open Decisions
+
+1. **Decision 1 (owner required)** — Hierarchy lifecycle: declarative rebuild-only
+   (Option 1b, recommended) vs. candidate→patch cycle (Option 1a). See
+   section "Decision 1" above.
+
+2. **Decision 2 (owner required)** — Canonical ID scheme: registry ids (Option 2a,
+   recommended) vs. reconciliation canonical ids (Option 2b). See section
+   "Decision 2" above.
+
+3. **guessed→validated policy** — The treatment of hierarchy arcs whose source
+   node carries `status: "guessed"` (i.e., the extraction did not attest the
+   registry match directly) is not specified here. This policy is shared with the
+   broader entity status hardening work and is tracked separately under
+   `SPEC_ONTOLOGY_LIFECYCLE_RECONCILIATION.md`.


### PR DESCRIPTION
## Quoi

Mini-spec **Draft** `spec/SPEC_ONTOLOGY_HIERARCHIES.md` (347 lignes) — surface de décision demandée pour les hiérarchies ontologiques (étude lifecycle 2026-06-08). Constat vérifié : `OntologyHierarchySpec` est déclaré/normalisé/validé (`src/types.ts:581-597`, `src/ontology-profile.ts:160-169`/`331-358`) mais `compileOntologyOutputs` ne lit jamais `profile.hierarchies` (`src/ontology-output.ts:220-268`) — aucun artefact généré. Le passthrough scène (7bbba08) est déjà prêt côté studio.

Propose le schéma `graphify_ontology_hierarchies_v1` (`hierarchies.json` + `hierarchy-index.json`, cycles interdits) et pose les 2 décisions :

- **D1 — cycle de vie** : 1b déclaratif/rebuild-only (**recommandé** v1) vs 1a candidate→patch comme les entités.
- **D2 — schéma d'ID parent-child** : 2a ids de registre (**recommandé**, stables cross-œuvres) vs 2b canonical_id de réconciliation.

## ⚠️ Process

PR à laisser **ouverte** comme surface de review : merger = acter les recommandations ; commenter/éditer = trancher autrement. L'implémentation (génération dans ontology-output) ne démarre qu'après décision.