### PR TITLE
fix(agent-stats): WP9 Phase 1.5 — correctness, privacy & alignment fixes (adversarial review)

### DIFF
--- a/src/agent-stats/claude-transcript.ts
+++ b/src/agent-stats/claude-transcript.ts
@@ -14,9 +14,28 @@
  * signals. Cross-host semantics live in normalize.ts.
  */
 
-import { classifyGitVerb, emptyGroundTruth, scrapeGroundTruth } from "./git-evidence.js";
+import { classifyGitVerb, emptyGroundTruth, isGroundTruthVerb, prUrlInRepo, scrapeGroundTruth } from "./git-evidence.js";
 import { redactExcerpt } from "./redact.js";
 import type { EvidenceSnippet, GitAction, GroundTruth, TokenTotals } from "./types.js";
+
+export interface ClaudeParseOptions {
+  /**
+   * Repo root for cross-repo segmentation. When set, git evidence, branches,
+   * files and token usage only accumulate from records whose cwd is at or
+   * under this root — a session's foreign-repo work is not counted.
+   */
+  scopeRoot?: string;
+  /** Origin repo ("owner/name") used to scope scraped PR urls. */
+  originRepo?: string;
+}
+
+interface PendingTool {
+  name: string;
+  command: string;
+  verb: GitAction["verb"] | null;
+  inScope: boolean;
+  timestamp?: string;
+}
 
 export interface RawClaudeSession {
   host: "claude";
@@ -65,14 +84,26 @@ function pushUnique(arr: string[], v: unknown): void {
   if (typeof v === "string" && v && !arr.includes(v)) arr.push(v);
 }
 
+/** True when `cwd` is unknown or sits at/under `scopeRoot` (none → in scope). */
+function cwdInScope(cwd: unknown, scopeRoot?: string): boolean {
+  if (!scopeRoot) return true;
+  if (typeof cwd !== "string" || !cwd) return true; // unknown cwd: keep (conservative)
+  return cwd === scopeRoot || cwd.startsWith(scopeRoot + "/");
+}
+
 /**
  * Parse one Claude transcript's JSONL content into a single RawClaudeSession.
  * `home` is the user's home dir, used to redact stored excerpts.
  */
-export function parseClaudeTranscript(content: string, sessionIdHint: string, home = ""): RawClaudeSession {
+export function parseClaudeTranscript(
+  content: string,
+  sessionIdHint: string,
+  home = "",
+  opts: ClaudeParseOptions = {},
+): RawClaudeSession {
   const session = emptySession(sessionIdHint);
-  // tool_use id -> { name, input } so we can join a later tool_result.
-  const pendingTools = new Map<string, { name: string; command: string; timestamp?: string }>();
+  // tool_use id -> paired input so a later tool_result can be verb-gated.
+  const pendingTools = new Map<string, PendingTool>();
 
   for (const rawLine of content.split("\n")) {
     const line = rawLine.trim();
@@ -84,16 +115,17 @@ export function parseClaudeTranscript(content: string, sessionIdHint: string, ho
       continue;
     }
     const type = r?.type;
+    const inScope = cwdInScope(r?.cwd, opts.scopeRoot);
     if (typeof r?.sessionId === "string") session.sessionId = r.sessionId;
     pushUnique(session.cwds, r?.cwd);
-    pushUnique(session.branches, r?.gitBranch);
+    if (inScope) pushUnique(session.branches, r?.gitBranch);
     if (typeof r?.version === "string") session.version = r.version;
     if (typeof r?.timestamp === "string") {
       if (!session.startedAt || r.timestamp < session.startedAt) session.startedAt = r.timestamp;
       if (!session.endedAt || r.timestamp > session.endedAt) session.endedAt = r.timestamp;
     }
 
-    if (type === "pr-link" && typeof r?.prUrl === "string") {
+    if (type === "pr-link" && typeof r?.prUrl === "string" && inScope && prUrlInRepo(r.prUrl, opts.originRepo)) {
       pushUnique(session.prUrls, r.prUrl);
       pushUnique(session.groundTruth.prUrls, r.prUrl);
       session.evidence.push({ kind: "pr-url", text: redactExcerpt(r.prUrl, home), timestamp: r.timestamp });
@@ -103,7 +135,7 @@ export function parseClaudeTranscript(content: string, sessionIdHint: string, ho
     if (type === "assistant" && message && typeof message === "object") {
       pushUnique(session.models, message.model);
       const usage = message.usage;
-      if (usage && typeof usage === "object") {
+      if (usage && typeof usage === "object" && inScope) {
         const inTok = Number(usage.input_tokens) || 0;
         const outTok = Number(usage.output_tokens) || 0;
         const cacheRead = Number(usage.cache_read_input_tokens) || 0;
@@ -116,7 +148,7 @@ export function parseClaudeTranscript(content: string, sessionIdHint: string, ho
       const blocks = Array.isArray(message.content) ? message.content : [];
       for (const b of blocks) {
         if (b && typeof b === "object" && b.type === "tool_use") {
-          recordToolUse(session, pendingTools, b, r?.timestamp, home);
+          recordToolUse(session, pendingTools, b, r?.timestamp, home, inScope);
         }
       }
     }
@@ -126,9 +158,13 @@ export function parseClaudeTranscript(content: string, sessionIdHint: string, ho
       for (const b of blocks) {
         if (b && typeof b === "object" && b.type === "tool_result") {
           const tool = pendingTools.get(b.tool_use_id);
-          if (tool && tool.name === "Bash") {
+          // SPOOF-RESISTANCE: only scrape ground truth from the output of a
+          // Bash command whose PAIRED INPUT classified as a mutating git verb
+          // and ran inside the repo scope. A `cat`/`grep` of a foreign
+          // transcript or CI log never acquires its shas / PR urls.
+          if (tool && tool.name === "Bash" && tool.inScope && isGroundTruthVerb(tool.verb)) {
             const before = session.groundTruth.commitShas.length + session.groundTruth.prUrls.length;
-            scrapeGroundTruth(toText(b.content), session.groundTruth);
+            scrapeGroundTruth(toText(b.content), session.groundTruth, opts.originRepo);
             const after = session.groundTruth.commitShas.length + session.groundTruth.prUrls.length;
             if (after > before) {
               session.evidence.push({
@@ -147,20 +183,21 @@ export function parseClaudeTranscript(content: string, sessionIdHint: string, ho
 
 function recordToolUse(
   session: RawClaudeSession,
-  pendingTools: Map<string, { name: string; command: string; timestamp?: string }>,
+  pendingTools: Map<string, PendingTool>,
   block: any,
   timestamp: string | undefined,
   home: string,
+  inScope: boolean,
 ): void {
   const name: string = block.name ?? "";
   const input = block.input ?? {};
-  if (name === "Edit" || name === "Write" || name === "NotebookEdit") {
+  if ((name === "Edit" || name === "Write" || name === "NotebookEdit") && inScope) {
     pushUnique(session.filesTouched, input.file_path ?? input.notebook_path);
   }
   if (name === "Bash" && typeof input.command === "string") {
     const verb = classifyGitVerb(input.command);
-    pendingTools.set(block.id, { name, command: input.command, timestamp });
-    if (verb) {
+    pendingTools.set(block.id, { name, command: input.command, verb, inScope, timestamp });
+    if (verb && inScope) {
       session.gitActions.push({ verb, command: redactExcerpt(input.command, home, 160), timestamp });
       if (verb === "checkout-b") {
         session.evidence.push({ kind: "git-checkout", text: redactExcerpt(input.command, home, 120), timestamp });
@@ -169,6 +206,6 @@ function recordToolUse(
       }
     }
   } else {
-    pendingTools.set(block.id, { name, command: "", timestamp });
+    pendingTools.set(block.id, { name, command: "", verb: null, inScope, timestamp });
   }
 }

--- a/src/agent-stats/codex-rollout.ts
+++ b/src/agent-stats/codex-rollout.ts
@@ -18,9 +18,26 @@
  * (string or argv array) and `workdir`.
  */
 
-import { classifyGitVerb, emptyGroundTruth, scrapeGroundTruth } from "./git-evidence.js";
+import { classifyGitVerb, emptyGroundTruth, isGroundTruthVerb, scrapeGroundTruth } from "./git-evidence.js";
 import { redactExcerpt } from "./redact.js";
 import type { EvidenceSnippet, GitAction, GroundTruth, SessionParent, TokenTotals } from "./types.js";
+
+export interface CodexParseOptions {
+  /**
+   * Repo root for cross-repo segmentation. When set, git evidence only
+   * accumulates from calls whose effective workdir is at or under this root.
+   */
+  scopeRoot?: string;
+  /** Origin repo ("owner/name") used to scope scraped PR urls. */
+  originRepo?: string;
+}
+
+interface PendingCall {
+  command: string;
+  verb: GitAction["verb"] | null;
+  inScope: boolean;
+  timestamp?: string;
+}
 
 export interface RawCodexSession {
   host: "codex";
@@ -38,9 +55,6 @@ export interface RawCodexSession {
   filesTouched: string[];
   prUrls: string[];
   evidence: EvidenceSnippet[];
-  /** Transient: last git command seen, to tie the next output to it. */
-  _lastGitCommand?: string;
-  _lastGitTs?: string;
 }
 
 function pushUnique(arr: string[], v: unknown): void {
@@ -91,9 +105,24 @@ function emptySession(sessionId: string): RawCodexSession {
   };
 }
 
+/** True when `cwd` is unknown or sits at/under `scopeRoot` (none → in scope). */
+function cwdInScope(cwd: string | undefined, scopeRoot?: string): boolean {
+  if (!scopeRoot) return true;
+  if (!cwd) return true; // unknown workdir: keep (conservative)
+  return cwd === scopeRoot || cwd.startsWith(scopeRoot + "/");
+}
+
 /** Parse one Codex rollout's JSONL content into a single RawCodexSession. */
-export function parseCodexRollout(content: string, sessionIdHint: string, home = ""): RawCodexSession {
+export function parseCodexRollout(
+  content: string,
+  sessionIdHint: string,
+  home = "",
+  opts: CodexParseOptions = {},
+): RawCodexSession {
   const session = emptySession(sessionIdHint);
+  // call_id -> paired input so a later function_call_output can be verb-gated.
+  const pendingCalls = new Map<string, PendingCall>();
+  let currentCwd: string | undefined;
   for (const rawLine of content.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
@@ -113,6 +142,7 @@ export function parseCodexRollout(content: string, sessionIdHint: string, home =
     if (type === "session_meta") {
       if (typeof payload.id === "string") session.sessionId = payload.id;
       pushUnique(session.cwds, payload.cwd);
+      if (typeof payload.cwd === "string") currentCwd = payload.cwd;
       if (typeof payload.cli_version === "string") session.version = payload.cli_version;
       const git = payload.git;
       if (git && typeof git === "object") pushUnique(session.branches, git.branch);
@@ -135,45 +165,51 @@ export function parseCodexRollout(content: string, sessionIdHint: string, home =
     if (type === "turn_context") {
       pushUnique(session.models, payload.model);
       pushUnique(session.cwds, payload.cwd);
+      if (typeof payload.cwd === "string") currentCwd = payload.cwd;
       continue;
     }
 
     if (type === "response_item" && payload.type === "function_call") {
       const command = commandFromArgs(payload.arguments);
-      pushUnique(session.cwds, workdirFromArgs(payload.arguments));
+      const workdir = workdirFromArgs(payload.arguments);
+      pushUnique(session.cwds, workdir);
+      const inScope = cwdInScope(workdir ?? currentCwd, opts.scopeRoot);
       // apply_patch tool — record touched files heuristically.
-      if (payload.name === "apply_patch" || /apply_patch/.test(command)) {
+      if ((payload.name === "apply_patch" || /apply_patch/.test(command)) && inScope) {
         for (const m of command.matchAll(/\*\*\* (?:Add|Update|Delete) File: (.+)/g)) {
           if (m[1]) pushUnique(session.filesTouched, m[1].trim());
         }
       }
       const verb = classifyGitVerb(command);
-      if (verb) {
+      if (typeof payload.call_id === "string") {
+        pendingCalls.set(payload.call_id, { command, verb, inScope, timestamp: r?.timestamp });
+      }
+      if (verb && inScope) {
         session.gitActions.push({ verb, command: redactExcerpt(command, home, 160), timestamp: r?.timestamp });
         if (verb === "checkout-b") {
           session.evidence.push({ kind: "git-checkout", text: redactExcerpt(command, home, 120), timestamp: r?.timestamp });
         } else if (verb === "push") {
           session.evidence.push({ kind: "git-push", text: redactExcerpt(command, home, 120), timestamp: r?.timestamp });
         }
-        // Remember the last git command so the next output can be tied to it.
-        session._lastGitCommand = command;
-        session._lastGitTs = r?.timestamp;
-      } else {
-        session._lastGitCommand = undefined;
       }
       continue;
     }
 
     if (type === "response_item" && payload.type === "function_call_output") {
+      // SPOOF-RESISTANCE: pair the output to its call_id and only scrape when
+      // the PAIRED INPUT classified as a mutating git verb inside the repo
+      // scope. Outputs of `cat`/`grep`/read-only git never feed ground truth.
+      const call = typeof payload.call_id === "string" ? pendingCalls.get(payload.call_id) : undefined;
+      if (!call || !call.inScope || !isGroundTruthVerb(call.verb)) continue;
       const output = typeof payload.output === "string" ? payload.output : JSON.stringify(payload.output ?? "");
       const before = session.groundTruth.commitShas.length + session.groundTruth.prUrls.length;
-      scrapeGroundTruth(output, session.groundTruth);
+      scrapeGroundTruth(output, session.groundTruth, opts.originRepo);
       const after = session.groundTruth.commitShas.length + session.groundTruth.prUrls.length;
       if (after > before) {
         session.evidence.push({
           kind: /pull\//.test(output) ? "pr-url" : "git-commit",
-          text: redactExcerpt(`${session._lastGitCommand ?? "git"} => ${output}`, home),
-          timestamp: session._lastGitTs,
+          text: redactExcerpt(`${call.command} => ${output}`, home),
+          timestamp: call.timestamp,
         });
         for (const u of session.groundTruth.prUrls) pushUnique(session.prUrls, u);
       }

--- a/src/agent-stats/correlate.ts
+++ b/src/agent-stats/correlate.ts
@@ -22,6 +22,7 @@
  *           worktree whose lifetime overlaps the branch's commits. Weakest.
  */
 
+import { branchFromCheckoutCommand } from "./git-evidence.js";
 import { matchInstance, type H2aInstance } from "./registry.js";
 import { resolveIdentity } from "./identity.js";
 import type { TrackIndex, TrackItem } from "./track-join.js";
@@ -77,6 +78,22 @@ function shaMatches(observed: string, known: string): boolean {
 }
 
 /**
+ * Branches the session DEMONSTRABLY worked: a branch its own `git commit`
+ * output named (`[branch sha]`), or one it created via `checkout -b` /
+ * `switch -c`. Merely OBSERVING a branch (host metadata) is not work — that
+ * is what made rank-2/4/5 spoofable on read-only sessions.
+ */
+export function workedBranches(fact: SessionFact): Set<string> {
+  const out = new Set<string>(fact.groundTruth.branches);
+  for (const action of fact.gitActions) {
+    if (action.verb !== "checkout-b") continue;
+    const branch = branchFromCheckoutCommand(action.command);
+    if (branch) out.add(branch);
+  }
+  return out;
+}
+
+/**
  * Produce ranked, evidence-tagged correlation links for every session.
  * A session may emit multiple links (e.g. one per commit it created, plus its
  * h2a identity link).
@@ -89,6 +106,7 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
   for (const fact of input.facts) {
     const inst = matchInstance(input.instances, fact.host, fact.cwds);
     const agentId = resolveIdentity(fact, inst).agentId;
+    const worked = workedBranches(fact);
 
     // ----- rank 1: commit-sha from this session's own git commit output -----
     for (const observed of fact.groundTruth.commitShas) {
@@ -115,12 +133,13 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
     // branch landed a (squashed) commit on the base, attribute THAT commit to
     // the session. The merge commit's sha is never one the session printed, so
     // rank 1 can't catch it; this is the bridge from branch work to main.
-    for (const branch of fact.branchesObserved) {
+    for (const branch of new Set([...fact.branchesObserved, ...worked])) {
       if (isHousekeepingBranch(branch)) continue;
       const merge = mergeByBranch.get(branch);
       if (!merge || !merge.mergeCommit) continue;
-      const didWork = fact.gitActions.some((a) => a.verb === "commit" || a.verb === "checkout-b");
-      if (!didWork) continue;
+      // BRANCH-SCOPED: the session must have committed on / created THAT
+      // branch — committing somewhere else does not earn this squash commit.
+      if (!worked.has(branch)) continue;
       links.push({
         factId: fact.factId,
         agentId,
@@ -155,8 +174,8 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
         (x): x is string => Boolean(x),
       );
       for (const tid of threadCandidates) {
-        const item = input.trackIndex.byThreadId.get(tid.toLowerCase());
-        if (item) {
+        // MULTI-WP: an id mandated to several WPs links to ALL of them.
+        for (const item of input.trackIndex.byThreadId.get(tid.toLowerCase()) ?? []) {
           emitWp(
             item,
             "track-wp-thread-id",
@@ -166,8 +185,7 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
       }
       // h2a instance id (registered) appears in delegation envelopes.
       if (inst) {
-        const item = input.trackIndex.byH2aId.get(inst.id);
-        if (item) {
+        for (const item of input.trackIndex.byH2aId.get(inst.id) ?? []) {
           emitWp(
             item,
             "track-wp-h2a-id",
@@ -177,12 +195,16 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
       }
     }
 
-    // ----- rank 4: h2a registry identity -----
+    // ----- rank 4: h2a registry identity (IDENTITY ONLY) -----
+    // The registry proves WHO the session is, never WHAT it shipped. A branch
+    // label is attached only when the session committed on / created that
+    // exact branch itself; merely sitting on a branch earns nothing.
     if (inst) {
+      const evidencedBranch = Array.from(worked).find((b) => !isHousekeepingBranch(b));
       links.push({
         factId: fact.factId,
         agentId,
-        target: { kind: "branch", branch: fact.branchesObserved[0] ?? "(workspace)" },
+        target: { kind: "branch", branch: evidencedBranch ?? "(workspace)" },
         rank: 4,
         rule: "h2a-registry",
         confidence: "medium",
@@ -193,8 +215,8 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
     // ----- rank 5: worktree × branch × time window (weak) -----
     for (const branch of fact.branchesObserved) {
       if (isHousekeepingBranch(branch)) continue;
-      // Only emit when the session actually performed a commit/checkout-b on it
-      // and we have NOT already proven it via rank 1 or rank 2.
+      // Only emit when the session actually performed a commit/checkout-b on
+      // THAT branch and we have NOT already proven it via rank 1 or rank 2.
       const provenStrong = links.some(
         (l) =>
           l.factId === fact.factId &&
@@ -203,8 +225,7 @@ export function correlate(input: CorrelateInput): CorrelationLink[] {
           l.target.branch === branch,
       );
       if (provenStrong) continue;
-      const didWork = fact.gitActions.some((a) => a.verb === "commit" || a.verb === "checkout-b");
-      if (!didWork) continue;
+      if (!worked.has(branch)) continue;
       links.push({
         factId: fact.factId,
         agentId,
@@ -233,6 +254,13 @@ function findByScan(observed: string, commits: GitCommitMeta[]): GitCommitMeta |
   return commits.find((c) => shaMatches(observed, c.sha));
 }
 
-function isHousekeepingBranch(branch: string): boolean {
-  return branch === "HEAD" || branch === "" || branch.startsWith("worktree-agent-");
+/** Default/housekeeping branches never earn branch credit (incl. `main`). */
+export function isHousekeepingBranch(branch: string): boolean {
+  return (
+    branch === "HEAD" ||
+    branch === "" ||
+    branch === "main" ||
+    branch === "master" ||
+    branch.startsWith("worktree-agent-")
+  );
 }

--- a/src/agent-stats/discover.ts
+++ b/src/agent-stats/discover.ts
@@ -39,11 +39,28 @@ function listFilesRec(dir: string, filter: (name: string) => boolean, out: strin
   }
 }
 
-/** Discover Claude Code transcripts for a repo slug (`-home-antoinefa-src-foo`). */
+/**
+ * Discover Claude Code transcripts for a repo slug (`-home-user-src-foo`).
+ *
+ * The host derives one project dir PER CWD, so worktree sessions live in
+ * sibling dirs like `<slug>--claude-worktrees-agent-x` (`.`→`-`), NOT under
+ * `<slug>`. We therefore scan every dir whose name is the slug or extends it
+ * (`<slug>-…`); repo membership is re-checked later from the parsed cwd, so
+ * over-inclusion (e.g. a `<slug>-sibling` repo) is filtered out downstream.
+ */
 export function discoverClaude(home: string, repoSlug: string): TranscriptFile[] {
-  const dir = join(home, ".claude", "projects", repoSlug);
+  const projectsDir = join(home, ".claude", "projects");
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(projectsDir);
+  } catch {
+    return [];
+  }
   const files: string[] = [];
-  listFilesRec(dir, (n) => n.endsWith(".jsonl"), files);
+  for (const name of entries) {
+    if (name !== repoSlug && !name.startsWith(repoSlug + "-")) continue;
+    listFilesRec(join(projectsDir, name), (n) => n.endsWith(".jsonl"), files);
+  }
   return files.map((path) => ({ host: "claude" as const, path, sessionId: basenameNoExt(path) }));
 }
 
@@ -75,7 +92,11 @@ function codexThreadId(p: string): string {
   return m && m[1] ? m[1] : b;
 }
 
-/** Convert a repo root path to the Claude Code project slug. */
+/**
+ * Convert a repo root path to the Claude Code project slug. The host maps
+ * EVERY non-alphanumeric character to `-` (not just `/`): a worktree under
+ * `<root>/.claude/worktrees/x` becomes `<slug>--claude-worktrees-x`.
+ */
 export function repoSlug(repoRoot: string): string {
-  return repoRoot.replace(/\//g, "-");
+  return repoRoot.replace(/[^A-Za-z0-9]/g, "-");
 }

--- a/src/agent-stats/git-evidence.ts
+++ b/src/agent-stats/git-evidence.ts
@@ -24,6 +24,32 @@ export function classifyGitVerb(command: string): GitAction["verb"] | null {
 const COMMIT_LINE_RE = /\[([A-Za-z0-9._/\-]+)\s+([0-9a-f]{7,40})\]/g;
 const PR_URL_RE = /https?:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/g;
 
+/**
+ * SPOOF-RESISTANCE (Phase 1.5): ground truth may only be scraped from the
+ * OUTPUT of a command whose INPUT classified as one of these mutating git
+ * verbs. A session that merely `cat`s/`grep`s another transcript or a CI log
+ * must never acquire the shas / PR urls printed in that text.
+ */
+export const GROUND_TRUTH_VERBS: ReadonlySet<GitAction["verb"]> = new Set([
+  "commit",
+  "checkout-b",
+  "push",
+  "pr-create",
+  "pr-merge",
+]);
+
+/** True when a classified verb is allowed to feed {@link scrapeGroundTruth}. */
+export function isGroundTruthVerb(verb: GitAction["verb"] | null): boolean {
+  return verb !== null && GROUND_TRUTH_VERBS.has(verb);
+}
+
+/** Parse the branch name out of a `git checkout -b X` / `git switch -c X`. */
+export function branchFromCheckoutCommand(command: string): string | null {
+  if (typeof command !== "string") return null;
+  const m = command.match(/\bgit\s+(?:checkout\s+-b|switch\s+-c)\s+(?:--\s+)?([^\s;|&"']+)/);
+  return m && m[1] ? m[1] : null;
+}
+
 /** Empty ground-truth accumulator. */
 export function emptyGroundTruth(): GroundTruth {
   return { commitShas: [], branches: [], shaBranch: {}, prUrls: [] };
@@ -34,8 +60,10 @@ export function emptyGroundTruth(): GroundTruth {
  * Recognizes:
  *   - `[branch abc1234] subject`  → commit sha + branch
  *   - `https://github.com/<repo>/pull/<n>` → PR url
+ * When `originRepo` ("owner/name") is given, PR urls from other repos are
+ * ignored — a session cannot acquire foreign-repo PRs.
  */
-export function scrapeGroundTruth(output: string, acc: GroundTruth): void {
+export function scrapeGroundTruth(output: string, acc: GroundTruth, originRepo?: string): void {
   if (typeof output !== "string" || output.length === 0) return;
   let m: RegExpExecArray | null;
   COMMIT_LINE_RE.lastIndex = 0;
@@ -49,8 +77,14 @@ export function scrapeGroundTruth(output: string, acc: GroundTruth): void {
   PR_URL_RE.lastIndex = 0;
   while ((m = PR_URL_RE.exec(output)) !== null) {
     const url = m[0];
-    if (url && !acc.prUrls.includes(url)) acc.prUrls.push(url);
+    if (url && prUrlInRepo(url, originRepo) && !acc.prUrls.includes(url)) acc.prUrls.push(url);
   }
+}
+
+/** True when a PR url belongs to `originRepo` ("owner/name"); permissive when unknown. */
+export function prUrlInRepo(url: string, originRepo?: string): boolean {
+  if (!originRepo) return true;
+  return url.toLowerCase().startsWith(`https://github.com/${originRepo.toLowerCase()}/pull/`);
 }
 
 /**

--- a/src/agent-stats/index.ts
+++ b/src/agent-stats/index.ts
@@ -33,17 +33,28 @@ import {
   type RepoScope,
 } from "./normalize.js";
 import { loadH2aInstances, matchInstance, type H2aInstance } from "./registry.js";
-import { aggregate, formatSessionsTable, formatStatsTable } from "./stats.js";
+import { aggregate, costWeightedTokens, formatSessionsTable, formatStatsTable } from "./stats.js";
 import {
+  appendLinks,
   ensureStore,
+  linkKey,
   loadCursors,
   loadFacts,
+  loadLinks,
   resolveStore,
   saveCursors,
   saveFacts,
   type AgentStore,
 } from "./store.js";
-import type { AgentStatsRow, CorrelationLink, FileCursor, SessionFact } from "./types.js";
+import { githubRepoFromRemote } from "../pr.js";
+import { parseWpLabel, prUrlInRepo } from "./git-evidence.js";
+import type {
+  AgentStatsRow,
+  AttributionResidual,
+  CorrelationLink,
+  FileCursor,
+  SessionFact,
+} from "./types.js";
 
 export interface SyncOptions {
   repoRoot: string;
@@ -78,18 +89,35 @@ export function readGitCommits(repoRoot: string): GitCommitMeta[] {
   return commits;
 }
 
-function parseFile(file: TranscriptFile, home: string): { fact: SessionFact; agyHash?: string } | null {
+/** Resolve the origin GitHub repo ("owner/name") for PR-url scoping. */
+export function resolveOriginRepo(repoRoot: string, runner?: CommandRunner): string | undefined {
+  try {
+    const url = runner
+      ? runner.run("git", ["remote", "get-url", "origin"], repoRoot)
+      : safeExecGit(repoRoot, ["remote", "get-url", "origin"]);
+    return url ? githubRepoFromRemote(url) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseFile(
+  file: TranscriptFile,
+  home: string,
+  scope?: { repoRoot: string; originRepo?: string },
+): { fact: SessionFact; agyHash?: string } | null {
   let content: string;
   try {
     content = readFileSync(file.path, "utf-8");
   } catch {
     return null;
   }
+  const parseOpts = { scopeRoot: scope?.repoRoot, originRepo: scope?.originRepo };
   if (file.host === "claude") {
-    return { fact: normalizeClaude(parseClaudeTranscript(content, file.sessionId, home)) };
+    return { fact: normalizeClaude(parseClaudeTranscript(content, file.sessionId, home, parseOpts)) };
   }
   if (file.host === "codex") {
-    return { fact: normalizeCodex(parseCodexRollout(content, file.sessionId, home)) };
+    return { fact: normalizeCodex(parseCodexRollout(content, file.sessionId, home, parseOpts)) };
   }
   const raw = parseAgyChat(content, file.sessionId);
   // agy projectHash is on the header; if absent, derive from the dir name.
@@ -156,8 +184,9 @@ export function syncAgentStats(opts: SyncOptions): SyncResult {
   const store = resolveStore(opts.repoRoot);
   ensureStore(store);
   const scope = makeRepoScope(opts.repoRoot);
+  const originRepo = resolveOriginRepo(opts.repoRoot);
   const facts = loadFacts(store);
-  const cursors = loadCursors(store);
+  const cursors = loadCursors(store, home);
 
   const files: TranscriptFile[] = [
     ...discoverClaude(home, repoSlug(opts.repoRoot)),
@@ -187,7 +216,7 @@ export function syncAgentStats(opts: SyncOptions): SyncResult {
       continue;
     }
 
-    const result = parseFile(file, home);
+    const result = parseFile(file, home, { repoRoot: opts.repoRoot, originRepo });
     cursors.set(file.path, cursorCurrent(prev, file.path)!);
     if (!result) continue;
     parsed++;
@@ -198,7 +227,7 @@ export function syncAgentStats(opts: SyncOptions): SyncResult {
   }
 
   saveFacts(store, facts);
-  saveCursors(store, cursors);
+  saveCursors(store, cursors, home);
   return { scanned: files.length, parsed, inRepo, skipped, factsTotal: facts.size };
 }
 
@@ -220,12 +249,17 @@ export function prNumberFromUrl(url: string): number | undefined {
  * `gh` CLI is used; if `gh` is unavailable the whole step is skipped.
  */
 export function collectPrMerges(repoRoot: string, facts: SessionFact[], runner?: CommandRunner): PrMergeMeta[] {
+  // ORIGIN SCOPING: PR urls a session printed are only trusted when they
+  // belong to this repo's origin — a pasted/echoed foreign-repo PR url must
+  // not seed an attribution lookup.
+  const originRepo = resolveOriginRepo(repoRoot, runner);
   // Gather candidate (branch, prNumber) pairs from session evidence.
   const prByBranch = new Map<string, number>();
   const branches = new Set<string>();
   for (const fact of facts) {
     for (const b of fact.branchesObserved) if (b && b !== "HEAD") branches.add(b);
     for (const url of fact.groundTruth.prUrls) {
+      if (!prUrlInRepo(url, originRepo)) continue;
       const n = prNumberFromUrl(url);
       if (n === undefined) continue;
       // The PR url belongs to a branch the session pushed; tie it to the first
@@ -274,6 +308,8 @@ export interface ComputeResult {
   facts: SessionFact[];
   instances: H2aInstance[];
   trackItems: Map<string, TrackItem>;
+  /** Honest coverage: commits in git log NOT attributed to any agent. */
+  residual?: AttributionResidual;
 }
 
 export interface ComputeOptions {
@@ -313,24 +349,62 @@ export function computeAgentStats(
   const prMerges = opts.injectedPrMerges
     ?? (opts.skipPrMerges ? [] : collectPrMerges(repoRoot, facts));
 
-  const links = correlate({ facts, instances, commits, trackIndex, prMerges });
+  const derived = correlate({ facts, instances, commits, trackIndex, prMerges });
+
+  // PERSISTED ATTRIBUTION (append-only, re-derivable): keep every resolved
+  // link in `.graphify/agents/links.jsonl` so attribution does not decay when
+  // a branch is GC'd or a squash hides the original shas from `git log`.
+  const persisted = loadLinks(store);
+  const seen = new Set(derived.map(linkKey));
+  const links = [...derived];
+  for (const link of persisted) {
+    const key = linkKey(link);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push(link);
+  }
+  try {
+    appendLinks(store, derived);
+  } catch {
+    /* read-only store — stats still work, persistence is best-effort */
+  }
+
   const rows = aggregate({ facts, links, instances });
-  return { rows, links, facts, instances, trackItems };
+
+  // Residual coverage: commits nobody claimed (by 7-char sha prefix).
+  const attributed = new Set<string>();
+  for (const link of links) {
+    if (link.target.kind === "commit") attributed.add(link.target.sha.slice(0, 7).toLowerCase());
+  }
+  const unattributedCommits = commits.filter((c) => !attributed.has(c.sha.slice(0, 7).toLowerCase())).length;
+  const residual: AttributionResidual = { totalCommits: commits.length, unattributedCommits };
+
+  return { rows, links, facts, instances, trackItems, residual };
 }
 
 export interface WpAgentStatsResult {
   item?: TrackItem;
   /** Correlation links targeting this track item (Track-WP joins). */
   links: CorrelationLink[];
-  /** Sessions attributed to this WP, with their resolved agent identity. */
+  /** MANDATED sessions (Track-ledger join), with their resolved identity. */
   sessions: { fact: SessionFact; agentId: string; rule: CorrelationLink["rule"] }[];
+  /** EVIDENCED deliverers: sessions with commit-level proof on a WP branch. */
+  evidenced: { fact: SessionFact; agentId: string; via: string }[];
+  /** True when the mandated and evidenced agent sets disagree (both known). */
+  mismatch: boolean;
+  /** Per-WP rollup over the attributed sessions. */
+  rollup: { tokens: number; tokensWeighted: number; commits: number };
   /** All track items (for an "unknown id" error message in the CLI). */
   allItems: TrackItem[];
 }
 
 /**
- * Conductor view: everything attributed to one Track work-package item. Joins
- * sessions to the WP via the Track ledger (Codex thread-id / h2a instance id).
+ * Conductor view: everything attributed to one Track work-package item.
+ * Shows BOTH sides of attribution:
+ *   - mandated   — the ledger said this session/agent owns the WP;
+ *   - evidenced  — a session printed commit-level proof on a WP-labelled
+ *                  branch (rank 1/2), whether or not it was mandated.
+ * The two disagreeing is itself a signal, so it is surfaced, not hidden.
  */
 export function wpAgentStats(
   repoRoot: string,
@@ -354,7 +428,48 @@ export function wpAgentStats(
     })
     .filter((s): s is NonNullable<typeof s> => s !== null);
 
-  return { item, links: wpLinks, sessions, allItems };
+  // Evidenced deliverers: rank-1/2 commit links on a branch carrying this WP
+  // label (e.g. `wp9-…`). Independent of the mandate — that is the point.
+  const evidenced: WpAgentStatsResult["evidenced"] = [];
+  const evidencedSeen = new Set<string>();
+  if (item?.wp) {
+    for (const l of links) {
+      if (l.rank > 2 || l.target.kind !== "commit" || !l.target.branch) continue;
+      if (parseWpLabel(l.target.branch) !== item.wp) continue;
+      if (evidencedSeen.has(l.factId)) continue;
+      evidencedSeen.add(l.factId);
+      const fact = factById.get(l.factId);
+      if (fact) evidenced.push({ fact, agentId: l.agentId, via: `${l.rule} on ${l.target.branch}` });
+    }
+  }
+
+  const mandatedAgents = new Set(sessions.map((s) => s.agentId));
+  const evidencedAgents = new Set(evidenced.map((s) => s.agentId));
+  const mismatch =
+    mandatedAgents.size > 0 &&
+    evidencedAgents.size > 0 &&
+    (Array.from(evidencedAgents).some((a) => !mandatedAgents.has(a)) ||
+      Array.from(mandatedAgents).some((a) => !evidencedAgents.has(a)));
+
+  // Per-WP rollup over the union of attributed sessions.
+  const rollupFacts = new Map<string, SessionFact>();
+  for (const s of sessions) rollupFacts.set(s.fact.factId, s.fact);
+  for (const s of evidenced) rollupFacts.set(s.fact.factId, s.fact);
+  const commitShas = new Set<string>();
+  for (const l of links) {
+    if (l.rank > 2 || l.target.kind !== "commit") continue;
+    if (!rollupFacts.has(l.factId)) continue;
+    commitShas.add(l.target.sha.slice(0, 7));
+  }
+  let tokens = 0;
+  let tokensWeighted = 0;
+  for (const f of rollupFacts.values()) {
+    tokens += f.tokens.total || 0;
+    tokensWeighted += costWeightedTokens(f.tokens, f.host);
+  }
+  const rollup = { tokens, tokensWeighted, commits: commitShas.size };
+
+  return { item, links: wpLinks, sessions, evidenced, mismatch, rollup, allItems };
 }
 
 /** Render the `agent-stats wp <id>` conductor view as a text block. */
@@ -374,7 +489,7 @@ export function formatWpView(result: WpAgentStatsResult, trackItemId: string): s
     `Mandated h2a instances: ${item.h2aInstanceIds.length ? item.h2aInstanceIds.join(", ") : "-"}`,
     "",
   ];
-  if (result.sessions.length === 0) {
+  if (result.sessions.length === 0 && result.evidenced.length === 0) {
     lines.push("No sessions joined to this WP yet (run `agent-stats sync` first, or no transcript matched a mandated id).");
     return lines.join("\n");
   }
@@ -392,10 +507,25 @@ export function formatWpView(result: WpAgentStatsResult, trackItemId: string): s
   for (const [agentId, a] of agents) {
     lines.push(`  ${agentId}  —  ${a.sessions} session(s)  via ${Array.from(a.rules).join(",")}`);
   }
-  lines.push("", `Sessions (${result.sessions.length}):`);
+  lines.push("", `Mandated sessions (${result.sessions.length}):`);
   for (const s of result.sessions) {
     lines.push(`  ${s.fact.host}:${s.fact.sessionId.slice(0, 8)}  ${s.agentId}  (${s.rule})`);
   }
+  lines.push("", `Evidenced deliverers (${result.evidenced.length}):`);
+  if (result.evidenced.length === 0) lines.push("  (no commit-level proof on a WP-labelled branch)");
+  for (const s of result.evidenced) {
+    lines.push(`  ${s.fact.host}:${s.fact.sessionId.slice(0, 8)}  ${s.agentId}  (${s.via})`);
+  }
+  if (result.mismatch) {
+    lines.push(
+      "",
+      "WARNING: mandated and evidenced agents disagree — the ledger mandate and the commit-level evidence point at different sessions.",
+    );
+  }
+  lines.push(
+    "",
+    `Rollup: ${result.rollup.commits} commit(s), ${result.rollup.tokens} tokens (${result.rollup.tokensWeighted} cost-weighted) across ${result.sessions.length + result.evidenced.length} session(s).`,
+  );
   return lines.join("\n");
 }
 

--- a/src/agent-stats/redact.ts
+++ b/src/agent-stats/redact.ts
@@ -22,9 +22,21 @@ const TOKEN_PATTERNS: RegExp[] = [
   /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
   /\bsk-[A-Za-z0-9_-]{20,}\b/g, // OpenAI-style
   /\b(?:AIza)[A-Za-z0-9_-]{20,}\b/g, // Google API key
+  /\bAKIA[0-9A-Z]{16}\b/g, // AWS access key id
+  /\bglpat-[A-Za-z0-9_-]{20,}\b/g, // GitLab PAT
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, // Slack tokens
+  /\bnpm_[A-Za-z0-9]{20,}\b/g, // npm token
   /\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, // JWT
   /\b(?:token|secret|api[_-]?key|password|bearer)\s*[:=]\s*\S+/gi,
 ];
+
+// `scheme://user:password@host` — drop the whole credentials pair.
+const URL_CREDENTIALS_RE = /([A-Za-z][A-Za-z0-9+.-]*:\/\/)[^\s/@:]+:[^\s/@]+@/g;
+
+// Claude Code project-slug form of a home dir (`-home-<user>-…`), which also
+// shows up inside /tmp/... seed paths. Requires a following `-segment` so
+// ordinary hyphenated prose ("take-home-pay") is left alone.
+const DASH_SLUG_HOME_RE = /-(?:home|Users)-[A-Za-z0-9._]+(?=-)/g;
 
 /** Replace the user's home directory prefix with `~`. */
 export function redactHome(text: string, home: string): string {
@@ -32,6 +44,9 @@ export function redactHome(text: string, home: string): string {
   // Replace both the literal home and any "/home/<user>" pattern generically.
   let out = text.split(home).join("~");
   out = out.replace(/\/(?:home|Users)\/[A-Za-z0-9._-]+/g, "~");
+  // Dash-slug home form (Claude project dirs), wherever it appears (~/.claude
+  // /projects/-home-<user>-…, /tmp/…/-home-<user>-…).
+  out = out.replace(DASH_SLUG_HOME_RE, "~");
   return out;
 }
 
@@ -39,6 +54,7 @@ export function redactHome(text: string, home: string): string {
 export function redact(text: string, home = ""): string {
   if (typeof text !== "string" || text.length === 0) return "";
   let out = redactHome(text, home);
+  out = out.replace(URL_CREDENTIALS_RE, "$1<token>@");
   out = out.replace(EMAIL_RE, "<email>");
   for (const re of TOKEN_PATTERNS) out = out.replace(re, "<token>");
   return out;

--- a/src/agent-stats/stats.ts
+++ b/src/agent-stats/stats.ts
@@ -9,7 +9,15 @@
 import { parseWpLabel } from "./git-evidence.js";
 import { matchInstance, type H2aInstance } from "./registry.js";
 import { resolveIdentity } from "./identity.js";
-import type { AgentStatsRow, CorrelationLink, SessionFact } from "./types.js";
+import type {
+  AgentHost,
+  AgentStatsRow,
+  AttributionResidual,
+  Confidence,
+  CorrelationLink,
+  SessionFact,
+  TokenTotals,
+} from "./types.js";
 
 export interface AggregateInput {
   facts: SessionFact[];
@@ -17,12 +25,39 @@ export interface AggregateInput {
   instances: H2aInstance[];
 }
 
+/**
+ * Cost-weighted tokens: cache READS are billed at roughly 10% of a fresh
+ * input token, so a cache-heavy session must not look 10× more expensive than
+ * it was. Hosts report usage differently:
+ *   - claude: `input` EXCLUDES cache reads; `total` additionally includes
+ *     cache-creation tokens (counted at face value here).
+ *   - codex: `input` INCLUDES cached input tokens.
+ *   - agy: no cache split — weighted ≈ total.
+ * This is a comparable-effort heuristic, not an exact invoice.
+ */
+export function costWeightedTokens(tokens: TokenTotals, host: AgentHost): number {
+  const input = tokens.input || 0;
+  const output = tokens.output || 0;
+  const cached = tokens.cached || 0;
+  const total = tokens.total || 0;
+  if (host === "codex") {
+    const fresh = Math.max(0, input - cached);
+    return Math.round(fresh + output + 0.1 * cached);
+  }
+  const creation = Math.max(0, total - input - output - cached);
+  return Math.round(input + output + creation + 0.1 * cached);
+}
+
+const CONFIDENCE_ORDER: Record<Confidence, number> = { high: 3, medium: 2, low: 1 };
+
 interface Acc {
   agentId: string;
   host: SessionFact["host"];
   registered: boolean;
   sessions: Set<string>;
   tokens: number;
+  tokensWeighted: number;
+  confidence: Confidence | "-";
   commits: Set<string>;
   branches: Set<string>;
   wps: Set<string>;
@@ -41,6 +76,8 @@ export function aggregate(input: AggregateInput): AgentStatsRow[] {
         registered,
         sessions: new Set(),
         tokens: 0,
+        tokensWeighted: 0,
+        confidence: "-",
         commits: new Set(),
         branches: new Set(),
         wps: new Set(),
@@ -57,15 +94,38 @@ export function aggregate(input: AggregateInput): AgentStatsRow[] {
     const a = accFor(id.agentId, fact.host, id.registered);
     a.sessions.add(fact.factId);
     a.tokens += fact.tokens.total || 0;
+    a.tokensWeighted += costWeightedTokens(fact.tokens, fact.host);
     if (fact.endedAt && (!a.lastActive || fact.endedAt > a.lastActive)) a.lastActive = fact.endedAt;
+  }
+
+  // SQUASH DEDUPE: branches an agent already proved via rank-1 commit output.
+  // A pr-merge squash commit for such a branch is the SAME unit of work as
+  // the branch commits — counting both would inflate every PR by one (N+1).
+  const rank1Branches = new Map<string, Set<string>>();
+  for (const link of input.links) {
+    if (link.rule !== "commit-sha-output" || link.target.kind !== "commit" || !link.target.branch) continue;
+    let set = rank1Branches.get(link.agentId);
+    if (!set) {
+      set = new Set();
+      rank1Branches.set(link.agentId, set);
+    }
+    set.add(link.target.branch);
   }
 
   // Evidence-backed commits/branches/WPs from correlation links.
   for (const link of input.links) {
     const a = accs.get(link.agentId);
     if (!a) continue;
+    if (link.confidence !== a.confidence && a.confidence !== "high") {
+      const cur = a.confidence === "-" ? 0 : CONFIDENCE_ORDER[a.confidence];
+      if (CONFIDENCE_ORDER[link.confidence] > cur) a.confidence = link.confidence;
+    }
     if (link.target.kind === "commit") {
-      a.commits.add(link.target.sha.slice(0, 7));
+      const isDupSquash =
+        link.rule === "pr-merge" &&
+        Boolean(link.target.branch) &&
+        rank1Branches.get(link.agentId)?.has(link.target.branch!) === true;
+      if (!isDupSquash) a.commits.add(link.target.sha.slice(0, 7));
       if (link.target.branch) {
         a.branches.add(link.target.branch);
         const wp = parseWpLabel(link.target.branch);
@@ -92,6 +152,8 @@ export function aggregate(input: AggregateInput): AgentStatsRow[] {
       registered: a.registered,
       sessions: a.sessions.size,
       tokens: a.tokens,
+      tokensWeighted: a.tokensWeighted,
+      confidence: a.confidence,
       commits: a.commits.size,
       branches: a.branches.size,
       wpsTouched: Array.from(a.wps).sort(),
@@ -122,19 +184,40 @@ function renderTable(headers: string[], data: string[][]): string {
   return [line(headers), line(widths.map((w) => "-".repeat(w))), ...data.map(line)].join("\n");
 }
 
-/** Render the per-agent stats table as a fixed-width string. */
-export function formatStatsTable(rows: AgentStatsRow[]): string {
-  if (rows.length === 0) return "No agent sessions found for this repo. Run `graphify agent-stats sync` first.";
-  const headers = ["AGENT", "SESS", "TOKENS", "COMMITS", "BRANCHES", "WPS", "LAST-ACTIVE"];
+/**
+ * Render the per-agent stats table as a fixed-width string. TOKENS(W) is the
+ * cost-weighted total (cache reads discounted); CONF is the best evidence
+ * confidence backing the row. When `residual` is given, an explicit
+ * "(unattributed/human)" row reports the commits no agent claimed — honest
+ * coverage instead of silently implying 100% attribution.
+ */
+export function formatStatsTable(rows: AgentStatsRow[], residual?: AttributionResidual): string {
+  if (rows.length === 0 && !residual) {
+    return "No agent sessions found for this repo. Run `graphify agent-stats sync` first.";
+  }
+  const headers = ["AGENT", "SESS", "TOKENS(W)", "CONF", "COMMITS", "BRANCHES", "WPS", "LAST-ACTIVE"];
   const data = rows.map((r) => [
     r.agentId,
     String(r.sessions),
-    fmtTokens(r.tokens),
+    fmtTokens(r.tokensWeighted),
+    r.confidence,
     String(r.commits),
     String(r.branches),
     r.wpsTouched.length ? r.wpsTouched.join(",") : "-",
     fmtDate(r.lastActive),
   ]);
+  if (residual) {
+    data.push([
+      "(unattributed/human)",
+      "-",
+      "-",
+      "-",
+      `${residual.unattributedCommits}/${residual.totalCommits}`,
+      "-",
+      "-",
+      "-",
+    ]);
+  }
   return renderTable(headers, data);
 }
 

--- a/src/agent-stats/store.ts
+++ b/src/agent-stats/store.ts
@@ -12,19 +12,27 @@
  * module persists whatever it is handed.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import type { FileCursor, SessionFact } from "./types.js";
+import type { CorrelationLink, FileCursor, SessionFact } from "./types.js";
 
 export interface AgentStore {
   dir: string;
   factsPath: string;
   cursorsPath: string;
+  /** Append-only resolved attribution links (re-derivable; survives branch GC). */
+  linksPath: string;
 }
 
 export function resolveStore(repoRoot: string): AgentStore {
   const dir = join(repoRoot, ".graphify", "agents");
-  return { dir, factsPath: join(dir, "facts.jsonl"), cursorsPath: join(dir, "cursors.json") };
+  return {
+    dir,
+    factsPath: join(dir, "facts.jsonl"),
+    cursorsPath: join(dir, "cursors.json"),
+    linksPath: join(dir, "links.jsonl"),
+  };
 }
 
 export function ensureStore(store: AgentStore): void {
@@ -60,20 +68,96 @@ export function saveFacts(store: AgentStore, facts: Map<string, SessionFact>): v
   writeFileSync(store.factsPath, lines.length ? lines.join("\n") + "\n" : "");
 }
 
-export function loadCursors(store: AgentStore): Map<string, FileCursor> {
+/** Exact-home tilde encoding for cursor paths (round-trips losslessly). */
+function encodeCursorPath(p: string, home: string): string {
+  return home && (p === home || p.startsWith(home + "/")) ? "~" + p.slice(home.length) : p;
+}
+
+function decodeCursorPath(p: string, home: string): string {
+  return home && (p === "~" || p.startsWith("~/")) ? home + p.slice(1) : p;
+}
+
+export function loadCursors(store: AgentStore, home = homedir()): Map<string, FileCursor> {
   const out = new Map<string, FileCursor>();
   if (!existsSync(store.cursorsPath)) return out;
   try {
     const arr = JSON.parse(readFileSync(store.cursorsPath, "utf-8"));
-    if (Array.isArray(arr)) for (const c of arr) if (c?.path) out.set(c.path, c);
+    if (Array.isArray(arr)) {
+      for (const c of arr) {
+        if (!c?.path) continue;
+        const abs = decodeCursorPath(c.path, home);
+        out.set(abs, { ...c, path: abs });
+      }
+    }
   } catch {
     /* ignore */
   }
   return out;
 }
 
-export function saveCursors(store: AgentStore, cursors: Map<string, FileCursor>): void {
+/**
+ * Persist cursors. PRIVACY: transcript paths live under the user's home dir;
+ * they are stored `~`-relative so no raw home path lands in cursors.json.
+ */
+export function saveCursors(store: AgentStore, cursors: Map<string, FileCursor>, home = homedir()): void {
   ensureStore(store);
-  const arr = Array.from(cursors.values()).sort((a, b) => a.path.localeCompare(b.path));
+  const arr = Array.from(cursors.values())
+    .map((c) => ({ ...c, path: encodeCursorPath(c.path, home) }))
+    .sort((a, b) => a.path.localeCompare(b.path));
   writeFileSync(store.cursorsPath, JSON.stringify(arr, null, 2) + "\n");
+}
+
+/** Stable identity of a correlation link (factId + rule + target). */
+export function linkKey(link: CorrelationLink): string {
+  const t = link.target;
+  const tail =
+    t.kind === "commit"
+      ? `${t.sha}|${t.branch ?? ""}`
+      : t.kind === "branch"
+        ? t.branch
+        : t.kind === "pr"
+          ? `${t.url ?? ""}|${t.number ?? ""}`
+          : `${t.trackItemId}|${t.wp ?? ""}`;
+  return `${link.factId}|${link.rule}|${t.kind}|${tail}`;
+}
+
+/** Load persisted attribution links (deduped by {@link linkKey}). */
+export function loadLinks(store: AgentStore): CorrelationLink[] {
+  if (!existsSync(store.linksPath)) return [];
+  const seen = new Set<string>();
+  const out: CorrelationLink[] = [];
+  for (const line of readFileSync(store.linksPath, "utf-8").split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const link = JSON.parse(t) as CorrelationLink;
+      if (!link?.factId || !link?.target) continue;
+      const key = linkKey(link);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(link);
+    } catch {
+      /* skip corrupt line */
+    }
+  }
+  return out;
+}
+
+/**
+ * APPEND-ONLY: persist any link not already on disk. Resolved attribution thus
+ * survives branch GC / squash cleanup — the numbers do not decay when the
+ * evidence can no longer be re-derived from `git log`.
+ */
+export function appendLinks(store: AgentStore, links: CorrelationLink[]): number {
+  const existing = new Set(loadLinks(store).map(linkKey));
+  const fresh = links.filter((l) => {
+    const key = linkKey(l);
+    if (existing.has(key)) return false;
+    existing.add(key);
+    return true;
+  });
+  if (fresh.length === 0) return 0;
+  ensureStore(store);
+  appendFileSync(store.linksPath, fresh.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return fresh.length;
 }

--- a/src/agent-stats/track-join.ts
+++ b/src/agent-stats/track-join.ts
@@ -53,7 +53,8 @@ function wpLabel(text: string): string | null {
 }
 
 interface ParsedSegment {
-  wp: string;
+  /** All WP labels this segment's ids are mandated to (multi-WP mandates). */
+  wps: string[];
   threadIds: string[];
   h2aIds: string[];
 }
@@ -63,17 +64,21 @@ interface ParsedSegment {
  * like `WP2 Header DS -> <id> (Name); WP6 ... -> <id> (Name)`. We split on the
  * WP-label boundaries so each segment's ids are attributed to the WP that opens
  * it; ids that appear before the first WP label are left unattributed.
+ *
+ * MULTI-WP MANDATES: a run of labels with no ids in between ("WP2/WP3/WP5 to
+ * <id>") carries every label forward — the id joins to ALL of those WPs.
  */
 function parseContext(context: string): ParsedSegment[] {
   const segments: ParsedSegment[] = [];
 
   const labelRe = /\b[wW][pP]\s?-?\d{1,3}\b/g;
-  const marks: { wp: string; index: number }[] = [];
+  const marks: { wp: string; index: number; len: number }[] = [];
   let lm: RegExpExecArray | null;
   while ((lm = labelRe.exec(context)) !== null) {
     const label = wpLabel(lm[0]);
-    if (label) marks.push({ wp: label, index: lm.index });
+    if (label) marks.push({ wp: label, index: lm.index, len: lm[0].length });
   }
+  let carried: string[] = [];
   for (let i = 0; i < marks.length; i++) {
     const mark = marks[i]!;
     const end = i + 1 < marks.length ? marks[i + 1]!.index : context.length;
@@ -82,7 +87,18 @@ function parseContext(context: string): ParsedSegment[] {
     // h2a ids contain colons + a host word that is never a WP label, so the
     // segment-bounded scan is safe; a WP that lists several ids keeps them all.
     const h2aIds = Array.from(new Set(Array.from(slice.matchAll(H2A_ID_RE), (m) => m[0])));
-    if (threadIds.length || h2aIds.length) segments.push({ wp: mark.wp, threadIds, h2aIds });
+    if (threadIds.length || h2aIds.length) {
+      segments.push({ wps: [...carried, mark.wp], threadIds, h2aIds });
+      carried = [];
+    } else {
+      // No ids in this label's own slice. Carry the label into the NEXT
+      // segment only when it is a tight run like "WP3/WP5" — i.e. nothing but
+      // a short separator sits between this label and the next one. Prose
+      // mentions ("owner of WP6 publication, WP7 coordination") do not carry.
+      const gap = context.slice(mark.index + mark.len, end);
+      if (i + 1 < marks.length && /^[\s/,&+|-]{0,3}$/.test(gap)) carried.push(mark.wp);
+      else carried = [];
+    }
   }
 
   return segments;
@@ -125,7 +141,10 @@ export function parseTrackLedger(ledger: string): Map<string, TrackItem> {
     const trackItemId = typeof e.aggregateId === "string" ? e.aggregateId : undefined;
     if (!trackItemId) continue;
     const title = typeof e.payload?.title === "string" ? e.payload.title : "";
-    const wp = wpLabel(title);
+    const body = typeof e.payload?.body === "string" ? e.payload.body : "";
+    // WP label from the title, falling back to the body (the real WP9 item's
+    // title carries no "WP9" token; only later decisions/body text do).
+    const wp = wpLabel(title) ?? wpLabel(body);
     const item: TrackItem = { trackItemId, wp, title, threadIds: [], h2aInstanceIds: [] };
     byId.set(trackItemId, item);
     if (wp) {
@@ -148,13 +167,49 @@ export function parseTrackLedger(ledger: string): Map<string, TrackItem> {
     const type = e?.type;
     if (type !== "dossier.revised" && type !== "decision.created" && type !== "decision.outcome") continue;
     const context = dossierContext(e.payload);
+    const title = typeof e.payload?.title === "string" ? e.payload.title : "";
+
+    // STRUCTURED JOIN (preferred): when the event carries `targets` ULIDs that
+    // resolve to known items, every id in its context attaches to exactly
+    // those items — never to items whose WP label merely appears in the prose
+    // (e.g. the conductor's id next to "remains owner of WP6 publication").
+    const targets: TrackItem[] = Array.isArray(e.payload?.targets)
+      ? e.payload.targets
+          .filter((t: unknown): t is string => typeof t === "string")
+          .map((t: string) => byId.get(t))
+          .filter((it: TrackItem | undefined): it is TrackItem => Boolean(it))
+      : [];
+    if (targets.length > 0) {
+      const threadIds = context ? Array.from(new Set(Array.from(context.matchAll(UUID_RE), (m) => m[0]))) : [];
+      const h2aIds = context ? Array.from(new Set(Array.from(context.matchAll(H2A_ID_RE), (m) => m[0]))) : [];
+      for (const item of targets) {
+        for (const tid of threadIds) if (!item.threadIds.includes(tid)) item.threadIds.push(tid);
+        for (const hid of h2aIds) if (!item.h2aInstanceIds.includes(hid)) item.h2aInstanceIds.push(hid);
+      }
+      // A single-target decision titled "WP9 …" names the item's WP even when
+      // the item title itself lacks the token.
+      if (targets.length === 1 && targets[0] && !targets[0].wp) {
+        const inferred = wpLabel(title);
+        if (inferred) {
+          targets[0].wp = inferred;
+          const arr = byWp.get(inferred);
+          if (arr) arr.push(targets[0]);
+          else byWp.set(inferred, [targets[0]]);
+        }
+      }
+      continue;
+    }
+
+    // PROSE FALLBACK: WP-label segmentation over the dossier context.
     if (!context) continue;
     for (const seg of parseContext(context)) {
-      const items = byWp.get(seg.wp);
-      if (!items) continue; // WP label without a matching track item — skip.
-      for (const item of items) {
-        for (const tid of seg.threadIds) if (!item.threadIds.includes(tid)) item.threadIds.push(tid);
-        for (const hid of seg.h2aIds) if (!item.h2aInstanceIds.includes(hid)) item.h2aInstanceIds.push(hid);
+      for (const wp of seg.wps) {
+        const items = byWp.get(wp);
+        if (!items) continue; // WP label without a matching track item — skip.
+        for (const item of items) {
+          for (const tid of seg.threadIds) if (!item.threadIds.includes(tid)) item.threadIds.push(tid);
+          for (const hid of seg.h2aIds) if (!item.h2aInstanceIds.includes(hid)) item.h2aInstanceIds.push(hid);
+        }
       }
     }
   }
@@ -176,20 +231,29 @@ export function loadTrackItems(repoRoot: string): Map<string, TrackItem> {
 }
 
 /**
- * Reverse lookups: thread-id → TrackItem and h2a-instance-id → TrackItem.
- * Used by correlate.ts to join a session to its mandated work-package.
+ * Reverse lookups: thread-id → TrackItem[] and h2a-instance-id → TrackItem[].
+ * MULTI-WP: an id mandated to several work-packages maps to ALL of them; the
+ * correlation step emits one WP link per mandated item.
  */
 export interface TrackIndex {
-  byThreadId: Map<string, TrackItem>;
-  byH2aId: Map<string, TrackItem>;
+  byThreadId: Map<string, TrackItem[]>;
+  byH2aId: Map<string, TrackItem[]>;
 }
 
 export function indexTrackItems(items: Map<string, TrackItem>): TrackIndex {
-  const byThreadId = new Map<string, TrackItem>();
-  const byH2aId = new Map<string, TrackItem>();
+  const byThreadId = new Map<string, TrackItem[]>();
+  const byH2aId = new Map<string, TrackItem[]>();
+  const push = (map: Map<string, TrackItem[]>, key: string, item: TrackItem) => {
+    const arr = map.get(key);
+    if (arr) {
+      if (!arr.includes(item)) arr.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  };
   for (const item of items.values()) {
-    for (const tid of item.threadIds) byThreadId.set(tid.toLowerCase(), item);
-    for (const hid of item.h2aInstanceIds) byH2aId.set(hid, item);
+    for (const tid of item.threadIds) push(byThreadId, tid.toLowerCase(), item);
+    for (const hid of item.h2aInstanceIds) push(byH2aId, hid, item);
   }
   return { byThreadId, byH2aId };
 }

--- a/src/agent-stats/types.ts
+++ b/src/agent-stats/types.ts
@@ -137,7 +137,12 @@ export interface AgentStatsRow {
   host: AgentHost;
   registered: boolean;
   sessions: number;
+  /** Raw token total (incl. cache reads/creation at face value). */
   tokens: number;
+  /** Cost-weighted tokens: cache reads discounted to ~10% of an input token. */
+  tokensWeighted: number;
+  /** Best evidence confidence backing this row's attribution links. */
+  confidence: Confidence | "-";
   /** Distinct commit shas attributed by ground-truth correlation. */
   commits: number;
   /** Distinct branches attributed. */
@@ -145,6 +150,12 @@ export interface AgentStatsRow {
   /** Distinct WP labels touched (parsed from branches / commit subjects). */
   wpsTouched: string[];
   lastActive?: string;
+}
+
+/** Coverage residual: commits in `git log` not attributed to any agent. */
+export interface AttributionResidual {
+  totalCommits: number;
+  unattributedCommits: number;
 }
 
 /** Incremental re-parse cursor: byte offset already consumed per file. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2419,12 +2419,12 @@ export async function main(): Promise<void> {
     .action(async (opts) => {
       const { computeAgentStats, formatStatsTable } = await import("./agent-stats/index.js");
       const repoRoot = resolveAgentStatsRepoRoot();
-      const { rows } = computeAgentStats(repoRoot);
+      const { rows, residual } = computeAgentStats(repoRoot);
       if (opts.json) {
-        console.log(JSON.stringify(rows, null, 2));
+        console.log(JSON.stringify({ rows, residual }, null, 2));
         return;
       }
-      console.log(formatStatsTable(rows));
+      console.log(formatStatsTable(rows, residual));
     });
   agentStats
     .command("sync")
@@ -2471,7 +2471,14 @@ export async function main(): Promise<void> {
       const repoRoot = resolveAgentStatsRepoRoot();
       const result = wpAgentStats(repoRoot, trackItemId, { skipPrMerges: opts.pr === false });
       if (opts.json) {
-        console.log(JSON.stringify({ item: result.item, links: result.links, sessions: result.sessions.map((s) => ({ factId: s.fact.factId, agentId: s.agentId, rule: s.rule })) }, null, 2));
+        console.log(JSON.stringify({
+          item: result.item,
+          links: result.links,
+          sessions: result.sessions.map((s) => ({ factId: s.fact.factId, agentId: s.agentId, rule: s.rule })),
+          evidenced: result.evidenced.map((s) => ({ factId: s.fact.factId, agentId: s.agentId, via: s.via })),
+          mismatch: result.mismatch,
+          rollup: result.rollup,
+        }, null, 2));
         return;
       }
       console.log(formatWpView(result, trackItemId));

--- a/tests/agent-stats-phase1.test.ts
+++ b/tests/agent-stats-phase1.test.ts
@@ -65,11 +65,13 @@ describe("agent-stats Track ledger parse (WP-join source)", () => {
     expect(wp2!.threadIds).not.toContain(WP9_THREAD_ID);
   });
 
-  it("builds reverse indexes (thread-id / h2a-id → item)", () => {
+  it("builds reverse indexes (thread-id / h2a-id → items)", () => {
     const items = parseTrackLedger(loadFixture("track-ledger.jsonl"));
     const idx = indexTrackItems(items);
-    expect(idx.byThreadId.get(WP9_THREAD_ID)?.wp).toBe("WP9");
-    expect(idx.byH2aId.get(WP9_H2A_ID)?.wp).toBe("WP9");
+    // Phase 1.5: indexes are multi-valued — an id mandated to several WPs
+    // joins to ALL of them.
+    expect((idx.byThreadId.get(WP9_THREAD_ID) ?? []).map((i) => i.wp)).toEqual(["WP9"]);
+    expect((idx.byH2aId.get(WP9_H2A_ID) ?? []).map((i) => i.wp)).toEqual(["WP9"]);
   });
 
   it("loadTrackItems returns an empty map when no ledger exists", () => {

--- a/tests/agent-stats-phase15.test.ts
+++ b/tests/agent-stats-phase15.test.ts
@@ -1,0 +1,615 @@
+/**
+ * WP9 agent-stats — Phase 1.5 hardening tests (adversarial-review fixes).
+ *
+ *   P0-1 Ground truth is gated on git verbs: a session that merely cat/greps a
+ *        foreign transcript or CI log must NOT acquire its shas / PR urls.
+ *   P0-2 Multi-WP join: an id mandated to several WPs joins to ALL of them, and
+ *        decision.targets ULIDs (structured) are preferred over regex-over-prose.
+ *   P0-3 rank-4 (h2a-registry) is identity ONLY — no branch credit without a
+ *        commit/checkout-b on that exact branch.
+ *   P0-4 rank-2 (pr-merge) is branch-scoped, squash commits dedupe against the
+ *        session's own branch commits, PR urls are scoped to the origin repo.
+ *   P0-5 discover scans worktree slug dirs (`.` → `-`).
+ *   P0-6 cross-repo sessions only credit in-repo work.
+ *   P1   redaction (dash-slug, new token shapes, cursors.json), residual row,
+ *        cost-weighted tokens + confidence, persisted links, wp view both-sides.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseClaudeTranscript } from "../src/agent-stats/claude-transcript.js";
+import { parseCodexRollout } from "../src/agent-stats/codex-rollout.js";
+import { normalizeClaude, normalizeCodex } from "../src/agent-stats/normalize.js";
+import { correlate, type PrMergeMeta } from "../src/agent-stats/correlate.js";
+import { aggregate } from "../src/agent-stats/stats.js";
+import { indexTrackItems, parseTrackLedger } from "../src/agent-stats/track-join.js";
+import { redact } from "../src/agent-stats/redact.js";
+import { discoverClaude, repoSlug } from "../src/agent-stats/discover.js";
+import { loadCursors, resolveStore, saveCursors } from "../src/agent-stats/store.js";
+import type { CommandRunner } from "../src/pr.js";
+import {
+  collectPrMerges,
+  computeAgentStats,
+  formatStatsTable,
+  formatWpView,
+  syncAgentStats,
+  wpAgentStats,
+} from "../src/agent-stats/index.js";
+import type { H2aInstance } from "../src/agent-stats/registry.js";
+import type { FileCursor, SessionFact } from "../src/agent-stats/types.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function tmp(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+// ---------------------------------------------------------------------------
+// P0-1: ground truth gated on git verbs (spoof resistance)
+// ---------------------------------------------------------------------------
+
+describe("ground truth is gated on git-verb inputs (spoof resistance)", () => {
+  function claudeLines(command: string, output: string): string {
+    return [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-10T10:00:00.000Z",
+        cwd: "/tmp/repo",
+        sessionId: "s-spoof",
+        message: { model: "m", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command } }] },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-06-10T10:00:01.000Z",
+        cwd: "/tmp/repo",
+        sessionId: "s-spoof",
+        message: { content: [{ type: "tool_result", tool_use_id: "t1", content: output }] },
+      }),
+    ].join("\n");
+  }
+
+  const FOREIGN = "[feat/foreign 1234567] stolen subject\nhttps://github.com/rhanka/graphify/pull/777";
+
+  it("claude: cat/grep of a foreign transcript does NOT acquire shas or PR urls", () => {
+    for (const cmd of ["cat ~/.claude/projects/other/x.jsonl", "grep -r commit ci.log", "tail -n 50 build.log"]) {
+      const s = parseClaudeTranscript(claudeLines(cmd, FOREIGN), "s-spoof");
+      expect(s.groundTruth.commitShas).toEqual([]);
+      expect(s.groundTruth.prUrls).toEqual([]);
+    }
+  });
+
+  it("claude: a read-only git command (git log/show) does not acquire shas", () => {
+    const s = parseClaudeTranscript(claudeLines("git log --oneline -5", FOREIGN), "s-spoof");
+    expect(s.groundTruth.commitShas).toEqual([]);
+  });
+
+  it("claude: a real `git commit` output still IS scraped", () => {
+    const s = parseClaudeTranscript(claudeLines("git add -A && git commit -m 'x'", "[feat/mine abcdef1] x"), "s-spoof");
+    expect(s.groundTruth.commitShas).toContain("abcdef1");
+    expect(s.groundTruth.shaBranch["abcdef1"]).toBe("feat/mine");
+  });
+
+  it("codex: non-git outputs are not scraped; outputs pair by call_id", () => {
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "2026-06-10T10:00:00.000Z", payload: { id: "cx-1", cwd: "/tmp/repo" } }),
+      // read-only command whose output embeds a foreign sha
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "a", arguments: JSON.stringify({ cmd: "grep -r sha /tmp/logs", workdir: "/tmp/repo" }) } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "a", output: FOREIGN } }),
+      // an output with an unknown call_id must not be scraped either
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "zz", output: "[main 9999999] ghost" } }),
+      // real commit is scraped
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "b", arguments: JSON.stringify({ cmd: "git commit -m ok", workdir: "/tmp/repo" }) } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "b", output: "[feat/mine 7654321] ok" } }),
+    ].join("\n");
+    const s = parseCodexRollout(lines, "cx-1");
+    expect(s.groundTruth.commitShas).toEqual(["7654321"]);
+    expect(s.groundTruth.prUrls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0-2: multi-WP join + decision.targets ULID join
+// ---------------------------------------------------------------------------
+
+describe("track-join: multi-WP ids and decision.targets ULIDs", () => {
+  const H2A = "claude:graphify:17bddf135979";
+
+  it("an id mandated to several WPs joins to ALL of them", () => {
+    const ledger = [
+      JSON.stringify({ type: "item.created", aggregateId: "01ITEMWP3AAAAAAAAAAAAAAAAA", payload: { title: "WP3 Graph storage backends" } }),
+      JSON.stringify({ type: "item.created", aggregateId: "01ITEMWP5AAAAAAAAAAAAAAAAA", payload: { title: "WP5 Track F upstream parity residuals" } }),
+      JSON.stringify({
+        type: "dossier.revised",
+        aggregateId: "01DOSSIERAAAAAAAAAAAAAAAAA",
+        payload: { dossier: { context: `Delegation envelopes deposited: WP3/WP5 to ${H2A} (env:wp3-wp5, recipientLive=false).` } },
+      }),
+    ].join("\n");
+    const items = parseTrackLedger(ledger);
+    const wp3 = Array.from(items.values()).find((i) => i.wp === "WP3")!;
+    const wp5 = Array.from(items.values()).find((i) => i.wp === "WP5")!;
+    expect(wp3.h2aInstanceIds).toContain(H2A);
+    expect(wp5.h2aInstanceIds).toContain(H2A);
+    // The reverse index maps the id to BOTH items.
+    const idx = indexTrackItems(items);
+    expect((idx.byH2aId.get(H2A) ?? []).map((i) => i.wp).sort()).toEqual(["WP3", "WP5"]);
+  });
+
+  it("correlate emits one WP link per mandated item for a multi-WP id", () => {
+    const ledger = [
+      JSON.stringify({ type: "item.created", aggregateId: "01ITEMWP3AAAAAAAAAAAAAAAAA", payload: { title: "WP3 Graph storage backends" } }),
+      JSON.stringify({ type: "item.created", aggregateId: "01ITEMWP5AAAAAAAAAAAAAAAAA", payload: { title: "WP5 Track F parity" } }),
+      JSON.stringify({
+        type: "dossier.revised",
+        aggregateId: "01DOSSIERAAAAAAAAAAAAAAAAA",
+        payload: { dossier: { context: "WP3/WP5 -> 019ea9d2-7979-7991-8216-1b465ec8005b (Ohm)" } },
+      }),
+    ].join("\n");
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "2026-06-09T01:00:00.000Z", payload: { id: "019ea9d2-7979-7991-8216-1b465ec8005b", cwd: "/tmp/repo" } }),
+    ].join("\n");
+    const fact = normalizeCodex(parseCodexRollout(lines, "019ea9d2-7979-7991-8216-1b465ec8005b"));
+    const links = correlate({ facts: [fact], instances: [], commits: [], trackIndex: indexTrackItems(parseTrackLedger(ledger)) });
+    const wpLinks = links.filter((l) => l.target.kind === "wp");
+    expect(wpLinks.map((l) => (l.target.kind === "wp" ? l.target.wp : "")).sort()).toEqual(["WP3", "WP5"]);
+  });
+
+  it("prefers decision.targets ULIDs: ids attach to the targeted item, not prose WP labels", () => {
+    const ledger = [
+      // The real WP9 item: title carries NO "WP9" token.
+      JSON.stringify({
+        type: "item.created",
+        aggregateId: "01KTSBMC1HJ1N8XMQYK17CGDAP",
+        payload: { title: "Agent-stats support layer: parse agentic conversations + track agents", body: "MAJOR backlog feature. Not started." },
+      }),
+      JSON.stringify({ type: "item.created", aggregateId: "01ITEMWP6AAAAAAAAAAAAAAAAA", payload: { title: "WP6 Public UAT and mysterypack publication" } }),
+      JSON.stringify({
+        type: "decision.created",
+        aggregateId: "01DECISIONWP9AAAAAAAAAAAAA",
+        payload: {
+          decisionKind: "delegation",
+          title: "WP9 agent-stats design (consensus)",
+          targets: ["01KTSBMC1HJ1N8XMQYK17CGDAP"],
+          dossier: { context: "WP9 agent-stats delegated to codex:graphify:b7615bbd3189. Conductor remains owner of WP6 publication." },
+        },
+      }),
+    ].join("\n");
+    const items = parseTrackLedger(ledger);
+    const wp9 = items.get("01KTSBMC1HJ1N8XMQYK17CGDAP")!;
+    const wp6 = items.get("01ITEMWP6AAAAAAAAAAAAAAAAA")!;
+    // The targeted item gets the id even though its title has no WP token...
+    expect(wp9.h2aInstanceIds).toContain("codex:graphify:b7615bbd3189");
+    // ...and inherits the WP label from the single-target decision title.
+    expect(wp9.wp).toBe("WP9");
+    // The prose mention of "WP6" must NOT leak the id into the WP6 item.
+    expect(wp6.h2aInstanceIds).toEqual([]);
+  });
+
+  it("parses the WP label from the item body when the title lacks it", () => {
+    const ledger = [
+      JSON.stringify({
+        type: "item.created",
+        aggregateId: "01ITEMBODYAAAAAAAAAAAAAAAA",
+        payload: { title: "Agent-stats support layer", body: "This is the WP9 workpackage for agent stats." },
+      }),
+    ].join("\n");
+    const item = parseTrackLedger(ledger).get("01ITEMBODYAAAAAAAAAAAAAAAA")!;
+    expect(item.wp).toBe("WP9");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0-3: rank-4 h2a-registry is identity-only
+// ---------------------------------------------------------------------------
+
+describe("rank-4 h2a-registry link is identity only", () => {
+  it("a read-only session gets NO branch credit from its registry match", () => {
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "2026-06-09T01:00:00.000Z", payload: { id: "ro-1", cwd: "/tmp/repo", git: { branch: "feat/observed-only" } } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: JSON.stringify({ cmd: "git log --oneline", workdir: "/tmp/repo" }) } }),
+    ].join("\n");
+    const fact = normalizeCodex(parseCodexRollout(lines, "ro-1"));
+    const instances: H2aInstance[] = [
+      { id: "codex:graphify:b7615bbd3189", host: "codex", name: "graphify", workspacePath: "/tmp/repo", label: "graphify" },
+    ];
+    const links = correlate({ facts: [fact], instances, commits: [] });
+    const rank4 = links.find((l) => l.rule === "h2a-registry");
+    expect(rank4).toBeDefined();
+    // Identity only: never a real branch without commit/checkout-b evidence.
+    expect(rank4!.target).toMatchObject({ kind: "branch", branch: "(workspace)" });
+    // And no other link credits the merely-observed branch.
+    expect(links.some((l) => l.target.kind === "branch" && l.target.branch === "feat/observed-only")).toBe(false);
+    const rows = aggregate({ facts: [fact], links, instances });
+    expect(rows[0]!.branches).toBe(0);
+  });
+
+  it("excludes main from rank-4 branch labels even when worked", () => {
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "2026-06-09T01:00:00.000Z", payload: { id: "m-1", cwd: "/tmp/repo", git: { branch: "main" } } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: JSON.stringify({ cmd: "git commit -m x", workdir: "/tmp/repo" }) } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "c1", output: "[main 1111111] x" } }),
+    ].join("\n");
+    const fact = normalizeCodex(parseCodexRollout(lines, "m-1"));
+    const instances: H2aInstance[] = [
+      { id: "codex:graphify:b7615bbd3189", host: "codex", name: "graphify", workspacePath: "/tmp/repo", label: "graphify" },
+    ];
+    const links = correlate({ facts: [fact], instances, commits: [] });
+    const rank4 = links.find((l) => l.rule === "h2a-registry");
+    expect(rank4!.target).toMatchObject({ kind: "branch", branch: "(workspace)" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0-4: rank-2 branch-scoped, squash dedupe, origin-scoped PR urls
+// ---------------------------------------------------------------------------
+
+describe("rank-2 pr-merge hardening", () => {
+  function commitFact(workBranch: string, observedBranch = workBranch): SessionFact {
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "2026-06-09T01:00:00.000Z", payload: { id: "sq-1", cwd: "/tmp/repo", git: { branch: observedBranch } } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: JSON.stringify({ cmd: "git commit -m wip", workdir: "/tmp/repo" }) } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "c1", output: `[${workBranch} abc1234] wip` } }),
+    ].join("\n");
+    return normalizeCodex(parseCodexRollout(lines, "sq-1"));
+  }
+
+  it("requires commit/checkout-b evidence on THAT branch (not any branch)", () => {
+    // Session observed feat/y but only ever committed on feat/x.
+    const fact = commitFact("feat/x", "feat/y");
+    const prMerges: PrMergeMeta[] = [{ number: 7, branch: "feat/y", mergeCommit: "f".repeat(40) }];
+    const links = correlate({ facts: [fact], instances: [], commits: [], prMerges });
+    expect(links.some((l) => l.rule === "pr-merge")).toBe(false);
+  });
+
+  it("dedupes the squash commit against the session's own branch commits (no N+1)", () => {
+    const fact = commitFact("feat/x");
+    const mergeSha = "f".repeat(40);
+    const links = correlate({
+      facts: [fact],
+      instances: [],
+      commits: [{ sha: "abc1234" + "0".repeat(33), subject: "wip" }],
+      prMerges: [{ number: 7, branch: "feat/x", mergeCommit: mergeSha }],
+    });
+    expect(links.some((l) => l.rule === "commit-sha-output")).toBe(true);
+    expect(links.some((l) => l.rule === "pr-merge")).toBe(true);
+    const rows = aggregate({ facts: [fact], links, instances: [] });
+    // 1 branch commit + its squash = ONE unit of work, not two.
+    expect(rows[0]!.commits).toBe(1);
+  });
+
+  it("collectPrMerges ignores PR urls from foreign repos (origin-scoped)", () => {
+    const fact: SessionFact = {
+      factId: "codex:s1",
+      host: "codex",
+      sessionId: "s1",
+      cwds: ["/tmp/repo"],
+      models: [],
+      tokens: { input: 0, output: 0, cached: 0, total: 0 },
+      gitActions: [{ verb: "commit", command: "git commit" }],
+      groundTruth: { commitShas: [], branches: [], shaBranch: {}, prUrls: ["https://github.com/evil/elsewhere/pull/99"] },
+      branchesObserved: ["feat/wp9"],
+      filesTouched: [],
+      evidence: [],
+    };
+    const calls: string[] = [];
+    const runner: CommandRunner = {
+      run(command, args) {
+        calls.push(`${command} ${args.join(" ")}`);
+        if (command === "git") return "https://github.com/rhanka/graphify.git";
+        if (args[1] === "list") return JSON.stringify([]);
+        return JSON.stringify({ number: 99, headRefName: "feat/wp9", mergeCommit: { oid: "9".repeat(40) }, commits: [] });
+      },
+    };
+    const merges = collectPrMerges("/tmp/repo", [fact], runner);
+    expect(merges).toEqual([]);
+    // It must never have fetched PR #99 from the foreign url.
+    expect(calls.some((c) => c.includes("view 99"))).toBe(false);
+  });
+
+  it("collectPrMerges still accepts origin-repo PR urls", () => {
+    const fact: SessionFact = {
+      factId: "codex:s1",
+      host: "codex",
+      sessionId: "s1",
+      cwds: ["/tmp/repo"],
+      models: [],
+      tokens: { input: 0, output: 0, cached: 0, total: 0 },
+      gitActions: [{ verb: "commit", command: "git commit" }],
+      groundTruth: { commitShas: [], branches: [], shaBranch: {}, prUrls: ["https://github.com/rhanka/graphify/pull/130"] },
+      branchesObserved: ["feat/wp9"],
+      filesTouched: [],
+      evidence: [],
+    };
+    const runner: CommandRunner = {
+      run(command, args) {
+        if (command === "git") return "git@github.com:rhanka/graphify.git";
+        if (args[1] === "list") return JSON.stringify([]);
+        return JSON.stringify({ number: 130, headRefName: "feat/wp9", mergeCommit: { oid: "1".repeat(40) }, commits: [] });
+      },
+    };
+    const merges = collectPrMerges("/tmp/repo", [fact], runner);
+    expect(merges).toHaveLength(1);
+    expect(merges[0]).toMatchObject({ number: 130, branch: "feat/wp9" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0-5: discover scans worktree slug dirs (. → -)
+// ---------------------------------------------------------------------------
+
+describe("discover: worktree slug dirs", () => {
+  it("repoSlug maps every non-alphanumeric character to '-' like the Claude host", () => {
+    expect(repoSlug("/home/u/src/graphify")).toBe("-home-u-src-graphify");
+    expect(repoSlug("/home/u/src/repo.js")).toBe("-home-u-src-repo-js");
+    expect(repoSlug("/home/u/src/graphify/.claude/worktrees/agent-x")).toBe(
+      "-home-u-src-graphify--claude-worktrees-agent-x",
+    );
+  });
+
+  it("discoverClaude scans the repo dir AND its worktree slug dirs", () => {
+    const home = tmp("agentstats-home-");
+    const repoRoot = "/home/u/src/graphify";
+    const slug = repoSlug(repoRoot);
+    const mainDir = join(home, ".claude", "projects", slug);
+    const wtDir = join(home, ".claude", "projects", `${slug}--claude-worktrees-agent-1`);
+    const otherDir = join(home, ".claude", "projects", "-home-u-src-other");
+    for (const d of [mainDir, wtDir, otherDir]) mkdirSync(d, { recursive: true });
+    writeFileSync(join(mainDir, "aaa.jsonl"), "{}\n");
+    writeFileSync(join(wtDir, "bbb.jsonl"), "{}\n");
+    writeFileSync(join(otherDir, "ccc.jsonl"), "{}\n");
+    const found = discoverClaude(home, slug).map((f) => f.sessionId).sort();
+    expect(found).toContain("aaa");
+    expect(found).toContain("bbb"); // worktree transcripts are now scanned
+    expect(found).not.toContain("ccc"); // unrelated repo stays out
+  });
+
+  it("syncAgentStats picks up a worktree-dir transcript end-to-end", () => {
+    const repoRoot = tmp("agentstats-repo-");
+    const home = tmp("agentstats-home-");
+    const fixture = readFileSync(new URL("./fixtures/agent-stats/claude-wp1-repo-keys.jsonl", import.meta.url), "utf-8")
+      .split("__REPO__")
+      .join(repoRoot);
+    const wtSlugDir = join(home, ".claude", "projects", `${repoSlug(repoRoot)}--claude-worktrees-agent-wp1abc`);
+    mkdirSync(wtSlugDir, { recursive: true });
+    writeFileSync(join(wtSlugDir, "fixture-wp1-0001.jsonl"), fixture);
+    const result = syncAgentStats({ repoRoot, home });
+    expect(result.inRepo).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0-6: cross-repo sessions only credit in-repo work
+// ---------------------------------------------------------------------------
+
+describe("cross-repo segmentation", () => {
+  it("claude: tokens/branches/commits from a foreign-repo cwd are not counted", () => {
+    const repo = "/tmp/repo";
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-10T10:00:00.000Z",
+        cwd: repo,
+        gitBranch: "feat/in-repo",
+        message: {
+          model: "m",
+          usage: { input_tokens: 100, output_tokens: 10 },
+          content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "git commit -m in" } }],
+        },
+      }),
+      JSON.stringify({ type: "user", timestamp: "2026-06-10T10:00:01.000Z", cwd: repo, message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "[feat/in-repo 1111111] in" }] } }),
+      // Foreign-repo segment of the same session:
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-10T10:05:00.000Z",
+        cwd: "/tmp/other-project",
+        gitBranch: "feat/foreign",
+        message: {
+          model: "m",
+          usage: { input_tokens: 5000, output_tokens: 500 },
+          content: [{ type: "tool_use", id: "t2", name: "Bash", input: { command: "git commit -m out" } }],
+        },
+      }),
+      JSON.stringify({ type: "user", timestamp: "2026-06-10T10:05:01.000Z", cwd: "/tmp/other-project", message: { content: [{ type: "tool_result", tool_use_id: "t2", content: "[feat/foreign 2222222] out" }] } }),
+    ].join("\n");
+    const s = parseClaudeTranscript(lines, "x-repo", "", { scopeRoot: repo });
+    expect(s.groundTruth.commitShas).toEqual(["1111111"]);
+    expect(s.branches).toContain("feat/in-repo");
+    expect(s.branches).not.toContain("feat/foreign");
+    expect(s.tokens.input).toBe(100);
+    expect(s.tokens.output).toBe(10);
+    // The foreign cwd is still recorded (identity/debug) but contributes no work.
+    expect(s.gitActions.filter((a) => a.verb === "commit")).toHaveLength(1);
+  });
+
+  it("codex: a git commit run with a foreign workdir is not credited", () => {
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "2026-06-10T10:00:00.000Z", payload: { id: "cx-seg", cwd: "/tmp/repo" } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "a", arguments: JSON.stringify({ cmd: "git commit -m out", workdir: "/tmp/other" }) } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "a", output: "[feat/foreign 2222222] out" } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "b", arguments: JSON.stringify({ cmd: "git commit -m in", workdir: "/tmp/repo" }) } }),
+      JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "b", output: "[feat/in 3333333] in" } }),
+    ].join("\n");
+    const s = parseCodexRollout(lines, "cx-seg", "", { scopeRoot: "/tmp/repo" });
+    expect(s.groundTruth.commitShas).toEqual(["3333333"]);
+    expect(s.gitActions.filter((a) => a.verb === "commit")).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Privacy: redaction hardening + cursors.json
+// ---------------------------------------------------------------------------
+
+describe("redaction hardening", () => {
+  it("redacts the dash-slug home form", () => {
+    const out = redact("ls ~/.claude/projects/-home-antoinefa-src-graphify--claude-worktrees-x/", "/home/antoinefa");
+    expect(out).not.toContain("antoinefa");
+  });
+
+  it("redacts a dash-slug inside a /tmp path", () => {
+    const out = redact("cp /tmp/seed/-home-antoinefa-src-graphify/file .", "/home/antoinefa");
+    expect(out).not.toContain("antoinefa");
+  });
+
+  it("redacts AWS, GitLab, Slack, npm tokens and user:token@host urls", () => {
+    const samples: [string, string][] = [
+      ["aws AKIAIOSFODNN7EXAMPLE key", "AKIAIOSFODNN7EXAMPLE"],
+      ["gitlab glpat-AbCdEfGhIjKlMnOpQrSt token", "glpat-AbCdEfGhIjKlMnOpQrSt"],
+      ["slack xoxb-123456789012-AbCdEfGhIjKl hook", "xoxb-123456789012-AbCdEfGhIjKl"],
+      ["npm npm_AbCdEfGhIjKlMnOpQrStUvWxYz012345 publish", "npm_AbCdEfGhIjKlMnOpQrStUvWxYz012345"],
+      ["git clone https://bob:s3cr3tpass@github.com/x/y.git", "s3cr3tpass"],
+    ];
+    for (const [raw, secret] of samples) {
+      expect(redact(raw, "/home/antoinefa")).not.toContain(secret);
+    }
+  });
+
+  it("cursors.json stores home-relative (~) paths, not raw home paths", () => {
+    const repoRoot = tmp("agentstats-curs-");
+    const home = tmp("agentstats-cursh-");
+    const store = resolveStore(repoRoot);
+    const cursors = new Map<string, FileCursor>();
+    const p = join(home, ".claude", "projects", "x", "s.jsonl");
+    cursors.set(p, { path: p, offset: 1, size: 1, mtimeMs: 1 });
+    saveCursors(store, cursors, home);
+    const raw = readFileSync(store.cursorsPath, "utf-8");
+    expect(raw).not.toContain(home);
+    expect(raw).toContain("~/.claude/projects/x/s.jsonl");
+    // Round-trip: loading restores the absolute path keyed map.
+    const loaded = loadCursors(store, home);
+    expect(loaded.get(p)?.offset).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Product: residual row, weighted tokens + confidence, persisted links, wp view
+// ---------------------------------------------------------------------------
+
+describe("stats table: residual row, weighted tokens, confidence", () => {
+  function rank1Fact(): SessionFact {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-10T10:00:00.000Z",
+        cwd: "/tmp/repo",
+        gitBranch: "feat/wp9",
+        message: {
+          model: "m",
+          usage: { input_tokens: 100, output_tokens: 10, cache_read_input_tokens: 1000, cache_creation_input_tokens: 100 },
+          content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "git commit -m x" } }],
+        },
+      }),
+      JSON.stringify({ type: "user", timestamp: "2026-06-10T10:00:01.000Z", cwd: "/tmp/repo", message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "[feat/wp9 abc1234] x" }] } }),
+    ].join("\n");
+    return normalizeClaude(parseClaudeTranscript(lines, "w-1"));
+  }
+
+  it("reports cost-weighted tokens (cache reads discounted) and a confidence band", () => {
+    const fact = rank1Fact();
+    const links = correlate({ facts: [fact], instances: [], commits: [{ sha: "abc1234" + "0".repeat(33), subject: "x" }] });
+    const rows = aggregate({ facts: [fact], links, instances: [] });
+    const row = rows[0]!;
+    // raw total = 100 + 10 + 1000 + 100 = 1210; weighted = 100 + 10 + 100 + 0.1*1000 = 310
+    expect(row.tokens).toBe(1210);
+    expect(row.tokensWeighted).toBe(310);
+    expect(row.confidence).toBe("high");
+    const table = formatStatsTable(rows);
+    expect(table).toContain("CONF");
+  });
+
+  it("renders an unattributed/human residual row for honest coverage", () => {
+    const repoRoot = tmp("agentstats-resid-");
+    mkdirSync(join(repoRoot, ".graphify", "agents"), { recursive: true });
+    writeFileSync(join(repoRoot, ".graphify", "agents", "facts.jsonl"), JSON.stringify(rank1Fact()) + "\n");
+    const { rows, residual } = computeAgentStats(repoRoot, {
+      injectedCommits: [
+        { sha: "abc1234" + "0".repeat(33), subject: "agent work" },
+        { sha: "d".repeat(40), subject: "human work" },
+      ],
+      skipPrMerges: true,
+    });
+    expect(residual).toBeDefined();
+    expect(residual!.totalCommits).toBe(2);
+    expect(residual!.unattributedCommits).toBe(1);
+    const table = formatStatsTable(rows, residual);
+    expect(table).toContain("unattributed/human");
+  });
+
+  it("persists attribution links append-only so numbers survive branch GC", () => {
+    const repoRoot = tmp("agentstats-links-");
+    mkdirSync(join(repoRoot, ".graphify", "agents"), { recursive: true });
+    writeFileSync(join(repoRoot, ".graphify", "agents", "facts.jsonl"), JSON.stringify(rank1Fact()) + "\n");
+    const first = computeAgentStats(repoRoot, {
+      injectedCommits: [{ sha: "abc1234" + "0".repeat(33), subject: "x" }],
+      skipPrMerges: true,
+    });
+    expect(first.rows[0]!.commits).toBe(1);
+    expect(existsSync(join(repoRoot, ".graphify", "agents", "links.jsonl"))).toBe(true);
+    // Branch GC: the sha vanished from git log. The persisted link keeps credit.
+    const second = computeAgentStats(repoRoot, { injectedCommits: [], skipPrMerges: true });
+    expect(second.rows[0]!.commits).toBe(1);
+    // Append-only and deduped: a third run does not grow the file.
+    const sizeAfterSecond = readFileSync(join(repoRoot, ".graphify", "agents", "links.jsonl"), "utf-8").length;
+    computeAgentStats(repoRoot, { injectedCommits: [], skipPrMerges: true });
+    const sizeAfterThird = readFileSync(join(repoRoot, ".graphify", "agents", "links.jsonl"), "utf-8").length;
+    expect(sizeAfterThird).toBe(sizeAfterSecond);
+  });
+});
+
+describe("agent-stats wp: mandated vs evidenced sessions", () => {
+  function setupRepo(): string {
+    const root = tmp("agentstats-wpv-");
+    mkdirSync(join(root, ".track"), { recursive: true });
+    writeFileSync(
+      join(root, ".track", "events.jsonl"),
+      readFileSync(new URL("./fixtures/agent-stats/track-ledger.jsonl", import.meta.url), "utf-8"),
+    );
+    mkdirSync(join(root, ".graphify", "agents"), { recursive: true });
+    // Mandated session (WP9 thread-id) that never committed anything.
+    const mandated = normalizeCodex(
+      parseCodexRollout(
+        JSON.stringify({ type: "session_meta", timestamp: "2026-06-09T01:00:00.000Z", payload: { id: "019ea9d4-c9f0-7832-9157-8e22c8e5d531", cwd: "/tmp/repo" } }),
+        "019ea9d4-c9f0-7832-9157-8e22c8e5d531",
+      ),
+    );
+    // Evidenced deliverer: unmandated session that committed on a wp9-labelled branch.
+    const evidenced = normalizeCodex(
+      parseCodexRollout(
+        [
+          JSON.stringify({ type: "session_meta", timestamp: "2026-06-09T02:00:00.000Z", payload: { id: "rogue-1", cwd: "/tmp/rogue" } }),
+          JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: JSON.stringify({ cmd: "git commit -m x", workdir: "/tmp/rogue" }) } }),
+          JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: "c1", output: "[wp9-rogue-branch 5555555] x" } }),
+        ].join("\n"),
+        "rogue-1",
+      ),
+    );
+    writeFileSync(
+      join(root, ".graphify", "agents", "facts.jsonl"),
+      JSON.stringify(mandated) + "\n" + JSON.stringify(evidenced) + "\n",
+    );
+    return root;
+  }
+
+  it("shows both mandated and evidenced sessions and flags the disagreement", () => {
+    const repoRoot = setupRepo();
+    const result = wpAgentStats(repoRoot, "WP9", {
+      injectedCommits: [{ sha: "5555555" + "0".repeat(33), subject: "x" }],
+      skipPrMerges: true,
+    });
+    expect(result.sessions).toHaveLength(1); // mandated
+    expect(result.evidenced).toHaveLength(1); // delivered on a WP9 branch
+    expect(result.evidenced[0]!.fact.sessionId).toBe("rogue-1");
+    expect(result.mismatch).toBe(true);
+    const view = formatWpView(result, "WP9");
+    expect(view).toContain("Evidenced");
+    expect(view).toMatch(/disagree|mismatch/i);
+    // Per-WP rollup of tokens + commits is present.
+    expect(view).toMatch(/Rollup/i);
+  });
+});


### PR DESCRIPTION
Addresses an adversarial review of the merged agent-stats: ground-truth only scraped from git-verb tool outputs (spoof-resistant), multi-WP join via decision.targets ULIDs (real WP9 item resolves), rank-4 identity-only, rank-2 branch-scoped + squash dedupe, Claude worktree-dir discovery (slug .→-), cross-repo segmentation, redaction hardening (dash-slug/tokens/cursors). Product: wp mandated+evidenced+mismatch flag, unattributed residual row, cost-weighted tokens + confidence, persisted append-only links. 27 new TDD tests; full npm test 1474 passed.