### PR TITLE
feat(studio): render P0 — zoom/pan/reset, connected-dim, node tooltip

### DIFF
--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -45,6 +45,15 @@
   let mergeFrame = null;
   let completedMergeKey = null;
   let hoveredEdge = $state(null);
+  let hoveredNode = $state(null);
+  let hoveredNodeId = $state(null);
+
+  // Pan state — not reactive, managed imperatively
+  let isPanning = false;
+  let panStartX = 0;
+  let panStartY = 0;
+  let panStartCameraX = 0;
+  let panStartCameraY = 0;
 
   const hasNodes = $derived((scene?.nodes?.length ?? 0) > 0);
   const hasLegend = $derived((legend?.length ?? 0) > 0);
@@ -93,6 +102,66 @@
     renderer.render();
   }
 
+  function applyCamera() {
+    if (!renderer) return;
+    renderer.setCamera(camera);
+    renderer.render();
+  }
+
+  // --- Zoom centred on cursor ---
+  function handleWheel(event) {
+    if (!renderer || !canvas) return;
+    event.preventDefault();
+
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / Math.max(1, rect.width);
+    const scaleY = canvas.height / Math.max(1, rect.height);
+
+    // Cursor position in screen coords (canvas pixels, centred on canvas)
+    const localX = event.clientX - rect.left;
+    const localY = event.clientY - rect.top;
+    const screenX = (localX - rect.width / 2) * scaleX;
+    const screenY = (localY - rect.height / 2) * scaleY;
+
+    // World point under cursor BEFORE zoom
+    const worldX = camera.x + screenX / camera.zoom;
+    const worldY = camera.y + screenY / camera.zoom;
+
+    const factor = event.deltaY < 0 ? 1.12 : 1 / 1.12;
+    const nextZoom = Math.max(0.05, Math.min(50, camera.zoom * factor));
+
+    // Shift camera so the world point stays under the cursor AFTER zoom
+    camera = {
+      zoom: nextZoom,
+      x: worldX - screenX / nextZoom,
+      y: worldY - screenY / nextZoom,
+    };
+    applyCamera();
+  }
+
+  // --- Pan on background drag ---
+  function handlePointerDown(event) {
+    const id = pickNode(event);
+    if (id) return; // clicking a node starts selection, not pan
+
+    isPanning = true;
+    panStartX = event.clientX;
+    panStartY = event.clientY;
+    panStartCameraX = camera.x;
+    panStartCameraY = camera.y;
+
+    if (canvas) {
+      canvas.setPointerCapture(event.pointerId);
+      canvas.style.cursor = "grabbing";
+    }
+  }
+
+  function handlePointerUp(event) {
+    if (!isPanning) return;
+    isPanning = false;
+    if (canvas) canvas.style.cursor = "default";
+  }
+
   function applyPayload() {
     if (!renderer || !payload) return;
 
@@ -107,6 +176,7 @@
     payload = buildGraphRendererPayload(scene ?? EMPTY_SCENE, {
       selectedIds: selectedIds ?? [],
       focusId,
+      hoveredNodeId,
       nodeRadius: NODE_RADIUS,
     });
     clearHoveredEdge({ notify: false, render: false });
@@ -219,11 +289,29 @@
   }
 
   function handlePointerMove(event) {
+    // Pan takes priority when dragging
+    if (isPanning) {
+      const rect = canvas?.getBoundingClientRect();
+      if (!rect) return;
+      const scaleX = canvas.width / Math.max(1, rect.width);
+      const scaleY = canvas.height / Math.max(1, rect.height);
+      const dx = (event.clientX - panStartX) * scaleX;
+      const dy = (event.clientY - panStartY) * scaleY;
+      camera = {
+        zoom: camera.zoom,
+        x: panStartCameraX - dx / camera.zoom,
+        y: panStartCameraY - dy / camera.zoom,
+      };
+      applyCamera();
+      return;
+    }
+
     if (!payload) return;
 
     const world = eventToWorld(event);
     if (!world) {
       clearHoveredEdge();
+      setHoveredNode(null);
       return;
     }
 
@@ -232,17 +320,56 @@
     if (nodeId) {
       clearHoveredEdge();
       if (canvas) canvas.style.cursor = "pointer";
+      setHoveredNode(nodeId, world.localX, world.localY);
       return;
     }
 
+    setHoveredNode(null);
     const edgeMaxDistance = (EDGE_PICK_RADIUS * world.scale) / Math.max(Number.EPSILON, camera.zoom);
     const hit = findNearestEdge(payload, world.x, world.y, edgeMaxDistance);
     if (canvas) canvas.style.cursor = hit ? "crosshair" : "default";
     setHoveredEdge(hit, world.localX, world.localY);
   }
 
