### PR TITLE
feat(scene): WP4 G2 — graphify_scene_hierarchies_v1 sidecar (signed workspace-bundle-contract-v1)

### DIFF
--- a/scripts/build-studio-demo.mjs
+++ b/scripts/build-studio-demo.mjs
@@ -91,6 +91,7 @@ if (!existsSync(join(spaDir, "index.html"))) {
 let buildStudioScene;
 let attachLayoutPositions;
 let buildEntitySidecar;
+let emitSceneHierarchies;
 let loadOntologyReconciliationCandidates;
 let queryOntologyReconciliationCandidates;
 try {
@@ -98,6 +99,7 @@ try {
     buildStudioScene,
     attachLayoutPositions,
     buildEntitySidecar,
+    emitSceneHierarchies,
     loadOntologyReconciliationCandidates,
     queryOntologyReconciliationCandidates,
   } = await import(join(root, "dist", "index.js")));
@@ -111,7 +113,13 @@ try {
 mkdirSync(outDir, { recursive: true });
 // Wipe stale generated data files but keep the dir (so an external .nojekyll or
 // similar is not collateral). We copy the SPA over the top.
-for (const f of ["scene.json", "graph.json", "reconciliation-candidates.json", "entities.json"]) {
+for (const f of [
+  "scene.json",
+  "scene-hierarchies.json",
+  "graph.json",
+  "reconciliation-candidates.json",
+  "entities.json",
+]) {
   rmSync(join(outDir, f), { force: true });
 }
 rmSync(join(outDir, "assets"), { recursive: true, force: true });
@@ -129,6 +137,21 @@ const nodes = Array.isArray(graph.nodes) ? graph.nodes : [];
 // mount. Matches the live server route byte-for-byte (deterministic layout).
 const scene = attachLayoutPositions(buildStudioScene(graph));
 writeFileSync(join(outDir, "scene.json"), JSON.stringify(scene));
+
+// --- 3b. scene-hierarchies.json (workspace-bundle-contract-v1, D1). ---
+// STANDALONE sidecar (never embedded in scene.json), emitted iff the
+// ontology compile produced <state>/ontology/hierarchies.json. Joins on the
+// raw registry ids: the scene contributes its lossless `registry_record_id`s.
+const sceneRawIds = new Set();
+for (const node of scene.nodes) {
+  const raw = typeof node.registry_record_id === "string" ? node.registry_record_id : node.id;
+  if (raw) sceneRawIds.add(raw);
+}
+const hierarchiesResult = emitSceneHierarchies({
+  ontologyOutputDir: join(stateDir, "ontology"),
+  sceneDir: outDir,
+  sceneNodeIds: sceneRawIds,
+});
 
 // --- 4. reconciliation-candidates.json: mirror the SPA's request. ---
 // The SPA fetches /api/ontology/reconciliation/candidates?sort=score&order=desc&limit=50.
@@ -177,5 +200,10 @@ writeFileSync(join(outDir, "entities.json"), JSON.stringify(entities));
 // --- Summary. ---
 console.log(`build-studio-demo: wrote standalone studio export to ${outDir}`);
 console.log(`  nodes: ${nodes.length} | scene nodes: ${scene.nodes.length} | scene edges: ${scene.edges.length}`);
+console.log(
+  hierarchiesResult.path
+    ? `  scene-hierarchies: ${Object.keys(hierarchiesResult.sidecar.hierarchies).length} hierarchies (${hierarchiesResult.path})`
+    : "  scene-hierarchies: none (no ontology/hierarchies.json in state dir)",
+);
 console.log(`  reconciliation candidates: ${candidatesResponse.total ?? candidatesResponse.items.length}`);
 console.log(`  entities index: ${Object.keys(entities).length} ids (${withDescription} with description, ${withOccurrences} with occurrences)`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -400,6 +400,24 @@ export type {
   StudioSceneNode,
   StudioSceneStats,
 } from "./studio-scene.js";
+export { SCENE_HIERARCHIES_SCHEMA, buildSceneHierarchySidecar } from "./scene-hierarchies.js";
+export type {
+  BuildSceneHierarchySidecarOptions,
+  SceneHierarchy,
+  SceneHierarchyConflict,
+  SceneHierarchyNodeEntry,
+  SceneHierarchyOverlayArc,
+  SceneHierarchySidecar,
+} from "./scene-hierarchies.js";
+export {
+  SCENE_HIERARCHIES_FILENAME,
+  clearSceneHierarchiesEmitterCache,
+  emitSceneHierarchies,
+} from "./scene-hierarchies-emitter.js";
+export type {
+  EmitSceneHierarchiesOptions,
+  EmitSceneHierarchiesResult,
+} from "./scene-hierarchies-emitter.js";
 export { buildEntitySidecar, resolveStudioAppDir } from "./studio-assets.js";
 export type { EntitySidecarResponse } from "./studio-assets.js";
 export { computeLayout, attachLayoutPositions } from "./graph-layout.js";

--- a/src/scene-hierarchies-emitter.ts
+++ b/src/scene-hierarchies-emitter.ts
@@ -1,0 +1,149 @@
+/**
+ * workspace-bundle-contract-v1 (WP4 G2) — scene-hierarchies.json emitter.
+ *
+ * Writes the STANDALONE `scene-hierarchies.json` artifact (schema
+ * `graphify_scene_hierarchies_v1`) next to `scene.json`, decoupled from the
+ * (optional) scene per frozen Decision 1:
+ *
+ *   - The sidecar is emitted IFF `<ontologyOutputDir>/hierarchies.json`
+ *     exists (the increment-A artifact produced by compileOntologyOutputs).
+ *     When it is absent, NO file is written (not a `null` placeholder).
+ *   - `buildStudioScene` never embeds the sidecar; scene.json stays
+ *     byte-identical with or without hierarchies.
+ *   - Cache-key = identity of hierarchies.json (path + mtime + size): the
+ *     sidecar is only rebuilt when the source artifact changes, mirroring
+ *     the scene cache in ontology-studio.ts.
+ *
+ * The pure builder lives in `scene-hierarchies.ts`; this module owns all
+ * the I/O.
+ */
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  buildSceneHierarchySidecar,
+  type SceneHierarchySidecar,
+} from "./scene-hierarchies.js";
+import type { OntologyHierarchyArc } from "./types.js";
+
+export const SCENE_HIERARCHIES_FILENAME = "scene-hierarchies.json";
+
+export interface EmitSceneHierarchiesOptions {
+  /** Ontology output dir containing `hierarchies.json` (e.g. <state>/ontology). */
+  ontologyOutputDir: string;
+  /** Dir where scene.json lives — `scene-hierarchies.json` is written there. */
+  sceneDir: string;
+  /**
+   * RAW registry ids present in the consuming scene (the verbatim
+   * `registry_record_id` values, D2). Optional: when omitted (e.g. the scene
+   * is absent — it is OPTIONAL per F1) every arc endpoint is considered
+   * present, so no orphan promotion / dangling pruning is applied.
+   */
+  sceneNodeIds?: Set<string>;
+  /** Optional per-hierarchy relation_type overrides. */
+  specs?: Record<string, { relation_type?: string }>;
+  /** Optional graph hash stamped on the envelope. */
+  graphHash?: string;
+}
+
+export interface EmitSceneHierarchiesResult {
+  /** True when scene-hierarchies.json was (re)written on this call. */
+  written: boolean;
+  /** Absolute target path, or null when hierarchies.json is absent. */
+  path: string | null;
+  /** The emitted sidecar, or null when hierarchies.json is absent. */
+  sidecar: SceneHierarchySidecar | null;
+  /** True when the cached sidecar was reused (source mtime unchanged). */
+  cached: boolean;
+}
+
+interface EmitterCacheEntry {
+  /** Identity of hierarchies.json + the inputs that shape the sidecar. */
+  sourceKey: string;
+  sidecar: SceneHierarchySidecar;
+}
+
+/** Cache keyed by target path (one entry per export/scene dir). */
+const emitterCache = new Map<string, EmitterCacheEntry>();
+
+/** Test hook: drop the mtime cache (e.g. between fixture roots). */
+export function clearSceneHierarchiesEmitterCache(): void {
+  emitterCache.clear();
+}
+
+function sourceKeyFor(
+  hierarchiesPath: string,
+  options: EmitSceneHierarchiesOptions,
+): string {
+  const stat = statSync(hierarchiesPath);
+  const sceneIdsKey = options.sceneNodeIds
+    ? [...options.sceneNodeIds].sort().join("")
+    : "*";
+  return [
+    hierarchiesPath,
+    String(stat.mtimeMs),
+    String(stat.size),
+    options.graphHash ?? "",
+    sceneIdsKey,
+  ].join("\u0000");
+}
+
+function readArcs(hierarchiesPath: string): OntologyHierarchyArc[] {
+  const raw: unknown = JSON.parse(readFileSync(hierarchiesPath, "utf-8"));
+  return Array.isArray(raw) ? (raw as OntologyHierarchyArc[]) : [];
+}
+
+/** All raw ids referenced by the arcs (default scene universe, F1). */
+function arcNodeIds(arcs: OntologyHierarchyArc[]): Set<string> {
+  const ids = new Set<string>();
+  for (const arc of arcs) {
+    ids.add(arc.parent_id);
+    ids.add(arc.child_id);
+  }
+  return ids;
+}
+
+/**
+ * Emit `scene-hierarchies.json` into `sceneDir` IFF
+ * `<ontologyOutputDir>/hierarchies.json` exists. Idempotent and cached on
+ * the source artifact's mtime: an unchanged source skips both the rebuild
+ * and the rewrite (unless the target file is missing).
+ */
+export function emitSceneHierarchies(
+  options: EmitSceneHierarchiesOptions,
+): EmitSceneHierarchiesResult {
+  const hierarchiesPath = join(options.ontologyOutputDir, "hierarchies.json");
+  if (!existsSync(hierarchiesPath)) {
+    // D1: the sidecar is core but source-gated — no hierarchies, no file.
+    return { written: false, path: null, sidecar: null, cached: false };
+  }
+
+  const targetPath = join(options.sceneDir, SCENE_HIERARCHIES_FILENAME);
+  const sourceKey = sourceKeyFor(hierarchiesPath, options);
+  const cachedEntry = emitterCache.get(targetPath);
+  const cached = cachedEntry !== undefined && cachedEntry.sourceKey === sourceKey;
+
+  let sidecar: SceneHierarchySidecar;
+  if (cached) {
+    sidecar = cachedEntry.sidecar;
+  } else {
+    const arcs = readArcs(hierarchiesPath);
+    sidecar = buildSceneHierarchySidecar({
+      arcs,
+      sceneNodeIds: options.sceneNodeIds ?? arcNodeIds(arcs),
+      ...(options.specs !== undefined ? { specs: options.specs } : {}),
+      ...(options.graphHash !== undefined ? { graphHash: options.graphHash } : {}),
+    });
+    emitterCache.set(targetPath, { sourceKey, sidecar });
+  }
+
+  // Rewrite only when the sidecar was rebuilt or the artifact vanished.
+  const mustWrite = !cached || !existsSync(targetPath);
+  if (mustWrite) {
+    mkdirSync(dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, JSON.stringify(sidecar, null, 2) + "\n", "utf-8");
+  }
+
+  return { written: mustWrite, path: targetPath, sidecar, cached };
+}

--- a/src/scene-hierarchies.ts
+++ b/src/scene-hierarchies.ts
@@ -1,0 +1,353 @@
+/**
+ * workspace-bundle-contract-v1 (WP4 G2) — scene hierarchy sidecar builder.
+ *
+ * Pure builder for the `graphify_scene_hierarchies_v1` artifact
+ * (`scene-hierarchies.json`), the AUTONOMOUS hierarchy sidecar of the
+ * Workspace Consumption Bundle (frozen contract, signed 2/2):
+ *
+ *   - D1 (transport): the sidecar is a STANDALONE file — never embedded in
+ *     scene.json (the scene is OPTIONAL per F1; the hierarchy is core).
+ *   - D2 (id contract): all keys / ids in this artifact are the RAW registry
+ *     ids, verbatim lossless (`AM0104.01`, `DE.AI.01`, `org:CODE`, dashed
+ *     UUIDs — no `.`/`-`→`_` transformation, no id_map). Consumers join the
+ *     scene via the `registry_record_id` carried by scene nodes.
+ *
+ * Lane rules (frozen):
+ *   - LANE 1 (tree): arcs with status ∈ {reference, validated}. Mono-parent
+ *     is ENFORCED — first parent wins by stable sort; losers are recorded in
+ *     `conflicts[]` and demoted into `overlay_arcs`. `status` is carried by
+ *     the CHILD entry. The sidecar is AUTHORITATIVE for traversal; the
+ *     node-level parent_id/child_ids from G1 are display-only.
+ *   - LANE 2 (overlay): the remaining statuses (proposed / inferred /
+ *     candidate). Empty in v1 (the profile pipeline only produces
+ *     status:"reference" arcs) apart from mono-parent demotions.
+ *   - Orphan tolerance (B6): a child whose parent is absent from
+ *     `sceneNodeIds` is promoted to root and listed in `orphan_ids`.
+ *   - Cycle parity: roots / levels / cycles reuse `buildHierarchyIndex`;
+ *     nodes on a cycle are reported in `cycles[]` and excluded from
+ *     `nodes_by_id` (exactly as the index excludes them from
+ *     root_ids/ancestor_paths).
+ *
+ * This module is PURE (no I/O). The standalone emitter lives in
+ * `scene-hierarchies-emitter.ts`.
+ */
+
+import { buildHierarchyIndex } from "./ontology-hierarchies.js";
+import type { OntologyHierarchyArc } from "./types.js";
+
+export const SCENE_HIERARCHIES_SCHEMA = "graphify_scene_hierarchies_v1";
+
+/** LANE 1 — authoritative tree statuses (frozen contract). */
+const TREE_LANE_STATUSES = new Set(["reference", "validated"]);
+
+/** Per-node entry of a hierarchy tree (LANE 1). Keyed by raw id. */
+export interface SceneHierarchyNodeEntry {
+  /** Raw id of the mono-parent, or null for roots (incl. promoted orphans). */
+  parent_id: string | null;
+  /** Raw ids of the kept (lane-1, acyclic) children, sorted. */
+  child_ids: string[];
+  /** Depth from the root (0 = root). */
+  level: number;
+  /** Optional display code (NOT the join key). */
+  code?: string;
+  /** Lifecycle status of the arc that attached this node to its parent. */
+  status: "reference" | "validated";
+  assertion_basis?: string;
+  derivation_method?: string;
+  /** Raw registry id, verbatim lossless (D2). Equals the entry key. */
+  registry_record_id: string;
+}
+
+/** LANE 2 — overlay (non-tree) arc. Empty in v1 except mono-parent demotions. */
+export interface SceneHierarchyOverlayArc {
+  parent_id: string;
+  child_id: string;
+  status: "proposed" | "inferred" | "candidate";
+  confidence?: number;
+  evidence_refs?: string[];
+  derivation_method?: string;
+}
+
+/** Mono-parent enforcement record: losers demoted into overlay_arcs. */
+export interface SceneHierarchyConflict {
+  child_id: string;
+  kept_parent_id: string;
+  demoted_parent_ids: string[];
+}
+
+export interface SceneHierarchy {
+  relation_type: string;
+  kind: "tree" | "forest";
+  root_ids: string[];
+  max_depth: number;
+  nodes_by_id: Record<string, SceneHierarchyNodeEntry>;
+  overlay_arcs: SceneHierarchyOverlayArc[];
+  orphan_ids: string[];
+  cycles: string[][];
+  conflicts: SceneHierarchyConflict[];
+  /** Arcs dropped without any trace elsewhere in the artifact. */
+  dangling_arc_count: number;
+}
+
+export interface SceneHierarchySidecar {
+  schema: typeof SCENE_HIERARCHIES_SCHEMA;
+  generated_at: string;
+  graph_hash: string | null;
+  hierarchies: Record<string, SceneHierarchy>;
+}
+
+export interface BuildSceneHierarchySidecarOptions {
+  /** All hierarchy arcs (every hierarchy mixed; grouped by hierarchy_id). */
+  arcs: OntologyHierarchyArc[];
+  /**
+   * RAW registry ids present in the consuming scene/workspace (D2 join key —
+   * the verbatim id_column values, i.e. the `registry_record_id` of scene
+   * nodes, NOT the slugged native scene ids).
+   */
+  sceneNodeIds: Set<string>;
+  /** Optional hierarchy specs (relation_type override per hierarchy_id). */
+  specs?: Record<string, { relation_type?: string }>;
+  /** Optional graph hash stamped on the envelope. */
+  graphHash?: string;
+}
+
+/**
+ * Build the `graphify_scene_hierarchies_v1` sidecar. Pure and deterministic:
+ * every list is stably sorted, so identical inputs yield identical artifacts
+ * regardless of arc order (only `generated_at` varies).
+ */
+export function buildSceneHierarchySidecar(
+  options: BuildSceneHierarchySidecarOptions,
+): SceneHierarchySidecar {
+  const { arcs, sceneNodeIds, specs, graphHash } = options;
+
+  const byHierarchy = new Map<string, OntologyHierarchyArc[]>();
+  for (const arc of arcs) {
+    const bucket = byHierarchy.get(arc.hierarchy_id);
+    if (bucket) bucket.push(arc);
+    else byHierarchy.set(arc.hierarchy_id, [arc]);
+  }
+
+  const hierarchies: Record<string, SceneHierarchy> = {};
+  for (const hierarchyId of [...byHierarchy.keys()].sort()) {
+    // Non-null: the key comes straight from the map.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const hierarchyArcs = byHierarchy.get(hierarchyId)!;
+    hierarchies[hierarchyId] = buildOneHierarchy(
+      hierarchyArcs,
+      sceneNodeIds,
+      specs?.[hierarchyId],
+    );
+  }
+
+  return {
+    schema: SCENE_HIERARCHIES_SCHEMA,
+    generated_at: new Date().toISOString(),
+    graph_hash: graphHash ?? null,
+    hierarchies,
+  };
+}
+
+function arcStatus(arc: OntologyHierarchyArc): string {
+  // Profile-declared arcs always carry status:"reference"; tolerate absent
+  // status on legacy artifacts by defaulting to the authoritative lane.
+  return arc.status ?? "reference";
+}
+
+function treeStatus(value: string): "reference" | "validated" {
+  return value === "validated" ? "validated" : "reference";
+}
+
+function overlayStatus(value: string): "proposed" | "inferred" | "candidate" {
+  return value === "inferred" || value === "candidate" ? value : "proposed";
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function overlayArcFrom(
+  arc: OntologyHierarchyArc,
+  status: "proposed" | "inferred" | "candidate",
+  derivationMethod?: string,
+): SceneHierarchyOverlayArc {
+  const out: SceneHierarchyOverlayArc = {
+    parent_id: arc.parent_id,
+    child_id: arc.child_id,
+    status,
+  };
+  if (typeof arc.confidence === "number") out.confidence = arc.confidence;
+  if (Array.isArray(arc.evidence_refs) && arc.evidence_refs.length > 0) {
+    out.evidence_refs = arc.evidence_refs;
+  }
+  if (derivationMethod) out.derivation_method = derivationMethod;
+  return out;
+}
+
+function buildOneHierarchy(
+  arcs: OntologyHierarchyArc[],
+  sceneNodeIds: Set<string>,
+  spec: { relation_type?: string } | undefined,
+): SceneHierarchy {
+  let danglingArcCount = 0;
+  const overlayArcs: SceneHierarchyOverlayArc[] = [];
+  /** LANE 1 arcs with both endpoints present, grouped per child. */
+  const treeArcsByChild = new Map<string, OntologyHierarchyArc[]>();
+  /** LANE 1 arcs whose child is present but parent is absent (orphan path). */
+  const absentParentArcsByChild = new Map<string, OntologyHierarchyArc[]>();
+
+  for (const arc of arcs) {
+    const status = arcStatus(arc);
+    if (TREE_LANE_STATUSES.has(status)) {
+      // LANE 1 — tree candidates.
+      if (!sceneNodeIds.has(arc.child_id)) {
+        danglingArcCount += 1; // child unknown: nothing to attach, no trace
+        continue;
+      }
+      if (!sceneNodeIds.has(arc.parent_id)) {
+        const bucket = absentParentArcsByChild.get(arc.child_id);
+        if (bucket) bucket.push(arc);
+        else absentParentArcsByChild.set(arc.child_id, [arc]);
+        continue;
+      }
+      const bucket = treeArcsByChild.get(arc.child_id);
+      if (bucket) bucket.push(arc);
+      else treeArcsByChild.set(arc.child_id, [arc]);
+    } else {
+      // LANE 2 — overlay passthrough (requires both endpoints present).
+      if (!sceneNodeIds.has(arc.child_id) || !sceneNodeIds.has(arc.parent_id)) {
+        danglingArcCount += 1;
+        continue;
+      }
+      overlayArcs.push(overlayArcFrom(arc, overlayStatus(status)));
+    }
+  }
+
+  // --- Mono-parent enforcement (LANE 1) -----------------------------------
+  // First parent wins by STABLE sort on parent_id (deterministic regardless
+  // of input arc order); losers → conflicts[] + demoted into overlay_arcs.
+  const conflicts: SceneHierarchyConflict[] = [];
+  const keptArcs: OntologyHierarchyArc[] = [];
+  const keptArcByChild = new Map<string, OntologyHierarchyArc>();
+
+  for (const child of [...treeArcsByChild.keys()].sort(compareStrings)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const candidates = [...treeArcsByChild.get(child)!].sort((a, b) =>
+      compareStrings(a.parent_id, b.parent_id),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const winner = candidates[0]!;
+    keptArcs.push(winner);
+    keptArcByChild.set(child, winner);
+
+    // Losers with DISTINCT parents are conflicts; exact duplicates of the
+    // winner are silently collapsed (they are already represented).
+    const demoted = candidates
+      .slice(1)
+      .filter((arc) => arc.parent_id !== winner.parent_id);
+    const demotedParentIds = [...new Set(demoted.map((arc) => arc.parent_id))].sort(
+      compareStrings,
+    );
+    if (demotedParentIds.length > 0) {
+      conflicts.push({
+        child_id: child,
+        kept_parent_id: winner.parent_id,
+        demoted_parent_ids: demotedParentIds,
+      });
+      const seenDemotedParents = new Set<string>();
+      for (const arc of demoted) {
+        if (seenDemotedParents.has(arc.parent_id)) continue;
+        seenDemotedParents.add(arc.parent_id);
+        overlayArcs.push(
+          overlayArcFrom(arc, "proposed", "mono_parent_demotion"),
+        );
+      }
+    }
+  }
+
+  // --- Orphan tolerance (B6) ----------------------------------------------
+  // A child whose EVERY lane-1 parent is absent from the scene is promoted
+  // to root and listed in orphan_ids. If the child also has a present
+  // parent, the absent-parent arcs are simply dangling.
+  const orphanIds: string[] = [];
+  const orphanStatusByChild = new Map<string, "reference" | "validated">();
+  for (const [child, missingArcs] of absentParentArcsByChild) {
+    if (keptArcByChild.has(child)) {
+      danglingArcCount += missingArcs.length;
+      continue;
+    }
+    orphanIds.push(child);
+    const sorted = [...missingArcs].sort((a, b) => compareStrings(a.parent_id, b.parent_id));
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    orphanStatusByChild.set(child, treeStatus(arcStatus(sorted[0]!)));
+    // One tolerated arc carries the promotion; extra absent parents leave no trace.
+    danglingArcCount += missingArcs.length - 1;
+  }
+  orphanIds.sort(compareStrings);
+
+  // --- Roots / levels / cycles: buildHierarchyIndex parity -----------------
+  const index = buildHierarchyIndex(keptArcs);
+  const cycleNodes = new Set(index.cycles.flat());
+
+  // Entry universe: acyclic nodes reachable from the index roots, plus
+  // promoted orphans (which may be absent from the index when they have no
+  // kept arcs at all).
+  const entryIds = new Set<string>(Object.keys(index.ancestor_paths));
+  for (const orphan of orphanIds) {
+    if (!cycleNodes.has(orphan)) entryIds.add(orphan);
+  }
+
+  const childIdsByParent = new Map<string, string[]>();
+  for (const arc of keptArcs) {
+    if (!entryIds.has(arc.parent_id) || !entryIds.has(arc.child_id)) continue;
+    const bucket = childIdsByParent.get(arc.parent_id);
+    if (bucket) bucket.push(arc.child_id);
+    else childIdsByParent.set(arc.parent_id, [arc.child_id]);
+  }
+
+  const nodesById: Record<string, SceneHierarchyNodeEntry> = {};
+  for (const id of [...entryIds].sort(compareStrings)) {
+    const keptArc = keptArcByChild.get(id);
+    const parentId =
+      keptArc && entryIds.has(keptArc.parent_id) ? keptArc.parent_id : null;
+    const status = keptArc
+      ? treeStatus(arcStatus(keptArc))
+      : // Roots/orphans have no attaching arc: orphan keeps the tolerated
+        // arc's status; plain roots default to the authoritative lane.
+        (orphanStatusByChild.get(id) ?? "reference");
+    nodesById[id] = {
+      parent_id: parentId,
+      child_ids: (childIdsByParent.get(id) ?? []).sort(compareStrings),
+      level: index.ancestor_paths[id]?.length ?? 0,
+      status,
+      // D2: the entry key IS the raw registry id; repeated verbatim so each
+      // entry is self-describing once detached from the map.
+      registry_record_id: id,
+    };
+  }
+
+  const rootIds = [...new Set([...index.root_ids, ...orphanIds])]
+    .filter((id) => entryIds.has(id))
+    .sort(compareStrings);
+
+  overlayArcs.sort(
+    (a, b) =>
+      compareStrings(a.child_id, b.child_id) ||
+      compareStrings(a.parent_id, b.parent_id) ||
+      compareStrings(a.status, b.status),
+  );
+
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    relation_type: spec?.relation_type ?? arcs[0]!.type,
+    kind: rootIds.length === 1 ? "tree" : "forest",
+    root_ids: rootIds,
+    max_depth: index.depth,
+    nodes_by_id: nodesById,
+    overlay_arcs: overlayArcs,
+    orphan_ids: orphanIds,
+    cycles: index.cycles,
+    conflicts,
+    dangling_arc_count: danglingArcCount,
+  };
+}

--- a/src/studio-scene.ts
+++ b/src/studio-scene.ts
@@ -169,6 +169,14 @@ const NODE_PROFILE_FIELDS = [
   "confidence_score",
   "evidence_refs",
   "canonical_id",
+  // workspace-bundle-contract-v1 (D2): lossless registry passthrough. The
+  // scene node keeps its native graphify id (`registry_<reg>_<slug>`), and
+  // ADDITIONALLY carries `registry_record_id` = the id_column value VERBATIM
+  // (e.g. "AM0104.01", "DE.AI.01", "org:CODE", dashed UUIDs — no `.`/`-`→`_`
+  // transformation), so consumers (aclp-am viewer, scene-hierarchies sidecar)
+  // can canonicalise/join on the raw registry id without an id_map.
+  "registry_id",
+  "registry_record_id",
   "entity_url",
   "source_file",
   "source_location",

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -60,6 +60,10 @@ const NODE_PROFILE_FIELDS = [
   "confidence_score",
   "evidence_refs",
   "canonical_id",
+  // workspace-bundle-contract-v1 (D2): lossless registry passthrough (raw
+  // id_column verbatim). Kept in lockstep with src/studio-scene.ts.
+  "registry_id",
+  "registry_record_id",
   "entity_url",
   "source_file",
   "source_location",

--- a/tests/scene-hierarchies-emitter.test.ts
+++ b/tests/scene-hierarchies-emitter.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SCENE_HIERARCHIES_FILENAME,
+  clearSceneHierarchiesEmitterCache,
+  emitSceneHierarchies,
+} from "../src/scene-hierarchies-emitter.js";
+import type { OntologyHierarchyArc } from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-scene-hier-emit-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function arc(parentId: string, childId: string): OntologyHierarchyArc {
+  return {
+    hierarchy_id: "h",
+    parent_id: parentId,
+    child_id: childId,
+    level: 0,
+    type: "parent_of",
+    source: "profile",
+    status: "reference",
+    confidence: 1.0,
+  };
+}
+
+function writeHierarchies(ontologyDir: string, arcs: OntologyHierarchyArc[]): string {
+  mkdirSync(ontologyDir, { recursive: true });
+  const path = join(ontologyDir, "hierarchies.json");
+  writeFileSync(path, JSON.stringify(arcs, null, 2) + "\n", "utf-8");
+  return path;
+}
+
+beforeEach(() => {
+  clearSceneHierarchiesEmitterCache();
+});
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("emitSceneHierarchies — standalone scene-hierarchies.json (D1)", () => {
+  it("writes scene-hierarchies.json next to scene.json when hierarchies.json exists", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology");
+    const sceneDir = join(root, "export");
+    writeHierarchies(ontologyDir, [arc("AM0104", "AM0104.01")]);
+    mkdirSync(sceneDir, { recursive: true });
+
+    const result = emitSceneHierarchies({
+      ontologyOutputDir: ontologyDir,
+      sceneDir,
+      graphHash: "feedface",
+    });
+
+    expect(result.written).toBe(true);
+    expect(result.cached).toBe(false);
+    expect(result.path).toBe(join(sceneDir, SCENE_HIERARCHIES_FILENAME));
+    expect(existsSync(result.path!)).toBe(true);
+
+    const onDisk = JSON.parse(readFileSync(result.path!, "utf-8"));
+    expect(onDisk).toEqual(result.sidecar);
+    expect(onDisk.schema).toBe("graphify_scene_hierarchies_v1");
+    expect(onDisk.graph_hash).toBe("feedface");
+    // Raw ids stay lossless join keys on disk.
+    expect(onDisk.hierarchies.h.nodes_by_id["AM0104.01"]).toMatchObject({
+      parent_id: "AM0104",
+      registry_record_id: "AM0104.01",
+    });
+  });
+
+  it("writes NO file (not null) when hierarchies.json is absent", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology"); // never created
+    const sceneDir = join(root, "export");
+    mkdirSync(sceneDir, { recursive: true });
+
+    const result = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+
+    expect(result).toEqual({ written: false, path: null, sidecar: null, cached: false });
+    expect(existsSync(join(sceneDir, SCENE_HIERARCHIES_FILENAME))).toBe(false);
+  });
+
+  it("reuses the cache when hierarchies.json is unchanged (same mtime)", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology");
+    const sceneDir = join(root, "export");
+    writeHierarchies(ontologyDir, [arc("r", "a")]);
+
+    const first = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    expect(first.written).toBe(true);
+
+    const second = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    expect(second.cached).toBe(true);
+    expect(second.written).toBe(false); // file already on disk, source unchanged
+    expect(second.sidecar).toBe(first.sidecar); // same instance — no rebuild
+  });
+
+  it("invalidates the cache when hierarchies.json mtime changes", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology");
+    const sceneDir = join(root, "export");
+    const hierarchiesPath = writeHierarchies(ontologyDir, [arc("r", "a")]);
+
+    const first = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    expect(Object.keys(first.sidecar!.hierarchies.h!.nodes_by_id).sort()).toEqual(["a", "r"]);
+
+    // New content + explicitly bumped mtime (sub-ms writes could otherwise tie).
+    writeFileSync(
+      hierarchiesPath,
+      JSON.stringify([arc("r", "a"), arc("a", "b")], null, 2) + "\n",
+      "utf-8",
+    );
+    const future = new Date(Date.now() + 5_000);
+    utimesSync(hierarchiesPath, future, future);
+
+    const second = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    expect(second.cached).toBe(false);
+    expect(second.written).toBe(true);
+    expect(Object.keys(second.sidecar!.hierarchies.h!.nodes_by_id).sort()).toEqual([
+      "a",
+      "b",
+      "r",
+    ]);
+    const onDisk = JSON.parse(readFileSync(second.path!, "utf-8"));
+    expect(onDisk).toEqual(second.sidecar);
+  });
+
+  it("rewrites a cached sidecar when the target file vanished", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology");
+    const sceneDir = join(root, "export");
+    writeHierarchies(ontologyDir, [arc("r", "a")]);
+
+    const first = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    rmSync(first.path!);
+
+    const again = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    expect(again.cached).toBe(true); // builder skipped…
+    expect(again.written).toBe(true); // …but the artifact is restored
+    expect(existsSync(again.path!)).toBe(true);
+  });
+
+  it("defaults the node universe to the arc endpoints when sceneNodeIds is omitted (scene optional, F1)", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology");
+    const sceneDir = join(root, "export");
+    writeHierarchies(ontologyDir, [arc("r", "a"), arc("a", "b")]);
+
+    const result = emitSceneHierarchies({ ontologyOutputDir: ontologyDir, sceneDir });
+    const h = result.sidecar!.hierarchies.h!;
+    expect(h.orphan_ids).toEqual([]);
+    expect(h.dangling_arc_count).toBe(0);
+    expect(h.root_ids).toEqual(["r"]);
+  });
+
+  it("applies sceneNodeIds when provided: missing parents become orphan promotions", () => {
+    const root = makeTempDir();
+    const ontologyDir = join(root, "ontology");
+    const sceneDir = join(root, "export");
+    writeHierarchies(ontologyDir, [arc("r", "a"), arc("a", "b")]);
+
+    const result = emitSceneHierarchies({
+      ontologyOutputDir: ontologyDir,
+      sceneDir,
+      sceneNodeIds: new Set(["a", "b"]), // "r" absent from the scene
+    });
+    const h = result.sidecar!.hierarchies.h!;
+    expect(h.orphan_ids).toEqual(["a"]);
+    expect(h.root_ids).toEqual(["a"]);
+    expect(h.nodes_by_id["a"]).toMatchObject({ parent_id: null, level: 0 });
+  });
+});

