### PR TITLE
P2 — adopt DS AppChrome + SelectableList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "graphify": "dist/cli.js"
       },
       "devDependencies": {
-        "@sentropic/design-system-themes": "^0.10.3",
-        "@sentropic/design-system-tokens": "^0.10.3",
+        "@sentropic/design-system-themes": "^0.11.0",
+        "@sentropic/design-system-tokens": "^0.11.0",
         "@types/node": "^25.8.0",
         "tsup": "^8.3.0",
         "typescript": "^6.0.3",
@@ -2199,18 +2199,18 @@
       ]
     },
     "node_modules/@sentropic/design-system-themes": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.10.3.tgz",
-      "integrity": "sha512-obIX2tMS/fxaXVocz9ChLJvngWGqfw/kyw9MeVmvhT4bHQteLnsQ3Yv6YlTuqikAdm9ICfy71J3YpsvoVVG+mA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.11.0.tgz",
+      "integrity": "sha512-NrwIkPLx1sktkXgcVaIM/K7H/vbYbYoCZFmfKa4V9a37BPAUysb+2IAvxoEh7ko7veteMCqkOsIMKNf/tsQOwg==",
       "dev": true,
       "dependencies": {
-        "@sentropic/design-system-tokens": "0.10.3"
+        "@sentropic/design-system-tokens": "0.11.0"
       }
     },
     "node_modules/@sentropic/design-system-tokens": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.10.3.tgz",
-      "integrity": "sha512-Ni5V+EHbXR61kzBG+xorOyhmU0Svog/7TqliXZe0/PDvv3nu8tmIJMD3FbLZWMTWkWywS7xV+DjIzMAmgAbqsQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.11.0.tgz",
+      "integrity": "sha512-2eNp0pQa7E8d/umBs6XIYZQlRjYrLVVE8mvcPAajxBjrROWPjnMgCcZtoh6aurWLX9DXKVFD5bMCsDVXs5SDUA==",
       "dev": true
     },
     "node_modules/@sentropic/graph": {

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "tsup": "^8.3.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6",
-    "@sentropic/design-system-themes": "^0.10.3",
-    "@sentropic/design-system-tokens": "^0.10.3"
+    "@sentropic/design-system-themes": "^0.11.0",
+    "@sentropic/design-system-tokens": "^0.11.0"
   }
 }

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -8,9 +8,9 @@
       "name": "graphify-ontology-studio-app",
       "version": "0.1.0",
       "dependencies": {
-        "@sentropic/design-system-svelte": "^0.16.0",
-        "@sentropic/design-system-themes": "^0.10.3",
-        "@sentropic/design-system-tokens": "^0.10.3"
+        "@sentropic/design-system-svelte": "^0.34.32",
+        "@sentropic/design-system-themes": "^0.11.0",
+        "@sentropic/design-system-tokens": "^0.11.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -1035,29 +1035,52 @@
       ]
     },
     "node_modules/@sentropic/design-system-svelte": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.16.0.tgz",
-      "integrity": "sha512-Pc9MsZK3QKTi+8iGfBMYsk/VpJapukWMX+uBVM04D6wEOMgRKnUqYWanVk9E0UEhETJHjnIPRhd/MZPXWLBMJA==",
+      "version": "0.34.32",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-svelte/-/design-system-svelte-0.34.32.tgz",
+      "integrity": "sha512-h2FQYptmZ/gzmeuwgdfORq2Zkx+A0PbF8Mn/QCwMOfmqbUXQZAsoTHVSs2dg2LoZ9gLJ9Rt8Egq70U1LEIqeTA==",
       "dependencies": {
         "@lucide/svelte": "^0.562.0",
-        "@sentropic/design-system-themes": "0.10.3"
+        "@sentropic/design-system-theme-carbon": "0.2.2",
+        "@sentropic/design-system-themes": "0.11.0"
       },
       "peerDependencies": {
         "svelte": "^5.53.2"
       }
     },
