### PR TITLE
feat(extract): first-class git extractor — Commit/Branch nodes, windowed (WP2)

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -16,6 +16,7 @@ import { FileType } from "./types.js";
 import { googleWorkspaceEnabled } from "./google-workspace.js";
 import { fileWithinSizeCap, zipWithinCaps } from "./office-guard.js";
 import type { DetectionResult, InputScopeInspection } from "./types.js";
+import { detectGitWindow } from "./extract-git.js";
 
 export const CODE_EXTENSIONS = new Set([
   ".py", ".ts", ".js", ".jsx", ".tsx", ".go", ".rs", ".java", ".cpp", ".cc", ".cxx",
@@ -798,6 +799,8 @@ export function detect(root: string, options?: DetectOptions): DetectionResult {
       `Consider running on a subfolder, or use --no-semantic to run AST-only.`;
   }
 
+  const gitWindow = detectGitWindow(rootResolved);
+
   return {
     files,
     total_files: totalFiles,
@@ -806,6 +809,7 @@ export function detect(root: string, options?: DetectOptions): DetectionResult {
     warning,
     skipped_sensitive: skippedSensitive,
     graphifyignore_patterns: ignorePatterns.length,
+    ...(gitWindow ? { git: gitWindow } : {}),
     ...(options?.scope
       ? {
         scope: {

--- a/src/extract-git.ts
+++ b/src/extract-git.ts
@@ -1,0 +1,409 @@
+import { execFileSync } from "node:child_process";
+import { resolve, relative, basename, dirname, extname, sep, isAbsolute } from "node:path";
+import { repoKey, commitId, branchId } from "./repo-key.js";
+import type { Extraction, GitDetectionWindow, GraphEdge, GraphNode, OntologyProfile } from "./types.js";
+
+export const GIT_EXTRACT_ADAPTER_VERSION = "graphify-git/1";
+
+const DEFAULT_MAX_COMMITS = 200;
+const DEFAULT_ACTIVE_WITHIN_DAYS = 30;
+
+export const CODE_GIT_ONTOLOGY_PROFILE: OntologyProfile = {
+  id: "code-git",
+  version: 1,
+  node_types: {
+    Commit: {
+      aliases: ["git commit", "revision"],
+      source_backed: true,
+    },
+    Branch: {
+      aliases: ["git branch", "ref"],
+      source_backed: true,
+    },
+    // Conservative compatibility type for MODIFIES targets. Existing AST file
+    // nodes do not yet stamp node_type="File", but profile validation needs a
+    // declared endpoint rather than an open-world reference.
+    File: {
+      aliases: ["source file"],
+      source_backed: true,
+    },
+  },
+  relation_types: {
+    PARENT_OF: {
+      source: "Commit",
+      target: "Commit",
+      derivation_method: "git_parent",
+    },
+    ON_BRANCH: {
+      source: "Commit",
+      target: "Branch",
+      derivation_method: "git_ref",
+    },
+    MODIFIES: {
+      source: "Commit",
+      target: "File",
+      derivation_method: "git_numstat",
+    },
+  },
+};
+
+export interface ExtractGitOptions {
+  branches?: string[];
+  maxCommits?: number;
+  sinceDays?: number;
+  activeWithinDays?: number;
+  observedAt?: string;
+  fileNodeIds?: Map<string, string> | Record<string, string>;
+}
+
+interface CommitInfo {
+  sha: string;
+  parents: string[];
+  author: string;
+  authoredAt: string;
+  messageSummary: string;
+  messageLength: number;
+}
+
+function runGit(cwd: string, args: string[]): string {
+  try {
+    return execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    const maybe = err as { status?: number; stdout?: string | Buffer };
+    if (maybe.status === 0 && maybe.stdout !== undefined) {
+      return String(maybe.stdout).trim();
+    }
+    throw err;
+  }
+}
+
+function tryGit(cwd: string, args: string[]): string | null {
+  try {
+    return runGit(cwd, args);
+  } catch {
+    return null;
+  }
+}
+
+function emptyExtraction(): Extraction {
+  return {
+    nodes: [],
+    edges: [],
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+}
+
+function isGitRepo(root: string): boolean {
+  return tryGit(root, ["rev-parse", "--is-inside-work-tree"]) === "true";
+}
+
+function gitRoot(root: string): string {
+  return tryGit(root, ["rev-parse", "--show-toplevel"]) ?? resolve(root);
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.floor(value));
+}
+
+function defaultBranch(root: string, current: string | null): string | null {
+  const remoteHead = tryGit(root, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]);
+  if (remoteHead) {
+    return remoteHead.replace(/^origin\//, "");
+  }
+  return current;
+}
+
+function discoverBranches(root: string, options: ExtractGitOptions): string[] {
+  if (options.branches && options.branches.length > 0) {
+    return [...new Set(options.branches.filter((branch) => branch.trim().length > 0))].sort();
+  }
+
+  const current = tryGit(root, ["branch", "--show-current"]);
+  const def = defaultBranch(root, current);
+  const activeWithinDays = positiveInteger(options.activeWithinDays, DEFAULT_ACTIVE_WITHIN_DAYS);
+  const cutoff = Date.now() - activeWithinDays * 24 * 60 * 60 * 1000;
+  const branches = new Set<string>();
+  if (def) branches.add(def);
+  if (current) branches.add(current);
+
+  const refs = tryGit(root, [
+    "for-each-ref",
+    "--format=%(refname:short)%00%(committerdate:iso-strict)",
+    "refs/heads",
+  ]);
+  for (const line of refs?.split("\n") ?? []) {
+    if (!line.trim()) continue;
+    const [name, date] = line.split("\0");
+    if (!name) continue;
+    const time = Date.parse(date ?? "");
+    if (Number.isFinite(time) && time >= cutoff) {
+      branches.add(name);
+    }
+  }
+
+  return [...branches].sort();
+}
+
+function revList(root: string, branch: string, options: ExtractGitOptions): string[] {
+  const maxCommits = positiveInteger(options.maxCommits, DEFAULT_MAX_COMMITS);
+  const args = ["rev-list", `--max-count=${maxCommits}`];
+  if (options.sinceDays !== undefined && Number.isFinite(options.sinceDays) && options.sinceDays > 0) {
+    args.push(`--since=${Math.floor(options.sinceDays)} days ago`);
+  }
+  args.push(branch);
+  const out = tryGit(root, args);
+  return out ? out.split("\n").filter(Boolean) : [];
+}
+
+function readCommit(root: string, sha: string): CommitInfo | null {
+  const out = tryGit(root, ["show", "-s", "--format=%H%x00%P%x00%an <%ae>%x00%aI%x00%s%x00%B", sha]);
+  if (!out) return null;
+  const parts = out.split("\0");
+  const fullMessage = parts.slice(5).join("\0");
+  return {
+    sha: parts[0] ?? sha,
+    parents: (parts[1] ?? "").split(" ").filter(Boolean),
+    author: parts[2] ?? "",
+    authoredAt: parts[3] ?? "",
+    messageSummary: parts[4] ?? "",
+    messageLength: fullMessage.length,
+  };
+}
+
+function portablePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function makeId(...parts: string[]): string {
+  const combined = parts
+    .filter(Boolean)
+    .map((p) => p.replace(/^[_.]+|[_.]+$/g, ""))
+    .join("_");
+  const cleaned = combined.replace(/[^a-zA-Z0-9]+/g, "_");
+  return cleaned.replace(/^_+|_+$/g, "").toLowerCase();
+}
+
+function qualifiedFileStem(filePath: string, rootDir: string): string {
+  const resolved = resolve(filePath);
+  const stem = basename(resolved, extname(resolved));
+  const parentDir = dirname(resolved);
+  if (resolve(parentDir) === resolve(rootDir)) return stem;
+  const parent = basename(parentDir);
+  return parent ? `${parent}.${stem}` : stem;
+}
+
+export function codeFileNodeId(repoRoot: string, filePath: string): string {
+  const absolute = isAbsolute(filePath) ? filePath : resolve(repoRoot, filePath);
+  return makeId(qualifiedFileStem(absolute, repoRoot));
+}
+
+export function buildCodeFileNodeIdMap(repoRoot: string, files: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const file of files) {
+    const rel = portablePath(relative(repoRoot, isAbsolute(file) ? file : resolve(repoRoot, file)));
+    if (!rel || rel.startsWith("..") || rel.split(sep).includes("..")) continue;
+    map.set(rel, codeFileNodeId(repoRoot, file));
+  }
+  return map;
+}
+
+function lookupFileNodeId(
+  fileNodeIds: ExtractGitOptions["fileNodeIds"],
+  path: string,
+  root: string,
+): string | null {
+  const portable = portablePath(path);
+  if (!fileNodeIds) return codeFileNodeId(root, portable);
+  if (fileNodeIds instanceof Map) {
+    return fileNodeIds.get(portable) ?? fileNodeIds.get(resolve(root, portable)) ?? null;
+  }
+  return fileNodeIds[portable] ?? fileNodeIds[resolve(root, portable)] ?? null;
+}
+
+function parseNumstatPath(raw: string): string {
+  return portablePath(raw.replace(/\{([^{}]*) => ([^{}]*)\}/g, "$2"));
+}
+
+function readModifiesEdges(
+  root: string,
+  repo: string,
+  sha: string,
+  repoKeyStr: string,
+  fileNodeIds: ExtractGitOptions["fileNodeIds"],
+): GraphEdge[] {
+  const out = tryGit(root, ["show", "--numstat", "--format=", "--find-renames", "--find-copies", sha]);
+  const edges: GraphEdge[] = [];
+  for (const line of out?.split("\n") ?? []) {
+    if (!line.trim()) continue;
+    const [addedRaw, deletedRaw, pathRaw] = line.split("\t");
+    if (!pathRaw || addedRaw === "-" || deletedRaw === "-") continue;
+    const filePath = parseNumstatPath(pathRaw);
+    const target = lookupFileNodeId(fileNodeIds, filePath, repo);
+    if (!target) continue;
+    edges.push({
+      source: commitId(repoKeyStr, sha),
+      target,
+      relation: "MODIFIES",
+      confidence: "EXTRACTED",
+      source_file: filePath,
+      added: Number.parseInt(addedRaw ?? "0", 10) || 0,
+      deleted: Number.parseInt(deletedRaw ?? "0", 10) || 0,
+      file_path: filePath,
+    });
+  }
+  return edges;
+}
+
+function commitNode(repoKeyStr: string, info: CommitInfo): GraphNode {
+  const short = info.sha.slice(0, 7);
+  return {
+    id: commitId(repoKeyStr, info.sha),
+    label: info.messageSummary ? `${short} ${info.messageSummary}` : short,
+    file_type: "concept",
+    source_file: "git",
+    node_type: "Commit",
+    repo: repoKeyStr,
+    sha: info.sha,
+    author: info.author,
+    authoredAt: info.authoredAt,
+    message_summary: info.messageSummary,
+    message_length: info.messageLength,
+    parents: info.parents,
+  };
+}
+
+function branchNode(repoKeyStr: string, name: string, headSha: string | undefined): GraphNode {
+  return {
+    id: branchId(repoKeyStr, name),
+    label: name,
+    file_type: "concept",
+    source_file: "git",
+    node_type: "Branch",
+    repo: repoKeyStr,
+    branch_name: name,
+    ...(headSha ? { head_sha: headSha } : {}),
+  };
+}
+
+function edgeKey(edge: GraphEdge): string {
+  return `${edge.source}\0${edge.target}\0${edge.relation}\0${String(edge.source_file ?? "")}`;
+}
+
+export function mergeExtractions(base: Extraction, extra: Extraction): Extraction {
+  const nodes = new Map<string, GraphNode>();
+  for (const node of [...(base.nodes ?? []), ...(extra.nodes ?? [])]) {
+    nodes.set(node.id, node);
+  }
+  const edges = new Map<string, GraphEdge>();
+  for (const edge of [...(base.edges ?? []), ...(extra.edges ?? [])]) {
+    edges.set(edgeKey(edge), edge);
+  }
+  return {
+    ...(extra.provenance ? { provenance: extra.provenance } : base.provenance ? { provenance: base.provenance } : {}),
+    nodes: [...nodes.values()],
+    edges: [...edges.values()],
+    hyperedges: [...(base.hyperedges ?? []), ...(extra.hyperedges ?? [])],
+    input_tokens: (base.input_tokens ?? 0) + (extra.input_tokens ?? 0),
+    output_tokens: (base.output_tokens ?? 0) + (extra.output_tokens ?? 0),
+  };
+}
+
+export function detectGitWindow(root: string = ".", options: ExtractGitOptions = {}): GitDetectionWindow | undefined {
+  const startRoot = resolve(root);
+  if (!isGitRepo(startRoot)) return undefined;
+  const repo = gitRoot(startRoot);
+  const head = tryGit(repo, ["rev-parse", "HEAD"]);
+  if (!head) return undefined;
+  return {
+    source_owner: "git",
+    source_hash: head,
+    branches: discoverBranches(repo, options),
+    max_commits: positiveInteger(options.maxCommits, DEFAULT_MAX_COMMITS),
+    active_within_days: positiveInteger(options.activeWithinDays, DEFAULT_ACTIVE_WITHIN_DAYS),
+    ...(options.sinceDays !== undefined && Number.isFinite(options.sinceDays) && options.sinceDays > 0
+      ? { since_days: Math.floor(options.sinceDays) }
+      : {}),
+  };
+}
+
+export function extractGit(root: string = ".", options: ExtractGitOptions = {}): Extraction {
+  const startRoot = resolve(root);
+  if (!isGitRepo(startRoot)) return emptyExtraction();
+
+  const repo = gitRoot(startRoot);
+  const head = tryGit(repo, ["rev-parse", "HEAD"]);
+  if (!head) return emptyExtraction();
+
+  const repoKeyStr = repoKey(repo);
+  const branches = discoverBranches(repo, options);
+  const commitsByBranch = new Map<string, string[]>();
+  const allShas = new Set<string>();
+  for (const branch of branches) {
+    const shas = revList(repo, branch, options);
+    commitsByBranch.set(branch, shas);
+    for (const sha of shas) allShas.add(sha);
+  }
+
+  const commitInfos = new Map<string, CommitInfo>();
+  for (const sha of [...allShas].sort()) {
+    const info = readCommit(repo, sha);
+    if (info) commitInfos.set(sha, info);
+  }
+
+  const nodes: GraphNode[] = [
+    ...[...commitInfos.values()].map((info) => commitNode(repoKeyStr, info)),
+    ...branches.map((branch) => branchNode(repoKeyStr, branch, commitsByBranch.get(branch)?.[0])),
+  ];
+
+  const includedCommits = new Set(commitInfos.keys());
+  const edges: GraphEdge[] = [];
+  for (const info of commitInfos.values()) {
+    for (const parent of info.parents) {
+      if (!includedCommits.has(parent)) continue;
+      edges.push({
+        source: commitId(repoKeyStr, parent),
+        target: commitId(repoKeyStr, info.sha),
+        relation: "PARENT_OF",
+        confidence: "EXTRACTED",
+        source_file: "git",
+      });
+    }
+    edges.push(...readModifiesEdges(repo, repo, info.sha, repoKeyStr, options.fileNodeIds));
+  }
+
+  for (const [branch, shas] of commitsByBranch.entries()) {
+    for (const sha of shas) {
+      if (!includedCommits.has(sha)) continue;
+      edges.push({
+        source: commitId(repoKeyStr, sha),
+        target: branchId(repoKeyStr, branch),
+        relation: "ON_BRANCH",
+        confidence: "EXTRACTED",
+        source_file: "git",
+      });
+    }
+  }
+
+  const dedupedEdges = new Map<string, GraphEdge>();
+  for (const edge of edges) dedupedEdges.set(edgeKey(edge), edge);
+
+  return {
+    provenance: {
+      source_owner: "git",
+      source_id: repoKeyStr,
+      observed_at: options.observedAt ?? new Date().toISOString(),
+      source_hash: head,
+      adapter_version: GIT_EXTRACT_ADAPTER_VERSION,
+    },
+    nodes,
+    edges: [...dedupedEdges.values()],
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,6 +278,15 @@ export { WIKI_DESCRIPTION_BATCH_SCHEMA, buildTargetKindsMap, buildWikiDescriptio
 export type { BuildWikiDescriptionBatchOptions, ParseWikiDescriptionBatchOptions, WikiDescriptionBatchResultRecord } from "./wiki-description-batch.js";
 export { detect, classifyFile, detectIncremental, saveManifest } from "./detect.js";
 export { extract, collectFiles } from "./extract.js";
+export {
+  CODE_GIT_ONTOLOGY_PROFILE,
+  GIT_EXTRACT_ADAPTER_VERSION,
+  buildCodeFileNodeIdMap,
+  codeFileNodeId,
+  detectGitWindow,
+  extractGit,
+  mergeExtractions,
+} from "./extract-git.js";
 export { fileHash, loadCached, saveCached, checkSemanticCache, saveSemanticCache } from "./cache.js";
 export {
   MAX_SEMANTIC_FRAGMENT_BYTES,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -17,6 +17,7 @@ import { generate } from "./report.js";
 import { backupIfProtected, persistGraphWithCitations } from "./export.js";
 import { safeToHtml } from "./html-export.js";
 import { extractWithDiagnostics, type ExtractionDiagnostic } from "./extract.js";
+import { buildCodeFileNodeIdMap, extractGit, mergeExtractions } from "./extract-git.js";
 import { resolveGraphifyPaths } from "./paths.js";
 import { markLifecycleAnalyzed } from "./lifecycle.js";
 import { persistCommunityLabels, resolveCommunityLabels } from "./community-labels.js";
@@ -170,6 +171,10 @@ export async function buildProject(
   }
 
   const extracted = await extractWithDiagnostics(codeFiles);
+  const gitExtraction = extractGit(rootResolved, {
+    fileNodeIds: buildCodeFileNodeIdMap(rootResolved, codeFiles),
+  });
+  const mergedExtraction = mergeExtractions(extracted.extraction, gitExtraction);
   const diagnostics = extracted.diagnostics;
 
   if (diagnostics.length > 0) {
@@ -181,7 +186,7 @@ export async function buildProject(
     });
   }
 
-  if (extracted.extraction.nodes.length === 0) {
+  if (mergedExtraction.nodes.length === 0) {
     const detail = diagnostics.length > 0
       ? ` ${formatDiagnosticSummary(diagnostics)}`
       : "";
@@ -192,7 +197,7 @@ export async function buildProject(
     );
   }
 
-  const extraction = makeExtractionPortable(extracted.extraction, rootResolved);
+  const extraction = makeExtractionPortable(mergedExtraction, rootResolved);
   const G = buildFromJson(extraction, { directed: options?.directed === true });
   if (G.order === 0) {
     throw new Error("Graph is empty after buildFromJson().");

--- a/src/repo-key.ts
+++ b/src/repo-key.ts
@@ -9,12 +9,20 @@ export interface RepoKeyRunner {
 
 const defaultRepoKeyRunner: RepoKeyRunner = {
   run(command: string, args: string[], cwd: string): string {
-    return execFileSync(command, args, {
-      cwd,
-      encoding: "utf-8",
-      maxBuffer: 64 * 1024 * 1024,
-      stdio: ["ignore", "pipe", "pipe"],
-    }).trim();
+    try {
+      return execFileSync(command, args, {
+        cwd,
+        encoding: "utf-8",
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+    } catch (err) {
+      const maybe = err as { status?: number; stdout?: string | Buffer };
+      if (maybe.status === 0 && maybe.stdout !== undefined) {
+        return String(maybe.stdout).trim();
+      }
+      throw err;
+    }
   },
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,15 @@ export interface InputScopeInspection {
   recommendation: string | null;
 }
 
+export interface GitDetectionWindow {
+  source_owner: "git";
+  source_hash: string;
+  branches: string[];
+  max_commits: number;
+  active_within_days: number;
+  since_days?: number;
+}
+
 /** A node in the knowledge graph. */
 export interface GraphNode {
   id: string;
@@ -137,6 +146,7 @@ export interface DetectionResult {
   warning: string | null;
   skipped_sensitive: string[];
   graphifyignore_patterns: number;
+  git?: GitDetectionWindow;
   /** Present in incremental mode. */
   incremental?: boolean;
   new_files?: Record<string, string[]>;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -45,6 +45,7 @@ import {
   hasUnansweredLabelInstructions,
   LABEL_INSTRUCTIONS_DIR,
 } from "./community-labeling.js";
+import { buildCodeFileNodeIdMap, extractGit, mergeExtractions } from "./extract-git.js";
 import type { Extraction, GraphifyInputScopeMode, InputScopeSource } from "./types.js";
 
 const WATCHED_EXTENSIONS = new Set([
@@ -82,6 +83,23 @@ function builtFromCommit(root: string, graphPath: string): string | null {
   } catch {
     return null;
   }
+}
+
+function changedCodeFilesFromHook(root: string, codeFiles: string[]): string[] | null {
+  const raw = process.env.GRAPHIFY_CHANGED;
+  if (!raw || raw.trim().length === 0) return null;
+  const changed = new Set(
+    raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => [line.replace(/\\/g, "/"), pathResolve(root, line).replace(/\\/g, "/")]),
+  );
+  return codeFiles.filter((file) => {
+    const abs = pathResolve(file).replace(/\\/g, "/");
+    const rel = toProjectRelativePath(root, file);
+    return changed.has(abs) || changed.has(rel);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -204,13 +222,15 @@ export async function rebuildCode(
     }
     saveManifest(rawDetection.files, paths.manifest, { root });
 
-    let codeFiles = (rawDetection.files.code ?? []).filter(
+    const allCodeFiles = (rawDetection.files.code ?? []).filter(
       (f: string) =>
         !f.includes(DEFAULT_GRAPHIFY_STATE_DIR) &&
         !f.includes(LEGACY_GRAPHIFY_STATE_DIR) &&
         !f.includes("__pycache__") &&
         !f.includes("node_modules"),
     );
+    const hookChangedCodeFiles = changedCodeFilesFromHook(root, allCodeFiles);
+    const codeFiles = hookChangedCodeFiles ?? allCodeFiles;
 
     let result: Extraction;
     if (codeFiles.length === 0) {
@@ -236,9 +256,15 @@ export async function rebuildCode(
         return false;
       }
     }
+    result = mergeExtractions(
+      result,
+      extractGit(root, {
+        fileNodeIds: buildCodeFileNodeIdMap(root, allCodeFiles),
+      }),
+    );
 
     const relativeResult = makeExtractionPortable(result, root);
-    const relativeCodeFiles = codeFiles.map((file) => toProjectRelativePath(root, file));
+    const relativeCodeFiles = allCodeFiles.map((file) => toProjectRelativePath(root, file));
 
     const detection = {
       ...portableDetection,

--- a/tests/extract-git.test.ts
+++ b/tests/extract-git.test.ts
@@ -1,0 +1,176 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { extractGit, CODE_GIT_ONTOLOGY_PROFILE } from "../src/extract-git.js";
+import { branchId, commitId, repoKey } from "../src/repo-key.js";
+import { normalizeOntologyProfile } from "../src/ontology-profile.js";
+import { validateExtraction } from "../src/validate.js";
+import type { Extraction, GraphNode } from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+function tempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-extract-git-"));
+  tempDirs.push(dir);
+  git(dir, ["init", "-q", "-b", "main"]);
+  git(dir, ["config", "user.name", "Graphify Test"]);
+  git(dir, ["config", "user.email", "graphify@example.test"]);
+  return dir;
+}
+
+function git(cwd: string, args: string[]): string {
+  try {
+    return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf-8" }).trim();
+  } catch (err) {
+    const maybe = err as { status?: number; stdout?: string | Buffer };
+    if (maybe.status === 0 && maybe.stdout !== undefined) return String(maybe.stdout).trim();
+    throw err;
+  }
+}
+
+function commit(repo: string, message: string): string {
+  git(repo, ["add", "."]);
+  git(repo, ["commit", "-q", "-m", message]);
+  return git(repo, ["rev-parse", "HEAD"]);
+}
+
+function write(repo: string, path: string, content: string): void {
+  const full = join(repo, path);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+function codeNode(id: string, path: string): GraphNode {
+  return {
+    id,
+    label: path.split("/").pop() ?? path,
+    file_type: "code",
+    source_file: path,
+  };
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("extractGit", () => {
+  it("extracts windowed commits, branches, git edges, SLOC deltas, and provenance", () => {
+    const repo = tempRepo();
+    write(repo, "src/a.ts", "export const a = 1;\n");
+    const first = commit(repo, "initial file\n\nbody that must not be stored");
+    write(repo, "src/a.ts", "export const a = 1;\nexport const b = 2;\n");
+    const second = commit(repo, "add b");
+    git(repo, ["checkout", "-q", "-b", "feature", first]);
+    write(repo, "src/b.ts", "export const feature = true;\n");
+    const feature = commit(repo, "feature file");
+    git(repo, ["checkout", "-q", "main"]);
+
+    const key = repoKey(repo);
+    const extraction = extractGit(repo, {
+      branches: ["main", "feature"],
+      maxCommits: 2,
+      observedAt: "2026-06-13T12:00:00.000Z",
+      fileNodeIds: new Map([
+        ["src/a.ts", "src_a"],
+        ["src/b.ts", "src_b"],
+      ]),
+    });
+
+    const combined: Extraction = {
+      ...extraction,
+      nodes: [codeNode("src_a", "src/a.ts"), codeNode("src_b", "src/b.ts"), ...extraction.nodes],
+    };
+    expect(validateExtraction(combined)).toEqual([]);
+
+    expect(extraction.provenance).toEqual({
+      source_owner: "git",
+      source_id: key,
+      observed_at: "2026-06-13T12:00:00.000Z",
+      source_hash: second,
+      adapter_version: expect.any(String),
+    });
+
+    expect(extraction.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: commitId(key, first),
+          node_type: "Commit",
+          sha: first,
+          message_summary: "initial file",
+          message_length: expect.any(Number),
+        }),
+        expect.objectContaining({ id: commitId(key, second), node_type: "Commit", parents: [first] }),
+        expect.objectContaining({ id: commitId(key, feature), node_type: "Commit", parents: [first] }),
+        expect.objectContaining({ id: branchId(key, "main"), node_type: "Branch", branch_name: "main" }),
+        expect.objectContaining({ id: branchId(key, "feature"), node_type: "Branch", branch_name: "feature" }),
+      ]),
+    );
+    expect(extraction.nodes.find((node) => node.id === commitId(key, first))).not.toHaveProperty(
+      "message_body",
+    );
+
+    expect(extraction.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: commitId(key, first),
+          target: commitId(key, second),
+          relation: "PARENT_OF",
+        }),
+        expect.objectContaining({
+          source: commitId(key, second),
+          target: branchId(key, "main"),
+          relation: "ON_BRANCH",
+        }),
+        expect.objectContaining({
+          source: commitId(key, feature),
+          target: branchId(key, "feature"),
+          relation: "ON_BRANCH",
+        }),
+        expect.objectContaining({
+          source: commitId(key, second),
+          target: "src_a",
+          relation: "MODIFIES",
+          added: 1,
+          deleted: 0,
+        }),
+      ]),
+    );
+  });
+
+  it("never walks the full history by defaulting to a bounded commit window", () => {
+    const repo = tempRepo();
+    write(repo, "src/a.ts", "export const a = 1;\n");
+    const first = commit(repo, "first");
+    write(repo, "src/a.ts", "export const a = 2;\n");
+    const second = commit(repo, "second");
+    write(repo, "src/a.ts", "export const a = 3;\n");
+    const third = commit(repo, "third");
+
+    const key = repoKey(repo);
+    const extraction = extractGit(repo, {
+      branches: ["main"],
+      maxCommits: 2,
+      fileNodeIds: new Map([["src/a.ts", "src_a"]]),
+    });
+
+    const commitIds = new Set(
+      extraction.nodes.filter((node) => node.node_type === "Commit").map((node) => node.id),
+    );
+    expect(commitIds).toEqual(new Set([commitId(key, third), commitId(key, second)]));
+    expect(commitIds.has(commitId(key, first))).toBe(false);
+  });
+
+  it("declares the conservative code-git ontology profile", () => {
+    const profile = normalizeOntologyProfile(CODE_GIT_ONTOLOGY_PROFILE);
+
+    expect(Object.keys(profile.node_types).sort()).toEqual(["Branch", "Commit", "File"]);
+    expect(Object.keys(profile.relation_types).sort()).toEqual(["MODIFIES", "ON_BRANCH", "PARENT_OF"]);
+    expect(profile.relation_types.MODIFIES.source_types).toEqual(["Commit"]);
+    expect(profile.relation_types.MODIFIES.target_types).toEqual(["File"]);
+  });
+});


### PR DESCRIPTION
WP2 sous MANDATE-graphify. Exécuté par codex headless (détaché, résilient quota), **vérifié + commité par le conducteur**.

**Fait** : `src/extract-git.ts` — nœuds `Commit`/`Branch` (ids via repo-key WP1), edges `PARENT_OF`/`ON_BRANCH`/`MODIFIES` (SLOC delta en attr), **fenêtré** (max 200 commits, jamais tout l'historique), provenance WP3, profil `code-git`, intégration pipeline + rebuild incrémental (hook post-commit). Zéro corps de commit brut.

**Décisions conducteur** (questions remontées par codex) : `File` reste endpoint de profil conservateur ; `PARENT_OF` parent→enfant ; `ON_BRANCH` tous les commits de la fenêtre. Aligné D1 (déclaratif) / D2 (ids de registre), ratifiés.

**Vérif (hors sandbox)** : suite complète **1809 passed / 0 failed** (194 fichiers) ; lint (tsc) OK. (graphify n'a pas de `format:check`.)

Rapport : `segmentation/wp/WP2-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)