--- a/tests/scene-hierarchies.test.ts
+++ b/tests/scene-hierarchies.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SCENE_HIERARCHIES_SCHEMA,
+  buildSceneHierarchySidecar,
+  type SceneHierarchySidecar,
+} from "../src/scene-hierarchies.js";
+import { buildHierarchyIndex } from "../src/ontology-hierarchies.js";
+import type { OntologyHierarchyArc, OntologyStatus } from "../src/types.js";
+
+function arc(
+  hierarchyId: string,
+  parentId: string,
+  childId: string,
+  status: OntologyStatus = "reference",
+  extra: Partial<OntologyHierarchyArc> = {},
+): OntologyHierarchyArc {
+  return {
+    hierarchy_id: hierarchyId,
+    parent_id: parentId,
+    child_id: childId,
+    level: 0,
+    type: "parent_of",
+    source: "profile",
+    status,
+    confidence: 1.0,
+    ...extra,
+  };
+}
+
+function ids(...values: string[]): Set<string> {
+  return new Set(values);
+}
+
+/** Strip the only non-deterministic field for full-value comparisons. */
+function stable(sidecar: SceneHierarchySidecar): Omit<SceneHierarchySidecar, "generated_at"> {
+  const { generated_at: _generatedAt, ...rest } = sidecar;
+  return rest;
+}
+
+describe("buildSceneHierarchySidecar — graphify_scene_hierarchies_v1", () => {
+  it("returns the envelope with hierarchies:{} for empty arcs", () => {
+    const sidecar = buildSceneHierarchySidecar({ arcs: [], sceneNodeIds: ids() });
+    expect(sidecar.schema).toBe(SCENE_HIERARCHIES_SCHEMA);
+    expect(sidecar.schema).toBe("graphify_scene_hierarchies_v1");
+    expect(sidecar.hierarchies).toEqual({});
+    expect(sidecar.graph_hash).toBeNull();
+    expect(typeof sidecar.generated_at).toBe("string");
+  });
+
+  it("stamps graph_hash when provided", () => {
+    const sidecar = buildSceneHierarchySidecar({
+      arcs: [],
+      sceneNodeIds: ids(),
+      graphHash: "abc123",
+    });
+    expect(sidecar.graph_hash).toBe("abc123");
+  });
+
+  it("builds a simple lane-1 tree: roots, levels, child_ids, max_depth, kind", () => {
+    const arcs = [
+      arc("h", "root", "a"),
+      arc("h", "root", "b"),
+      arc("h", "a", "a1", "validated"),
+    ];
+    const sidecar = buildSceneHierarchySidecar({
+      arcs,
+      sceneNodeIds: ids("root", "a", "b", "a1"),
+    });
+    const h = sidecar.hierarchies["h"]!;
+    expect(h.relation_type).toBe("parent_of");
+    expect(h.kind).toBe("tree");
+    expect(h.root_ids).toEqual(["root"]);
+    expect(h.max_depth).toBe(2);
+    expect(h.orphan_ids).toEqual([]);
+    expect(h.cycles).toEqual([]);
+    expect(h.conflicts).toEqual([]);
+    expect(h.overlay_arcs).toEqual([]);
+    expect(h.dangling_arc_count).toBe(0);
+
+    expect(h.nodes_by_id["root"]).toEqual({
+      parent_id: null,
+      child_ids: ["a", "b"],
+      level: 0,
+      status: "reference",
+      registry_record_id: "root",
+    });
+    expect(h.nodes_by_id["a"]).toMatchObject({ parent_id: "root", level: 1, child_ids: ["a1"] });
+    // status is carried by the CHILD entry (the arc that attached it).
+    expect(h.nodes_by_id["a1"]).toMatchObject({
+      parent_id: "a",
+      level: 2,
+      child_ids: [],
+      status: "validated",
+    });
+  });
+
+  it("lane-splits by status: reference/validated → tree, the rest → overlay_arcs", () => {
+    const arcs = [
+      arc("h", "r", "a", "reference"),
+      arc("h", "r", "b", "validated"),
+      arc("h", "a", "c", "proposed", { confidence: 0.7, evidence_refs: ["doc#1"] }),
+      arc("h", "b", "c", "inferred", { confidence: 0.4 }),
+      arc("h", "a", "b", "candidate"),
+    ];
+    const h = buildSceneHierarchySidecar({
+      arcs,
+      sceneNodeIds: ids("r", "a", "b", "c"),
+    }).hierarchies["h"]!;
+
+    // Tree only contains the lane-1 arcs.
+    expect(Object.keys(h.nodes_by_id).sort()).toEqual(["a", "b", "r"]);
+    expect(h.nodes_by_id["a"]!.status).toBe("reference");
+    expect(h.nodes_by_id["b"]!.status).toBe("validated");
+    // `c` only appears via overlays — never as a tree entry.
+    expect(h.nodes_by_id["c"]).toBeUndefined();
+
+    expect(h.overlay_arcs).toEqual([
+      { parent_id: "a", child_id: "b", status: "candidate", confidence: 1.0 },
+      { parent_id: "a", child_id: "c", status: "proposed", confidence: 0.7, evidence_refs: ["doc#1"] },
+      { parent_id: "b", child_id: "c", status: "inferred", confidence: 0.4 },
+    ]);
+    expect(h.conflicts).toEqual([]);
+    expect(h.dangling_arc_count).toBe(0);
+  });
+
+  it("enforces mono-parent deterministically: first wins by stable sort, losers → conflicts + overlay", () => {
+    const base = [
+      arc("h", "p2", "x", "validated"),
+      arc("h", "p1", "x", "reference", { evidence_refs: ["reg#row42"] }),
+      arc("h", "r", "p1"),
+      arc("h", "r", "p2"),
+    ];
+    const scene = ids("r", "p1", "p2", "x");
+    const h = buildSceneHierarchySidecar({ arcs: base, sceneNodeIds: scene }).hierarchies["h"]!;
+
+    // p1 < p2 → p1 wins regardless of input order.
+    expect(h.nodes_by_id["x"]).toMatchObject({ parent_id: "p1", level: 2, status: "reference" });
+    expect(h.conflicts).toEqual([
+      { child_id: "x", kept_parent_id: "p1", demoted_parent_ids: ["p2"] },
+    ]);
+    expect(h.overlay_arcs).toEqual([
+      {
+        parent_id: "p2",
+        child_id: "x",
+        status: "proposed",
+        confidence: 1.0,
+        derivation_method: "mono_parent_demotion",
+      },
+    ]);
+    expect(h.nodes_by_id["p2"]!.child_ids).toEqual([]); // demoted arc is not a tree edge
+
+    // Determinism: reversed input order yields the exact same artifact.
+    const reversed = buildSceneHierarchySidecar({
+      arcs: [...base].reverse(),
+      sceneNodeIds: scene,
+    });
+    expect(stable(reversed)).toEqual(
+      stable(buildSceneHierarchySidecar({ arcs: base, sceneNodeIds: scene })),
+    );
+  });
+
+  it("collapses exact duplicate arcs without a conflict", () => {
+    const h = buildSceneHierarchySidecar({
+      arcs: [arc("h", "r", "a"), arc("h", "r", "a")],
+      sceneNodeIds: ids("r", "a"),
+    }).hierarchies["h"]!;
+    expect(h.conflicts).toEqual([]);
+    expect(h.overlay_arcs).toEqual([]);
+    expect(h.nodes_by_id["a"]!.parent_id).toBe("r");
+  });
+
+  it("promotes orphans to roots (parent absent from sceneNodeIds) and lists orphan_ids", () => {
+    const arcs = [
+      arc("h", "missing", "org:CODE", "validated"),
+      arc("h", "org:CODE", "leaf"),
+      arc("h", "r", "a"),
+    ];
+    const h = buildSceneHierarchySidecar({
+      arcs,
+      sceneNodeIds: ids("org:CODE", "leaf", "r", "a"),
+    }).hierarchies["h"]!;
+
+    expect(h.orphan_ids).toEqual(["org:CODE"]);
+    expect(h.root_ids).toEqual(["org:CODE", "r"]);
+    expect(h.kind).toBe("forest");
+    // Promoted root: parent null, level 0, status from the tolerated arc.
+    expect(h.nodes_by_id["org:CODE"]).toEqual({
+      parent_id: null,
+      child_ids: ["leaf"],
+      level: 0,
+      status: "validated",
+      registry_record_id: "org:CODE",
+    });
+    expect(h.nodes_by_id["leaf"]).toMatchObject({ parent_id: "org:CODE", level: 1 });
+    // The tolerated arc is accounted for by the promotion — not dangling.
+    expect(h.dangling_arc_count).toBe(0);
+  });
+
+  it("promotes a leaf orphan (no children) to a level-0 root entry", () => {
+    const h = buildSceneHierarchySidecar({
+      arcs: [arc("h", "ghost", "alone")],
+      sceneNodeIds: ids("alone"),
+    }).hierarchies["h"]!;
+    expect(h.orphan_ids).toEqual(["alone"]);
+    expect(h.root_ids).toEqual(["alone"]);
+    expect(h.nodes_by_id["alone"]).toEqual({
+      parent_id: null,
+      child_ids: [],
+      level: 0,
+      status: "reference",
+      registry_record_id: "alone",
+    });
+  });
+
+  it("counts dangling arcs: unknown child, or absent parent when the child already has one", () => {
+    const arcs = [
+      arc("h", "r", "a"),
+      arc("h", "r", "unknown-child"), // child not in scene → dangling
+      arc("h", "ghost", "a"), // a already parented by r → dangling
+      arc("h", "ghost", "overlay-child", "proposed"), // overlay needs both endpoints → dangling
+    ];
+    const h = buildSceneHierarchySidecar({
+      arcs,
+      sceneNodeIds: ids("r", "a", "overlay-child"),
+    }).hierarchies["h"]!;
+    expect(h.dangling_arc_count).toBe(3);
+    expect(h.orphan_ids).toEqual([]);
+    expect(h.overlay_arcs).toEqual([]);
+    expect(h.nodes_by_id["a"]!.parent_id).toBe("r");
+  });
+
+  it("reports cycles with buildHierarchyIndex parity and excludes cycle nodes from the tree", () => {
+    const cycleArcs = [
+      arc("h", "c1", "c2"),
+      arc("h", "c2", "c3"),
+      arc("h", "c3", "c1"),
+      arc("h", "r", "a"),
+    ];
+    const h = buildSceneHierarchySidecar({
+      arcs: cycleArcs,
+      sceneNodeIds: ids("c1", "c2", "c3", "r", "a"),
+    }).hierarchies["h"]!;
+
+    const index = buildHierarchyIndex(cycleArcs);
+    // Parity on cycle MEMBERSHIP (the cycle path representation is
+    // rotation-equivalent: DFS start order may differ once arcs are
+    // stably re-sorted by the mono-parent pass).
+    const cycleNodeSet = (cycles: string[][]) =>
+      cycles.map((c) => [...new Set(c)].sort());
+    expect(cycleNodeSet(h.cycles)).toEqual(cycleNodeSet(index.cycles));
+    expect(h.cycles.length).toBe(1);
+    expect(h.root_ids).toEqual(index.root_ids); // cycle nodes excluded from roots
+    expect(h.max_depth).toBe(index.depth);
+    // Cycle members carry no tree entry; the clean branch is intact.
+    expect(Object.keys(h.nodes_by_id).sort()).toEqual(["a", "r"]);
+  });
+
+  it("splits multiple hierarchies sharing ids into independent trees", () => {
+    const arcs = [
+      arc("alpha", "AM01", "AM0104"),
+      arc("alpha", "AM0104", "AM0104.01"),
+      arc("beta", "DE", "AM0104.01", "validated", { type: "maps_to" }),
+    ];
+    const sidecar = buildSceneHierarchySidecar({
+      arcs,
+      sceneNodeIds: ids("AM01", "AM0104", "AM0104.01", "DE"),
+      specs: { beta: { relation_type: "maps_to_spec" } },
+    });
+
+    expect(Object.keys(sidecar.hierarchies)).toEqual(["alpha", "beta"]);
+    const alpha = sidecar.hierarchies["alpha"]!;
+    const beta = sidecar.hierarchies["beta"]!;
+
+    // Same raw id, independent placement per hierarchy.
+    expect(alpha.nodes_by_id["AM0104.01"]).toMatchObject({ parent_id: "AM0104", level: 2 });
+    expect(beta.nodes_by_id["AM0104.01"]).toMatchObject({ parent_id: "DE", level: 1, status: "validated" });
+    // relation_type: spec override wins, else first arc's type.
+    expect(alpha.relation_type).toBe("parent_of");
+    expect(beta.relation_type).toBe("maps_to_spec");
+  });
+
+  it("keeps raw ids verbatim lossless as join keys (D2: no `.`/`-`→`_`)", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const arcs = [
+      arc("h", "AM0104", "AM0104.01"),
+      arc("h", "AM0104.01", "DE.AI.01"),
+      arc("h", "DE.AI.01", uuid),
+      arc("h", uuid, "org:CODE"),
+    ];
+    const sceneNodeIds = ids("AM0104", "AM0104.01", "DE.AI.01", uuid, "org:CODE");
+    const h = buildSceneHierarchySidecar({ arcs, sceneNodeIds }).hierarchies["h"]!;
+
+    for (const raw of sceneNodeIds) {
+      const entry = h.nodes_by_id[raw];
+      expect(entry, raw).toBeDefined();
+      expect(entry!.registry_record_id).toBe(raw); // verbatim
+    }
+    // No slugged collision artifacts ever appear as keys.
+    for (const key of Object.keys(h.nodes_by_id)) {
+      expect(sceneNodeIds.has(key), key).toBe(true);
+    }
+    expect(h.nodes_by_id["AM0104_01"]).toBeUndefined();
+    expect(h.nodes_by_id["DE_AI_01"]).toBeUndefined();
+    expect(h.nodes_by_id[uuid.replace(/-/g, "_")]).toBeUndefined();
+    expect(h.nodes_by_id["org_CODE"]).toBeUndefined();
+  });
+
+  it("round-trips through JSON cleanly (the artifact is pure data)", () => {
+    const sidecar = buildSceneHierarchySidecar({
+      arcs: [arc("h", "r", "a"), arc("h", "r", "b", "validated")],
+      sceneNodeIds: ids("r", "a", "b"),
+      graphHash: "deadbeef",
+    });
+    expect(JSON.parse(JSON.stringify(sidecar))).toEqual(sidecar);
+  });
+});

