### PR TITLE
docs(wp4/f3): correct contract status comment (signed 2/2 + stabilized)

### DIFF
--- a/src/workspace-manifest.ts
+++ b/src/workspace-manifest.ts
@@ -38,8 +38,11 @@ export const WORKSPACE_MANIFEST_SCHEMA_VERSION = 1 as const;
 
 /**
  * The bundle contract this manifest stamps. `workspace-bundle-contract-v1` is
- * the negotiated contract with the aclp-am peer (consumer ratified 2026-06-12;
- * graphify-side ratification pending at the time of writing). Stamping the
+ * the negotiated contract with the aclp-am peer — signed by both parties and
+ * stabilized 2026-06-12 (h2a negotiation `workspace-bundle-contract-v1`,
+ * artifactHash sha256:5b08e19d…; the `graphify_principal:"pending"` field inside
+ * the proposed contract body is a frozen propose-time snapshot, superseded by
+ * graphify's own signature at journal seq2). Stamping the
  * contract id lets the consumer assert WHICH bundle shape it is reading — the
  * artifact set + the join semantics defined by the contract (join on
  * `registry_record_id`; the scene-hierarchies sidecar is authoritative for


### PR DESCRIPTION
One-line doc-comment fix in `src/workspace-manifest.ts`. #161's comment said graphify-side ratification was "pending" — it read the frozen propose-time `graphify_principal:"pending"` field from the contract body. The h2a negotiation `workspace-bundle-contract-v1` is actually **signed 2/2 and stabilized** (2026-06-12; journal seq1=aclp-am sig, seq2=graphify sig, seq4=stabilized, artifactHash sha256:5b08e19d…). Comment-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)