### PR TITLE
fix(ontology): resolve ontology_status field (OBJ-2) + arc/scene-node join contract (Q3-1)

### DIFF
--- a/spec/SPEC_ONTOLOGY_LIFECYCLE_RECONCILIATION.md
+++ b/spec/SPEC_ONTOLOGY_LIFECYCLE_RECONCILIATION.md
@@ -457,6 +457,45 @@ Future tests should cover:
 - path jail blocks writes outside the repo
 - dirty worktree warning is emitted before apply
 
+## Arc↔scene-node join contract (Q3-1)
+
+Hierarchy arcs (`hierarchies.json`) carry `parent_id` / `child_id` which are
+**registry-native node ids** — the same value that appears as `id` on the
+corresponding scene node in `scene.json` (or `graph.json`).
+
+The join key is `id`, NOT `code`.
+
+`code` is a separate display field (e.g. `AM-01-04` for the node whose id is
+`AM0104`).  Its format is profile-specific and may be absent.
+
+### Canonical join pattern
+
+```typescript
+// arc:   { parent_id: "AM0101", child_id: "AM0104", … }
+// nodes: [{ id: "AM0104", code: "AM-01-04", label: "Investment Planning", … }]
+
+const nodeById = new Map(sceneNodes.map((n) => [n.id, n]));
+const parentNode = nodeById.get(arc.parent_id); // join on id
+const childNode  = nodeById.get(arc.child_id);  // join on id
+// ✗ NEVER: nodeById.get(arc.parent_id === node.code)  — code ≠ id in general
+```
+
+### Why code ≠ id
+
+| field  | example value | semantics                                       |
+|--------|---------------|-------------------------------------------------|
+| `id`   | `AM0104`      | Registry-native primary key (join anchor).      |
+| `code` | `AM-01-04`    | Human-readable display code (may differ, may be absent). |
+
+A consumer that joins arcs to nodes by `code` will silently miss matches
+whenever the registry uses a different format for its primary key.
+
+### Spec reference
+
+`OntologyHierarchyArc.parent_id` / `.child_id` — see `src/types.ts`.
+Arc generation — see `src/ontology-hierarchies.ts` (`compileHierarchies`).
+Scene node `id` field — see `StudioSceneNode` in `src/studio-scene.ts`.
+
 ## UAT
 
 - Public-pack-derived isolated UAT was executed in `/tmp/graphify-mystery-uat` from `../public-domaine-mystery-sagas-pack`.

--- a/src/ontology-hierarchies.ts
+++ b/src/ontology-hierarchies.ts
@@ -59,6 +59,13 @@ export function compileHierarchies(options: CompileHierarchiesOptions): Ontology
       // Skip self-loops (id == parent means "this is a root" in some schemas)
       if (parentValue === childValue) continue;
 
