### PR TITLE
feat(ontology): generate hierarchies.json from profile-declared hierarchies (increment A)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,10 @@ export type {
   NormalizedOntologyProfileOutputs,
   ProfileBinding,
   RegistryRecord,
+  OntologyHierarchyArc,
+  OntologyHierarchyIndex,
+  NormalizedOntologyHierarchySpec,
+  OntologyHierarchySpec,
 } from "./types.js";
 export { inspectInputScope } from "./input-scope.js";
 export type { InputScopeInventory, InspectInputScopeOptions } from "./input-scope.js";
@@ -104,6 +108,10 @@ export {
 export {
   compileOntologyOutputs,
 } from "./ontology-output.js";
+export {
+  buildHierarchyIndex,
+  compileHierarchies,
+} from "./ontology-hierarchies.js";
 export {
   filterOntologyReconciliationCandidates,
   generateOntologyReconciliationCandidates,
@@ -171,6 +179,9 @@ export type {
   CompileOntologyOutputsResult,
   OntologyOutputConfig,
 } from "./ontology-output.js";
+export type {
+  CompileHierarchiesOptions,
+} from "./ontology-hierarchies.js";
 export type {
   GenerateOntologyReconciliationCandidatesOptions,
   OntologyReconciliationCandidate,

--- a/src/ontology-hierarchies.ts
+++ b/src/ontology-hierarchies.ts
@@ -1,0 +1,223 @@
+/**
+ * Ontology increment A — profile-declared hierarchy artefacts.
+ *
+ * Compiles `hierarchies.json` (list of OntologyHierarchyArc) and
+ * `hierarchy-index.json` (OntologyHierarchyIndex) from the hierarchy
+ * declarations in a NormalizedOntologyProfile.
+ *
+ * Scope: DECLARATIVE path only (profile → artefact).  The derivation path
+ * (reconciliation candidates → hierarchy arcs) is owned by the D1/D2
+ * decisions and lives in ontology-reconciliation.ts / ontology-patch.ts —
+ * those modules are NOT touched here.
+ */
+
+import type {
+  NormalizedOntologyHierarchySpec,
+  OntologyHierarchyArc,
+  OntologyHierarchyIndex,
+  RegistryRecord,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// compileHierarchies
+// ---------------------------------------------------------------------------
+
+export interface CompileHierarchiesOptions {
+  /** Normalized hierarchies from the profile (profile.hierarchies). */
+  hierarchies: Record<string, NormalizedOntologyHierarchySpec>;
+  /** Registry records keyed by registry id, as loaded from disk. */
+  registries: Record<string, RegistryRecord[]>;
+}
+
+/**
+ * Build the flat list of hierarchy arcs from profile-declared hierarchies.
+ *
+ * For each hierarchy spec, iterates over the bound registry rows and reads
+ * `parent_column` / `child_column` from each raw record.  Records that
+ * lack either column value are silently skipped (they represent roots or
+ * orphaned leaves, which the index will surface via root_ids / depth).
+ *
+ * IDs used are the registry-native ids exactly as declared — no remapping
+ * to canonical ids here (that would be decision D2).
+ */
+export function compileHierarchies(options: CompileHierarchiesOptions): OntologyHierarchyArc[] {
+  const { registries } = options;
+  const hierarchies = options.hierarchies ?? {};
+  const arcs: OntologyHierarchyArc[] = [];
+
+  for (const [hierarchyId, spec] of Object.entries(hierarchies)) {
+    const records = registries[spec.registry] ?? [];
+    for (const record of records) {
+      const raw = record.raw;
+      const parentValue = columnValue(raw, spec.parent_column);
+      const childValue = columnValue(raw, spec.child_column);
+
+      // A row contributes an arc only when BOTH parent and child are present.
+      // Rows where child_column equals the row's own id_column value but
+      // parent_column is blank are roots — they don't produce an arc.
+      if (!parentValue || !childValue) continue;
+      // Skip self-loops (id == parent means "this is a root" in some schemas)
+      if (parentValue === childValue) continue;
+
+      arcs.push({
+        hierarchy_id: hierarchyId,
+        parent_id: parentValue,
+        child_id: childValue,
+        level: 0, // filled in by buildHierarchyIndex
+        type: spec.relation_type,
+        source: "profile",
+      });
+    }
+  }
+
+  return arcs;
+}
+
+function columnValue(raw: Record<string, unknown>, column: string): string {
+  const v = raw[column];
+  if (v === null || v === undefined) return "";
+  const s = String(v).trim();
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// buildHierarchyIndex
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the OntologyHierarchyIndex from a flat list of arcs.
+ *
+ * Cycle detection: Tarjan-style DFS.  Any node whose ancestor path leads
+ * back to itself is part of a cycle.  Cycles are reported in `cycles[]` and
+ * the nodes involved are excluded from `ancestor_paths` and `root_ids`.
+ *
+ * Handles disconnected forests (multiple trees / multiple registries).
+ */
+export function buildHierarchyIndex(arcs: OntologyHierarchyArc[]): OntologyHierarchyIndex {
+  if (arcs.length === 0) {
+    return {
+      schema: "graphify_ontology_hierarchies_v1",
+      root_ids: [],
+      depth: 0,
+      ancestor_paths: {},
+      cycles: [],
+    };
+  }
+
+  // Build adjacency maps
+  const childrenOf = new Map<string, Set<string>>();
+  const parentsOf = new Map<string, Set<string>>();
+  const allNodes = new Set<string>();
+
+  for (const arc of arcs) {
+    allNodes.add(arc.parent_id);
+    allNodes.add(arc.child_id);
+    if (!childrenOf.has(arc.parent_id)) childrenOf.set(arc.parent_id, new Set());
+    childrenOf.get(arc.parent_id)!.add(arc.child_id);
+    if (!parentsOf.has(arc.child_id)) parentsOf.set(arc.child_id, new Set());
+    parentsOf.get(arc.child_id)!.add(arc.parent_id);
+  }
+
+  // Detect cycles via iterative DFS (Tarjan SCC condensed to cycle sets)
+  const cycleNodes = new Set<string>();
+  const cycles: string[][] = [];
+
+  {
+    const WHITE = 0, GREY = 1, BLACK = 2;
+    const color = new Map<string, number>();
+    for (const n of allNodes) color.set(n, WHITE);
+
+    // Stack-based DFS: each frame = [node, iterator over children, path]
+    for (const start of allNodes) {
+      if (color.get(start) !== WHITE) continue;
+      // [node, childrenIterator, pathStack]
+      const stack: Array<{ node: string; children: Iterator<string>; path: string[] }> = [];
+      const pathSet = new Set<string>();
+
+      color.set(start, GREY);
+      pathSet.add(start);
+      stack.push({
+        node: start,
+        children: (childrenOf.get(start) ?? new Set<string>()).values(),
+        path: [start],
+      });
+
+      while (stack.length > 0) {
+        // stack.length > 0 guarantees the element exists; non-null assertion is safe.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const frame = stack[stack.length - 1]!;
+        const { done, value: child } = frame.children.next();
+        if (done) {
+          color.set(frame.node, BLACK);
+          pathSet.delete(frame.node);
+          stack.pop();
+          continue;
+        }
+        const childColor = color.get(child) ?? WHITE;
+        if (childColor === BLACK) continue;
+        if (childColor === GREY) {
+          // Back edge → cycle found
+          const cycleStart = frame.path.indexOf(child);
+          const cyclePath = frame.path.slice(cycleStart);
+          cycles.push([...cyclePath, child]); // close the cycle
+          for (const n of cyclePath) cycleNodes.add(n);
+          cycleNodes.add(child);
+          continue;
+        }
+        // WHITE — push new frame
+        const newPath = [...frame.path, child];
+        color.set(child, GREY);
+        pathSet.add(child);
+        stack.push({
+          node: child,
+          children: (childrenOf.get(child) ?? new Set<string>()).values(),
+          path: newPath,
+        });
+      }
+    }
+  }
+
+  // Compute root_ids (nodes with no parents, excluding cycle nodes)
+  const root_ids: string[] = [];
+  for (const node of allNodes) {
+    if (cycleNodes.has(node)) continue;
+    const parents = parentsOf.get(node);
+    if (!parents || parents.size === 0) root_ids.push(node);
+  }
+
+  // BFS from roots to compute ancestor_paths and depth
+  const ancestor_paths: Record<string, string[]> = {};
+  let maxDepth = 0;
+
+  for (const root of root_ids) {
+    ancestor_paths[root] = [];
+    const queue: Array<{ node: string; ancestors: string[] }> = [{ node: root, ancestors: [] }];
+    const visited = new Set<string>([root]);
+
+    while (queue.length > 0) {
+      const { node, ancestors } = queue.shift()!;
+      const depth = ancestors.length;
+      if (depth > maxDepth) maxDepth = depth;
+
+      const children = childrenOf.get(node);
+      if (!children) continue;
+      for (const child of children) {
+        if (cycleNodes.has(child)) continue;
+        if (visited.has(child)) continue;
+        visited.add(child);
+        const childAncestors = [...ancestors, node];
+        ancestor_paths[child] = childAncestors;
+        if (childAncestors.length > maxDepth) maxDepth = childAncestors.length;
+        queue.push({ node: child, ancestors: childAncestors });
+      }
+    }
+  }
+
+  return {
+    schema: "graphify_ontology_hierarchies_v1",
+    root_ids: root_ids.sort(),
+    depth: maxDepth,
+    ancestor_paths,
+    cycles,
+  };
+}

--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -2,8 +2,9 @@ import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import type { Extraction, GraphEdge, GraphNode, NormalizedOntologyProfile } from "./types.js";
+import type { Extraction, GraphEdge, GraphNode, NormalizedOntologyProfile, RegistryRecord } from "./types.js";
 import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
+import { buildHierarchyIndex, compileHierarchies } from "./ontology-hierarchies.js";
 
 export interface OntologyOutputConfig {
   enabled: boolean;
@@ -29,6 +30,12 @@ export interface CompileOntologyOutputsOptions {
    * the canonical `node.id` (not the source graph node ids).
    */
   descriptions?: WikiDescriptionSidecarIndex;
+  /**
+   * Optional registry records keyed by registry id.  When provided and the
+   * profile declares hierarchies, `compileOntologyOutputs` will generate
+   * `hierarchies.json` and `hierarchy-index.json` in `outputDir`.
+   */
+  registries?: Record<string, RegistryRecord[]>;
 }
 
 export interface CompileOntologyOutputsResult {
@@ -37,6 +44,8 @@ export interface CompileOntologyOutputsResult {
   relationCount: number;
   wikiPageCount: number;
   validationIssues: string[];
+  /** Number of hierarchy arcs written to hierarchies.json (0 when no hierarchies declared). */
+  hierarchyArcCount: number;
 }
 
 interface CompiledNode {
@@ -219,14 +228,33 @@ function writeWiki(
 
 export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): CompileOntologyOutputsResult {
   if (!options.config.enabled) {
-    return { enabled: false, nodeCount: 0, relationCount: 0, wikiPageCount: 0, validationIssues: [] };
+    return { enabled: false, nodeCount: 0, relationCount: 0, wikiPageCount: 0, validationIssues: [], hierarchyArcCount: 0 };
   }
 
   const { nodes, aliasIssues } = compileNodes(options.extraction, options.profile, options.config);
   const relations = compileRelations(options.extraction, nodes, options.config);
   const validationIssues = [...aliasIssues];
   const wikiPageCount = writeWiki(options.outputDir, nodes, relations, options.config, options.descriptions);
-  const manifest = {
+
+  // ---- Hierarchy artefacts (increment A — additive, no-op when no hierarchies) ----
+  let hierarchyArcCount = 0;
+  const hasHierarchies = Object.keys(options.profile.hierarchies ?? {}).length > 0;
+  const hierarchiesPath = join(options.outputDir, "hierarchies.json");
+  const hierarchyIndexPath = join(options.outputDir, "hierarchy-index.json");
+
+  if (hasHierarchies) {
+    const arcs = compileHierarchies({
+      hierarchies: options.profile.hierarchies,
+      registries: options.registries ?? {},
+    });
+    const index = buildHierarchyIndex(arcs);
+    writeJson(hierarchiesPath, arcs);
+    writeJson(hierarchyIndexPath, index);
+    hierarchyArcCount = arcs.length;
+  }
+  // ---- End hierarchy artefacts ----
+
+  const manifest: Record<string, unknown> = {
     schema: "graphify_ontology_outputs_v1",
     graph_hash: sha256(JSON.stringify(options.extraction)),
     profile_hash: options.profile.profile_hash,
@@ -236,6 +264,11 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
     wiki_page_count: wikiPageCount,
     source_graph: ".graphify/graph.json",
   };
+
+  if (hasHierarchies) {
+    manifest.hierarchies_path = hierarchiesPath;
+    manifest.hierarchy_index_path = hierarchyIndexPath;
+  }
 
   writeJson(join(options.outputDir, "manifest.json"), manifest);
   writeJson(join(options.outputDir, "nodes.json"), nodes);
@@ -265,5 +298,5 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
     })),
   });
 
-  return { enabled: true, nodeCount: nodes.length, relationCount: relations.length, wikiPageCount, validationIssues };
+  return { enabled: true, nodeCount: nodes.length, relationCount: relations.length, wikiPageCount, validationIssues, hierarchyArcCount };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -630,6 +630,44 @@ export interface NormalizedOntologyHierarchySpec {
   child_node_type: string;
 }
 
+/** One directed arc in a profile-declared hierarchy. */
+export interface OntologyHierarchyArc {
+  /** Identifier of the hierarchy (key in profile.hierarchies). */
+  hierarchy_id: string;
+  /** Registry-native id of the parent node. */
+  parent_id: string;
+  /** Registry-native id of the child node. */
+  child_id: string;
+  /**
+   * Depth of the child relative to the root (0 = root, 1 = child of root, …).
+   * Only populated by buildHierarchyIndex; kept 0 here, filled in by the index.
+   */
+  level: number;
+  /** Relation type declared in the hierarchy spec. */
+  type: string;
+  /** Always "profile" for profile-declared hierarchies. */
+  source: "profile";
+  /** Optional evidence references carried by the registry record. */
+  evidence_refs?: string[];
+}
+
+/** Pre-computed index over a set of OntologyHierarchyArc entries. */
+export interface OntologyHierarchyIndex {
+  schema: "graphify_ontology_hierarchies_v1";
+  /** Ids of nodes that have no parent in any arc. */
+  root_ids: string[];
+  /** Maximum depth across all arcs (0 when arcs is empty). */
+  depth: number;
+  /** Map: node_id → array of ancestor ids from root down to direct parent. */
+  ancestor_paths: Record<string, string[]>;
+  /**
+   * Cycles detected during index construction.  Each entry is an ordered list
+   * of node ids forming the cycle.  Nodes involved in cycles are excluded from
+   * ancestor_paths and root_ids.
+   */
+  cycles: string[][];
+}
+
 export type OntologyRelationExport = string | { relation_type?: string };
 
 export interface OntologyOutputWikiPolicy {

--- a/tests/ontology-hierarchies.test.ts
+++ b/tests/ontology-hierarchies.test.ts
@@ -1,0 +1,506 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { compileHierarchies, buildHierarchyIndex } from "../src/ontology-hierarchies.js";
+import { compileOntologyOutputs } from "../src/ontology-output.js";
+import type {
+  NormalizedOntologyHierarchySpec,
+  OntologyHierarchyArc,
+  RegistryRecord,
+} from "../src/types.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+import type { Extraction } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const cleanupDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-ontology-hierarchies-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+/** Minimal NormalizedOntologyProfile factory. */
+function makeProfile(
+  hierarchies: Record<string, NormalizedOntologyHierarchySpec> = {},
+): NormalizedOntologyProfile {
+  return {
+    id: "test",
+    version: "1",
+    default_language: "en",
+    profile_hash: "test-hash",
+    node_types: {
+      Category: {},
+    },
+    relation_types: {
+      parent_of: { source_types: ["Category"], target_types: ["Category"], requires_evidence: false, assertion_basis: [], derivation_methods: [] },
+    },
+    registries: {},
+    citation_policy: { minimum_granularity: "file", require_source_file: false, allow_bbox: false },
+    hardening: {
+      statuses: ["candidate", "validated"],
+      default_status: "candidate",
+      promotion_requires: [],
+      status_transitions: [],
+    },
+    inference_policy: { allow_inferred_relations: false, allowed_relation_types: [], require_evidence_refs: false },
+    evidence_policy: { require_evidence_refs: false, min_refs: 0, node_types: [], relation_types: [] },
+    hierarchies,
+    outputs: {
+      ontology: {
+        enabled: false,
+        artifact_schema: "graphify_ontology_outputs_v1",
+        canonical_node_types: [],
+        source_node_types: [],
+        occurrence_node_types: [],
+        alias_fields: [],
+        relation_exports: [],
+        wiki: { enabled: false, page_node_types: [], include_backlinks: false, include_source_snippets: false },
+      },
+    },
+  };
+}
+
+/** Make a RegistryRecord from minimal fields. */
+function makeRecord(
+  registryId: string,
+  id: string,
+  raw: Record<string, unknown>,
+): RegistryRecord {
+  return {
+    registryId,
+    id,
+    label: id,
+    aliases: [],
+    nodeType: "Category",
+    sourceFile: "/fake/registry.csv",
+    raw,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// compileHierarchies — unit tests
+// ---------------------------------------------------------------------------
+
+describe("compileHierarchies", () => {
+  it("returns empty array when no hierarchies declared", () => {
+    const arcs = compileHierarchies({ hierarchies: {}, registries: {} });
+    expect(arcs).toEqual([]);
+  });
+
+  it("returns empty array when registry is empty", () => {
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const arcs = compileHierarchies({ hierarchies: { taxonomy: spec }, registries: { cats: [] } });
+    expect(arcs).toEqual([]);
+  });
+
+  it("skips rows with blank parent (root nodes)", () => {
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const records: RegistryRecord[] = [
+      makeRecord("cats", "root", { id: "root", parent_id: "" }),
+      makeRecord("cats", "child1", { id: "child1", parent_id: "root" }),
+    ];
+    const arcs = compileHierarchies({ hierarchies: { taxonomy: spec }, registries: { cats: records } });
+    expect(arcs).toHaveLength(1);
+    expect(arcs[0].parent_id).toBe("root");
+    expect(arcs[0].child_id).toBe("child1");
+  });
+
+  it("generates correct arcs for a 3-level hierarchy", () => {
+    // root → level1 → level2
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const records: RegistryRecord[] = [
+      makeRecord("cats", "root", { id: "root", parent_id: "" }),
+      makeRecord("cats", "level1", { id: "level1", parent_id: "root" }),
+      makeRecord("cats", "level2", { id: "level2", parent_id: "level1" }),
+    ];
+    const arcs = compileHierarchies({ hierarchies: { taxonomy: spec }, registries: { cats: records } });
+
+    expect(arcs).toHaveLength(2);
+
+    const arc0 = arcs.find((a) => a.child_id === "level1")!;
+    expect(arc0).toBeDefined();
+    expect(arc0.parent_id).toBe("root");
+    expect(arc0.hierarchy_id).toBe("taxonomy");
+    expect(arc0.type).toBe("parent_of");
+    expect(arc0.source).toBe("profile");
+
+    const arc1 = arcs.find((a) => a.child_id === "level2")!;
+    expect(arc1).toBeDefined();
+    expect(arc1.parent_id).toBe("level1");
+  });
+
+  it("skips self-loops (parent_id === id)", () => {
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const records: RegistryRecord[] = [
+      makeRecord("cats", "self", { id: "self", parent_id: "self" }),
+    ];
+    const arcs = compileHierarchies({ hierarchies: { taxonomy: spec }, registries: { cats: records } });
+    expect(arcs).toHaveLength(0);
+  });
+
+  it("produces arcs from multiple hierarchies", () => {
+    const specA: NormalizedOntologyHierarchySpec = {
+      registry: "catsA",
+      parent_column: "parent",
+      child_column: "id",
+      relation_type: "part_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const specB: NormalizedOntologyHierarchySpec = {
+      registry: "catsB",
+      parent_column: "parent",
+      child_column: "id",
+      relation_type: "belongs_to",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const recsA: RegistryRecord[] = [
+      makeRecord("catsA", "p1", { id: "c1", parent: "p1" }),
+    ];
+    const recsB: RegistryRecord[] = [
+      makeRecord("catsB", "p2", { id: "c2", parent: "p2" }),
+    ];
+    const arcs = compileHierarchies({
+      hierarchies: { hierA: specA, hierB: specB },
+      registries: { catsA: recsA, catsB: recsB },
+    });
+    expect(arcs).toHaveLength(2);
+    expect(arcs.find((a) => a.hierarchy_id === "hierA")?.type).toBe("part_of");
+    expect(arcs.find((a) => a.hierarchy_id === "hierB")?.type).toBe("belongs_to");
+  });
+
+  it("round-trips through JSON cleanly", () => {
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const records: RegistryRecord[] = [
+      makeRecord("cats", "root", { id: "root", parent_id: "" }),
+      makeRecord("cats", "child", { id: "child", parent_id: "root" }),
+    ];
+    const arcs = compileHierarchies({ hierarchies: { tax: spec }, registries: { cats: records } });
+    const json = JSON.stringify(arcs);
+    const parsed = JSON.parse(json) as OntologyHierarchyArc[];
+    expect(parsed).toEqual(arcs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHierarchyIndex — unit tests
+// ---------------------------------------------------------------------------
+
+describe("buildHierarchyIndex", () => {
+  it("returns empty index for empty arcs", () => {
+    const idx = buildHierarchyIndex([]);
+    expect(idx.schema).toBe("graphify_ontology_hierarchies_v1");
+    expect(idx.root_ids).toEqual([]);
+    expect(idx.depth).toBe(0);
+    expect(idx.ancestor_paths).toEqual({});
+    expect(idx.cycles).toEqual([]);
+  });
+
+  it("builds correct index for a 3-level linear chain", () => {
+    // root → mid → leaf
+    const arcs: OntologyHierarchyArc[] = [
+      { hierarchy_id: "h", parent_id: "root", child_id: "mid", level: 0, type: "parent_of", source: "profile" },
+      { hierarchy_id: "h", parent_id: "mid", child_id: "leaf", level: 0, type: "parent_of", source: "profile" },
+    ];
+    const idx = buildHierarchyIndex(arcs);
+
+    expect(idx.root_ids).toContain("root");
+    expect(idx.depth).toBe(2);
+    expect(idx.ancestor_paths["root"]).toEqual([]);
+    expect(idx.ancestor_paths["mid"]).toEqual(["root"]);
+    expect(idx.ancestor_paths["leaf"]).toEqual(["root", "mid"]);
+    expect(idx.cycles).toHaveLength(0);
+  });
+
+  it("detects a cycle and excludes cycled nodes from paths and roots", () => {
+    // a → b → c → a (cycle)
+    const arcs: OntologyHierarchyArc[] = [
+      { hierarchy_id: "h", parent_id: "a", child_id: "b", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "b", child_id: "c", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "c", child_id: "a", level: 0, type: "t", source: "profile" },
+    ];
+    const idx = buildHierarchyIndex(arcs);
+
+    // Must not hang — cycle is detected
+    expect(idx.cycles).toHaveLength(1);
+    const cycleNodes = new Set(idx.cycles[0]);
+    expect(cycleNodes.has("a") || cycleNodes.has("b") || cycleNodes.has("c")).toBe(true);
+
+    // Cycled nodes must be absent from root_ids
+    for (const node of ["a", "b", "c"]) {
+      expect(idx.root_ids).not.toContain(node);
+    }
+
+    // No ancestor_paths for cycled nodes
+    for (const node of ["a", "b", "c"]) {
+      expect(idx.ancestor_paths[node]).toBeUndefined();
+    }
+  });
+
+  it("handles a mixed graph with one cycle and one clean tree", () => {
+    // clean: root → child
+    // cycle: x → y → x
+    const arcs: OntologyHierarchyArc[] = [
+      { hierarchy_id: "h", parent_id: "root", child_id: "child", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "x", child_id: "y", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "y", child_id: "x", level: 0, type: "t", source: "profile" },
+    ];
+    const idx = buildHierarchyIndex(arcs);
+
+    expect(idx.root_ids).toContain("root");
+    expect(idx.root_ids).not.toContain("x");
+    expect(idx.root_ids).not.toContain("y");
+
+    expect(idx.ancestor_paths["root"]).toEqual([]);
+    expect(idx.ancestor_paths["child"]).toEqual(["root"]);
+    expect(idx.ancestor_paths["x"]).toBeUndefined();
+    expect(idx.ancestor_paths["y"]).toBeUndefined();
+
+    expect(idx.cycles).toHaveLength(1);
+    expect(idx.depth).toBe(1);
+  });
+
+  it("computes correct depth for a wide tree", () => {
+    // root → A → B → C (depth 3)
+    // root → X (depth 1)
+    const arcs: OntologyHierarchyArc[] = [
+      { hierarchy_id: "h", parent_id: "root", child_id: "A", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "A", child_id: "B", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "B", child_id: "C", level: 0, type: "t", source: "profile" },
+      { hierarchy_id: "h", parent_id: "root", child_id: "X", level: 0, type: "t", source: "profile" },
+    ];
+    const idx = buildHierarchyIndex(arcs);
+
+    expect(idx.depth).toBe(3);
+    expect(idx.ancestor_paths["C"]).toEqual(["root", "A", "B"]);
+    expect(idx.ancestor_paths["X"]).toEqual(["root"]);
+  });
+
+  it("round-trips through JSON cleanly", () => {
+    const arcs: OntologyHierarchyArc[] = [
+      { hierarchy_id: "h", parent_id: "root", child_id: "child", level: 0, type: "t", source: "profile" },
+    ];
+    const idx = buildHierarchyIndex(arcs);
+    const json = JSON.stringify(idx);
+    const parsed = JSON.parse(json);
+    expect(parsed).toEqual(idx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileOntologyOutputs integration — hierarchy files written / skipped
+// ---------------------------------------------------------------------------
+
+describe("compileOntologyOutputs — hierarchy integration", () => {
+  const minimalExtraction: Extraction = {
+    input_tokens: 0,
+    output_tokens: 0,
+    nodes: [],
+    edges: [],
+  };
+
+  it("does NOT write hierarchy files when profile has no hierarchies", () => {
+    const outputDir = makeTempDir();
+    const profile = makeProfile({});
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction: minimalExtraction,
+      profile,
+      config: { enabled: true },
+    });
+
+    expect(existsSync(join(outputDir, "hierarchies.json"))).toBe(false);
+    expect(existsSync(join(outputDir, "hierarchy-index.json"))).toBe(false);
+  });
+
+  it("writes hierarchies.json and hierarchy-index.json when hierarchies declared", () => {
+    const outputDir = makeTempDir();
+
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const profile = makeProfile({ taxonomy: spec });
+
+    const registries: Record<string, RegistryRecord[]> = {
+      cats: [
+        makeRecord("cats", "root", { id: "root", parent_id: "" }),
+        makeRecord("cats", "child1", { id: "child1", parent_id: "root" }),
+        makeRecord("cats", "child2", { id: "child2", parent_id: "root" }),
+        makeRecord("cats", "grandchild", { id: "grandchild", parent_id: "child1" }),
+      ],
+    };
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction: minimalExtraction,
+      profile,
+      config: { enabled: true },
+      registries,
+    });
+
+    // Both files must exist
+    expect(existsSync(join(outputDir, "hierarchies.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "hierarchy-index.json"))).toBe(true);
+
+    // Validate hierarchies.json content
+    const arcs = readJson<OntologyHierarchyArc[]>(join(outputDir, "hierarchies.json"));
+    expect(arcs).toHaveLength(3); // root→child1, root→child2, child1→grandchild
+    expect(arcs.every((a) => a.source === "profile")).toBe(true);
+    expect(arcs.every((a) => a.hierarchy_id === "taxonomy")).toBe(true);
+
+    // Validate hierarchy-index.json content
+    const idx = readJson<{ schema: string; root_ids: string[]; depth: number; ancestor_paths: Record<string, string[]>; cycles: string[][] }>(
+      join(outputDir, "hierarchy-index.json"),
+    );
+    expect(idx.schema).toBe("graphify_ontology_hierarchies_v1");
+    expect(idx.root_ids).toContain("root");
+    expect(idx.depth).toBe(2);
+    expect(idx.ancestor_paths["grandchild"]).toEqual(["root", "child1"]);
+    expect(idx.cycles).toHaveLength(0);
+  });
+
+  it("adds hierarchy files to manifest when they exist", () => {
+    const outputDir = makeTempDir();
+
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const profile = makeProfile({ taxonomy: spec });
+
+    const registries: Record<string, RegistryRecord[]> = {
+      cats: [
+        makeRecord("cats", "root", { id: "root", parent_id: "" }),
+        makeRecord("cats", "child", { id: "child", parent_id: "root" }),
+      ],
+    };
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction: minimalExtraction,
+      profile,
+      config: { enabled: true },
+      registries,
+    });
+
+    const manifest = readJson<Record<string, unknown>>(join(outputDir, "manifest.json"));
+    expect(manifest.hierarchies_path).toBeDefined();
+    expect(manifest.hierarchy_index_path).toBeDefined();
+  });
+
+  it("returns hierarchyArcCount in result when hierarchies present", () => {
+    const outputDir = makeTempDir();
+
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const profile = makeProfile({ taxonomy: spec });
+
+    const registries: Record<string, RegistryRecord[]> = {
+      cats: [
+        makeRecord("cats", "root", { id: "root", parent_id: "" }),
+        makeRecord("cats", "child", { id: "child", parent_id: "root" }),
+      ],
+    };
+
+    const result = compileOntologyOutputs({
+      outputDir,
+      extraction: minimalExtraction,
+      profile,
+      config: { enabled: true },
+      registries,
+    });
+
+    expect(result.hierarchyArcCount).toBe(1);
+  });
+
+  it("does not write hierarchy files when compilation is disabled", () => {
+    const outputDir = makeTempDir();
+    const spec: NormalizedOntologyHierarchySpec = {
+      registry: "cats",
+      parent_column: "parent_id",
+      child_column: "id",
+      relation_type: "parent_of",
+      parent_node_type: "Category",
+      child_node_type: "Category",
+    };
+    const profile = makeProfile({ taxonomy: spec });
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction: minimalExtraction,
+      profile,
+      config: { enabled: false },
+    });
+
+    expect(existsSync(join(outputDir, "hierarchies.json"))).toBe(false);
+    expect(existsSync(join(outputDir, "hierarchy-index.json"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Incrément A du flux ontologie (mandat conducteur : ownership ontologie côté logique/artefacts). **Additif, réversible, sans trancher D1/D2.**

- `src/ontology-hierarchies.ts` : `compileHierarchies(profile)` → arcs `{hierarchy_id, parent_id, child_id, level, type, source:"profile"}` depuis les hiérarchies **profil-déclarées** (registry binding déjà dans `OntologyHierarchySpec`) ; `buildHierarchyIndex(arcs)` → `{root_ids, depth, ancestor_paths, cycles}` avec **détection de cycles** (signalés, pas de hang).
- Câblage `compileOntologyOutputs` : écrit `.graphify/ontology/hierarchies.json` + `hierarchy-index.json` **seulement si** `profile.hierarchies` non vide ; sinon aucun fichier (zéro changement de comportement).
- Types additifs (`OntologyHierarchyArc`, `OntologyHierarchyIndex`), exports index.ts.

**Frontière D1/D2 préservée** : chemin DÉCLARATIF profil→artefact uniquement. Le chemin DÉRIVÉ (réconciliation candidats → hiérarchies) reste intouché — `ontology-reconciliation.ts`/`ontology-patch.ts` non modifiés. Alimente le passthrough scène 7bbba08 (parent_id/child_ids/hierarchy_id) → rendu hiérarchie côté studio en aval.

Tests : 18 ciblés (3 niveaux → arcs+index, profil sans hiérarchie → aucun fichier, cycle → signalé, round-trip JSON) ; suite **1370/0 failed** ; lint+build OK.

NB : récupéré après interruption du subagent (state in-process perdu) — re-vérifié intégralement avant push.