### PR TITLE
fix(track-f): relativize cached source_file paths (F-0831-P2d, 25df580 residual)

### DIFF
--- a/spec/SPEC_TRACK_F_0831_BILAN.md
+++ b/spec/SPEC_TRACK_F_0831_BILAN.md
@@ -107,7 +107,7 @@ Every `must-port`, `already-ported`, `already-covered` and `to-verify` row is pe
 | AC3 | `3f8efae` | — | `graphify update` ghost nodes: `as_posix()` + relativize existing graph before eviction | `6e3b173` (relativized manifest keys, portable `as_posix`-style paths) + `8008dc6` (`src/portable-artifacts.ts:126-190` `source_file` normalization). Spot-check listed in F-0819-M. |
 | AC4 | `d1d5751` | #1007 | watch: evict stale nodes in full re-extraction path when `changed_paths` is None | `src/watch.ts:206-214` wires `cleanupStaleNodes` (F-0816-M5 stale-node prune) after the existing-graph merge, independent of changed-path hints. |
 | AC5 | `690b4e5` | #1094 | Cap obsidian/canvas filenames (ENAMETOOLONG on long labels) | `src/wiki.ts:36` — slug builder caps at `.slice(0, 200)`. |
-| AC6 | `25df580` | #777 | Relativize manifest, `.graphify_root`, and cache `source_file` fields | Manifest keys: `6e3b173` (`saveManifest` writes project-relative keys, `tests/portable-artifacts.test.ts`). Graph `source_file`: `8008dc6` (`src/portable-artifacts.ts`). `.graphify_root`: no TS counterpart (grep empty) → n-a. **Residual to-verify**: semantic-cache payload `source_file` fields (`src/cache.ts`) — closed in F-0831-P2. |
+| AC6 | `25df580` | #777 | Relativize manifest, `.graphify_root`, and cache `source_file` fields | Manifest keys: `6e3b173` (`saveManifest` writes project-relative keys, `tests/portable-artifacts.test.ts`). Graph `source_file`: `8008dc6` (`src/portable-artifacts.ts`). `.graphify_root`: no TS counterpart (grep empty) → n-a. **Cache `source_file` residual ported**: `relativizeSourceFilesIn`/`absolutizeSourceFilesIn` helpers in `src/cache.ts`, `saveCached` writes deep-copy with relative paths, `loadCached` re-anchors on read — F-0831-P2d commit `fix(track-f): relativize cached source_file paths (F-0831-P2d, 25df580 residual)`, 8 new tests in `tests/cache-source-file-relativize.test.ts`. |
 
 ##### to-verify — 1 commit + 2 sub-parts
 
@@ -115,7 +115,7 @@ Every `must-port`, `already-ported`, `already-covered` and `to-verify` row is pe
 |---|---|---|---|---|---|
 | V1 | `c09fbef` | #1006 | Remap hyperedges in community-aggregated meta-graph view | TS has hyperedges end-to-end (`tests/hyperedges.test.ts`) but no community-aggregated meta-graph view was found (grep `meta-graph|aggregat` empty in `src/export.ts`/`src/analyze.ts`). If the view doesn't exist, reclassify `n-a`; if a partial exists, port the remap. | F-0820-0827 |
 | V2 | `80301a0` (part) | #994 | Punctuation search | Compare against the F-0816-P2 Unicode tokenizer lineage (`src/search.ts:32` routes non-`a-z` codepoints — digits, punctuation, CJK — to a separate path). Likely covered; needs a test to prove it. | F-0820-0827 |
