### PR TITLE
F3 — workspace-manifest for the aclp-am consumption bundle (workspace-bundle-contract-v1)

### DIFF
--- a/scripts/build-studio-demo.mjs
+++ b/scripts/build-studio-demo.mjs
@@ -92,6 +92,7 @@ let buildStudioScene;
 let attachLayoutPositions;
 let buildEntitySidecar;
 let emitSceneHierarchies;
+let emitWorkspaceManifest;
 let loadOntologyReconciliationCandidates;
 let queryOntologyReconciliationCandidates;
 try {
@@ -100,6 +101,7 @@ try {
     attachLayoutPositions,
     buildEntitySidecar,
     emitSceneHierarchies,
+    emitWorkspaceManifest,
     loadOntologyReconciliationCandidates,
     queryOntologyReconciliationCandidates,
   } = await import(join(root, "dist", "index.js")));
@@ -119,6 +121,7 @@ for (const f of [
   "graph.json",
   "reconciliation-candidates.json",
   "entities.json",
+  "workspace-manifest.json",
 ]) {
   rmSync(join(outDir, f), { force: true });
 }
@@ -197,6 +200,14 @@ for (const node of nodes) {
 }
 writeFileSync(join(outDir, "entities.json"), JSON.stringify(entities));
 
+// --- 6. workspace-manifest.json (workspace-bundle-contract-v1). ---
+// The bundle descriptor the aclp-am peer consumes first: it discovers the
+// artifacts, validates their schema ids, and verifies integrity via the
+// per-artifact sha256 + size. Emitted LAST so it hashes the final bytes of
+// every artifact above; absent artifacts are recorded present:false (the
+// scene is OPTIONAL per F1, so a no-scene bundle stays valid).
+const manifestResult = emitWorkspaceManifest({ bundleDir: outDir });
+
 // --- Summary. ---
 console.log(`build-studio-demo: wrote standalone studio export to ${outDir}`);
 console.log(`  nodes: ${nodes.length} | scene nodes: ${scene.nodes.length} | scene edges: ${scene.edges.length}`);
@@ -207,3 +218,6 @@ console.log(
 );
 console.log(`  reconciliation candidates: ${candidatesResponse.total ?? candidatesResponse.items.length}`);
 console.log(`  entities index: ${Object.keys(entities).length} ids (${withDescription} with description, ${withOccurrences} with occurrences)`);