--- a/tests/studio-scene.test.ts
+++ b/tests/studio-scene.test.ts
@@ -192,6 +192,46 @@ describe("buildStudioScene — parity with studio buildScene", () => {
     });
   });
 
+  it("exposes registry_record_id / registry_id verbatim (lossless, D2) and stays byte-identical otherwise", () => {
+    // workspace-bundle-contract-v1 (D2): scene nodes carry the raw id_column
+    // value VERBATIM — no `.`/`-`→`_` slugging — alongside the native scene id.
+    const rawIds = ["AM0104.01", "DE.AI.01", "org:CODE", "550e8400-e29b-41d4-a716-446655440000"];
+    const withRegistry = {
+      nodes: rawIds.map((raw, i) => ({
+        id: `registry_aclp_${raw.replace(/[^A-Za-z0-9]+/g, "_")}`,
+        label: `Record ${i}`,
+        node_type: "ACLPProcess",
+        registry_id: "aclp",
+        registry_record_id: raw,
+      })),
+      links: [],
+    };
+    const scene = buildStudioScene(withRegistry);
+    scene.nodes.forEach((node, i) => {
+      expect(node.registry_record_id).toBe(rawIds[i]); // verbatim, lossless
+      expect(node.registry_id).toBe("aclp");
+    });
+    // SPA adapter stays in lockstep (parity incl. serialized field order).
+    expectParity(withRegistry);
+    expectGranularParity(withRegistry);
+
+    // Back-compat: a graph WITHOUT registry fields produces a byte-identical
+    // scene before/after the allowlist addition (additive change only).
+    const withoutRegistry = {
+      nodes: withRegistry.nodes.map(({ registry_id, registry_record_id, ...rest }) => rest),
+      links: [],
+    };
+    const plainScene = buildStudioScene(withoutRegistry);
+    for (const node of plainScene.nodes) {
+      expect("registry_id" in node).toBe(false);
+      expect("registry_record_id" in node).toBe(false);
+    }
+    const stripped = scene.nodes.map(({ registry_id, registry_record_id, ...rest }) => rest);
+    expect(JSON.stringify(stripped)).toBe(JSON.stringify(plainScene.nodes));
+    expect(scene.edges).toEqual(plainScene.edges);
+    expect(scene.stats).toEqual(plainScene.stats);
+  });
+
   it("applies built-in shape variants (fill/border) and profile visual_encoding overrides", () => {
     const graph = {
       nodes: [


### PR DESCRIPTION
Graphify side of the SIGNED `workspace-bundle-contract-v1` (ACLP-AM ↔ graphify, 2/2 ed25519). Additive, no breakage.

- **Lossless raw-id** (`registry_record_id`/`registry_id`) exposed on scene nodes (`src/studio-scene.ts` + studio mirror, lockstep) — verbatim id_column (`AM0104.01`/UUID/`org:CODE`), no slugging.
- **`buildSceneHierarchySidecar`** (`src/scene-hierarchies.ts`): `graphify_scene_hierarchies_v1` — 2 lanes (reference/validated strict mono-parent tree + proposed/inferred overlay, empty v1), conflicts/orphan_ids/cycles/dangling diagnostics, joins on the lossless raw id; reuses `buildHierarchyIndex`.
- **Standalone emitter** (`src/scene-hierarchies-emitter.ts`): writes `scene-hierarchies.json` next to scene.json iff `hierarchies.json` exists (D1: decoupled from the optional scene), mtime cache-key; `buildStudioScene` untouched.

Matches the frozen contract schema field-for-field/enum-for-enum. Validation: lint clean, `npm test` 1598 passed / 0 failed. F3 (workspace-manifest) left open for a follow-up. Peer stabilize pending on the ACLP-AM side.