-    "node_modules/@sentropic/design-system-themes": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.10.3.tgz",
-      "integrity": "sha512-obIX2tMS/fxaXVocz9ChLJvngWGqfw/kyw9MeVmvhT4bHQteLnsQ3Yv6YlTuqikAdm9ICfy71J3YpsvoVVG+mA==",
+    "node_modules/@sentropic/design-system-theme-carbon": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-theme-carbon/-/design-system-theme-carbon-0.2.2.tgz",
+      "integrity": "sha512-3FXw/qOyL2sHfLP/E/hwo7wTpCUa7USMdFinRP04+uPMWLjVytP8PGP9kcrvNH9WRNeo1Zuk7vskIaKq8Gnb1g==",
       "dependencies": {
-        "@sentropic/design-system-tokens": "0.10.3"
+        "@sentropic/design-system-themes": "0.10.2",
+        "@sentropic/design-system-tokens": "0.10.2"
+      }
+    },
+    "node_modules/@sentropic/design-system-theme-carbon/node_modules/@sentropic/design-system-themes": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.10.2.tgz",
+      "integrity": "sha512-6BtRp21krV1xPZjR0pjfaYAAN3zK2tbiKtzmdRY4GTtKXbTTx4unVQ37q+6Fn+s/nL7WorY6UXffjwFQMkEVow==",
+      "dependencies": {
+        "@sentropic/design-system-tokens": "0.10.2"
+      }
+    },
+    "node_modules/@sentropic/design-system-theme-carbon/node_modules/@sentropic/design-system-tokens": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.10.2.tgz",
+      "integrity": "sha512-GOi3gKItMqhSrAk4Bag5QN8ef6gkDGcL2m9yDT01qVtWeNxPWFRTYfauwmoGDXYucAlj/07IwpDBaOf2rYhCVg=="
+    },
+    "node_modules/@sentropic/design-system-themes": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-themes/-/design-system-themes-0.11.0.tgz",
+      "integrity": "sha512-NrwIkPLx1sktkXgcVaIM/K7H/vbYbYoCZFmfKa4V9a37BPAUysb+2IAvxoEh7ko7veteMCqkOsIMKNf/tsQOwg==",
+      "dependencies": {
+        "@sentropic/design-system-tokens": "0.11.0"
       }
     },
     "node_modules/@sentropic/design-system-tokens": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.10.3.tgz",
-      "integrity": "sha512-Ni5V+EHbXR61kzBG+xorOyhmU0Svog/7TqliXZe0/PDvv3nu8tmIJMD3FbLZWMTWkWywS7xV+DjIzMAmgAbqsQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@sentropic/design-system-tokens/-/design-system-tokens-0.11.0.tgz",
+      "integrity": "sha512-2eNp0pQa7E8d/umBs6XIYZQlRjYrLVVE8mvcPAajxBjrROWPjnMgCcZtoh6aurWLX9DXKVFD5bMCsDVXs5SDUA=="
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,8 +18,8 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@sentropic/design-system-svelte": "^0.16.0",
-    "@sentropic/design-system-themes": "^0.10.3",
-    "@sentropic/design-system-tokens": "^0.10.3"
+    "@sentropic/design-system-svelte": "^0.34.32",
+    "@sentropic/design-system-themes": "^0.11.0",
+    "@sentropic/design-system-tokens": "^0.11.0"
   }
 }

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -10,7 +10,7 @@
    * architecture.
    */
   import { onMount } from "svelte";
-  import { Header, Button, Badge, ButtonGroup } from "@sentropic/design-system-svelte";
+  import { AppChrome, Button, Badge, ButtonGroup } from "@sentropic/design-system-svelte";
 
   import GraphCanvas from "./components/GraphCanvas.svelte";
   import LeftRail from "./components/LeftRail.svelte";
@@ -130,13 +130,12 @@
 </script>
 
 <div class="app" data-st-theme="entropic">
-  <Header
+  <AppChrome
     class="app-header"
-    title="Graphify Studio"
-    label="Graphify Ontology Studio"
-    sticky={true}
+    brandName="Graphify"
+    productName="Ontology Studio"
   >
