### PR TITLE
feat(merge): cross-repo identity keys + fix homonym-repo tag collision (WP1)

### DIFF
--- a/src/merge-graphs.ts
+++ b/src/merge-graphs.ts
@@ -1,14 +1,18 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import type Graph from "graphology";
 import { createGraph, isDirectedGraph, loadGraphFromData, serializeGraph } from "./graph.js";
 import { assertGraphJsonFileSize, assertGraphJsonSize } from "./graph-size-guard.js";
 import { loadHyperedges, mergeHyperedges, setHyperedges } from "./hyperedges.js";
 import type { Hyperedge } from "./hyperedges.js";
+import type { RepoKeyRunner } from "./repo-key.js";
+import { repoKey } from "./repo-key.js";
 
 export interface MergeGraphsOptions {
   inputs: string[];
   out: string;
+  /** Optional runner for git commands, injectable for testing. */
+  runner?: RepoKeyRunner;
 }
 
 export interface MergeGraphsResult {
@@ -19,12 +23,40 @@ export interface MergeGraphsResult {
   edgeCount: number;
 }
 
-function repoTagFromGraphPath(graphPath: string): string {
-  const parentName = basename(dirname(graphPath));
-  if (parentName === ".graphify" || parentName === "graphify-out") {
-    return basename(dirname(dirname(graphPath))) || "unknown";
+/**
+ * Derive a stable repo tag from a graph file path.
+ *
+ * The tag is computed via `repoKey()` which uses the remote origin URL (preferred)
+ * or falls back to a deterministic local key — never just the basename, so two
+ * repos with the same directory name cannot collide.
+ *
+ * If an explicit `tag` override is provided (rétrocompat for callers that build
+ * the tag themselves) it is returned as-is.
+ */
+function repoTagFromGraphPath(
+  graphPath: string,
+  tag?: string,
+  runner?: RepoKeyRunner,
+): string {
+  if (tag !== undefined) return tag;
+
+  // Walk up from the graph file to the repo root:
+  // .graphify/graph.json      → repoRoot = dirname(dirname(graphPath))
+  // graphify-out/graph.json   → repoRoot = dirname(dirname(graphPath))
+  // any-other-dir/graph.json  → repoRoot = dirname(graphPath)  (best-effort)
+  const parent = dirname(graphPath);
+  const grandparent = dirname(parent);
+  const parentName = parent.split("/").at(-1) ?? "";
+  const repoRoot =
+    parentName === ".graphify" || parentName === "graphify-out"
+      ? grandparent
+      : parent;
+
+  try {
+    return repoKey(repoRoot, runner);
+  } catch {
+    return "unknown";
   }
-  return parentName || "unknown";
 }
 
 function mergedGraphType(graphs: Graph[]): boolean {
@@ -51,7 +83,7 @@ export function mergeGraphsFromFiles(options: MergeGraphsOptions): MergeGraphsRe
     assertGraphJsonFileSize(resolved, "read");
     const raw = JSON.parse(readFileSync(resolved, "utf-8")) as Record<string, unknown>;
     const graph = loadGraphFromData(raw);
-    const repo = repoTagFromGraphPath(resolved);
+    const repo = repoTagFromGraphPath(resolved, undefined, options.runner);
     graph.forEachNode((nodeId, attrs) => {
       if (attrs.repo === undefined) {
         graph.setNodeAttribute(nodeId, "repo", repo);

--- a/src/repo-key.ts
+++ b/src/repo-key.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { basename, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { githubRepoFromRemote } from "./pr.js";
+
+export interface RepoKeyRunner {
+  run(command: string, args: string[], cwd: string): string;
+}
+
+const defaultRepoKeyRunner: RepoKeyRunner = {
+  run(command: string, args: string[], cwd: string): string {
+    return execFileSync(command, args, {
+      cwd,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  },
+};
+
+/**
+ * Parse a non-GitHub remote URL and extract a stable host/path key.
+ *
+ * Handles:
+ *   - https://gitlab.example.com/owner/name.git    → "gitlab.example.com/owner/name"
+ *   - git@gitlab.example.com:owner/name.git        → "gitlab.example.com/owner/name"
+ *   - ssh://git@self-hosted.io/owner/name.git      → "self-hosted.io/owner/name"
+ *
+ * Returns undefined if the URL cannot be parsed.
+ */
+function remoteKeyFromUrl(remoteUrl: string): string | undefined {
+  const trimmed = remoteUrl.trim().replace(/\.git$/i, "");
+
+  // SSH URL: ssh://[user@]host/path  (must be before SCP pattern)
+  const sshUrl = trimmed.match(/^ssh:\/\/(?:[^@]+@)?([^/\s]+)(\/.+)$/i);
+  if (sshUrl) {
+    const host = sshUrl[1] ?? "";
+    const path = (sshUrl[2] ?? "").replace(/^\/+/, "").replace(/\/+$/, "");
+    if (host && path) return `${host}/${path}`;
+  }
+
+  // HTTPS: https://host/path
+  const https = trimmed.match(/^https?:\/\/([^/\s]+)(\/.+)$/i);
+  if (https) {
+    const host = https[1] ?? "";
+    const path = (https[2] ?? "").replace(/^\/+/, "").replace(/\/+$/, "");
+    if (host && path) return `${host}/${path}`;
+  }
+
+  // SSH scp-style: git@host:path  (colon delimiter, no :// prefix)
+  const scp = trimmed.match(/^(?:[^@]+@)?([^:/\s]+):(?!\/\/)(.+)$/);
+  if (scp) {
+    const host = scp[1] ?? "";
+    const path = (scp[2] ?? "").replace(/^\/+/, "").replace(/\/+$/, "").replace(/:/g, "/");
+    if (host && path) return `${host}/${path}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Derive a stable, unique key for a repository.
+ *
+ * Resolution order:
+ *  1. GitHub remote   → `repo:github.com/<owner>/<name>`
+ *  2. Non-GitHub remote → `repo:<host>/<path-normalised>`
+ *  3. No remote       → `repo:local/<basename>@<8-hex-sha256-of-resolved-path>`
+ *
+ * The `runner` parameter is injectable for testing (avoids real git calls).
+ */
+export function repoKey(
+  repoRoot: string,
+  runner: RepoKeyRunner = defaultRepoKeyRunner,
+): string {
+  const absRoot = resolve(repoRoot);
+
+  let remoteUrl: string | undefined;
+  try {
+    remoteUrl = runner.run("git", ["remote", "get-url", "origin"], absRoot);
+  } catch {
+    // no remote — fall through to local fallback
+  }
+
+  if (remoteUrl) {
+    // Try GitHub first
+    const github = githubRepoFromRemote(remoteUrl);
+    if (github) {
+      return `repo:github.com/${github}`;
+    }
+
+    // Non-GitHub remote
+    const fallback = remoteKeyFromUrl(remoteUrl);
+    if (fallback) {
+      return `repo:${fallback}`;
+    }
+  }
+
+  // No remote or unparseable URL — deterministic local fallback
+  const name = basename(absRoot);
+  const hash = createHash("sha256").update(absRoot).digest("hex").slice(0, 8);
+  return `repo:local/${name}@${hash}`;
+}
+
+/** Stable identifier for a commit in the context of a repo key. */
+export function commitId(repoKeyStr: string, sha: string): string {
+  return `commit:${repoKeyStr}@${sha}`;
+}
+
+/** Stable identifier for a branch in the context of a repo key. */
+export function branchId(repoKeyStr: string, name: string): string {
+  return `branch:${repoKeyStr}#${name}`;
+}
+
+/** Stable identifier for a pull request in the context of a repo key. */
+export function prId(repoKeyStr: string, n: number): string {
+  return `pr:${repoKeyStr}#${n}`;
+}

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -584,12 +584,12 @@ describe("public CLI runtime command parity", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.logs.join("\n")).toContain("Merged 2 graphs");
-    expect(merged.nodes).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: "alpha", repo: "repo-a" }),
-        expect.objectContaining({ id: "beta", repo: "repo-b" }),
-      ]),
-    );
+    // repo tags are now stable cross-repo keys derived from remote or local path hash
+    const alphaNode = merged.nodes.find((n) => n.id === "alpha");
+    const betaNode = merged.nodes.find((n) => n.id === "beta");
+    expect(alphaNode?.repo).toMatch(/^repo:(local\/repo-a@[0-9a-f]{8}|github\.com\/.+)$/);
+    expect(betaNode?.repo).toMatch(/^repo:(local\/repo-b@[0-9a-f]{8}|github\.com\/.+)$/);
+    expect(alphaNode?.repo).not.toBe(betaNode?.repo);
   });
 
   it("supports one-shot update rebuilds for code-only projects", async () => {

--- a/tests/repo-key.test.ts
+++ b/tests/repo-key.test.ts
@@ -1,0 +1,285 @@
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { repoKey, commitId, branchId, prId, type RepoKeyRunner } from "../src/repo-key.js";
+import { mergeGraphsFromFiles } from "../src/merge-graphs.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeRunner(remoteUrl: string | null): RepoKeyRunner {
+  return {
+    run(_command: string, args: string[], _cwd: string): string {
+      if (args[0] === "remote" && args[1] === "get-url") {
+        if (remoteUrl === null) throw new Error("no remote configured");
+        return remoteUrl;
+      }
+      throw new Error(`unexpected git args: ${args.join(" ")}`);
+    },
+  };
+}
+
+function remoteRunner(map: Record<string, string | null>): RepoKeyRunner {
+  return {
+    run(_command: string, args: string[], cwd: string): string {
+      if (args[0] === "remote" && args[1] === "get-url") {
+        const remote = map[cwd];
+        if (remote === undefined) throw new Error(`no entry for cwd: ${cwd}`);
+        if (remote === null) throw new Error("no remote configured");
+        return remote;
+      }
+      throw new Error(`unexpected git args: ${args.join(" ")}`);
+    },
+  };
+}
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-repo-key-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// repoKey() — GitHub remotes
+// ---------------------------------------------------------------------------
+
+describe("repoKey — GitHub HTTPS", () => {
+  it("returns repo:github.com/owner/name for HTTPS URL", () => {
+    const runner = fakeRunner("https://github.com/acme/myrepo.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:github.com/acme/myrepo");
+  });
+
+  it("returns repo:github.com/owner/name for SSH URL", () => {
+    const runner = fakeRunner("git@github.com:acme/myrepo.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:github.com/acme/myrepo");
+  });
+
+  it("returns repo:github.com/owner/name for ssh:// URL", () => {
+    const runner = fakeRunner("ssh://git@github.com/acme/myrepo.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:github.com/acme/myrepo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repoKey() — Non-GitHub remotes (GitLab / self-hosted)
+// ---------------------------------------------------------------------------
+
+describe("repoKey — non-GitHub remote fallback", () => {
+  it("GitLab HTTPS → repo:gitlab.com/owner/name", () => {
+    const runner = fakeRunner("https://gitlab.com/owner/name.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:gitlab.com/owner/name");
+  });
+
+  it("GitLab SSH scp-style → repo:gitlab.com/owner/name", () => {
+    const runner = fakeRunner("git@gitlab.com:owner/name.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:gitlab.com/owner/name");
+  });
+
+  it("self-hosted HTTPS → repo:self-hosted.internal/org/project", () => {
+    const runner = fakeRunner("https://self-hosted.internal/org/project.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:self-hosted.internal/org/project");
+  });
+
+  it("self-hosted SSH URL → repo:git.corp.example/group/repo", () => {
+    const runner = fakeRunner("ssh://git@git.corp.example/group/repo.git");
+    expect(repoKey("/some/path", runner)).toBe("repo:git.corp.example/group/repo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repoKey() — No remote (local fallback)
+// ---------------------------------------------------------------------------
+
+describe("repoKey — no remote local fallback", () => {
+  it("returns repo:local/<basename>@<8-hex> when no remote", () => {
+    const runner = fakeRunner(null);
+    const absPath = resolve("/tmp/graphify-workspace/myproject");
+    const expectedHash = createHash("sha256").update(absPath).digest("hex").slice(0, 8);
+    const key = repoKey(absPath, runner);
+    expect(key).toBe(`repo:local/myproject@${expectedHash}`);
+  });
+
+  it("never returns bare basename without a hash suffix", () => {
+    const runner = fakeRunner(null);
+    const key = repoKey("/home/user/graphify", runner);
+    expect(key).not.toBe("graphify");
+    expect(key).not.toBe("repo:local/graphify");
+    expect(key).toMatch(/^repo:local\/graphify@[0-9a-f]{8}$/);
+  });
+
+  it("two paths with same basename but different paths produce different keys", () => {
+    const runner = fakeRunner(null);
+    const key1 = repoKey("/a/graphify", runner);
+    const key2 = repoKey("/b/graphify", runner);
+    expect(key1).not.toBe(key2);
+    // Both must include a hash suffix
+    expect(key1).toMatch(/^repo:local\/graphify@[0-9a-f]{8}$/);
+    expect(key2).toMatch(/^repo:local\/graphify@[0-9a-f]{8}$/);
+  });
+
+  it("is deterministic for the same path", () => {
+    const runner = fakeRunner(null);
+    expect(repoKey("/stable/path/myrepo", runner)).toBe(repoKey("/stable/path/myrepo", runner));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ID helpers
+// ---------------------------------------------------------------------------
+
+describe("commitId / branchId / prId", () => {
+  const key = "repo:github.com/acme/myrepo";
+
+  it("commitId formats as commit:<repoKey>@<sha>", () => {
+    expect(commitId(key, "abc123")).toBe("commit:repo:github.com/acme/myrepo@abc123");
+  });
+
+  it("branchId formats as branch:<repoKey>#<name>", () => {
+    expect(branchId(key, "main")).toBe("branch:repo:github.com/acme/myrepo#main");
+  });
+
+  it("prId formats as pr:<repoKey>#<n>", () => {
+    expect(prId(key, 42)).toBe("pr:repo:github.com/acme/myrepo#42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anti-collision: homonym repos (same basename, different remotes/paths)
+// ---------------------------------------------------------------------------
+
+describe("merge-graphs — homonym repo collision prevention", () => {
+  function makeGraphJson(nodes: Array<{ id: string; label: string }>): string {
+    return JSON.stringify({
+      directed: false,
+      graph: {},
+      nodes: nodes.map((n) => ({ ...n, source_file: "src/index.ts", file_type: "code" })),
+      links: [],
+    }, null, 2);
+  }
+
+  it("two repos with same basename but different GitHub remotes get different repo tags", () => {
+    const dir = tempDir();
+
+    // Both repos are named "graphify" but belong to different GitHub owners
+    const repoA = join(dir, "user-a", "graphify");
+    const repoB = join(dir, "user-b", "graphify");
+    mkdirSync(join(repoA, ".graphify"), { recursive: true });
+    mkdirSync(join(repoB, ".graphify"), { recursive: true });
+
+    const graphA = join(repoA, ".graphify", "graph.json");
+    const graphB = join(repoB, ".graphify", "graph.json");
+    writeFileSync(graphA, makeGraphJson([{ id: "NodeA", label: "Node A" }]), "utf-8");
+    writeFileSync(graphB, makeGraphJson([{ id: "NodeB", label: "Node B" }]), "utf-8");
+
+    const out = join(dir, "merged.json");
+
+    // Build a runner that maps each repo root to its remote
+    const runner = remoteRunner({
+      [resolve(repoA)]: "https://github.com/user-a/graphify.git",
+      [resolve(repoB)]: "https://github.com/user-b/graphify.git",
+    });
+
+    mergeGraphsFromFiles({ inputs: [graphA, graphB], out, runner });
+
+    // readFileSync imported at top
+    const merged = JSON.parse(readFileSync(out, "utf-8")) as {
+      nodes: Array<{ id: string; repo?: string }>;
+    };
+
+    const repoTags = merged.nodes.map((n) => n.repo);
+    expect(repoTags[0]).toBe("repo:github.com/user-a/graphify");
+    expect(repoTags[1]).toBe("repo:github.com/user-b/graphify");
+    expect(repoTags[0]).not.toBe(repoTags[1]);
+  });
+
+  it("two repos with same basename but no remote get different deterministic local keys", () => {
+    const dir = tempDir();
+
+    const repoA = join(dir, "team-x", "graphify");
+    const repoB = join(dir, "team-y", "graphify");
+    mkdirSync(join(repoA, ".graphify"), { recursive: true });
+    mkdirSync(join(repoB, ".graphify"), { recursive: true });
+
+    const graphA = join(repoA, ".graphify", "graph.json");
+    const graphB = join(repoB, ".graphify", "graph.json");
+    writeFileSync(graphA, makeGraphJson([{ id: "NodeX", label: "Node X" }]), "utf-8");
+    writeFileSync(graphB, makeGraphJson([{ id: "NodeY", label: "Node Y" }]), "utf-8");
+
+    const out = join(dir, "merged-local.json");
+
+    // No remotes configured → local fallback
+    const runner = remoteRunner({
+      [resolve(repoA)]: null,
+      [resolve(repoB)]: null,
+    });
+
+    mergeGraphsFromFiles({ inputs: [graphA, graphB], out, runner });
+
+    // readFileSync imported at top
+    const merged = JSON.parse(readFileSync(out, "utf-8")) as {
+      nodes: Array<{ id: string; repo?: string }>;
+    };
+
+    const repoTags = merged.nodes.map((n) => n.repo);
+    // Both have same basename "graphify" but MUST differ (different absolute paths)
+    expect(repoTags[0]).not.toBe(repoTags[1]);
+    // Both must follow the local fallback pattern
+    expect(repoTags[0]).toMatch(/^repo:local\/graphify@[0-9a-f]{8}$/);
+    expect(repoTags[1]).toMatch(/^repo:local\/graphify@[0-9a-f]{8}$/);
+  });
+
+  it("existing repo tag on node is preserved (not overwritten by runner)", () => {
+    const dir = tempDir();
+
+    const repoA = join(dir, "org", "graphify");
+    mkdirSync(join(repoA, ".graphify"), { recursive: true });
+
+    const graphPath = join(repoA, ".graphify", "graph.json");
+    // Node already has a repo attribute set
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "PinnedNode", label: "Pinned", source_file: "src/a.ts", file_type: "code", repo: "repo:github.com/legacy/owner" },
+        ],
+        links: [],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const otherRepo = join(dir, "other", "repo");
+    mkdirSync(join(otherRepo, ".graphify"), { recursive: true });
+    const graphB = join(otherRepo, ".graphify", "graph.json");
+    writeFileSync(graphB, makeGraphJson([{ id: "FreshNode", label: "Fresh" }]), "utf-8");
+
+    const out = join(dir, "merged-pinned.json");
+    const runner = remoteRunner({
+      [resolve(repoA)]: "https://github.com/new/owner.git",
+      [resolve(otherRepo)]: "https://github.com/other/repo.git",
+    });
+
+    mergeGraphsFromFiles({ inputs: [graphPath, graphB], out, runner });
+
+    // readFileSync imported at top
+    const merged = JSON.parse(readFileSync(out, "utf-8")) as {
+      nodes: Array<{ id: string; repo?: string }>;
+    };
+
+    const pinned = merged.nodes.find((n) => n.id === "PinnedNode");
+    expect(pinned?.repo).toBe("repo:github.com/legacy/owner");
+  });
+});


### PR DESCRIPTION
WP1 sous `MANDATE-graphify` (h2a, signé, artefact sha256:bac1a2cb…).

**Fait** : `src/repo-key.ts` — `repoKey()` à 3 niveaux (GitHub `repo:github.com/<owner>/<name>` → non-GitHub `repo:<host>/<path>` → local `repo:local/<basename>@<8hex>`, jamais le basename nu) + helpers `commitId/branchId/prId` ; fix `repoTagFromGraphPath` dans `src/merge-graphs.ts` (bug: tag par basename → collision repos homonymes), rétrocompat tag explicite conservée.

**Tests** : 65 verts (repo-key + cli-runtime), anti-collision homonymes prouvée, suite complète 1384/0 failed.

**Hors périmètre** (respecté) : extraction git (WP2), provenance (WP3), schéma Extraction intact.

Rapport : `segmentation/wp/WP1-REPORT.md` (repo codex-claude). Socle de WP2/WP3/WP5/WP6/WP9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)