+console.log(
+  `  workspace-manifest: ${manifestResult.manifest.present_count}/${manifestResult.manifest.artifacts.length} artifacts present (${manifestResult.path})`,
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,6 +427,24 @@ export type {
   EmitSceneHierarchiesOptions,
   EmitSceneHierarchiesResult,
 } from "./scene-hierarchies-emitter.js";
+export {
+  WORKSPACE_MANIFEST_SCHEMA,
+  WORKSPACE_MANIFEST_SCHEMA_VERSION,
+  WORKSPACE_BUNDLE_CONTRACT,
+  WORKSPACE_MANIFEST_FILENAME,
+  buildWorkspaceManifest,
+} from "./workspace-manifest.js";
+export type {
+  WorkspaceManifest,
+  WorkspaceManifestArtifact,
+  WorkspaceManifestArtifactInput,
+  BuildWorkspaceManifestOptions,
+} from "./workspace-manifest.js";
+export { emitWorkspaceManifest } from "./workspace-manifest-emitter.js";
+export type {
+  EmitWorkspaceManifestOptions,
+  EmitWorkspaceManifestResult,
+} from "./workspace-manifest-emitter.js";
 export { buildEntitySidecar, resolveStudioAppDir } from "./studio-assets.js";
 export type { EntitySidecarResponse } from "./studio-assets.js";
 export { computeLayout, attachLayoutPositions } from "./graph-layout.js";

--- a/src/workspace-manifest-emitter.ts
+++ b/src/workspace-manifest-emitter.ts
@@ -1,0 +1,147 @@
+/**
+ * workspace-bundle-contract-v1 (WP4 / F3) — workspace-manifest.json emitter.
+ *
+ * Writes the bundle descriptor `workspace-manifest.json` (schema
+ * `graphify_workspace_manifest_v1`) into the bundle root, alongside the scene
+ * + its sidecars. The aclp-am peer consumes the manifest first: it discovers
+ * the bundle's artifacts, validates their schema ids, and verifies integrity
+ * via the per-artifact sha256 + size_bytes — without out-of-band knowledge of
+ * which files a given build emitted.
+ *
+ * The bundle (per the signed contract's `bundle_artifacts`) is:
+ *   - scene                  scene.json                     (OPTIONAL, F1)
+ *   - scene-hierarchies      scene-hierarchies.json         (CORE,
+ *                            graphify_scene_hierarchies_v1)
+ *   - reconciliation-candidates
+ *                            reconciliation-candidates.json
+ *                            (graphify_ontology_reconciliation_candidates_v1)
+ *   - graph                  graph.json                     (canonical graph)
+ *   - entities               entities.json                  (entity sidecars)
+ *
+ * Design (mirrors `scene-hierarchies-emitter.ts`):
+ *   - The PURE manifest shape lives in `workspace-manifest.ts`; this module
+ *     owns ALL the I/O. It reads the REAL bytes of each candidate artifact
+ *     from disk and hands them to the builder, so the recorded sha256/size
+ *     describe exactly what is on disk.
+ *   - An artifact that is not on disk is recorded as `present: false` (NOT
+ *     dropped): the consumer can distinguish "the producer chose not to emit
+ *     this" from "this build is malformed".
+ *   - Deterministic: two runs over a byte-identical bundle produce a
+ *     byte-identical manifest except for `generated_at`. `generated_at` is
+ *     overridable for reproducible builds / tests.
+ *   - The manifest does NOT list itself (it cannot hash a file that does not
+ *     exist yet, and a self-referential hash is meaningless).
+ */
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  WORKSPACE_MANIFEST_FILENAME,
+  buildWorkspaceManifest,
+  type WorkspaceManifest,
+  type WorkspaceManifestArtifactInput,
+} from "./workspace-manifest.js";
+
+export { WORKSPACE_MANIFEST_FILENAME } from "./workspace-manifest.js";
+
+import { SCENE_HIERARCHIES_SCHEMA } from "./scene-hierarchies.js";
+import { ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA } from "./ontology-reconciliation.js";
+
+/**
+ * A candidate bundle artifact: its logical name, on-disk filename (relative to
+ * the bundle root), and the schema id it claims. The emitter probes the file
+ * and records present/absent + hash.
+ */
+interface BundleArtifactSpec {
+  name: string;
+  filename: string;
+  schema: string | null;
+  role?: string;
+}
+
+/**
+ * The canonical bundle layout the aclp-am peer consumes. Order here is
+ * irrelevant (the builder sorts by name); this is the closed set the emitter
+ * always reports on, so a missing artifact surfaces as `present: false`.
+ */
+const BUNDLE_ARTIFACTS: readonly BundleArtifactSpec[] = [
+  { name: "scene", filename: "scene.json", schema: null, role: "scene" },
+  {
+    name: "scene-hierarchies",
+    filename: "scene-hierarchies.json",
+    schema: SCENE_HIERARCHIES_SCHEMA,
+    role: "hierarchy",
+  },
+  {
+    name: "reconciliation-candidates",
+    filename: "reconciliation-candidates.json",
+    schema: ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA,
+    role: "reconciliation",
+  },
+  { name: "graph", filename: "graph.json", schema: null, role: "graph" },
+  { name: "entities", filename: "entities.json", schema: null, role: "entities" },
+];
+
+export interface EmitWorkspaceManifestOptions {
+  /** Bundle root: where the artifacts live and where the manifest is written. */
+  bundleDir: string;
+  /**
+   * Optional override of the artifact set (tests / non-default layouts). When
+   * omitted the canonical {@link BUNDLE_ARTIFACTS} layout is used.
+   */
+  artifacts?: readonly BundleArtifactSpec[];
+  /** Optional graph hash stamped on the manifest envelope. */
+  graphHash?: string | null;
+  /** Override the timestamp (reproducible builds / tests). */
+  generatedAt?: string;
+}
+
+export interface EmitWorkspaceManifestResult {
+  /** Absolute path of the written manifest. */
+  path: string;
+  /** The manifest that was written. */
+  manifest: WorkspaceManifest;
+}
+
+/**
+ * Build and write `workspace-manifest.json` into `bundleDir`, hashing the REAL
+ * bytes of each bundle artifact present on disk. Always writes the manifest
+ * (the manifest itself is the descriptor of record); a missing artifact is
+ * reported as `present: false` rather than omitted.
+ */
+export function emitWorkspaceManifest(
+  options: EmitWorkspaceManifestOptions,
+): EmitWorkspaceManifestResult {
+  const specs = options.artifacts ?? BUNDLE_ARTIFACTS;
+
+  const inputs: WorkspaceManifestArtifactInput[] = specs.map((spec) => {
+    const filePath = join(options.bundleDir, spec.filename);
+    // Read the real bytes IFF the artifact is a regular file on disk. A
+    // directory or a missing path yields present:false (no hash).
+    let bytes: Buffer | null = null;
+    if (existsSync(filePath) && statSync(filePath).isFile()) {
+      bytes = readFileSync(filePath);
+    }
+    const input: WorkspaceManifestArtifactInput = {
+      name: spec.name,
+      path: spec.filename,
+      schema: spec.schema,
+      bytes,
+    };
+    if (spec.role !== undefined) input.role = spec.role;
+    return input;
+  });
+
+  const manifest = buildWorkspaceManifest({
+    artifacts: inputs,
+    ...(options.graphHash !== undefined ? { graphHash: options.graphHash } : {}),
+    ...(options.generatedAt !== undefined ? { generatedAt: options.generatedAt } : {}),
+  });
+
+  const targetPath = join(options.bundleDir, WORKSPACE_MANIFEST_FILENAME);
+  mkdirSync(options.bundleDir, { recursive: true });
+  writeFileSync(targetPath, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+
+  return { path: targetPath, manifest };
+}

--- a/src/workspace-manifest.ts
+++ b/src/workspace-manifest.ts
@@ -1,0 +1,141 @@
+/**
+ * workspace-bundle-contract-v1 (WP4 / F3) — workspace-manifest builder.
+ *
+ * The aclp-am peer consumes a *bundle* of graphify outputs (the scene plus its
+ * ontology / hierarchy sidecars). Until now each artifact was emitted
+ * independently and there was no single descriptor letting the consumer
+ * discover and validate the bundle as a whole. This module produces that
+ * descriptor: `workspace-manifest.json` (schema `graphify_workspace_manifest_v1`).
+ *
+ * Design constraints (mirrors the signed `workspace-bundle-contract-v1`):
+ *   - Pure & deterministic: the builder takes the artifact descriptors and
+ *     their bytes; it does no I/O. The emitter (`workspace-manifest-emitter.ts`)
+ *     owns the filesystem.
+ *   - Additive & honest: every artifact carries an explicit `present` flag and,
+ *     when present, a `sha256` content hash + `size_bytes`. A missing artifact
+ *     is recorded as `present: false` (NOT silently dropped) so the consumer
+ *     can distinguish "not produced" from "I forgot to look".
+ *   - Stable ordering: artifacts are sorted by logical `name` so two builds of
+ *     the same bundle produce a byte-identical manifest (modulo `generated_at`).
+ *   - Schema-pinned: each artifact records the schema id it claims to satisfy,
+ *     so the consumer can refuse a bundle whose schema it does not understand.
+ *
+ * The manifest is a *discovery + integrity* descriptor, not a replacement for
+ * any artifact. It carries no graph data of its own.
+ */
+
+import { createHash } from "node:crypto";
+
+export const WORKSPACE_MANIFEST_SCHEMA = "graphify_workspace_manifest_v1";
+export const WORKSPACE_MANIFEST_FILENAME = "workspace-manifest.json";
+
+/**
+ * The signed contract this bundle honours. The aclp-am peer signed
+ * `workspace-bundle-contract-v1` (stabilized 2/2, ed25519); the manifest stamps
+ * it so the consumer can assert the join semantics (registry_record_id key,
+ * status:"reference" declarative lane) without out-of-band knowledge.
+ */
+export const WORKSPACE_BUNDLE_CONTRACT = "workspace-bundle-contract-v1";
+
+/** A single bundle artifact as supplied to the builder. */
+export interface WorkspaceManifestArtifactInput {
+  /** Stable logical name, e.g. "scene", "scene-hierarchies", "hierarchies". */
+  name: string;
+  /** Path relative to the bundle root (POSIX separators), e.g. "scene.json". */
+  path: string;
+  /** Schema id the artifact claims, or null when the artifact is schemaless. */
+  schema: string | null;
+  /**
+   * Raw bytes of the artifact, or null/undefined when the artifact was not
+   * produced. A null value yields `present: false` with no hash.
+   */
+  bytes?: Buffer | string | null;
+  /** Optional free-form role hint for the consumer (e.g. "consumption"). */
+  role?: string;
+}
+
+/** A single artifact entry as written into the manifest. */
+export interface WorkspaceManifestArtifact {
+  name: string;
+  path: string;
+  schema: string | null;
+  present: boolean;
+  /** sha256 hex of the bytes, or null when absent. */
+  sha256: string | null;
+  /** Byte length, or null when absent. */
+  size_bytes: number | null;
+  /** Present only when supplied. */
+  role?: string;
+}
+
+export interface WorkspaceManifest {
+  schema: typeof WORKSPACE_MANIFEST_SCHEMA;
+  contract: typeof WORKSPACE_BUNDLE_CONTRACT;
+  generated_at: string;
+  /** Optional graph hash linking the bundle to a graph.json snapshot. */
+  graph_hash: string | null;
+  /** Count of artifacts with `present: true`. */
+  present_count: number;
+  /** Artifacts, sorted by `name`. */
+  artifacts: WorkspaceManifestArtifact[];
+}
+
+export interface BuildWorkspaceManifestOptions {
+  artifacts: WorkspaceManifestArtifactInput[];
+  /** Optional graph hash stamped on the envelope. */
+  graphHash?: string | null;
+  /** Override the timestamp (tests / reproducible builds). */
+  generatedAt?: string;
+}
+
+function sha256Hex(bytes: Buffer | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function byteLength(bytes: Buffer | string): number {
+  return Buffer.isBuffer(bytes) ? bytes.length : Buffer.byteLength(bytes, "utf-8");
+}
+
+/**
+ * Build the `graphify_workspace_manifest_v1` descriptor. Pure and
+ * deterministic: identical artifact inputs (same names/paths/schemas/bytes)
+ * produce an identical manifest, except for `generated_at` when not pinned.
+ *
+ * Throws on a duplicate logical `name` so the bundle cannot silently shadow an
+ * artifact (the consumer indexes by name).
+ */
+export function buildWorkspaceManifest(
+  options: BuildWorkspaceManifestOptions,
+): WorkspaceManifest {
+  const seen = new Set<string>();
+  const artifacts: WorkspaceManifestArtifact[] = options.artifacts.map((input) => {
+    if (seen.has(input.name)) {
+      throw new Error(`workspace-manifest: duplicate artifact name "${input.name}"`);
+    }
+    seen.add(input.name);
+
+    const present = input.bytes !== undefined && input.bytes !== null;
+    const entry: WorkspaceManifestArtifact = {
+      name: input.name,
+      path: input.path,
+      schema: input.schema,
+      present,
+      sha256: present ? sha256Hex(input.bytes as Buffer | string) : null,
+      size_bytes: present ? byteLength(input.bytes as Buffer | string) : null,
+    };
+    if (input.role !== undefined) entry.role = input.role;
+    return entry;
+  });
+
+  // Deterministic order: by logical name (stable across builds).
+  artifacts.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  return {
+    schema: WORKSPACE_MANIFEST_SCHEMA,
+    contract: WORKSPACE_BUNDLE_CONTRACT,
+    generated_at: options.generatedAt ?? new Date().toISOString(),
+    graph_hash: options.graphHash ?? null,
+    present_count: artifacts.filter((a) => a.present).length,
+    artifacts,
+  };
+}

--- a/src/workspace-manifest.ts
+++ b/src/workspace-manifest.ts
@@ -30,6 +30,13 @@ export const WORKSPACE_MANIFEST_SCHEMA = "graphify_workspace_manifest_v1";
 export const WORKSPACE_MANIFEST_FILENAME = "workspace-manifest.json";
 
 /**
+ * Numeric schema version, separate from the string schema id. The signed
+ * contract annotates the manifest with "+schema_version" so the consumer can
+ * gate on a monotonic integer (additive bumps) without parsing the schema id.
+ */
+export const WORKSPACE_MANIFEST_SCHEMA_VERSION = 1 as const;
+
+/**
  * The signed contract this bundle honours. The aclp-am peer signed
  * `workspace-bundle-contract-v1` (stabilized 2/2, ed25519); the manifest stamps
  * it so the consumer can assert the join semantics (registry_record_id key,
@@ -70,6 +77,8 @@ export interface WorkspaceManifestArtifact {
 
 export interface WorkspaceManifest {
   schema: typeof WORKSPACE_MANIFEST_SCHEMA;
+  /** Monotonic integer schema version (contract "+schema_version"). */
+  schema_version: typeof WORKSPACE_MANIFEST_SCHEMA_VERSION;
   contract: typeof WORKSPACE_BUNDLE_CONTRACT;
   generated_at: string;
   /** Optional graph hash linking the bundle to a graph.json snapshot. */
@@ -132,6 +141,7 @@ export function buildWorkspaceManifest(
 
   return {
     schema: WORKSPACE_MANIFEST_SCHEMA,
+    schema_version: WORKSPACE_MANIFEST_SCHEMA_VERSION,
     contract: WORKSPACE_BUNDLE_CONTRACT,
     generated_at: options.generatedAt ?? new Date().toISOString(),
     graph_hash: options.graphHash ?? null,

--- a/src/workspace-manifest.ts
+++ b/src/workspace-manifest.ts
@@ -37,10 +37,14 @@ export const WORKSPACE_MANIFEST_FILENAME = "workspace-manifest.json";
 export const WORKSPACE_MANIFEST_SCHEMA_VERSION = 1 as const;
 
 /**
- * The signed contract this bundle honours. The aclp-am peer signed
- * `workspace-bundle-contract-v1` (stabilized 2/2, ed25519); the manifest stamps
- * it so the consumer can assert the join semantics (registry_record_id key,
- * status:"reference" declarative lane) without out-of-band knowledge.
+ * The bundle contract this manifest stamps. `workspace-bundle-contract-v1` is
+ * the negotiated contract with the aclp-am peer (consumer ratified 2026-06-12;
+ * graphify-side ratification pending at the time of writing). Stamping the
+ * contract id lets the consumer assert WHICH bundle shape it is reading — the
+ * artifact set + the join semantics defined by the contract (join on
+ * `registry_record_id`; the scene-hierarchies sidecar is authoritative for
+ * traversal). The manifest itself carries only discovery + integrity data; the
+ * join keys live in the artifacts it lists, not here.
  */
 export const WORKSPACE_BUNDLE_CONTRACT = "workspace-bundle-contract-v1";
 

--- a/tests/workspace-manifest.test.ts
+++ b/tests/workspace-manifest.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  WORKSPACE_BUNDLE_CONTRACT,
+  WORKSPACE_MANIFEST_FILENAME,
+  WORKSPACE_MANIFEST_SCHEMA,
+  WORKSPACE_MANIFEST_SCHEMA_VERSION,
+  buildWorkspaceManifest,
+} from "../src/workspace-manifest.js";
+import { emitWorkspaceManifest } from "../src/workspace-manifest-emitter.js";
+import {
+  scanPortableGraphifyArtifacts,
+} from "../src/portable-artifacts.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-ws-manifest-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf-8").digest("hex");
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1)", () => {
+  it("stamps the schema id, numeric schema_version, and signed contract", () => {
+    const manifest = buildWorkspaceManifest({
+      artifacts: [],
+      generatedAt: "2026-06-14T00:00:00.000Z",
+    });
+    expect(manifest.schema).toBe(WORKSPACE_MANIFEST_SCHEMA);
+    expect(manifest.schema).toBe("graphify_workspace_manifest_v1");
+    expect(manifest.schema_version).toBe(WORKSPACE_MANIFEST_SCHEMA_VERSION);
+    expect(manifest.schema_version).toBe(1);
+    expect(manifest.contract).toBe(WORKSPACE_BUNDLE_CONTRACT);
+    expect(manifest.contract).toBe("workspace-bundle-contract-v1");
+    expect(manifest.generated_at).toBe("2026-06-14T00:00:00.000Z");
+    expect(manifest.graph_hash).toBeNull();
+    expect(manifest.present_count).toBe(0);
+    expect(manifest.artifacts).toEqual([]);
+  });
+
+  it("records present:true with sha256 + size for supplied bytes", () => {
+    const body = '{"x":1}';
+    const manifest = buildWorkspaceManifest({
+      artifacts: [{ name: "scene", path: "scene.json", schema: null, bytes: body }],
+      generatedAt: "t",
+    });
+    expect(manifest.artifacts).toHaveLength(1);
+    const a = manifest.artifacts[0]!;
+    expect(a).toMatchObject({
+      name: "scene",
+      path: "scene.json",
+      schema: null,
+      present: true,
+      sha256: sha256(body),
+      size_bytes: Buffer.byteLength(body, "utf-8"),
+    });
+    expect(manifest.present_count).toBe(1);
+  });
+
+  it("records present:false (NOT dropped) for null/undefined bytes", () => {
+    const manifest = buildWorkspaceManifest({
+      artifacts: [
+        { name: "scene", path: "scene.json", schema: null, bytes: null },
+        { name: "hierarchies", path: "scene-hierarchies.json", schema: "s" },
+      ],
+      generatedAt: "t",
+    });
+    // Both artifacts SURVIVE in the manifest — the consumer must see them.
+    expect(manifest.artifacts.map((a) => a.name)).toEqual([
+      "hierarchies",
+      "scene",
+    ]);
+    for (const a of manifest.artifacts) {
+      expect(a.present).toBe(false);
+      expect(a.sha256).toBeNull();
+      expect(a.size_bytes).toBeNull();
+    }
+    expect(manifest.present_count).toBe(0);
+  });
+
+  it("sorts artifacts by logical name (stable, deterministic ordering)", () => {
+    const manifest = buildWorkspaceManifest({
+      artifacts: [
+        { name: "scene", path: "scene.json", schema: null, bytes: "a" },
+        { name: "graph", path: "graph.json", schema: null, bytes: "b" },
+        { name: "entities", path: "entities.json", schema: null, bytes: "c" },
+      ],
+      generatedAt: "t",
+    });
+    expect(manifest.artifacts.map((a) => a.name)).toEqual([
+      "entities",
+      "graph",
+      "scene",
+    ]);
+  });
+
+  it("is byte-identical for identical inputs modulo generated_at", () => {
+    const inputs = {
+      artifacts: [
+        { name: "scene", path: "scene.json", schema: null, bytes: "a" },
+        { name: "graph", path: "graph.json", schema: null, bytes: "b" },
+      ],
+    };
+    const a = buildWorkspaceManifest({ ...inputs, generatedAt: "X" });
+    const b = buildWorkspaceManifest({ ...inputs, generatedAt: "X" });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+
+    // Different inputs order, same set → same serialization (modulo time).
+    const c = buildWorkspaceManifest({
+      artifacts: [...inputs.artifacts].reverse(),
+      generatedAt: "X",
+    });
+    expect(JSON.stringify(c)).toBe(JSON.stringify(a));
+  });
+
+  it("throws on a duplicate logical name (no silent shadowing)", () => {
+    expect(() =>
+      buildWorkspaceManifest({
+        artifacts: [
+          { name: "scene", path: "scene.json", schema: null, bytes: "a" },
+          { name: "scene", path: "scene2.json", schema: null, bytes: "b" },
+        ],
+        generatedAt: "t",
+      }),
+    ).toThrow(/duplicate artifact name "scene"/);
+  });
+
+  it("stamps the supplied graph hash", () => {
+    const manifest = buildWorkspaceManifest({
+      artifacts: [],
+      graphHash: "feedface",
+      generatedAt: "t",
+    });
+    expect(manifest.graph_hash).toBe("feedface");
+  });
+});
+
+describe("emitWorkspaceManifest — owns the I/O, hashes real bytes", () => {
+  function writeBundle(dir: string, files: Record<string, string>): void {
+    mkdirSync(dir, { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      writeFileSync(join(dir, name), body, "utf-8");
+    }
+  }
+
+  it("writes workspace-manifest.json into the bundle dir", () => {
+    const dir = makeTempDir();
+    writeBundle(dir, {
+      "scene.json": '{"nodes":[]}',
+      "graph.json": '{"nodes":[],"edges":[]}',
+    });
+    const result = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "t" });
+    expect(result.path).toBe(join(dir, WORKSPACE_MANIFEST_FILENAME));
+    expect(existsSync(result.path)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(result.path, "utf-8"));
+    expect(onDisk).toEqual(result.manifest);
+    expect(onDisk.schema).toBe("graphify_workspace_manifest_v1");
+    expect(onDisk.schema_version).toBe(1);
+  });
+
+  it("hashes the REAL bytes on disk (sha256 + size correctness)", () => {
+    const dir = makeTempDir();
+    const sceneBody = '{"nodes":[{"id":"a"}]}';
+    writeBundle(dir, { "scene.json": sceneBody });
+    const { manifest } = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "t" });
+    const scene = manifest.artifacts.find((a) => a.name === "scene")!;
+    expect(scene.present).toBe(true);
+    expect(scene.sha256).toBe(sha256(sceneBody));
+    expect(scene.size_bytes).toBe(Buffer.byteLength(sceneBody, "utf-8"));
+  });
+
+  it("records present:false for absent artifacts (not silently dropped)", () => {
+    const dir = makeTempDir();
+    // Only the scene exists; every other bundle artifact is absent.
+    writeBundle(dir, { "scene.json": "{}" });
+    const { manifest } = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "t" });
+
+    const byName = new Map(manifest.artifacts.map((a) => [a.name, a]));
+    expect(byName.get("scene")!.present).toBe(true);
+    for (const name of [
+      "scene-hierarchies",
+      "reconciliation-candidates",
+      "graph",
+      "entities",
+    ]) {
+      const entry = byName.get(name);
+      expect(entry, `${name} must be reported`).toBeDefined();
+      expect(entry!.present).toBe(false);
+      expect(entry!.sha256).toBeNull();
+      expect(entry!.size_bytes).toBeNull();
+    }
+  });
+
+  it("carries the contract schema ids for the core sidecars", () => {
+    const dir = makeTempDir();
+    writeBundle(dir, {
+      "scene-hierarchies.json": "{}",
+      "reconciliation-candidates.json": "{}",
+    });
+    const { manifest } = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "t" });
+    const byName = new Map(manifest.artifacts.map((a) => [a.name, a]));
+    expect(byName.get("scene-hierarchies")!.schema).toBe(
+      "graphify_scene_hierarchies_v1",
+    );
+    expect(byName.get("reconciliation-candidates")!.schema).toBe(
+      "graphify_ontology_reconciliation_candidates_v1",
+    );
+  });
+
+  it("does NOT list the manifest itself", () => {
+    const dir = makeTempDir();
+    writeBundle(dir, { "scene.json": "{}" });
+    const { manifest } = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "t" });
+    expect(
+      manifest.artifacts.some((a) => a.path === WORKSPACE_MANIFEST_FILENAME),
+    ).toBe(false);
+  });
+
+  it("is byte-identical across two runs over a byte-identical bundle (modulo generated_at)", () => {
+    const dir = makeTempDir();
+    writeBundle(dir, {
+      "scene.json": '{"nodes":[]}',
+      "graph.json": '{"nodes":[]}',
+      "entities.json": "{}",
+    });
+    const first = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "FIXED" });
+    const firstBytes = readFileSync(first.path, "utf-8");
+    // Second run must reproduce the same file byte-for-byte (the manifest from
+    // the first run is now on disk but must not be self-included).
+    const second = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "FIXED" });
+    const secondBytes = readFileSync(second.path, "utf-8");
+    expect(secondBytes).toBe(firstBytes);
+  });
+
+  it("ignores a directory shadowing an artifact name (present:false)", () => {
+    const dir = makeTempDir();
+    writeBundle(dir, { "scene.json": "{}" });
+    // graph.json is a directory, not a file → must be present:false, no hash.
+    mkdirSync(join(dir, "graph.json"), { recursive: true });
+    const { manifest } = emitWorkspaceManifest({ bundleDir: dir, generatedAt: "t" });
+    const graph = manifest.artifacts.find((a) => a.name === "graph")!;
+    expect(graph.present).toBe(false);
+    expect(graph.sha256).toBeNull();
+  });
+
+  it("emits a portable manifest (relative paths only — passes portable-check)", () => {
+    // Emit into a .graphify-shaped tree and assert the manifest carries no
+    // absolute/escaping paths (contract "portable-check").
+    const root = makeTempDir();
+    const bundleDir = join(root, "studio");
+    writeBundle(bundleDir, {
+      "scene.json": "{}",
+      "scene-hierarchies.json": "{}",
+    });
+    emitWorkspaceManifest({
+      bundleDir,
+      graphHash: "abc123",
+      generatedAt: "t",
+    });
+    const scan = scanPortableGraphifyArtifacts(root);
+    const manifestIssues = scan.issues.filter((i) =>
+      i.path.endsWith(WORKSPACE_MANIFEST_FILENAME),
+    );
+    expect(manifestIssues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds the **workspace-manifest** — the bundle descriptor the aclp-am peer consumes first to discover + integrity-check the graphify consumption bundle (scene + sidecars), per the negotiated `workspace-bundle-contract-v1`.

- **`src/workspace-manifest.ts`** — pure/deterministic builder for `graphify_workspace_manifest_v1`. Per-artifact `present` flag + `sha256` + `size_bytes` + schema id, stable ordering by logical name. Carries `schema_version: 1` (contract "+schema_version"). A missing artifact is recorded `present: false` (never silently dropped) so the consumer distinguishes "not produced" from a malformed build. No I/O.
- **`src/workspace-manifest-emitter.ts`** — owns the filesystem. Reads the **real bytes** of each bundle artifact (`scene.json`, `scene-hierarchies.json`, `reconciliation-candidates.json`, `graph.json`, `entities.json`), hashes them, and writes `workspace-manifest.json` into the bundle root. Mirrors the `scene-hierarchies-emitter` pattern. The manifest never lists itself; a directory shadowing an artifact name is treated as absent.
- **Wired into the emit path** (`scripts/build-studio-demo.mjs`): emitted **last**, so it hashes the final on-disk bytes of every artifact above. The scene is OPTIONAL (F1), so a no-scene bundle stays valid.

## Contract cross-check

- Schema ids stamped on the two core sidecars: `graphify_scene_hierarchies_v1` (D1 standalone) and `graphify_ontology_reconciliation_candidates_v1`.
- The manifest carries only discovery + integrity data; the join keys (`registry_record_id`, D2) live in the listed artifacts, not the manifest.
- **portable-check**: the manifest records bundle-relative POSIX paths only (no absolute/escaping paths) — covered by a `scanPortableGraphifyArtifacts` assertion in the test suite.

## Tests

`tests/workspace-manifest.test.ts` — 15 tests: deterministic byte-identical output (modulo `generated_at`), `present: false` correctness for absent artifacts, sha256/size correctness on real bytes, contract schema ids, self-exclusion, directory-shadow safety, duplicate-name guard, and the portable-check assertion. Verified end-to-end against the `dist` build.

## Open item for the peer (non-blocking for this PR)

`workspace-bundle-contract-v1` is **consumer-ratified** (aclp-am, 2026-06-12) with **graphify-side ratification pending**. This PR implements graphify's side of the bundle (the contract's `ownership.graphify` clause) but does NOT itself sign the contract. If the peer wants the manifest to additionally expose the contract's declarative-lane fields inline (rather than only via the listed sidecars), that's a v2 additive change — flagged, not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)