### PR TITLE
test(cli-runtime): fix ENOTEMPTY teardown flake (main red)

### DIFF
--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -10,7 +10,11 @@ const tempDirs: string[] = [];
 
 afterEach(() => {
   while (tempDirs.length > 0) {
-    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    // maxRetries guards against an ENOTEMPTY race: a CLI build/hook can write
+    // into the temp .graphify dir between rmSync enumerating entries and the
+    // final rmdir, leaving the dir non-empty on the first pass (seen only on
+    // the loaded test(20) CI shard). Retry instead of failing teardown.
+    rmSync(tempDirs.pop()!, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 });
 


### PR DESCRIPTION
## Quoi

`main` est rouge sur `999ddfb` : `test (20)` échoue dans `cli-runtime.test.ts > writes graph freshness metadata and detects stale HEAD drift` avec `ENOTEMPTY: directory not empty, rmdir '/tmp/graphify-cli-runtime-...'`.

**Pas une régression** : la logique du test passe (reproduit 3/3 en local sur `999ddfb`). C'est une **race de teardown** — un build/hook CLI écrit dans le `.graphify` temporaire entre l'énumération des entrées par `rmSync` et le `rmdir` final, ne se manifeste que sur le shard `test (20)` chargé. Le `recursive+force` seul ne réessaie pas.

**Fix** : `afterEach` passe en `rmSync(..., { maxRetries: 5, retryDelay: 100 })` — Node réessaie exactement sur ce cas ENOTEMPTY/EBUSY.

## Vérif (observée)

`tests/cli-runtime.test.ts` : 48/48 ; lint clean. Aucune modif de logique produit (test-only).