### PR TITLE
fix(track-f): strip punctuation from query terms (80301a0 #994)

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -15,7 +15,9 @@ export function normalizeSearchText(value: string): string {
  * filtered.
  *
  * Behaviour:
- * - splits on whitespace
+ * - tokenises on Unicode word runs (mirrors Python `re.findall(r"\w+")`,
+ *   upstream 80301a0 / #994) so punctuation is stripped: "extract?" matches
+ *   the "extract" node and "ok?" is filtered like "ok"
  * - lowercases each raw token
  * - drops the token if it is composed entirely of ASCII a-z and shorter
  *   than 3 chars; non-ASCII (or mixed) tokens of any length are kept
@@ -23,8 +25,10 @@ export function normalizeSearchText(value: string): string {
 export function queryTerms(question: string): string[] {
   if (typeof question !== "string") return [];
   const out: string[] = [];
-  for (const raw of question.split(/\s+/)) {
-    const term = raw.toLowerCase().trim();
+  // \p{L}\p{N}_ runs ≈ Python's unicode-aware \w+ (upstream 80301a0 / #994):
+  // CJK / Cyrillic / accented tokens survive, punctuation splits and drops.
+  for (const raw of question.toLowerCase().match(/[\p{L}\p{N}_]+/gu) ?? []) {
+    const term = raw;
     if (!term) continue;
     let englishOnly = true;
     for (let i = 0; i < term.length; i++) {

--- a/tests/serve-query-terms.test.ts
+++ b/tests/serve-query-terms.test.ts
@@ -43,6 +43,14 @@ describe("Track F F-0816-P2 (row 12) — queryTerms", () => {
     expect(queryTerms("a前 café résumé")).toEqual(["a前", "café", "résumé"]);
   });
 
+  it("strips punctuation from terms (upstream 80301a0 / #994)", () => {
+    // Python tokenises with re.findall(r"\w+", raw.lower()): "extract?"
+    // must match the "extract" node, and a trailing "?" must not smuggle
+    // short English stopwords past the length filter ("ok?" -> dropped).
+    expect(queryTerms("what calls extract?")).toEqual(["what", "calls", "extract"]);
+    expect(queryTerms("ok? graph.json!")).toEqual(["graph", "json"]);
+  });
+
   it("filters short Latin-with-diacritic tokens like é but keeps semantic CJK pairs", () => {
     // A single accented letter like "é" alone is still short noise; the
     // upstream helper does not treat single accented chars as semantic.


### PR DESCRIPTION
`queryTerms()` gardait "extract?" au lieu de "extract" (le filtre ne gérait pas la ponctuation). Passage à un tokeniser Unicode `[\p{L}\p{N}_]+` ≈ `re.findall(r"\w+")` upstream : ponctuation strippée, tokens CJK/accentués préservés. TDD : test rouge constaté → vert. Suite : 1199 passed, 0 failed.