### PR TITLE
P1 — studio DS bump 0.16→0.34 (transparent, no breakage)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "graphify": "dist/cli.js"
       },
       "devDependencies": {
-        "@sentropic/design-system-themes": "^0.10.3",
-        "@sentropic/design-system-tokens": "^0.10.3",
+        "@sentropic/design-system-themes": "^0.11.0",
+        "@sentropic/design-system-tokens": "^0.11.0",
         "@types/node": "^25.8.0",
         "tsup": "^8.3.0",
         "typescript": "^6.0.3",
@@ -2199,18 +2199,18 @@
       ]
     },
     "node_modules/@sentropic/design-system-themes": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.10.3.tgz",
-      "integrity": "sha512-obIX2tMS/fxaXVocz9ChLJvngWGqfw/kyw9MeVmvhT4bHQteLnsQ3Yv6YlTuqikAdm9ICfy71J3YpsvoVVG+mA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.11.0.tgz",
+      "integrity": "sha512-NrwIkPLx1sktkXgcVaIM/K7H/vbYbYoCZFmfKa4V9a37BPAUysb+2IAvxoEh7ko7veteMCqkOsIMKNf/tsQOwg==",
       "dev": true,
       "dependencies": {
-        "@sentropic/design-system-tokens": "0.10.3"
+        "@sentropic/design-system-tokens": "0.11.0"
       }
     },
     "node_modules/@sentropic/design-system-tokens": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.10.3.tgz",
-      "integrity": "sha512-Ni5V+EHbXR61kzBG+xorOyhmU0Svog/7TqliXZe0/PDvv3nu8tmIJMD3FbLZWMTWkWywS7xV+DjIzMAmgAbqsQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.11.0.tgz",
+      "integrity": "sha512-2eNp0pQa7E8d/umBs6XIYZQlRjYrLVVE8mvcPAajxBjrROWPjnMgCcZtoh6aurWLX9DXKVFD5bMCsDVXs5SDUA==",
       "dev": true
     },
     "node_modules/@sentropic/graph": {

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "tsup": "^8.3.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6",
-    "@sentropic/design-system-themes": "^0.10.3",
-    "@sentropic/design-system-tokens": "^0.10.3"
+    "@sentropic/design-system-themes": "^0.11.0",
+    "@sentropic/design-system-tokens": "^0.11.0"
   }
 }

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -8,9 +8,9 @@
       "name": "graphify-ontology-studio-app",
       "version": "0.1.0",
       "dependencies": {
-        "@sentropic/design-system-svelte": "^0.16.0",
-        "@sentropic/design-system-themes": "^0.10.3",
-        "@sentropic/design-system-tokens": "^0.10.3"
+        "@sentropic/design-system-svelte": "^0.34.32",
+        "@sentropic/design-system-themes": "^0.11.0",
+        "@sentropic/design-system-tokens": "^0.11.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -1035,29 +1035,52 @@
       ]
     },
     "node_modules/@sentropic/design-system-svelte": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.16.0.tgz",
-      "integrity": "sha512-Pc9MsZK3QKTi+8iGfBMYsk/VpJapukWMX+uBVM04D6wEOMgRKnUqYWanVk9E0UEhETJHjnIPRhd/MZPXWLBMJA==",
+      "version": "0.34.32",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.34.32.tgz",
+      "integrity": "sha512-h2FQYptmZ/gzmeuwgdfORq2Zkx+A0PbF8Mn/QCwMOfmqbUXQZAsoTHVSs2dg2LoZ9gLJ9Rt8Egq70U1LEIqeTA==",
       "dependencies": {
         "@lucide/svelte": "^0.562.0",
-        "@sentropic/design-system-themes": "0.10.3"
+        "@sentropic/design-system-theme-carbon": "0.2.2",
+        "@sentropic/design-system-themes": "0.11.0"
       },
       "peerDependencies": {
         "svelte": "^5.53.2"
       }
     },
