### PR TITLE
fix(studio): recon label truncation (BUG-1) + pairing legibility & dangling-id guard (BUG-2)

### DIFF
--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -11,6 +11,7 @@
     interpolateMergeStyle,
     interpolateMergePositions,
     isBoxShape,
+    truncateLabel,
   } from "../lib/graphRendererPayload.js";
 
   const EMPTY_SCENE = {
@@ -57,6 +58,10 @@
     // 'none'  → no generic labels (workspace / main graph).
     // 'plain' → plain-text labels (no box) for high-degree + active nodes (recon).
     labelMode = "none",
+    // BUG-1: max DRAWN chars for in-box labels + DOM overlay labels. The full
+    // label is always available on hover (tooltip + overlay `title`). Undefined
+    // falls back to the renderer default (DEFAULT_LABEL_MAX_CHARS).
+    labelMaxChars = undefined,
   } = $props();
 
   let container;
@@ -317,6 +322,7 @@
       focusId,
       hoveredNodeId,
       nodeRadius: NODE_RADIUS,
+      ...(Number.isFinite(labelMaxChars) ? { labelMaxChars } : {}),
     });
     clearHoveredEdge({ notify: false, render: false });
     computeNodeDegrees();
@@ -470,9 +476,13 @@
       const screen = worldToScreen(worldX, worldY);
       if (!screen) continue;
       const radius = (payload.style?.nodeSizes?.[idx] ?? NODE_RADIUS) * camera.zoom;
+      // BUG-1: cap the DRAWN overlay text; keep the full name for the `title`
+      // hover so long entity names no longer overflow the canvas.
+      const fullLabel = node?.label ?? id;
       next.push({
         id,
-        label: node?.label ?? id,
+        label: truncateLabel(fullLabel, labelMaxChars),
+        fullLabel,
         x: screen.x,
         y: screen.y - radius - 4,
         active: activeIds.has(id),
@@ -932,6 +942,7 @@
         <span
           class={item.active ? "node-label node-label-active" : "node-label"}
           style={`left: ${item.x}px; top: ${item.y}px;`}
+          title={item.fullLabel}
         >{item.label}</span>
       {/each}
     </div>

--- a/studio/src/components/ReconciliationView.svelte
+++ b/studio/src/components/ReconciliationView.svelte
@@ -26,7 +26,11 @@
     nodeType,
   } from "../lib/graphAdapter.js";
 
-  let { graph, onOpenEntity } = $props();
+  // BUG-1: `labelMaxChars` parameterizes the DRAWN focal-box label length. The
+  // two recon entities are pinned close together; a long name (e.g. "Dr. John H.
+  // Watson") otherwise sizes an over-wide box that overflows the slot. The full
+  // name remains on hover (GraphCanvas tooltip) and in the rail/detail `title`s.
+  let { graph, onOpenEntity, labelMaxChars = 22 } = $props();
 
   let candidates = $state([]);
   let total = $state(0);
@@ -115,6 +119,21 @@
     const n = idx.get(id);
     return n ? nodeType(n) : null;
   }
