### PR TITLE
feat(validate/cli): fragment ingestion gate + optional provenance (WP3)

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -173,6 +173,7 @@ function readExistingGraphExtraction(graphPath: string): { extraction: Extractio
 
   return {
     extraction: {
+      ...(asRecord(rawGraphAttrs.provenance) ? { provenance: rawGraphAttrs.provenance as Extraction["provenance"] } : {}),
       nodes,
       edges,
       hyperedges: rawHyperedges as Extraction["hyperedges"],
@@ -276,6 +277,9 @@ export function buildFromJson(extraction: Extraction, options?: BuildOptions): G
   }
 
   const G = createGraph(options?.directed === true);
+  if (extraction.provenance) {
+    G.setAttribute("provenance", extraction.provenance);
+  }
 
   for (const node of extraction.nodes ?? []) {
     const { id, ...attrs } = node;
@@ -366,6 +370,7 @@ export function build(extractions: Extraction[], options?: BuildOptions): Graph 
     output_tokens: 0,
   };
   for (const ext of extractions) {
+    if (ext.provenance) combined.provenance = ext.provenance;
     combined.nodes.push(...(ext.nodes ?? []));
     combined.edges.push(...(ext.edges ?? []));
     (combined.hyperedges ??= []).push(...(ext.hyperedges ?? []));
@@ -416,6 +421,7 @@ export function buildMerge(newChunks: Extraction[], options?: BuildMergeOptions)
     output_tokens: 0,
   };
   for (const chunk of [...base, ...newChunks]) {
+    if (chunk.provenance) mergedExtraction.provenance = chunk.provenance;
     mergedExtraction.nodes.push(...(chunk.nodes ?? []));
     mergedExtraction.edges.push(...(chunk.edges ?? []));
     (mergedExtraction.hyperedges ??= []).push(...(chunk.hyperedges ?? []));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -311,6 +311,7 @@ function printOntologyPatchResult(result: {
 
 function ensureCliExtractionShape(value?: Partial<Extraction> | null): Extraction {
   return {
+    ...(value?.provenance ? { provenance: value.provenance } : {}),
     nodes: value?.nodes ?? [],
     edges: value?.edges ?? [],
     hyperedges: value?.hyperedges ?? [],
@@ -3109,6 +3110,29 @@ export async function main(): Promise<void> {
       } else {
         console.log(JSON.stringify(result, null, 2));
       }
+    });
+
+  program
+    .command("build")
+    .description("Build or update .graphify/graph.json from validated graph fragments")
+    .requiredOption("--fragment <path>", "Extraction fragment JSON to validate and merge")
+    .option("--graph <path>", "Graph JSON output path", ".graphify/graph.json")
+    .action(async (opts) => {
+      const fragmentPath = resolve(opts.fragment);
+      const graphPath = resolve(opts.graph);
+      const fragment = ensureCliExtractionShape(readJson<Partial<Extraction>>(fragmentPath));
+      const { assertValid } = await import("./validate.js");
+      const { buildMerge } = await import("./build.js");
+      const { toJson } = await import("./export.js");
+
+      assertValid(fragment);
+      mkdirSync(dirname(graphPath), { recursive: true });
+      const graph = buildMerge([fragment], { graphPath });
+      toJson(graph, new Map(), graphPath, { force: true });
+      console.log(
+        `[graphify build] ingested fragment ${fragmentPath} into ${graphPath}: ` +
+        `${graph.order} nodes, ${graph.size} edges`,
+      );
     });
 
   program

--- a/src/export.ts
+++ b/src/export.ts
@@ -511,7 +511,9 @@ export function toJson(
   // canonical fields (label, source_file, relation) were HTML-escaped on
   // every write. Untrusted node / edge metadata sites must apply the helper
   // at the assignment site instead.
+  const provenance = G.getAttribute("provenance");
   const sanitisedGraphBlock = sanitizeMetadata({
+    ...(provenance !== undefined ? { provenance } : {}),
     community_labels: communityLabelsObject,
     ...buildFreshnessMetadata(outputPath),
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,8 +95,19 @@ export interface Hyperedge {
   [key: string]: unknown;
 }
 
+/** Origin metadata for an externally produced extraction fragment. */
+export interface ExtractionProvenance {
+  source_owner: string;
+  source_id: string;
+  observed_at: string;
+  source_hash: string;
+  adapter_version: string;
+  ttl?: string;
+}
+
 /** Output of an extraction pass. */
 export interface Extraction {
+  provenance?: ExtractionProvenance;
   nodes: GraphNode[];
   edges: GraphEdge[];
   hyperedges?: Hyperedge[];

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -6,6 +6,17 @@ export const VALID_FILE_TYPES = new Set(["code", "document", "paper", "image", "
 export const VALID_CONFIDENCES = new Set(["EXTRACTED", "INFERRED", "AMBIGUOUS"]);
 export const REQUIRED_NODE_FIELDS = ["id", "label", "file_type", "source_file"] as const;
 export const REQUIRED_EDGE_FIELDS = ["source", "target", "relation", "confidence", "source_file"] as const;
+export const REQUIRED_PROVENANCE_FIELDS = [
+  "source_owner",
+  "source_id",
+  "observed_at",
+  "source_hash",
+  "adapter_version",
+] as const;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
 
 /**
  * Validate an extraction JSON dict against the graphify schema.
@@ -18,6 +29,22 @@ export function validateExtraction(data: unknown): string[] {
 
   const d = data as Record<string, unknown>;
   const errors: string[] = [];
+
+  if ("provenance" in d && d.provenance !== undefined) {
+    if (typeof d.provenance !== "object" || d.provenance === null || Array.isArray(d.provenance)) {
+      errors.push("'provenance' must be an object when present");
+    } else {
+      const provenance = d.provenance as Record<string, unknown>;
+      for (const field of REQUIRED_PROVENANCE_FIELDS) {
+        if (!isNonEmptyString(provenance[field])) {
+          errors.push(`provenance.${field} must be a non-empty string`);
+        }
+      }
+      if ("ttl" in provenance && provenance.ttl !== undefined && !isNonEmptyString(provenance.ttl)) {
+        errors.push("provenance.ttl must be a non-empty string when present");
+      }
+    }
+  }
 
   // Nodes
   if (!("nodes" in d)) {
@@ -43,6 +70,9 @@ export function validateExtraction(data: unknown): string[] {
           `Node ${i} (id=${JSON.stringify(node.id ?? "?")}) has invalid file_type ` +
             `'${node.file_type}' - must be one of ${JSON.stringify([...VALID_FILE_TYPES].sort())}`,
         );
+      }
+      if ("id" in node && !isNonEmptyString(node.id)) {
+        errors.push(`Node ${i} id must be a non-empty string`);
       }
     }
   }
@@ -78,6 +108,12 @@ export function validateExtraction(data: unknown): string[] {
           `Edge ${i} has invalid confidence '${edge.confidence}' ` +
             `- must be one of ${JSON.stringify([...VALID_CONFIDENCES].sort())}`,
         );
+      }
+      if ("source" in edge && !isNonEmptyString(edge.source)) {
+        errors.push(`Edge ${i} source must be a non-empty string`);
+      }
+      if ("target" in edge && !isNonEmptyString(edge.target)) {
+        errors.push(`Edge ${i} target must be a non-empty string`);
       }
       if ("source" in edge && nodeIds.size > 0 && !nodeIds.has(edge.source as string)) {
         errors.push(`Edge ${i} source '${edge.source}' does not match any node id`);

--- a/tests/fragment-gate.test.ts
+++ b/tests/fragment-gate.test.ts
@@ -1,0 +1,143 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildMerge } from "../src/build.js";
+import { main } from "../src/cli.js";
+import { toJson } from "../src/export.js";
+import type { Extraction } from "../src/types.js";
+import { validateExtraction } from "../src/validate.js";
+
+const cleanupDirs: string[] = [];
+
+function tempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-fragment-gate-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+async function runCli(args: string[], cwd: string) {
+  const previousArgv = process.argv;
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const logs: string[] = [];
+
+  console.log = (...items: unknown[]) => {
+    logs.push(items.join(" "));
+  };
+  process.argv = ["node", "graphify", ...args];
+  process.chdir(cwd);
+  try {
+    await main();
+    return { logs };
+  } finally {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    console.log = originalLog;
+  }
+}
+
+function conversationFragment(): Extraction {
+  return {
+    provenance: {
+      source_owner: "agent-stats",
+      source_id: "conversation:codex:wp3",
+      observed_at: "2026-06-13T10:00:00.000Z",
+      source_hash: "sha256:conversation-fragment",
+      adapter_version: "agent-stats@0.1.0",
+      ttl: "P30D",
+    },
+    nodes: [
+      {
+        id: "conversation:codex:wp3",
+        label: "WP3 Fragment Gate",
+        file_type: "document",
+        source_file: "agent-stats/conversations/wp3.jsonl",
+        node_type: "Conversation",
+      },
+      {
+        id: "agent-session:codex:wp3",
+        label: "Codex WP3 session",
+        file_type: "document",
+        source_file: "agent-stats/conversations/wp3.jsonl",
+        node_type: "AgentSession",
+      },
+    ],
+    edges: [
+      {
+        source: "agent-session:codex:wp3",
+        target: "conversation:codex:wp3",
+        relation: "participates_in",
+        confidence: "EXTRACTED",
+        source_file: "agent-stats/conversations/wp3.jsonl",
+      },
+    ],
+    input_tokens: 12,
+    output_tokens: 4,
+  };
+}
+
+describe("fragment ingestion gate", () => {
+  it("accepts legacy extractions without provenance", () => {
+    expect(validateExtraction({
+      nodes: [{ id: "a", label: "A", file_type: "code", source_file: "src/a.ts" }],
+      edges: [],
+      input_tokens: 0,
+      output_tokens: 0,
+    })).toEqual([]);
+  });
+
+  it("round-trips provenance and non-code node_type through buildMerge graph.json", () => {
+    const dir = tempProject();
+    const graphPath = join(dir, ".graphify", "graph.json");
+    const fragment = conversationFragment();
+    mkdirSync(join(dir, ".graphify"), { recursive: true });
+
+    expect(validateExtraction(fragment)).toEqual([]);
+
+    const graph = buildMerge([fragment], { graphPath });
+    toJson(graph, new Map(), graphPath, { force: true });
+
+    const persisted = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+      graph?: { provenance?: unknown };
+      nodes?: Array<{ id?: string; node_type?: string }>;
+      links?: Array<{ source?: string; target?: string; relation?: string }>;
+    };
+
+    expect(persisted.graph?.provenance).toEqual(fragment.provenance);
+    expect(persisted.nodes?.find((node) => node.id === "conversation:codex:wp3")?.node_type)
+      .toBe("Conversation");
+    expect(persisted.links).toContainEqual(expect.objectContaining({
+      source: "agent-session:codex:wp3",
+      target: "conversation:codex:wp3",
+      relation: "participates_in",
+    }));
+  });
+
+  it("ingests a validated fragment through graphify build --fragment", async () => {
+    const dir = tempProject();
+    const graphifyDir = join(dir, ".graphify");
+    const fragmentPath = join(dir, "conversation-fragment.json");
+    const graphPath = join(graphifyDir, "graph.json");
+    mkdirSync(graphifyDir, { recursive: true });
+    writeFileSync(fragmentPath, JSON.stringify(conversationFragment(), null, 2), "utf-8");
+
+    const result = await runCli(["build", "--fragment", fragmentPath], dir);
+
+    expect(result.logs.join("\n")).toContain("ingested fragment");
+    expect(existsSync(graphPath)).toBe(true);
+    const persisted = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+      graph?: { provenance?: unknown };
+      nodes?: Array<{ id?: string; node_type?: string }>;
+    };
+    expect(persisted.graph?.provenance).toEqual(conversationFragment().provenance);
+    expect(persisted.nodes?.find((node) => node.id === "agent-session:codex:wp3")?.node_type)
+      .toBe("AgentSession");
+  });
+});


### PR DESCRIPTION
WP3 sous `MANDATE-graphify`. Exécuté par codex headless en worktree, **vérifié + commité par le conducteur**.

**Fait** : `Extraction.provenance?` optionnel (rétrocompat) ; `validateExtraction` ouvert aux `node_type` non-code (per-profil, pas de whitelist globale) ; commande **`graphify build --fragment <x.json>`** (validate→buildMerge→`.graphify/graph.json`, provenance round-trippée sous `graph.provenance`). Porte d'ingestion commune de WP5/WP6/h2a. Périmètre : 80 lignes (types/validate/build/cli/export) + `tests/fragment-gate.test.ts`.

**Coordination ontologie** : aligné sur `ontology-profile`/`ontology-hierarchies` (par-profil) — **aucun conflit avec #106/#141**. Différé WP5 : provenance unique vs journal append-only multi-fragments.

**Vérif (hors sandbox)** : suite complète **1705 passed / 0 failed** (179 fichiers) ; WP3 tests 75/75 ; lint OK. NB : les « 6 échecs ontology-studio-write » rapportés par codex étaient le `listen EPERM` de son sandbox — passent 9/9 hors sandbox.

Rapport : `segmentation/wp/WP3-REPORT.md` (repo codex-claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)