+  function setHoveredNode(nodeId, localX = 0, localY = 0) {
+    const prevId = hoveredNodeId;
+    if (nodeId === prevId) return;
+
+    hoveredNodeId = nodeId;
+    if (nodeId && payload) {
+      const node = payload.nodeById?.get(nodeId);
+      const graph = payload.renderGraph;
+      const nodeIdx = payload.nodeIndexById?.get(nodeId);
+      // Compute degree: count edges where this node is source or target
+      const edgeCount = graph ? graph.edges.length / 2 : 0;
+      let degree = 0;
+      for (let e = 0; e < edgeCount; e++) {
+        if (graph.edges[e * 2] === nodeIdx || graph.edges[e * 2 + 1] === nodeIdx) degree++;
+      }
+      hoveredNode = node ? { ...node, degree, localX, localY } : null;
+    } else {
+      hoveredNode = null;
+    }
+
+    // Rebuild payload with new hoveredNodeId for connected-dim
+    if (mounted && payload) {
+      payload = buildGraphRendererPayload(scene ?? EMPTY_SCENE, {
+        selectedIds: selectedIds ?? [],
+        focusId,
+        hoveredNodeId,
+        nodeRadius: NODE_RADIUS,
+      });
+      if (renderer) {
+        renderer.setStyle(payload.style);
+        renderer.render();
+      }
+    }
+  }
+
   function handlePointerLeave() {
     clearHoveredEdge();
+    setHoveredNode(null);
+    isPanning = false;
   }
 
   function legendClass(value) {
@@ -378,6 +505,15 @@
 </script>
 
 <div class="canvas" bind:this={container}>
+  <div class="canvas-toolbar" aria-label="Graph controls">
+    <button
+      class="toolbar-btn"
+      type="button"
+      aria-label="Reset view"
+      onclick={fitAndRender}
+    >Reset</button>
+  </div>
+
   <canvas
     class="canvas-element"
     bind:this={canvas}
@@ -385,8 +521,25 @@
     onclick={handleClick}
     ondblclick={handleDoubleClick}
     onpointermove={handlePointerMove}
+    onpointerdown={handlePointerDown}
+    onpointerup={handlePointerUp}
     onmouseleave={handlePointerLeave}
+    onwheel={handleWheel}
   ></canvas>
+
+  {#if hoveredNode}
+    <div
+      class="node-tooltip"
+      style={`left: ${hoveredNode.localX + 14}px; top: ${hoveredNode.localY + 14}px;`}
+      role="status"
+    >
+      <strong>{hoveredNode.label}</strong>
+      {#if hoveredNode.node_type}
+        <span class="node-tooltip-type">{hoveredNode.node_type}</span>
+      {/if}
+      <span class="node-tooltip-degree">Degree: {hoveredNode.degree}</span>
+    </div>
+  {/if}
 
   {#if hoveredEdge?.edge}
     <div
@@ -431,6 +584,32 @@
     overflow: hidden;
   }
 
+  .canvas-toolbar {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 3;
+    display: flex;
+    gap: 0.35rem;
+    pointer-events: auto;
+  }
+
+  .toolbar-btn {
+    padding: 0.3rem 0.6rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--st-semantic-surface-default, #fff) 90%, transparent);
+    color: var(--st-semantic-text-default, #1e293b);
+    font-size: 0.75rem;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
+  }
+
+  .toolbar-btn:hover {
+    background: var(--st-semantic-surface-hover, #f1f5f9);
+  }
+
   .canvas-element {
     display: block;
     width: 100%;
@@ -454,6 +633,40 @@
     font-style: italic;
     pointer-events: none;
     text-align: center;
+  }
+
+  .node-tooltip {
+    position: absolute;
+    z-index: 2;
+    max-width: min(20rem, calc(100% - 1.5rem));
+    padding: 0.45rem 0.55rem;
+    border-radius: 4px;
+    background: var(--st-semantic-surface-inverse, #0f172a);
+    color: var(--st-semantic-text-inverse, #fff);
+    box-shadow: 0 8px 20px rgb(15 23 42 / 0.18);
+    font-size: 0.75rem;
+    line-height: 1.3;
+    pointer-events: none;
+  }
+
+  .node-tooltip strong,
+  .node-tooltip-type,
+  .node-tooltip-degree {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .node-tooltip-type {
+    opacity: 0.7;
+    font-size: 0.7rem;
+  }
+
+  .node-tooltip-degree {
+    opacity: 0.6;
+    font-size: 0.7rem;
+    margin-top: 0.15rem;
   }
 
   .edge-tooltip {

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -74,9 +74,12 @@ function edgeWidth(edge) {
   return 1;
 }
 
+const DIM_ALPHA = Math.round(255 * 0.35); // 89
+
 export function buildGraphRendererPayload(scene, options = {}) {
   const selectedIds = new Set(options.selectedIds ?? []);
   const focusId = options.focusId ?? null;
+  const hoveredNodeId = options.hoveredNodeId ?? null;
   const nodeRadius = options.nodeRadius ?? 3;
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
@@ -88,6 +91,7 @@ export function buildGraphRendererPayload(scene, options = {}) {
     return {
       id: node.id,
       label: node.label ?? node.id,
+      node_type: node.node_type ?? node.type ?? null,
       x: position.x,
       y: position.y,
       fixed: position.fixed,
@@ -118,6 +122,43 @@ export function buildGraphRendererPayload(scene, options = {}) {
   });
   const nodeIndexById = new Map(nodes.map((node, index) => [node.id, index]));
   const renderedEdges = Array.from(renderGraph.edgeInputIndices ?? [], (inputIndex) => edges[inputIndex]);
+
+  // Connected-dim: when a node is selected or hovered, dim non-neighbours
+  const activeFocusIds = new Set([...selectedIds, focusId, hoveredNodeId].filter(Boolean));
+  if (activeFocusIds.size > 0) {
+    // Build neighbour set: all nodes directly connected to any active focus node
+    const neighbourSet = new Set(activeFocusIds);
+    const edgeCount = renderGraph.edges.length / 2;
+    for (let e = 0; e < edgeCount; e++) {
+      const srcIdx = renderGraph.edges[e * 2];
+      const tgtIdx = renderGraph.edges[e * 2 + 1];
+      const srcId = renderGraph.nodeIds[srcIdx];
+      const tgtId = renderGraph.nodeIds[tgtIdx];
+      if (activeFocusIds.has(srcId)) neighbourSet.add(tgtId);
+      if (activeFocusIds.has(tgtId)) neighbourSet.add(srcId);
+    }
+
+    // Dim node alphas for non-neighbours
+    const nodeCount = renderGraph.nodeIds.length;
+    for (let i = 0; i < nodeCount; i++) {
+      const id = renderGraph.nodeIds[i];
+      if (!neighbourSet.has(id)) {
+        style.nodeColors[i * 4 + 3] = DIM_ALPHA;
+      }
+    }
+
+    // Dim edge alphas for non-incident edges
+    for (let e = 0; e < edgeCount; e++) {
+      const srcIdx = renderGraph.edges[e * 2];
+      const tgtIdx = renderGraph.edges[e * 2 + 1];
+      const srcId = renderGraph.nodeIds[srcIdx];
+      const tgtId = renderGraph.nodeIds[tgtIdx];
+      const isIncident = activeFocusIds.has(srcId) || activeFocusIds.has(tgtId);
+      if (!isIncident) {
+        style.edgeColors[e * 4 + 3] = DIM_ALPHA;
+      }
+    }
+  }
 
   return {
     renderGraph,

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -31,4 +31,60 @@ describe("GraphCanvas renderer", () => {
     expect(source).toContain("findNearestEdge");
     expect(source).toContain("onpointermove");
   });
+
+  // --- P0: Zoom / Pan / Reset ---
+  it("adds a wheel listener for zoom centred on the cursor", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("onwheel");
+    // zoom must use setCamera or mutate camera.zoom
+    expect(source).toContain("camera.zoom");
+    // zoom must be centred: world point under cursor is preserved → camera.x/y updated
+    expect(source).toContain("camera.x");
+    expect(source).toContain("camera.y");
+  });
+
+  it("pans with pointer drag on the background (pointerdown / pointermove / pointerup)", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("onpointerdown");
+    expect(source).toContain("onpointerup");
+    // pan accumulates delta via camera.x/camera.y
+    const hasPan = source.includes("camera.x") && source.includes("camera.y");
+    expect(hasPan).toBe(true);
+  });
+
+  it("exposes a Reset button that calls renderer.fitView and re-renders", () => {
+    const source = graphCanvasSource();
+    // button with some reset label / aria
+    expect(source.toLowerCase()).toMatch(/reset/);
+    // triggers fitAndRender or fitView
+    expect(source).toMatch(/fitAndRender|fitView/);
+  });
+
+  it("respects prefers-reduced-motion by not adding JS animation for pan/zoom", () => {
+    const source = graphCanvasSource();
+    // No requestAnimationFrame or transition for camera pan/zoom
+    // (rAF is fine for merge animation but not zoom/pan per spec)
+    // Simply verify we're not wrapping zoom/pan delta in rAF loops
+    // Presence of prefers-reduced-motion media query OR absence of rAF in zoom handler
+    // We test the simpler invariant: zoom/pan apply immediately (setCamera called directly)
+    expect(source).toContain("renderer.setCamera");
+  });
+
+  // --- P0: Connected-dim is wired from the canvas ---
+  it("passes hoveredNodeId down to buildGraphRendererPayload on pointermove", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("hoveredNodeId");
+    expect(source).toContain("buildGraphRendererPayload");
+  });
+
+  // --- P1: Node hover tooltip ---
+  it("shows a node tooltip on hover with label, type/node_type, and degree", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("hoveredNode");
+    // tooltip element rendered when hoveredNode is set
+    expect(source).toContain("node-tooltip");
+    // shows at least label and degree
+    expect(source).toMatch(/\.label/);
+    expect(source).toMatch(/degree|degré/i);
+  });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -8,6 +8,24 @@ import {
   interpolateMergePositions,
 } from "../lib/graphRendererPayload.js";
 
+// --- helpers for connected-dim tests ---
+function makeTriangleScene() {
+  return {
+    nodes: [
+      { id: "a", label: "Alpha", x: 0, y: 0, weight: 1, group: "G1" },
+      { id: "b", label: "Beta", x: 100, y: 0, weight: 1, group: "G1" },
+      { id: "c", label: "Gamma", x: 50, y: 80, weight: 1, group: "G2" },
+      { id: "d", label: "Delta", x: -50, y: 80, weight: 1, group: "G2" },
+    ],
+    edges: [
+      { source: "a", target: "b", relation: "links" },
+      { source: "a", target: "c", relation: "links" },
+      { source: "b", target: "d", relation: "links" },
+    ],
+    stats: { nodeCount: 4, edgeCount: 3, communityCount: 2 },
+  };
+}
+
 describe("graphRendererPayload", () => {
   it("maps a studio scene into @sentropic/graph buffers with selection styling", () => {
     const payload = buildGraphRendererPayload(
@@ -86,6 +104,73 @@ describe("graphRendererPayload", () => {
 
     expect([...positions]).toEqual([50, 20, 100, 40, -20, 10]);
     expect([...payload.renderGraph.positions]).toEqual([0, 0, 100, 40, -20, 10]);
+  });
+
+  // --- connected-dim: hoveredNodeId ---
+  it("dims non-neighbour nodes and their edges when hoveredNodeId is set", () => {
+    const scene = makeTriangleScene();
+    // Hover on "a": neighbours are b and c. d is NOT a neighbour.
+    const payload = buildGraphRendererPayload(scene, { hoveredNodeId: "a", nodeRadius: 3 });
+
+    const nodeIndexById = payload.nodeIndexById;
+    const iA = nodeIndexById.get("a");
+    const iB = nodeIndexById.get("b");
+    const iC = nodeIndexById.get("c");
+    const iD = nodeIndexById.get("d");
+
+    // focused node (a) and its direct neighbours (b, c) stay fully opaque
+    expect(payload.style.nodeColors[iA * 4 + 3]).toBe(255);
+    expect(payload.style.nodeColors[iB * 4 + 3]).toBe(255);
+    expect(payload.style.nodeColors[iC * 4 + 3]).toBe(255);
+
+    // d is NOT a neighbour → dimmed to ≤ 90 (255 * 0.35 ≈ 89)
+    expect(payload.style.nodeColors[iD * 4 + 3]).toBeLessThanOrEqual(90);
+  });
+
+  it("dims non-incident edges when hoveredNodeId is set", () => {
+    const scene = makeTriangleScene();
+    // a → b (index 0), a → c (index 1), b → d (index 2)
+    // Hover "a": edges 0 and 1 are incident → full alpha; edge 2 is not → dimmed
+    const payload = buildGraphRendererPayload(scene, { hoveredNodeId: "a", nodeRadius: 3 });
+    const graph = payload.renderGraph;
+    const iA = payload.nodeIndexById.get("a");
+    const edgeCount = graph.edges.length / 2;
+
+    for (let e = 0; e < edgeCount; e++) {
+      const src = graph.edges[e * 2];
+      const tgt = graph.edges[e * 2 + 1];
+      const isIncident = src === iA || tgt === iA;
+      const alpha = payload.style.edgeColors[e * 4 + 3];
+      if (isIncident) {
+        expect(alpha).toBe(255);
+      } else {
+        expect(alpha).toBeLessThanOrEqual(90);
+      }
+    }
+  });
+
+  it("dims non-neighbour nodes when a node is selected (selectedIds)", () => {
+    const scene = makeTriangleScene();
+    // Select "b": neighbours are a and d. c is NOT a direct neighbour of b.
+    const payload = buildGraphRendererPayload(scene, { selectedIds: ["b"], nodeRadius: 3 });
+    const iA = payload.nodeIndexById.get("a");
+    const iB = payload.nodeIndexById.get("b");
+    const iC = payload.nodeIndexById.get("c");
+    const iD = payload.nodeIndexById.get("d");
+
+    expect(payload.style.nodeColors[iA * 4 + 3]).toBe(255); // neighbour of b
+    expect(payload.style.nodeColors[iB * 4 + 3]).toBe(255); // selected itself
+    expect(payload.style.nodeColors[iD * 4 + 3]).toBe(255); // neighbour of b
+    expect(payload.style.nodeColors[iC * 4 + 3]).toBeLessThanOrEqual(90); // not a neighbour
+  });
+
+  it("does NOT dim anything when neither selectedIds nor hoveredNodeId are provided", () => {
+    const scene = makeTriangleScene();
+    const payload = buildGraphRendererPayload(scene, { nodeRadius: 3 });
+    const nodeCount = payload.renderGraph.nodeIds.length;
+    for (let i = 0; i < nodeCount; i++) {
+      expect(payload.style.nodeColors[i * 4 + 3]).toBe(255);
+    }
   });
 
   it("fades the merging source node and its incident edges during merge", () => {


### PR DESCRIPTION
Comble les 3 gaps de régression du rendu studio (audit parité) : **(1) zoom molette centré curseur + pan au drag + bouton reset** (GraphCanvas.svelte, via camera/setCamera/fitView existants) ; **(2) connected-dim** sélection ET hover (graphRendererPayload.js : voisins directs pleins, non-voisins alpha×0.35, arêtes non-incidentes estompées, highlight couleur intact) ; **(3) tooltip au survol d'un nœud** (label/type/degré). Aucune dépendance, prefers-reduced-motion respecté. Tests : 66 (+10) ; suite 1245/0 failed ; lint+build OK. ⚠️ Touche les fichiers renderer — coordonné avec codex (wave2 SG1).