+      // Q3-1 — Arc↔scene-node join contract:
+      //   parent_id and child_id are REGISTRY-NATIVE NODE IDS (the value of
+      //   the id_column declared in the profile registry spec, e.g. process_id).
+      //   They match the `id` field on the corresponding scene node in
+      //   scene.json / graph.json.  The `code` field on a scene node is a
+      //   SEPARATE display field (e.g. "AM-01-04" for node id "AM0104") and is
+      //   NOT the join key.  Always join arcs to scene nodes by `id`, not `code`.
       arcs.push({
         hierarchy_id: hierarchyId,
         parent_id: parentValue,

--- a/src/studio-scene.ts
+++ b/src/studio-scene.ts
@@ -136,9 +136,16 @@ function copyOwnFields(
   }
 }
 
+// OBJ-2 (ACLP-AM review): `ontology_status` was allowlisted here but is
+// NEVER produced by any pipeline code (not emitted by compileHierarchies,
+// profile loading, reconciliation, or any other source). It would be a pure
+// duplicate of `status` (the 5-state lifecycle field: reference / attached /
+// needs_review / rejected / superseded) with no distinct semantics.
+// Decision: REMOVED. Use `status` for the lifecycle state, `review_status`
+// for the human-review axis. Any node/edge carrying `ontology_status` in
+// existing graph.json is a stale artefact; the viewer ignores unknown fields.
 const NODE_PROFILE_FIELDS = [
   "status",
-  "ontology_status",
   "review_status",
   "assertion_basis",
   "derivation_method",
@@ -162,7 +169,6 @@ const EDGE_PROFILE_FIELDS = [
   "assertion_basis",
   "review_status",
   "status",
-  "ontology_status",
   "derivation_method",
   "confidence_score",
   "evidence_refs",

--- a/tests/ontology-aclp-am.test.ts
+++ b/tests/ontology-aclp-am.test.ts
@@ -23,6 +23,19 @@ import type {
 // pipeline (see scripts/regen note in the fixture), so this test is a true
 // round-trip assertion, not a hand-fabricated snapshot.
 //
+// NIT — fixture topology:
+//   processes.csv  = MONO-ROOT demonstration fixture (super-root "AM" owns all
+//                    sub-domains). This is a simplified demo shape — the real
+//                    ACLP-AM has 17 independent L0 roots (AM01..AM90) with no
+//                    synthetic super-root.  Do NOT interpret this fixture as
+//                    implying that ACLP-AM has a single top-level node in
+//                    production; forest.csv is the representative topology.
+//
+//   forest.csv     = REPRESENTATIVE MULTI-ROOT fixture (4 ACLP roots AM01/AM03/
+//                    AM06/AM08 + 1 orphan parent).  This is the correct model:
+//                    the real ACLP-AM has 17 roots (no super-node).  Any
+//                    consumer that expects a single root is incorrect.
+//
 // DR-1 / DR-2 (WP4-B review): additional forest fixture tests verify:
 //   - Multi-root forest (N root_ids, no synthetic super-root)
 //   - Orphan tolerance: node with missing parent_id → treated as extra root

--- a/tests/studio-scene.test.ts
+++ b/tests/studio-scene.test.ts
@@ -140,6 +140,9 @@ describe("buildStudioScene — parity with studio buildScene", () => {
   });
 
   it("preserves profile metadata and fx/fy pins in the build-time scene", () => {
+    // OBJ-2: `ontology_status` is NOT in NODE_PROFILE_FIELDS (removed: never
+    // produced by any pipeline, duplicated `status` semantics). Input nodes
+    // may still carry it as a raw field but it will NOT be copied to the scene.
     const scene = buildStudioScene({
       nodes: [
         {
@@ -147,7 +150,6 @@ describe("buildStudioScene — parity with studio buildScene", () => {
           label: "Manage identity",
           node_type: "ACLPProcess",
           status: "validated",
-          ontology_status: "validated",
           parent_id: "AM0104",
           level: 2,
           fx: 120,
@@ -170,7 +172,6 @@ describe("buildStudioScene — parity with studio buildScene", () => {
     expect(scene.nodes[0]).toMatchObject({
       type: "ACLPProcess",
       status: "validated",
-      ontology_status: "validated",
       parent_id: "AM0104",
       level: 2,
       x: 120,
@@ -178,6 +179,8 @@ describe("buildStudioScene — parity with studio buildScene", () => {
       fx: 120,
       fy: -40,
     });
+    // ontology_status is not copied to the scene node (not in NODE_PROFILE_FIELDS)
+    expect((scene.nodes[0] as Record<string, unknown>)["ontology_status"]).toBeUndefined();
     expect(scene.nodes[1]).toMatchObject({ type: "ABPProcess", fixed: true });
     expect(scene.edges[0]).toMatchObject({
       relation: "candidate_maps_to",


### PR DESCRIPTION
Clôt les 2 loose ends du contrat de consommation viewer ontologie (revue ACLP-AM PR #121) — précondition pour que le peer aclp-am démarre son intégration A1-A3. Additif/réversible, ne touche pas les contrats v1 validés.

## OBJ-2 — `ontology_status` : RETIRÉ
Investigation : le champ n'est allowlisté que dans `NODE_PROFILE_FIELDS`/`EDGE_PROFILE_FIELDS` (src/studio-scene.ts, 7bbba08) + une fixture passthrough. **Jamais produit** nulle part (ni compileHierarchies, ni profil, ni réconciliation). `status` porte déjà le lifecycle 5-états. → doublon pur → retiré des deux allowlists (+ commentaire de décision) ; test ajouté qui confirme qu'il n'est PAS copié vers la scène.

## Q3-1 — contrat de jointure arc↔scene-node
- `spec/SPEC_ONTOLOGY_LIFECYCLE_RECONCILIATION.md` : section « Arc↔scene-node join contract » (parent_id/child_id = node ids registre = `sceneNode.id` ; `code` ≠ clé de jointure ; pattern de jointure + table id vs code).
- `src/ontology-hierarchies.ts` : commentaire au point de génération.

## Nit
`tests/ontology-aclp-am.test.ts` : commentaire clarifiant processes.csv = mono-racine démo vs forest.csv = représentatif multi-racines (réel ACLP = 17 racines, pas de super-nœud).

Hors scope : DR-3/DR-4 (lane v2 extracted) = increment C. Tests **1408/0 failed** ; lint+build OK.