### PR TITLE
feat(citations): exhaustive capture + tiered lazy storage + corpus-type policy

### DIFF
--- a/spec/SPEC_CITATIONS.md
+++ b/spec/SPEC_CITATIONS.md
@@ -7,6 +7,7 @@
 - Activation: detection is always exhaustive; tiering and the lazy store are the default emit path; corpus-type tuning is automatic with an explicit override
 - Default behavior: `.graphify/graph.json` carries a citation COUNT + a small inline top-K per node; the FULL citation list moves to a lazily-loaded per-entity store served through the existing `/api/ontology/entity/<id>` sidecar route
 - Product decision (user, 2026-06-13): "extract ALL citations; don't bloat graph.json or the studio; describe prompt cap stays tunable, default 3 → 10, long-docs/entity-corpus → all"
+- Decisions resolved (user, 2026-06-13): inline K=8 with most-distinct-source selection; citation identity excludes `bbox` for prose (includes it only for figure/image corpora); stale pre-feature graphs WARN + render legacy inline (no auto-backfill); the full list + count live in a single keyed `citations.json` (not folded into `occurrences.json`, not a per-id directory); edge citations stay out of v1. See `## Decisions` below — these are binding, not proposals.
 - Constraint: `.graphify/graph.json` remains the single source of truth (description-contract work). The lazy store is a DERIVED projection of graph.json, never a competing truth.
 - Delivery: PR1 is this spec; implementation follows the roadmap below.
 - CLI, config and field-name surfaces in this document are PROPOSED; they freeze at the implementation PR.
@@ -231,18 +232,18 @@ Automated tests should cover:
 - Run `graphify describe` on the mystery corpus: descriptions ground on many distinct sources (cap = all), while a code project's descriptions still cap at 3.
 - Run `backfill-citations` on a pre-feature graph: it renders under the new schema with a lower-bound count caveat; re-extract then shows the true exhaustive count.
 
-## Open decisions
+## Decisions
 
-These need a human call.
+Resolved by the conductor on 2026-06-13. These are BINDING for the implementation PR — the `PROPOSED` markers elsewhere in this spec resolve to the values below.
 
-1. **Where does the frequency count live — fold into `occurrences.json`, or a dedicated `citations.json`?** `occurrences.json` is the historically intended frequency artifact (empty today) and `buildEntitySidecar` already reads it keyed by id. Either (a) populate `occurrences.json` with `{ count }` and keep the full citation list in `citations.json`, or (b) put both count and list in `citations.json` and leave `occurrences.json` for non-citation occurrence data. Recommendation: (b) — keep citations self-contained in one store; revisit if occurrences gains independent meaning.
+1. **Frequency count + full list live in a single dedicated `citations.json`** (schema `graphify_ontology_citations_v1`), NOT folded into `occurrences.json`. `occurrences.json` is left for non-citation occurrence data; citation count and the exhaustive list are self-contained in one store. Revisit only if occurrences gains independent meaning.
 