-    "node_modules/@sentropic/design-system-themes": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.10.3.tgz",
-      "integrity": "sha512-obIX2tMS/fxaXVocz9ChLJvngWGqfw/kyw9MeVmvhT4bHQteLnsQ3Yv6YlTuqikAdm9ICfy71J3YpsvoVVG+mA==",
+    "node_modules/@sentropic/design-system-theme-carbon": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-theme-carbon/-/design-system-theme-carbon-0.2.2.tgz",
+      "integrity": "sha512-3FXw/qOyL2sHfLP/E/hwo7wTpCUa7USMdFinRP04+uPMWLjVytP8PGP9kcrvNH9WRNeo1Zuk7vskIaKq8Gnb1g==",
       "dependencies": {
-        "@sentropic/design-system-tokens": "0.10.3"
+        "@sentropic/design-system-themes": "0.10.2",
+        "@sentropic/design-system-tokens": "0.10.2"
+      }
+    },
+    "node_modules/@sentropic/design-system-theme-carbon/node_modules/@sentropic/design-system-themes": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.10.2.tgz",
+      "integrity": "sha512-6BtRp21krV1xPZjR0pjfaYAAN3zK2tbiKtzmdRY4GTtKXbTTx4unVQ37q+6Fn+s/nL7WorY6UXffjwFQMkEVow==",
+      "dependencies": {
+        "@sentropic/design-system-tokens": "0.10.2"
+      }
+    },
+    "node_modules/@sentropic/design-system-theme-carbon/node_modules/@sentropic/design-system-tokens": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.10.2.tgz",
+      "integrity": "sha512-GOi3gKItMqhSrAk4Bag5QN8ef6gkDGcL2m9yDT01qVtWeNxPWFRTYfauwmoGDXYucAlj/07IwpDBaOf2rYhCVg=="
+    },
+    "node_modules/@sentropic/design-system-themes": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.11.0.tgz",
+      "integrity": "sha512-NrwIkPLx1sktkXgcVaIM/K7H/vbYbYoCZFmfKa4V9a37BPAUysb+2IAvxoEh7ko7veteMCqkOsIMKNf/tsQOwg==",
+      "dependencies": {
+        "@sentropic/design-system-tokens": "0.11.0"
       }
     },
     "node_modules/@sentropic/design-system-tokens": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.10.3.tgz",
-      "integrity": "sha512-Ni5V+EHbXR61kzBG+xorOyhmU0Svog/7TqliXZe0/PDvv3nu8tmIJMD3FbLZWMTWkWywS7xV+DjIzMAmgAbqsQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.11.0.tgz",
+      "integrity": "sha512-2eNp0pQa7E8d/umBs6XIYZQlRjYrLVVE8mvcPAajxBjrROWPjnMgCcZtoh6aurWLX9DXKVFD5bMCsDVXs5SDUA=="
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,8 +18,8 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@sentropic/design-system-svelte": "^0.16.0",
-    "@sentropic/design-system-themes": "^0.10.3",
-    "@sentropic/design-system-tokens": "^0.10.3"
+    "@sentropic/design-system-svelte": "^0.34.32",
+    "@sentropic/design-system-themes": "^0.11.0",
+    "@sentropic/design-system-tokens": "^0.11.0"
   }
 }


### PR DESCRIPTION
Phase 1 of the DS homogenization plan: bump `@sentropic/design-system-svelte` 0.16→0.34.32 + themes/tokens 0.10.3→0.11.0. Stacked on #153 (P0 spike: search→DS Search, counts→Badge).

**The bump is transparent — zero code breakage.** `Header` is kept in 0.34 (same API; `AppHeader`/`AppChrome` added alongside), every studio-used component (Button/ButtonGroup/Badge/SelectableRow/Search) unchanged, theme `entropic` intact in themes 0.11. Build green (3960→4100 modules, +7kB CSS = extra 0.34 component code), 104/104 studio tests pass, before/after screenshot visually identical (`.graphify/scratch/studio-ds/bump-{before,after}.png`).

Foundation for P2 (adopt AppChrome + SelectableList) / P3 (contribute Collapsible count+compact, NumberBadge, SelectableRow caption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)