+  // BUG-2: a candidate references two node ids; either can be ABSENT from the
+  // loaded graph (e.g. a stale candidates queue whose ids no longer match a
+  // re-extracted graph). When that happens the centre graph can only render ONE
+  // box, so the proposed pair reads as a lone node. We detect the missing side
+  // here so the panels can flag it explicitly instead of silently degrading.
+  function present(id) {
+    return id != null && idx.has(id);
+  }
+  const missingSides = $derived.by(() => {
+    if (!active) return [];
+    const out = [];
+    if (!present(active.candidate_id)) out.push({ role: "Candidate", id: active.candidate_id });
+    if (!present(active.canonical_id)) out.push({ role: "Canonical", id: active.canonical_id });
+    return out;
+  });
 
   async function reload() {
     const res = await fetchReconciliationCandidates();
@@ -205,7 +224,10 @@
                 class:active={activeId === c.id}
                 onclick={() => { activeId = c.id; actionResult = null; }}
               >
-                <span class="recon-rail-label">{label(c.candidate_id)} ↔ {label(c.canonical_id)}</span>
+                <span
+                  class="recon-rail-label"
+                  title={`${label(c.candidate_id)} ↔ ${label(c.canonical_id)}`}
+                >{label(c.candidate_id)} ↔ {label(c.canonical_id)}</span>
                 <span class="recon-rail-score">{Math.round((c.score ?? 0) * 100)}%</span>
               </button>
             </li>
@@ -223,6 +245,7 @@
         centerOnIds={selectedIds}
         focusId={active.candidate_id}
         labelMode="plain"
+        {labelMaxChars}
         onSelect={(id) => onOpenEntity?.(id)}
         onOpenEntity={(id) => onOpenEntity?.(id)}
         {mergePair}
@@ -239,16 +262,27 @@
         <p class="recon-empty">No candidate selected.</p>
       {:else}
         <header class="recon-detail-head">
-          <p class="recon-kicker">Reconciliation candidate</p>
-          <h2>{label(active.candidate_id)} ↔ {label(active.canonical_id)}</h2>
+          <p class="recon-kicker">Proposed match · these two entities</p>
+          <h2 title={`${label(active.candidate_id)} ↔ ${label(active.canonical_id)}`}>
+            {label(active.candidate_id)} ↔ {label(active.canonical_id)}
+          </h2>
           <p class="recon-detail-score">
             {active.proposed_patch_operation} · score {Math.round((active.score ?? 0) * 100)}%
           </p>
         </header>
 
+        {#if missingSides.length}
+          <p class="recon-warning" role="alert">
+            {missingSides.map((s) => `${s.role} “${s.id}”`).join(" and ")}
+            {missingSides.length > 1 ? "are" : "is"} not in the loaded graph — the
+            pair can’t be shown in full. The reconciliation queue may be stale
+            (regenerate candidates for the current graph).
+          </p>
+        {/if}
+
         <dl class="recon-compare">
-          <div><dt>Candidate</dt><dd>{label(active.candidate_id)} <small>{typeOf(active.candidate_id) ?? ""}</small></dd></div>
-          <div><dt>Canonical</dt><dd>{label(active.canonical_id)} <small>{typeOf(active.canonical_id) ?? ""}</small></dd></div>
+          <div><dt>Candidate</dt><dd title={label(active.candidate_id)}>{label(active.candidate_id)} <small>{typeOf(active.candidate_id) ?? (present(active.candidate_id) ? "" : "missing")}</small></dd></div>
+          <div><dt>Canonical</dt><dd title={label(active.canonical_id)}>{label(active.canonical_id)} <small>{typeOf(active.canonical_id) ?? (present(active.canonical_id) ? "" : "missing")}</small></dd></div>
           {#if active.shared_terms?.length}
             <div><dt>Shared</dt><dd>{active.shared_terms.join(", ")}</dd></div>
           {/if}
@@ -359,15 +393,30 @@
     margin: 0; text-transform: uppercase; letter-spacing: 0.06em;
     font-size: 0.7rem; font-weight: 700; color: var(--st-semantic-text-muted, #64748b);
   }
-  .recon-detail-head h2 { margin: 0.15rem 0 0.2rem; font-size: 1.05rem; line-height: 1.25; }
+  .recon-detail-head h2 {
+    margin: 0.15rem 0 0.2rem; font-size: 1.05rem; line-height: 1.25;
+    /* BUG-1: long entity names must not overflow the panel; wrap, then clamp to
+       two lines with an ellipsis. Full text stays on the title hover. */
+    overflow-wrap: anywhere;
+    display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
   .recon-detail-score { margin: 0; font-size: 0.8rem; color: var(--st-semantic-text-muted, #64748b); }
+  /* BUG-2: stale/dangling-id warning when a proposed side is missing from the graph. */
+  .recon-warning {
+    margin: 0.7rem 0 0; padding: 0.5rem 0.6rem; font-size: 0.78rem; line-height: 1.35;
+    border: 1px solid var(--st-semantic-feedback-warningBorder, #fcd34d);
+    background: var(--st-semantic-feedback-warningSurface, #fffbeb);
+    color: var(--st-semantic-feedback-warningText, #92400e);
+    border-radius: var(--st-radius-sm, 4px);
+  }
   .recon-compare { margin: 0.9rem 0 0; display: grid; gap: 0.3rem; font-size: 0.84rem; }
   .recon-compare > div { display: grid; grid-template-columns: 6rem 1fr; gap: 0.5rem; }
   .recon-compare dt {
     margin: 0; color: var(--st-semantic-text-muted, #64748b);
     text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.68rem; font-weight: 600;
   }
-  .recon-compare dd { margin: 0; }
+  .recon-compare dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
   .recon-compare small { color: var(--st-semantic-text-muted, #64748b); }
   .recon-reasons, .recon-evidence {
     list-style: none; margin: 0; padding: 0; display: grid; gap: 0.2rem;

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -108,6 +108,33 @@ export function isBoxShape(shape) {
   return value === "box" || value === "roundedbox";
 }
 
+/**
+ * Default character budget for an in-canvas / overlay node label. The renderer
+ * sizes a box glyph to its label's drawn width, so a long entity name (e.g.
+ * "Dr. John H. Watson") yields a wide box that overflows a compact recon focal
+ * slot. We cap the DRAWN text and append an ellipsis; the full, untruncated name
+ * is still reachable on hover (the GraphCanvas tooltip + the recon rail/detail
+ * `title`s carry `node.label` verbatim). Parameterizable so a view can opt into
+ * a wider/narrower budget without touching the renderer.
+ */
+export const DEFAULT_LABEL_MAX_CHARS = 22;
+
+/**
+ * Truncate a label to at most `maxChars` glyphs, appending a single-character
+ * ellipsis (…) when clipped. Trims trailing whitespace before the ellipsis so we
+ * never render "Foo …". A non-positive / non-finite `maxChars` disables clipping
+ * (returns the label unchanged) so callers can opt out explicitly.
+ * @param {unknown} label     the source label (coerced to string)
+ * @param {number} [maxChars] max visible glyphs before the ellipsis
+ * @returns {string} the display label (truncated when longer than the budget)
+ */
+export function truncateLabel(label, maxChars = DEFAULT_LABEL_MAX_CHARS) {
+  const text = String(label ?? "");
+  if (!Number.isFinite(maxChars) || maxChars <= 0) return text;
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars).replace(/\s+$/u, "") + "…";
+}
+
 function cloneStyle(style) {
   return {
     nodeSizes: new Float32Array(style.nodeSizes),
@@ -176,6 +203,11 @@ export function buildGraphRendererPayload(scene, options = {}) {
   const focusId = options.focusId ?? null;
   const hoveredNodeId = options.hoveredNodeId ?? null;
   const requestedRadius = options.nodeRadius ?? 3;
+  // BUG-1: max DRAWN chars for in-box labels (recon focal pair). Default keeps
+  // long names from overflowing; a view can override via options.labelMaxChars.
+  const labelMaxChars = Number.isFinite(options.labelMaxChars)
+    ? options.labelMaxChars
+    : DEFAULT_LABEL_MAX_CHARS;
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
 
@@ -242,7 +274,12 @@ export function buildGraphRendererPayload(scene, options = {}) {
     if (node.forceBoxLabel !== true || !isBoxShape(node.shape)) continue;
     const index = nodeIndexById.get(node.id);
     if (!Number.isInteger(index)) continue;
-    baseStyle.nodeLabels[index] = node.label || String(node.id);
+    // BUG-1: the renderer sizes the box to the drawn label width, so a long
+    // entity name overflows the compact recon focal slot. Cap the DRAWN text
+    // (parameterizable via labelMaxChars; default DEFAULT_LABEL_MAX_CHARS). The
+    // full name stays reachable on hover (GraphCanvas tooltip uses node.label,
+    // which is left untouched on the payload node) and in the recon rail/detail.
+    baseStyle.nodeLabels[index] = truncateLabel(node.label || String(node.id), labelMaxChars);
   }
   const renderedEdges = Array.from(renderGraph.edgeInputIndices ?? [], (inputIndex) => edges[inputIndex]);
 

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -4,12 +4,14 @@ import {
   buildConnectedDimStyle,
   buildGraphRendererPayload,
   densityScale,
+  DEFAULT_LABEL_MAX_CHARS,
   findNearestEdge,
   findNearestNode,
   findNearestNodeId,
   interpolateMergeStyle,
   interpolateMergePositions,
   isBoxShape,
+  truncateLabel,
 } from "../lib/graphRendererPayload.js";
 
 // --- Item 1: density-aware base node size ---
@@ -144,6 +146,78 @@ describe("forceBoxLabel (reconciliation focal-pair override)", () => {
     const leafIdx = payload.nodeIndexById.get("leafbox");
     // Degree-1 box below the 15% gate: still NO in-box label without the flag.
     expect(payload.baseStyle.nodeLabels[leafIdx]).toBe("");
+  });
+});
+
+// --- BUG-1: label truncation (overflow guard for long entity names) ---
+describe("truncateLabel", () => {
+  it("returns short labels unchanged", () => {
+    expect(truncateLabel("Holmes", 22)).toBe("Holmes");
+    expect(truncateLabel("Dr. Watson", 22)).toBe("Dr. Watson");
+  });
+
+  it("clips long labels and appends a single ellipsis", () => {
+    const out = truncateLabel("Dr. John H. Watson, M.D., Late of the Army", 18);
+    expect(out.endsWith("…")).toBe(true);
+    // 18 visible glyphs (whitespace trimmed) + the ellipsis.
+    expect([...out].length).toBeLessThanOrEqual(19);
+    expect(out).toBe("Dr. John H. Watson…");
+  });
+
+  it("trims trailing whitespace before the ellipsis (no 'Foo …')", () => {
+    expect(truncateLabel("Inspector Lestrade Yard", 10)).toBe("Inspector…");
+  });
+
+  it("disables clipping for a non-positive / non-finite budget", () => {
+    const long = "x".repeat(100);
+    expect(truncateLabel(long, 0)).toBe(long);
+    expect(truncateLabel(long, Number.POSITIVE_INFINITY)).toBe(long);
+  });
+
+  it("coerces non-string input safely", () => {
+    expect(truncateLabel(null)).toBe("");
+    expect(truncateLabel(undefined)).toBe("");
+  });
+
+  it("uses DEFAULT_LABEL_MAX_CHARS when no budget is given", () => {
+    const long = "y".repeat(DEFAULT_LABEL_MAX_CHARS + 5);
+    const out = truncateLabel(long);
+    expect([...out].length).toBe(DEFAULT_LABEL_MAX_CHARS + 1); // budget + ellipsis
+  });
+});
+
+// --- BUG-1: the renderer payload caps the DRAWN in-box focal label ---
+describe("buildGraphRendererPayload focal-box label truncation", () => {
+  const longName = "Dr. John H. Watson, M.D., Late of the Army Medical Department";
+  const makeScene = () => ({
+    nodes: [
+      { id: "twin-a", label: longName, type: "Character", shape: "roundedbox", forceBoxLabel: true, x: 0, y: 0, weight: 1 },
+      { id: "twin-b", label: "Sherlock Holmes", type: "Character", shape: "roundedbox", forceBoxLabel: true, x: 30, y: 0, weight: 1 },
+    ],
+    edges: [{ source: "twin-a", target: "twin-b", relation: "≈ reconcile" }],
+  });
+
+  it("truncates the long focal-box label by default while keeping node.label full", () => {
+    const payload = buildGraphRendererPayload(makeScene(), { nodeRadius: 3 });
+    const aIdx = payload.nodeIndexById.get("twin-a");
+    const drawn = payload.baseStyle.nodeLabels[aIdx];
+    expect(drawn.endsWith("…")).toBe(true);
+    expect(drawn.length).toBeLessThan(longName.length);
+    // The full name is still on the payload node (hover tooltip source).
+    expect(payload.nodeById.get("twin-a").label).toBe(longName);
+  });
+
+  it("honours an explicit labelMaxChars override", () => {
+    const payload = buildGraphRendererPayload(makeScene(), { nodeRadius: 3, labelMaxChars: 6 });
+    const aIdx = payload.nodeIndexById.get("twin-a");
+    // "Dr. John...".slice(0,6) -> "Dr. Jo" (no trailing ws) -> "Dr. Jo…"
+    expect(payload.baseStyle.nodeLabels[aIdx]).toBe("Dr. Jo…");
+  });
+
+  it("leaves short focal labels untouched (no spurious ellipsis)", () => {
+    const payload = buildGraphRendererPayload(makeScene(), { nodeRadius: 3 });
+    const bIdx = payload.nodeIndexById.get("twin-b");
+    expect(payload.baseStyle.nodeLabels[bIdx]).toBe("Sherlock Holmes");
   });
 });
 


### PR DESCRIPTION
Studio fixes for two issues found on the re-published mystery studio. No graph/data is touched here; the live graph re-publish is a separate human decision.

## BUG-1 — long entity names overflow
The renderer sizes a focal box to its label's drawn width, so long names (e.g. *Dr. John H. Watson*) overflow the compact reconciliation slot; the DOM overlay labels and the right-panel header/compare values overflow too.

- New `truncateLabel(label, maxChars)` + `DEFAULT_LABEL_MAX_CHARS=22` in `graphRendererPayload.js`; parameterizable via `labelMaxChars` (prop on `GraphCanvas`, prop on `ReconciliationView`).
- Applied to the in-canvas `forceBoxLabel` focal labels and the `GraphCanvas` DOM overlay; full name preserved on hover (node tooltip uses untouched `node.label`).
- Panels: `title` hovers (full name) on the rail row, detail `h2`, and compare values; `h2` clamped to two lines, compare values wrap.

## BUG-2 — only one entity shown / unclear which pair is proposed
A candidate references two node ids. When one is **absent** from the loaded graph (a stale queue vs a re-extracted graph), the centre graph renders only ONE box, so the proposed pair reads as a lone node — exactly the reported symptom (the live queue's `character_king_bohemia` / `character_john_watson` ids no longer exist in the new graph).

- Detect the missing side (`present()` / `missingSides`) and surface an explicit warning instead of degrading silently.
- Reframe the detail header as **"Proposed match · these two entities"** so the pairing is unambiguous.

The real cause of the dangling ids (a stale `reconciliation-candidates.json`) is a pack-side data fix tracked separately (regenerate candidates for the current graph).

## Tests / build
- `+9` vitest cases (truncation unit + focal-box payload truncation). **113 tests green.**
- `npm run build` clean (requires `@sentropic/design-system-svelte@^0.34.33`; the local checkout had a stale 0.16.0 that blocks the build for an unrelated `App.svelte` `AppChrome` import — `npm install` resolves it).