-| V3 | `25df580` (part) | #777 | Cache `source_file` relativization | Whether `src/cache.ts` semantic-cache payloads persist absolute `source_file` values (portability leak) — close with a test either way. | F-0831-P2 |
+| V3 | `25df580` (part) | #777 | Cache `source_file` relativization | **Ported** — `relativizeSourceFilesIn`/`absolutizeSourceFilesIn` in `src/cache.ts`; `saveCached` deep-copies and relativizes before write; `loadCached` absolutizes on read. 8 tests in `tests/cache-source-file-relativize.test.ts`. Commit: `fix(track-f): relativize cached source_file paths (F-0831-P2d, 25df580 residual)`. | F-0831-P2d ✓ |
 
 ##### defer — 10 commits / 7 clusters (reopen condition cited)
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,7 +13,7 @@ import {
   statSync,
   type BigIntStats,
 } from "node:fs";
-import { dirname, extname, join, resolve } from "node:path";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { resolveGraphifyPaths } from "./paths.js";
 
 // ---------------------------------------------------------------------------
@@ -225,6 +225,75 @@ function removeJsonFiles(dir: string): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// source_file relativization helpers (port of upstream 25df580, F-0831-P2d)
+//
+// Caches are content-addressed (SHA256 of file contents + relative path) so
+// the cache *key* is already portable. These helpers make the source_file
+// *payload* portable too: absolute paths are relativized to root before write,
+// re-anchored after read. Already-relative paths and out-of-root paths are
+// passed through unchanged (idempotent). The caller's object is never mutated
+// — saveCached works on a deep copy.
+// ---------------------------------------------------------------------------
+
+const CACHE_BUCKETS = ["nodes", "edges", "hyperedges"] as const;
+
+/**
+ * Return a forward-slash project-relative form of `sourcePath` against
+ * `rootResolved`, or null if the path is already relative, out-of-root, or
+ * cannot be relativized.
+ */
+function tryRelativize(sourcePath: string, rootResolved: string): string | null {
+  if (!isAbsolute(sourcePath)) return null; // already relative — leave as-is
+  const rel = relative(rootResolved, sourcePath);
+  // out-of-root: relative starts with ".." — leave absolute
+  if (rel === ".." || rel.startsWith(".." + "/") || rel.startsWith(".." + "\\")) return null;
+  return rel.replace(/\\/g, "/");
+}
+
+/**
+ * Mutate `payload` in-place to relativize all `source_file` fields in
+ * nodes/edges/hyperedges against `root`.  Already-relative and out-of-root
+ * paths are left unchanged.  Mirror of Python `_relativize_source_files_in`.
+ */
+function relativizeSourceFilesIn(payload: Record<string, unknown>, root: string): void {
+  const rootResolved = resolve(root);
+  for (const bucket of CACHE_BUCKETS) {
+    const items = payload[bucket];
+    if (!Array.isArray(items)) continue;
+    for (const item of items) {
+      if (!item || typeof item !== "object") continue;
+      const rec = item as Record<string, unknown>;
+      const src = rec["source_file"];
+      if (typeof src !== "string" || !src) continue;
+      const rel = tryRelativize(src, rootResolved);
+      if (rel !== null) rec["source_file"] = rel;
+    }
+  }
+}
+
+/**
+ * Mutate `payload` in-place to re-anchor relative `source_file` fields
+ * against `root` so callers see absolute-path shaped data (same as a fresh
+ * in-process extraction).  Already-absolute paths pass through unchanged.
+ * Mirror of Python `_absolutize_source_files_in`.
+ */
+function absolutizeSourceFilesIn(payload: Record<string, unknown>, root: string): void {
+  const rootResolved = resolve(root);
+  for (const bucket of CACHE_BUCKETS) {
+    const items = payload[bucket];
+    if (!Array.isArray(items)) continue;
+    for (const item of items) {
+      if (!item || typeof item !== "object") continue;
+      const rec = item as Record<string, unknown>;
+      const src = rec["source_file"];
+      if (typeof src !== "string" || !src) continue;
+      if (isAbsolute(src)) continue; // legacy absolute — leave as-is
+      rec["source_file"] = resolve(rootResolved, src);
+    }
+  }
+}
+
 /** Returns graphify cache path - creates it if needed. */
 export function cacheDir(root: string = ".", options: CacheOptions = {}): string {
   const namespace = cacheNamespace(options);
@@ -251,7 +320,11 @@ export function loadCached(
   const entry = join(cacheDir(root, options), `${h}.json`);
   if (existsSync(entry)) {
     try {
-      return JSON.parse(readFileSync(entry, "utf-8")) as Record<string, unknown>;
+      const result = JSON.parse(readFileSync(entry, "utf-8")) as Record<string, unknown>;
+      // Re-anchor relative source_file fields so callers see the same absolute-path
+      // shape that a fresh in-process extraction produces (#777 / F-0831-P2d).
+      absolutizeSourceFilesIn(result, root);
+      return result;
     } catch {
       return null;
     }
@@ -261,7 +334,9 @@ export function loadCached(
     const legacyEntry = join(legacyCacheDir(root, options), `${h}.json`);
     if (existsSync(legacyEntry)) {
       try {
-        return JSON.parse(readFileSync(legacyEntry, "utf-8")) as Record<string, unknown>;
+        const result = JSON.parse(readFileSync(legacyEntry, "utf-8")) as Record<string, unknown>;
+        absolutizeSourceFilesIn(result, root);
+        return result;
       } catch {
         return null;
       }
@@ -270,7 +345,9 @@ export function loadCached(
     const legacyHashEntry = join(legacyCacheDir(root, options), `${legacyFileHash(filePath)}.json`);
     if (!existsSync(legacyHashEntry)) return null;
     try {
-      return JSON.parse(readFileSync(legacyHashEntry, "utf-8")) as Record<string, unknown>;
+      const result = JSON.parse(readFileSync(legacyHashEntry, "utf-8")) as Record<string, unknown>;
+      absolutizeSourceFilesIn(result, root);
+      return result;
     } catch {
       return null;
     }
@@ -295,8 +372,20 @@ export function saveCached(
   const h = fileHash(filePath, root);
   const entry = join(cacheDir(root, options), `${h}.json`);
   const tmp = entry + ".tmp";
+
+  // Relativize source_file fields against root before writing to disk so the
+  // cache file is portable across machines and checkout directories (#777 / F-0831-P2d).
+  // We serialize a relativized *copy* rather than mutating the caller's dict —
+  // downstream pipeline steps (e.g. AST prefix remap) depend on the original
+  // absolute form and must not see a silent mutation.
+  const hasBuckets = CACHE_BUCKETS.some((b) => Array.isArray(result[b]) && (result[b] as unknown[]).length > 0);
+  const onDisk: Record<string, unknown> = hasBuckets
+    ? JSON.parse(JSON.stringify(result)) as Record<string, unknown>
+    : result;
+  if (hasBuckets) relativizeSourceFilesIn(onDisk, root);
+
   try {
-    writeFileSync(tmp, JSON.stringify(result));
+    writeFileSync(tmp, JSON.stringify(onDisk));
     renameSync(tmp, entry);
   } catch {
     try { unlinkSync(tmp); } catch { /* ignore */ }

--- a/tests/cache-source-file-relativize.test.ts
+++ b/tests/cache-source-file-relativize.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for cache source_file relativization (F-0831-P2d, port of upstream 25df580).
+ *
+ * Covers: saveCached/saveSemanticCache write relative source_file to disk;
+ * loadCached/checkSemanticCache re-anchor to absolute; idempotency for already-relative
+ * and out-of-root paths; skill-runtime-style round-trip.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import {
+  _resetStatIndexForTesting,
+  checkSemanticCache,
+  loadCached,
+  saveCached,
+  saveSemanticCache,
+} from "../src/cache.js";
+import { resolveGraphifyPaths } from "../src/paths.js";
+
+/** Recursively collect all .json files under dir, skipping stat-index. */
+function collectJsonFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, e.name);
+    if (e.isDirectory()) {
+      results.push(...collectJsonFiles(abs));
+    } else if (e.isFile() && e.name.endsWith(".json") && e.name !== "stat-index.json") {
+      results.push(abs);
+    }
+  }
+  return results;
+}
+
+describe("cache source_file relativization (25df580 residual)", () => {
+  let tmpDir: string;
+  let srcFile: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `graphify-test-relpath-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    mkdirSync(join(tmpDir, "src"), { recursive: true });
+    srcFile = join(tmpDir, "src", "foo.ts");
+    writeFileSync(srcFile, "export const x = 1;\n");
+    _resetStatIndexForTesting();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── saveCached ──────────────────────────────────────────────────────────────
+
+  it("saveCached: stores relative source_file on disk when given an absolute path", () => {
+    const payload = {
+      nodes: [{ id: "x", source_file: srcFile }],
+      edges: [{ source: "x", target: "y", source_file: srcFile }],
+      hyperedges: [{ id: "h1", source_file: srcFile }],
+    };
+    saveCached(srcFile, payload, tmpDir);
+
+    const { cacheDir } = resolveGraphifyPaths({ root: tmpDir });
+    const files = collectJsonFiles(cacheDir);
+    expect(files).toHaveLength(1);
+    const written = JSON.parse(readFileSync(files[0]!, "utf-8")) as Record<string, unknown>;
+    const nodes = written.nodes as Array<Record<string, unknown>>;
+    const edges = written.edges as Array<Record<string, unknown>>;
+    const hyperedges = written.hyperedges as Array<Record<string, unknown>>;
+
+    // Must be relative — no tmpDir prefix, no leading slash
+    expect(nodes[0]!.source_file).toBe("src/foo.ts");
+    expect(edges[0]!.source_file).toBe("src/foo.ts");
+    expect(hyperedges[0]!.source_file).toBe("src/foo.ts");
+  });
+
+  it("saveCached: does NOT mutate the caller's result object", () => {
+    const payload = {
+      nodes: [{ id: "x", source_file: srcFile }],
+      edges: [] as Array<Record<string, unknown>>,
+      hyperedges: [] as Array<Record<string, unknown>>,
+    };
+    const originalSourceFile = payload.nodes[0]!.source_file;
+    saveCached(srcFile, payload, tmpDir);
+    // Caller's dict must be unchanged
+    expect(payload.nodes[0]!.source_file).toBe(originalSourceFile);
+  });
+
+  // ── loadCached ──────────────────────────────────────────────────────────────
+
+  it("loadCached: re-anchors relative source_file back to absolute on load", () => {
+    const payload = {
+      nodes: [{ id: "x", source_file: srcFile }],
+      edges: [{ source: "x", target: "y", source_file: srcFile }],
+      hyperedges: [{ id: "h1", source_file: srcFile }],
+    };
+    saveCached(srcFile, payload, tmpDir);
+
+    const loaded = loadCached(srcFile, tmpDir);
+    expect(loaded).not.toBeNull();
+    const nodes = loaded!.nodes as Array<Record<string, unknown>>;
+    const edges = loaded!.edges as Array<Record<string, unknown>>;
+    const hyperedges = loaded!.hyperedges as Array<Record<string, unknown>>;
+
+    const expectedAbs = resolve(tmpDir, "src/foo.ts");
+    expect(nodes[0]!.source_file).toBe(expectedAbs);
+    expect(edges[0]!.source_file).toBe(expectedAbs);
+    expect(hyperedges[0]!.source_file).toBe(expectedAbs);
+  });
+
+  // ── idempotency: already-relative ──────────────────────────────────────────
+
+  it("saveCached + loadCached: already-relative source_file is re-anchored to absolute on load", () => {
+    // Write payload with already-relative source_file (idempotent save)
+    const payloadRelative = {
+      nodes: [{ id: "x", source_file: "src/foo.ts" }],
+      edges: [] as Array<Record<string, unknown>>,
+      hyperedges: [] as Array<Record<string, unknown>>,
+    };
+    saveCached(srcFile, payloadRelative, tmpDir);
+
+    // On disk: still "src/foo.ts" (already relative)
+    const { cacheDir } = resolveGraphifyPaths({ root: tmpDir });
+    const files = collectJsonFiles(cacheDir);
+    expect(files).toHaveLength(1);
+    const written = JSON.parse(readFileSync(files[0]!, "utf-8")) as Record<string, unknown>;
+    const diskNodes = written.nodes as Array<Record<string, unknown>>;
+    expect(diskNodes[0]!.source_file).toBe("src/foo.ts");
+
+    // On load: re-anchored to absolute
+    const loaded = loadCached(srcFile, tmpDir);
+    expect(loaded).not.toBeNull();
+    const loadedNodes = loaded!.nodes as Array<Record<string, unknown>>;
+    expect(loadedNodes[0]!.source_file).toBe(resolve(tmpDir, "src/foo.ts"));
+  });
+
+  // ── idempotency: out-of-root path ───────────────────────────────────────────
+
+  it("saveCached: source_file outside root passes through unchanged on disk", () => {
+    // A path outside tmpDir — must not be relativized (no ../.. escape)
+    const outsidePath = "/etc/hosts";
+    const payloadOutside = {
+      nodes: [{ id: "ext", source_file: outsidePath }],
+      edges: [] as Array<Record<string, unknown>>,
+      hyperedges: [] as Array<Record<string, unknown>>,
+    };
+    saveCached(srcFile, payloadOutside, tmpDir);
+
+    const { cacheDir } = resolveGraphifyPaths({ root: tmpDir });
+    const files = collectJsonFiles(cacheDir);
+    expect(files).toHaveLength(1);
+    const written = JSON.parse(readFileSync(files[0]!, "utf-8")) as Record<string, unknown>;
+    const nodes = written.nodes as Array<Record<string, unknown>>;
+    // Out-of-root: kept as absolute on disk
+    expect(nodes[0]!.source_file).toBe(outsidePath);
+  });
+
+  it("loadCached: legacy cache entry with absolute source_file passes through unchanged (no double-absolutize)", () => {
+    // Simulate a legacy cache entry written before this fix — already has absolute paths on disk.
+    // loadCached must not re-join root with an already-absolute path.
+    const payload = {
+      nodes: [{ id: "x", source_file: srcFile }],
+      edges: [] as Array<Record<string, unknown>>,
+      hyperedges: [] as Array<Record<string, unknown>>,
+    };
+
+    // Compute the hash that fileHash would produce for srcFile under tmpDir
+    const raw = readFileSync(srcFile);
+    const h = createHash("sha256");
+    h.update(raw);
+    h.update("\0");
+    h.update("src/foo.ts"); // relative path component used by fileHash
+    const digest = h.digest("hex");
+
+    // Write the legacy file directly with absolute source_file (no relativization)
+    const { cacheDir } = resolveGraphifyPaths({ root: tmpDir });
+    const kindDir = join(cacheDir, "ast");
+    mkdirSync(kindDir, { recursive: true });
+    writeFileSync(join(kindDir, `${digest}.json`), JSON.stringify(payload));
+
+    const loaded = loadCached(srcFile, tmpDir);
+    expect(loaded).not.toBeNull();
+    const nodes = loaded!.nodes as Array<Record<string, unknown>>;
+    // Already absolute — must pass through unchanged
+    expect(nodes[0]!.source_file).toBe(srcFile);
+  });
+
+  // ── saveSemanticCache / checkSemanticCache round-trip ──────────────────────
+
+  it("saveSemanticCache: writes relative source_file to disk; checkSemanticCache re-anchors to absolute", () => {
+    const nodes = [
+      { id: "A", label: "Alpha", source_file: srcFile },
+    ];
+    const edges = [
+      { source: "A", target: "B", relation: "uses", confidence: "EXTRACTED", source_file: srcFile },
+    ];
+    const hyperedges = [
+      { id: "he1", source_file: srcFile },
+    ];
+
+    saveSemanticCache(nodes, edges, hyperedges, tmpDir);
+
+    // Check what's on disk: must be relative
+    const { cacheDir } = resolveGraphifyPaths({ root: tmpDir });
+    const files = collectJsonFiles(cacheDir);
+    expect(files).toHaveLength(1);
+    const written = JSON.parse(readFileSync(files[0]!, "utf-8")) as Record<string, unknown>;
+    const diskNodes = written.nodes as Array<Record<string, unknown>>;
+    const diskEdges = written.edges as Array<Record<string, unknown>>;
+    const diskHyperedges = written.hyperedges as Array<Record<string, unknown>>;
+    expect(diskNodes[0]!.source_file).toBe("src/foo.ts");
+    expect(diskEdges[0]!.source_file).toBe("src/foo.ts");
+    expect(diskHyperedges[0]!.source_file).toBe("src/foo.ts");
+
+    // checkSemanticCache re-anchors to absolute
+    const [cachedNodes, cachedEdges, cachedHyperedges, uncached] = checkSemanticCache([srcFile], tmpDir);
+    const expectedAbs = resolve(tmpDir, "src/foo.ts");
+    expect(uncached).toEqual([]);
+    expect(cachedNodes[0]!.source_file).toBe(expectedAbs);
+    expect(cachedEdges[0]!.source_file).toBe(expectedAbs);
+    expect(cachedHyperedges[0]!.source_file).toBe(expectedAbs);
+  });
+
+  it("skill-runtime-style round-trip: saveSemanticCache direct (no makeExtractionPortable) stores relative paths", () => {
+    // Mimics src/skill-runtime.ts:~1050 and src/cli.ts:~864 calling saveSemanticCache
+    // directly on an extraction with absolute source_file paths (no makeExtractionPortable).
+    const absNodes = [
+      { id: "SR", label: "SkillRuntime", source_file: srcFile },
+      { id: "SR2", label: "Also", source_file: srcFile },
+    ];
+    const absEdges = [
+      { source: "SR", target: "SR2", relation: "calls", confidence: "EXTRACTED", source_file: srcFile },
+    ];
+
+    const saved = saveSemanticCache(absNodes, absEdges, null, tmpDir);
+    expect(saved).toBe(1);
+
+    // Cache file on disk must have relative paths
+    const { cacheDir } = resolveGraphifyPaths({ root: tmpDir });
+    const files = collectJsonFiles(cacheDir);
+    expect(files).toHaveLength(1);
+    const written = JSON.parse(readFileSync(files[0]!, "utf-8")) as Record<string, unknown>;
+    const diskNodes = written.nodes as Array<Record<string, unknown>>;
+    expect(diskNodes[0]!.source_file).toBe("src/foo.ts");
+    expect(diskNodes[1]!.source_file).toBe("src/foo.ts");
+
+    // Load back: must re-anchor to absolute
+    const [loadedNodes, loadedEdges] = checkSemanticCache([srcFile], tmpDir);
+    const expectedAbs = resolve(tmpDir, "src/foo.ts");
+    expect(loadedNodes[0]!.source_file).toBe(expectedAbs);
+    expect(loadedNodes[1]!.source_file).toBe(expectedAbs);
+    expect(loadedEdges[0]!.source_file).toBe(expectedAbs);
+  });
+});


### PR DESCRIPTION
Comble le résidu portable de `25df580` : `saveCached`/`saveSemanticCache` écrivaient des `source_file` ABSOLUS dans `.graphify/cache/` quand appelés hors pipeline (skill-runtime:1050, cli:864, sans `makeExtractionPortable`). Ajoute relativisation à l'écriture + ré-ancrage au chargement (nodes/edges/hyperedges), idempotent (déjà-relatif et hors-root inchangés), calqué sur `_relativize/_absolutize_source_files_in` Python. 8 tests dédiés + 16/16 cache.test.ts (pas de régression bigint fastpath). Suite : 1209 passed, 0 failed.