-    {#snippet navigation()}
+    {#snippet identity()}
       <ButtonGroup attached size="sm" label="Studio view" class="app-view-switcher">
         <Button
           size="sm"
@@ -160,7 +159,7 @@
         </Button>
       </ButtonGroup>
     {/snippet}
-    {#snippet actions()}
+    {#snippet extraSelectors()}
       {#if loaded && !loadError}
         <span class="app-stats" aria-label="Graph summary">
           <Badge tone="neutral">{scene.stats.nodeCount} nodes</Badge>
@@ -169,7 +168,7 @@
         </span>
       {/if}
     {/snippet}
-  </Header>
+  </AppChrome>
 
   <main class="app-body">
     {#if !loaded}
@@ -236,7 +235,7 @@
     height: 100%;
     min-height: 0;
   }
-  /* DS Header owns surface/layout/sticky; local CSS only sizes slot content. */
+  /* DS AppChrome owns surface/layout/sticky; local CSS only sizes slot content. */
   :global(.app-view-switcher) {
     white-space: nowrap;
   }

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -5,7 +5,12 @@
    * the selection (click = add/remove); selected rows are marked. The selection
    * itself is shown in the right column (SelectionPanel).
    */
-  import { SelectableRow, Search, Badge } from "@sentropic/design-system-svelte";
+  import {
+    SelectableList,
+    SelectableRow,
+    Search,
+    Badge,
+  } from "@sentropic/design-system-svelte";
   import Accordion from "./Accordion.svelte";
   import TypeShapeGlyph from "./TypeShapeGlyph.svelte";
   import {
@@ -59,9 +64,34 @@
   });
   const entityTotal = $derived(entitiesByType.reduce((n, g) => n + g.count, 0));
 
-  const typeSet = $derived(new Set(selection.types));
+  // Communities + Entities use STANDALONE SelectableRows (selected/onselect), so
+  // they need the selection-membership sets for the per-row `selected` flag.
+  // (Types uses a SelectableList controlled by selection.types — see below.)
   const commSet = $derived(new Set(selection.communities));
   const entSet = $derived(new Set(selection.entities));
+
+  // Types is wrapped in a DS SelectableList (only ~3 rows, so the listbox roving
+  // tabindex is cheap). The list is controlled by the current selection array and
+  // emits the FULL new array on every change; the studio's viewerState model is a
+  // per-element toggle (toggleType), so recover the single key that flipped between
+  // `prev` and `next` and forward it to the existing toggle action. A multi-toggle
+  // changes exactly one key per activate.
+  //
+  // NOTE: Communities (222) and Entities (1000s) deliberately do NOT use
+  // SelectableList — its register()/sortByDom() is O(n) per row → O(n²) at mount
+  // of a large list, which pegs the main thread when those accordions expand.
+  // Standalone rows keep the multi-toggle behavior at zero registration cost.
+  function toggledKey(prev, next) {
+    const before = new Set(prev);
+    const after = new Set(next);
+    for (const k of after) if (!before.has(k)) return k; // added
+    for (const k of before) if (!after.has(k)) return k; // removed
+    return null;
+  }
+  function onListChange(prev, next, toggle) {
+    const key = toggledKey(prev, next);
+    if (key != null) toggle?.(key);
+  }
 </script>
 
 <aside class="rail" aria-label="Search">
@@ -83,19 +113,25 @@
     {#if typeList.length === 0}
       <p class="rail-empty">No types.</p>
     {:else}
-      <ul class="rail-list">
+      <SelectableList
+        class="rail-list"
+        label="Types"
+        multiple
+        value={selection.types}
+        onchange={(next) => onListChange(selection.types, next, onToggleType)}
+      >
         {#each typeList as t (t.key)}
-          <li>
-            <SelectableRow value={t.key} selected={typeSet.has(t.key)} onselect={() => onToggleType?.(t.key)}>
-              <span class="rail-row-content">
-                <TypeShapeGlyph type={t.key} />
-                <span class="rail-row-label">{t.key}</span>
-                <Badge tone="neutral">{t.count}</Badge>
-              </span>
-            </SelectableRow>
-          </li>
+          <SelectableRow value={t.key}>
+            {#snippet leading()}
+              <TypeShapeGlyph type={t.key} />
+            {/snippet}
+            {t.key}
+            {#snippet trailing()}
+              <Badge tone="neutral">{t.count}</Badge>
+            {/snippet}
+          </SelectableRow>
         {/each}
-      </ul>
+      </SelectableList>
     {/if}
   </Accordion>
 
@@ -106,16 +142,22 @@
       <ul class="rail-list">
         {#each communityInfo.live as c (c.key)}
           <li>
-            <SelectableRow value={c.key} selected={commSet.has(c.key)} onselect={() => onToggleCommunity?.(c.key)}>
-              <span class="rail-row-content">
+            <SelectableRow
+              value={c.key}
+              selected={commSet.has(c.key)}
+              onselect={() => onToggleCommunity?.(c.key)}
+            >
+              {#snippet leading()}
                 <span
                   class="rail-swatch"
                   style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
                   aria-hidden="true"
                 ></span>
-                <span class="rail-row-label">{c.key}</span>
+              {/snippet}
+              {c.key}
+              {#snippet trailing()}
                 <Badge tone="neutral">{c.count}</Badge>
-              </span>
+              {/snippet}
             </SelectableRow>
           </li>
         {/each}
@@ -140,10 +182,12 @@
               <ul class="rail-list">
                 {#each grp.items as r (r.id)}
                   <li>
-                    <SelectableRow value={r.id} selected={entSet.has(r.id)} onselect={() => onToggleEntity?.(r.id)}>
-                      <span class="rail-row-content" title={r.id}>
-                        <span class="rail-row-label">{r.label}</span>
-                      </span>
+                    <SelectableRow
+                      value={r.id}
+                      selected={entSet.has(r.id)}
+                      onselect={() => onToggleEntity?.(r.id)}
+                    >
+                      <span class="rail-ent-label" title={r.id}>{r.label}</span>
                     </SelectableRow>
                   </li>
                 {/each}
@@ -200,28 +244,24 @@
     padding: 0.5rem 0.85rem 0.7rem;
     border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
   }
-  .rail-list {
+  /* The Communities/Entities lists are plain <ul> of standalone SelectableRows. */
+  ul.rail-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
     gap: 1px;
   }
-  /* SelectableRow (DS, R8-5) owns the row wrapper + selected styling; this is
-     just the inner layout (swatch | label | count). */
-  .rail-row-content {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    width: 100%;
-    min-width: 0;
-    font-size: 0.85rem;
+  /* The Types list is a DS SelectableList (listbox wrapper, roving tabindex); each
+     SelectableRow owns leading | content | trailing layout + selected styling. We
+     only tighten the inter-row gap to the rail's dense 1px feel. */
+  :global(.rail-list.st-selectableList) {
+    gap: 1px;
   }
-  .rail-row-label {
-    flex: 1;
-    /* min-width:0 lets the flex item shrink below its content so the ellipsis
-       kicks in (and the count to its right stays in view) instead of overflowing. */
-    min-width: 0;
+  /* Entity rows wrap the label in a titled span (hover tooltip = full id). The
+     DS row content already ellipsizes; the span just carries the title. */
+  .rail-ent-label {
+    display: block;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/studio/src/tests/appHeader.test.js
+++ b/studio/src/tests/appHeader.test.js
@@ -5,18 +5,19 @@ import { describe, expect, it } from "vitest";
 const appSource = readFileSync(resolve(process.cwd(), "src/App.svelte"), "utf8");
 
 describe("App header DS structure", () => {
-  it("uses the DS Header slots for sticky segmented navigation and graph stats", () => {
-    expect(appSource).toMatch(/import \{[^}]*Header[^}]*Button[^}]*Badge[^}]*ButtonGroup[^}]*\}/);
-    expect(appSource).toMatch(/<Header[\s\S]*sticky=\{true\}/);
+  it("uses the DS AppChrome chrome for brand, segmented navigation and graph stats", () => {
+    expect(appSource).toMatch(/import \{[^}]*AppChrome[^}]*Button[^}]*Badge[^}]*ButtonGroup[^}]*\}/);
+    expect(appSource).toMatch(/<AppChrome[\s\S]*brandName="Graphify"/);
+    expect(appSource).toMatch(/<AppChrome[\s\S]*productName="Ontology Studio"/);
     expect(appSource).toMatch(
-      /{#snippet navigation\(\)}[\s\S]*<ButtonGroup[\s\S]*attached[\s\S]*label="Studio view"/,
+      /{#snippet identity\(\)}[\s\S]*<ButtonGroup[\s\S]*attached[\s\S]*label="Studio view"/,
     );
     expect(appSource).toMatch(/aria-pressed=\{viewerState\.activeView === "workspace"\}/);
     expect(appSource).toMatch(/aria-pressed=\{viewerState\.activeView === "reconciliation"\}/);
     expect(appSource).toMatch(/onclick=\{\(\) => handleSetView\("workspace"\)\}/);
     expect(appSource).toMatch(/onclick=\{\(\) => handleSetView\("reconciliation"\)\}/);
     expect(appSource).toMatch(
-      /{#snippet actions\(\)}[\s\S]*class="app-stats"[\s\S]*aria-label="Graph summary"/,
+      /{#snippet extraSelectors\(\)}[\s\S]*class="app-stats"[\s\S]*aria-label="Graph summary"/,
     );
     expect(appSource).toContain("<Badge tone=\"neutral\">{scene.stats.nodeCount} nodes</Badge>");
     expect(appSource).toContain("<Badge tone=\"neutral\">{scene.stats.edgeCount} edges</Badge>");
@@ -24,8 +25,8 @@ describe("App header DS structure", () => {
   });
 
   it("keeps responsive header behavior on local slot content instead of DS internals", () => {
-    expect(appSource).not.toMatch(/st-header__/);
-    expect(appSource).not.toMatch(/\.st-header\.app-header/);
+    expect(appSource).not.toMatch(/st-appChrome__/);
+    expect(appSource).not.toMatch(/st-appHeader__/);
     expect(appSource).not.toMatch(/\.app-view-switcher \.st-button/);
     expect(appSource).toMatch(/class="view-label view-label--full">Knowledge graph</);
     expect(appSource).toMatch(/class="view-label view-label--full">Entity reconciliation</);

--- a/studio/src/tests/typeShapeGlyph.test.js
+++ b/studio/src/tests/typeShapeGlyph.test.js
@@ -45,11 +45,12 @@ describe("TypeShapeGlyph (left-rail type swatches)", () => {
     expect(variantForType({ type: "Object" })).toEqual({ fill: "hollow" });
   });
 
-  it("LeftRail shows the glyph LEFT of each type label in the Types list", () => {
+  it("LeftRail shows the glyph in the DS SelectableRow leading slot, left of the type label", () => {
     expect(railSource).toMatch(/import TypeShapeGlyph from "\.\/TypeShapeGlyph\.svelte"/);
-    // Glyph first, then the label, inside the type row content.
+    // DS slots: the glyph lives in the `leading` slot (rendered left of content)
+    // and the type label is the row's default content.
     expect(railSource).toMatch(
-      /<TypeShapeGlyph type=\{t\.key\} \/>\s*<span class="rail-row-label">\{t\.key\}<\/span>/,
+      /<SelectableRow value=\{t\.key\}>\s*\{#snippet leading\(\)}\s*<TypeShapeGlyph type=\{t\.key\} \/>\s*\{\/snippet}\s*\{t\.key\}/,
     );
   });
 


### PR DESCRIPTION
## Phase 2 — adopt existing DS 0.34 components (no new DS components)

Stacked on the P1 bump (`feat/studio-ds-bump-0.34`, DS 0.34.32). Two mechanical adoptions of components the DS already ships.

### Part A — left-rail rows → DS native slots
`LeftRail.svelte` Types/Communities/Entities rows move from a hand-rolled `<span class="rail-row-content">` (glyph | label | count) inside `SelectableRow`'s `children` to the **native slots**:
- `leading` = `TypeShapeGlyph` (Types) / community swatch (Communities)
- `children` = the label
- `trailing` = the DS `Badge` count (Types + Communities, kept from the #153 spike)

The redundant `.rail-row-content` / `.rail-row-label` CSS is removed.

**SelectableList scope (perf decision):** only **Types** (3 rows) is wrapped in `SelectableList` for the listbox roving-tabindex a11y. Its multi-toggle into `viewerState` is preserved by diffing the list's full-array `onchange` back to the single flipped key. **Communities (222) and Entities (1000s) keep STANDALONE `SelectableRow`s** (`selected`/`onselect`) — `SelectableList.register()`/`sortByDom()` is O(n) per row → **O(n²) at mount** of a large list, which pegs the main thread when those accordions expand (caught in pre-UAT: the page hung on Communities expand). Standalone rows keep the exact multi-toggle at zero registration cost.

### Part B — header → AppChrome
`App.svelte` replaces the DS `Header` with `AppChrome` (composes `AppHeader`):
- `brandName="Graphify"`, `productName="Ontology Studio"` (two-line brand block)
- view-switcher `ButtonGroup` → `identity` snippet (toggle behavior + aria preserved)
- nodes/edges/groups stats `Badge`s → `extraSelectors` snippet
- theme/locale/color-mode switchers left unset (optional, omitted)
- `data-st-theme="entropic"` unchanged

### Verify
- `npm run build` clean
- `npm test` green (104/104) — header + glyph tests updated to assert the new AppChrome + SelectableRow-slot structure
- Behavior unchanged: filtering, view switch, multi-toggle selection
- Before/after PNGs captured (cached chromium): new AppChrome header shows the "Graphify / Ontology Studio" brand block on a taller translucent bar; rail rows pixel-equivalent

**Do not merge** — visible header change, awaiting user review.