### PR TITLE
Track F M3 — MCP config extractor (upstream 2c01a89)

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -35,6 +35,21 @@ export const CODE_EXTENSIONS = new Set([
   ".sln", ".csproj", ".fsproj", ".vbproj", ".props", ".targets",
 ]);
 
+/**
+ * MCP (Model Context Protocol) config files, classified by FILENAME (not
+ * extension — a bare `.json` is otherwise unclassified). Dispatched to
+ * `extractMcpConfig`. Port of upstream safishamsi 2c01a89 (#... mcp_ingest).
+ * `.mcp.json` is a hidden file: the detection walk skips dot-prefixed
+ * basenames, so it is classified here for explicit single-file targets but not
+ * picked up during a directory scan (consistent with the hidden-file policy).
+ */
+export const MCP_CONFIG_FILENAMES = new Set([
+  ".mcp.json",
+  "claude_desktop_config.json",
+  "mcp.json",
+  "mcp_servers.json",
+]);
+
 export const DOC_EXTENSIONS = new Set([".md", ".mdx", ".qmd", ".txt", ".rst", ".html", ".yaml", ".yml"]);
 export const PAPER_EXTENSIONS = new Set([".pdf"]);
 export const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
@@ -331,6 +346,8 @@ function hasCodeShebang(filePath: string): boolean {
 export function classifyFile(filePath: string): FileType | null {
   const ext = extname(filePath).toLowerCase();
   if (CODE_EXTENSIONS.has(ext)) return FileType.CODE;
+  // MCP config files are recognised by full filename, not extension.
+  if (MCP_CONFIG_FILENAMES.has(basename(filePath))) return FileType.CODE;
   if (PAPER_EXTENSIONS.has(ext)) {
     // PDFs inside Xcode asset catalogs are vector icons, not papers
     const parts = filePath.split(sep);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -11,6 +11,7 @@ import { resolve, basename, extname, dirname, join, relative, sep } from "node:p
 import { createRequire } from "node:module";
 import type { GraphNode, GraphEdge, Extraction } from "./types.js";
 import { loadCached, saveCached } from "./cache.js";
+import { sanitizeLabel } from "./security.js";
 
 // ---------------------------------------------------------------------------
 // web-tree-sitter types  (re-exported from the package)
@@ -4903,6 +4904,205 @@ async function _extractCsprojAsync(filePath: string, rootDir?: string): Promise<
 }
 
 // ---------------------------------------------------------------------------
+// MCP (Model Context Protocol) server configuration files.
+// Port of upstream safishamsi 2c01a89 (#... mcp_ingest): extracts the
+// `mcpServers` map of `.mcp.json` / `claude_desktop_config.json` / `mcp.json` /
+// `mcp_servers.json` into server / command / package / env-var nodes.
+//
+// Symmetry: graphify exposes itself AS an MCP server (`--mcp`); this indexes
+// MCP servers AS a corpus type, completing the loop.
+//
+// Security parity with upstream:
+//   - Env var VALUES are NEVER read — only env var NAMES become nodes
+//     (`env: {"API_KEY": "sk-..."}` → node "API_KEY" only).
+//   - File size capped at 1 MiB (matches the generic JSON extractor cap).
+//   - args are NOT persisted (they can embed paths / secrets); only a detected
+//     npm/pypi package id from args becomes a node.
+//   - All labels go through sanitizeLabel.
+//
+// Cross-config emergent edges: command / package / env_var nodes use GLOBAL ids
+// (no per-file stem) so the same package or env var shared across two configs
+// produces one shared node. Server nodes ARE stem-scoped so two configs both
+// declaring "filesystem" do not collide.
+// ---------------------------------------------------------------------------
+
+/** Recognised MCP config filenames (matched on basename, case-sensitive). */
+const _MCP_CONFIG_FILENAMES: ReadonlySet<string> = new Set([
+  ".mcp.json",
+  "claude_desktop_config.json",
+  "mcp.json",
+  "mcp_servers.json",
+]);
+
+const _MCP_MAX_BYTES = 1_048_576; // 1 MiB
+const _MCP_MAX_SERVERS_PER_FILE = 200;
+
+/** True when `filePath`'s basename is a recognised MCP config filename. */
+export function isMcpConfigPath(filePath: string): boolean {
+  return _MCP_CONFIG_FILENAMES.has(basename(filePath));
+}
+
+// Patterns observed in real MCP server configs (npx / uvx / pnpx / python):
+//   ["-y", "@modelcontextprotocol/server-filesystem", "/data"]
+//   ["-y", "@org/pkg@1.2.3"]   ["mcp-server-fetch"]   ["mcp-server-time", "--tz=UTC"]
+const _MCP_NPM_PKG_RE = /^@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*(?:@[\w.\-+]+)?$/;
+const _MCP_PY_PKG_RE = /^[a-z0-9][a-z0-9._-]*-mcp(?:-[a-z0-9._-]+)?$|^mcp-[a-z0-9][a-z0-9._-]*$/;
+const _MCP_ARG_FLAG_RE = /^-{1,2}\w/;
+
+/** Drop the `@version` suffix from an npm package id, preserving the scope. */
+function _mcpStripVersion(pkg: string): string {
+  if (pkg.startsWith("@")) {
+    const versionAt = pkg.indexOf("@", 1);
+    return versionAt === -1 ? pkg : pkg.slice(0, versionAt);
+  }
+  const versionAt = pkg.indexOf("@");
+  return versionAt === -1 ? pkg : pkg.slice(0, versionAt);
+}
+
+/** First arg that looks like an npm or pypi package id, else null. */
+function _mcpDetectPackageFromArgs(args: unknown[]): string | null {
+  for (const raw of args) {
+    if (typeof raw !== "string") continue;
+    const arg = raw.trim();
+    if (!arg || _MCP_ARG_FLAG_RE.test(arg)) continue;
+    if (_MCP_NPM_PKG_RE.test(arg)) return _mcpStripVersion(arg);
+    if (_MCP_PY_PKG_RE.test(arg)) return arg;
+  }
+  return null;
+}
+
+/**
+ * Parse an MCP config file into graphify nodes and edges. Mirrors the other
+ * extractors: `{ nodes, edges }` on success, `{ nodes: [], edges: [], error }`
+ * on parse failure / oversize / missing `mcpServers` map (indistinguishable
+ * from "no MCP config here" for downstream callers).
+ */
+export function extractMcpConfig(filePath: string, rootDir?: string): ExtractionResult {
+  let raw: Buffer;
+  try {
+    raw = readFileSync(filePath) as Buffer;
+  } catch (e: unknown) {
+    return { nodes: [], edges: [], error: `mcp_ingest read error: ${String(e)}` };
+  }
+  if (raw.length > _MCP_MAX_BYTES) {
+    return { nodes: [], edges: [], error: "mcp config too large to index" };
+  }
+
+  let doc: unknown;
+  try {
+    doc = JSON.parse(raw.toString("utf-8"));
+  } catch (e: unknown) {
+    return { nodes: [], edges: [], error: `mcp_ingest json error: ${String(e)}` };
+  }
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+    return { nodes: [], edges: [], error: "mcp_ingest: root is not an object" };
+  }
+
+  const docObj = doc as Record<string, unknown>;
+  let servers = docObj["mcpServers"];
+  if (typeof servers !== "object" || servers === null || Array.isArray(servers)) {
+    // Some tools nest the map (e.g. {"mcp": {"servers": {...}}}). Try one
+    // well-known alternate shape, no exhaustive search.
+    const nested = docObj["mcp"];
+    if (typeof nested === "object" && nested !== null && !Array.isArray(nested)) {
+      servers = (nested as Record<string, unknown>)["servers"];
+    }
+    if (typeof servers !== "object" || servers === null || Array.isArray(servers)) {
+      return { nodes: [], edges: [], error: "mcp_ingest: no mcpServers map" };
+    }
+  }
+
+  const resolvedRoot = rootDir ?? dirname(resolve(filePath));
+  const fileNid = _makeId(resolve(filePath));
+  const fileStem = qualifiedFileStem(filePath, resolvedRoot);
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  const seenIds = new Set<string>();
+  const seenEdges = new Set<string>();
+
+  function addNode(nid: string, label: string, mcpKind: string): boolean {
+    if (!nid || seenIds.has(nid)) return false;
+    seenIds.add(nid);
+    nodes.push({
+      id: nid,
+      label: sanitizeLabel(label),
+      file_type: "code",
+      source_file: filePath,
+      source_location: "L1",
+      node_type: mcpKind,
+    });
+    return true;
+  }
+
+  function addEdge(source: string, target: string, relation: string): void {
+    if (!source || !target || source === target) return;
+    const key = `${source} ${target} ${relation}`;
+    if (seenEdges.has(key)) return;
+    seenEdges.add(key);
+    edges.push({
+      source,
+      target,
+      relation,
+      confidence: "EXTRACTED",
+      confidence_score: 1.0,
+      source_file: filePath,
+      source_location: "L1",
+      weight: 1.0,
+    });
+  }
+
+  addNode(fileNid, basename(filePath), "mcp_config_file");
+
+  let serverCount = 0;
+  for (const [serverName, spec] of Object.entries(servers as Record<string, unknown>)) {
+    if (!serverName) continue;
+    if (typeof spec !== "object" || spec === null || Array.isArray(spec)) continue;
+    if (serverCount >= _MCP_MAX_SERVERS_PER_FILE) break;
+    serverCount += 1;
+
+    const specObj = spec as Record<string, unknown>;
+    const serverNid = _makeId(fileStem, "mcp_server", serverName);
+    addNode(serverNid, serverName, "mcp_server");
+    addEdge(fileNid, serverNid, "contains");
+
+    const command = specObj["command"];
+    if (typeof command === "string" && command.trim()) {
+      const cmd = command.trim();
+      const cmdNid = _makeId("mcp_command", cmd);
+      addNode(cmdNid, cmd, "mcp_command");
+      addEdge(serverNid, cmdNid, "references");
+    }
+
+    const args = specObj["args"];
+    if (Array.isArray(args)) {
+      const pkg = _mcpDetectPackageFromArgs(args);
+      if (pkg) {
+        const pkgNid = _makeId("mcp_package", pkg);
+        addNode(pkgNid, pkg, "mcp_package");
+        addEdge(serverNid, pkgNid, "references");
+      }
+    }
+
+    const env = specObj["env"];
+    if (typeof env === "object" && env !== null && !Array.isArray(env)) {
+      // ONLY KEYS. Values may contain secrets and are never read here.
+      for (const envName of Object.keys(env as Record<string, unknown>)) {
+        if (!envName) continue;
+        const envNid = _makeId("env_var", envName);
+        addNode(envNid, envName, "env_var");
+        addEdge(serverNid, envNid, "requires_env");
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+async function _extractMcpConfigAsync(filePath: string, rootDir?: string): Promise<ExtractionResult> {
+  return extractMcpConfig(filePath, rootDir);
+}
+
+// ---------------------------------------------------------------------------
 // Main extract() and collectFiles()
 // ---------------------------------------------------------------------------
 
@@ -5082,9 +5282,14 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
     }
     const filePath = normalizedPaths[i]!;
     const ext = extname(filePath).toLowerCase();
-    const extractor = basename(filePath).endsWith(".blade.php")
-      ? extractRegexBackedCode
-      : _DISPATCH[ext];
+    // Filename-based dispatch takes precedence over the suffix lookup so an
+    // MCP config (`.mcp.json`, `mcp.json`, …) is not swallowed by generic
+    // `.json` handling. Port of upstream 2c01a89 (dispatched-by-filename).
+    const extractor = isMcpConfigPath(filePath)
+      ? _extractMcpConfigAsync
+      : basename(filePath).endsWith(".blade.php")
+        ? extractRegexBackedCode
+        : _DISPATCH[ext];
     if (!extractor) continue;
 
     const cached = loadCached(filePath, root);
@@ -5242,7 +5447,12 @@ export function collectFiles(target: string, options?: { followSymlinks?: boolea
         walkDir(fullPath, visited);
       } else if (stat.isFile()) {
         const ext = extname(entry);
-        if (_EXTENSIONS.has(ext)) {
+        // MCP config files are dispatched by FILENAME, not extension (a bare
+        // `.json` would otherwise be ignored). `.mcp.json` is a hidden file and
+        // is intentionally skipped here (the `entry.startsWith(".")` guard
+        // above), consistent with graphify's hidden-file policy — it is still
+        // extracted when passed as an explicit single-file target.
+        if (_EXTENSIONS.has(ext) || _MCP_CONFIG_FILENAMES.has(entry)) {
           results.push(fullPath);
         }
       }

--- a/tests/extract-mcp-config.test.ts
+++ b/tests/extract-mcp-config.test.ts
@@ -1,0 +1,249 @@
+/**
+ * F-0820-0827 M3: MCP (Model Context Protocol) config extractor.
+ *
+ * Port of upstream safishamsi 2c01a89 (mcp_ingest). Surfaces:
+ *   - src/extract.ts: extractMcpConfig, isMcpConfigPath, filename dispatch,
+ *     collectFiles inclusion of non-hidden MCP config filenames.
+ *   - src/detect.ts: classifyFile returns CODE for MCP config filenames;
+ *     MCP_CONFIG_FILENAMES export.
+ *
+ * Security parity checks: env VALUES never read (only NAMES), 1 MiB cap,
+ * args not persisted (only a detected package id).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { extractMcpConfig, isMcpConfigPath, collectFiles } from "../src/extract.js";
+import { classifyFile, MCP_CONFIG_FILENAMES } from "../src/detect.js";
+import { FileType } from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-mcp-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeConfig(dir: string, name: string, doc: unknown): string {
+  const path = join(dir, name);
+  writeFileSync(path, JSON.stringify(doc, null, 2), "utf-8");
+  return path;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("isMcpConfigPath — filename recognition", () => {
+  it("recognises every contract filename", () => {
+    for (const name of [".mcp.json", "claude_desktop_config.json", "mcp.json", "mcp_servers.json"]) {
+      expect(isMcpConfigPath(join("/x", name))).toBe(true);
+    }
+  });
+  it("rejects unrelated json files", () => {
+    expect(isMcpConfigPath("/x/package.json")).toBe(false);
+    expect(isMcpConfigPath("/x/tsconfig.json")).toBe(false);
+    expect(isMcpConfigPath("/x/mcp.yaml")).toBe(false);
+  });
+});
+
+describe("extractMcpConfig — server / command / package / env nodes", () => {
+  it("extracts a typical npx + env config into nodes and edges", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", {
+      mcpServers: {
+        filesystem: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"],
+          env: { ALLOWED_DIR: "/data", API_KEY: "sk-secret-do-not-read" },
+        },
+      },
+    });
+
+    const { nodes, edges, error } = extractMcpConfig(path, dir);
+    expect(error).toBeUndefined();
+
+    const byKind = (k: string) => nodes.filter((n) => n.node_type === k);
+    expect(byKind("mcp_config_file")).toHaveLength(1);
+    expect(byKind("mcp_server").map((n) => n.label)).toEqual(["filesystem"]);
+    expect(byKind("mcp_command").map((n) => n.label)).toEqual(["npx"]);
+    // Package id parsed from args, version stripped (none here), scope kept.
+    expect(byKind("mcp_package").map((n) => n.label)).toEqual([
+      "@modelcontextprotocol/server-filesystem",
+    ]);
+    // env: ONLY the NAMES become nodes.
+    expect(byKind("env_var").map((n) => n.label).sort()).toEqual(["ALLOWED_DIR", "API_KEY"]);
+
+    // Edge relations: contains / references / requires_env.
+    const rel = (r: string) => edges.filter((e) => e.relation === r).length;
+    expect(rel("contains")).toBe(1); // file -> server
+    expect(rel("references")).toBe(2); // server -> command, server -> package
+    expect(rel("requires_env")).toBe(2); // server -> each env var
+  });
+
+  it("NEVER reads env VALUES — only the names appear anywhere", () => {
+    const dir = makeTempDir();
+    const secret = "sk-super-secret-token-value";
+    const path = writeConfig(dir, "mcp.json", {
+      mcpServers: { s: { command: "node", env: { TOKEN: secret } } },
+    });
+    const { nodes, edges } = extractMcpConfig(path, dir);
+    const blob = JSON.stringify({ nodes, edges });
+    expect(blob).toContain("TOKEN");
+    expect(blob).not.toContain(secret);
+  });
+
+  it("does NOT persist args (paths / positional secrets) as nodes", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", {
+      mcpServers: { s: { command: "npx", args: ["-y", "mcp-server-fetch", "/home/secret/path"] } },
+    });
+    const { nodes } = extractMcpConfig(path, dir);
+    const labels = nodes.map((n) => n.label);
+    expect(labels).not.toContain("/home/secret/path");
+    expect(labels).not.toContain("-y");
+    // The python-style package IS detected.
+    expect(labels).toContain("mcp-server-fetch");
+  });
+
+  it("strips the @version suffix from scoped and unscoped npm packages", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", {
+      mcpServers: {
+        a: { command: "npx", args: ["@org/pkg@1.2.3"] },
+        b: { command: "npx", args: ["plain-pkg@4.5.6"] },
+      },
+    });
+    const { nodes } = extractMcpConfig(path, dir);
+    const pkgs = nodes.filter((n) => n.node_type === "mcp_package").map((n) => n.label).sort();
+    // plain-pkg@4.5.6 is not an npm-scoped match and not a -mcp python match,
+    // so only the scoped package is detected (version stripped).
+    expect(pkgs).toEqual(["@org/pkg"]);
+  });
+
+  it("shares command / package / env nodes across servers (global ids)", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", {
+      mcpServers: {
+        a: { command: "npx", args: ["@x/a-mcp"], env: { SHARED: "1" } },
+        b: { command: "npx", args: ["@x/b-mcp"], env: { SHARED: "2" } },
+      },
+    });
+    const { nodes } = extractMcpConfig(path, dir);
+    // One shared "npx" command, one shared "SHARED" env var, two servers, two pkgs.
+    expect(nodes.filter((n) => n.node_type === "mcp_command")).toHaveLength(1);
+    expect(nodes.filter((n) => n.node_type === "env_var")).toHaveLength(1);
+    expect(nodes.filter((n) => n.node_type === "mcp_server")).toHaveLength(2);
+  });
+
+  it("supports the nested {mcp:{servers:{...}}} shape", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", {
+      mcp: { servers: { only: { command: "node" } } },
+    });
+    const { nodes, error } = extractMcpConfig(path, dir);
+    expect(error).toBeUndefined();
+    expect(nodes.filter((n) => n.node_type === "mcp_server").map((n) => n.label)).toEqual(["only"]);
+  });
+
+  it("returns an error (not throw) when there is no mcpServers map", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", { somethingElse: true });
+    const { nodes, edges, error } = extractMcpConfig(path, dir);
+    expect(error).toMatch(/no mcpServers map/);
+    expect(nodes).toEqual([]);
+    expect(edges).toEqual([]);
+  });
+
+  it("returns an error on malformed JSON (no throw)", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "mcp.json");
+    writeFileSync(path, "{not valid json", "utf-8");
+    const { error } = extractMcpConfig(path, dir);
+    expect(error).toMatch(/json error/);
+  });
+
+  it("returns an error on a non-object root", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "mcp.json");
+    writeFileSync(path, "[1,2,3]", "utf-8");
+    const { error } = extractMcpConfig(path, dir);
+    expect(error).toMatch(/root is not an object/);
+  });
+
+  it("rejects files larger than the 1 MiB cap", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "mcp.json");
+    // 1 MiB + a bit of valid-ish padding.
+    const padding = " ".repeat(1_048_577);
+    writeFileSync(path, `{"mcpServers":{}}${padding}`, "utf-8");
+    const { error } = extractMcpConfig(path, dir);
+    expect(error).toMatch(/too large/);
+  });
+
+  it("skips non-object server entries silently (no crash)", () => {
+    const dir = makeTempDir();
+    const path = writeConfig(dir, "mcp.json", {
+      mcpServers: { good: { command: "node" }, broken: "not-an-object", alsoBroken: 42 },
+    });
+    const { nodes, error } = extractMcpConfig(path, dir);
+    expect(error).toBeUndefined();
+    expect(nodes.filter((n) => n.node_type === "mcp_server").map((n) => n.label)).toEqual(["good"]);
+  });
+
+  it("is deterministic: identical input yields identical nodes/edges", () => {
+    const dir = makeTempDir();
+    const doc = {
+      mcpServers: {
+        z: { command: "uvx", args: ["mcp-server-time"], env: { TZ: "UTC" } },
+        a: { command: "npx", args: ["@m/a-mcp"] },
+      },
+    };
+    const p1 = writeConfig(dir, "mcp.json", doc);
+    const r1 = extractMcpConfig(p1, dir);
+    const r2 = extractMcpConfig(p1, dir);
+    expect(JSON.stringify(r1)).toBe(JSON.stringify(r2));
+  });
+});
+
+describe("detect.classifyFile — MCP config filenames classified as CODE", () => {
+  it("classifies every MCP config filename as CODE", () => {
+    for (const name of MCP_CONFIG_FILENAMES) {
+      expect(classifyFile(join("/proj", name))).toBe(FileType.CODE);
+    }
+  });
+  it("leaves an ordinary .json file unclassified", () => {
+    expect(classifyFile("/proj/data.json")).toBeNull();
+  });
+});
+
+describe("collectFiles — non-hidden MCP configs picked up; .mcp.json stays hidden", () => {
+  it("includes mcp.json / mcp_servers.json / claude_desktop_config.json from a directory walk", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "mcp.json"), "{}", "utf-8");
+    writeFileSync(join(dir, "mcp_servers.json"), "{}", "utf-8");
+    writeFileSync(join(dir, "claude_desktop_config.json"), "{}", "utf-8");
+    writeFileSync(join(dir, "unrelated.json"), "{}", "utf-8"); // must NOT be collected
+    writeFileSync(join(dir, ".mcp.json"), "{}", "utf-8"); // hidden — skipped on walk
+
+    const collected = collectFiles(dir).map((p) => p.split("/").pop());
+    expect(collected).toContain("mcp.json");
+    expect(collected).toContain("mcp_servers.json");
+    expect(collected).toContain("claude_desktop_config.json");
+    expect(collected).not.toContain("unrelated.json");
+    expect(collected).not.toContain(".mcp.json");
+  });
+
+  it("collects an explicit .mcp.json single-file target (hidden-file escape hatch)", () => {
+    const dir = makeTempDir();
+    const hidden = join(dir, ".mcp.json");
+    writeFileSync(hidden, "{}", "utf-8");
+    expect(collectFiles(hidden)).toEqual([hidden]);
+  });
+});


### PR DESCRIPTION
## What

Ports upstream **M3** (`safishamsi` `2c01a89`, `mcp_ingest`) — a Track F WP5 residual. Adds an extractor for **MCP (Model Context Protocol) server configuration files**, completing the loop: graphify exposes itself *as* an MCP server (`--mcp`), and now indexes MCP servers *as* a corpus type.

Recognised by **filename** (not extension — a bare `.json` would otherwise be ignored):
`.mcp.json`, `claude_desktop_config.json`, `mcp.json`, `mcp_servers.json`.

Extracts the `mcpServers` map into:
- `mcp_config_file` (the file), `mcp_server` (one per entry), `mcp_command`, `mcp_package` (npm/pypi id parsed from args), `env_var` (NAME only).
- edges: `contains` (file→server), `references` (server→command/package), `requires_env` (server→env var).

## Wiring

- `src/extract.ts`: `extractMcpConfig` + `isMcpConfigPath`; filename dispatch in `extractWithDiagnostics` takes precedence over the `.json` suffix lookup; `collectFiles` includes the non-hidden config filenames.
- `src/detect.ts`: `classifyFile` returns `CODE` for MCP config filenames; `MCP_CONFIG_FILENAMES` export.
- `.mcp.json` is a hidden file: the detection/collect walks skip dot-prefixed basenames (consistent with graphify's hidden-file policy), so it is extracted only as an explicit single-file target. The three non-hidden filenames are picked up on a directory scan.

## Security parity with upstream

- **Env VALUES are never read** — only env var NAMES become nodes (a `sk-...` value never appears in the graph; covered by a non-leakage test).
- File size capped at **1 MiB**.
- `args` are NOT persisted (they can embed paths/secrets) — only a detected package id.
- All labels go through `sanitizeLabel`.
- Command/package/env nodes use **global ids** (shared deps across configs collapse to one node); server nodes are **stem-scoped** (two configs both declaring "filesystem" don't collide).

## Tests

`tests/extract-mcp-config.test.ts` — 18 tests: node/edge shape, secret-value non-leakage, args non-persistence, `@version` stripping (scoped + unscoped), cross-config node sharing, nested `{mcp:{servers}}` shape, error paths (no `mcpServers` / malformed JSON / oversize / non-object root / broken server entries), determinism, and `classifyFile` + `collectFiles` dispatch. Verified end-to-end through the `extract` → `collectFiles` pipeline against a real fixture (secret not leaked, env NAME present, correct edge relations).

Size **M**, additive, reversible (new extractor + two filename-dispatch hooks; no existing extraction path changed). Confidence: **verified** (unit + end-to-end smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)