-2. **Inline top-K default value and selection key.** Recommendation: K = 8, most-distinct-source primary key. Alternatives the human may prefer: K = 5 (leaner eager payload) or earliest-in-document (simpler, less salient). Pick one; it freezes the determinism contract.
+2. **Inline top-K: K = 8, most-distinct-source primary selection key** (then locator specificity, then stable lexicographic tie-break on `(source_file, page, section, paragraph_id)`). This freezes the determinism contract: two builds of the same graph produce byte-identical `citations_top`. Earliest-in-document was rejected (fills a hub's preview with whichever work sorts first).
 
-3. **Citation dedupe granularity.** Is a citation identity `source_file + page + section + paragraph_id` (passages differing only in `bbox` collapse), or is `bbox` part of identity (every distinct region counts)? Finer identity inflates counts; coarser merges legitimately distinct passages. Recommendation: exclude `bbox` from identity for prose corpora; include it only for image/figure-heavy corpora.
+3. **Citation identity excludes `bbox` for prose corpora** — identity = `source_file + page + section + paragraph_id`; passages differing only in `bbox` collapse to one citation. `bbox` is part of identity ONLY for figure/image-heavy corpora (so distinct figure regions on a page count separately). Keeps prose "cited N times" realistic, not bbox-inflated.
 
-4. **Keyed file vs per-id directory for Level-2.** Recommendation: single keyed `citations.json` (reuses the occurrences/descriptions caching path). Switch to `.graphify/citations/<id>.json` only if the keyed file exceeds a size budget (PROPOSED trigger: > ~10 MB or a corpus where a single load stalls server start). Human sets the budget / confirms the trigger.
+4. **Level-2 is a single keyed `citations.json`** (reuses the `occurrences.json`/`descriptions.json` in-memory-index caching path, cached by graph.json mtime). It is NOT a per-id directory. A switch to `.graphify/citations/<id>.json` is reconsidered only if the keyed file later exceeds a size budget (deferred trigger: > ~10 MB or a corpus where a single load stalls server start) — not a v1 concern.
 
-5. **Backfill default posture for stale graphs.** When a pre-feature graph is opened, default to (a) warn + render legacy inline only, or (b) auto-run a non-destructive backfill to populate the new fields/store. Recommendation: (a) warn — auto-backfill produces lower-bound counts that could be mistaken for true exhaustive counts; keep exhaustiveness an explicit re-extract.
+5. **Stale pre-feature graphs WARN + render legacy inline** on open; no auto-backfill. True exhaustiveness stays an explicit `graphify backfill-citations` (lower-bound counts, clearly captioned) or a re-extract. Auto-backfill was rejected because its lower-bound counts could be mistaken for the true exhaustive count.
 
-6. **Edge citations.** v1 leaves `GraphEdge.citations[]` (`src/types.ts:75`) unchanged (edges are far less cited than hub entities). Confirm edges stay out of the tiered model for v1, or fold them in if edge citation volume is also unbounded in the entity corpus.
+6. **Edge citations stay OUT of the tiered model for v1.** `GraphEdge.citations[]` (`src/types.ts:75`) is unchanged — edges are far less cited than hub entities. Folding edges in is a follow-up only if edge citation volume proves unbounded in an entity corpus.

--- a/spec/SPEC_CITATIONS.md
+++ b/spec/SPEC_CITATIONS.md
@@ -169,7 +169,7 @@ Key points:
 - **CLI flag (override).** Placement corrected after review:
   - `--citation-cap <n|all>` on the commands that build the description prompt: `graphify describe|label|update` (these call `toJson`/the describe engine). `describe`/`label` have no such flag today (`cli.ts:3853-3858`), so it is added.
   - `--citations-top-k <n>` on the commands that WRITE graph.json node citations via `toJson`: `graphify extract|update|watch` — NOT the top-level `graphify build` (`cli.ts:2750`), which is a non-LLM profile chain (`validate → dataprep → ontology-output`) that never runs `toJson` and cannot apply the flag.
-  - Precedence: CLI flag > config > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required.
+  - Precedence (v1): CLI flag > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required. (The `citations:` YAML config block is NOT loaded by the code-mode CLI in v1 — flag + corpus-type only; config wiring deferred. The resolver keeps an inert `config` slot for a future tier.)
 
 ## Studio UX
 
@@ -214,6 +214,11 @@ graphify backfill-citations [path]                # project legacy citations[] -
 `--citations-top-k` is NOT added to the top-level `graphify build` (non-LLM profile chain; does not write graph.json node citations).
 
 ```yaml
+# (v1: NOT loaded by the code-mode CLI — flag + corpus-type only; config wiring
+#  deferred. The code-mode loader is ontology-profile-only and
+#  `resolveCitationPolicyForRoot` never passes `config`, so these keys are inert
+#  today. The `config` slot is retained in `resolveCitationPolicy` for a future
+#  PR, but the surface advertised below is the real 3-tier v1 precedence.)
 citations:
   describe_cap: 10        # n | "all" ; corpus-type default unless set
   inline_top_k: 8         # Level-1 inline K
@@ -221,7 +226,7 @@ citations:
   dedupe_key: [source_file, page, section, paragraph_id]   # bbox added only for figure/image corpora
 ```
 
-Precedence: CLI flag > config > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required.
+Precedence (v1): CLI flag > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required. (The `citations:` YAML block above is NOT wired in v1 — config wiring is deferred; the `resolveCitationPolicy` `config` slot stays for future use but does not participate in the advertised v1 precedence.)
 
 ## Test plan
 

--- a/spec/SPEC_CITATIONS.md
+++ b/spec/SPEC_CITATIONS.md
@@ -5,86 +5,88 @@
 - Product: Graphify TypeScript port
 - Scope: exhaustive citation capture per entity + tiered (inline / lazy) citation storage + corpus-type-aware citation policy
 - Activation: detection is always exhaustive; tiering and the lazy store are the default emit path; corpus-type tuning is automatic with an explicit override
-- Default behavior: `.graphify/graph.json` carries a citation COUNT + a small inline top-K per node; the FULL citation list moves to a lazily-loaded per-entity store served through the existing `/api/ontology/entity/<id>` sidecar route
+- Default behavior: `.graphify/graph.json` carries, per node, a true `citation_count` + a small deterministic K-bounded inline `citations` set; the FULL citation list moves to a co-derived, lazily-loaded per-entity store served through the existing `/api/ontology/entity/<id>` sidecar route
 - Product decision (user, 2026-06-13): "extract ALL citations; don't bloat graph.json or the studio; describe prompt cap stays tunable, default 3 → 10, long-docs/entity-corpus → all"
-- Decisions resolved (user, 2026-06-13): inline K=8 with most-distinct-source selection; citation identity excludes `bbox` for prose (includes it only for figure/image corpora); stale pre-feature graphs WARN + render legacy inline (no auto-backfill); the full list + count live in a single keyed `citations.json` (not folded into `occurrences.json`, not a per-id directory); edge citations stay out of v1. See `## Decisions` below — these are binding, not proposals.
-- Constraint: `.graphify/graph.json` remains the single source of truth (description-contract work). The lazy store is a DERIVED projection of graph.json, never a competing truth.
-- Delivery: PR1 is this spec; implementation follows the roadmap below.
-- CLI, config and field-name surfaces in this document are PROPOSED; they freeze at the implementation PR.
+- Decisions resolved (user, 2026-06-13): inline K=8 with most-distinct-source selection; citation identity excludes `bbox` for prose (includes it only for figure/image corpora); stale pre-feature graphs WARN + render legacy inline (no auto-backfill); the full list lives in a single keyed `citations.json` (not folded into `occurrences.json`, not a per-id directory); edge citations stay out of v1. See `## Decisions` — binding.
+- Review-driven corrections (conductor + two adversarial Opus 4.8 reviews, 2026-06-13): the source-of-truth framing is corrected (citations are a co-derived exception, NOT a graph.json projection); the producer is re-anchored from `ontology-output.ts` to the `toJson` path; graph.json leanness now has an explicit trim requirement; the inline field keeps the name `citations` (no client rename); `graph_signature`, the top-K algorithm, the union-at-merge change, and the CLI flag placement are pinned. See `## Review remediation`.
+- Delivery: this PR (#150) lands the spec; implementation follows on the same branch.
+- CLI and config surfaces are PROPOSED; they freeze at the implementation PR. Field names and the producer anchor below are BINDING (they were the subject of review).
 
-This spec makes citation capture exhaustive and citation storage tiered. Today only a bounded SAMPLE of citations survives on hub entities (the mystery graph caps out around ~15 citations on Sherlock and ~12 on Watson, though those entities are cited hundreds of times across 25 works), and `occurrences.json` — the artifact that should track true citation frequency — is written as an empty array (`src/ontology-output.ts:286`). The design captures every citation, records a real frequency count, keeps `graph.json` lean by storing only a count plus a deterministic inline top-K on each node, and serves the full citation list on demand through the per-entity sidecar pattern that already exists for descriptions and occurrences (`src/studio-assets.ts:235` `buildEntitySidecar`, `/api/ontology/entity/<id>` in `src/ontology-studio.ts:490`).
+This spec makes citation capture exhaustive and citation storage tiered. Today only a bounded SAMPLE of citations survives on hub entities (the mystery graph caps out around ~15 citations on Sherlock and ~12 on Watson, though those entities are cited hundreds of times across 25 works), and `occurrences.json` — the artifact that should track citation frequency — is written as an empty array (`src/ontology-output.ts:286`). The design captures every EXTRACTED citation, records a real frequency count, keeps `graph.json` lean by storing only a count plus a deterministic K-bounded inline set per node, and serves the full citation list on demand through the per-entity sidecar pattern that already exists for occurrences (`src/studio-assets.ts:235` `buildEntitySidecar`, `/api/ontology/entity/<id>` in `src/ontology-studio.ts:490`).
 
 ## Problem
 
-Citations on graph nodes are typed as `OntologyCitation[]` (`src/types.ts:53` on `GraphNode`, `:75` on `GraphEdge`; the `OntologyCitation` shape is `src/types.ts:473-481` — `source_file`, optional `source_url`, `page`, `section`, `paragraph_id`, `figure_id`, `bbox`). Four concrete problems block exhaustive, scalable citation handling:
+Citations on graph nodes are typed as `OntologyCitation[]` (`src/types.ts:53` on `GraphNode`, `:75` on `GraphEdge`; the `OntologyCitation` shape is `src/types.ts:473-481` — `source_file`, optional `source_url`, `page`, `section`, `paragraph_id`, `figure_id`, `bbox`; note there is NO `quote`/verbatim-text field). Four concrete problems block exhaustive, scalable citation handling:
 
-1. **Capture is a sample, not a census.** There is NO `.slice()`, cap, or sampling limit on citation STORAGE anywhere in `src/` (verified: the only citation-length references are `src/node-descriptions.ts:358/527`, `src/profile-validate.ts:288`, none of which bound storage). The bound is emergent: citations land on nodes only through the profile/ontology extraction path (`src/profile-prompts.ts:150-152,178` instruct the assistant to "include … citations" and "preserve page-level citations when available"), each assistant chunk naturally emits a handful, and nothing aggregates the union across all chunks/works into one exhaustive per-entity list. A hub entity cited in 25 works keeps only the citations that happened to ride along in the chunks where it was the focus. Exhaustiveness therefore requires a change to the AGGREGATION CONTRACT, not the removal of a cap.
+1. **Capture is a sample, not a census — and the assembly pipeline actively discards duplicates.** There is NO `.slice()`, cap, or sampling limit on citation STORAGE on the ontology path. (Survey carve-out: a `MAX_CITATIONS` constant with a `.slice(0, MAX_CITATIONS)` does exist at `src/agent-stats/report.ts:54,281`, but it caps anonymized per-agent TELEMETRY evidence snippets — an unrelated subsystem, nothing to do with `OntologyCitation` graph storage. The describe-prompt cap `MAX_CITATIONS = 3` at `src/node-descriptions.ts:376` is the only citation cap on the ontology path, and it bounds the PROMPT, not storage.) The ~15-on-Sherlock bound is **emergent from two compounding behaviors**:
+   - citations land on nodes only through per-chunk profile/ontology extraction (`src/profile-prompts.ts:150-152,178` instruct the assistant to "include … citations" and "preserve page-level citations"); each chunk emits a handful for the entities it extracts AS NODES, and an entity merely mentioned in a chunk where it is not extracted contributes no citation; and
+   - when chunks are assembled, duplicate-entity citations are **thrown away**, not unioned: `src/build.ts:286` uses graphology `mergeNode(id, attrs)` (shallow last-write-wins — a later chunk's `citations` array REPLACES the earlier), and the ast+semantic assembly paths skip duplicates outright (`src/cli.ts:330-333`, `src/skill-runtime.ts:419-428`: `if (seen.has(node.id)) continue;`). So a hub entity keeps only ONE chunk's worth of citations, not the union across all chunks/works.
 
-2. **Frequency is tracked nowhere.** `occurrences.json` is written unconditionally as `[]` (`src/ontology-output.ts:286`). The reader side already exists and is keyed by node id: `buildEntitySidecar` loads `occurrences.json`, reads `occRaw.nodes[id]`, and returns it in the sidecar (`src/studio-assets.ts:254-261`). The producer was never wired. So "cited N times" — a degree-independent salience signal — is unavailable for display, for describe grounding, and for ranking the inline top-K.
+   Exhaustiveness therefore requires a change to the **assembly/aggregation contract** (union citations across chunks at merge time), not the removal of a cap. It is bounded by what extraction emits per chunk — see Non-Goals for the honest ceiling.
 
-3. **The studio loads the full graph eagerly, and renders citations from it.** The SPA fetches `graph.json` verbatim (`/api/ontology/graph.json`, `src/ontology-studio.ts:246-263`, "Returned verbatim (no re-parse)"). The EntityPanel renders citations from the eagerly-loaded node: `citationsByFile(node)` reads `node.citations[]` (`studio/src/components/EntityPanel.svelte:25`, `studio/src/lib/graphAdapter.js:702-716`), grouping by `source_file` into a file→passages double accordion. Note that `scene.json` already EXCLUDES `citations` (only `evidence_refs` is in `NODE_PROFILE_FIELDS`, `src/studio-scene.ts`), but the SPA still pulls the full `graph.json`, so exhaustive per-hub citations would bloat the eager fetch and the in-memory graph regardless of `scene.json`.
+2. **Frequency is tracked nowhere.** `occurrences.json` is written unconditionally as `[]` (`src/ontology-output.ts:286`). The reader side already exists, keyed by node id: `buildEntitySidecar` loads `occurrences.json`, reads `occRaw.nodes[id]`, and returns it in the sidecar (`src/studio-assets.ts:254-261`). The producer was never wired. So "cited N times" — a degree-independent salience signal — is unavailable for display, describe grounding, or ranking the inline set.
 
-4. **The describe prompt cap is a single hardcoded constant.** `MAX_CITATIONS = 3` (`src/node-descriptions.ts:376`) caps how many citation snippets are injected into the description prompt per node, deduped/truncated by `collectCitationContext` (`src/node-descriptions.ts:402-450`, `CITATION_MAXLEN = 120` at `:373`). Three is right for code symbols and wrong for long documents and entity corpora, where a description should be grounded in many distinct sources. The cap is not tunable per corpus and is not exposed to the skill or CLI.
+3. **The studio loads the full graph eagerly and renders citations from it.** The SPA fetches `graph.json` verbatim (`/api/ontology/graph.json`, `src/ontology-studio.ts:246-263`, "Returned verbatim (no re-parse)"). `graph.json` is produced by `toJson` (`src/export.ts:449`), which spreads `...attrs` (`:469`) — i.e. it serializes EVERY node attribute verbatim, including the full `citations[]`. The EntityPanel renders citations from the eagerly-loaded node: `citationsByFile(node)` reads `node.citations[]` (`studio/src/components/EntityPanel.svelte:25`, `studio/src/lib/graphAdapter.js:702-716`), grouping by `source_file`. `scene.json` already EXCLUDES `citations` (`NODE_PROFILE_FIELDS`, `src/studio-scene.ts:164`), but the SPA still pulls the full `graph.json`, so exhaustive per-hub citations would bloat the eager fetch and the in-memory graph regardless of `scene.json`. **Critically: because `toJson` spreads `...attrs`, simply ADDING an exhaustive `citations[]` makes graph.json bigger; leanness requires actively TRIMMING the inline set (see Tiered model).**
 
-Without an explicit tiered model, making capture exhaustive would push hundreds of citation objects per hub entity straight into `graph.json` and into every eager studio fetch.
+4. **The describe prompt cap is a single hardcoded constant.** `MAX_CITATIONS = 3` (`src/node-descriptions.ts:376`) caps how many citation snippets are injected into the description prompt per node, deduped/truncated by `collectCitationContext` (`src/node-descriptions.ts:402-450`, `CITATION_MAXLEN = 120` at `:373`). This feeds both the API path and the no-key assistant path (`collectCitationContext` → `NodeContext.citations` → `emitDescriptionInstructions`, `node-descriptions.ts:477,997`). Three is right for code symbols and wrong for long documents and entity corpora. The cap is not tunable per corpus and not exposed to the skill or CLI.
 
 ## Goals
 
-- Capture EVERY distinct citation per entity, plus a true frequency count.
-- Keep `graph.json` lean: a count + a small deterministic inline top-K per node, never the full list for hub entities.
-- Move the FULL per-entity citation list into a lazily-loaded store, reusing the existing per-entity sidecar route — do not invent a parallel fetch path.
-- Keep the lazy store a DERIVED projection of `graph.json` so there is exactly one source of truth.
-- Make the describe-prompt citation cap tunable: default 3 for code, 10 default, all for long-docs/entity corpora; settable by the skill per corpus type and by a CLI flag.
+- Capture EVERY distinct EXTRACTED citation per entity (union across chunks/works), plus a true frequency count.
+- Keep `graph.json` lean: a `citation_count` + a small deterministic K-bounded inline `citations` set per node, never the full list for hub entities — enforced by an explicit trim before `toJson`.
+- Move the FULL per-entity citation list into a lazily-loaded store, reusing the existing per-entity sidecar route — no new fetch path.
+- Make the describe-prompt citation cap tunable: 3 for code, 10 default, all for long-docs/entity corpora; settable by the skill per corpus type and by a CLI flag; on the no-key path.
 - Determine corpus type automatically from existing detection signals, with an explicit override.
 - Keep the studio fast: never ship hundreds of citations eagerly; fetch the full list only on entity selection.
-- Backward-compatible: existing bounded graphs keep working and gain exhaustive citations via re-extract or backfill, not a breaking migration.
+- Backward-compatible: existing bounded graphs keep working and gain exhaustive citations via re-extract (or a lossy backfill), not a breaking migration.
 
 ## Non-Goals
 
 This section is the architecture boundary. These exclusions are deliberate.
 
-- **No second source of truth.** The lazy citation store is a DERIVED, regenerable projection of `graph.json`. It is rebuilt from `graph.json`, never edited independently, and never read back into the graph. If it disappears, a rebuild recreates it byte-for-byte from the canonical graph.
+- **Exhaustive ≠ every textual mention.** v1 captures every citation that EXTRACTION emits, unioned across all chunks/works. It does NOT add a new extraction-prompt pass to emit a citation for every place an entity is mentioned-but-not-extracted-as-a-node. True mention-level exhaustiveness is an extraction-prompt change, out of scope; v1 already yields a large multiple of today's collapsed single-chunk sample (the duplicate-discard in Problem #1 is what bounds it today).
+- **No verbatim-quote capture.** `OntologyCitation` (`src/types.ts:473-481`) carries locators only (`source_file`/`page`/`section`/`paragraph_id`/`figure_id`/`bbox`), no `quote`. The studio's file→passages accordion renders locators, not verbatim passage text (it already passes `quote: null` today). Adding a quote field is out of scope.
+- **citations.json is a CO-DERIVED artifact, not edited independently.** It is produced in the same build pass as graph.json from the extraction output; it is never hand-edited and never read back into the graph. It is rebuildable LLM-free from the extraction output (NOT from graph.json's K-bounded projection — see the source-of-truth note in the tiered model). If it disappears and the extraction output is present, a rebuild recreates it deterministically; otherwise a re-extract is required.
 - **No new fetch mechanism in the studio.** Full citations are served through the existing `/api/ontology/entity/<id>` route and the existing client `fetchEntity(id)` + `entityCache` (`studio/src/lib/api.js:81-87`). No new endpoint, no new client cache.
-- **No change to the `OntologyCitation` shape.** `src/types.ts:473-481` stays. Tiering is about WHERE citations live and HOW MANY are inline, not about a new citation type.
-- **No eager bloat.** `scene.json` and the eager `graph.json` fetch carry only the count + inline top-K, never the full per-entity list.
-- **No provider calls added by storage.** Tiering, counting and emitting are deterministic; they make no LLM call. Exhaustive capture reuses the existing assistant/profile extraction path; corpus-type tuning only changes the prompt cap.
-- **No automatic destructive re-extraction.** Backfill of existing graphs is opt-in (`--backfill-citations`); the default for a stale graph is a warning, matching the existing staleness posture.
+- **No change to the `OntologyCitation` shape.** `src/types.ts:473-481` stays. Tiering is about WHERE citations live and HOW MANY are inline.
+- **No eager bloat.** `scene.json` and the eager `graph.json` fetch carry only `citation_count` + the K-bounded inline `citations`, never the full per-entity list.
+- **No provider calls added by storage.** Tiering, counting and emitting are deterministic; no LLM call. Exhaustive capture reuses the existing assistant/profile extraction path; corpus-type tuning only changes the prompt cap.
+- **No automatic destructive re-extraction.** Backfill of existing graphs is opt-in (`graphify backfill-citations`); the default for a stale graph is a warning, matching the existing staleness posture.
 
-## Compatibility Contract
+## Source of truth (corrected framing)
 
-For an existing graph built before this feature:
+graphify already treats `graph.json` as canonical for topology + `node.description` (the description-contract work). Citations are a **deliberate, necessary exception**, forced by the user's own two constraints — "extract ALL citations" AND "don't bloat graph.json": the exhaustive set cannot be both lean-on-graph.json and full-on-graph.json. So:
 
-- it loads and renders unchanged; nodes with bounded `citations[]` keep their citations inline and continue to display.
-- no lazy store is required for the studio to work; absence of the store degrades to "render the inline citations only" (the current behavior).
-- `graph.json` schema is additive: new optional fields (`citation_count`, `citations_top` — names PROPOSED) coexist with the existing optional `citations[]`.
-- nothing reads a credential, opens a network connection, or calls a provider as a side effect of this feature.
+- The **upstream source** of citations is the EXTRACTION output (the per-chunk extraction JSON graphify already persists).
+- The build aggregation pass produces, in ONE pass over the assembled graph, **two co-derived projections**: graph.json (`citation_count` + K-bounded inline `citations`) and `citations.json` (the full per-entity set). Neither derives from the other; both derive from extraction.
+- `citations.json` is the durable carrier of the exhaustive tail beyond K. It is rebuildable from the extraction output (LLM-free), not from graph.json's K-bounded inline set. graph.json remains canonical for topology + descriptions and delegates the citation tail to this co-derived sidecar.
+
+This corrects the earlier draft's "citations.json is a projection of graph.json" framing, which was false (you cannot reconstruct a 214-citation tail from an 8-element inline set).
 
 ## Tiered Storage Model
 
-Two levels. Level-1 is inline on the node in `graph.json`; Level-2 is the full list in a lazy store.
+Two levels. Level-1 is inline on the node in `graph.json`; Level-2 is the full list in a co-derived lazy store.
 
-### Level-1 — inline on the node (in `graph.json`, the source of truth)
+### Level-1 — inline on the node (in `graph.json`)
 
-Two new optional fields on `GraphNode` (PROPOSED names; `GraphEdge` gets the same treatment if edge citations ever go exhaustive — out of scope for v1, edges keep `citations[]` as-is):
+- `citation_count: number` (NEW) — the TRUE number of distinct citations for this entity across the whole corpus (size of the deduped union). The degree-independent "cited N times" signal. Authoritative even when the inline set is truncated.
+- `citations: OntologyCitation[]` (EXISTING field, semantics tightened) — now the K-bounded deterministic top-K subset (default K = 8), NOT an arbitrary sample and NOT the full list. **The field keeps its name** so the studio's `citationsByFile`/inline render keep working with zero rename; the producer MUST trim it to the top-K before `toJson` writes graph.json.
 
-- `citation_count: number` — the TRUE number of distinct citations for this entity across the whole corpus. This is the degree-independent "cited N times" signal. It is computed at build/aggregation time and is authoritative even when the inline list is truncated.
-- `citations_top: OntologyCitation[]` — a SMALL, deterministic top-K subset (default K = 8, PROPOSED) for quick display, describe grounding, and offline/store-absent fallback. Same `OntologyCitation` shape, no new type.
+Keeping the name `citations` (rather than introducing `citations_top`) was a review decision: `studio/src/lib/graphAdapter.js:702-716` and `EntityPanel.svelte` read `node.citations`; a rename would silently zero the inline render until every client read is rewired. With the name retained, the only client change for Level-1 is the count header (below).
 
-The legacy `citations: OntologyCitation[]` field is retained for backward-compat reads but is deprecated as the full carrier: new builds populate `citations_top` (the bounded inline set) and `citation_count`. A migration shim treats a legacy `citations[]` with no `citations_top` as `citations_top = citations`, `citation_count = citations.length` (a conservative count — see Migration).
+Rationale for count + bounded-inline (not count-only): it preserves a working studio and a working `describe` even when the lazy store is absent (fresh clone, partial artifacts, offline), and bounds the eager payload by K regardless of how cited an entity is.
 
-Rationale for keeping a count + top-K inline rather than count-only: it preserves a working studio and a working `describe` even when the lazy store is absent (fresh clone, partial artifact set, offline), and it keeps `scene.json`/eager-graph payload bounded by K regardless of how cited an entity is.
+`GraphEdge.citations` (`src/types.ts:75`) is unchanged in v1 (edges are far less cited; out of scope per Decision 6).
 
-### Level-2 — the full per-entity citation list (lazy, derived)
+### Level-2 — the full per-entity citation list (lazy, co-derived)
 
-The full, exhaustive citation list per node id lives OUTSIDE `graph.json`, in a single keyed file:
-
-- Path: `.graphify/ontology/citations.json` (PROPOSED), schema `graphify_ontology_citations_v1`.
-- Shape (keyed by node id, mirroring the `occurrences.json` `{ nodes: { <id>: … } }` convention that `buildEntitySidecar` already reads at `src/studio-assets.ts:257-261`):
+- Path: `.graphify/ontology/citations.json`, schema `graphify_ontology_citations_v1`.
+- Keyed by node id, mirroring the `occurrences.json` `{ nodes: { <id>: … } }` convention that `buildEntitySidecar` already reads (`src/studio-assets.ts:257-261`):
 
 ```json
 {
   "schema": "graphify_ontology_citations_v1",
-  "graph_signature": "<topology/identity signature of graph.json at emit time>",
+  "graph_signature": "<citation-content hash of graph.json at emit time>",
   "nodes": {
     "doyle_sherlock_holmes": {
       "count": 214,
@@ -94,42 +96,43 @@ The full, exhaustive citation list per node id lives OUTSIDE `graph.json`, in a 
 }
 ```
 
-Why one keyed file and NOT a directory of `.graphify/citations/<id>.json`: the studio already serves per-entity slices from single keyed JSON files loaded once and indexed in memory (`occurrences.json` via `buildEntitySidecar`; `descriptions.json` via `loadDescriptionIndex`, cached by graph.json mtime at `src/studio-assets.ts:186-212`). A keyed file reuses that exact caching path with no new disk-walk, no per-id file churn, and a single signature to validate freshness. A per-id directory is reconsidered only if the keyed file grows past the budget (see Open decisions).
+One keyed file, NOT a per-id directory (Decision 4): it reuses a single mtime-keyed in-memory index (the `loadGraphNodeDescriptions` caching pattern, `src/studio-assets.ts:186-212`) — one load, indexed in memory, per-id slice on request. A per-id directory is reconsidered only past a size budget (deferred trigger: > ~10 MB).
 
 ### How the two levels are emitted, cached, kept consistent
 
-- **Single producer.** Both levels are written from the SAME aggregation pass over the assembled graph at build time (the ontology-output stage that today writes the empty `occurrences.json` at `src/ontology-output.ts:286`). The pass walks every node's exhaustive citation set, computes `count`, selects the deterministic top-K (see below), writes `citation_count` + `citations_top` onto the node in `graph.json`, and writes the full list into `citations.json`. One pass, one truth, two projections.
-- **Consistency by construction.** Because both come from the same pass and `citations.json` carries the `graph_signature` of the `graph.json` it was emitted against, the studio (and `hook-rebuild`) can detect a stale store the same way `scene.json` detects staleness (`src/ontology-studio.ts:277` caches scene keyed on graph.json identity = path + mtime + size). If the signature does not match the current `graph.json`, the store is treated as absent and the inline top-K is used — never silently mixed.
-- **Sidecar extension, not a new route.** `buildEntitySidecar` gains a `citations` field on its response (`EntitySidecarResponse`, `src/studio-assets.ts:219-223`): it loads `citations.json` exactly like it loads `occurrences.json` today, reads `nodes[id]`, and returns `{ count, citations }`. The `/api/ontology/entity/<id>` route (`src/ontology-studio.ts:490-494`) is unchanged — it already returns whatever `buildEntitySidecar` produces.
+- **Single producer, correctly anchored.** Both levels are written from ONE aggregation pass over the assembled graphology graph, in the path that already owns per-node `citations[]` and writes graph.json — i.e. just BEFORE `toJson` (`src/export.ts:449`, reached from `cli.ts` extract/update/describe/label, `watch.ts:399`, `pipeline.ts:244`, `skill-runtime.ts:1181`). The pass: walks each node's unioned citation set, computes `count`, selects the deterministic top-K, **replaces `node.citations` with the top-K**, sets `node.citation_count`, and writes the full per-entity set into `citations.json`. (NOTE: this is NOT `compileOntologyOutputs` in `src/ontology-output.ts` — that stage operates on `CompiledNode`, which has no `citations` field and does not write graph.json; the empty `occurrences.json` write at `:286` merely proves the sidecar READER exists. The producer lives on the `toJson` path.)
+- **graph_signature = a citation-content hash.** `graph_signature` is a sha256 over the sorted projection `{ node_id → its inline citations }` of graph.json at emit time. It is explicitly NOT `computeTopologySignature` (`src/export.ts:422-447`, which hashes only ids + edges and is blind to node attributes — using it would miss citation changes and repeat the byte-identical-graph drop bug fixed in `d96ec5f`), and NOT graph.json mtime+size (a deterministic content-identical rebuild changes mtime and would falsely invalidate). Contract: byte-identical citation content ⇒ identical signature; any citation change ⇒ different signature.
+- **Consistency by construction.** Both projections come from the same pass; `citations.json` carries the `graph_signature` of the graph.json it was emitted against. On read, if the signature does not match the current graph.json's citation-content hash, the store is treated as ABSENT and the inline K-set is used — never silently mixed.
+- **Sidecar extension, not a new route.** `buildEntitySidecar` gains a `citations` field on its response (`EntitySidecarResponse`, `src/studio-assets.ts:219-223`): it loads `citations.json` through an mtime-keyed in-memory index (the `loadGraphNodeDescriptions` pattern, NOT the uncached `loadJsonSafe`-per-request that `occurrences.json` uses today at `:254`), reads `nodes[id]`, returns `{ count, citations }`. The `/api/ontology/entity/<id>` route (`src/ontology-studio.ts:490-494`) is unchanged.
 
 ## Exhaustive Extraction
 
-### Capture every citation + a frequency count
+### Capture every extracted citation + a frequency count
 
-The fix is an AGGREGATION CONTRACT, not a cap removal (there is no cap to remove). Concretely:
+The fix is in the assembly/aggregation contract (Problem #1), not a cap removal:
 
-- The profile/ontology extraction path already instructs the assistant to attach citations per chunk (`src/profile-prompts.ts:150-152,178`). The new requirement: when assembling the final graph, UNION every citation seen for a given entity across all chunks and all source files, deduped by a citation identity key (PROPOSED: `source_file` + `page` + `section` + `paragraph_id`; passages differing only in `bbox` are treated as the same citation unless `paragraph_id` differs — see Open decisions on dedupe granularity).
-- `count` = size of the deduped union. This is what populates `citation_count` (Level-1) and `nodes[id].count` (Level-2), and finally makes `occurrences.json`'s intended frequency signal real (the empty `[]` at `src/ontology-output.ts:286` is replaced by a populated structure, or `occurrences.json` is kept as occurrences and citation frequency lives in `citations.json` — see Open decisions on whether to fold counts into `occurrences.json` vs a dedicated `citations.json`).
-- The skill emits ALL citations into the extraction output for documents/papers/entity corpora (detection always-all; see policy below). The deterministic aggregation/dedupe/top-K selection happens in TypeScript at build time, not in the prompt, so it is replayable and provider-neutral.
+- **Union at merge, not discard.** The chunk-assembly merge must UNION each entity's `citations[]` across all chunks instead of last-write-wins / skip-duplicate. Concretely the three sites that collapse duplicates today must union citations keyed by node id: `src/build.ts:286` (`mergeNode` — union the `citations` attr rather than replace), `src/cli.ts:330-333` and `src/skill-runtime.ts:419-428` (`if (seen.has(id)) continue` — before skipping, fold the duplicate's `citations` into the kept node). Dedup the union by the citation identity key (PROPOSED: `source_file` + `page` + `section` + `paragraph_id`; `bbox` excluded for prose, included only for figure/image corpora — Decision 3).
+- **`count`** = size of the deduped union → populates `citation_count` (Level-1) and `nodes[id].count` (Level-2). This finally makes the frequency signal real (the empty `[]` at `src/ontology-output.ts:286` stays for non-citation occurrence data; citation counts live in `citations.json` — Decision 1).
+- The skill emits ALL citations into the extraction output for documents/papers/entity corpora (detection always-all; see policy). The deterministic union/dedupe/top-K happens in TypeScript at assembly time, provider-neutral and replayable.
 
-### Deterministic inline top-K selection
+### Deterministic inline top-K selection (algorithm pinned)
 
-The inline `citations_top` must be deterministic and meaningful — the same graph must always yield the same K. Selection order (PROPOSED default), with deterministic tie-breaks so two builds of the same graph are byte-identical:
+The inline `citations` (top-K) must be a pure, deterministic function of the citation SET — two builds of the same graph must be byte-identical. Algorithm:
 
-1. **Most-distinct-source first.** Prefer citations that cover the widest set of distinct `source_file`s — a hub entity's top-K should span many works, not 8 passages from one chapter. This maximizes the grounding value of the inline set for `describe`.
-2. **Then highest confidence/specificity.** Citations with a finer locator (has `page`/`section`/`paragraph_id`) rank above bare `source_file`-only refs.
-3. **Then earliest by stable sort key.** Final tie-break on `(source_file, page, section, paragraph_id)` lexicographic order — deterministic, matches the existing `uniqueSorted` posture in reconciliation (`src/ontology-reconciliation.ts:234-237`).
+1. **Normalize input order.** Sort the full deduped citation list lexicographically by `(source_file, page, section, paragraph_id)` (stable, total — matches the `uniqueSorted` posture at `src/ontology-reconciliation.ts:234-237`). This removes any dependence on extraction/iteration order.
+2. **Greedy most-distinct-source cover.** Walk the sorted list; greedily pick the next citation whose `source_file` is not yet represented in the selection, until K are chosen or every source is covered. Every greedy tie is broken by the lexicographic key from step 1.
+3. **Fill remainder by locator specificity, then lexicographic.** If sources are exhausted before K, fill remaining slots from the sorted list preferring finer locators (has `page`/`section`/`paragraph_id` over bare `source_file`), final tie-break lexicographic.
 
-"Earliest in document order" was rejected as the primary key: it would fill a hub entity's top-K with passages from whichever work sorts first, defeating the point of a salience preview. Most-distinct-source gives the strongest at-a-glance grounding. K is configurable; default 8.
+"Earliest in document order" was rejected as the primary key (it fills a hub's preview with whichever work sorts first). Most-distinct-source maximizes grounding value for `describe`. K is configurable; default 8.
 
 ### Backward-compat with existing bounded graphs
 
-Two paths, both opt-in:
+Two opt-in paths:
 
-- **Re-extract (preferred for correctness).** Re-running extraction on the corpus produces exhaustive citations natively. This is the honest path: only a re-extract can recover citations the original bounded build never captured.
-- **Backfill (cheap, lossy on count).** `graphify backfill-citations` (PROPOSED) walks the existing `graph.json`, and for each node with legacy `citations[]` but no `citations_top`/`citation_count`, sets `citations_top = dedupe(citations)`, `citation_count = |dedupe(citations)|`, and writes a `citations.json` from the same legacy data. This cannot invent citations that were never captured, so `count` reflects only what the bounded graph holds — the command prints a clear caveat that counts are lower bounds until a re-extract. Backfill is for keeping old graphs renderable under the new schema, not for achieving exhaustiveness.
+- **Re-extract (correct).** Re-running extraction on the corpus produces exhaustive citations natively (union across chunks). Only a re-extract recovers citations the original duplicate-discard dropped. **For curated graphs this must be paired with description preservation — see Migration.**
+- **Backfill (cheap, lossy on count).** `graphify backfill-citations` walks the existing `graph.json`, and for each node with a legacy `citations[]` but no `citation_count`, sets `citations` = top-K(dedupe(citations)), `citation_count` = |dedupe(citations)|, and writes `citations.json` from the same legacy data. It cannot invent citations the bounded graph never held, so `count` is a LOWER BOUND — the command prints that caveat. Idempotent on a second run (dedupe key is stable). Backfill keeps old graphs renderable under the new schema; it does NOT achieve exhaustiveness, and **cannot meet the "hundreds on Sherlock" UAT target** (that needs a re-extract).
 
-`hook-rebuild` (the LLM-free incremental path) recomputes Level-1 fields and `citations.json` from whatever citations are already on the graph — it never adds new citations (no LLM), it only re-projects, keeping the two levels consistent after edits.
+`hook-rebuild` (LLM-free) re-projects Level-1 (`citation_count` + trimmed inline `citations`) and re-derives `citations.json` from the extraction output if present; it never adds new citations and never calls a provider. If only graph.json's K-set is available (no extraction output), it can only validate/refresh consistency, not regenerate the full tail.
 
 ## Corpus-Type-Aware Citation Policy
 
@@ -137,73 +140,85 @@ Three knobs, one corpus-type signal.
 
 ### The corpus-type signal
 
-Corpus type is derived from the EXISTING detection output `.graphify/.graphify_detect.json`, which already carries `files: Record<FileType, string[]>` (buckets: `code`, `document`, `paper`, `image`, …) plus `total_words` and `total_files` (`src/detect.ts:801-804,722,776`). The skill classifies (PROPOSED thresholds):
+Corpus type is derived from the EXISTING detection output `.graphify/.graphify_detect.json`, which carries `files: Record<FileType, string[]>` (buckets include `code`, `document`, `paper`, `image`, `video` — `src/detect.ts:722-724`), `total_words` (`:804`), `total_files` (`:803`). The skill classifies (PROPOSED thresholds):
 
 - `code` — `files.code` dominates and `files.document`/`files.paper` are empty/negligible.
 - `long-document` — `files.document`/`files.paper` present AND `total_words` above the corpus-warn threshold (long-form prose / papers; the mystery corpus lands here).
-- `entity-corpus` — ontology/profile mode is active (the graph is entities-over-documents, e.g. the mystery sagas).
-- `mixed` — anything else; treated as the middle default.
+- `entity-corpus` — ontology/profile mode is active (entities-over-documents).
+- `mixed` — anything else; the middle default.
 
-No new detection pass is added; this reads `.graphify_detect.json` which the skill already produces and persists (`src/skills/skill.md:165`).
+No new detection pass is added; this reads `.graphify_detect.json` which the skill already produces and persists (`src/skills/skill.md`). A `corpus_type` field is additive (none exists today).
 
 ### The three knobs and their defaults
 
 | Knob | What it controls | code | mixed (default) | long-document / entity-corpus |
 |---|---|---|---|---|
 | Detection | how many citations the assistant captures | all | all | all |
-| Inline top-K (`citations_top` size) | quick-display + describe-fallback + eager payload bound | 3 | 8 | 8 (capped for payload; count is unbounded) |
+| Inline K (`citations` size) | quick-display + describe-fallback + eager payload bound | 3 | 8 | 8 (capped for payload; `citation_count` is unbounded) |
 | Describe prompt cap (`MAX_CITATIONS`) | citation snippets injected per node into the description prompt | 3 | 10 | all (or a high cap, e.g. 50) |
 
 Key points:
 
 - **Detection is ALWAYS all.** Exhaustiveness is not corpus-dependent; only display/prompt density is. The full list always lands in `citations.json`.
-- **The describe cap default rises 3 → 10.** `MAX_CITATIONS` (`src/node-descriptions.ts:376`) becomes a resolved value, not a hardcoded constant: 3 for code, 10 default, all/high for long-docs/entity corpora. `collectCitationContext` (`src/node-descriptions.ts:402-450`) reads the resolved cap instead of the constant.
-- **Inline top-K stays bounded** even for long-docs/entity corpora, because it rides in the eager payload; the unbounded truth is `citation_count` + the lazy `citations.json`.
+- **The describe cap default rises 3 → 10.** `MAX_CITATIONS` (`src/node-descriptions.ts:376`) becomes a RESOLVED value threaded as a plain parameter on `GenerateNodeDescriptionsOptions` (`:736`, no `citationCap` field today) → `collectCitationContext` (`:402-450`) reads the resolved cap. Because it is a plain parameter, it flows on the NO-KEY assistant path (`collectCitationContext` → `NodeContext.citations` → `emitDescriptionInstructions`) with no provider — verified the cap governs exactly what the no-key assistant sees.
+- **Inline K stays bounded** even for long-docs/entity corpora (it rides the eager payload); the unbounded truth is `citation_count` + the lazy `citations.json`.
 
 ### The skill knob + CLI flag
 
-- **Skill (default path, no key).** The skill, after detection, sets the policy per corpus type when invoking describe/label/build. This is the primary path (graphify runs assistant-first, no API key by default). The skill writes the resolved cap/top-K into the describe invocation; nothing in core implies a value.
-- **CLI flag (override).** `graphify describe|label|build --citation-cap <n|all> --citations-top-k <n>` (PROPOSED). Flag overrides skill, skill overrides corpus-type default, corpus-type default overrides the global fallback (10). `--citation-cap all` is the long-doc value. A config block (`citations.describe_cap`, `citations.inline_top_k`) mirrors the flags for non-interactive runs, matching the `SPEC_STORAGE_BACKENDS`/`SPEC_LLM_EXECUTION_PORTS` precedence convention (flag > env/config > corpus default > global default).
+- **Skill (default path, no key).** After detection the skill sets the policy per corpus type when invoking describe/label/extract. Primary path (assistant-first, no API key). The skill writes the resolved cap/K into the invocation; core implies nothing.
+- **CLI flag (override).** Placement corrected after review:
+  - `--citation-cap <n|all>` on the commands that build the description prompt: `graphify describe|label|update` (these call `toJson`/the describe engine). `describe`/`label` have no such flag today (`cli.ts:3853-3858`), so it is added.
+  - `--citations-top-k <n>` on the commands that WRITE graph.json node citations via `toJson`: `graphify extract|update|watch` — NOT the top-level `graphify build` (`cli.ts:2750`), which is a non-LLM profile chain (`validate → dataprep → ontology-output`) that never runs `toJson` and cannot apply the flag.
+  - Precedence: CLI flag > config > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required.
 
 ## Studio UX
 
-- **Count always visible.** The EntityPanel "Citations" accordion header already shows a `count` (`studio/src/components/EntityPanel.svelte:108`, `citationTotal`). It switches from "sum of inline citations" to `node.citation_count` (the true count), so a hub entity reads "Citations (214)" even before its full list loads.
-- **Inline top-K renders immediately.** On selection, `citationsByFile(node)` (`graphAdapter.js:702-716`) renders the inline `citations_top` from the already-loaded graph — instant, no fetch, no spinner.
-- **Full list lazy-loaded on selection.** When the panel opens for an entity, `App.svelte`'s `ensureEntity(id)` → `fetchEntity(id)` → `/api/ontology/entity/<id>` (`studio/src/lib/api.js:81-87`) already runs on focus. The sidecar response gains `citations: { count, citations }`. When it arrives, the panel replaces the inline top-K with the full file→passages double accordion. The render component (`citationsByFile`) is unchanged; only its DATA source upgrades from inline to sidecar.
-- **Performance budget.** The eager payload (`graph.json` fetch + `scene.json`) carries at most `citations_top` (K, default 8) per node — bounded regardless of corpus. `scene.json` already excludes `citations` entirely. The only place hundreds of citations exist is `citations.json`, loaded once by the server and indexed in memory (same path as `occurrences.json`/`descriptions.json`, cached by graph.json mtime, `src/studio-assets.ts:186-212`), and sliced per id on each `/api/ontology/entity` request. Target: eager bundle growth from this feature ≤ K citations/node; a single entity fetch returns one node's slice (hundreds of objects worst case, kilobytes), not the corpus-wide list.
+- **Count always visible (one client edit).** The EntityPanel "Citations" header count is `citationTotal`, today derived by SUMMING the inline citations (`EntityPanel.svelte:25-26,108`). It switches to read `node.citation_count`, so a hub reads "Citations (214)" immediately, before the full list loads. This is the one required Level-1 client change.
+- **Inline top-K renders immediately (no change).** On selection, `citationsByFile(node)` (`graphAdapter.js:702-716`) renders `node.citations` (now the K-set) from the already-loaded graph — instant, no fetch. No rename needed (field kept as `citations`).
+- **Full list lazy-loaded on selection (additive wiring).** `App.svelte`'s focus path already runs `ensureEntity(id)` → `fetchEntity(id)` → `/api/ontology/entity/<id>` (`api.js:81-87`); the sidecar response gains `citations: { count, citations }`. New, additive client wiring consumes it: when it arrives, the panel replaces the inline K-set with the full file→passages accordion (the render component `citationsByFile` is reused; its DATA upgrades from the inline node to the sidecar payload). Passages render locators (section/page), not verbatim quotes (no `quote` in the schema).
+- **Performance budget.** The eager payload (`graph.json` fetch + `scene.json`) carries at most `citation_count` + K inline citations per node — bounded regardless of corpus, BECAUSE the producer trims `node.citations` to K before `toJson` (without that trim, `...attrs` would pass the full set through and bloat graph.json — the load-bearing requirement). `scene.json` already excludes `citations`. The only place hundreds of citations exist is `citations.json`, loaded once via the mtime-keyed index and sliced per id. Target: eager bundle growth ≤ K citations/node; a single entity fetch returns one node's slice (kilobytes), not the corpus-wide list.
 
 ## Reconciliation Interaction
 
-Today reconciliation unions `source_refs` into `evidence_refs` via `uniqueSorted` (a deduped union, no cap, `src/ontology-reconciliation.ts:234-237`) but does NOT touch the `citations[]` arrays of merged entities. Under this design:
+Today reconciliation PROPOSES merges; it does not apply them or touch `citations`. `generateOntologyReconciliationCandidates` (`src/ontology-reconciliation.ts:214-265`) emits a candidate queue (`status: "candidate"`, human/workbench-gated); its `uniqueSorted` union (`:234-237`) is over `source_refs` → `evidence_refs` for the candidate record, not node `citations`. Under this design:
 
-- When two entities are reconciled into one canonical, their exhaustive citation sets UNION (same dedupe identity key as capture). `citation_count` of the merged entity = size of the unioned deduped set — so merging Sherlock-from-work-A with Sherlock-from-work-B correctly raises the count rather than picking one side's sample.
-- The inline `citations_top` is RE-SELECTED from the union by the same deterministic most-distinct-source rule, so the merged entity's preview spans both works.
-- This happens in the same single aggregation pass, AFTER reconciliation has decided merges, so the lazy `citations.json` and the inline fields are always computed on the post-merge graph. There is no separate citation-merge code path to drift.
+- v1's citation union happens at the chunk-assembly merge (Exhaustive Extraction) — i.e. same-id citations across chunks/works are unioned there, which already covers the common hub case (Sherlock across 25 works that resolve to one id).
+- When an accepted reconciliation merge is APPLIED (the merge-apply path, e.g. `src/merge-driver.ts:124` `mergeNode`, which is also last-write-wins today), the citation union must follow the SAME union-not-replace change as the assembly merge, so an accepted merge of Sherlock-A + Sherlock-B sums distinct citations and re-selects top-K from the union. There is no separate citation-merge code; it rides the merge-apply path.
+- This spec does NOT claim "no path to drift": if merge-apply is human-gated/asynchronous, the union is correct whenever that path runs; citation-union-on-accept is in scope only insofar as the merge-apply path exists. Building a new merge-apply path is out of v1 scope.
 
 ## Migration
 
-- **Schema additive.** `citation_count` + `citations_top` are new optional `GraphNode` fields; legacy `citations[]` stays readable. No existing graph breaks.
-- **Producer flip.** The empty-array write at `src/ontology-output.ts:286` is replaced by the real aggregation pass emitting `citations.json` (and, if counts fold into occurrences, a populated `occurrences.json`).
-- **Existing graphs.** Default: a graph built before this feature renders via its legacy inline `citations[]` (no behavior change). Run `graphify backfill-citations` to project legacy citations into the new fields + store (counts are lower bounds), or re-extract for true exhaustiveness. A `branch.json` stale flag / `needs_update` marker, if present, already warns per project convention before relying on results.
-- **Studio fallback.** If `citations.json` is absent or its `graph_signature` is stale, the panel shows count (`citation_count`) + the inline top-K and skips the lazy upgrade — degraded but correct.
+- **Schema additive.** `citation_count` is a new optional `GraphNode` field; `citations` keeps its name and shape (semantics tighten to top-K on new builds). No existing graph breaks; old `citations[]` (bounded sample) renders unchanged.
+- **Producer change.** The chunk-assembly merge unions citations (was discard); a pre-`toJson` aggregation pass trims `node.citations` to K, sets `citation_count`, and emits `citations.json`. The empty-array write at `src/ontology-output.ts:286` stays for non-citation occurrence data.
+- **Exports unaffected.** `src/export.ts`/`src/wiki.ts` html/wiki/obsidian exporters do NOT read `citations` (grep-verified: zero citation references) — so trimming the inline set has no human-facing export impact. The only citation-bearing artifact is graph.json itself (governed by the trim) and `citations.json`.
+- **Existing graphs.** Default: a pre-feature graph renders via its legacy inline `citations[]` (no behavior change) + a staleness WARNING (Decision 5). `graphify backfill-citations` projects legacy citations into the new fields + store (lower-bound counts), or re-extract for true exhaustiveness.
+- **Curated mystery graph (live, operational tension — flagged for a rollout decision).** The curated graph at `~/src/public-domaine-mystery-sagas-pack` was just refilled with descriptions WITHOUT a re-extract. The UAT target ("hundreds of citations on Sherlock") is achievable ONLY by a re-extract — which regenerates node sets and would overwrite the curated descriptions — NOT by backfill (which yields lower-bound counts, ~15). The two rollout options:
+  - **(a) backfill** — preserve the curated descriptions, accept lower-bound counts (UAT "hundreds" UNMET on this graph until a future re-extract);
+  - **(b) re-extract + re-describe** — true exhaustive counts, paired with a description-preservation step (re-extract, then re-run the no-key `describe --fill-missing` refill, or snapshot descriptions and re-stamp).
+  This is a product/ops call for the conductor at rollout time; it does NOT block this feature's implementation. The UAT target is conditional on which path is run.
+- **Studio fallback.** If `citations.json` is absent or its `graph_signature` mismatches, the panel shows `citation_count` + the inline K-set and skips the lazy upgrade — degraded but correct.
 
 ## CLI and config surface
 
 PROPOSED; freezes at the implementation PR.
 
 ```
-graphify describe [path] --citation-cap <n|all>      # describe-prompt cap (default: corpus-type resolved; 3 code / 10 default / all long-doc)
+graphify describe [path] --citation-cap <n|all>   # describe-prompt cap (default: corpus-resolved; 3 code / 10 default / all long-doc)
 graphify label    [path] --citation-cap <n|all>
-graphify build    [path] --citations-top-k <n>       # inline Level-1 K (default 8)
-graphify backfill-citations [path]                   # project legacy citations[] -> citation_count/citations_top + citations.json (lossy on count)
+graphify update   [path] --citation-cap <n|all> --citations-top-k <n>
+graphify extract  [path] --citations-top-k <n>    # inline Level-1 K (default 8); writes graph.json via toJson
+graphify watch           --citations-top-k <n>
+graphify backfill-citations [path]                # project legacy citations[] -> citation_count + K-set + citations.json (lossy on count)
 ```
+
+`--citations-top-k` is NOT added to the top-level `graphify build` (non-LLM profile chain; does not write graph.json node citations).
 
 ```yaml
 citations:
   describe_cap: 10        # n | "all" ; corpus-type default unless set
-  inline_top_k: 8         # Level-1 inline set size
-  store: ontology/citations.json   # Level-2 keyed store path (relative to .graphify/)
-  dedupe_key: [source_file, page, section, paragraph_id]
+  inline_top_k: 8         # Level-1 inline K
+  store: ontology/citations.json   # Level-2 keyed store (relative to .graphify/)
+  dedupe_key: [source_file, page, section, paragraph_id]   # bbox added only for figure/image corpora
 ```
 
 Precedence: CLI flag > config > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required.
@@ -212,38 +227,50 @@ Precedence: CLI flag > config > corpus-type default (from `.graphify_detect.json
 
 Automated tests should cover:
 
-- a node with N>K exhaustive citations gets `citation_count = N` and `citations_top.length = K`; the eager payload never exceeds K per node.
-- `citations.json` is keyed by node id, carries the current `graph_signature`, and `buildEntitySidecar` returns `{ count, citations }` for a present id and a null/empty for an absent id.
-- `citations.json` whose `graph_signature` mismatches the current `graph.json` is treated as absent: sidecar returns no full list, panel falls back to inline.
-- inline top-K is deterministic: two builds of the same graph produce byte-identical `citations_top` (most-distinct-source ordering + stable tie-break).
-- describe prompt cap resolves per corpus type: code → 3, default → 10, long-doc/entity → all/high; `--citation-cap` overrides; `collectCitationContext` honors the resolved cap (regression on `src/node-descriptions.ts:376/408`).
-- corpus-type classification from a synthetic `.graphify_detect.json` (code-only, paper-heavy long-doc, ontology entity-corpus, mixed).
-- reconciliation union: merging two entities sums distinct citations (not max of the two), and re-selects top-K from the union.
-- `backfill-citations` on a legacy graph populates the new fields and store from `citations[]` and prints the lower-bound caveat; idempotent on a second run.
-- `hook-rebuild` re-projects Level-1 + `citations.json` from existing citations without an LLM call and without inventing citations.
-- no provider/network/secret access is triggered by any citation emit or backfill path (matches `SPEC_LLM_EXECUTION_PORTS` default-no-op posture).
-- the eager `graph.json` fetch and `scene.json` for a graph with a 200-citation hub entity stay within the K-per-node payload budget.
+- **Union at merge:** a node appearing in N chunks each with distinct citations ends with the deduped UNION (not one chunk's set); covers `build.ts:286` mergeNode and the `cli.ts:330`/`skill-runtime.ts:419` skip-duplicate paths (regression on the discard).
+- **Trim + count:** a node with M>K unioned citations gets `citation_count = M` and inline `citations.length = K`; graph.json (post-`toJson`) carries only K per node — assert byte-size of a 200-citation-hub graph stays within the K·node budget.
+- **citations.json:** keyed by node id, carries the current citation-content `graph_signature`; `buildEntitySidecar` returns `{ count, citations }` for a present id, null/empty for absent; signature mismatch ⇒ treated as absent, panel falls back to inline.
+- **Deterministic top-K:** two builds of the same graph produce byte-identical inline `citations` (sorted-input + greedy most-distinct-source + stable tie-break); a content-identical rebuild yields an identical `graph_signature` (NO false-stale), and any citation change yields a different signature (NO silent stale-serve) — the `d96ec5f` bug class.
+- **Describe cap resolution:** code → 3, default → 10, long-doc/entity → all/high; `--citation-cap` overrides; `collectCitationContext` honors the resolved cap on BOTH the API and the no-key assistant path (regression on `node-descriptions.ts:376/408/477`).
+- **Corpus-type classification** from a synthetic `.graphify_detect.json` (code-only, paper-heavy long-doc, ontology entity-corpus, mixed).
+- **Reconciliation union:** an applied merge of two entities sums distinct citations (not max/last-write) and re-selects top-K from the union.
+- **backfill-citations** populates the new fields + store from legacy `citations[]`, prints the lower-bound caveat, idempotent on re-run.
+- **hook-rebuild** re-projects Level-1 + `citations.json` LLM-free (from extraction output) without inventing citations.
+- **No provider/network/secret** access on any citation emit/backfill path.
+- **citations.json caching:** loaded via an mtime-keyed in-memory index (not re-read per `/api/ontology/entity` request).
 
 ## UAT
 
-- Build the public-domain mystery graph (25 works); confirm Sherlock/Watson now carry `citation_count` in the hundreds (not ~15) and a K-sized `citations_top`.
+- Re-extract the public-domain mystery graph (25 works); confirm Sherlock/Watson carry `citation_count` in the hundreds (not ~15) and a K-sized inline `citations`. (Backfill alone CANNOT meet this — see Migration.)
 - Open the studio, select Sherlock: count reads the true number immediately; inline top-K renders instantly; the full file→passages list populates on the lazy fetch without a visible graph reload.
 - Confirm `graph.json` size growth is bounded (K citations/node) and the eager fetch stays fast at hub entities.
 - Run `graphify describe` on the mystery corpus: descriptions ground on many distinct sources (cap = all), while a code project's descriptions still cap at 3.
-- Run `backfill-citations` on a pre-feature graph: it renders under the new schema with a lower-bound count caveat; re-extract then shows the true exhaustive count.
+- Run `backfill-citations` on a pre-feature graph: renders under the new schema with the lower-bound caveat; re-extract then shows true exhaustive counts.
 
 ## Decisions
 
-Resolved by the conductor on 2026-06-13. These are BINDING for the implementation PR — the `PROPOSED` markers elsewhere in this spec resolve to the values below.
+Resolved by the conductor on 2026-06-13. BINDING for the implementation PR.
 
-1. **Frequency count + full list live in a single dedicated `citations.json`** (schema `graphify_ontology_citations_v1`), NOT folded into `occurrences.json`. `occurrences.json` is left for non-citation occurrence data; citation count and the exhaustive list are self-contained in one store. Revisit only if occurrences gains independent meaning.
+1. **Frequency count + full list live in a dedicated `citations.json`** (`graphify_ontology_citations_v1`), NOT folded into `occurrences.json` (left for non-citation occurrence data).
+2. **Inline top-K: K = 8, most-distinct-source** (pinned greedy algorithm above; stable lexicographic tie-break). Field KEEPS the name `citations` (no `citations_top` rename — review decision, avoids a studio render regression).
+3. **Citation identity excludes `bbox` for prose** (`source_file + page + section + paragraph_id`); `bbox` is part of identity ONLY for figure/image-heavy corpora.
+4. **Level-2 is a single keyed `citations.json`** (reuses the mtime-keyed in-memory index), NOT a per-id directory; revisit past a ~10 MB budget.
+5. **Stale pre-feature graphs WARN + render legacy inline** on open; no auto-backfill. True exhaustiveness stays an explicit `backfill-citations` (lower-bound) or re-extract.
+6. **Edge citations stay OUT of v1.** `GraphEdge.citations[]` unchanged.
 
-2. **Inline top-K: K = 8, most-distinct-source primary selection key** (then locator specificity, then stable lexicographic tie-break on `(source_file, page, section, paragraph_id)`). This freezes the determinism contract: two builds of the same graph produce byte-identical `citations_top`. Earliest-in-document was rejected (fills a hub's preview with whichever work sorts first).
+## Review remediation
 
-3. **Citation identity excludes `bbox` for prose corpora** — identity = `source_file + page + section + paragraph_id`; passages differing only in `bbox` collapse to one citation. `bbox` is part of identity ONLY for figure/image-heavy corpora (so distinct figure regions on a page count separately). Keeps prose "cited N times" realistic, not bbox-inflated.
+Two independent adversarial Opus 4.8 reviews (2026-06-13) returned BLOCK; all findings are folded into this revision:
 
-4. **Level-2 is a single keyed `citations.json`** (reuses the `occurrences.json`/`descriptions.json` in-memory-index caching path, cached by graph.json mtime). It is NOT a per-id directory. A switch to `.graphify/citations/<id>.json` is reconsidered only if the keyed file later exceeds a size budget (deferred trigger: > ~10 MB or a corpus where a single load stalls server start) — not a v1 concern.
-
-5. **Stale pre-feature graphs WARN + render legacy inline** on open; no auto-backfill. True exhaustiveness stays an explicit `graphify backfill-citations` (lower-bound counts, clearly captioned) or a re-extract. Auto-backfill was rejected because its lower-bound counts could be mistaken for the true exhaustive count.
-
-6. **Edge citations stay OUT of the tiered model for v1.** `GraphEdge.citations[]` (`src/types.ts:75`) is unchanged — edges are far less cited than hub entities. Folding edges in is a follow-up only if edge citation volume proves unbounded in an entity corpus.
+- **Source-of-truth framing (A#1, BLOCK):** corrected — citations.json is a co-derived, durable carrier of the exhaustive tail, not a projection of graph.json. See `## Source of truth`.
+- **Union vs merge-discard (A#2, BLOCK):** disclosed — `mergeNode` last-write-wins (`build.ts:286`) and `if(seen) continue` (`cli.ts:330`, `skill-runtime.ts:419`) discard duplicate citations; the union must change those sites. Exhaustive ceiling (extraction-emit-bounded) stated in Non-Goals.
+- **Producer mis-anchor (B#A, BLOCK):** re-anchored from `ontology-output.ts:286` (CompiledNode, no citations, no graph.json write) to the pre-`toJson` aggregation pass.
+- **graph.json leanness (B#B, BLOCK):** explicit trim requirement added — `toJson` spreads `...attrs`, so the node's inline `citations` MUST be replaced by the K-set before write; keeping both arrays would bloat worse.
+- **Studio render contract (B#C, MUST-FIX):** field kept as `citations` (no rename); only `citationTotal`→`citation_count` and the additive lazy-consume wiring change.
+- **graph_signature (A#3, MUST-FIX):** defined as a citation-content hash, not topology-signature, not mtime+size.
+- **Top-K determinism (A#5, MUST-FIX):** exact greedy algorithm + input sort pinned.
+- **Reconciliation (A#4, MUST-FIX):** stated as candidate-proposal today; union rides the merge-apply path; no "no drift" claim.
+- **CLI flag placement (B#D, MUST-FIX):** `--citations-top-k` moved off `build` to extract/update/watch; `--citation-cap` on describe/label/update.
+- **citations.json caching (B#F, MUST-FIX):** mtime-keyed index, not uncached per-request.
+- **Survey carve-out (A#6), quote/locators (A#7), export non-impact (B#E):** folded into Problem/Non-Goals/Migration.
+- **Curated mystery migration (B#G, needs product call):** flagged as a rollout decision in Migration (backfill vs re-extract+re-describe); does not block implementation.

--- a/spec/SPEC_CITATIONS.md
+++ b/spec/SPEC_CITATIONS.md
@@ -1,0 +1,248 @@
+# SPEC_CITATIONS
+
+## Status
+
+- Product: Graphify TypeScript port
+- Scope: exhaustive citation capture per entity + tiered (inline / lazy) citation storage + corpus-type-aware citation policy
+- Activation: detection is always exhaustive; tiering and the lazy store are the default emit path; corpus-type tuning is automatic with an explicit override
+- Default behavior: `.graphify/graph.json` carries a citation COUNT + a small inline top-K per node; the FULL citation list moves to a lazily-loaded per-entity store served through the existing `/api/ontology/entity/<id>` sidecar route
+- Product decision (user, 2026-06-13): "extract ALL citations; don't bloat graph.json or the studio; describe prompt cap stays tunable, default 3 → 10, long-docs/entity-corpus → all"
+- Constraint: `.graphify/graph.json` remains the single source of truth (description-contract work). The lazy store is a DERIVED projection of graph.json, never a competing truth.
+- Delivery: PR1 is this spec; implementation follows the roadmap below.
+- CLI, config and field-name surfaces in this document are PROPOSED; they freeze at the implementation PR.
+
+This spec makes citation capture exhaustive and citation storage tiered. Today only a bounded SAMPLE of citations survives on hub entities (the mystery graph caps out around ~15 citations on Sherlock and ~12 on Watson, though those entities are cited hundreds of times across 25 works), and `occurrences.json` — the artifact that should track true citation frequency — is written as an empty array (`src/ontology-output.ts:286`). The design captures every citation, records a real frequency count, keeps `graph.json` lean by storing only a count plus a deterministic inline top-K on each node, and serves the full citation list on demand through the per-entity sidecar pattern that already exists for descriptions and occurrences (`src/studio-assets.ts:235` `buildEntitySidecar`, `/api/ontology/entity/<id>` in `src/ontology-studio.ts:490`).
+
+## Problem
+
+Citations on graph nodes are typed as `OntologyCitation[]` (`src/types.ts:53` on `GraphNode`, `:75` on `GraphEdge`; the `OntologyCitation` shape is `src/types.ts:473-481` — `source_file`, optional `source_url`, `page`, `section`, `paragraph_id`, `figure_id`, `bbox`). Four concrete problems block exhaustive, scalable citation handling:
+
+1. **Capture is a sample, not a census.** There is NO `.slice()`, cap, or sampling limit on citation STORAGE anywhere in `src/` (verified: the only citation-length references are `src/node-descriptions.ts:358/527`, `src/profile-validate.ts:288`, none of which bound storage). The bound is emergent: citations land on nodes only through the profile/ontology extraction path (`src/profile-prompts.ts:150-152,178` instruct the assistant to "include … citations" and "preserve page-level citations when available"), each assistant chunk naturally emits a handful, and nothing aggregates the union across all chunks/works into one exhaustive per-entity list. A hub entity cited in 25 works keeps only the citations that happened to ride along in the chunks where it was the focus. Exhaustiveness therefore requires a change to the AGGREGATION CONTRACT, not the removal of a cap.
+
+2. **Frequency is tracked nowhere.** `occurrences.json` is written unconditionally as `[]` (`src/ontology-output.ts:286`). The reader side already exists and is keyed by node id: `buildEntitySidecar` loads `occurrences.json`, reads `occRaw.nodes[id]`, and returns it in the sidecar (`src/studio-assets.ts:254-261`). The producer was never wired. So "cited N times" — a degree-independent salience signal — is unavailable for display, for describe grounding, and for ranking the inline top-K.
+
+3. **The studio loads the full graph eagerly, and renders citations from it.** The SPA fetches `graph.json` verbatim (`/api/ontology/graph.json`, `src/ontology-studio.ts:246-263`, "Returned verbatim (no re-parse)"). The EntityPanel renders citations from the eagerly-loaded node: `citationsByFile(node)` reads `node.citations[]` (`studio/src/components/EntityPanel.svelte:25`, `studio/src/lib/graphAdapter.js:702-716`), grouping by `source_file` into a file→passages double accordion. Note that `scene.json` already EXCLUDES `citations` (only `evidence_refs` is in `NODE_PROFILE_FIELDS`, `src/studio-scene.ts`), but the SPA still pulls the full `graph.json`, so exhaustive per-hub citations would bloat the eager fetch and the in-memory graph regardless of `scene.json`.
+
+4. **The describe prompt cap is a single hardcoded constant.** `MAX_CITATIONS = 3` (`src/node-descriptions.ts:376`) caps how many citation snippets are injected into the description prompt per node, deduped/truncated by `collectCitationContext` (`src/node-descriptions.ts:402-450`, `CITATION_MAXLEN = 120` at `:373`). Three is right for code symbols and wrong for long documents and entity corpora, where a description should be grounded in many distinct sources. The cap is not tunable per corpus and is not exposed to the skill or CLI.
+
+Without an explicit tiered model, making capture exhaustive would push hundreds of citation objects per hub entity straight into `graph.json` and into every eager studio fetch.
+
+## Goals
+
+- Capture EVERY distinct citation per entity, plus a true frequency count.
+- Keep `graph.json` lean: a count + a small deterministic inline top-K per node, never the full list for hub entities.
+- Move the FULL per-entity citation list into a lazily-loaded store, reusing the existing per-entity sidecar route — do not invent a parallel fetch path.
+- Keep the lazy store a DERIVED projection of `graph.json` so there is exactly one source of truth.
+- Make the describe-prompt citation cap tunable: default 3 for code, 10 default, all for long-docs/entity corpora; settable by the skill per corpus type and by a CLI flag.
+- Determine corpus type automatically from existing detection signals, with an explicit override.
+- Keep the studio fast: never ship hundreds of citations eagerly; fetch the full list only on entity selection.
+- Backward-compatible: existing bounded graphs keep working and gain exhaustive citations via re-extract or backfill, not a breaking migration.
+
+## Non-Goals
+
+This section is the architecture boundary. These exclusions are deliberate.
+
+- **No second source of truth.** The lazy citation store is a DERIVED, regenerable projection of `graph.json`. It is rebuilt from `graph.json`, never edited independently, and never read back into the graph. If it disappears, a rebuild recreates it byte-for-byte from the canonical graph.
+- **No new fetch mechanism in the studio.** Full citations are served through the existing `/api/ontology/entity/<id>` route and the existing client `fetchEntity(id)` + `entityCache` (`studio/src/lib/api.js:81-87`). No new endpoint, no new client cache.
+- **No change to the `OntologyCitation` shape.** `src/types.ts:473-481` stays. Tiering is about WHERE citations live and HOW MANY are inline, not about a new citation type.
+- **No eager bloat.** `scene.json` and the eager `graph.json` fetch carry only the count + inline top-K, never the full per-entity list.
+- **No provider calls added by storage.** Tiering, counting and emitting are deterministic; they make no LLM call. Exhaustive capture reuses the existing assistant/profile extraction path; corpus-type tuning only changes the prompt cap.
+- **No automatic destructive re-extraction.** Backfill of existing graphs is opt-in (`--backfill-citations`); the default for a stale graph is a warning, matching the existing staleness posture.
+
+## Compatibility Contract
+
+For an existing graph built before this feature:
+
+- it loads and renders unchanged; nodes with bounded `citations[]` keep their citations inline and continue to display.
+- no lazy store is required for the studio to work; absence of the store degrades to "render the inline citations only" (the current behavior).
+- `graph.json` schema is additive: new optional fields (`citation_count`, `citations_top` — names PROPOSED) coexist with the existing optional `citations[]`.
+- nothing reads a credential, opens a network connection, or calls a provider as a side effect of this feature.
+
+## Tiered Storage Model
+
+Two levels. Level-1 is inline on the node in `graph.json`; Level-2 is the full list in a lazy store.
+
+### Level-1 — inline on the node (in `graph.json`, the source of truth)
+
+Two new optional fields on `GraphNode` (PROPOSED names; `GraphEdge` gets the same treatment if edge citations ever go exhaustive — out of scope for v1, edges keep `citations[]` as-is):
+
+- `citation_count: number` — the TRUE number of distinct citations for this entity across the whole corpus. This is the degree-independent "cited N times" signal. It is computed at build/aggregation time and is authoritative even when the inline list is truncated.
+- `citations_top: OntologyCitation[]` — a SMALL, deterministic top-K subset (default K = 8, PROPOSED) for quick display, describe grounding, and offline/store-absent fallback. Same `OntologyCitation` shape, no new type.
+
+The legacy `citations: OntologyCitation[]` field is retained for backward-compat reads but is deprecated as the full carrier: new builds populate `citations_top` (the bounded inline set) and `citation_count`. A migration shim treats a legacy `citations[]` with no `citations_top` as `citations_top = citations`, `citation_count = citations.length` (a conservative count — see Migration).
+
+Rationale for keeping a count + top-K inline rather than count-only: it preserves a working studio and a working `describe` even when the lazy store is absent (fresh clone, partial artifact set, offline), and it keeps `scene.json`/eager-graph payload bounded by K regardless of how cited an entity is.
+
+### Level-2 — the full per-entity citation list (lazy, derived)
+
+The full, exhaustive citation list per node id lives OUTSIDE `graph.json`, in a single keyed file:
+
+- Path: `.graphify/ontology/citations.json` (PROPOSED), schema `graphify_ontology_citations_v1`.
+- Shape (keyed by node id, mirroring the `occurrences.json` `{ nodes: { <id>: … } }` convention that `buildEntitySidecar` already reads at `src/studio-assets.ts:257-261`):
+
+```json
+{
+  "schema": "graphify_ontology_citations_v1",
+  "graph_signature": "<topology/identity signature of graph.json at emit time>",
+  "nodes": {
+    "doyle_sherlock_holmes": {
+      "count": 214,
+      "citations": [ { "source_file": "…", "section": "…", "page": 12 }, … ]
+    }
+  }
+}
+```
+
+Why one keyed file and NOT a directory of `.graphify/citations/<id>.json`: the studio already serves per-entity slices from single keyed JSON files loaded once and indexed in memory (`occurrences.json` via `buildEntitySidecar`; `descriptions.json` via `loadDescriptionIndex`, cached by graph.json mtime at `src/studio-assets.ts:186-212`). A keyed file reuses that exact caching path with no new disk-walk, no per-id file churn, and a single signature to validate freshness. A per-id directory is reconsidered only if the keyed file grows past the budget (see Open decisions).
+
+### How the two levels are emitted, cached, kept consistent
+
+- **Single producer.** Both levels are written from the SAME aggregation pass over the assembled graph at build time (the ontology-output stage that today writes the empty `occurrences.json` at `src/ontology-output.ts:286`). The pass walks every node's exhaustive citation set, computes `count`, selects the deterministic top-K (see below), writes `citation_count` + `citations_top` onto the node in `graph.json`, and writes the full list into `citations.json`. One pass, one truth, two projections.
+- **Consistency by construction.** Because both come from the same pass and `citations.json` carries the `graph_signature` of the `graph.json` it was emitted against, the studio (and `hook-rebuild`) can detect a stale store the same way `scene.json` detects staleness (`src/ontology-studio.ts:277` caches scene keyed on graph.json identity = path + mtime + size). If the signature does not match the current `graph.json`, the store is treated as absent and the inline top-K is used — never silently mixed.
+- **Sidecar extension, not a new route.** `buildEntitySidecar` gains a `citations` field on its response (`EntitySidecarResponse`, `src/studio-assets.ts:219-223`): it loads `citations.json` exactly like it loads `occurrences.json` today, reads `nodes[id]`, and returns `{ count, citations }`. The `/api/ontology/entity/<id>` route (`src/ontology-studio.ts:490-494`) is unchanged — it already returns whatever `buildEntitySidecar` produces.
+
+## Exhaustive Extraction
+
+### Capture every citation + a frequency count
+
+The fix is an AGGREGATION CONTRACT, not a cap removal (there is no cap to remove). Concretely:
+
+- The profile/ontology extraction path already instructs the assistant to attach citations per chunk (`src/profile-prompts.ts:150-152,178`). The new requirement: when assembling the final graph, UNION every citation seen for a given entity across all chunks and all source files, deduped by a citation identity key (PROPOSED: `source_file` + `page` + `section` + `paragraph_id`; passages differing only in `bbox` are treated as the same citation unless `paragraph_id` differs — see Open decisions on dedupe granularity).
+- `count` = size of the deduped union. This is what populates `citation_count` (Level-1) and `nodes[id].count` (Level-2), and finally makes `occurrences.json`'s intended frequency signal real (the empty `[]` at `src/ontology-output.ts:286` is replaced by a populated structure, or `occurrences.json` is kept as occurrences and citation frequency lives in `citations.json` — see Open decisions on whether to fold counts into `occurrences.json` vs a dedicated `citations.json`).
+- The skill emits ALL citations into the extraction output for documents/papers/entity corpora (detection always-all; see policy below). The deterministic aggregation/dedupe/top-K selection happens in TypeScript at build time, not in the prompt, so it is replayable and provider-neutral.
+
+### Deterministic inline top-K selection
+
+The inline `citations_top` must be deterministic and meaningful — the same graph must always yield the same K. Selection order (PROPOSED default), with deterministic tie-breaks so two builds of the same graph are byte-identical:
+
+1. **Most-distinct-source first.** Prefer citations that cover the widest set of distinct `source_file`s — a hub entity's top-K should span many works, not 8 passages from one chapter. This maximizes the grounding value of the inline set for `describe`.
+2. **Then highest confidence/specificity.** Citations with a finer locator (has `page`/`section`/`paragraph_id`) rank above bare `source_file`-only refs.
+3. **Then earliest by stable sort key.** Final tie-break on `(source_file, page, section, paragraph_id)` lexicographic order — deterministic, matches the existing `uniqueSorted` posture in reconciliation (`src/ontology-reconciliation.ts:234-237`).
+
+"Earliest in document order" was rejected as the primary key: it would fill a hub entity's top-K with passages from whichever work sorts first, defeating the point of a salience preview. Most-distinct-source gives the strongest at-a-glance grounding. K is configurable; default 8.
+
+### Backward-compat with existing bounded graphs
+
+Two paths, both opt-in:
+
+- **Re-extract (preferred for correctness).** Re-running extraction on the corpus produces exhaustive citations natively. This is the honest path: only a re-extract can recover citations the original bounded build never captured.
+- **Backfill (cheap, lossy on count).** `graphify backfill-citations` (PROPOSED) walks the existing `graph.json`, and for each node with legacy `citations[]` but no `citations_top`/`citation_count`, sets `citations_top = dedupe(citations)`, `citation_count = |dedupe(citations)|`, and writes a `citations.json` from the same legacy data. This cannot invent citations that were never captured, so `count` reflects only what the bounded graph holds — the command prints a clear caveat that counts are lower bounds until a re-extract. Backfill is for keeping old graphs renderable under the new schema, not for achieving exhaustiveness.
+
+`hook-rebuild` (the LLM-free incremental path) recomputes Level-1 fields and `citations.json` from whatever citations are already on the graph — it never adds new citations (no LLM), it only re-projects, keeping the two levels consistent after edits.
+
+## Corpus-Type-Aware Citation Policy
+
+Three knobs, one corpus-type signal.
+
+### The corpus-type signal
+
+Corpus type is derived from the EXISTING detection output `.graphify/.graphify_detect.json`, which already carries `files: Record<FileType, string[]>` (buckets: `code`, `document`, `paper`, `image`, …) plus `total_words` and `total_files` (`src/detect.ts:801-804,722,776`). The skill classifies (PROPOSED thresholds):
+
+- `code` — `files.code` dominates and `files.document`/`files.paper` are empty/negligible.
+- `long-document` — `files.document`/`files.paper` present AND `total_words` above the corpus-warn threshold (long-form prose / papers; the mystery corpus lands here).
+- `entity-corpus` — ontology/profile mode is active (the graph is entities-over-documents, e.g. the mystery sagas).
+- `mixed` — anything else; treated as the middle default.
+
+No new detection pass is added; this reads `.graphify_detect.json` which the skill already produces and persists (`src/skills/skill.md:165`).
+
+### The three knobs and their defaults
+
+| Knob | What it controls | code | mixed (default) | long-document / entity-corpus |
+|---|---|---|---|---|
+| Detection | how many citations the assistant captures | all | all | all |
+| Inline top-K (`citations_top` size) | quick-display + describe-fallback + eager payload bound | 3 | 8 | 8 (capped for payload; count is unbounded) |
+| Describe prompt cap (`MAX_CITATIONS`) | citation snippets injected per node into the description prompt | 3 | 10 | all (or a high cap, e.g. 50) |
+
+Key points:
+
+- **Detection is ALWAYS all.** Exhaustiveness is not corpus-dependent; only display/prompt density is. The full list always lands in `citations.json`.
+- **The describe cap default rises 3 → 10.** `MAX_CITATIONS` (`src/node-descriptions.ts:376`) becomes a resolved value, not a hardcoded constant: 3 for code, 10 default, all/high for long-docs/entity corpora. `collectCitationContext` (`src/node-descriptions.ts:402-450`) reads the resolved cap instead of the constant.
+- **Inline top-K stays bounded** even for long-docs/entity corpora, because it rides in the eager payload; the unbounded truth is `citation_count` + the lazy `citations.json`.
+
+### The skill knob + CLI flag
+
+- **Skill (default path, no key).** The skill, after detection, sets the policy per corpus type when invoking describe/label/build. This is the primary path (graphify runs assistant-first, no API key by default). The skill writes the resolved cap/top-K into the describe invocation; nothing in core implies a value.
+- **CLI flag (override).** `graphify describe|label|build --citation-cap <n|all> --citations-top-k <n>` (PROPOSED). Flag overrides skill, skill overrides corpus-type default, corpus-type default overrides the global fallback (10). `--citation-cap all` is the long-doc value. A config block (`citations.describe_cap`, `citations.inline_top_k`) mirrors the flags for non-interactive runs, matching the `SPEC_STORAGE_BACKENDS`/`SPEC_LLM_EXECUTION_PORTS` precedence convention (flag > env/config > corpus default > global default).
+
+## Studio UX
+
+- **Count always visible.** The EntityPanel "Citations" accordion header already shows a `count` (`studio/src/components/EntityPanel.svelte:108`, `citationTotal`). It switches from "sum of inline citations" to `node.citation_count` (the true count), so a hub entity reads "Citations (214)" even before its full list loads.
+- **Inline top-K renders immediately.** On selection, `citationsByFile(node)` (`graphAdapter.js:702-716`) renders the inline `citations_top` from the already-loaded graph — instant, no fetch, no spinner.
+- **Full list lazy-loaded on selection.** When the panel opens for an entity, `App.svelte`'s `ensureEntity(id)` → `fetchEntity(id)` → `/api/ontology/entity/<id>` (`studio/src/lib/api.js:81-87`) already runs on focus. The sidecar response gains `citations: { count, citations }`. When it arrives, the panel replaces the inline top-K with the full file→passages double accordion. The render component (`citationsByFile`) is unchanged; only its DATA source upgrades from inline to sidecar.
+- **Performance budget.** The eager payload (`graph.json` fetch + `scene.json`) carries at most `citations_top` (K, default 8) per node — bounded regardless of corpus. `scene.json` already excludes `citations` entirely. The only place hundreds of citations exist is `citations.json`, loaded once by the server and indexed in memory (same path as `occurrences.json`/`descriptions.json`, cached by graph.json mtime, `src/studio-assets.ts:186-212`), and sliced per id on each `/api/ontology/entity` request. Target: eager bundle growth from this feature ≤ K citations/node; a single entity fetch returns one node's slice (hundreds of objects worst case, kilobytes), not the corpus-wide list.
+
+## Reconciliation Interaction
+
+Today reconciliation unions `source_refs` into `evidence_refs` via `uniqueSorted` (a deduped union, no cap, `src/ontology-reconciliation.ts:234-237`) but does NOT touch the `citations[]` arrays of merged entities. Under this design:
+
+- When two entities are reconciled into one canonical, their exhaustive citation sets UNION (same dedupe identity key as capture). `citation_count` of the merged entity = size of the unioned deduped set — so merging Sherlock-from-work-A with Sherlock-from-work-B correctly raises the count rather than picking one side's sample.
+- The inline `citations_top` is RE-SELECTED from the union by the same deterministic most-distinct-source rule, so the merged entity's preview spans both works.
+- This happens in the same single aggregation pass, AFTER reconciliation has decided merges, so the lazy `citations.json` and the inline fields are always computed on the post-merge graph. There is no separate citation-merge code path to drift.
+
+## Migration
+
+- **Schema additive.** `citation_count` + `citations_top` are new optional `GraphNode` fields; legacy `citations[]` stays readable. No existing graph breaks.
+- **Producer flip.** The empty-array write at `src/ontology-output.ts:286` is replaced by the real aggregation pass emitting `citations.json` (and, if counts fold into occurrences, a populated `occurrences.json`).
+- **Existing graphs.** Default: a graph built before this feature renders via its legacy inline `citations[]` (no behavior change). Run `graphify backfill-citations` to project legacy citations into the new fields + store (counts are lower bounds), or re-extract for true exhaustiveness. A `branch.json` stale flag / `needs_update` marker, if present, already warns per project convention before relying on results.
+- **Studio fallback.** If `citations.json` is absent or its `graph_signature` is stale, the panel shows count (`citation_count`) + the inline top-K and skips the lazy upgrade — degraded but correct.
+
+## CLI and config surface
+
+PROPOSED; freezes at the implementation PR.
+
+```
+graphify describe [path] --citation-cap <n|all>      # describe-prompt cap (default: corpus-type resolved; 3 code / 10 default / all long-doc)
+graphify label    [path] --citation-cap <n|all>
+graphify build    [path] --citations-top-k <n>       # inline Level-1 K (default 8)
+graphify backfill-citations [path]                   # project legacy citations[] -> citation_count/citations_top + citations.json (lossy on count)
+```
+
+```yaml
+citations:
+  describe_cap: 10        # n | "all" ; corpus-type default unless set
+  inline_top_k: 8         # Level-1 inline set size
+  store: ontology/citations.json   # Level-2 keyed store path (relative to .graphify/)
+  dedupe_key: [source_file, page, section, paragraph_id]
+```
+
+Precedence: CLI flag > config > corpus-type default (from `.graphify_detect.json`) > global default (cap 10, K 8). `assistant`-mode skill runs set the corpus-type default before invoking; no key required.
+
+## Test plan
+
+Automated tests should cover:
+
+- a node with N>K exhaustive citations gets `citation_count = N` and `citations_top.length = K`; the eager payload never exceeds K per node.
+- `citations.json` is keyed by node id, carries the current `graph_signature`, and `buildEntitySidecar` returns `{ count, citations }` for a present id and a null/empty for an absent id.
+- `citations.json` whose `graph_signature` mismatches the current `graph.json` is treated as absent: sidecar returns no full list, panel falls back to inline.
+- inline top-K is deterministic: two builds of the same graph produce byte-identical `citations_top` (most-distinct-source ordering + stable tie-break).
+- describe prompt cap resolves per corpus type: code → 3, default → 10, long-doc/entity → all/high; `--citation-cap` overrides; `collectCitationContext` honors the resolved cap (regression on `src/node-descriptions.ts:376/408`).
+- corpus-type classification from a synthetic `.graphify_detect.json` (code-only, paper-heavy long-doc, ontology entity-corpus, mixed).
+- reconciliation union: merging two entities sums distinct citations (not max of the two), and re-selects top-K from the union.
+- `backfill-citations` on a legacy graph populates the new fields and store from `citations[]` and prints the lower-bound caveat; idempotent on a second run.
+- `hook-rebuild` re-projects Level-1 + `citations.json` from existing citations without an LLM call and without inventing citations.
+- no provider/network/secret access is triggered by any citation emit or backfill path (matches `SPEC_LLM_EXECUTION_PORTS` default-no-op posture).
+- the eager `graph.json` fetch and `scene.json` for a graph with a 200-citation hub entity stay within the K-per-node payload budget.
+
+## UAT
+
+- Build the public-domain mystery graph (25 works); confirm Sherlock/Watson now carry `citation_count` in the hundreds (not ~15) and a K-sized `citations_top`.
+- Open the studio, select Sherlock: count reads the true number immediately; inline top-K renders instantly; the full file→passages list populates on the lazy fetch without a visible graph reload.
+- Confirm `graph.json` size growth is bounded (K citations/node) and the eager fetch stays fast at hub entities.
+- Run `graphify describe` on the mystery corpus: descriptions ground on many distinct sources (cap = all), while a code project's descriptions still cap at 3.
+- Run `backfill-citations` on a pre-feature graph: it renders under the new schema with a lower-bound count caveat; re-extract then shows the true exhaustive count.
+
+## Open decisions
+
+These need a human call.
+
+1. **Where does the frequency count live — fold into `occurrences.json`, or a dedicated `citations.json`?** `occurrences.json` is the historically intended frequency artifact (empty today) and `buildEntitySidecar` already reads it keyed by id. Either (a) populate `occurrences.json` with `{ count }` and keep the full citation list in `citations.json`, or (b) put both count and list in `citations.json` and leave `occurrences.json` for non-citation occurrence data. Recommendation: (b) — keep citations self-contained in one store; revisit if occurrences gains independent meaning.
+
+2. **Inline top-K default value and selection key.** Recommendation: K = 8, most-distinct-source primary key. Alternatives the human may prefer: K = 5 (leaner eager payload) or earliest-in-document (simpler, less salient). Pick one; it freezes the determinism contract.
+
+3. **Citation dedupe granularity.** Is a citation identity `source_file + page + section + paragraph_id` (passages differing only in `bbox` collapse), or is `bbox` part of identity (every distinct region counts)? Finer identity inflates counts; coarser merges legitimately distinct passages. Recommendation: exclude `bbox` from identity for prose corpora; include it only for image/figure-heavy corpora.
+
+4. **Keyed file vs per-id directory for Level-2.** Recommendation: single keyed `citations.json` (reuses the occurrences/descriptions caching path). Switch to `.graphify/citations/<id>.json` only if the keyed file exceeds a size budget (PROPOSED trigger: > ~10 MB or a corpus where a single load stalls server start). Human sets the budget / confirms the trigger.
+
+5. **Backfill default posture for stale graphs.** When a pre-feature graph is opened, default to (a) warn + render legacy inline only, or (b) auto-run a non-destructive backfill to populate the new fields/store. Recommendation: (a) warn — auto-backfill produces lower-bound counts that could be mistaken for true exhaustive counts; keep exhaustiveness an explicit re-extract.
+
+6. **Edge citations.** v1 leaves `GraphEdge.citations[]` (`src/types.ts:75`) unchanged (edges are far less cited than hub entities). Confirm edges stay out of the tiered model for v1, or fold them in if edge citation volume is also unbounded in the entity corpus.

--- a/src/build.ts
+++ b/src/build.ts
@@ -11,7 +11,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, relative as pathRelative, resolve } from "node:path";
 import Graph from "graphology";
-import type { Extraction } from "./types.js";
+import type { Extraction, OntologyCitation } from "./types.js";
+import { unionCitations } from "./citations.js";
 import { createGraph } from "./graph.js";
 import { assertGraphJsonFileSize } from "./graph-size-guard.js";
 import { cleanupStaleNodes } from "./semantic-cleanup.js";
@@ -282,6 +283,17 @@ export function buildFromJson(extraction: Extraction, options?: BuildOptions): G
     const normalizedAttrs = { ...attrs };
     if ("source_file" in normalizedAttrs) {
       normalizedAttrs.source_file = normalizeSourceFilePath(normalizedAttrs.source_file, root) ?? normalizedAttrs.source_file;
+    }
+    // SPEC_CITATIONS: graphology mergeNode is shallow last-write-wins, so a
+    // later chunk's `citations` would REPLACE the earlier chunk's set, dropping
+    // the union. Union them by citation identity before the merge so a hub
+    // entity keeps every distinct citation across chunks.
+    if (G.hasNode(id) && Array.isArray(normalizedAttrs.citations)) {
+      const existing = G.getNodeAttribute(id, "citations");
+      normalizedAttrs.citations = unionCitations([
+        Array.isArray(existing) ? (existing as OntologyCitation[]) : [],
+        normalizedAttrs.citations as OntologyCitation[],
+      ]);
     }
     G.mergeNode(id, normalizedAttrs);
   }

--- a/src/citation-policy.ts
+++ b/src/citation-policy.ts
@@ -13,6 +13,13 @@
  *
  *   CLI flag  >  config (`citations.*`)  >  corpus-type default  >  global default
  *
+ * v1 wiring note: the `config` tier is NOT populated by the code-mode CLI —
+ * `resolveCitationPolicyForRoot` never passes `config` (the loader is
+ * ontology-profile-only), so the effective v1 precedence is the 3-tier
+ * `CLI flag > corpus-type default > global default`. The `config` slot is
+ * retained here for a future PR that wires the `citations:` YAML block; until
+ * then it is inert (SPEC_CITATIONS "CLI and config surface", F3/7a).
+ *
  * Everything here is a PURE function: no fs, no LLM, no network. Callers read
  * `.graphify_detect.json` and pass the parsed object in.
  */

--- a/src/citation-policy.ts
+++ b/src/citation-policy.ts
@@ -1,0 +1,153 @@
+/**
+ * Corpus-type-aware citation policy (SPEC_CITATIONS.md "Corpus-Type-Aware
+ * Citation Policy").
+ *
+ * Two knobs are resolved here:
+ *   - `describeCap`  — the per-node citation cap injected into the description
+ *                      prompt (`CitationCap` in node-descriptions: number | "all").
+ *   - `inlineTopK`   — the Level-1 inline `citations` size written to graph.json.
+ *
+ * One signal drives both: the corpus type, derived from the EXISTING detection
+ * output `.graphify_detect.json` (no new detection pass). Resolution precedence
+ * is, highest first:
+ *
+ *   CLI flag  >  config (`citations.*`)  >  corpus-type default  >  global default
+ *
+ * Everything here is a PURE function: no fs, no LLM, no network. Callers read
+ * `.graphify_detect.json` and pass the parsed object in.
+ */
+
+/** The describe-prompt cap value. Mirrors `CitationCap` in node-descriptions. */
+export type CitationCapValue = number | "all";
+
+/** The resolved corpus type. */
+export type CorpusType = "code" | "long-document" | "entity-corpus" | "mixed";
+
+/**
+ * The corpus-warn threshold (in words) above which document/paper corpora are
+ * treated as "long-document". Kept in sync with `CORPUS_WARN_THRESHOLD` in
+ * src/detect.ts — that is the same threshold `needs_graph` and the long-form
+ * warning already use.
+ */
+export const CITATION_POLICY_LONG_DOC_WORD_THRESHOLD = 50_000;
+
+/** Global fallback when no corpus type and no explicit override is present. */
+export const CITATION_POLICY_GLOBAL_DEFAULT: {
+  readonly describeCap: CitationCapValue;
+  readonly inlineTopK: number;
+} = { describeCap: 10, inlineTopK: 8 };
+
+/** Per-corpus-type defaults (spec table "The three knobs and their defaults"). */
+const CORPUS_TYPE_DEFAULTS: Record<
+  CorpusType,
+  { describeCap: CitationCapValue; inlineTopK: number }
+> = {
+  code: { describeCap: 3, inlineTopK: 3 },
+  mixed: { describeCap: 10, inlineTopK: 8 },
+  "long-document": { describeCap: "all", inlineTopK: 8 },
+  "entity-corpus": { describeCap: "all", inlineTopK: 8 },
+};
+
+/** The slice of `.graphify_detect.json` the corpus classifier reads. */
+export interface DetectionLike {
+  files?: Partial<Record<string, unknown>>;
+  total_words?: unknown;
+}
+
+export interface ResolveCorpusTypeOptions {
+  /**
+   * Ontology/profile mode is active (entities-over-documents). When true the
+   * corpus is `entity-corpus` regardless of the file buckets. This is the
+   * explicit override the skill/CLI sets for profile builds.
+   */
+  profileMode?: boolean;
+}
+
+function bucketLength(files: Partial<Record<string, unknown>> | undefined, bucket: string): number {
+  const list = files?.[bucket];
+  return Array.isArray(list) ? list.length : 0;
+}
+
+/**
+ * Classify a corpus from a `.graphify_detect.json`-shaped object (or null).
+ *
+ * Rules (spec "The corpus-type signal"):
+ *   - profile/ontology mode active → `entity-corpus` (explicit override).
+ *   - `files.code` dominates and document/paper are empty/negligible → `code`.
+ *   - document/paper present AND `total_words` above the corpus-warn threshold
+ *     → `long-document`.
+ *   - anything else → `mixed` (the middle default; also the fallback for a
+ *     missing/empty detect).
+ */
+export function resolveCorpusType(
+  detect: DetectionLike | null | undefined,
+  options: ResolveCorpusTypeOptions = {},
+): CorpusType {
+  if (options.profileMode) return "entity-corpus";
+  if (!detect || typeof detect !== "object") return "mixed";
+
+  const files = detect.files;
+  const totalWords = typeof detect.total_words === "number" && Number.isFinite(detect.total_words)
+    ? detect.total_words
+    : 0;
+
+  const code = bucketLength(files, "code");
+  const document = bucketLength(files, "document");
+  const paper = bucketLength(files, "paper");
+  const prose = document + paper;
+
+  // code dominates and prose is empty/negligible.
+  if (code > 0 && prose === 0) return "code";
+
+  // long-form prose / papers above the warn threshold.
+  if (prose > 0 && totalWords >= CITATION_POLICY_LONG_DOC_WORD_THRESHOLD) {
+    return "long-document";
+  }
+
+  return "mixed";
+}
+
+export interface CitationPolicyOverrides {
+  describeCap?: CitationCapValue;
+  inlineTopK?: number;
+}
+
+export interface ResolveCitationPolicyInput {
+  /** Corpus type (from `resolveCorpusType`). Absent → global default only. */
+  corpusType?: CorpusType;
+  /** Config-level knobs (`citations.describe_cap` / `citations.inline_top_k`). */
+  config?: CitationPolicyOverrides;
+  /** Explicit CLI flags (`--citation-cap` / `--citations-top-k`). Highest precedence. */
+  cli?: CitationPolicyOverrides;
+}
+
+export interface ResolvedCitationPolicy {
+  describeCap: CitationCapValue;
+  inlineTopK: number;
+}
+
+/**
+ * Resolve the two citation knobs with the pinned precedence
+ * (CLI > config > corpus-type default > global default). The two knobs resolve
+ * INDEPENDENTLY: a CLI `--citations-top-k` does not pin the describe cap, and a
+ * config `describe_cap` does not pin K.
+ */
+export function resolveCitationPolicy(input: ResolveCitationPolicyInput): ResolvedCitationPolicy {
+  const corpusDefault = input.corpusType
+    ? CORPUS_TYPE_DEFAULTS[input.corpusType]
+    : CITATION_POLICY_GLOBAL_DEFAULT;
+
+  const describeCap =
+    input.cli?.describeCap ??
+    input.config?.describeCap ??
+    corpusDefault.describeCap ??
+    CITATION_POLICY_GLOBAL_DEFAULT.describeCap;
+
+  const inlineTopK =
+    input.cli?.inlineTopK ??
+    input.config?.inlineTopK ??
+    corpusDefault.inlineTopK ??
+    CITATION_POLICY_GLOBAL_DEFAULT.inlineTopK;
+
+  return { describeCap, inlineTopK };
+}

--- a/src/citations.ts
+++ b/src/citations.ts
@@ -100,6 +100,22 @@ export function unionCitations(
   return out;
 }
 
+/**
+ * Fold `dup`'s citations into `kept` (the surviving node) as the deduped union.
+ * Used at the skip-duplicate assembly sites (cli/skill-runtime) so a duplicate
+ * entity's distinct citations are preserved rather than discarded. Mutates
+ * `kept.citations` in place; a no-op when neither side carries citations.
+ */
+export function foldCitationsInto(
+  kept: { citations?: OntologyCitation[] | unknown },
+  dup: { citations?: OntologyCitation[] | unknown },
+): void {
+  const keptCites = Array.isArray(kept.citations) ? (kept.citations as OntologyCitation[]) : [];
+  const dupCites = Array.isArray(dup.citations) ? (dup.citations as OntologyCitation[]) : [];
+  if (keptCites.length === 0 && dupCites.length === 0) return;
+  kept.citations = unionCitations([keptCites, dupCites]);
+}
+
 /** True when a citation carries a finer locator than a bare source_file. */
 function hasFineLocator(c: OntologyCitation): boolean {
   return c.page != null || (c.section != null && c.section !== "") || (c.paragraph_id != null && c.paragraph_id !== "");

--- a/src/citations.ts
+++ b/src/citations.ts
@@ -206,14 +206,22 @@ export function aggregateCitations(G: Graph, options: AggregateCitationsOptions 
   const map: CitationAggregateMap = {};
 
   G.forEachNode((nodeId, attrs) => {
-    const raw = (attrs as Record<string, unknown>).citations;
+    const record = attrs as Record<string, unknown>;
+    const raw = record.citations;
     if (!Array.isArray(raw) || raw.length === 0) return;
     const union = unionCitations([raw as OntologyCitation[]], { includeBbox });
     if (union.length === 0) return;
+    // Idempotency guard: a prior aggregation pass already trimmed the inline
+    // set to K and stamped the TRUE count. Re-deriving the count from the
+    // trimmed inline would undercount, so keep the larger known count. (Within
+    // a single build pass this is a no-op; it only protects an accidental
+    // double-call on the same in-memory graph.)
+    const priorCount = typeof record.citation_count === "number" ? record.citation_count : 0;
+    const count = Math.max(union.length, priorCount);
     const inline = selectTopCitations(union, topK);
-    G.setNodeAttribute(nodeId, "citation_count", union.length);
+    G.setNodeAttribute(nodeId, "citation_count", count);
     G.setNodeAttribute(nodeId, "citations", inline);
-    map[nodeId] = { count: union.length, citations: union };
+    map[nodeId] = { count, citations: union };
   });
 
   return map;

--- a/src/citations.ts
+++ b/src/citations.ts
@@ -12,7 +12,7 @@
  * replayable from already-extracted citation locators.
  */
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type Graph from "graphology";
 import type { OntologyCitation } from "./types.js";
@@ -353,4 +353,163 @@ export function writeCitationsSidecar(
   };
   writeFileSync(target, JSON.stringify(payload, null, 2), "utf-8");
   return target;
+}
+
+// ---------------------------------------------------------------------------
+// hook-rebuild re-projection (LLM-free)
+// ---------------------------------------------------------------------------
+
+/** Read an existing `citations.json` store, or null when absent/unreadable. */
+function readExistingSidecar(outDir: string): CitationAggregateMap | null {
+  const target = join(outDir, CITATIONS_SIDECAR_RELPATH);
+  if (!existsSync(target)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(target, "utf-8")) as {
+      nodes?: Record<string, { count?: unknown; citations?: unknown }>;
+    };
+    if (!parsed || typeof parsed !== "object" || !parsed.nodes) return null;
+    const map: CitationAggregateMap = {};
+    for (const [id, entry] of Object.entries(parsed.nodes)) {
+      const citations = Array.isArray(entry?.citations) ? (entry.citations as OntologyCitation[]) : [];
+      const count = typeof entry?.count === "number" ? entry.count : citations.length;
+      map[id] = { count, citations };
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+/** Read per-node full citations from a persisted extraction JSON, or null. */
+function readExtractionCitations(extractionPath: string): Record<string, OntologyCitation[]> | null {
+  if (!existsSync(extractionPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(extractionPath, "utf-8")) as {
+      nodes?: Array<{ id?: unknown; citations?: unknown }>;
+    };
+    if (!parsed || !Array.isArray(parsed.nodes)) return null;
+    const out: Record<string, OntologyCitation[]> = {};
+    for (const node of parsed.nodes) {
+      const id = typeof node?.id === "string" ? node.id : null;
+      if (!id) continue;
+      if (!Array.isArray(node.citations) || node.citations.length === 0) continue;
+      const existing = out[id] ?? [];
+      out[id] = unionCitations([existing, node.citations as OntologyCitation[]]);
+    }
+    return Object.keys(out).length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ReprojectCitationsOptions {
+  /** Inline Level-1 K. Default CITATIONS_INLINE_TOP_K (8). */
+  topK?: number;
+  /** Include bbox in identity (figure/image corpora). Default false. */
+  includeBbox?: boolean;
+  /**
+   * Path to the persisted merged extraction JSON (`.graphify_extract.json`). When
+   * present AND it carries richer per-node citations than graph.json, the FULL
+   * Level-1 + Level-2 projection is rebuilt from it. Absent → the no-shrink
+   * guard path (preserve an existing fuller sidecar).
+   */
+  extractionPath?: string;
+  /**
+   * A snapshot of the prior `citations.json` captured BEFORE any same-pass
+   * write that may have shrunk it (e.g. a preceding `persistGraphWithCitations`
+   * in the hook path). When supplied it is the no-shrink baseline instead of the
+   * on-disk store — so the guard compares against the genuinely fuller tail, not
+   * an already-overwritten K-set. Falls back to the on-disk store when absent.
+   */
+  priorSidecar?: CitationAggregateMap | null;
+}
+
+/**
+ * Read the current on-disk `citations.json` as an aggregate map (or null when
+ * absent / unreadable). Exposed so callers can snapshot the RICH sidecar before
+ * a same-pass write shrinks it, then hand it back via `priorSidecar`.
+ */
+export function readCitationsSidecar(outDir: string): CitationAggregateMap | null {
+  return readExistingSidecar(outDir);
+}
+
+export interface ReprojectCitationsResult {
+  /** True when the sidecar was fully rebuilt from the extraction output. */
+  rebuiltFromExtraction: boolean;
+  /** Absolute path of the (re)written sidecar, or null when none written. */
+  sidecarPath: string | null;
+}
+
+/**
+ * LLM-free citation re-projection for `hook-rebuild` (SPEC_CITATIONS.md
+ * "Exhaustive Extraction" → hook-rebuild). Re-projects Level-1
+ * (`citation_count` + trimmed inline `citations`) and re-derives the Level-2
+ * `citations.json`, with the pass-1 fidelity guard:
+ *
+ *   - If the extraction output is available AND richer than graph.json, rebuild
+ *     the FULL sidecar (and Level-1) from it — the exhaustive tail is recovered.
+ *   - If only the K-trimmed graph.json is available, re-project Level-1 in place
+ *     (the aggregateCitations idempotency guard keeps the larger known count)
+ *     and write the sidecar MERGED with any existing store, taking the richer
+ *     per-node entry — so a re-projection from a trimmed graph NEVER clobbers a
+ *     fuller `citations.json`.
+ *
+ * Never adds a citation the inputs do not already contain. No LLM, no network.
+ * Mutates `G` in place.
+ */
+export function reprojectCitationsLLMFree(
+  G: Graph,
+  outDir: string,
+  options: ReprojectCitationsOptions = {},
+): ReprojectCitationsResult {
+  const topK = options.topK ?? CITATIONS_INLINE_TOP_K;
+  const includeBbox = options.includeBbox ?? false;
+
+  const extractionCitations = options.extractionPath
+    ? readExtractionCitations(options.extractionPath)
+    : null;
+
+  // Path 1: full rebuild from the extraction output. Fold the extraction's full
+  // per-node citations into G BEFORE aggregating so Level-1 + Level-2 both
+  // derive from the exhaustive set.
+  if (extractionCitations) {
+    G.forEachNode((nodeId) => {
+      const fromExtraction = extractionCitations[nodeId];
+      if (!fromExtraction || fromExtraction.length === 0) return;
+      // The extraction output IS the upstream source of truth (SPEC "Source of
+      // truth"): the full sidecar derives from it, NOT from graph.json's
+      // K-bounded inline. Replace the node's citations with the extraction set
+      // so Level-1 + Level-2 both re-derive from the exhaustive list.
+      const union = unionCitations([fromExtraction], { includeBbox });
+      G.setNodeAttribute(nodeId, "citations", union);
+      // Clear the stale count so aggregateCitations stamps the true union size
+      // (the prior count may be stale relative to a re-extraction).
+      G.removeNodeAttribute(nodeId, "citation_count");
+    });
+    const map = aggregateCitations(G, { topK, includeBbox });
+    const sidecarPath = writeCitationsSidecar(outDir, map, G);
+    return { rebuiltFromExtraction: true, sidecarPath };
+  }
+
+  // Path 2: trimmed graph only. Re-project Level-1 in place (guarded count) and
+  // merge with the existing sidecar so a fuller tail is never shrunk. Prefer the
+  // caller-supplied pre-write snapshot over the on-disk store (which a preceding
+  // same-pass write may already have shrunk).
+  const freshMap = aggregateCitations(G, { topK, includeBbox });
+  const existing = options.priorSidecar ?? readExistingSidecar(outDir);
+  if (existing) {
+    for (const [id, prior] of Object.entries(existing)) {
+      const fresh = freshMap[id];
+      // Keep whichever entry is richer (larger count / longer list).
+      if (!fresh || prior.count > fresh.count || prior.citations.length > fresh.citations.length) {
+        freshMap[id] = prior;
+        // Reflect the richer count back onto Level-1 so graph.json stays honest.
+        if (G.hasNode(id) && prior.count > 0) {
+          G.setNodeAttribute(id, "citation_count", Math.max(prior.count, fresh?.count ?? 0));
+        }
+      }
+    }
+  }
+  const sidecarPath = writeCitationsSidecar(outDir, freshMap, G);
+  return { rebuiltFromExtraction: false, sidecarPath };
 }

--- a/src/citations.ts
+++ b/src/citations.ts
@@ -186,12 +186,29 @@ export interface AggregateCitationsOptions {
   topK?: number;
   /** Include bbox in identity (figure/image corpora). Default false. */
   includeBbox?: boolean;
+  /**
+   * A snapshot of the prior `citations.json` (the FULL per-node union before
+   * this pass), captured via `readCitationsSidecar` BEFORE the aggregation /
+   * graph.json write. When supplied, each node's fresh `citations` are unioned
+   * with its prior FULL set (NOT the already-trimmed K-set in graph.json) before
+   * the count + top-K are computed.
+   *
+   * This is the F1 (finalize-update) fix: the live `/graphify update` flow loads
+   * a graph whose inline `citations` are already K-trimmed; a re-extracted hub's
+   * fresh chunk carries only a handful of citations and `mergeNode` is
+   * last-write-wins, so without this the exhaustive tail in citations.json would
+   * be lost and the stale `citation_count` would be locked by the idempotency
+   * Math.max. Unioning the prior FULL set recovers the true union and re-stamps
+   * the correct count.
+   */
+  priorSidecar?: CitationAggregateMap | null;
 }
 
 /**
  * One pass over the assembled graph. For every node carrying citations:
  *   - compute the deduped union (the node's `citations` are already the
- *     post-merge union; this re-dedupes defensively),
+ *     post-merge union; this re-dedupes defensively), unioned with the prior
+ *     FULL per-node set from `priorSidecar` when supplied,
  *   - set `node.citation_count = union.length` (the true, degree-independent
  *     count, authoritative even when the inline set is trimmed),
  *   - replace `node.citations` with the deterministic top-K (the graph.json
@@ -203,20 +220,36 @@ export interface AggregateCitationsOptions {
 export function aggregateCitations(G: Graph, options: AggregateCitationsOptions = {}): CitationAggregateMap {
   const topK = options.topK ?? CITATIONS_INLINE_TOP_K;
   const includeBbox = options.includeBbox ?? false;
+  const prior = options.priorSidecar ?? null;
   const map: CitationAggregateMap = {};
 
   G.forEachNode((nodeId, attrs) => {
     const record = attrs as Record<string, unknown>;
     const raw = record.citations;
-    if (!Array.isArray(raw) || raw.length === 0) return;
-    const union = unionCitations([raw as OntologyCitation[]], { includeBbox });
+    const priorEntry = prior?.[nodeId] ?? null;
+    const hasFresh = Array.isArray(raw) && raw.length > 0;
+    const hasPrior = priorEntry != null && Array.isArray(priorEntry.citations) && priorEntry.citations.length > 0;
+    if (!hasFresh && !hasPrior) return;
+    // F1: union the fresh extraction with the prior FULL per-node set from the
+    // sidecar (NOT the trimmed inline), so a re-extracted hub recovers the
+    // exhaustive tail instead of collapsing to the fresh chunk's handful.
+    const union = unionCitations(
+      [
+        hasFresh ? (raw as OntologyCitation[]) : [],
+        hasPrior ? priorEntry.citations : [],
+      ],
+      { includeBbox },
+    );
     if (union.length === 0) return;
-    // Idempotency guard: a prior aggregation pass already trimmed the inline
-    // set to K and stamped the TRUE count. Re-deriving the count from the
-    // trimmed inline would undercount, so keep the larger known count. (Within
-    // a single build pass this is a no-op; it only protects an accidental
-    // double-call on the same in-memory graph.)
-    const priorCount = typeof record.citation_count === "number" ? record.citation_count : 0;
+    // Count = the unioned set size. When a `priorSidecar` is supplied the union
+    // above already covers the FULL tail (prior sidecar ∪ fresh), so it is
+    // authoritative and the (possibly stale) node `citation_count` must NOT be
+    // allowed to override it — that stale count + trimmed inline is exactly the
+    // F1 inconsistency. Without a prior sidecar, fall back to the idempotency
+    // guard: a prior aggregation pass on this SAME in-memory graph already
+    // trimmed the inline set and stamped the true count, so re-deriving from the
+    // trimmed inline would undercount — keep the larger known count.
+    const priorCount = prior ? 0 : (typeof record.citation_count === "number" ? record.citation_count : 0);
     const count = Math.max(union.length, priorCount);
     const inline = selectTopCitations(union, topK);
     G.setNodeAttribute(nodeId, "citation_count", count);

--- a/src/citations.ts
+++ b/src/citations.ts
@@ -227,6 +227,81 @@ export function aggregateCitations(G: Graph, options: AggregateCitationsOptions 
   return map;
 }
 
+export interface BackfillCitationsOptions {
+  /** Inline Level-1 K. Default CITATIONS_INLINE_TOP_K (8). */
+  topK?: number;
+  /** Include bbox in identity (figure/image corpora). Default false. */
+  includeBbox?: boolean;
+}
+
+export interface BackfillCitationsResult {
+  /** How many LEGACY nodes (citations[] but no citation_count) were projected. */
+  backfilledNodes: number;
+  /** Absolute path of the written `citations.json`, or null when none written. */
+  sidecarPath: string | null;
+  /**
+   * Always true when at least one node was backfilled: backfill projects only
+   * the bounded sample already in graph.json, so the counts are a LOWER BOUND.
+   */
+  lowerBound: boolean;
+}
+
+/**
+ * Lossy backward-compat projection (SPEC_CITATIONS.md "Backfill"). Walks the
+ * graph and, for every node carrying a legacy `citations[]` but no
+ * `citation_count`, sets `citation_count = |dedupe(citations)|`, trims the
+ * inline `citations` to the deterministic top-K, and records the full deduped
+ * set for the co-derived `citations.json`.
+ *
+ * Nodes that already carry a `citation_count` are LEFT UNTOUCHED (their true
+ * count — possibly from a real exhaustive extract — is never downgraded to the
+ * trimmed inline length); they are still included in the emitted sidecar from
+ * their existing inline set so a re-run reproduces a byte-identical store.
+ *
+ * Counts are a LOWER BOUND: backfill cannot invent citations the bounded graph
+ * never held. Idempotent — a second run finds nothing left to backfill.
+ *
+ * Mutates `G` in place. No LLM, no network.
+ */
+export function backfillCitations(
+  G: Graph,
+  outDir: string,
+  options: BackfillCitationsOptions = {},
+): BackfillCitationsResult {
+  const topK = options.topK ?? CITATIONS_INLINE_TOP_K;
+  const includeBbox = options.includeBbox ?? false;
+  const map: CitationAggregateMap = {};
+  let backfilledNodes = 0;
+
+  G.forEachNode((nodeId, attrs) => {
+    const record = attrs as Record<string, unknown>;
+    const raw = record.citations;
+    if (!Array.isArray(raw) || raw.length === 0) return;
+
+    const union = unionCitations([raw as OntologyCitation[]], { includeBbox });
+    if (union.length === 0) return;
+
+    const hasCount = typeof record.citation_count === "number";
+    if (hasCount) {
+      // Already projected (backfill or real extract): do not touch the count or
+      // the inline set, but mirror the existing inline citations into the
+      // sidecar so the store stays consistent and re-runs are byte-identical.
+      map[nodeId] = { count: record.citation_count as number, citations: union };
+      return;
+    }
+
+    // Legacy node: project it.
+    const inline = selectTopCitations(union, topK);
+    G.setNodeAttribute(nodeId, "citation_count", union.length);
+    G.setNodeAttribute(nodeId, "citations", inline);
+    map[nodeId] = { count: union.length, citations: union };
+    backfilledNodes += 1;
+  });
+
+  const sidecarPath = backfilledNodes > 0 ? writeCitationsSidecar(outDir, map, G) : null;
+  return { backfilledNodes, sidecarPath, lowerBound: backfilledNodes > 0 };
+}
+
 /**
  * Citation-content hash: sha256 over the sorted projection
  * `{ node_id -> inline citations }`. Explicitly NOT computeTopologySignature

--- a/src/citations.ts
+++ b/src/citations.ts
@@ -1,0 +1,257 @@
+/**
+ * Citation identity, union, and deterministic inline top-K selection.
+ *
+ * This module is the pure, provider-neutral core of the exhaustive-citations
+ * feature (SPEC_CITATIONS.md). It owns:
+ *   - the citation identity key (dedupe key),
+ *   - the union of citation lists across chunks/works (the discard fix),
+ *   - the deterministic inline top-K selection pinned by the spec, and
+ *   - the pre-toJson aggregation pass + the co-derived `citations.json` emitter.
+ *
+ * No LLM, no network, no secrets — everything here is deterministic and
+ * replayable from already-extracted citation locators.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type Graph from "graphology";
+import type { OntologyCitation } from "./types.js";
+
+/** Default inline Level-1 K (most-distinct-source top-K). Spec Decision 2. */
+export const CITATIONS_INLINE_TOP_K = 8;
+
+/** Schema tag for the co-derived Level-2 store. */
+export const CITATIONS_SIDECAR_SCHEMA = "graphify_ontology_citations_v1";
+
+/** Relative path (under the graph dir) of the Level-2 keyed store. */
+export const CITATIONS_SIDECAR_RELPATH = "ontology/citations.json";
+
+export interface CitationKeyOptions {
+  /** Include bbox in identity (figure/image corpora). Default false (prose). */
+  includeBbox?: boolean;
+}
+
+function locatorPart(value: unknown): string {
+  if (value == null) return "";
+  return String(value);
+}
+
+/**
+ * Stable identity key for a citation. Prose identity is
+ * `source_file|page|section|paragraph_id`; figure/image corpora append `bbox`.
+ * Missing locator fields collapse to empty segments (never the literal
+ * "undefined") so equality is well-defined.
+ */
+export function citationKey(c: OntologyCitation, options: CitationKeyOptions = {}): string {
+  const base = [
+    locatorPart(c.source_file),
+    locatorPart(c.page),
+    locatorPart(c.section),
+    locatorPart(c.paragraph_id),
+  ].join("|");
+  if (options.includeBbox) {
+    const bbox = Array.isArray(c.bbox) ? c.bbox.join(",") : "";
+    return `${base}|${bbox}`;
+  }
+  return base;
+}
+
+/**
+ * Total, stable lexicographic order by (source_file, page, section,
+ * paragraph_id). Matches the `uniqueSorted` posture used elsewhere
+ * (ontology-reconciliation). Removes any dependence on extraction order.
+ */
+function compareCitations(a: OntologyCitation, b: OntologyCitation): number {
+  const fields: (keyof OntologyCitation)[] = ["source_file", "page", "section", "paragraph_id"];
+  for (const f of fields) {
+    const av = locatorPart(a[f]);
+    const bv = locatorPart(b[f]);
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+export interface UnionOptions {
+  includeBbox?: boolean;
+}
+
+/**
+ * Union of one or more citation lists. Dedupes by identity key (first-seen
+ * preserved internally for traceability), then returns a stable
+ * lexicographically-sorted array. Malformed / non-array inputs are skipped.
+ */
+export function unionCitations(
+  lists: ReadonlyArray<ReadonlyArray<OntologyCitation> | null | undefined>,
+  options: UnionOptions = {},
+): OntologyCitation[] {
+  const seen = new Set<string>();
+  const out: OntologyCitation[] = [];
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue;
+    for (const c of list) {
+      if (!c || typeof c !== "object") continue;
+      const key = citationKey(c as OntologyCitation, { includeBbox: options.includeBbox });
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(c as OntologyCitation);
+    }
+  }
+  out.sort(compareCitations);
+  return out;
+}
+
+/** True when a citation carries a finer locator than a bare source_file. */
+function hasFineLocator(c: OntologyCitation): boolean {
+  return c.page != null || (c.section != null && c.section !== "") || (c.paragraph_id != null && c.paragraph_id !== "");
+}
+
+/**
+ * Deterministic inline top-K selection (spec PINNED algorithm):
+ *   1. sort the deduped list lexicographically (input-order independent);
+ *   2. greedy most-distinct-source cover: pick the next citation whose
+ *      source_file is not yet represented, ties broken by the lexicographic
+ *      key, until K chosen or every source is covered;
+ *   3. fill the remainder (sources exhausted before K) preferring finer
+ *      locators (page/section/paragraph_id over bare source_file), then
+ *      lexicographic.
+ *
+ * Pure: two calls on the same SET (any order) return byte-identical output.
+ */
+export function selectTopCitations(all: ReadonlyArray<OntologyCitation>, K: number): OntologyCitation[] {
+  if (K <= 0) return [];
+  // Step 0: dedupe + sort. unionCitations gives the canonical sorted order.
+  const sorted = unionCitations([all]);
+  if (sorted.length <= K) return sorted;
+
+  const chosen: OntologyCitation[] = [];
+  const chosenKeys = new Set<string>();
+  const coveredSources = new Set<string>();
+
+  // Step 2: greedy most-distinct-source cover (sorted order = stable tie-break).
+  for (const c of sorted) {
+    if (chosen.length >= K) break;
+    const src = locatorPart(c.source_file);
+    if (coveredSources.has(src)) continue;
+    coveredSources.add(src);
+    chosen.push(c);
+    chosenKeys.add(citationKey(c));
+  }
+
+  if (chosen.length < K) {
+    // Step 3: fill by locator specificity, then lexicographic. `sorted` is
+    // already lexicographic, so a stable partition by fineness preserves the
+    // lexicographic tie-break within each bucket.
+    const remaining = sorted.filter((c) => !chosenKeys.has(citationKey(c)));
+    const fine = remaining.filter((c) => hasFineLocator(c));
+    const coarse = remaining.filter((c) => !hasFineLocator(c));
+    for (const c of [...fine, ...coarse]) {
+      if (chosen.length >= K) break;
+      chosen.push(c);
+      chosenKeys.add(citationKey(c));
+    }
+  }
+
+  return chosen;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation pass + co-derived citations.json emitter
+// ---------------------------------------------------------------------------
+
+export interface CitationAggregateEntry {
+  count: number;
+  citations: OntologyCitation[];
+}
+
+export type CitationAggregateMap = Record<string, CitationAggregateEntry>;
+
+export interface AggregateCitationsOptions {
+  /** Inline Level-1 K. Default CITATIONS_INLINE_TOP_K (8). */
+  topK?: number;
+  /** Include bbox in identity (figure/image corpora). Default false. */
+  includeBbox?: boolean;
+}
+
+/**
+ * One pass over the assembled graph. For every node carrying citations:
+ *   - compute the deduped union (the node's `citations` are already the
+ *     post-merge union; this re-dedupes defensively),
+ *   - set `node.citation_count = union.length` (the true, degree-independent
+ *     count, authoritative even when the inline set is trimmed),
+ *   - replace `node.citations` with the deterministic top-K (the graph.json
+ *     leanness / trim requirement),
+ *   - collect `{ [id]: { count, citations: fullUnion } }` for the Level-2 store.
+ *
+ * Mutates the graph in place and returns the full-union map.
+ */
+export function aggregateCitations(G: Graph, options: AggregateCitationsOptions = {}): CitationAggregateMap {
+  const topK = options.topK ?? CITATIONS_INLINE_TOP_K;
+  const includeBbox = options.includeBbox ?? false;
+  const map: CitationAggregateMap = {};
+
+  G.forEachNode((nodeId, attrs) => {
+    const raw = (attrs as Record<string, unknown>).citations;
+    if (!Array.isArray(raw) || raw.length === 0) return;
+    const union = unionCitations([raw as OntologyCitation[]], { includeBbox });
+    if (union.length === 0) return;
+    const inline = selectTopCitations(union, topK);
+    G.setNodeAttribute(nodeId, "citation_count", union.length);
+    G.setNodeAttribute(nodeId, "citations", inline);
+    map[nodeId] = { count: union.length, citations: union };
+  });
+
+  return map;
+}
+
+/**
+ * Citation-content hash: sha256 over the sorted projection
+ * `{ node_id -> inline citations }`. Explicitly NOT computeTopologySignature
+ * (blind to node attrs) and NOT mtime+size (a content-identical rebuild would
+ * falsely invalidate). Byte-identical inline citations ⇒ identical signature;
+ * any citation change ⇒ a different signature.
+ */
+export function computeCitationSignature(G: Graph): string {
+  const projection: Record<string, OntologyCitation[]> = {};
+  G.forEachNode((nodeId, attrs) => {
+    const inline = (attrs as Record<string, unknown>).citations;
+    if (Array.isArray(inline) && inline.length > 0) {
+      projection[nodeId] = inline as OntologyCitation[];
+    }
+  });
+  const sortedIds = Object.keys(projection).sort();
+  const canonical = sortedIds.map((id) => [id, projection[id]] as const);
+  const hash = createHash("sha256");
+  hash.update(JSON.stringify(canonical));
+  return hash.digest("hex");
+}
+
+/**
+ * Write the Level-2 keyed store `<outDir>/ontology/citations.json`. The store
+ * is co-derived with graph.json (same aggregation pass) and carries the
+ * citation-content `graph_signature` of the graph it was emitted against.
+ * Returns the absolute path written, or null when the map is empty (nothing to
+ * emit — avoids littering empty sidecars).
+ */
+export function writeCitationsSidecar(
+  outDir: string,
+  map: CitationAggregateMap,
+  G: Graph,
+): string | null {
+  if (Object.keys(map).length === 0) return null;
+  const target = join(outDir, CITATIONS_SIDECAR_RELPATH);
+  const dir = dirname(target);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // Stable node ordering for byte-identical rebuilds.
+  const nodes: Record<string, CitationAggregateEntry> = {};
+  for (const id of Object.keys(map).sort()) {
+    const entry = map[id];
+    if (entry) nodes[id] = entry;
+  }
+  const payload = {
+    schema: CITATIONS_SIDECAR_SCHEMA,
+    graph_signature: computeCitationSignature(G),
+    nodes,
+  };
+  writeFileSync(target, JSON.stringify(payload, null, 2), "utf-8");
+  return target;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3822,7 +3822,7 @@ export async function main(): Promise<void> {
     .option("--backend <provider>", "LLM provider (default: auto-detect from API keys)")
     .option("--model <id>", "LLM model override")
     .option("--label-mode <mode>", "Execution mode: assistant (default, no key) or direct (API key)", "")
-    .option("--citation-cap <n|all>", "Per-node citation cap forwarded to the description engine when this run also (re)describes; resolved from corpus type when absent")
+    .option("--citation-cap <n|all>", "Accepted for CLI symmetry; has no effect on `label` (use `describe`/`update` to ground descriptions)")
     .action(async (labelPath = ".", opts) => {
       const root = resolve(labelPath);
       const paths = resolveGraphifyPaths({ root });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5150,6 +5150,10 @@ export async function main(): Promise<void> {
         describe: false,
         label: false,
         markDescribePending: true,
+        // Re-derive citations.json LLM-free with the no-shrink guard so the
+        // fast commit-time rebuild never clobbers a fuller existing sidecar
+        // (and rebuilds the full tail from the extraction output when present).
+        citationsReproject: true,
         scope: scopeSelection.mode,
         scopeSource: scopeSelection.source,
       });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import {
   resolveCliInputScopeSelection,
   resolveConfiguredInputScopeSelection,
 } from "./input-scope.js";
+import { foldCitationsInto } from "./citations.js";
 import { forEachTraversalNeighbor, loadGraphFromData } from "./graph.js";
 import { communitiesFromGraph, communityLabelsFromGraph } from "./graph-communities.js";
 import { safeExecGit } from "./git.js";
@@ -319,17 +320,23 @@ function ensureCliExtractionShape(value?: Partial<Extraction> | null): Extractio
   };
 }
 
-function mergeCliAstAndSemantic(
+export function mergeCliAstAndSemantic(
   astInput: Partial<Extraction> | null | undefined,
   semanticInput: Partial<Extraction> | null | undefined,
 ): Extraction {
   const ast = ensureCliExtractionShape(astInput);
   const semantic = ensureCliExtractionShape(semanticInput);
   const mergedNodes: Extraction["nodes"] = [...ast.nodes];
-  const seen = new Set(ast.nodes.map((node) => node.id));
+  const byId = new Map(mergedNodes.map((node) => [node.id, node]));
   for (const node of semantic.nodes) {
-    if (seen.has(node.id)) continue;
-    seen.add(node.id);
+    const kept = byId.get(node.id);
+    if (kept) {
+      // SPEC_CITATIONS: before skipping the duplicate, fold its citations into
+      // the kept node so the union (not one chunk's set) survives assembly.
+      foldCitationsInto(kept, node);
+      continue;
+    }
+    byId.set(node.id, node);
     mergedNodes.push(node);
   }
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4007,6 +4007,27 @@ export async function main(): Promise<void> {
 
       const instructionDir = join(paths.stateDir, DESCRIPTION_INSTRUCTIONS_DIR);
 
+      // F4: the graph's inline `citations` is already K-trimmed (<= 8), so a
+      // resolved cap above K (e.g. `--citation-cap all/50` on a long-doc hub)
+      // would inject at most K snippets. Load the fuller per-node citation set
+      // from citations.json and feed it to the describe engine so descriptions
+      // ground on many distinct sources. Absent/missing entries fall back to the
+      // inline set (collectNodeContext never shrinks). No LLM / network.
+      let citationsByNode: Record<string, unknown[]> | undefined;
+      {
+        const { readCitationsSidecar } = await import("./citations.js");
+        const sidecar = readCitationsSidecar(dirname(paths.graph));
+        if (sidecar) {
+          const map: Record<string, unknown[]> = {};
+          for (const [id, entry] of Object.entries(sidecar)) {
+            if (Array.isArray(entry.citations) && entry.citations.length > 0) {
+              map[id] = entry.citations;
+            }
+          }
+          if (Object.keys(map).length > 0) citationsByNode = map;
+        }
+      }
+
       console.log("Generating node descriptions...");
       const result = await generateNodeDescriptions(G, {
         ...(backendArg ? { provider: backendArg } : {}),
@@ -4014,6 +4035,7 @@ export async function main(): Promise<void> {
         ...(descriptionModeArg ? { mode: descriptionModeArg } : {}),
         ...(opts.fillMissing ? { onlyMissing: true } : {}),
         citationCap: citationPolicy.describeCap,
+        ...(citationsByNode ? { citationsByNode } : {}),
         instructionDir,
       });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,12 @@ import {
   resolveConfiguredInputScopeSelection,
 } from "./input-scope.js";
 import { foldCitationsInto } from "./citations.js";
+import {
+  resolveCitationPolicy,
+  resolveCorpusType,
+  type CitationCapValue,
+  type ResolvedCitationPolicy,
+} from "./citation-policy.js";
 import { forEachTraversalNeighbor, loadGraphFromData } from "./graph.js";
 import { communitiesFromGraph, communityLabelsFromGraph } from "./graph-communities.js";
 import { safeExecGit } from "./git.js";
@@ -128,6 +134,72 @@ function readJson<T>(path: string): T {
 
 function isJsonRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ---------------------------------------------------------------------------
+// Citation-policy CLI plumbing (SPEC_CITATIONS.md "CLI and config surface").
+//
+// `--citation-cap <n|all>` (describe/label/update) and `--citations-top-k <n>`
+// (extract/update/watch) override the corpus-type default resolved from
+// `.graphify_detect.json`. Precedence: CLI flag > config > corpus-type > global.
+// (Config is flag-only on the code-mode engine path — see report.)
+// ---------------------------------------------------------------------------
+
+/** Parse `--citation-cap <n|all>`. Invalid / empty → undefined (no override). */
+export function parseCitationCapFlag(raw: unknown): CitationCapValue | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "") return undefined;
+  if (trimmed === "all") return "all";
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n < 0 || String(n) !== trimmed) return undefined;
+  return n;
+}
+
+/** Parse `--citations-top-k <n>`. Non-positive / invalid → undefined (no override). */
+export function parseTopKFlag(raw: unknown): number | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n <= 0 || String(n) !== trimmed) return undefined;
+  return n;
+}
+
+/**
+ * Resolve the citation policy for a project root: read the corpus type from
+ * `.graphify_detect.json` (when present), apply the corpus-type default, then
+ * layer any explicit CLI flags on top. Never throws and never calls an LLM —
+ * a missing/garbage detect file degrades to the global default (cap 10, K 8).
+ */
+export function resolveCitationPolicyForRoot(
+  root: string,
+  flags: {
+    describeCapFlag?: CitationCapValue | undefined;
+    topKFlag?: number | undefined;
+    profileMode?: boolean;
+  },
+): ResolvedCitationPolicy {
+  let detect: { files?: Record<string, unknown>; total_words?: unknown } | null = null;
+  try {
+    const detectPath = resolveGraphifyPaths({ root }).scratch.detect;
+    if (existsSync(detectPath)) {
+      const parsed = readJson<unknown>(detectPath);
+      if (isJsonRecord(parsed)) {
+        detect = parsed as { files?: Record<string, unknown>; total_words?: unknown };
+      }
+    }
+  } catch {
+    /* missing / unreadable / malformed detect → global default */
+  }
+  const corpusType = resolveCorpusType(detect, { profileMode: flags.profileMode ?? false });
+  return resolveCitationPolicy({
+    corpusType,
+    cli: {
+      ...(flags.describeCapFlag !== undefined ? { describeCap: flags.describeCapFlag } : {}),
+      ...(flags.topKFlag !== undefined ? { inlineTopK: flags.topKFlag } : {}),
+    },
+  });
 }
 
 function loadWikiDescriptionSidecarIndex(inputPath?: string): WikiDescriptionSidecarIndex | undefined {
@@ -3129,6 +3201,7 @@ export async function main(): Promise<void> {
     .option("--concurrency <n>", "Direct backend semantic chunk concurrency", "4")
     .option("--token-budget <n>", "Approximate direct backend token budget per semantic chunk", "60000")
     .option("--no-cluster", "Write the raw merged extraction and skip graph clustering/reporting")
+    .option("--citations-top-k <n>", "Inline Level-1 citations kept per node in graph.json (default: corpus-resolved; 3 code / 8 others)")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
     .option(
@@ -3403,7 +3476,14 @@ export async function main(): Promise<void> {
         );
 
         writeFileSync(paths.report, report, "utf-8");
-        persistGraphWithCitations(G, communities, paths.graph, { communityLabels: labels, force: true });
+        const extractCitationPolicy = resolveCitationPolicyForRoot(outputRoot, {
+          topKFlag: parseTopKFlag(opts.citationsTopK),
+        });
+        persistGraphWithCitations(G, communities, paths.graph, {
+          communityLabels: labels,
+          force: true,
+          citations: { topK: extractCitationPolicy.inlineTopK },
+        });
         // Track C-3.5: pick up ontology profile for visual encoding override
         // when a graphify.yaml + ontology-profile is present in the project.
         const ontologyProfileForExtractHtml = await tryLoadHtmlOntologyProfile(root);
@@ -3466,15 +3546,18 @@ export async function main(): Promise<void> {
     .command("watch [path]")
     .description("Watch a folder and auto-rebuild graph outputs on code changes")
     .option("--debounce <seconds>", "Wait time before rebuild", "3")
+    .option("--citations-top-k <n>", "Inline Level-1 citations kept per node in graph.json (default: corpus-resolved; 3 code / 8 others)")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
     .action(async (watchPath, opts) => {
       const { watch } = await import("./watch.js");
       const debounce = Number.parseFloat(opts.debounce);
       const scopeSelection = resolveCliScopeSelection(opts);
+      const topKFlag = parseTopKFlag(opts.citationsTopK);
       await watch(watchPath ?? ".", Number.isFinite(debounce) ? debounce : 3, {
         scope: scopeSelection.mode,
         scopeSource: scopeSelection.source,
+        ...(topKFlag !== undefined ? { citationsTopK: topKFlag } : {}),
       });
     });
 
@@ -3515,6 +3598,8 @@ export async function main(): Promise<void> {
     .option("--label-backend <provider>", "Community-label LLM provider (default: auto-detect from API keys)")
     .option("--label-model <id>", "Community-label LLM model override")
     .option("--label-mode <mode>", "Label execution mode: assistant (default, no key) or direct (API key)", "")
+    .option("--citation-cap <n|all>", "Per-node citation snippets injected into the description prompt (default: corpus-resolved; 3 code / 10 mixed / all long-doc)")
+    .option("--citations-top-k <n>", "Inline Level-1 citations kept per node in graph.json (default: corpus-resolved; 3 code / 8 others)")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
     .action(async (updatePath = ".", opts) => {
@@ -3524,6 +3609,10 @@ export async function main(): Promise<void> {
       }
       const { rebuildCode } = await import("./watch.js");
       const scopeSelection = resolveCliScopeSelection(opts);
+      const updateCitationPolicy = resolveCitationPolicyForRoot(resolve(updatePath), {
+        describeCapFlag: parseCitationCapFlag(opts.citationCap),
+        topKFlag: parseTopKFlag(opts.citationsTopK),
+      });
       const projectConfigDiscovery = discoverProjectConfig(updatePath);
       if (projectConfigDiscovery.found) {
         console.warn(
@@ -3568,6 +3657,8 @@ export async function main(): Promise<void> {
         ...(typeof opts.labelMode === "string" && (opts.labelMode === "assistant" || opts.labelMode === "direct")
           ? { labelMode: opts.labelMode as "assistant" | "direct" }
           : {}),
+        citationCap: updateCitationPolicy.describeCap,
+        citationsTopK: updateCitationPolicy.inlineTopK,
         scope: scopeSelection.mode,
         scopeSource: scopeSelection.source,
       });
@@ -3731,6 +3822,7 @@ export async function main(): Promise<void> {
     .option("--backend <provider>", "LLM provider (default: auto-detect from API keys)")
     .option("--model <id>", "LLM model override")
     .option("--label-mode <mode>", "Execution mode: assistant (default, no key) or direct (API key)", "")
+    .option("--citation-cap <n|all>", "Per-node citation cap forwarded to the description engine when this run also (re)describes; resolved from corpus type when absent")
     .action(async (labelPath = ".", opts) => {
       const root = resolve(labelPath);
       const paths = resolveGraphifyPaths({ root });
@@ -3740,6 +3832,13 @@ export async function main(): Promise<void> {
       }
 
       mkdirSync(paths.stateDir, { recursive: true });
+
+      // `label` (re)names communities and never builds the description prompt,
+      // so the resolved cap is informational here (kept for CLI-surface
+      // symmetry with describe/update and validated/normalized via the policy).
+      resolveCitationPolicyForRoot(root, {
+        describeCapFlag: parseCitationCapFlag(opts.citationCap),
+      });
 
       const rawGraphText = readFileSync(paths.graph, "utf-8");
       const rawGraphParsed = JSON.parse(rawGraphText) as {
@@ -3863,6 +3962,7 @@ export async function main(): Promise<void> {
     .option("--description-model <id>", "LLM model override")
     .option("--description-mode <mode>", "Execution mode: assistant (default, no key) or direct (API key)", "")
     .option("--fill-missing", "Only describe nodes whose description is empty/absent (idempotent gap-fill)")
+    .option("--citation-cap <n|all>", "Per-node citation snippets injected into the description prompt (default: corpus-resolved; 3 code / 10 mixed / all long-doc)")
     .action(async (describePath = ".", opts) => {
       const root = resolve(describePath);
       const paths = resolveGraphifyPaths({ root });
@@ -3872,6 +3972,10 @@ export async function main(): Promise<void> {
       }
 
       mkdirSync(paths.stateDir, { recursive: true });
+
+      const citationPolicy = resolveCitationPolicyForRoot(root, {
+        describeCapFlag: parseCitationCapFlag(opts.citationCap),
+      });
 
       const rawGraphText = readFileSync(paths.graph, "utf-8");
       const rawGraphParsed = JSON.parse(rawGraphText) as {
@@ -3909,6 +4013,7 @@ export async function main(): Promise<void> {
         ...(modelArg ? { model: modelArg } : {}),
         ...(descriptionModeArg ? { mode: descriptionModeArg } : {}),
         ...(opts.fillMissing ? { onlyMissing: true } : {}),
+        citationCap: citationPolicy.describeCap,
         instructionDir,
       });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4042,6 +4042,70 @@ export async function main(): Promise<void> {
       );
     });
 
+  // ---------------------------------------------------------------------------
+  // graphify backfill-citations [path]
+  // Lossy backward-compat projection of a pre-feature graph: for each node with
+  // a legacy citations[] but no citation_count, set citation_count, trim the
+  // inline set to top-K, and co-emit citations.json. NO LLM / network — purely
+  // deterministic. Counts are a LOWER BOUND (the bounded graph never held the
+  // full union); a re-extract is required for true exhaustive counts.
+  // ---------------------------------------------------------------------------
+  program
+    .command("backfill-citations [path]")
+    .description("Project legacy graph.json citations[] into citation_count + a K-trimmed inline set + citations.json (lower-bound counts; no LLM)")
+    .option("--citations-top-k <n>", "Inline Level-1 citations kept per node (default: corpus-resolved; 3 code / 8 others)")
+    .action(async (backfillPath = ".", opts) => {
+      const root = resolve(backfillPath);
+      const paths = resolveGraphifyPaths({ root });
+      if (!existsSync(paths.graph)) {
+        console.error(`error: no graph found at ${paths.graph} - run /graphify first`);
+        process.exit(1);
+      }
+      mkdirSync(paths.stateDir, { recursive: true });
+
+      const policy = resolveCitationPolicyForRoot(root, {
+        topKFlag: parseTopKFlag(opts.citationsTopK),
+      });
+
+      const rawGraphText = readFileSync(paths.graph, "utf-8");
+      const G = makeGraphPortable(loadGraphFromData(JSON.parse(rawGraphText)), root);
+      const { backfillCitations } = await import("./citations.js");
+      const { toJson } = await import("./export.js");
+
+      // Preserve existing community assignments + names so toJson writes the
+      // graph back byte-for-byte aside from the citation fields.
+      const communities = communitiesFromGraph(G);
+      const communityLabels = communityLabelsFromGraph(G, communities);
+
+      const result = backfillCitations(G, dirname(paths.graph), {
+        topK: policy.inlineTopK,
+      });
+
+      // Re-write graph.json with the trimmed inline citations + citation_count.
+      // Only when something was projected — a graph with nothing to backfill is
+      // left untouched (true no-op, no spurious diff).
+      if (result.backfilledNodes > 0) {
+        toJson(G, communities, paths.graph, { communityLabels, force: true });
+      }
+
+      if (result.backfilledNodes === 0) {
+        console.log(
+          "backfill-citations: nothing to backfill — no node carries a legacy citations[] without a citation_count. graph.json unchanged.",
+        );
+        return;
+      }
+
+      console.log(
+        `backfill-citations: projected ${result.backfilledNodes} node(s); ` +
+          `wrote citation_count + a top-${policy.inlineTopK} inline set + ${result.sidecarPath}.`,
+      );
+      console.log(
+        "CAVEAT (LOWER BOUND): these counts reflect ONLY the bounded citation sample already in graph.json. " +
+          "The original duplicate-discard dropped citations a backfill cannot recover. " +
+          "Re-extract the corpus for true exhaustive counts.",
+      );
+    });
+
   const wikiCommand = program
     .command("wiki")
     .description("Generate and maintain Graphify wiki artifacts");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3358,7 +3358,7 @@ export async function main(): Promise<void> {
           return;
         }
 
-        const [{ buildFromJson }, { cluster, scoreAll }, { godNodes, surprisingConnections, suggestQuestions }, { generate }, { toJson }, { safeToHtml }] = await Promise.all([
+        const [{ buildFromJson }, { cluster, scoreAll }, { godNodes, surprisingConnections, suggestQuestions }, { generate }, { persistGraphWithCitations }, { safeToHtml }] = await Promise.all([
           import("./build.js"),
           import("./cluster.js"),
           import("./analyze.js"),
@@ -3403,7 +3403,7 @@ export async function main(): Promise<void> {
         );
 
         writeFileSync(paths.report, report, "utf-8");
-        toJson(G, communities, paths.graph, { communityLabels: labels, force: true });
+        persistGraphWithCitations(G, communities, paths.graph, { communityLabels: labels, force: true });
         // Track C-3.5: pick up ontology profile for visual encoding override
         // when a graphify.yaml + ontology-profile is present in the project.
         const ontologyProfileForExtractHtml = await tryLoadHtmlOntologyProfile(root);

--- a/src/export.ts
+++ b/src/export.ts
@@ -10,6 +10,11 @@ import { isDirectedGraph } from "./graph.js";
 import { assertGraphJsonFileSize, assertGraphJsonSize } from "./graph-size-guard.js";
 import { safeGitRevParse } from "./git.js";
 import type { Hyperedge, NormalizedOntologyProfile, OntologyVisualEncoding } from "./types.js";
+import {
+  aggregateCitations,
+  writeCitationsSidecar,
+  type AggregateCitationsOptions,
+} from "./citations.js";
 import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
 import {
   type NumericMapLike,
@@ -547,6 +552,38 @@ export function toJson(
   assertGraphJsonSize(Buffer.byteLength(serialized, "utf-8"), "write", outputPath);
   writeFileSync(outputPath, serialized, "utf-8");
   return true;
+}
+
+/**
+ * Co-emit chokepoint (SPEC_CITATIONS area 6). Runs the citation aggregation
+ * pass over the assembled graph IMMEDIATELY before graph.json is written, then
+ * writes graph.json (trimmed inline `citations` + `citation_count`) and the
+ * co-derived `citations.json` so the two projections are always consistent.
+ *
+ * The aggregation mutates `G` in place: each node's `citations` is trimmed to
+ * the deterministic top-K and `citation_count` is stamped with the true union
+ * size; the full per-entity union is written to
+ * `<dirname(graphPath)>/ontology/citations.json`.
+ *
+ * Returns the same boolean as `toJson` (false when the shrink-guard refuses the
+ * write). The sidecar is only written when graph.json itself was written and at
+ * least one node carries citations (no empty sidecar littering).
+ */
+export function persistGraphWithCitations(
+  G: Graph,
+  communities: NumericMapLike<string[]>,
+  outputPath: string,
+  options?: JsonOptions & { citations?: AggregateCitationsOptions },
+): boolean {
+  const map = aggregateCitations(G, options?.citations ?? {});
+  const jsonOptions: JsonOptions | undefined = options
+    ? { ...(options.communityLabels ? { communityLabels: options.communityLabels } : {}), ...(options.force ? { force: true } : {}) }
+    : undefined;
+  const written = toJson(G, communities, outputPath, jsonOptions);
+  if (written) {
+    writeCitationsSidecar(dirname(outputPath), map, G);
+  }
+  return written;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/merge-driver.ts
+++ b/src/merge-driver.ts
@@ -3,8 +3,10 @@ import { resolve } from "node:path";
 
 import type { SerializedGraphData } from "./graph.js";
 import { createGraph, serializeGraph } from "./graph.js";
+import { unionCitations } from "./citations.js";
 import { mergeHyperedges, setHyperedges } from "./hyperedges.js";
 import type { Hyperedge } from "./hyperedges.js";
+import type { OntologyCitation } from "./types.js";
 
 export interface MergeGraphJsonResult {
   out: string;
@@ -121,7 +123,31 @@ export function mergeGraphJsonFiles(
   for (const raw of graphs) {
     for (const node of raw.nodes ?? []) {
       const { id, ...attrs } = node;
-      merged.mergeNode(id, attrs);
+      // SPEC_CITATIONS F5: graphology mergeNode is shallow last-write-wins, so
+      // one branch's K-set + one branch's count would survive and the other
+      // branch's distinct citations would be silently dropped. Union the
+      // `citations` by identity and reconcile `citation_count` to the larger of
+      // both counts and the union size, so an accepted git merge of two graph.json
+      // K-sets sums distinct citations instead of discarding half.
+      const incoming = { ...attrs } as Record<string, unknown>;
+      if (merged.hasNode(id)) {
+        const existingCites = merged.getNodeAttribute(id, "citations");
+        if (Array.isArray(incoming.citations) || Array.isArray(existingCites)) {
+          const union = unionCitations([
+            Array.isArray(existingCites) ? (existingCites as OntologyCitation[]) : [],
+            Array.isArray(incoming.citations) ? (incoming.citations as OntologyCitation[]) : [],
+          ]);
+          incoming.citations = union;
+          const existingCount = merged.getNodeAttribute(id, "citation_count");
+          const counts = [
+            typeof existingCount === "number" ? existingCount : 0,
+            typeof incoming.citation_count === "number" ? incoming.citation_count : 0,
+            union.length,
+          ];
+          incoming.citation_count = Math.max(...counts);
+        }
+      }
+      merged.mergeNode(id, incoming);
     }
   }
 

--- a/src/node-descriptions.ts
+++ b/src/node-descriptions.ts
@@ -372,8 +372,34 @@ function isDescribableNode(attrs: Record<string, unknown>): boolean {
 /** Snippet length cap for an individual citation/evidence string. */
 const CITATION_MAXLEN = 120;
 
-/** Max citation / evidence entries injected per node prompt line. */
+/**
+ * Code-default fallback for the per-node prompt citation cap. Used only when no
+ * cap is threaded through (kept at 3, the historic value). SPEC_CITATIONS pass
+ * 1: the resolved default when a caller does not specify is 10
+ * (RESOLVED_DEFAULT_CITATION_CAP), set at the resolution boundary below.
+ */
 const MAX_CITATIONS = 3;
+
+/**
+ * Tunable per-node prompt citation cap. A number bounds the snippets injected
+ * per node; "all" injects every citation. Threaded from
+ * GenerateNodeDescriptionsOptions / DescribeNodesOptions.
+ */
+export type CitationCap = number | "all";
+
+/** Resolved default cap for this pass when a caller does not specify one. */
+export const RESOLVED_DEFAULT_CITATION_CAP = 10;
+
+/**
+ * Resolve a (possibly undefined) cap option to a concrete numeric limit.
+ * "all" → Infinity; undefined → RESOLVED_DEFAULT_CITATION_CAP; a finite number
+ * → itself (clamped to >= 0).
+ */
+function resolveCitationCap(cap: CitationCap | undefined): number {
+  if (cap === "all") return Number.POSITIVE_INFINITY;
+  if (typeof cap === "number" && Number.isFinite(cap)) return Math.max(0, cap);
+  return RESOLVED_DEFAULT_CITATION_CAP;
+}
 
 export interface NodeContext {
   id: string;
@@ -399,13 +425,16 @@ export interface NodeContext {
  * quote, page, section, …) and `evidence_refs` (string[]). Returns a small,
  * deduped, truncated list suitable for direct injection into a prompt line.
  */
-function collectCitationContext(attrs: Record<string, unknown>): string[] {
+function collectCitationContext(
+  attrs: Record<string, unknown>,
+  cap: number = MAX_CITATIONS,
+): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   const push = (value: string): void => {
     const snippet = truncate(value, CITATION_MAXLEN);
     const key = snippet.toLowerCase();
-    if (snippet && !seen.has(key) && out.length < MAX_CITATIONS) {
+    if (snippet && !seen.has(key) && out.length < cap) {
       seen.add(key);
       out.push(snippet);
     }
@@ -414,7 +443,7 @@ function collectCitationContext(attrs: Record<string, unknown>): string[] {
   const citations = attrs.citations;
   if (Array.isArray(citations)) {
     for (const entry of citations) {
-      if (out.length >= MAX_CITATIONS) break;
+      if (out.length >= cap) break;
       if (typeof entry === "string") {
         push(entry);
         continue;
@@ -440,7 +469,7 @@ function collectCitationContext(attrs: Record<string, unknown>): string[] {
   const evidenceRefs = attrs.evidence_refs;
   if (Array.isArray(evidenceRefs)) {
     for (const ref of evidenceRefs) {
-      if (out.length >= MAX_CITATIONS) break;
+      if (out.length >= cap) break;
       const value = safeString(ref);
       if (value) push(value);
     }
@@ -461,9 +490,22 @@ function collectNeighbors(G: Graph, nodeId: string, limit: number): string[] {
   return out;
 }
 
-export function collectNodeContext(G: Graph, nodeId: string): NodeContext {
+export interface CollectNodeContextOptions {
+  /**
+   * Per-node prompt citation cap. A number bounds the snippets; "all" injects
+   * every citation. Unspecified resolves to RESOLVED_DEFAULT_CITATION_CAP (10).
+   */
+  citationCap?: CitationCap;
+}
+
+export function collectNodeContext(
+  G: Graph,
+  nodeId: string,
+  options: CollectNodeContextOptions = {},
+): NodeContext {
   const attrs = G.getNodeAttributes(nodeId) as Record<string, unknown>;
   const isCode = isCodeNode(attrs);
+  const cap = resolveCitationCap(options.citationCap);
   return {
     id: nodeId,
     label: truncate(safeString(attrs.label) ?? nodeId),
@@ -474,7 +516,7 @@ export function collectNodeContext(G: Graph, nodeId: string): NodeContext {
     degree: G.degree(nodeId),
     neighbors: collectNeighbors(G, nodeId, 6),
     // Citation grounding only matters for entity nodes; skip the work for code.
-    citations: isCode ? [] : collectCitationContext(attrs),
+    citations: isCode ? [] : collectCitationContext(attrs, cap),
   };
 }
 
@@ -683,6 +725,12 @@ export interface DescribeNodesOptions {
   callLlm?: CallLlmFn;
   /** Only rank/describe nodes whose `description` attr is empty/absent. */
   onlyMissing?: boolean;
+  /**
+   * Per-node prompt citation cap (SPEC_CITATIONS). A number bounds the citation
+   * snippets injected per node; "all" injects every citation. Unspecified
+   * resolves to RESOLVED_DEFAULT_CITATION_CAP (10).
+   */
+  citationCap?: CitationCap;
 }
 
 /**
@@ -706,7 +754,9 @@ export async function describeNodes(
   const callLlm = options.callLlm ?? (await makeDefaultCallLlm(options.provider, options.model));
 
   for (const batch of chunk(targetIds, batchSize)) {
-    const contexts = batch.map((id) => collectNodeContext(G, id));
+    const contexts = batch.map((id) =>
+      collectNodeContext(G, id, { citationCap: options.citationCap }),
+    );
     const prompt = buildNodeDescriptionPrompt(contexts);
     const validIds = new Set(batch);
     const maxTokens = Math.min(120 + 48 * batch.length, 8192);
@@ -761,6 +811,13 @@ export interface GenerateNodeDescriptionsOptions {
    * directory (callers that know the project root pass it here).
    */
   instructionDir?: string;
+  /**
+   * Per-node prompt citation cap (SPEC_CITATIONS). A number bounds the citation
+   * snippets injected per node into the description prompt; "all" injects every
+   * citation. Unspecified resolves to RESOLVED_DEFAULT_CITATION_CAP (10).
+   * Flows on BOTH the direct (API) path and the no-key assistant path.
+   */
+  citationCap?: CitationCap;
 }
 
 /**
@@ -991,7 +1048,7 @@ export async function generateNodeDescriptions(
       return skip("assistant", "noBackend");
     }
     const batches = chunk(
-      targetIds.map((id) => collectNodeContext(G, id)),
+      targetIds.map((id) => collectNodeContext(G, id, { citationCap: options.citationCap })),
       batchSize,
     );
     const { instructionPaths, answerPaths } = emitDescriptionInstructions(
@@ -1049,6 +1106,7 @@ export async function generateNodeDescriptions(
       ...(options.batchSize !== undefined ? { batchSize: options.batchSize } : {}),
       ...(options.callLlm ? { callLlm: options.callLlm } : {}),
       ...(options.onlyMissing !== undefined ? { onlyMissing: options.onlyMissing } : {}),
+      ...(options.citationCap !== undefined ? { citationCap: options.citationCap } : {}),
     });
 
     let describedCount = 0;

--- a/src/node-descriptions.ts
+++ b/src/node-descriptions.ts
@@ -428,6 +428,7 @@ export interface NodeContext {
 function collectCitationContext(
   attrs: Record<string, unknown>,
   cap: number = MAX_CITATIONS,
+  citationsOverride?: unknown[],
 ): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
@@ -440,7 +441,11 @@ function collectCitationContext(
     }
   };
 
-  const citations = attrs.citations;
+  // F4: on the describe-on-existing-graph path the node's in-memory `citations`
+  // is already K-trimmed; a caller that loaded the fuller per-node set from
+  // citations.json passes it here so `--citation-cap all/50` can ground on more
+  // than K distinct sources. Falls back to the inline attr otherwise.
+  const citations = citationsOverride ?? attrs.citations;
   if (Array.isArray(citations)) {
     for (const entry of citations) {
       if (out.length >= cap) break;
@@ -496,6 +501,15 @@ export interface CollectNodeContextOptions {
    * every citation. Unspecified resolves to RESOLVED_DEFAULT_CITATION_CAP (10).
    */
   citationCap?: CitationCap;
+  /**
+   * F4: fuller per-node citation sets (keyed by node id), loaded from
+   * citations.json on the describe-on-existing-graph path. When an entry is
+   * present AND longer than the node's K-trimmed inline `citations`, it is used
+   * for prompt grounding so `--citation-cap all/50` can reach beyond K distinct
+   * sources. A missing/empty/smaller entry falls back to the inline set (never
+   * shrinks).
+   */
+  citationsByNode?: Record<string, unknown[]>;
 }
 
 export function collectNodeContext(
@@ -506,6 +520,12 @@ export function collectNodeContext(
   const attrs = G.getNodeAttributes(nodeId) as Record<string, unknown>;
   const isCode = isCodeNode(attrs);
   const cap = resolveCitationCap(options.citationCap);
+  // F4: prefer the fuller sidecar set only when it is genuinely richer than the
+  // K-trimmed inline — otherwise keep the inline so we never shrink grounding.
+  const inlineLen = Array.isArray(attrs.citations) ? attrs.citations.length : 0;
+  const override = options.citationsByNode?.[nodeId];
+  const citationsOverride =
+    Array.isArray(override) && override.length > inlineLen ? override : undefined;
   return {
     id: nodeId,
     label: truncate(safeString(attrs.label) ?? nodeId),
@@ -516,7 +536,7 @@ export function collectNodeContext(
     degree: G.degree(nodeId),
     neighbors: collectNeighbors(G, nodeId, 6),
     // Citation grounding only matters for entity nodes; skip the work for code.
-    citations: isCode ? [] : collectCitationContext(attrs, cap),
+    citations: isCode ? [] : collectCitationContext(attrs, cap, citationsOverride),
   };
 }
 
@@ -731,6 +751,12 @@ export interface DescribeNodesOptions {
    * resolves to RESOLVED_DEFAULT_CITATION_CAP (10).
    */
   citationCap?: CitationCap;
+  /**
+   * F4: fuller per-node citation sets (from citations.json) keyed by node id.
+   * On the describe-on-existing-graph path the inline `citations` is K-trimmed,
+   * so the caller passes the fuller set here to ground beyond K.
+   */
+  citationsByNode?: Record<string, unknown[]>;
 }
 
 /**
@@ -755,7 +781,10 @@ export async function describeNodes(
 
   for (const batch of chunk(targetIds, batchSize)) {
     const contexts = batch.map((id) =>
-      collectNodeContext(G, id, { citationCap: options.citationCap }),
+      collectNodeContext(G, id, {
+        citationCap: options.citationCap,
+        ...(options.citationsByNode ? { citationsByNode: options.citationsByNode } : {}),
+      }),
     );
     const prompt = buildNodeDescriptionPrompt(contexts);
     const validIds = new Set(batch);
@@ -818,6 +847,13 @@ export interface GenerateNodeDescriptionsOptions {
    * Flows on BOTH the direct (API) path and the no-key assistant path.
    */
   citationCap?: CitationCap;
+  /**
+   * F4: fuller per-node citation sets (from citations.json) keyed by node id.
+   * Supplied by the describe-on-existing-graph CLI path so `--citation-cap
+   * all/50` can ground on more than the K-trimmed inline `citations`. Flows on
+   * BOTH the direct (API) path and the no-key assistant path.
+   */
+  citationsByNode?: Record<string, unknown[]>;
 }
 
 /**
@@ -1048,7 +1084,12 @@ export async function generateNodeDescriptions(
       return skip("assistant", "noBackend");
     }
     const batches = chunk(
-      targetIds.map((id) => collectNodeContext(G, id, { citationCap: options.citationCap })),
+      targetIds.map((id) =>
+        collectNodeContext(G, id, {
+          citationCap: options.citationCap,
+          ...(options.citationsByNode ? { citationsByNode: options.citationsByNode } : {}),
+        }),
+      ),
       batchSize,
     );
     const { instructionPaths, answerPaths } = emitDescriptionInstructions(
@@ -1107,6 +1148,7 @@ export async function generateNodeDescriptions(
       ...(options.callLlm ? { callLlm: options.callLlm } : {}),
       ...(options.onlyMissing !== undefined ? { onlyMissing: options.onlyMissing } : {}),
       ...(options.citationCap !== undefined ? { citationCap: options.citationCap } : {}),
+      ...(options.citationsByNode ? { citationsByNode: options.citationsByNode } : {}),
     });
 
     let describedCount = 0;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -14,7 +14,7 @@ import { buildFromJson } from "./build.js";
 import { cluster, scoreAll } from "./cluster.js";
 import { godNodes, surprisingConnections, suggestQuestions } from "./analyze.js";
 import { generate } from "./report.js";
-import { backupIfProtected, toJson } from "./export.js";
+import { backupIfProtected, persistGraphWithCitations } from "./export.js";
 import { safeToHtml } from "./html-export.js";
 import { extractWithDiagnostics, type ExtractionDiagnostic } from "./extract.js";
 import { resolveGraphifyPaths } from "./paths.js";
@@ -241,7 +241,7 @@ export async function buildProject(
   }
 
   writeFileSync(reportPath, report, "utf-8");
-  toJson(G, communities, graphPath, { communityLabels: labels });
+  persistGraphWithCitations(G, communities, graphPath, { communityLabels: labels });
   persistCommunityLabels(labels, paths.scratch.labels);
 
   let htmlPath: string | undefined;

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -21,7 +21,12 @@ import {
   type SemanticFragment,
 } from "./semantic-fragment-validation.js";
 import { buildFromJson } from "./build.js";
-import { foldCitationsInto } from "./citations.js";
+import {
+  foldCitationsInto,
+  unionCitations,
+  readCitationsSidecar,
+  type CitationAggregateMap,
+} from "./citations.js";
 import { cluster, scoreAll } from "./cluster.js";
 import { detect, detectIncremental, saveManifest } from "./detect.js";
 import {
@@ -113,6 +118,7 @@ import type {
   GodNodeEntry,
   GraphDiffResult,
   InputScopeSource,
+  OntologyCitation,
   SuggestedQuestion,
   SurpriseEntry,
   NormalizedOntologyProfile,
@@ -318,7 +324,21 @@ function mergeHyperedges(
 
 function mergeGraphs(target: Graph, source: Graph): void {
   source.forEachNode((nodeId, attrs) => {
-    target.mergeNode(nodeId, attrs);
+    // SPEC_CITATIONS F1: graphology mergeNode is shallow last-write-wins, so the
+    // source (fresh re-extraction) node's `citations` would REPLACE the target
+    // (existing graph) node's set, dropping the union. Mirror build.ts:291-298 —
+    // union the `citations` attr by identity BEFORE the merge so a re-extracted
+    // hub keeps every distinct citation across the old and new node. Code nodes
+    // rarely carry citations; when neither side has any this is a no-op.
+    const incoming = { ...(attrs as Record<string, unknown>) };
+    if (target.hasNode(nodeId) && Array.isArray(incoming.citations)) {
+      const existing = target.getNodeAttribute(nodeId, "citations");
+      incoming.citations = unionCitations([
+        Array.isArray(existing) ? (existing as OntologyCitation[]) : [],
+        incoming.citations as OntologyCitation[],
+      ]);
+    }
+    target.mergeNode(nodeId, incoming);
   });
   source.forEachEdge((_edge, attrs, sourceId, targetId) => {
     if (!target.hasNode(sourceId) || !target.hasNode(targetId)) return;
@@ -1268,8 +1288,19 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       );
       analyzed.analysis.diff = graphDiff(oldGraph, mergedGraph);
 
+      // SPEC_CITATIONS F1: the existing graph's inline `citations` are already
+      // K-trimmed; mergeGraphs unions old↔new inline sets, but the exhaustive
+      // tail lives in citations.json. Snapshot that FULL prior store (exactly
+      // the watch.ts:428-453 hook-rebuild pattern) and hand it to the aggregation
+      // pass so each node's prior FULL union ∪ the fresh extraction is what sets
+      // `citation_count` + the top-K — recovering the true union, not the trimmed
+      // K-set, and re-stamping a count consistent with citations.json.
+      const finalizePriorSidecar: CitationAggregateMap | null = readCitationsSidecar(
+        dirname(resolve(opts.graphOut)),
+      );
       persistGraphWithCitations(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
+        ...(finalizePriorSidecar ? { citations: { priorSidecar: finalizePriorSidecar } } : {}),
       });
       writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
       writeJson(opts.analysisOut, analyzed.analysis);
@@ -1566,8 +1597,16 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       );
       analyzed.analysis.diff = graphDiff(oldGraph, mergedGraph);
 
+      // SPEC_CITATIONS F1 (mirrors finalize-update): recover the exhaustive
+      // citation tail from the prior citations.json before re-aggregating, so a
+      // re-extracted hub's count + top-K derive from the prior FULL union ∪ fresh
+      // rather than the K-trimmed inline.
+      const mergeUpdatePriorSidecar: CitationAggregateMap | null = readCitationsSidecar(
+        dirname(resolve(opts.graphOut)),
+      );
       persistGraphWithCitations(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
+        ...(mergeUpdatePriorSidecar ? { citations: { priorSidecar: mergeUpdatePriorSidecar } } : {}),
       });
       writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
       writeJson(opts.analysisOut, analyzed.analysis);

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -21,6 +21,7 @@ import {
   type SemanticFragment,
 } from "./semantic-fragment-validation.js";
 import { buildFromJson } from "./build.js";
+import { foldCitationsInto } from "./citations.js";
 import { cluster, scoreAll } from "./cluster.js";
 import { detect, detectIncremental, saveManifest } from "./detect.js";
 import {
@@ -409,7 +410,7 @@ function placeholderDetection(root: string = "."): DetectionResult {
   };
 }
 
-function mergeSemanticArtifacts(
+export function mergeSemanticArtifacts(
   cached: Partial<Extraction> | null | undefined,
   fresh: Partial<Extraction> | null | undefined,
 ): Extraction {
@@ -417,10 +418,15 @@ function mergeSemanticArtifacts(
   const freshExtraction = ensureExtractionShape(fresh);
 
   const dedupedNodes: Extraction["nodes"] = [];
-  const seen = new Set<string>();
+  const byId = new Map<string, Extraction["nodes"][number]>();
   for (const node of [...cachedExtraction.nodes, ...freshExtraction.nodes]) {
-    if (seen.has(node.id)) continue;
-    seen.add(node.id);
+    const kept = byId.get(node.id);
+    if (kept) {
+      // SPEC_CITATIONS: fold the duplicate's citations into the kept node.
+      foldCitationsInto(kept, node);
+      continue;
+    }
+    byId.set(node.id, node);
     dedupedNodes.push(node);
   }
 
@@ -433,7 +439,7 @@ function mergeSemanticArtifacts(
   };
 }
 
-function mergeAstAndSemantic(
+export function mergeAstAndSemantic(
   astInput: Partial<Extraction> | null | undefined,
   semanticInput: Partial<Extraction> | null | undefined,
 ): Extraction {
@@ -441,10 +447,15 @@ function mergeAstAndSemantic(
   const semantic = ensureExtractionShape(semanticInput);
 
   const mergedNodes: Extraction["nodes"] = [...ast.nodes];
-  const seen = new Set(ast.nodes.map((node) => node.id));
+  const byId = new Map(mergedNodes.map((node) => [node.id, node]));
   for (const node of semantic.nodes) {
-    if (seen.has(node.id)) continue;
-    seen.add(node.id);
+    const kept = byId.get(node.id);
+    if (kept) {
+      // SPEC_CITATIONS: fold the duplicate's citations into the kept node.
+      foldCitationsInto(kept, node);
+      continue;
+    }
+    byId.set(node.id, node);
     mergedNodes.push(node);
   }
 

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -29,7 +29,7 @@ import {
   resolveCliInputScopeSelection,
   resolveConfiguredInputScopeSelection,
 } from "./input-scope.js";
-import { toCypher, toGraphml, toHtml, toJson, toSvg, pushToNeo4j } from "./export.js";
+import { persistGraphWithCitations, toCypher, toGraphml, toHtml, toJson, toSvg, pushToNeo4j } from "./export.js";
 import { safeToHtml } from "./html-export.js";
 import { extractWithDiagnostics } from "./extract.js";
 import {
@@ -1189,7 +1189,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         { labelsPath },
       );
 
-      toJson(G, analyzed.communities, resolve(opts.graphOut), {
+      persistGraphWithCitations(G, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
       });
       writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
@@ -1268,7 +1268,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       );
       analyzed.analysis.diff = graphDiff(oldGraph, mergedGraph);
 
-      toJson(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
+      persistGraphWithCitations(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
       });
       writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
@@ -1319,7 +1319,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       );
 
       mkdirSync(dirname(resolve(opts.graphOut)), { recursive: true });
-      toJson(G, analyzed.communities, resolve(opts.graphOut), {
+      persistGraphWithCitations(G, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
       });
       writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
@@ -1375,7 +1375,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       analysis.labels = mapToObject(labels);
       writeFileSync(resolve(opts.reportOut), report, "utf-8");
       if (opts.graphOut) {
-        toJson(G, communities, resolve(opts.graphOut), { communityLabels: labels });
+        persistGraphWithCitations(G, communities, resolve(opts.graphOut), { communityLabels: labels });
       }
       if (opts.htmlOut) {
         safeToHtml(G, communities, resolve(opts.htmlOut), { communityLabels: labels }, {
@@ -1566,7 +1566,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       );
       analyzed.analysis.diff = graphDiff(oldGraph, mergedGraph);
 
-      toJson(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
+      persistGraphWithCitations(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
       });
       writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
@@ -1613,6 +1613,10 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       ]) {
         mkdirSync(dirname(target), { recursive: true });
       }
+      // Reload-only re-cluster path: G comes from an existing graph.json whose
+      // inline citations are already K-trimmed, so re-emitting the sidecar here
+      // would shrink its full list to K. Keep plain toJson and leave the
+      // co-derived citations.json (emitted by the extract/assemble pass) intact.
       toJson(G, analyzed.communities, resolve(opts.graphOut), {
         communityLabels: analyzed.labels,
       });

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -1103,10 +1103,16 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const fresh = freshLoad.extraction;
 
       const dedupedNodes: Extraction["nodes"] = [];
-      const seen = new Set<string>();
+      const byId = new Map<string, Extraction["nodes"][number]>();
       for (const node of [...cached.nodes, ...fresh.nodes]) {
-        if (seen.has(node.id)) continue;
-        seen.add(node.id);
+        const kept = byId.get(node.id);
+        if (kept) {
+          // SPEC_CITATIONS F2: fold the duplicate's citations into the kept node
+          // (mirrors mergeSemanticArtifacts) instead of discarding them.
+          foldCitationsInto(kept, node);
+          continue;
+        }
+        byId.set(node.id, node);
         dedupedNodes.push(node);
       }
 
@@ -1136,10 +1142,16 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const semantic = loadAndSanitizeFragment(opts.semantic, "semantic").extraction;
 
       const mergedNodes: Extraction["nodes"] = [...ast.nodes];
-      const seen = new Set(ast.nodes.map((node) => node.id));
+      const byId = new Map(mergedNodes.map((node) => [node.id, node]));
       for (const node of semantic.nodes) {
-        if (seen.has(node.id)) continue;
-        seen.add(node.id);
+        const kept = byId.get(node.id);
+        if (kept) {
+          // SPEC_CITATIONS F2: fold the semantic duplicate's citations into the
+          // kept AST node (mirrors mergeAstAndSemantic) instead of discarding.
+          foldCitationsInto(kept, node);
+          continue;
+        }
+        byId.set(node.id, node);
         mergedNodes.push(node);
       }
 

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -501,6 +501,29 @@ graphify describe . --description-mode direct --description-backend anthropic
 
 `graphify describe` loads the existing `graph.json`, runs the same description pipeline as `graphify update --description`, and writes back — without touching node IDs, edges, communities, or any other node attributes. Only `description` is added/updated. Use it when `graphify update` would re-extract and destroy a curated graph.
 
+**Citation density per corpus type (no key needed).** `describe`/`update`/`extract`/`watch` auto-tune two citation knobs from the corpus type they read out of `.graphify/.graphify_detect.json` (no extra step): the **describe-prompt cap** (citation snippets grounding each description) and the **inline top-K** (citations kept per node in `graph.json`; the full per-entity tail always lands in `.graphify/ontology/citations.json`). Resolution precedence is **CLI flag > corpus-type default > global default (cap 10, K 8)**. Corpus-type defaults:
+
+| Corpus type | describe cap | inline K |
+|---|---|---|
+| code (code dominates, no docs/papers) | 3 | 3 |
+| mixed (the middle default) | 10 | 8 |
+| long-document (docs/papers, large word count) | all | 8 |
+| entity-corpus (ontology/profile mode) | all | 8 |
+
+You normally rely on the auto-resolved policy. Override it explicitly per detected corpus type when needed — e.g. a long-form prose corpus should ground descriptions on many distinct sources, while a code project stays terse:
+
+```bash
+# Long-document / entity corpus: ground on every distinct source.
+graphify describe . --citation-cap all
+# Code project: keep descriptions terse.
+graphify describe . --citation-cap 3
+# Bound how many citations ride inline in graph.json (the full tail stays in citations.json):
+graphify extract . --citations-top-k 8
+graphify update  . --citation-cap all --citations-top-k 8
+```
+
+`--citation-cap <n|all>` is on `describe`/`label`/`update`; `--citations-top-k <n>` is on `extract`/`update`/`watch`. Both are flag-only overrides (no key, no config file required) — absent, the corpus-type default above applies. To project a pre-feature graph into the new schema without re-extracting (lower-bound counts; re-extract for true exhaustive counts), run `graphify backfill-citations .`.
+
 **Legacy manual label approach** (still works; skip if using the CLI two-step above):
 
 Read `.graphify/.graphify_analysis.json`. For each community key, look at its node labels and write a 2-5 word name. Then regenerate the report:

--- a/src/studio-assets.ts
+++ b/src/studio-assets.ts
@@ -12,9 +12,12 @@
  * a missing sidecar yields nulls so the entity panel stays graph-only.
  */
 
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, normalize, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import type { OntologyCitation } from "./types.js";
 
 export interface StudioAssetResult {
   status: number;
@@ -216,10 +219,127 @@ export function __resetGraphDescriptionCache(): void {
   graphDescriptionCache.clear();
 }
 
+// ---------------------------------------------------------------------------
+// Level-2 citations store (`ontology/citations.json`, SPEC_CITATIONS.md). The
+// full per-entity citation list lives here, served lazily on entity selection.
+// Like the description index above, it can be large and is hit once per
+// selection, so it is loaded through a single mtime-keyed in-memory index
+// (the loadGraphNodeDescriptions pattern) — NOT re-parsed per request.
+//
+// Consistency gate: the store carries the citation-content `graph_signature`
+// of the graph.json it was emitted against. On read, the signature is matched
+// against the current graph.json's citation-content hash; on MISMATCH the
+// store is treated as ABSENT (the client then falls back to the inline K-set).
+// ---------------------------------------------------------------------------
+
+/** One node's Level-2 citation record: true count + the full union list. */
+export interface CitationSidecarEntry {
+  count: number;
+  citations: OntologyCitation[];
+}
+
+interface CitationsSidecarShape {
+  schema?: unknown;
+  graph_signature?: unknown;
+  nodes?: Record<string, CitationSidecarEntry>;
+}
+
+interface CitationsSidecarCacheEntry {
+  mtimeMs: number;
+  store: CitationsSidecarShape | null;
+}
+
+const citationsSidecarCache = new Map<string, CitationsSidecarCacheEntry>();
+
+/**
+ * Load `<stateDir>/ontology/citations.json` through an mtime-keyed in-memory
+ * index. Returns null when the store is missing/unreadable. Cached per state
+ * dir, invalidated on mtime change (an in-process rebuild is picked up).
+ */
+function loadCitationsSidecar(stateDir: string): CitationsSidecarShape | null {
+  const path = join(stateDir, "ontology", "citations.json");
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    citationsSidecarCache.delete(stateDir);
+    return null;
+  }
+  const cached = citationsSidecarCache.get(stateDir);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.store;
+
+  const store = loadJsonSafe<CitationsSidecarShape>(path);
+  citationsSidecarCache.set(stateDir, { mtimeMs, store });
+  return store;
+}
+
+/** Test seam: drop the cached citations.json index. */
+export function __resetCitationsSidecarCache(): void {
+  citationsSidecarCache.clear();
+}
+
+interface GraphFileShapeWithCitations {
+  nodes?: Array<{ id?: unknown; citations?: unknown }>;
+}
+
+/**
+ * Citation-content hash of the on-disk graph.json — a faithful replica of the
+ * pass-1 `computeCitationSignature` (src/citations.ts), which hashes the sorted
+ * projection `{ node_id -> inline citations }` over the in-memory graph. Here
+ * the projection is read from the serialized graph.json node array (toJson
+ * spreads `...attrs`, so each node's inline `citations` is verbatim). Byte-
+ * identical inline citations ⇒ identical signature; any change ⇒ a different
+ * one. Kept in lock-step with citations.ts; the union test cross-checks them.
+ */
+function computeGraphCitationSignature(stateDir: string): string {
+  const graphPath = join(stateDir, "graph.json");
+  const graph = loadJsonSafe<GraphFileShapeWithCitations>(graphPath);
+  const projection: Record<string, OntologyCitation[]> = {};
+  if (graph && Array.isArray(graph.nodes)) {
+    for (const node of graph.nodes) {
+      const id = node?.id;
+      if (typeof id !== "string" || !id) continue;
+      const inline = node?.citations;
+      if (Array.isArray(inline) && inline.length > 0) {
+        projection[id] = inline as OntologyCitation[];
+      }
+    }
+  }
+  const sortedIds = Object.keys(projection).sort();
+  const canonical = sortedIds.map((id) => [id, projection[id]] as const);
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+/**
+ * The Level-2 citation record for a node id, or undefined when the store is
+ * absent / signature-stale / has no entry for the id. The signature gate is
+ * evaluated once per (cached) store read.
+ */
+function loadCitationsForNode(stateDir: string, id: string): CitationSidecarEntry | undefined {
+  const store = loadCitationsSidecar(stateDir);
+  if (!store || !store.nodes) return undefined;
+  // Consistency gate: a content-stale store is treated as ABSENT so the client
+  // falls back to the inline K-set rather than silently mixing tiers.
+  const stamped = typeof store.graph_signature === "string" ? store.graph_signature : "";
+  if (!stamped || stamped !== computeGraphCitationSignature(stateDir)) return undefined;
+  const entry = store.nodes[id];
+  if (!entry || typeof entry !== "object") return undefined;
+  const count = typeof entry.count === "number" ? entry.count : 0;
+  const citations = Array.isArray(entry.citations) ? entry.citations : [];
+  return { count, citations };
+}
+
 export interface EntitySidecarResponse {
   id: string;
   description: { status: string; description: string | null } | null;
   occurrences: unknown;
+  /**
+   * Level-2 full per-entity citation list, lazily served (SPEC_CITATIONS.md).
+   * Present only when `ontology/citations.json` exists, its `graph_signature`
+   * matches the current graph.json, and it carries an entry for this id;
+   * undefined otherwise (the client then renders the inline K-set).
+   */
+  citations?: CitationSidecarEntry;
 }
 
 /**
@@ -261,5 +381,9 @@ export function buildEntitySidecar(stateDir: string, id: string): EntitySidecarR
     occurrences = nodes[id] ?? null;
   }
 
-  return { id, description, occurrences };
+  const citations = loadCitationsForNode(stateDir, id);
+
+  const response: EntitySidecarResponse = { id, description, occurrences };
+  if (citations) response.citations = citations;
+  return response;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,14 @@ export interface GraphNode {
   previous_status?: OntologyStatus;
   review_status?: OntologyStatus;
   citations?: OntologyCitation[];
+  /**
+   * True number of distinct citations for this entity across the whole corpus
+   * (size of the deduped union). Degree-independent "cited N times" signal,
+   * authoritative even when the inline `citations` set is trimmed to the
+   * deterministic top-K. Populated by the pre-toJson aggregation pass; the full
+   * list beyond K lives in the co-derived `citations.json`. Additive/optional.
+   */
+  citation_count?: number;
   evidence_refs?: string[];
   confidence_handle?: string;
   provenance_handle?: string;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -161,7 +161,7 @@ export async function rebuildCode(
     const { cluster, scoreAll } = await import("./cluster.js");
     const { godNodes, surprisingConnections, suggestQuestions } = await import("./analyze.js");
     const { generate } = await import("./report.js");
-    const { toJson, computeTopologySignature } = await import("./export.js");
+    const { persistGraphWithCitations, computeTopologySignature } = await import("./export.js");
 
     const root = pathResolve(watchPath);
     const scopeInventory = inspectInputScope(root, {
@@ -396,7 +396,7 @@ export async function rebuildCode(
       descriptionsComplete = result.coverage.described >= result.coverage.describable;
     }
 
-    const jsonWritten = toJson(G, communities, paths.graph, {
+    const jsonWritten = persistGraphWithCitations(G, communities, paths.graph, {
       communityLabels: labels,
       force: options.force,
     });

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -31,6 +31,7 @@ import {
   toProjectRelativePath,
 } from "./portable-artifacts.js";
 import { loadGraphFromData } from "./graph.js";
+import type { CitationAggregateMap } from "./citations.js";
 import { assertGraphJsonFileSize } from "./graph-size-guard.js";
 import { persistCommunityLabels, resolveCommunityLabels } from "./community-labels.js";
 import {
@@ -163,6 +164,14 @@ export async function rebuildCode(
      * module default (8).
      */
     citationsTopK?: number;
+    /**
+     * hook-rebuild signal: after writing graph.json, re-derive `citations.json`
+     * LLM-free with the no-shrink guard — a re-projection from a K-trimmed
+     * graph.json must never clobber a fuller existing sidecar, and when the
+     * persisted extraction output is available the full tail is rebuilt from it.
+     * Only the fast git-hook rebuild sets this.
+     */
+    citationsReproject?: boolean;
   } = {},
 ): Promise<boolean> {
   try {
@@ -411,6 +420,17 @@ export async function rebuildCode(
       descriptionsComplete = result.coverage.described >= result.coverage.describable;
     }
 
+    // hook-rebuild fidelity guard: `persistGraphWithCitations` below re-derives
+    // `citations.json` from the (already K-trimmed) in-memory graph, which would
+    // SHRINK a fuller existing sidecar. Snapshot the rich store BEFORE the write
+    // so the re-projection can restore the exhaustive tail (it is no longer on
+    // disk once persist overwrites it).
+    let priorCitationsSidecar: CitationAggregateMap | null = null;
+    if (options.citationsReproject) {
+      const { readCitationsSidecar } = await import("./citations.js");
+      priorCitationsSidecar = readCitationsSidecar(dirname(paths.graph));
+    }
+
     const jsonWritten = persistGraphWithCitations(G, communities, paths.graph, {
       communityLabels: labels,
       force: options.force,
@@ -419,6 +439,20 @@ export async function rebuildCode(
     if (!jsonWritten) {
       return false;
     }
+
+    // Re-run the LLM-free re-projection with the no-shrink guard so the
+    // exhaustive tail survives — rebuilding from the persisted extraction output
+    // when present, else preserving the pre-write snapshot. No-op when no node
+    // carries citations. Only fires for the git hook (full builds skip this).
+    if (options.citationsReproject) {
+      const { reprojectCitationsLLMFree } = await import("./citations.js");
+      reprojectCitationsLLMFree(G, dirname(paths.graph), {
+        ...(options.citationsTopK !== undefined ? { topK: options.citationsTopK } : {}),
+        ...(existsSync(paths.scratch.extract) ? { extractionPath: paths.scratch.extract } : {}),
+        priorSidecar: priorCitationsSidecar,
+      });
+    }
+
     persistCommunityLabels(labels, paths.scratch.labels);
     writeFileSync(paths.report, report, "utf-8");
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -149,6 +149,20 @@ export async function rebuildCode(
      * only when THIS flag is set — never merely because `describe === false`.
      */
     markDescribePending?: boolean;
+    /**
+     * Per-node citation cap injected into the description prompt. Forwarded to
+     * `generateNodeDescriptions`. Resolved from corpus type by the CLI when a
+     * `--citation-cap` flag is absent; undefined here → the node-descriptions
+     * resolved default (10).
+     */
+    citationCap?: number | "all";
+    /**
+     * Inline Level-1 citations kept per node in graph.json (the K-bounded set).
+     * Forwarded to `persistGraphWithCitations`. Resolved from corpus type by the
+     * CLI when a `--citations-top-k` flag is absent; undefined → the citations
+     * module default (8).
+     */
+    citationsTopK?: number;
   } = {},
 ): Promise<boolean> {
   try {
@@ -388,6 +402,7 @@ export async function rebuildCode(
         ...(options.descriptionMaxNodes !== undefined ? { maxNodes: options.descriptionMaxNodes } : {}),
         ...(options.descriptionOnlyMissing ? { onlyMissing: true } : {}),
         ...(options.descriptionMode ? { mode: options.descriptionMode } : {}),
+        ...(options.citationCap !== undefined ? { citationCap: options.citationCap } : {}),
         instructionDir: join(paths.stateDir, "description-instructions"),
       });
       // "Complete" = every describable node now has a description. When a backend
@@ -399,6 +414,7 @@ export async function rebuildCode(
     const jsonWritten = persistGraphWithCitations(G, communities, paths.graph, {
       communityLabels: labels,
       force: options.force,
+      ...(options.citationsTopK !== undefined ? { citations: { topK: options.citationsTopK } } : {}),
     });
     if (!jsonWritten) {
       return false;
@@ -670,6 +686,8 @@ export async function watch(
   options: {
     scope?: GraphifyInputScopeMode;
     scopeSource?: InputScopeSource;
+    /** Inline Level-1 citations kept per node in graph.json. Default: corpus-resolved. */
+    citationsTopK?: number;
   } = {},
 ): Promise<void> {
   let chokidar: typeof import("chokidar");

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -14,6 +14,7 @@
     nodeCommunity,
     nodeSourcePath,
     citationsByFile,
+    citationsByFileFrom,
   } from "../lib/graphAdapter.js";
   import { renderInlineMarkdown } from "../lib/markdown.js";
 
@@ -21,9 +22,27 @@
 
   const node = $derived(focusId ? (indexNodes(graph).get(focusId) ?? null) : null);
   const relations = $derived(focusId ? relationRowsFor(focusId, graph) : []);
-  // SVELTE-2: citations grouped by file (file > passages double accordion).
-  const citationFiles = $derived(node ? citationsByFile(node) : []);
-  const citationTotal = $derived(citationFiles.reduce((n, f) => n + f.count, 0));
+  // SVELTE-2 + exhaustive-citations: the inline node.citations (K-bounded set)
+  // renders INSTANTLY off the already-loaded graph. When the lazy entity sidecar
+  // arrives with the full per-entity list (entity.citations.citations), it
+  // REPLACES the inline render with the complete file > passages accordion —
+  // same renderer, richer data. Passages render locators (section/page); the
+  // schema carries no verbatim quote.
+  const fullCitations = $derived(
+    Array.isArray(entity?.citations?.citations) ? entity.citations.citations : null,
+  );
+  const citationFiles = $derived.by(() => {
+    if (!node) return [];
+    if (fullCitations) return citationsByFileFrom(fullCitations, node.source_file ?? null);
+    return citationsByFile(node);
+  });
+  // Level-1: the Citations header shows the TRUE count (node.citation_count),
+  // so a hub reads "Citations (214)" immediately, before the full list loads.
+  // Old graphs (no citation_count) fall back to summing the inline citations.
+  const citationTotal = $derived.by(() => {
+    if (node && typeof node.citation_count === "number") return node.citation_count;
+    return citationFiles.reduce((n, f) => n + f.count, 0);
+  });
   const description = $derived.by(() => {
     const sidecar = entity?.description;
     if (sidecar && sidecar.status === "generated" && typeof sidecar.description === "string") {

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -693,17 +693,23 @@ export function communityStats(graph) {
 }
 
 /**
- * SVELTE-2: group a node's citations by source file, with their passages.
- * Each citation is `{ source_file, section?, quote? }`. Returns one entry per
- * distinct file, with its passages (section + optional verbatim quote). Used by
- * the entity panel's double accordion (file > passages) for full traceability.
+ * SVELTE-2: group an EXPLICIT citation list by source file, with their
+ * passages. Each citation is `{ source_file, section?, page?, quote? }`. Used
+ * for the citations lazy upgrade: the panel feeds the inline K-set (instant)
+ * first, then the sidecar's full per-entity list once `fetchEntity` resolves —
+ * the same renderer over richer data. `fallbackSourceFile` covers citations
+ * with no own `source_file` (legacy graphs). Passages render LOCATORS
+ * (section/page); there is no verbatim `quote` field in the citation schema, so
+ * `quote` stays null on the new lazy path (the render guards on it).
+ * @param {Array<object>|null|undefined} list
+ * @param {string|null} [fallbackSourceFile]
  * @returns {{ file: string, count: number, passages: { section: string|null, quote: string|null }[] }[]}
  */
-export function citationsByFile(node) {
-  const cites = Array.isArray(node?.citations) ? node.citations : [];
+export function citationsByFileFrom(list, fallbackSourceFile = null) {
+  const cites = Array.isArray(list) ? list : [];
   const byFile = new Map();
   for (const c of cites) {
-    const file = displayValue(c?.source_file) ?? displayValue(node?.source_file) ?? "(unknown source)";
+    const file = displayValue(c?.source_file) ?? displayValue(fallbackSourceFile) ?? "(unknown source)";
     if (!byFile.has(file)) byFile.set(file, []);
     byFile.get(file).push({
       section: displayValue(c?.section) ?? null,
@@ -713,6 +719,18 @@ export function citationsByFile(node) {
   return [...byFile.entries()]
     .map(([file, passages]) => ({ file, count: passages.length, passages }))
     .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+}
+
+/**
+ * SVELTE-2: group a node's inline citations by source file. Thin wrapper over
+ * {@link citationsByFileFrom} that reads `node.citations` (now the K-bounded
+ * inline set) and falls back to `node.source_file`. Renders instantly off the
+ * already-loaded graph; the lazy upgrade calls `citationsByFileFrom` directly
+ * with the sidecar's full list.
+ * @returns {{ file: string, count: number, passages: { section: string|null, quote: string|null }[] }[]}
+ */
+export function citationsByFile(node) {
+  return citationsByFileFrom(node?.citations, node?.source_file ?? null);
 }
 
 /**

--- a/studio/src/tests/entityPanel.test.js
+++ b/studio/src/tests/entityPanel.test.js
@@ -40,3 +40,27 @@ describe("EntityPanel description", () => {
     expect(panelSource).toMatch(/\.entity-description\s*{[\s\S]*font-size:\s*0\.9rem;[\s\S]*}/);
   });
 });
+
+describe("EntityPanel citations (exhaustive-citations Level-1/Level-2)", () => {
+  it("Citations header count reads node.citation_count (true count), not the inline sum", () => {
+    // A hub reads "Citations (214)" immediately from the Level-1 true count;
+    // only old graphs (no citation_count) fall back to the inline length.
+    expect(panelSource).toMatch(/node\.citation_count/);
+    expect(panelSource).toMatch(/typeof node\.citation_count === "number"/);
+    // The count is fed to the Citations accordion.
+    expect(panelSource).toMatch(/<Accordion title="Citations" count=\{citationTotal\}/);
+  });
+
+  it("renders the inline K-set instantly, then upgrades to the sidecar's full list", () => {
+    // Inline node.citations (K-set) renders before the fetch resolves; when the
+    // lazy sidecar arrives with citations.citations, the full list replaces it.
+    expect(panelSource).toMatch(/citationsByFileFrom/);
+    expect(panelSource).toMatch(/entity\?\.citations\?\.citations/);
+    // The full list is preferred over the inline node citations when present.
+    expect(panelSource).toMatch(/Array\.isArray\(entity\?\.citations\?\.citations\)/);
+  });
+
+  it("imports citationsByFileFrom for the lazy upgrade", () => {
+    expect(panelSource).toMatch(/citationsByFileFrom/);
+  });
+});

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -262,6 +262,31 @@ describe("citationsByFile (SVELTE-2)", () => {
     const g = citationsByFile({ source_file: "x.txt", citations: [{ section: "s" }] });
     expect(g[0].file).toBe("x.txt");
   });
+
+  it("citationsByFileFrom groups an explicit citation list (lazy sidecar upgrade)", async () => {
+    const { citationsByFileFrom, citationsByFile } = await import("../lib/graphAdapter.js");
+    // The full sidecar list (more than the inline K-set on the node) groups the
+    // same way as citationsByFile(node) does over node.citations.
+    const fullList = [
+      { source_file: "a.txt", section: "ch1" },
+      { source_file: "a.txt", section: "ch2" },
+      { source_file: "b.txt", page: 5 },
+      { source_file: "c.txt", section: "intro" },
+    ];
+    const groups = citationsByFileFrom(fullList);
+    expect(groups.map((g) => g.file)).toEqual(["a.txt", "b.txt", "c.txt"]);
+    expect(groups.find((g) => g.file === "a.txt").count).toBe(2);
+    // Parity: citationsByFile(node) delegates to citationsByFileFrom(node.citations).
+    expect(citationsByFile({ citations: fullList })).toEqual(groups);
+  });
+
+  it("citationsByFileFrom accepts a fallback source_file and handles empty", async () => {
+    const { citationsByFileFrom } = await import("../lib/graphAdapter.js");
+    expect(citationsByFileFrom([])).toEqual([]);
+    expect(citationsByFileFrom(null)).toEqual([]);
+    const g = citationsByFileFrom([{ section: "s" }], "x.txt");
+    expect(g[0].file).toBe("x.txt");
+  });
 });
 
 describe("candidateSubgraph (SVELTE-7)", () => {

--- a/tests/citation-policy.test.ts
+++ b/tests/citation-policy.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  CITATION_POLICY_GLOBAL_DEFAULT,
+  resolveCitationPolicy,
+  resolveCorpusType,
+} from "../src/citation-policy.js";
+
+/**
+ * A minimal `.graphify_detect.json`-shaped fixture. `resolveCorpusType` reads
+ * only `files` buckets + `total_words`; everything else is ignored.
+ */
+function detect(
+  files: Partial<Record<"code" | "document" | "paper" | "image" | "video", number>>,
+  totalWords = 0,
+): { files: Record<string, string[]>; total_words: number } {
+  const buckets: Record<string, string[]> = {
+    code: [], document: [], paper: [], image: [], video: [],
+  };
+  for (const [bucket, count] of Object.entries(files)) {
+    buckets[bucket] = Array.from({ length: count ?? 0 }, (_v, i) => `${bucket}/${i}.txt`);
+  }
+  const total_files = Object.values(buckets).reduce((s, v) => s + v.length, 0);
+  return { files: buckets, total_words: totalWords, total_files } as never;
+}
+
+describe("resolveCorpusType", () => {
+  it("classifies a code-only corpus as 'code'", () => {
+    expect(resolveCorpusType(detect({ code: 40 }, 12_000))).toBe("code");
+  });
+
+  it("classifies long-form prose above the corpus-warn threshold as 'long-document'", () => {
+    // documents present + total_words past the 50k warn threshold.
+    expect(resolveCorpusType(detect({ document: 12 }, 120_000))).toBe("long-document");
+  });
+
+  it("classifies a paper-heavy corpus above the threshold as 'long-document'", () => {
+    expect(resolveCorpusType(detect({ paper: 8 }, 80_000))).toBe("long-document");
+  });
+
+  it("classifies ontology/profile mode as 'entity-corpus' regardless of buckets", () => {
+    expect(resolveCorpusType(detect({ document: 3 }, 1_000), { profileMode: true })).toBe(
+      "entity-corpus",
+    );
+  });
+
+  it("falls back to 'mixed' for a small mixed corpus below the threshold", () => {
+    expect(resolveCorpusType(detect({ code: 5, document: 3 }, 5_000))).toBe("mixed");
+  });
+
+  it("treats short documents (below warn threshold) as 'mixed', not 'long-document'", () => {
+    expect(resolveCorpusType(detect({ document: 2 }, 4_000))).toBe("mixed");
+  });
+
+  it("treats a missing / empty detect as 'mixed'", () => {
+    expect(resolveCorpusType(null)).toBe("mixed");
+    expect(resolveCorpusType({} as never)).toBe("mixed");
+  });
+});
+
+describe("resolveCitationPolicy — corpus-type defaults", () => {
+  it("code → describe cap 3, inline K 3", () => {
+    const p = resolveCitationPolicy({ corpusType: "code" });
+    expect(p.describeCap).toBe(3);
+    expect(p.inlineTopK).toBe(3);
+  });
+
+  it("mixed (default) → describe cap 10, inline K 8", () => {
+    const p = resolveCitationPolicy({ corpusType: "mixed" });
+    expect(p.describeCap).toBe(10);
+    expect(p.inlineTopK).toBe(8);
+  });
+
+  it("long-document → describe cap 'all', inline K 8", () => {
+    const p = resolveCitationPolicy({ corpusType: "long-document" });
+    expect(p.describeCap).toBe("all");
+    expect(p.inlineTopK).toBe(8);
+  });
+
+  it("entity-corpus → describe cap 'all', inline K 8", () => {
+    const p = resolveCitationPolicy({ corpusType: "entity-corpus" });
+    expect(p.describeCap).toBe("all");
+    expect(p.inlineTopK).toBe(8);
+  });
+
+  it("no corpus type → the global default (cap 10, K 8)", () => {
+    const p = resolveCitationPolicy({});
+    expect(p.describeCap).toBe(CITATION_POLICY_GLOBAL_DEFAULT.describeCap);
+    expect(p.inlineTopK).toBe(CITATION_POLICY_GLOBAL_DEFAULT.inlineTopK);
+    expect(p.describeCap).toBe(10);
+    expect(p.inlineTopK).toBe(8);
+  });
+});
+
+describe("resolveCitationPolicy — precedence (CLI > config > corpus-type > global)", () => {
+  it("CLI flag overrides everything", () => {
+    const p = resolveCitationPolicy({
+      corpusType: "long-document", // would give cap 'all'
+      config: { describeCap: 25, inlineTopK: 12 },
+      cli: { describeCap: 4, inlineTopK: 2 },
+    });
+    expect(p.describeCap).toBe(4);
+    expect(p.inlineTopK).toBe(2);
+  });
+
+  it("config overrides corpus-type default when no CLI flag", () => {
+    const p = resolveCitationPolicy({
+      corpusType: "code", // would give cap 3 / K 3
+      config: { describeCap: 50, inlineTopK: 6 },
+    });
+    expect(p.describeCap).toBe(50);
+    expect(p.inlineTopK).toBe(6);
+  });
+
+  it("corpus-type default applies when neither CLI nor config set it", () => {
+    const p = resolveCitationPolicy({ corpusType: "code" });
+    expect(p.describeCap).toBe(3);
+    expect(p.inlineTopK).toBe(3);
+  });
+
+  it("the two knobs resolve independently (CLI K only, config cap only)", () => {
+    const p = resolveCitationPolicy({
+      corpusType: "long-document",
+      config: { describeCap: 30 },
+      cli: { inlineTopK: 5 },
+    });
+    // cap: no CLI cap → config cap 30 wins over corpus 'all'
+    expect(p.describeCap).toBe(30);
+    // K: CLI K 5 wins over corpus 8
+    expect(p.inlineTopK).toBe(5);
+  });
+
+  it("accepts 'all' as a CLI describe cap override", () => {
+    const p = resolveCitationPolicy({ corpusType: "code", cli: { describeCap: "all" } });
+    expect(p.describeCap).toBe("all");
+  });
+});

--- a/tests/citations-backfill.test.ts
+++ b/tests/citations-backfill.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `backfill-citations`: project legacy `citations[]` into the new schema
+ * (`citation_count` + K-trimmed inline + co-derived `citations.json`) WITHOUT a
+ * re-extract. Counts are a LOWER BOUND (the bounded graph never held the full
+ * union). Idempotent on a second run.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import { backfillCitations, CITATIONS_INLINE_TOP_K } from "../src/citations.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-backfill-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+function legacyGraph(citationCount: number): Graph {
+  const G = new Graph();
+  const citations: OntologyCitation[] = [];
+  for (let i = 0; i < citationCount; i += 1) {
+    citations.push({ source_file: `work${i % 10}.txt`, page: i, section: `ch${i % 3}` });
+  }
+  // legacy node: has `citations[]` but NO `citation_count`.
+  G.addNode("sherlock", { label: "Sherlock", citations });
+  G.addNode("bare", { label: "Bare" });
+  return G;
+}
+
+describe("backfillCitations", () => {
+  it("populates citation_count, trims inline to K, and writes citations.json", () => {
+    const dir = tempDir();
+    const G = legacyGraph(20);
+    const result = backfillCitations(G, dir, { topK: CITATIONS_INLINE_TOP_K });
+
+    expect(G.getNodeAttribute("sherlock", "citation_count")).toBe(20);
+    expect((G.getNodeAttribute("sherlock", "citations") as OntologyCitation[]).length).toBe(
+      CITATIONS_INLINE_TOP_K,
+    );
+    expect(result.backfilledNodes).toBe(1);
+    expect(result.sidecarPath).not.toBeNull();
+    expect(result.lowerBound).toBe(true);
+
+    const sidecar = JSON.parse(readFileSync(join(dir, "ontology", "citations.json"), "utf-8")) as {
+      nodes: Record<string, { count: number; citations: OntologyCitation[] }>;
+    };
+    expect(sidecar.nodes.sherlock.count).toBe(20);
+    expect(sidecar.nodes.sherlock.citations).toHaveLength(20);
+    // bare node never gains a count or a sidecar entry.
+    expect(G.getNodeAttribute("bare", "citation_count")).toBeUndefined();
+    expect(sidecar.nodes.bare).toBeUndefined();
+  });
+
+  it("count = size of the deduped union, not the raw legacy list length", () => {
+    const dir = tempDir();
+    const G = new Graph();
+    G.addNode("dupy", {
+      citations: [
+        { source_file: "a.txt", page: 1 },
+        { source_file: "a.txt", page: 1 }, // exact dup
+        { source_file: "b.txt", page: 2 },
+      ],
+    });
+    backfillCitations(G, dir, {});
+    expect(G.getNodeAttribute("dupy", "citation_count")).toBe(2);
+  });
+
+  it("is a no-op on a second run (idempotent — already has citation_count)", () => {
+    const dir = tempDir();
+    const G = legacyGraph(20);
+    const first = backfillCitations(G, dir, {});
+    expect(first.backfilledNodes).toBe(1);
+
+    const inlineAfterFirst = JSON.stringify(G.getNodeAttribute("sherlock", "citations"));
+    const countAfterFirst = G.getNodeAttribute("sherlock", "citation_count");
+
+    const second = backfillCitations(G, dir, {});
+    // Nothing left to backfill: every legacy node already has a citation_count.
+    expect(second.backfilledNodes).toBe(0);
+    expect(G.getNodeAttribute("sherlock", "citation_count")).toBe(countAfterFirst);
+    expect(JSON.stringify(G.getNodeAttribute("sherlock", "citations"))).toBe(inlineAfterFirst);
+  });
+
+  it("skips nodes that already carry a citation_count (exhaustive nodes untouched)", () => {
+    const dir = tempDir();
+    const G = new Graph();
+    // already-projected node: has citation_count + a trimmed inline set.
+    G.addNode("hub", {
+      citation_count: 500,
+      citations: [{ source_file: "x.txt", page: 1 }],
+    });
+    const result = backfillCitations(G, dir, {});
+    expect(result.backfilledNodes).toBe(0);
+    // The true count is preserved (NOT downgraded to the trimmed inline length).
+    expect(G.getNodeAttribute("hub", "citation_count")).toBe(500);
+  });
+
+  it("writes no sidecar when there is nothing to backfill", () => {
+    const dir = tempDir();
+    const G = new Graph();
+    G.addNode("x", { label: "X" }); // no citations at all
+    const result = backfillCitations(G, dir, {});
+    expect(result.backfilledNodes).toBe(0);
+    expect(result.sidecarPath).toBeNull();
+    expect(existsSync(join(dir, "ontology", "citations.json"))).toBe(false);
+  });
+});

--- a/tests/citations-describe-existing-graph.test.ts
+++ b/tests/citations-describe-existing-graph.test.ts
@@ -1,0 +1,183 @@
+/**
+ * F4: `describe --citation-cap all` on an EXISTING graph must not be clamped by
+ * the K-trimmed inline `citations`. On the describe-on-existing-graph path the
+ * node's in-memory `citations` is already trimmed to <= K, so a cap of all/50 on
+ * a long-doc hub would inject at most K snippets — defeating "ground on many
+ * distinct sources". The fix loads citations.json and feeds the fuller per-node
+ * set into the node context.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import { collectNodeContext } from "../src/node-descriptions.js";
+import { writeCitationsSidecar } from "../src/citations.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-describe-existing-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+function cites(n: number): OntologyCitation[] {
+  const out: OntologyCitation[] = [];
+  for (let i = 0; i < n; i += 1) out.push({ source_file: `work${i}.txt`, page: i + 1, section: `ch${i}` });
+  return out;
+}
+
+describe("F4 unit: collectNodeContext citationsByNode override", () => {
+  function hub(inlineK: number): Graph {
+    const G = new Graph({ type: "undirected" });
+    G.addNode("ent_hub", { label: "Hub", node_type: "Person", citations: cites(inlineK) });
+    G.addNode("ent_other", { label: "Other", node_type: "Place" });
+    G.addUndirectedEdge("ent_hub", "ent_other", { relation: "knows" });
+    return G;
+  }
+
+  it("injects up to 20 snippets from the override when cap=all (inline trimmed to 8)", () => {
+    const G = hub(8);
+    const ctx = collectNodeContext(G, "ent_hub", {
+      citationCap: "all",
+      citationsByNode: { ent_hub: cites(20) },
+    });
+    expect(ctx.citations).toHaveLength(20);
+  });
+
+  it("still respects a low cap (3) even with a fuller override", () => {
+    const G = hub(8);
+    const ctx = collectNodeContext(G, "ent_hub", {
+      citationCap: 3,
+      citationsByNode: { ent_hub: cites(20) },
+    });
+    expect(ctx.citations).toHaveLength(3);
+  });
+
+  it("falls back to inline when no override entry for the node", () => {
+    const G = hub(8);
+    const ctx = collectNodeContext(G, "ent_hub", {
+      citationCap: "all",
+      citationsByNode: { someOtherId: cites(20) },
+    });
+    expect(ctx.citations).toHaveLength(8);
+  });
+
+  it("keeps inline when the override is SMALLER than inline (never shrinks)", () => {
+    const G = hub(8);
+    const ctx = collectNodeContext(G, "ent_hub", {
+      citationCap: "all",
+      citationsByNode: { ent_hub: cites(2) },
+    });
+    expect(ctx.citations).toHaveLength(8);
+  });
+});
+
+describe("F4 e2e: describe --citation-cap all reads citations.json on the existing-graph path", () => {
+  async function runDescribe(root: string, citationCap: string | undefined): Promise<void> {
+    const { main } = await import("../src/cli.js");
+    const argv = ["node", "graphify", "describe", root, "--description-mode", "assistant"];
+    if (citationCap !== undefined) argv.push("--citation-cap", citationCap);
+    const originalArgv = process.argv;
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    console.log = () => {};
+    console.warn = () => {};
+    console.error = () => {};
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    process.argv = argv;
+    try {
+      await main();
+    } finally {
+      process.argv = originalArgv;
+      console.log = originalLog;
+      console.warn = originalWarn;
+      console.error = originalError;
+      process.stderr.write = originalWrite;
+    }
+  }
+
+  function setupProject(inlineK: number, fullCount: number): string {
+    const root = tempDir();
+    const stateDir = join(root, ".graphify");
+    mkdirSync(stateDir, { recursive: true });
+
+    const inline = cites(inlineK);
+    const graph = {
+      directed: false,
+      multigraph: false,
+      graph: { topology_signature: "sig", freshness: {} },
+      nodes: [
+        {
+          id: "ent_hub",
+          label: "Hub",
+          node_type: "Person",
+          file_type: "document",
+          source_file: "work0.txt",
+          community: 0,
+          community_name: "Community 0",
+          citation_count: fullCount,
+          citations: inline,
+        },
+        {
+          id: "ent_other",
+          label: "Other",
+          node_type: "Place",
+          file_type: "document",
+          source_file: "work1.txt",
+          community: 0,
+          community_name: "Community 0",
+        },
+      ],
+      links: [{ source: "ent_hub", target: "ent_other", relation: "knows", confidence: "EXTRACTED", confidence_score: 1.0 }],
+      community_labels: { "0": "Community 0" },
+      hyperedges: [],
+    };
+    writeFileSync(join(stateDir, "graph.json"), JSON.stringify(graph, null, 2), "utf-8");
+
+    // The full per-node citation set lives in citations.json.
+    const G = new Graph();
+    G.addNode("ent_hub", { citations: inline });
+    writeCitationsSidecar(stateDir, { ent_hub: { count: fullCount, citations: cites(fullCount) } }, G);
+    return root;
+  }
+
+  function countSnippets(prompt: string): number {
+    const m = prompt.match(/citations=\[([^\]]*)\]/);
+    if (!m || !m[1].trim()) return 0;
+    return m[1].split(/",\s*"/).length;
+  }
+
+  function emittedPrompt(root: string): string {
+    const dir = join(root, ".graphify", "description-instructions");
+    const md = readdirSync(dir).find((f) => f.endsWith(".md"));
+    if (!md) return "";
+    return readFileSync(join(dir, md), "utf-8");
+  }
+
+  it("injects >K (up to 20) snippets when citations.json holds 20 and cap=all", async () => {
+    const root = setupProject(8, 20);
+    await runDescribe(root, "all");
+    expect(countSnippets(emittedPrompt(root))).toBe(20);
+  });
+
+  it("still caps at 3 when cap=3 even with a 20-citation sidecar", async () => {
+    const root = setupProject(8, 20);
+    await runDescribe(root, "3");
+    expect(countSnippets(emittedPrompt(root))).toBe(3);
+  });
+
+  it("falls back to inline (8) when no sidecar is present", async () => {
+    const root = setupProject(8, 20);
+    // Remove the sidecar so only the inline K-set is available.
+    rmSync(join(root, ".graphify", "ontology", "citations.json"), { force: true });
+    await runDescribe(root, "all");
+    expect(countSnippets(emittedPrompt(root))).toBe(8);
+  });
+});

--- a/tests/citations-finalize-update.test.ts
+++ b/tests/citations-finalize-update.test.ts
@@ -1,0 +1,257 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import {
+  aggregateCitations,
+  CITATIONS_INLINE_TOP_K,
+  readCitationsSidecar,
+  writeCitationsSidecar,
+  type CitationAggregateMap,
+} from "../src/citations.js";
+import { persistGraphWithCitations } from "../src/export.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-finalize-update-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+function cite(i: number): OntologyCitation {
+  return { source_file: `work${i % 25}.txt`, page: i, section: `ch${i % 7}` };
+}
+
+/**
+ * F1 regression. The live `/graphify update` -> finalize-update path loads the
+ * prior exhaustive graph (full union in citations.json, K-trimmed inline in
+ * graph.json) and a fresh re-extraction of a hub that brings ONE new/overlapping
+ * citation. The prior FULL union must be recovered (not the trimmed inline
+ * K-set), so the node ends count == |prior_full ∪ fresh|, inline == K, and
+ * citations.json holds the full union — never count:N / list:1.
+ */
+describe("F1: aggregateCitations(priorSidecar) recovers the exhaustive tail", () => {
+  it("unions the prior FULL per-node set (from the sidecar) with the fresh extraction", () => {
+    // Prior FULL union: 214 distinct citations (lives in citations.json).
+    const priorFull: OntologyCitation[] = [];
+    for (let i = 0; i < 214; i += 1) priorFull.push(cite(i));
+    const priorSidecar: CitationAggregateMap = {
+      hub: { count: 214, citations: priorFull },
+    };
+
+    // Fresh re-extraction: the hub re-appears but the chunk only carries ONE
+    // overlapping citation (the K-trim + last-write-wins lost the tail). This is
+    // exactly the inconsistent count:214 / inline:1 case from the finding.
+    const G = new Graph();
+    G.addNode("hub", {
+      label: "Hub",
+      source_file: "work0.txt",
+      file_type: "document",
+      // A stale count survives mergeNode (fresh node had none); the fresh inline
+      // is a single citation.
+      citation_count: 214,
+      citations: [cite(0)],
+    });
+
+    const map = aggregateCitations(G, { priorSidecar });
+
+    // The node ends with the TRUE union size (prior 214 ∪ fresh {0} = 214).
+    expect(G.getNodeAttribute("hub", "citation_count")).toBe(214);
+    const inline = G.getNodeAttribute("hub", "citations") as OntologyCitation[];
+    expect(inline).toHaveLength(CITATIONS_INLINE_TOP_K);
+    // Inline ⊆ union.
+    const unionKeys = new Set(map.hub.citations.map((c) => `${c.source_file}|${c.page}|${c.section}`));
+    for (const c of inline) {
+      expect(unionKeys.has(`${c.source_file}|${c.page}|${c.section}`)).toBe(true);
+    }
+    // citations.json carries the FULL union, NOT the trimmed inline.
+    expect(map.hub.count).toBe(214);
+    expect(map.hub.citations).toHaveLength(214);
+  });
+
+  it("adds a genuinely new fresh citation to the prior union (count grows)", () => {
+    const priorFull: OntologyCitation[] = [];
+    for (let i = 0; i < 10; i += 1) priorFull.push(cite(i));
+    const priorSidecar: CitationAggregateMap = {
+      hub: { count: 10, citations: priorFull },
+    };
+
+    const G = new Graph();
+    G.addNode("hub", {
+      label: "Hub",
+      source_file: "work0.txt",
+      file_type: "document",
+      citation_count: 10,
+      // Fresh chunk introduces a brand-new citation (page 999) plus an overlap.
+      citations: [cite(0), { source_file: "newwork.txt", page: 999, section: "ch0" }],
+    });
+
+    const map = aggregateCitations(G, { priorSidecar });
+    expect(map.hub.count).toBe(11);
+    expect(G.getNodeAttribute("hub", "citation_count")).toBe(11);
+    expect(map.hub.citations).toHaveLength(11);
+  });
+
+  it("persistGraphWithCitations(priorSidecar) writes the full union to citations.json", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+
+    const priorFull: OntologyCitation[] = [];
+    for (let i = 0; i < 214; i += 1) priorFull.push(cite(i));
+    const priorSidecar: CitationAggregateMap = {
+      hub: { count: 214, citations: priorFull },
+    };
+
+    const G = new Graph();
+    G.addNode("hub", {
+      label: "Hub",
+      source_file: "work0.txt",
+      file_type: "document",
+      citation_count: 214,
+      citations: [cite(0)],
+    });
+
+    const written = persistGraphWithCitations(G, new Map([[0, ["hub"]]]), graphPath, {
+      force: true,
+      citations: { priorSidecar },
+    });
+    expect(written).toBe(true);
+
+    const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+      nodes: Array<{ id: string; citations?: unknown[]; citation_count?: number }>;
+    };
+    const hub = graph.nodes.find((n) => n.id === "hub")!;
+    expect(hub.citation_count).toBe(214);
+    expect(hub.citations).toHaveLength(CITATIONS_INLINE_TOP_K);
+
+    const sidecarPath = join(dir, "ontology", "citations.json");
+    expect(existsSync(sidecarPath)).toBe(true);
+    const sidecar = readCitationsSidecar(dir)!;
+    // The full union (214), NOT count:214 / list:1.
+    expect(sidecar.hub.count).toBe(214);
+    expect(sidecar.hub.citations).toHaveLength(214);
+  });
+});
+
+/**
+ * End-to-end F1: the actual `merge-update` runtime subcommand. Mirrors the live
+ * `/graphify update` flow — load an existing exhaustive graph (K-trimmed inline,
+ * full tail in citations.json), merge a fresh re-extraction of the hub that
+ * brings one overlapping citation, and confirm mergeGraphs unions inline +
+ * persist recovers the FULL prior tail from the snapshot (never count:N/list:1).
+ */
+describe("F1 e2e: merge-update recovers the exhaustive tail via the prior sidecar", () => {
+  async function runRuntime(args: string[]): Promise<void> {
+    const { main } = await import("../src/skill-runtime.js");
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    console.log = () => {};
+    console.warn = () => {};
+    try {
+      await main(["node", "skill-runtime", ...args]);
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+    }
+  }
+
+  it("does not lock a stale count and writes the full union to citations.json", async () => {
+    const root = tempDir();
+    const stateDir = join(root, ".graphify");
+    mkdirSync(stateDir, { recursive: true });
+    const graphPath = join(stateDir, "graph.json");
+
+    // Prior exhaustive graph: hub with K-trimmed inline + stale-but-true count.
+    const priorFull: OntologyCitation[] = [];
+    for (let i = 0; i < 214; i += 1) priorFull.push(cite(i));
+    const inline = priorFull.slice(0, CITATIONS_INLINE_TOP_K);
+    const priorGraph = {
+      directed: false,
+      multigraph: false,
+      graph: {},
+      nodes: [
+        {
+          id: "hub",
+          label: "Hub",
+          source_file: "work0.txt",
+          file_type: "document",
+          citation_count: 214,
+          citations: inline,
+        },
+        { id: "spoke", label: "Spoke", source_file: "work1.txt", file_type: "document" },
+      ],
+      links: [{ source: "hub", target: "spoke", relation: "mentions" }],
+    };
+    writeFileSync(graphPath, JSON.stringify(priorGraph, null, 2), "utf-8");
+
+    // The FULL tail lives in the co-derived citations.json.
+    const G = new Graph();
+    G.addNode("hub", { citations: inline });
+    writeCitationsSidecar(stateDir, { hub: { count: 214, citations: priorFull } }, G);
+
+    // Fresh re-extraction: hub re-appears carrying only ONE overlapping citation.
+    const extractPath = join(stateDir, "extract.json");
+    writeFileSync(
+      extractPath,
+      JSON.stringify({
+        nodes: [
+          {
+            id: "hub",
+            label: "Hub",
+            source_file: "work0.txt",
+            file_type: "document",
+            citations: [cite(0)],
+          },
+          { id: "spoke", label: "Spoke", source_file: "work1.txt", file_type: "document" },
+        ],
+        edges: [{ source: "hub", target: "spoke", relation: "mentions" }],
+        input_tokens: 0,
+        output_tokens: 0,
+      }),
+      "utf-8",
+    );
+
+    const detectPath = join(stateDir, "detect.json");
+    writeFileSync(
+      detectPath,
+      JSON.stringify({
+        files: { code: [], document: ["work0.txt", "work1.txt"], paper: [], image: [], video: [] },
+        total_files: 2,
+        total_words: 1000,
+        needs_graph: false,
+        skipped_sensitive: [],
+        graphifyignore_patterns: 0,
+      }),
+      "utf-8",
+    );
+
+    await runRuntime([
+      "merge-update",
+      "--existing-graph", graphPath,
+      "--extract", extractPath,
+      "--detect", detectPath,
+      "--root", root,
+      "--graph-out", graphPath,
+      "--report-out", join(stateDir, "report.md"),
+      "--analysis-out", join(stateDir, "analysis.json"),
+    ]);
+
+    const out = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+      nodes: Array<{ id: string; citations?: unknown[]; citation_count?: number }>;
+    };
+    const hub = out.nodes.find((n) => n.id === "hub")!;
+    // The stale count is NOT locked; the inline is K-bounded.
+    expect(hub.citation_count).toBe(214);
+    expect(hub.citations).toHaveLength(CITATIONS_INLINE_TOP_K);
+
+    // citations.json holds the FULL union (214), NOT count:214 / list:1.
+    const sidecar = readCitationsSidecar(stateDir)!;
+    expect(sidecar.hub.count).toBe(214);
+    expect(sidecar.hub.citations).toHaveLength(214);
+  });
+});

--- a/tests/citations-merge-subcommands.test.ts
+++ b/tests/citations-merge-subcommands.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-merge-subcommands-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+async function runRuntime(args: string[]): Promise<void> {
+  const { main } = await import("../src/skill-runtime.js");
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    await main(["node", "skill-runtime", ...args]);
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+function node(id: string, citations: OntologyCitation[]) {
+  return { id, label: id, source_file: "doc.txt", file_type: "document" as const, citations };
+}
+
+function writeExtraction(path: string, nodes: ReturnType<typeof node>[]): void {
+  writeFileSync(
+    path,
+    JSON.stringify({ nodes, edges: [], hyperedges: [], input_tokens: 0, output_tokens: 0 }),
+    "utf-8",
+  );
+}
+
+describe("F2: standalone merge-semantic / merge-extraction fold dup citations", () => {
+  it("merge-semantic unions a duplicate node's citations instead of dropping them", async () => {
+    const dir = tempDir();
+    const cachedPath = join(dir, "cached.json");
+    const newPath = join(dir, "new.json");
+    const outPath = join(dir, "out.json");
+
+    writeExtraction(cachedPath, [node("hub", [{ source_file: "a.txt", page: 1 }])]);
+    writeExtraction(newPath, [
+      node("hub", [
+        { source_file: "b.txt", page: 2 },
+        { source_file: "a.txt", page: 1 }, // overlap, deduped
+      ]),
+    ]);
+
+    await runRuntime(["merge-semantic", "--cached", cachedPath, "--new", newPath, "--out", outPath]);
+
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string; citations?: OntologyCitation[] }>;
+    };
+    const hub = merged.nodes.find((n) => n.id === "hub")!;
+    // deduped union a:1, b:2 — NOT just the cached chunk's single citation.
+    expect(hub.citations).toHaveLength(2);
+    const keys = hub.citations!.map((c) => `${c.source_file}:${c.page}`).sort();
+    expect(keys).toEqual(["a.txt:1", "b.txt:2"]);
+  });
+
+  it("merge-extraction folds the semantic duplicate's citations into the AST node", async () => {
+    const dir = tempDir();
+    const astPath = join(dir, "ast.json");
+    const semanticPath = join(dir, "semantic.json");
+    const outPath = join(dir, "out.json");
+
+    writeExtraction(astPath, [node("hub", [{ source_file: "a.txt", page: 1 }])]);
+    writeExtraction(semanticPath, [node("hub", [{ source_file: "c.txt", page: 3 }])]);
+
+    await runRuntime([
+      "merge-extraction",
+      "--ast", astPath,
+      "--semantic", semanticPath,
+      "--out", outPath,
+    ]);
+
+    const merged = JSON.parse(readFileSync(outPath, "utf-8")) as {
+      nodes: Array<{ id: string; citations?: OntologyCitation[] }>;
+    };
+    const hub = merged.nodes.find((n) => n.id === "hub")!;
+    expect(hub.citations).toHaveLength(2);
+    const keys = hub.citations!.map((c) => `${c.source_file}:${c.page}`).sort();
+    expect(keys).toEqual(["a.txt:1", "c.txt:3"]);
+  });
+});

--- a/tests/citations-persist.test.ts
+++ b/tests/citations-persist.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import { persistGraphWithCitations } from "../src/export.js";
+import { CITATIONS_INLINE_TOP_K } from "../src/citations.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-citations-persist-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+function hubGraph(citationCount: number): Graph {
+  const G = new Graph();
+  const citations: OntologyCitation[] = [];
+  for (let i = 0; i < citationCount; i += 1) {
+    citations.push({ source_file: `work${i % 25}.txt`, page: i, section: `ch${i % 7}` });
+  }
+  G.addNode("hub", { label: "Hub", source_file: "work0.txt", file_type: "document", citations });
+  return G;
+}
+
+describe("persistGraphWithCitations co-emit", () => {
+  it("co-emits graph.json (trimmed) and citations.json (full) in one call", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    const written = persistGraphWithCitations(hubGraph(200), new Map([[0, ["hub"]]]), graphPath, { force: true });
+    expect(written).toBe(true);
+
+    const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+      nodes: Array<{ id: string; citations?: unknown[]; citation_count?: number }>;
+    };
+    const hub = graph.nodes.find((n) => n.id === "hub")!;
+    expect(hub.citation_count).toBe(200);
+    expect(hub.citations).toHaveLength(CITATIONS_INLINE_TOP_K);
+
+    const sidecarPath = join(dir, "ontology", "citations.json");
+    expect(existsSync(sidecarPath)).toBe(true);
+    const sidecar = JSON.parse(readFileSync(sidecarPath, "utf-8")) as {
+      schema: string;
+      nodes: Record<string, { count: number; citations: unknown[] }>;
+    };
+    expect(sidecar.schema).toBe("graphify_ontology_citations_v1");
+    expect(sidecar.nodes.hub.count).toBe(200);
+    expect(sidecar.nodes.hub.citations).toHaveLength(200);
+  });
+
+  it("keeps graph.json within the K-per-node bound for a 200-citation hub", () => {
+    const dirTrim = tempDir();
+    const trimmedPath = join(dirTrim, "graph.json");
+    persistGraphWithCitations(hubGraph(200), new Map([[0, ["hub"]]]), trimmedPath, { force: true });
+    const trimmedSize = Buffer.byteLength(readFileSync(trimmedPath, "utf-8"), "utf-8");
+
+    // A naive full-inline graph.json (no trim) for the same hub is far larger.
+    // Assert the trimmed graph.json is a small fraction of the full list — the
+    // leanness contract. 200 citations vs K=8 inline ⇒ well under half.
+    const fullInline = hubGraph(200);
+    // Serialize the full citations inline to size the no-trim baseline.
+    const baselineBytes = Buffer.byteLength(
+      JSON.stringify(fullInline.getNodeAttribute("hub", "citations")),
+      "utf-8",
+    );
+    expect(trimmedSize).toBeLessThan(baselineBytes);
+  });
+
+  it("does not write a sidecar when no node carries citations", () => {
+    const dir = tempDir();
+    const graphPath = join(dir, "graph.json");
+    const G = new Graph();
+    G.addNode("x", { label: "X", source_file: "a.ts", file_type: "code" });
+    persistGraphWithCitations(G, new Map([[0, ["x"]]]), graphPath, { force: true });
+    expect(existsSync(join(dir, "ontology", "citations.json"))).toBe(false);
+  });
+
+  it("produces byte-identical graph.json + sidecar across two builds", () => {
+    const d1 = tempDir();
+    const d2 = tempDir();
+    persistGraphWithCitations(hubGraph(120), new Map([[0, ["hub"]]]), join(d1, "graph.json"), { force: true });
+    persistGraphWithCitations(hubGraph(120), new Map([[0, ["hub"]]]), join(d2, "graph.json"), { force: true });
+
+    const sidecar1 = JSON.parse(readFileSync(join(d1, "ontology", "citations.json"), "utf-8")) as { graph_signature: string; nodes: unknown };
+    const sidecar2 = JSON.parse(readFileSync(join(d2, "ontology", "citations.json"), "utf-8")) as { graph_signature: string; nodes: unknown };
+    expect(sidecar1.graph_signature).toBe(sidecar2.graph_signature);
+    expect(JSON.stringify(sidecar1.nodes)).toBe(JSON.stringify(sidecar2.nodes));
+  });
+});

--- a/tests/citations-reproject.test.ts
+++ b/tests/citations-reproject.test.ts
@@ -1,0 +1,166 @@
+/**
+ * hook-rebuild re-projection (LLM-free). Two contracts:
+ *   1. With extraction output present, re-derive the FULL sidecar from it.
+ *   2. With only a K-trimmed graph.json, NEVER clobber a fuller existing
+ *      citations.json (the pass-1 idempotency / no-shrink guard).
+ *
+ * No LLM, no network.
+ */
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import {
+  CITATIONS_INLINE_TOP_K,
+  reprojectCitationsLLMFree,
+  writeCitationsSidecar,
+  aggregateCitations,
+} from "../src/citations.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-reproject-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+function trimmedGraph(): { G: Graph; trueCount: number } {
+  // Mimics a graph.json AFTER a full build: node.citations is the K-trimmed
+  // inline set, citation_count carries the TRUE union size.
+  const G = new Graph();
+  const inline: OntologyCitation[] = [];
+  for (let i = 0; i < CITATIONS_INLINE_TOP_K; i += 1) {
+    inline.push({ source_file: `work${i}.txt`, page: i });
+  }
+  G.addNode("sherlock", { label: "Sherlock", citation_count: 214, citations: inline });
+  return { G, trueCount: 214 };
+}
+
+function fullSidecar(dir: string, count: number): void {
+  // A rich existing citations.json (the full tail beyond K).
+  const citations: OntologyCitation[] = [];
+  for (let i = 0; i < count; i += 1) {
+    citations.push({ source_file: `work${i % 25}.txt`, page: i, section: `ch${i % 7}` });
+  }
+  mkdirSync(join(dir, "ontology"), { recursive: true });
+  writeFileSync(
+    join(dir, "ontology", "citations.json"),
+    JSON.stringify({
+      schema: "graphify_ontology_citations_v1",
+      graph_signature: "stale",
+      nodes: { sherlock: { count, citations } },
+    }),
+    "utf-8",
+  );
+}
+
+describe("reprojectCitationsLLMFree — no-shrink guard (trimmed graph only)", () => {
+  it("preserves a fuller existing citations.json (never shrinks to the K-set)", () => {
+    const dir = tempDir();
+    fullSidecar(dir, 214);
+    const { G } = trimmedGraph();
+
+    const result = reprojectCitationsLLMFree(G, dir, {});
+
+    const sidecar = JSON.parse(readFileSync(join(dir, "ontology", "citations.json"), "utf-8")) as {
+      nodes: Record<string, { count: number; citations: OntologyCitation[] }>;
+    };
+    // The full 214-citation tail SURVIVES — not clobbered down to K.
+    expect(sidecar.nodes.sherlock.count).toBe(214);
+    expect(sidecar.nodes.sherlock.citations.length).toBe(214);
+    expect(result.rebuiltFromExtraction).toBe(false);
+    // Level-1 stays intact: count preserved, inline still K.
+    expect(G.getNodeAttribute("sherlock", "citation_count")).toBe(214);
+    expect((G.getNodeAttribute("sherlock", "citations") as OntologyCitation[]).length).toBe(
+      CITATIONS_INLINE_TOP_K,
+    );
+  });
+
+  it("re-derives the signature so the preserved sidecar matches the current graph", () => {
+    const dir = tempDir();
+    fullSidecar(dir, 214);
+    const { G } = trimmedGraph();
+    reprojectCitationsLLMFree(G, dir, {});
+    const sidecar = JSON.parse(readFileSync(join(dir, "ontology", "citations.json"), "utf-8")) as {
+      graph_signature: string;
+    };
+    expect(sidecar.graph_signature).not.toBe("stale");
+    expect(sidecar.graph_signature).toHaveLength(64);
+  });
+});
+
+describe("reprojectCitationsLLMFree — full rebuild from extraction output", () => {
+  it("rebuilds the FULL sidecar from the extraction output when present", () => {
+    const dir = tempDir();
+    const { G } = trimmedGraph(); // inline is K-trimmed only
+
+    // Extraction output holds the full per-node citations (the durable upstream).
+    const fullCitations: OntologyCitation[] = [];
+    for (let i = 0; i < 214; i += 1) {
+      fullCitations.push({ source_file: `work${i % 25}.txt`, page: i, section: `ch${i % 7}` });
+    }
+    const extractionPath = join(dir, ".graphify_extract.json");
+    writeFileSync(
+      extractionPath,
+      JSON.stringify({ nodes: [{ id: "sherlock", citations: fullCitations }], edges: [] }),
+      "utf-8",
+    );
+
+    const result = reprojectCitationsLLMFree(G, dir, { extractionPath });
+    expect(result.rebuiltFromExtraction).toBe(true);
+
+    const sidecar = JSON.parse(readFileSync(join(dir, "ontology", "citations.json"), "utf-8")) as {
+      nodes: Record<string, { count: number; citations: OntologyCitation[] }>;
+    };
+    expect(sidecar.nodes.sherlock.count).toBe(214);
+    expect(sidecar.nodes.sherlock.citations).toHaveLength(214);
+    // Level-1 re-projected from the FULL extraction set → true count + K inline.
+    expect(G.getNodeAttribute("sherlock", "citation_count")).toBe(214);
+    expect((G.getNodeAttribute("sherlock", "citations") as OntologyCitation[]).length).toBe(
+      CITATIONS_INLINE_TOP_K,
+    );
+  });
+
+  it("never invents citations: a smaller extraction does not inflate the count", () => {
+    const dir = tempDir();
+    const G = new Graph();
+    G.addNode("x", { citations: [{ source_file: "a.txt", page: 1 }] });
+    const extractionPath = join(dir, ".graphify_extract.json");
+    writeFileSync(
+      extractionPath,
+      JSON.stringify({ nodes: [{ id: "x", citations: [{ source_file: "a.txt", page: 1 }] }] }),
+      "utf-8",
+    );
+    reprojectCitationsLLMFree(G, dir, { extractionPath });
+    expect(G.getNodeAttribute("x", "citation_count")).toBe(1);
+  });
+
+  it("does no harm and writes no sidecar when nothing carries citations", () => {
+    const dir = tempDir();
+    const G = new Graph();
+    G.addNode("plain", { label: "Plain" });
+    const result = reprojectCitationsLLMFree(G, dir, {});
+    expect(result.rebuiltFromExtraction).toBe(false);
+    expect(result.sidecarPath).toBeNull();
+  });
+});
+
+describe("aggregateCitations idempotency guard (regression — count not undercounted)", () => {
+  it("keeps the larger prior citation_count when re-aggregating a trimmed graph", () => {
+    const { G } = trimmedGraph();
+    // Re-aggregating the trimmed graph must NOT drop the count to K.
+    aggregateCitations(G);
+    expect(G.getNodeAttribute("sherlock", "citation_count")).toBe(214);
+    // And the freshly written sidecar from this trimmed graph would only hold K
+    // — which is exactly why the reproject guard exists (covered above).
+    const dir = tempDir();
+    const map = aggregateCitations(G);
+    const path = writeCitationsSidecar(dir, map, G);
+    expect(path).not.toBeNull();
+  });
+});

--- a/tests/citations-union-merge.test.ts
+++ b/tests/citations-union-merge.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { buildFromJson } from "../src/build.js";
+import { mergeCliAstAndSemantic } from "../src/cli.js";
+import { mergeSemanticArtifacts, mergeAstAndSemantic } from "../src/skill-runtime.js";
+import type { Extraction, OntologyCitation } from "../src/types.js";
+
+function node(id: string, citations: OntologyCitation[]) {
+  return { id, label: id, source_file: "doc.txt", file_type: "document" as const, citations };
+}
+
+function extraction(nodes: ReturnType<typeof node>[]): Extraction {
+  return { nodes, edges: [], hyperedges: [], input_tokens: 0, output_tokens: 0 };
+}
+
+describe("union at assembly merge (build.ts mergeNode)", () => {
+  it("unions citations across duplicate node ids instead of last-write-wins", () => {
+    // Same entity emitted in two chunks, each with a distinct citation set.
+    const G = buildFromJson(
+      extraction([
+        node("sherlock", [{ source_file: "study.txt", page: 1 }]),
+        node("sherlock", [{ source_file: "sign.txt", page: 2 }]),
+        node("sherlock", [{ source_file: "study.txt", page: 1 }]), // dup of chunk 1
+      ]),
+    );
+    const cites = G.getNodeAttribute("sherlock", "citations") as OntologyCitation[];
+    // UNION (deduped), not just the last chunk's single citation.
+    expect(cites).toHaveLength(2);
+    const sources = cites.map((c) => `${c.source_file}:${c.page}`).sort();
+    expect(sources).toEqual(["sign.txt:2", "study.txt:1"]);
+  });
+
+  it("keeps a single chunk's citations intact for non-duplicated nodes", () => {
+    const G = buildFromJson(
+      extraction([node("watson", [{ source_file: "study.txt", page: 5 }])]),
+    );
+    expect(G.getNodeAttribute("watson", "citations")).toHaveLength(1);
+  });
+});
+
+describe("union at skip-duplicate assembly (cli + skill-runtime)", () => {
+  function chunkExtraction(citations: OntologyCitation[]): Partial<Extraction> {
+    return { nodes: [node("hub", citations)], edges: [], input_tokens: 0, output_tokens: 0 };
+  }
+
+  it("mergeCliAstAndSemantic folds the duplicate's citations into the kept node", () => {
+    const merged = mergeCliAstAndSemantic(
+      chunkExtraction([{ source_file: "a.txt", page: 1 }]),
+      chunkExtraction([{ source_file: "b.txt", page: 2 }]),
+    );
+    const hub = merged.nodes.find((n) => n.id === "hub")!;
+    expect(hub.citations).toHaveLength(2);
+  });
+
+  it("mergeSemanticArtifacts folds the duplicate's citations into the kept node", () => {
+    const merged = mergeSemanticArtifacts(
+      chunkExtraction([{ source_file: "a.txt", page: 1 }]),
+      chunkExtraction([{ source_file: "b.txt", page: 2 }, { source_file: "a.txt", page: 1 }]),
+    );
+    const hub = merged.nodes.find((n) => n.id === "hub")!;
+    // deduped union: a:1, b:2
+    expect(hub.citations).toHaveLength(2);
+  });
+
+  it("mergeAstAndSemantic folds the duplicate's citations into the kept node", () => {
+    const merged = mergeAstAndSemantic(
+      chunkExtraction([{ source_file: "a.txt", page: 1 }]),
+      chunkExtraction([{ source_file: "c.txt", page: 3 }]),
+    );
+    const hub = merged.nodes.find((n) => n.id === "hub")!;
+    expect(hub.citations).toHaveLength(2);
+  });
+
+  it("does not crash when neither side carries citations", () => {
+    const merged = mergeCliAstAndSemantic(
+      { nodes: [{ id: "x", label: "x", source_file: "d", file_type: "code" }], edges: [], input_tokens: 0, output_tokens: 0 },
+      { nodes: [{ id: "x", label: "x", source_file: "d", file_type: "code" }], edges: [], input_tokens: 0, output_tokens: 0 },
+    );
+    expect(merged.nodes).toHaveLength(1);
+  });
+});

--- a/tests/citations.test.ts
+++ b/tests/citations.test.ts
@@ -1,0 +1,267 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import {
+  CITATIONS_INLINE_TOP_K,
+  aggregateCitations,
+  citationKey,
+  computeCitationSignature,
+  selectTopCitations,
+  unionCitations,
+  writeCitationsSidecar,
+} from "../src/citations.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-citations-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("citationKey", () => {
+  it("derives a stable key from source_file|page|section|paragraph_id", () => {
+    const c: OntologyCitation = {
+      source_file: "doyle/study.txt",
+      page: 12,
+      section: "ch1",
+      paragraph_id: "p3",
+    };
+    expect(citationKey(c, { includeBbox: false })).toBe("doyle/study.txt|12|ch1|p3");
+  });
+
+  it("excludes bbox by default (prose) and includes it when requested (figures)", () => {
+    const c: OntologyCitation = {
+      source_file: "fig/plate.png",
+      figure_id: "f1",
+      bbox: [1, 2, 3, 4],
+    };
+    const prose = citationKey(c, { includeBbox: false });
+    const fig = citationKey(c, { includeBbox: true });
+    expect(fig).not.toBe(prose);
+    expect(fig).toContain("1,2,3,4");
+    expect(prose).not.toContain("1,2,3,4");
+  });
+
+  it("treats missing locator fields as empty, not 'undefined'", () => {
+    const c: OntologyCitation = { source_file: "a.txt" };
+    expect(citationKey(c, { includeBbox: false })).toBe("a.txt|||");
+  });
+});
+
+describe("unionCitations", () => {
+  it("dedupes across lists by identity, preserving first-seen for selection", () => {
+    const a: OntologyCitation[] = [
+      { source_file: "b.txt", page: 2 },
+      { source_file: "a.txt", page: 1 },
+    ];
+    const b: OntologyCitation[] = [
+      { source_file: "a.txt", page: 1 }, // dup of a[1]
+      { source_file: "c.txt", page: 3 },
+    ];
+    const out = unionCitations([a, b], { includeBbox: false });
+    expect(out).toHaveLength(3);
+    // stable lexicographic sort by (source_file, page, section, paragraph_id)
+    expect(out.map((c) => c.source_file)).toEqual(["a.txt", "b.txt", "c.txt"]);
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const x: OntologyCitation[] = [
+      { source_file: "z.txt", page: 9 },
+      { source_file: "a.txt", page: 1 },
+      { source_file: "m.txt", section: "s" },
+    ];
+    const reversed = [...x].reverse();
+    const u1 = unionCitations([x], { includeBbox: false });
+    const u2 = unionCitations([reversed], { includeBbox: false });
+    expect(JSON.stringify(u1)).toBe(JSON.stringify(u2));
+  });
+
+  it("ignores non-array / malformed entries gracefully", () => {
+    const out = unionCitations(
+      [
+        [{ source_file: "a.txt" }],
+        undefined as unknown as OntologyCitation[],
+        [null as unknown as OntologyCitation, { source_file: "b.txt" }],
+      ],
+      { includeBbox: false },
+    );
+    expect(out.map((c) => c.source_file)).toEqual(["a.txt", "b.txt"]);
+  });
+});
+
+describe("selectTopCitations", () => {
+  const K = CITATIONS_INLINE_TOP_K;
+
+  it("exports a default inline K of 8", () => {
+    expect(K).toBe(8);
+  });
+
+  it("is byte-identical across two runs (determinism)", () => {
+    const all: OntologyCitation[] = [];
+    for (let i = 0; i < 30; i += 1) {
+      all.push({ source_file: `src${i % 5}.txt`, page: i, section: `s${i}` });
+    }
+    const run1 = selectTopCitations(all, K);
+    const run2 = selectTopCitations([...all].reverse(), K);
+    expect(JSON.stringify(run1)).toBe(JSON.stringify(run2));
+    expect(run1).toHaveLength(K);
+  });
+
+  it("maximizes distinct-source coverage before repeating a source", () => {
+    // 4 distinct sources, several citations each; K=3 must cover 3 sources.
+    const all: OntologyCitation[] = [
+      { source_file: "a.txt", page: 1 },
+      { source_file: "a.txt", page: 2 },
+      { source_file: "b.txt", page: 1 },
+      { source_file: "b.txt", page: 2 },
+      { source_file: "c.txt", page: 1 },
+      { source_file: "d.txt", page: 1 },
+    ];
+    const top = selectTopCitations(all, 3);
+    const sources = new Set(top.map((c) => c.source_file));
+    expect(sources.size).toBe(3);
+  });
+
+  it("breaks greedy ties by the lexicographic key (stable, first source wins its earliest citation)", () => {
+    const all: OntologyCitation[] = [
+      { source_file: "b.txt", page: 5 },
+      { source_file: "a.txt", page: 9 },
+      { source_file: "a.txt", page: 2 },
+    ];
+    const top = selectTopCitations(all, 2);
+    // a.txt covered first (lexicographically), and its earliest (page 2) wins.
+    expect(top[0]).toEqual({ source_file: "a.txt", page: 2 });
+    expect(top[1]).toEqual({ source_file: "b.txt", page: 5 });
+  });
+
+  it("fills remaining slots by locator specificity when sources are exhausted", () => {
+    // 2 sources, 5 citations, K=3. After covering a.txt and b.txt once each
+    // (bare-locator wins the cover by lex key), one fill slot remains; the fill
+    // step prefers a finer locator (has page/section) over the bare extras.
+    const all: OntologyCitation[] = [
+      { source_file: "a.txt" }, // bare
+      { source_file: "a.txt", page: 7 }, // finer
+      { source_file: "b.txt" }, // bare
+      { source_file: "b.txt", section: "intro" }, // finer
+      { source_file: "b.txt" }, // dup of bare b.txt
+    ];
+    const top = selectTopCitations(all, 3);
+    expect(top).toHaveLength(3);
+    // First two cover distinct sources; the third is a finer-locator fill.
+    const fill = top[2];
+    expect(fill.page != null || fill.section != null).toBe(true);
+  });
+
+  it("returns the whole deduped set when it is smaller than K", () => {
+    const all: OntologyCitation[] = [
+      { source_file: "a.txt", page: 1 },
+      { source_file: "a.txt", page: 1 }, // dup
+      { source_file: "b.txt", page: 2 },
+    ];
+    const top = selectTopCitations(all, 8);
+    expect(top).toHaveLength(2);
+  });
+});
+
+function hubGraph(citationCount: number): Graph {
+  const G = new Graph();
+  const citations: OntologyCitation[] = [];
+  for (let i = 0; i < citationCount; i += 1) {
+    citations.push({ source_file: `work${i % 25}.txt`, page: i, section: `ch${i % 7}` });
+  }
+  G.addNode("sherlock", { label: "Sherlock", citations });
+  G.addNode("bare", { label: "Bare" }); // no citations
+  return G;
+}
+
+describe("aggregateCitations", () => {
+  it("sets citation_count = |union| and trims node.citations to K", () => {
+    const G = hubGraph(200);
+    const map = aggregateCitations(G, { topK: CITATIONS_INLINE_TOP_K });
+
+    const inline = G.getNodeAttribute("sherlock", "citations") as OntologyCitation[];
+    expect(G.getNodeAttribute("sherlock", "citation_count")).toBe(200);
+    expect(inline).toHaveLength(CITATIONS_INLINE_TOP_K);
+
+    // Map carries the FULL union, count matches.
+    expect(map.sherlock.count).toBe(200);
+    expect(map.sherlock.citations).toHaveLength(200);
+    // Untouched nodes do not appear and gain no count.
+    expect(map.bare).toBeUndefined();
+    expect(G.getNodeAttribute("bare", "citation_count")).toBeUndefined();
+  });
+
+  it("count = size of the deduped union (not the raw list)", () => {
+    const G = new Graph();
+    G.addNode("dupy", {
+      citations: [
+        { source_file: "a.txt", page: 1 },
+        { source_file: "a.txt", page: 1 }, // exact dup
+        { source_file: "b.txt", page: 2 },
+      ],
+    });
+    aggregateCitations(G);
+    expect(G.getNodeAttribute("dupy", "citation_count")).toBe(2);
+  });
+});
+
+describe("writeCitationsSidecar + computeCitationSignature", () => {
+  it("writes a keyed graphify_ontology_citations_v1 store with count=N and full list", () => {
+    const dir = tempDir();
+    const G = hubGraph(214);
+    const map = aggregateCitations(G);
+    const path = writeCitationsSidecar(dir, map, G);
+    expect(path).toBe(join(dir, "ontology", "citations.json"));
+
+    const payload = JSON.parse(readFileSync(path!, "utf-8")) as {
+      schema: string;
+      graph_signature: string;
+      nodes: Record<string, { count: number; citations: OntologyCitation[] }>;
+    };
+    expect(payload.schema).toBe("graphify_ontology_citations_v1");
+    expect(payload.nodes.sherlock.count).toBe(214);
+    expect(payload.nodes.sherlock.citations).toHaveLength(214);
+    expect(typeof payload.graph_signature).toBe("string");
+    expect(payload.graph_signature).toHaveLength(64); // sha256 hex
+  });
+
+  it("returns null and writes nothing when no node carries citations", () => {
+    const dir = tempDir();
+    const G = new Graph();
+    G.addNode("x", { label: "X" });
+    const map = aggregateCitations(G);
+    expect(writeCitationsSidecar(dir, map, G)).toBeNull();
+  });
+
+  it("signature is stable across an identical rebuild (no false-stale)", () => {
+    const G1 = hubGraph(50);
+    aggregateCitations(G1);
+    const sig1 = computeCitationSignature(G1);
+
+    const G2 = hubGraph(50);
+    aggregateCitations(G2);
+    const sig2 = computeCitationSignature(G2);
+
+    expect(sig2).toBe(sig1);
+  });
+
+  it("signature changes iff the inline citations change", () => {
+    const G = hubGraph(50);
+    aggregateCitations(G);
+    const before = computeCitationSignature(G);
+
+    // Mutate inline citations on the hub → signature must move.
+    G.setNodeAttribute("sherlock", "citations", [{ source_file: "different.txt", page: 999 }]);
+    const after = computeCitationSignature(G);
+    expect(after).not.toBe(before);
+
+    // A no-op re-read yields the same signature.
+    expect(computeCitationSignature(G)).toBe(after);
+  });
+});

--- a/tests/cli-backfill-citations.test.ts
+++ b/tests/cli-backfill-citations.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `graphify backfill-citations [path]` — end-to-end via the real CLI program.
+ * Asserts the projection writes citation_count + a trimmed inline set +
+ * citations.json, prints the LOWER-BOUND caveat, and is a no-op on re-run.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { main } from "../src/cli.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const d = tempDirs.pop()!;
+    try { require("node:fs").rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+function legacyGraphProject(citationCount: number): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-backfill-cli-"));
+  tempDirs.push(dir);
+  const graphDir = join(dir, ".graphify");
+  mkdirSync(graphDir, { recursive: true });
+  const citations = [];
+  for (let i = 0; i < citationCount; i += 1) {
+    citations.push({ source_file: `work${i % 10}.txt`, page: i, section: `ch${i % 3}` });
+  }
+  writeFileSync(
+    join(graphDir, "graph.json"),
+    JSON.stringify({
+      directed: false,
+      graph: {},
+      nodes: [
+        { id: "sherlock", label: "Sherlock", file_type: "document", source_file: "work0.txt", community: 0, citations },
+        { id: "bare", label: "Bare", file_type: "document", source_file: "work1.txt", community: 0 },
+      ],
+      links: [],
+      community_labels: { "0": "Mystery" },
+    }),
+    "utf-8",
+  );
+  return dir;
+}
+
+async function runCli(args: string[], cwd: string) {
+  const previousArgv = process.argv;
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const logs: string[] = [];
+  const errors: string[] = [];
+  console.log = (...items: unknown[]) => { logs.push(items.join(" ")); };
+  console.error = (...items: unknown[]) => { errors.push(items.join(" ")); };
+  process.exit = ((code?: string | number | null) => {
+    throw new Error(`process.exit ${code ?? 0}`);
+  }) as typeof process.exit;
+  process.argv = ["node", "graphify", ...args];
+  process.chdir(cwd);
+  try {
+    await main();
+    return { logs, errors, exitCode: 0 };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/^process\.exit (\d+)/);
+    if (match) return { logs, errors, exitCode: Number(match[1]) };
+    return { logs, errors: [...errors, message], exitCode: 1 };
+  } finally {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+}
+
+describe("graphify backfill-citations", () => {
+  it("populates fields + store and prints the lower-bound caveat", async () => {
+    const dir = legacyGraphProject(20);
+    const { logs } = await runCli(["backfill-citations", dir], dir);
+
+    const graph = JSON.parse(readFileSync(join(dir, ".graphify", "graph.json"), "utf-8")) as {
+      nodes: Array<{ id: string; citations?: unknown[]; citation_count?: number }>;
+    };
+    const sherlock = graph.nodes.find((n) => n.id === "sherlock")!;
+    expect(sherlock.citation_count).toBe(20);
+    expect(sherlock.citations).toHaveLength(8); // default K (mixed/global)
+
+    expect(existsSync(join(dir, ".graphify", "ontology", "citations.json"))).toBe(true);
+    const sidecar = JSON.parse(
+      readFileSync(join(dir, ".graphify", "ontology", "citations.json"), "utf-8"),
+    ) as { nodes: Record<string, { count: number; citations: unknown[] }> };
+    expect(sidecar.nodes.sherlock.count).toBe(20);
+    expect(sidecar.nodes.sherlock.citations).toHaveLength(20);
+
+    const caveat = logs.join("\n");
+    expect(caveat).toMatch(/LOWER BOUND/i);
+    expect(caveat).toMatch(/[Rr]e-extract/);
+  });
+
+  it("is a no-op on a second run (idempotent)", async () => {
+    const dir = legacyGraphProject(20);
+    await runCli(["backfill-citations", dir], dir);
+    const afterFirst = readFileSync(join(dir, ".graphify", "graph.json"), "utf-8");
+
+    const { logs } = await runCli(["backfill-citations", dir], dir);
+    const afterSecond = readFileSync(join(dir, ".graphify", "graph.json"), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst); // graph.json untouched
+    expect(logs.join("\n")).toMatch(/nothing to backfill/i);
+  });
+
+  it("respects --citations-top-k", async () => {
+    const dir = legacyGraphProject(20);
+    await runCli(["backfill-citations", dir, "--citations-top-k", "3"], dir);
+    const graph = JSON.parse(readFileSync(join(dir, ".graphify", "graph.json"), "utf-8")) as {
+      nodes: Array<{ id: string; citations?: unknown[]; citation_count?: number }>;
+    };
+    const sherlock = graph.nodes.find((n) => n.id === "sherlock")!;
+    expect(sherlock.citation_count).toBe(20);
+    expect(sherlock.citations).toHaveLength(3);
+  });
+});

--- a/tests/cli-citation-flags.test.ts
+++ b/tests/cli-citation-flags.test.ts
@@ -102,3 +102,37 @@ describe("resolveCitationPolicyForRoot", () => {
     expect(p.describeCap).toBe("all");
   });
 });
+
+describe("7b: `label --citation-cap` help is honest (no effect on label)", () => {
+  async function labelHelp(): Promise<string> {
+    const { main } = await import("../src/cli.js");
+    const out: string[] = [];
+    const originalArgv = process.argv;
+    const originalLog = console.log;
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const originalExit = process.exit;
+    console.log = (...a: unknown[]) => { out.push(a.join(" ")); };
+    process.stdout.write = ((chunk: unknown) => { out.push(String(chunk)); return true; }) as typeof process.stdout.write;
+    process.exit = ((): never => { throw new Error("__exit__"); }) as typeof process.exit;
+    process.argv = ["node", "graphify", "label", "--help"];
+    try {
+      await main();
+    } catch (err) {
+      if ((err as Error).message !== "__exit__") throw err;
+    } finally {
+      process.argv = originalArgv;
+      console.log = originalLog;
+      process.stdout.write = originalWrite;
+      process.exit = originalExit;
+    }
+    return out.join("\n");
+  }
+
+  it("does not promise that the flag grounds descriptions on `label`", async () => {
+    const help = await labelHelp();
+    expect(help).toContain("--citation-cap");
+    expect(help).toMatch(/has no effect on .?label.?/);
+    // The old over-promising wording must be gone.
+    expect(help).not.toContain("forwarded to the description engine");
+  });
+});

--- a/tests/cli-citation-flags.test.ts
+++ b/tests/cli-citation-flags.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the CLI citation-flag plumbing:
+ *   - `parseCitationCapFlag` / `parseTopKFlag` (flag string → typed value)
+ *   - `resolveCitationPolicyForRoot` (reads `.graphify_detect.json`, applies
+ *     the corpus-type default, then the CLI flag override).
+ *
+ * These exercise the resolution layer the describe/label/extract/update/watch
+ * actions call; the precedence itself is covered in citation-policy.test.ts.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parseCitationCapFlag,
+  parseTopKFlag,
+  resolveCitationPolicyForRoot,
+} from "../src/cli.js";
+
+const cleanupDirs: string[] = [];
+function projectWithDetect(
+  detect: Record<string, unknown> | null,
+): string {
+  const root = join(tmpdir(), `graphify-cit-flags-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  cleanupDirs.push(root);
+  mkdirSync(join(root, ".graphify"), { recursive: true });
+  if (detect) {
+    writeFileSync(join(root, ".graphify", ".graphify_detect.json"), JSON.stringify(detect), "utf-8");
+  }
+  return root;
+}
+function buckets(b: Partial<Record<string, number>>, totalWords = 0) {
+  const files: Record<string, string[]> = { code: [], document: [], paper: [], image: [], video: [] };
+  for (const [k, n] of Object.entries(b)) files[k] = Array.from({ length: n ?? 0 }, (_v, i) => `${k}/${i}`);
+  return { files, total_words: totalWords, total_files: Object.values(files).reduce((s, v) => s + v.length, 0) };
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("parseCitationCapFlag", () => {
+  it("parses a numeric cap", () => {
+    expect(parseCitationCapFlag("5")).toBe(5);
+  });
+  it("parses 'all' (case-insensitive)", () => {
+    expect(parseCitationCapFlag("all")).toBe("all");
+    expect(parseCitationCapFlag("ALL")).toBe("all");
+  });
+  it("returns undefined for empty / missing / invalid", () => {
+    expect(parseCitationCapFlag(undefined)).toBeUndefined();
+    expect(parseCitationCapFlag("")).toBeUndefined();
+    expect(parseCitationCapFlag("abc")).toBeUndefined();
+    expect(parseCitationCapFlag("-3")).toBeUndefined();
+  });
+});
+
+describe("parseTopKFlag", () => {
+  it("parses a positive integer", () => {
+    expect(parseTopKFlag("12")).toBe(12);
+  });
+  it("returns undefined for non-positive / invalid / missing", () => {
+    expect(parseTopKFlag(undefined)).toBeUndefined();
+    expect(parseTopKFlag("0")).toBeUndefined();
+    expect(parseTopKFlag("-1")).toBeUndefined();
+    expect(parseTopKFlag("x")).toBeUndefined();
+  });
+});
+
+describe("resolveCitationPolicyForRoot", () => {
+  it("uses the corpus-type default from .graphify_detect.json (code → cap 3, K 3)", () => {
+    const root = projectWithDetect(buckets({ code: 30 }, 9_000));
+    const p = resolveCitationPolicyForRoot(root, {});
+    expect(p.describeCap).toBe(3);
+    expect(p.inlineTopK).toBe(3);
+  });
+
+  it("uses long-document default for a large prose corpus (cap 'all', K 8)", () => {
+    const root = projectWithDetect(buckets({ document: 10 }, 120_000));
+    const p = resolveCitationPolicyForRoot(root, {});
+    expect(p.describeCap).toBe("all");
+    expect(p.inlineTopK).toBe(8);
+  });
+
+  it("CLI flags override the corpus-type default", () => {
+    const root = projectWithDetect(buckets({ code: 30 }, 9_000)); // code → cap 3 / K 3
+    const p = resolveCitationPolicyForRoot(root, { describeCapFlag: "all", topKFlag: 6 });
+    expect(p.describeCap).toBe("all");
+    expect(p.inlineTopK).toBe(6);
+  });
+
+  it("falls back to the global default when no detect file is present", () => {
+    const root = projectWithDetect(null);
+    const p = resolveCitationPolicyForRoot(root, {});
+    expect(p.describeCap).toBe(10);
+    expect(p.inlineTopK).toBe(8);
+  });
+
+  it("profileMode forces entity-corpus (cap 'all') regardless of buckets", () => {
+    const root = projectWithDetect(buckets({ document: 2 }, 2_000));
+    const p = resolveCitationPolicyForRoot(root, { profileMode: true });
+    expect(p.describeCap).toBe("all");
+  });
+});

--- a/tests/merge-driver.test.ts
+++ b/tests/merge-driver.test.ts
@@ -128,4 +128,71 @@ describe("merge graph driver", () => {
 
     expect(() => mergeGraphJsonFiles(ancestor, current, other)).toThrow("exceeds 100000-node cap");
   });
+
+  // F5: the node merge picked one branch's K-set + one count (last-write-wins),
+  // silently dropping the other branch's distinct citations. Union them by
+  // identity and set citation_count = max(both counts, |union|).
+  it("unions a node's citations across both branches and reconciles citation_count", () => {
+    const dir = tempDir();
+    const ancestor = join(dir, "ancestor.json");
+    const current = join(dir, "current.json");
+    const other = join(dir, "other.json");
+
+    const baseNode = { id: "hub", label: "Hub", source_file: "doc.txt", file_type: "document" as const };
+
+    writeFileSync(
+      ancestor,
+      JSON.stringify({ directed: false, graph: {}, nodes: [baseNode], links: [] }),
+      "utf-8",
+    );
+    writeFileSync(
+      current,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          {
+            ...baseNode,
+            citation_count: 5,
+            citations: [
+              { source_file: "a.txt", page: 1 },
+              { source_file: "b.txt", page: 2 },
+            ],
+          },
+        ],
+        links: [],
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      other,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          {
+            ...baseNode,
+            citation_count: 7,
+            citations: [
+              { source_file: "b.txt", page: 2 }, // overlap with current
+              { source_file: "c.txt", page: 3 },
+            ],
+          },
+        ],
+        links: [],
+      }),
+      "utf-8",
+    );
+
+    mergeGraphJsonFiles(ancestor, current, other);
+    const merged = JSON.parse(readFileSync(current, "utf-8")) as {
+      nodes: Array<{ id: string; citations?: Array<{ source_file?: string; page?: number }>; citation_count?: number }>;
+    };
+    const hub = merged.nodes.find((n) => n.id === "hub")!;
+    // deduped union a:1, b:2, c:3 (3 distinct) — NOT one branch's 2.
+    const keys = (hub.citations ?? []).map((c) => `${c.source_file}:${c.page}`).sort();
+    expect(keys).toEqual(["a.txt:1", "b.txt:2", "c.txt:3"]);
+    // count = max(5, 7, |union|=3) = 7 (never silently below either branch).
+    expect(hub.citation_count).toBe(7);
+  });
 });

--- a/tests/node-descriptions-citation-cap.test.ts
+++ b/tests/node-descriptions-citation-cap.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import {
+  buildNodeDescriptionPrompt,
+  collectNodeContext,
+  generateNodeDescriptions,
+} from "../src/node-descriptions.js";
+
+const cleanupDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-citation-cap-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+function entityWith(nCitations: number): Graph {
+  const G = new Graph({ type: "undirected" });
+  const citations = [];
+  for (let i = 0; i < nCitations; i += 1) {
+    citations.push({ source_file: `work${i}.txt`, page: i + 1, section: `ch${i}` });
+  }
+  G.addNode("ent_hub", { label: "Hub", node_type: "Person", citations });
+  // A neighbor so the node is well-formed.
+  G.addNode("ent_other", { label: "Other", node_type: "Place" });
+  G.addUndirectedEdge("ent_hub", "ent_other", { relation: "knows" });
+  return G;
+}
+
+describe("collectNodeContext citation cap", () => {
+  it("caps at 3 when citationCap=3", () => {
+    const G = entityWith(20);
+    const ctx = collectNodeContext(G, "ent_hub", { citationCap: 3 });
+    expect(ctx.citations).toHaveLength(3);
+  });
+
+  it("caps at 10 when citationCap=10 (the resolved default for this pass)", () => {
+    const G = entityWith(20);
+    const ctx = collectNodeContext(G, "ent_hub", { citationCap: 10 });
+    expect(ctx.citations).toHaveLength(10);
+  });
+
+  it("includes all citations when citationCap='all'", () => {
+    const G = entityWith(20);
+    const ctx = collectNodeContext(G, "ent_hub", { citationCap: "all" });
+    expect(ctx.citations).toHaveLength(20);
+  });
+
+  it("defaults to the resolved cap (10) when unspecified", () => {
+    const G = entityWith(20);
+    const ctx = collectNodeContext(G, "ent_hub");
+    expect(ctx.citations).toHaveLength(10);
+  });
+});
+
+describe("citation cap flows to the no-key assistant instruction file", () => {
+  function countCitationSnippets(prompt: string): number {
+    const m = prompt.match(/citations=\[([^\]]*)\]/);
+    if (!m || !m[1].trim()) return 0;
+    // snippets are JSON-stringified strings joined by ", "
+    return m[1].split(/",\s*"/).length;
+  }
+
+  it("emitted prompt honors a low cap (3)", async () => {
+    const G = entityWith(20);
+    const dir = tempDir();
+    const result = await generateNodeDescriptions(G, {
+      mode: "assistant",
+      instructionDir: dir,
+      quiet: true,
+      citationCap: 3,
+    });
+    expect(result.source).toBe("assistant");
+    const md = readdirSync(dir).find((f) => f.endsWith(".md"))!;
+    const text = readFileSync(join(dir, md), "utf-8");
+    expect(countCitationSnippets(text)).toBeLessThanOrEqual(3);
+    expect(countCitationSnippets(text)).toBeGreaterThan(0);
+  });
+
+  it("emitted prompt honors a high cap (all)", async () => {
+    const G = entityWith(20);
+    const dir = tempDir();
+    await generateNodeDescriptions(G, {
+      mode: "assistant",
+      instructionDir: dir,
+      quiet: true,
+      citationCap: "all",
+    });
+    const md = readdirSync(dir).find((f) => f.endsWith(".md"))!;
+    const text = readFileSync(join(dir, md), "utf-8");
+    expect(countCitationSnippets(text)).toBe(20);
+  });
+
+  it("default (unspecified) caps the emitted prompt at 10", async () => {
+    const G = entityWith(20);
+    const dir = tempDir();
+    await generateNodeDescriptions(G, { mode: "assistant", instructionDir: dir, quiet: true });
+    const md = readdirSync(dir).find((f) => f.endsWith(".md"))!;
+    const text = readFileSync(join(dir, md), "utf-8");
+    expect(countCitationSnippets(text)).toBe(10);
+  });
+});
+
+describe("citation cap flows to the direct (API) path", () => {
+  it("collectNodeContext cap governs the prompt the direct caller sends", async () => {
+    const G = entityWith(20);
+    let capturedPrompt = "";
+    await generateNodeDescriptions(G, {
+      provider: "anthropic",
+      citationCap: 3,
+      callLlm: async (prompt: string) => {
+        capturedPrompt = prompt;
+        return JSON.stringify({ ent_hub: "A hub." });
+      },
+      quiet: true,
+    });
+    const m = capturedPrompt.match(/citations=\[([^\]]*)\]/);
+    expect(m).not.toBeNull();
+    const count = m![1].trim() ? m![1].split(/",\s*"/).length : 0;
+    expect(count).toBeLessThanOrEqual(3);
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+describe("buildNodeDescriptionPrompt still works with explicit contexts", () => {
+  it("renders the citations array verbatim from NodeContext", () => {
+    const prompt = buildNodeDescriptionPrompt([
+      {
+        id: "x",
+        label: "X",
+        isCode: false,
+        sourceFile: "a.txt",
+        sourceLocation: null,
+        nodeType: "Person",
+        degree: 1,
+        neighbors: ["Y"],
+        citations: ["c1 (p.1)", "c2 (p.2)"],
+      },
+    ]);
+    expect(prompt).toContain("c1 (p.1)");
+    expect(prompt).toContain("c2 (p.2)");
+  });
+});

--- a/tests/ontology-studio-entity-citations.test.ts
+++ b/tests/ontology-studio-entity-citations.test.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /api/ontology/entity/<id> — Level-2 citations passthrough.
+ *
+ * The entity route returns `buildEntitySidecar` output verbatim. This pins that
+ * the sidecar's new `citations: { count, citations }` field (the lazily-served
+ * full per-entity list, SPEC_CITATIONS.md) reaches the HTTP response for a hub
+ * id, and is absent when the co-derived store is missing.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import Graph from "graphology";
+
+import { handleOntologyStudioRequest } from "../src/ontology-studio.js";
+import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
+import { aggregateCitations, writeCitationsSidecar } from "../src/citations.js";
+import { __resetCitationsSidecarCache, __resetGraphDescriptionCache } from "../src/studio-assets.js";
+import type { OntologyCitation } from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  __resetGraphDescriptionCache();
+  __resetCitationsSidecarCache();
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = require("node:fs").mkdtempSync(join(tmpdir(), "graphify-entity-cite-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Emit graph.json + ontology/citations.json into stateDir via the engine. */
+function seedHub(stateDir: string, hubCitations: OntologyCitation[]): number {
+  mkdirSync(join(stateDir, "ontology"), { recursive: true });
+  const G = new Graph({ type: "directed" });
+  G.addNode("hub", { label: "Sherlock", citations: hubCitations.map((c) => ({ ...c })) });
+  G.addNode("leaf", { label: "Watson" });
+  const map = aggregateCitations(G);
+  const nodes = G.mapNodes((id, attrs) => ({ id, ...attrs }));
+  writeFileSync(join(stateDir, "graph.json"), JSON.stringify({ nodes, edges: [] }));
+  writeCitationsSidecar(stateDir, map, G);
+  return map.hub!.count;
+}
+
+describe("GET /api/ontology/entity/<id> citations", () => {
+  it("includes the full Level-2 citations list for a hub id", () => {
+    const fixture = writeOntologyWriteFixture(makeTempDir());
+    const cites: OntologyCitation[] = Array.from({ length: 12 }, (_, i) => ({
+      source_file: `work_${i}.txt`,
+      section: `ch${i}`,
+      page: i + 1,
+    }));
+    const count = seedHub(fixture.stateDir, cites);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath },
+      "GET",
+      "/api/ontology/entity/hub",
+    );
+
+    expect(result.status).toBe(200);
+    const payload = JSON.parse(result.body);
+    expect(payload.id).toBe("hub");
+    expect(payload.citations).toBeDefined();
+    expect(payload.citations.count).toBe(count);
+    expect(count).toBe(12);
+    expect(payload.citations.citations).toHaveLength(12);
+  });
+
+  it("omits citations when the co-derived store is absent", () => {
+    const fixture = writeOntologyWriteFixture(makeTempDir());
+    writeFileSync(
+      join(fixture.stateDir, "graph.json"),
+      JSON.stringify({ nodes: [{ id: "hub", label: "Sherlock" }], edges: [] }),
+    );
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath },
+      "GET",
+      "/api/ontology/entity/hub",
+    );
+
+    expect(result.status).toBe(200);
+    const payload = JSON.parse(result.body);
+    expect(payload.citations).toBeUndefined();
+  });
+});

--- a/tests/studio-assets.test.ts
+++ b/tests/studio-assets.test.ts
@@ -11,13 +11,21 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import Graph from "graphology";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
   buildEntitySidecar,
   serveStudioAsset,
   __resetGraphDescriptionCache,
+  __resetCitationsSidecarCache,
 } from "../src/studio-assets.js";
+import {
+  aggregateCitations,
+  writeCitationsSidecar,
+  CITATIONS_SIDECAR_RELPATH,
+} from "../src/citations.js";
+import type { OntologyCitation } from "../src/types.js";
 
 function makeStateDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "graphify-studio-assets-"));
@@ -47,6 +55,110 @@ function writeGraph(dir: string, nodes: Array<Record<string, unknown>>): void {
 
 afterEach(() => {
   __resetGraphDescriptionCache();
+  __resetCitationsSidecarCache();
+});
+
+/**
+ * Build a real (graph.json + ontology/citations.json) pair via the engine
+ * aggregation pass so the studio-side signature gate is tested against the
+ * SAME content hash the producer stamps. `hubCitations` is the full union for
+ * the hub node; the engine trims the inline set + writes the co-derived store.
+ */
+function makeCitationStateDir(hubCitations: OntologyCitation[]): { dir: string; count: number } {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-citations-"));
+  mkdirSync(join(dir, "ontology"), { recursive: true });
+  const G = new Graph({ type: "directed" });
+  G.addNode("hub", { label: "Hub", citations: hubCitations.map((c) => ({ ...c })) });
+  G.addNode("leaf", { label: "Leaf" });
+  const map = aggregateCitations(G);
+  // graph.json mirrors toJson's `...attrs` spread: each node serializes its
+  // (now trimmed) inline `citations` + `citation_count`.
+  const nodes = G.mapNodes((id, attrs) => ({ id, ...attrs }));
+  writeFileSync(join(dir, "graph.json"), JSON.stringify({ nodes, edges: [] }));
+  writeCitationsSidecar(dir, map, G);
+  return { dir, count: map.hub!.count };
+}
+
+function citation(source: string, section: string, page?: number): OntologyCitation {
+  return page == null ? { source_file: source, section } : { source_file: source, section, page };
+}
+
+describe("buildEntitySidecar citations (Level-2 lazy store)", () => {
+  it("returns { count, citations } for a present hub id", () => {
+    const cites = [
+      citation("a.txt", "ch1", 1),
+      citation("b.txt", "ch2", 2),
+      citation("c.txt", "ch3", 3),
+      citation("d.txt", "ch4", 4),
+      citation("e.txt", "ch5", 5),
+      citation("f.txt", "ch6", 6),
+      citation("g.txt", "ch7", 7),
+      citation("h.txt", "ch8", 8),
+      citation("i.txt", "ch9", 9),
+      citation("j.txt", "ch10", 10),
+    ];
+    const { dir, count } = makeCitationStateDir(cites);
+    const res = buildEntitySidecar(dir, "hub");
+    expect(res.citations).not.toBeUndefined();
+    expect(res.citations!.count).toBe(count);
+    expect(count).toBe(10);
+    // The full union (10) is served, not just the inline top-K.
+    expect(res.citations!.citations).toHaveLength(10);
+  });
+
+  it("returns undefined citations for an absent id", () => {
+    const { dir } = makeCitationStateDir([citation("a.txt", "ch1", 1)]);
+    const res = buildEntitySidecar(dir, "ghost");
+    expect(res.citations).toBeUndefined();
+  });
+
+  it("returns undefined citations when no citations.json exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-nocite-"));
+    writeFileSync(join(dir, "graph.json"), JSON.stringify({ nodes: [{ id: "hub" }], edges: [] }));
+    const res = buildEntitySidecar(dir, "hub");
+    expect(res.citations).toBeUndefined();
+  });
+
+  it("treats the store as ABSENT on graph_signature mismatch (client falls back to inline)", () => {
+    const { dir } = makeCitationStateDir([
+      citation("a.txt", "ch1", 1),
+      citation("b.txt", "ch2", 2),
+    ]);
+    // Rewrite graph.json with DIFFERENT inline citations -> the on-disk
+    // citation-content hash no longer matches the stamped graph_signature.
+    writeFileSync(
+      join(dir, "graph.json"),
+      JSON.stringify({
+        nodes: [{ id: "hub", citations: [citation("z.txt", "zzz", 99)], citation_count: 2 }],
+        edges: [],
+      }),
+    );
+    __resetGraphDescriptionCache();
+    __resetCitationsSidecarCache();
+    const res = buildEntitySidecar(dir, "hub");
+    expect(res.citations).toBeUndefined();
+  });
+
+  it("caches citations.json by mtime (no re-parse at an unchanged mtime)", async () => {
+    const { dir } = makeCitationStateDir([citation("a.txt", "ch1", 1)]);
+    const citePath = join(dir, CITATIONS_SIDECAR_RELPATH);
+    const { utimesSync } = await import("node:fs");
+    // Pin mtime to a whole-second epoch so a later restore is exact (mtimeMs
+    // has sub-ms drift across writes otherwise). First read populates the
+    // mtime-keyed index for this stamp.
+    const pinned = new Date(1_700_000_000_000); // 2023-11-14T22:13:20Z, integer ms
+    utimesSync(citePath, pinned, pinned);
+    __resetCitationsSidecarCache();
+    const first = buildEntitySidecar(dir, "hub");
+    expect(first.citations).not.toBeUndefined();
+    // Corrupt the file but restore the SAME mtime: a re-parse would now fail
+    // (loadJsonSafe -> null -> undefined). A stable result proves the cache
+    // served the second call without re-reading citations.json.
+    writeFileSync(citePath, "}{ not json");
+    utimesSync(citePath, pinned, pinned);
+    const second = buildEntitySidecar(dir, "hub");
+    expect(second.citations).toEqual(first.citations);
+  });
 });
 
 describe("buildEntitySidecar", () => {

--- a/tests/watch-hook-citations-reproject.test.ts
+++ b/tests/watch-hook-citations-reproject.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Integration: the hook-rebuild path (`rebuildCode` with citationsReproject)
+ * re-derives citations.json LLM-free WITHOUT clobbering a fuller existing
+ * sidecar. Proves the wiring from rebuildCode → reprojectCitationsLLMFree.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rebuildCode } from "../src/watch.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function project(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-hook-cit-"));
+  tempDirs.push(dir);
+  // A code file so the AST rebuild proceeds (non-empty graph).
+  writeFileSync(join(dir, "mod.ts"), "export function alpha() { return beta(); }\nfunction beta() { return 1; }\n", "utf-8");
+  return dir;
+}
+
+describe("hook-rebuild citations re-projection", () => {
+  it("preserves a fuller existing citations.json after an LLM-free rebuild", async () => {
+    const dir = project();
+    const stateDir = join(dir, ".graphify");
+    mkdirSync(join(stateDir, "ontology"), { recursive: true });
+
+    // Seed a graph.json carrying a HUB with a K-trimmed inline set + true count.
+    const inline = Array.from({ length: 8 }, (_v, i) => ({ source_file: `w${i}.txt`, page: i }));
+    writeFileSync(
+      join(stateDir, "graph.json"),
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [{ id: "sherlock", label: "Sherlock", file_type: "document", source_file: "w0.txt", community: 0, citation_count: 214, citations: inline }],
+        links: [],
+      }),
+      "utf-8",
+    );
+
+    // Seed a RICH citations.json (the full 214-citation tail).
+    const full = Array.from({ length: 214 }, (_v, i) => ({ source_file: `w${i % 25}.txt`, page: i, section: `c${i % 7}` }));
+    writeFileSync(
+      join(stateDir, "ontology", "citations.json"),
+      JSON.stringify({ schema: "graphify_ontology_citations_v1", graph_signature: "stale", nodes: { sherlock: { count: 214, citations: full } } }),
+      "utf-8",
+    );
+
+    // Run the hook-rebuild path (LLM-free) with the reproject guard.
+    const ok = await rebuildCode(dir, false, {
+      describe: false,
+      label: false,
+      markDescribePending: true,
+      citationsReproject: true,
+      force: true,
+    });
+    expect(ok).toBe(true);
+
+    // The fuller sidecar tail SURVIVES (the hub merged from the prior graph.json
+    // is re-projected, but its 214-tail is not shrunk to the K-set).
+    const sidecar = JSON.parse(readFileSync(join(stateDir, "ontology", "citations.json"), "utf-8")) as {
+      nodes: Record<string, { count: number; citations: unknown[] }>;
+    };
+    expect(sidecar.nodes.sherlock.count).toBe(214);
+    expect(sidecar.nodes.sherlock.citations).toHaveLength(214);
+  });
+});


### PR DESCRIPTION
Exhaustive per-entity citation capture + tiered (inline / lazy) storage + corpus-type-aware policy. Spec-first, then implemented on this branch. Track WP `01KV0KPV040Z1H3V16E6YASPG8`.

## What ships
- **Exhaustive capture**: union every extracted citation per entity across chunks/works (fixes the silent duplicate-discard at `build.ts`/`cli.ts`/`skill-runtime.ts` merge sites) + a true `citation_count`.
- **Tiered storage**: Level-1 inline on `graph.json` = `citation_count` + a deterministic K-bounded `citations` set (K=8, most-distinct-source); Level-2 = full per-entity list in `.graphify/ontology/citations.json` (`graphify_ontology_citations_v1`, content-hash `graph_signature`), served lazily via the existing `/api/ontology/entity/<id>` sidecar. The store is a **co-derived projection of the extraction output**, never a second source of truth; graph.json is actively **trimmed to K** before `toJson` so the eager studio fetch stays lean.
- **Corpus-type policy**: describe-prompt cap resolves 3 (code) / 10 (default) / all (long-docs + entity corpus); skill-tunable on the no-key path + `--citation-cap`/`--citations-top-k` CLI flags. Detection always-all.
- **Studio**: true count shown immediately, inline K-set renders instantly, full list lazy-loads on selection; signature-gated fallback to inline on stale/absent store.
- **Migration**: additive schema; stale graphs warn + render legacy inline; `graphify backfill-citations` (lossy lower-bound); `hook-rebuild` re-projects LLM-free with a no-shrink guard.

## Quality
- Spec hardened by two adversarial Opus 4.8 reviews (2 BLOCKs folded before impl).
- Implementation reviewed by two more adversarial Opus 4.8 passes (both SHIP-WITH-NITS); the one MUST-FIX (F1: `finalize-update` re-discard + stale-count lock) + 4 NITs fixed TDD.
- Green: root **1806 passed / 12 skipped**, studio **104 passed**, lint clean, vite build clean. No network/API-key on any citation path (no-key by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)