### PR TITLE
feat(studio): show node descriptions (graph.json node.description) in the node panel

### DIFF
--- a/src/studio-assets.ts
+++ b/src/studio-assets.ts
@@ -125,7 +125,7 @@ export function serveStudioAsset(pathname: string): StudioAssetResult | null {
 }
 
 // ---------------------------------------------------------------------------
-// Per-entity sidecar (wiki description + occurrences) for the SPA right panel.
+// Per-entity sidecar (node description + occurrences) for the SPA right panel.
 // Mirrors the loaders in ontology-studio-workspace.ts, kept standalone so the
 // SPA route does not depend on the server-rendered workspace model.
 // ---------------------------------------------------------------------------
@@ -160,6 +160,62 @@ function loadDescriptionIndex(stateDir: string): WikiSidecarIndex | null {
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// graph.json node-description index (WP11). Each node carries a one-sentence
+// `description`; the sidecar surfaces it as the primary description. graph.json
+// can be multi-MB and the entity route is hit once per selection, so the
+// id -> description map is cached and only rebuilt when the file's mtime moves.
+// ---------------------------------------------------------------------------
+
+interface GraphNodeDescriptionCacheEntry {
+  mtimeMs: number;
+  byId: Map<string, string>;
+}
+
+const graphDescriptionCache = new Map<string, GraphNodeDescriptionCacheEntry>();
+
+interface GraphFileShape {
+  nodes?: Array<{ id?: unknown; description?: unknown }>;
+}
+
+/**
+ * Map of node id -> trimmed non-empty `description` from `<stateDir>/graph.json`.
+ * Returns an empty map when graph.json is missing/unreadable. Cached per state
+ * dir, invalidated on mtime change (so an in-process rebuild is picked up).
+ */
+function loadGraphNodeDescriptions(stateDir: string): Map<string, string> {
+  const graphPath = join(stateDir, "graph.json");
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(graphPath).mtimeMs;
+  } catch {
+    graphDescriptionCache.delete(stateDir);
+    return new Map();
+  }
+  const cached = graphDescriptionCache.get(stateDir);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.byId;
+
+  const byId = new Map<string, string>();
+  const graph = loadJsonSafe<GraphFileShape>(graphPath);
+  if (graph && Array.isArray(graph.nodes)) {
+    for (const node of graph.nodes) {
+      const id = node?.id;
+      if (typeof id !== "string" || !id) continue;
+      const desc = node?.description;
+      if (typeof desc !== "string") continue;
+      const trimmed = desc.trim();
+      if (trimmed) byId.set(id, trimmed);
+    }
+  }
+  graphDescriptionCache.set(stateDir, { mtimeMs, byId });
+  return byId;
+}
+
+/** Test seam: drop the cached graph.json node-description index. */
+export function __resetGraphDescriptionCache(): void {
+  graphDescriptionCache.clear();
+}
+
 export interface EntitySidecarResponse {
   id: string;
   description: { status: string; description: string | null } | null;
@@ -167,19 +223,32 @@ export interface EntitySidecarResponse {
 }
 
 /**
- * Build the `/api/ontology/entity/<id>` payload: the wiki description sidecar
- * entry (normalised to { status, description }) plus the occurrence record for
- * this node id, if any. Returns the shape the SPA's EntityPanel expects.
+ * Build the `/api/ontology/entity/<id>` payload: the node description
+ * (normalised to { status, description }) plus the occurrence record for this
+ * node id, if any. Returns the shape the SPA's EntityPanel expects.
+ *
+ * Description precedence (WP11): the node's own `graph.json` description wins;
+ * the opt-in wiki sidecar index is consulted only when the node has none. So a
+ * graph whose nodes all carry descriptions reports them all here even without a
+ * wiki sidecar present.
  */
 export function buildEntitySidecar(stateDir: string, id: string): EntitySidecarResponse {
-  const index = loadDescriptionIndex(stateDir);
-  const entry = index?.nodes?.[id];
   let description: EntitySidecarResponse["description"] = null;
-  if (entry) {
-    description =
-      entry.status === "generated"
-        ? { status: "generated", description: entry.description ?? null }
-        : { status: "insufficient_evidence", description: null };
+
+  // 1. graph.json node.description (the default WP11 source).
+  const nodeDescription = loadGraphNodeDescriptions(stateDir).get(id);
+  if (nodeDescription) {
+    description = { status: "generated", description: nodeDescription };
+  } else {
+    // 2. Fall back to the opt-in wiki description sidecar.
+    const index = loadDescriptionIndex(stateDir);
+    const entry = index?.nodes?.[id];
+    if (entry) {
+      description =
+        entry.status === "generated"
+          ? { status: "generated", description: entry.description ?? null }
+          : { status: "insufficient_evidence", description: null };
+    }
   }
 
   const occRaw = loadJsonSafe<Record<string, unknown>>(join(stateDir, "ontology", "occurrences.json"));

--- a/studio/src/tests/entityPanel.test.js
+++ b/studio/src/tests/entityPanel.test.js
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The right-hand entity panel renders the per-node description. The description
+ * is sourced from the entity sidecar (`entity.description`), which now carries
+ * the graph.json `node.description` (WP11) as a { status: "generated",
+ * description } record (see src/studio-assets.ts buildEntitySidecar). This test
+ * pins the panel's derivation + render so the node description keeps reaching
+ * the UI. Source-string assertions match the studio's existing component-test
+ * style (see appHeader.test.js).
+ */
+const panelSource = readFileSync(
+  resolve(process.cwd(), "src/components/EntityPanel.svelte"),
+  "utf8",
+);
+
+describe("EntityPanel description", () => {
+  it("derives the description from the entity sidecar (entity.description)", () => {
+    // Reads the sidecar produced by buildEntitySidecar, which surfaces
+    // graph.json node.description as a generated entry.
+    expect(panelSource).toMatch(/const sidecar = entity\?\.description;/);
+    expect(panelSource).toMatch(/sidecar\.status === "generated"/);
+    expect(panelSource).toMatch(/typeof sidecar\.description === "string"/);
+    expect(panelSource).toMatch(/return sidecar\.description\.trim\(\);/);
+  });
+
+  it("renders the description text in a Description section when present", () => {
+    expect(panelSource).toMatch(/{#if description}/);
+    expect(panelSource).toMatch(/<h3 class="entity-section-heading">Description<\/h3>/);
+    expect(panelSource).toMatch(
+      /<div class="entity-description">\{@html renderInlineMarkdown\(description\)\}<\/div>/,
+    );
+  });
+
+  it("keeps the description readable (small, wrapped) via .entity-description", () => {
+    // Small font + line-height for a one-sentence node description.
+    expect(panelSource).toMatch(/\.entity-description\s*{[\s\S]*line-height:\s*1\.5;[\s\S]*}/);
+    expect(panelSource).toMatch(/\.entity-description\s*{[\s\S]*font-size:\s*0\.9rem;[\s\S]*}/);
+  });
+});

--- a/tests/studio-assets.test.ts
+++ b/tests/studio-assets.test.ts
@@ -1,17 +1,23 @@
 /**
  * Track G studio-svelte — server-side plumbing for the client Svelte SPA.
  *
- * Covers the two load-bearing helpers added to serve the SPA + its per-entity
+ * Covers the load-bearing helpers added to serve the SPA + its per-entity
  * data: the static-asset traversal guard and the entity sidecar assembly
- * (wiki description + occurrences) read from a `.graphify` state dir.
+ * (node description + occurrences) read from a `.graphify` state dir, including
+ * the WP11 precedence where each graph.json node's own `description` wins over
+ * the opt-in wiki sidecar.
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { buildEntitySidecar, serveStudioAsset } from "../src/studio-assets.js";
+import {
+  buildEntitySidecar,
+  serveStudioAsset,
+  __resetGraphDescriptionCache,
+} from "../src/studio-assets.js";
 
 function makeStateDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "graphify-studio-assets-"));
@@ -34,7 +40,53 @@ function makeStateDir(): string {
   return dir;
 }
 
+/** Write a graph.json carrying WP11 per-node `description` fields. */
+function writeGraph(dir: string, nodes: Array<Record<string, unknown>>): void {
+  writeFileSync(join(dir, "graph.json"), JSON.stringify({ nodes, edges: [] }));
+}
+
+afterEach(() => {
+  __resetGraphDescriptionCache();
+});
+
 describe("buildEntitySidecar", () => {
+  it("surfaces the graph.json node.description as the generated description (WP11)", () => {
+    const dir = makeStateDir();
+    writeGraph(dir, [
+      { id: "sym_a", description: "Entry point that wires the asset routes." },
+    ]);
+    const res = buildEntitySidecar(dir, "sym_a");
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "Entry point that wires the asset routes.",
+    });
+  });
+
+  it("prefers node.description over the wiki sidecar for the same id", () => {
+    const dir = makeStateDir();
+    // work_a also exists in the wiki sidecar ("A landmark **novel**."); the
+    // node's own description must win.
+    writeGraph(dir, [{ id: "work_a", description: "Node-level one-liner." }]);
+    const res = buildEntitySidecar(dir, "work_a");
+    expect(res.description).toEqual({ status: "generated", description: "Node-level one-liner." });
+  });
+
+  it("falls back to the wiki sidecar when the node has no description", () => {
+    const dir = makeStateDir();
+    // graph.json present but work_a carries no description -> wiki fallback.
+    writeGraph(dir, [{ id: "work_a" }]);
+    const res = buildEntitySidecar(dir, "work_a");
+    expect(res.description).toEqual({ status: "generated", description: "A landmark **novel**." });
+  });
+
+  it("ignores blank/non-string node descriptions and falls back", () => {
+    const dir = makeStateDir();
+    writeGraph(dir, [{ id: "place_b", description: "   " }]);
+    const res = buildEntitySidecar(dir, "place_b");
+    // Blank node description -> wiki sidecar (insufficient_evidence) takes over.
+    expect(res.description).toEqual({ status: "insufficient_evidence", description: null });
+  });
+
   it("returns the generated wiki description for a node", () => {
     const dir = makeStateDir();
     const res = buildEntitySidecar(dir, "work_a");


### PR DESCRIPTION
WP11 writes a one-sentence description onto each graph.json node, but the studio panel showed nothing (it read the old opt-in wiki sidecar). Fix: `buildEntitySidecar` (src/studio-assets.ts) now prefers the node's own graph.json `description` (status 'generated'), falling back to the wiki sidecar. Server route + build-studio-demo entities.json both carry it; EntityPanel already renders it. Full suite 1423 passed. SPA unchanged (server/build-side fix).