### PR TITLE
feat: CORE reconciliation + assembly hardening (schema hygiene, aliases, fuzzy tier, de-orphan)

### DIFF
--- a/spec/SPEC_GRAPHIFY.md
+++ b/spec/SPEC_GRAPHIFY.md
@@ -83,6 +83,14 @@ Legacy compatibility:
 
 Every edge keeps provenance confidence: EXTRACTED, INFERRED, or AMBIGUOUS, with scores where available.
 
+### Assembly Hygiene (CORE, config-gated, default OFF)
+
+Between step 6 (merge AST + semantic) and step 7 (build the graph), an optional, deterministic, idempotent, NO-KEY pre-pass canonicalizes the assembled extraction. It is gated through `BuildOptions.assemblyHygiene` (and exposed standalone as `applyAssemblyHygiene`), default OFF so the base non-profile contract is unchanged. The three sub-steps run in fixed order and benefit any corpus (`src/assembly-hygiene.ts`):
+
+1. **Schema hygiene (`normalizeSchemaHygiene`).** Canonicalizes synonymous id-prefixes through an explicit, extensible synonym map (defaults `location_`→`place_`, `org_`→`organization_`) and normalizes the node `type` to its canonical Capitalized form (default overrides `place`→`Location`, `chapter`/`story`→`ChapterOrStory`; bare lowercase types fold to Capitalize, e.g. `character`→`Character`). When two nodes collapse onto the same canonical id their edges, string-array fields, and citations are **UNIONed** (the 0.14.0 citation-union-at-merge posture — never last-write-wins-dropped); scalar attrs are filled first-seen by sorted id order. Self-loops created by a collapse are dropped. Re-running on its own output is a no-op.
+2. **Alias / normalized_terms derivation (`deriveAliasesAndNormalizedTerms`).** Derives `aliases` + `normalized_terms` from the label CONSERVATIVELY: strips leading honorifics/titles (Dr., Sir, Colonel, Inspector, Mr., Mrs., Lord, Lady, Captain, Professor, …) and parentheticals (`Hugo Oberstein (spy)`→alias `Hugo Oberstein`), lowercases the normalized terms. No fuzzy stemming (no invented collisions). Merges with — never clobbers — any pre-existing aliases/terms; idempotent.
+3. **De-orphan (`deOrphanByContainer`).** Links each degree-0 entity node to its FINEST available container — a ChapterOrStory/Scene/Section sharing its provenance (`source_file` or path slug), else the Work — through a derived `appears_in` edge (`derived:true`, `derivation_method:"deorphan:finest-container"`, `confidence:"INFERRED"`). Finest-container is chosen over straight-to-Work because all-orphans→Work inflates Work-node degree (Work hubs outrank protagonists) and distorts the force layout. Idempotent: respects pre-existing `appears_in`, never double-adds, never links a container node into itself.
+
 ## Configured Ontology Dataprep Profiles
 
 Configured ontology dataprep profiles are an additive layer over the existing pipeline. They activate only through a discovered project config (`graphify.yaml`, `graphify.yml`, `.graphify/config.yaml`, `.graphify/config.yml`) or an explicit `--config`/`--profile` option. Without that activation, the normal non-profile graphify behavior and base `validateExtraction()` contract remain unchanged.

--- a/spec/SPEC_ONTOLOGY_RECONCILIATION_ALGORITHM.md
+++ b/spec/SPEC_ONTOLOGY_RECONCILIATION_ALGORITHM.md
@@ -57,6 +57,21 @@ For each candidate pair, `score = Σ wᵢ · signalᵢ`, every contribution expo
 
 Weights `wᵢ` and tier thresholds are **profile-configurable with code defaults** (works cold, portable per corpus).
 
+### 2a. Implemented tiers (MVP — `src/ontology-reconciliation.ts`)
+
+The deployed deterministic generator (`generateOntologyReconciliationCandidates`) emits two tiers, each candidate tagged with `tier`:
+
+- **Exact tier** (`tier: "exact"`). A shared NORMALIZED term across `{label, aliases, normalized_terms}` (case/whitespace-folded). When the two normalized LABELS are equal the pair scores **1.0** (canonical exact match); a shared non-label term (alias / normalized_term) scores **0.85**. This tier is exact-only and depends on the assembly-stage alias/normalized_terms derivation to be more than label-equality (see `SPEC_GRAPHIFY.md → Assembly Hygiene`).
+- **Fuzzy tier** (`tier: "fuzzy"`, strictly LOWER confidence). Engaged only for a pair with no shared exact term. It compares honorific-stripped tokens across tagged surface VARIANTS of each label/alias — the parenthetical-**stripped** surface (a `name` variant) and the parenthetical **content** alone (a `paren` variant) — and matches when an admissible variant pair is token-SEQUENCE **equal** (score 0.9), the smaller token set strictly **contains** the larger (score 0.75), or the best `name`↔`name` token **Jaccard** clears `fuzzyThreshold` (default **0.6**, score 0.7). Leading honorifics/titles (Dr., Sir, Colonel, Inspector, Mr., Mrs., Lord, Lady, Captain, Professor, M./Mme./Mlle., …) are stripped before tokenization. Guard rails that keep precision high on a large corpus:
+  - **≥ 2 meaningful tokens** required on the smaller side, so a single generic locator ("Greenford", "Seawood", "inn", "butler") cannot match every node that merely mentions it.
+  - **`paren`↔`paren` never compared**, so two unrelated nodes sharing a generic descriptor ("(servant)", "(mentioned)", "(Evidence)", "(murder weapon)") do not collide; a `paren` variant matches only another node's real NAME (this is what surfaces "Exmoor estate" ⊆ "Devonshire (Exmoor estate)").
+  - **Order-preserving equality** + a **formulaic-series guard**: a pair whose token symmetric-difference is entirely ordinal-ish (roman numerals, digits, single letters) is rejected — "Edward I/II/III", "Part I, Chapter II" vs "Part II, Chapter I" are distinct members, not variants.
+  - **Structural container types excluded from the fuzzy tier** by default (`fuzzyExcludeTypes` = Work, ChapterOrStory, Scene, Section, Saga): fuzzy coreference is for ENTITIES; distinct chapters/works are never the same thing and their formulaic titles ("The Adventures of …", "Part I, Chapter II: …") would otherwise dominate the output. The exact tier still runs on these types.
+
+The **type-guard** (`left.type !== right.type` → skip) applies AFTER schema hygiene has canonicalized types, so `place`/`Location` no longer split a pair. Output is ranked by score (exact above fuzzy) and capped (`cap`, default 200). The fuzzy tier is config-gated (`fuzzy`, default ON) and never auto-applies — every candidate remains a non-destructive `accept_match` for human convergence.
+
+**Precision contract (mystery pack).** The fuzzy tier MUST surface genuine qualifier-variants — "Hugo Oberstein" ↔ "Hugo Oberstein (spy)"; "British Museum" ↔ "British Museum (Egyptian Antiquities)" (bridged across `place_`/`location_` by schema hygiene); "Devonshire (Exmoor estate)" ↔ "Exmoor estate"; "Reuben Hornby" ↔ "Reuben Hornby (accused)"; "Gournay-Martin" ↔ "M. Gournay-Martin" — and MUST reject siblings ("Sir Henry" ↔ "Sir Charles Baskerville"), regnal series ("Edward I/II/III"), generic honorific collisions ("Inspector Lestrade" ↔ "Inspector Gregson"), and distinct "Château de …". These cases are pinned in `tests/ontology-reconciliation-fuzzy.test.ts`.
+
 ## 3. LLM signal (phase 2, optional)
 
 The LLM may **re-rank the review shortlist** and **propose thresholds/rules** (active learning). It is **never** part of deterministic validation or patch apply — consistent with `SPEC_ONTOLOGY_LIFECYCLE_RECONCILIATION.md`.

--- a/src/assembly-hygiene.ts
+++ b/src/assembly-hygiene.ts
@@ -1,0 +1,505 @@
+/**
+ * Assembly hygiene — deterministic, idempotent, NO-KEY normalization that runs
+ * on the assembled extraction (node/edge dicts) BEFORE the graphology build.
+ *
+ * Three CORE assembly steps (each independently config-gated, each a pure
+ * transform of an `Extraction` → `Extraction`):
+ *
+ *   (A) `normalizeSchemaHygiene` — canonicalize synonymous id-prefixes
+ *       (`location_`→`place_`, `org_`→`organization_`, …) and normalize the
+ *       node `type` to its canonical Capitalized form. When two nodes collapse
+ *       onto the same canonical id, their edges/attrs/citations are UNIONed (the
+ *       0.14.0 citation-union-at-merge posture), never last-write-wins-dropped.
+ *
+ *   (B) `deriveAliasesAndNormalizedTerms` — derive `aliases` +
+ *       `normalized_terms` conservatively from the label: strip leading
+ *       honorifics/titles, strip parentheticals, lowercase. No fuzzy stemming
+ *       (no invented collisions).
+ *
+ *   (D) `deOrphanByContainer` — link every degree-0 entity node to its FINEST
+ *       available container (ChapterOrStory/Scene/Section matching provenance,
+ *       else the Work) via a derived `appears_in` edge. Idempotent: respects
+ *       pre-existing `appears_in`, never double-adds. Finest-container (not
+ *       straight-to-Work) keeps Work hubs from outranking real protagonists.
+ *
+ * Everything here is deterministic and replayable: no LLM, no network, no
+ * secrets, stable ordering, and re-running on its own output is a no-op.
+ */
+import type { Extraction, GraphEdge, GraphNode, OntologyCitation } from "./types.js";
+import { unionCitations } from "./citations.js";
+
+// ---------------------------------------------------------------------------
+// (A) Schema hygiene — id-prefix + type canonicalization with merge-union
+// ---------------------------------------------------------------------------
+
+/**
+ * Config for schema hygiene. Both maps are extensible/overridable per corpus.
+ *
+ * `idPrefixSynonyms`: maps a synonymous id-prefix to its canonical prefix
+ * (without the trailing underscore). e.g. `{ location: "place", org:
+ * "organization" }` rewrites `location_british_museum` → `place_british_museum`.
+ *
+ * `typeSynonyms`: maps a (lowercased) type token to its canonical form. The
+ * default also folds bare lowercase types to their Capitalized counterpart, so
+ * `character`→`Character`. Entries here override the default Capitalize rule
+ * (e.g. `place`→`Location`, `chapter`→`ChapterOrStory`).
+ */
+export interface SchemaHygieneConfig {
+  idPrefixSynonyms?: Record<string, string>;
+  typeSynonyms?: Record<string, string>;
+}
+
+/** Default id-prefix synonym map (canonical ← synonym). */
+export const DEFAULT_ID_PREFIX_SYNONYMS: Record<string, string> = {
+  location: "place",
+  org: "organization",
+};
+
+/**
+ * Default type synonym map. Keyed by the LOWERCASED type token. Only entries
+ * whose canonical form is NOT the simple Capitalize need listing; bare
+ * lowercase types (`character`→`Character`) are folded by the Capitalize rule.
+ */
+export const DEFAULT_TYPE_SYNONYMS: Record<string, string> = {
+  place: "Location",
+  chapter: "ChapterOrStory",
+  story: "ChapterOrStory",
+};
+
+function capitalize(value: string): string {
+  if (!value) return value;
+  return value[0]!.toUpperCase() + value.slice(1);
+}
+
+/**
+ * Canonical form of a node `type`. A type that already starts with an
+ * uppercase letter is treated as canonical and returned unchanged (so
+ * `ChapterOrStory`, `CrimeOrScheme` survive). A lowercase type is mapped
+ * through the synonym map, falling back to a plain Capitalize.
+ */
+export function canonicalType(type: string | undefined, synonyms: Record<string, string>): string | undefined {
+  if (typeof type !== "string" || type.length === 0) return type;
+  // Already canonical (starts uppercase) — leave compound canonical types intact.
+  if (type[0] === type[0]!.toUpperCase() && type[0] !== type[0]!.toLowerCase()) return type;
+  const key = type.toLowerCase();
+  if (synonyms[key]) return synonyms[key];
+  return capitalize(type);
+}
+
+/**
+ * Canonical id: rewrites a synonymous id-prefix to its canonical prefix.
+ * `location_british_museum` → `place_british_museum`. Ids without a known
+ * synonym prefix are returned unchanged.
+ */
+export function canonicalId(id: string, prefixSynonyms: Record<string, string>): string {
+  const match = /^([a-z]+)_(.*)$/.exec(id);
+  if (!match) return id;
+  const [, prefix, rest] = match;
+  const canonical = prefixSynonyms[prefix!];
+  if (!canonical || canonical === prefix) return id;
+  return `${canonical}_${rest}`;
+}
+
+function asCitations(value: unknown): OntologyCitation[] {
+  return Array.isArray(value) ? (value as OntologyCitation[]) : [];
+}
+
+function unionStringArrays(a: unknown, b: unknown): string[] {
+  const out = new Set<string>();
+  for (const v of Array.isArray(a) ? a : []) if (typeof v === "string" && v) out.add(v);
+  for (const v of Array.isArray(b) ? b : []) if (typeof v === "string" && v) out.add(v);
+  return Array.from(out).sort((x, y) => x.localeCompare(y));
+}
+
+const UNION_STRING_ARRAY_FIELDS = ["aliases", "normalized_terms", "registry_refs", "evidence_refs"] as const;
+
+/**
+ * Merge `incoming` into `kept` when two nodes collapse onto one canonical id.
+ * Citations + string-array fields are UNIONed (never dropped); scalar attrs are
+ * filled only where `kept` is missing them (first-seen, deterministic by sorted
+ * iteration order), so a non-empty value never silently loses to a later empty.
+ */
+function unionNodeInto(kept: GraphNode, incoming: GraphNode): void {
+  // Citations: deduped union by identity (0.14.0 posture).
+  const keptCites = asCitations(kept.citations);
+  const incCites = asCitations(incoming.citations);
+  if (keptCites.length > 0 || incCites.length > 0) {
+    kept.citations = unionCitations([keptCites, incCites]);
+  }
+  // String-array fields: deduped union.
+  for (const field of UNION_STRING_ARRAY_FIELDS) {
+    const merged = unionStringArrays(kept[field], incoming[field]);
+    if (merged.length > 0) (kept as Record<string, unknown>)[field] = merged;
+  }
+  // Scalar attrs: fill only where kept is missing (preserve first-seen non-empty).
+  for (const [key, value] of Object.entries(incoming)) {
+    if (key === "id" || key === "citations" || (UNION_STRING_ARRAY_FIELDS as readonly string[]).includes(key)) continue;
+    const current = (kept as Record<string, unknown>)[key];
+    const currentEmpty = current === undefined || current === null || current === "";
+    const incomingPresent = value !== undefined && value !== null && value !== "";
+    if (currentEmpty && incomingPresent) (kept as Record<string, unknown>)[key] = value;
+  }
+}
+
+/**
+ * (A) Normalize id-prefixes + types, collapsing duplicate nodes via union.
+ *
+ * Deterministic + idempotent: re-running on the output is a no-op (canonical
+ * ids/types are stable fixed points). Edges are rewritten through the same
+ * id-remap; self-loops created by a collapse are dropped.
+ */
+export function normalizeSchemaHygiene(
+  extraction: Extraction,
+  config: SchemaHygieneConfig = {},
+): Extraction {
+  const prefixSynonyms = { ...DEFAULT_ID_PREFIX_SYNONYMS, ...(config.idPrefixSynonyms ?? {}) };
+  const typeSynonyms = { ...DEFAULT_TYPE_SYNONYMS, ...(config.typeSynonyms ?? {}) };
+
+  const nodes = extraction.nodes ?? [];
+  // Process nodes in a stable id order so the first-seen winner of a collapse
+  // is deterministic regardless of extraction order.
+  const ordered = [...nodes].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+  const remap = new Map<string, string>();
+  const canonicalById = new Map<string, GraphNode>();
+  const result: GraphNode[] = [];
+
+  for (const node of ordered) {
+    const newId = canonicalId(String(node.id), prefixSynonyms);
+    const newType = canonicalType(node.type as string | undefined, typeSynonyms);
+    if (newId !== node.id) remap.set(String(node.id), newId);
+
+    const existing = canonicalById.get(newId);
+    if (!existing) {
+      const normalized: GraphNode = { ...node, id: newId };
+      if (newType !== undefined) (normalized as Record<string, unknown>).type = newType;
+      canonicalById.set(newId, normalized);
+      result.push(normalized);
+      continue;
+    }
+    // Collapse: union the incoming node into the surviving canonical node.
+    const incoming: GraphNode = { ...node, id: newId };
+    if (newType !== undefined) (incoming as Record<string, unknown>).type = newType;
+    unionNodeInto(existing, incoming);
+  }
+
+  // Stable output node order by canonical id so re-running is a byte-stable
+  // fixed point (a collapse changes push-order vs. a second no-collapse pass).
+  result.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+  if (remap.size === 0) {
+    // No id remap, but types may still have changed; result already carries
+    // normalized types. Edges/hyperedges are untouched by id rewriting.
+    return { ...extraction, nodes: result };
+  }
+
+  const resolve = (id: string): string => remap.get(id) ?? id;
+  const seenEdge = new Set<string>();
+  const edges: GraphEdge[] = [];
+  for (const edge of extraction.edges ?? []) {
+    const source = resolve(String(edge.source));
+    const target = resolve(String(edge.target));
+    if (source === target) continue; // self-loop from collapse
+    const key = `${source} ${target} ${edge.relation ?? ""}`;
+    if (seenEdge.has(key)) continue;
+    seenEdge.add(key);
+    edges.push({ ...edge, source, target });
+  }
+
+  const hyperedges = (extraction.hyperedges ?? []).map((h) => ({
+    ...h,
+    nodes: h.nodes.map(resolve),
+  }));
+
+  return { ...extraction, nodes: result, edges, hyperedges };
+}
+
+// ---------------------------------------------------------------------------
+// (B) Alias / normalized_terms derivation
+// ---------------------------------------------------------------------------
+
+/** Leading honorifics/titles stripped to derive a bare-name alias. */
+export const DEFAULT_HONORIFICS = [
+  "dr",
+  "sir",
+  "colonel",
+  "col",
+  "inspector",
+  "mr",
+  "mrs",
+  "ms",
+  "miss",
+  "lord",
+  "lady",
+  "captain",
+  "capt",
+  "professor",
+  "prof",
+  "doctor",
+  "madame",
+  "madam",
+  "monsieur",
+  "the",
+] as const;
+
+export interface AliasDerivationConfig {
+  honorifics?: readonly string[];
+}
+
+/** Lowercase a candidate term to its normalized form (trim + collapse spaces). */
+function normalizeTermLocal(value: string): string {
+  return value.trim().replace(/\s+/gu, " ").toLowerCase();
+}
+
+/**
+ * Strip a single leading honorific (with optional trailing period) from a name.
+ * Returns the stripped name, or null when nothing was stripped.
+ */
+function stripLeadingHonorific(name: string, honorifics: Set<string>): string | null {
+  const match = /^([A-Za-zÀ-ÖØ-öø-ÿ]+)\.?\s+(.+)$/u.exec(name.trim());
+  if (!match) return null;
+  const [, head, rest] = match;
+  if (!honorifics.has(head!.toLowerCase())) return null;
+  return rest!.trim();
+}
+
+/** Strip trailing/embedded parentheticals: "Hugo Oberstein (spy)" → "Hugo Oberstein". */
+function stripParenthetical(name: string): string | null {
+  const stripped = name.replace(/\s*\([^)]*\)\s*/gu, " ").replace(/\s+/gu, " ").trim();
+  if (stripped && stripped !== name.trim()) return stripped;
+  return null;
+}
+
+/**
+ * Derive alias + normalized-term candidates for a single label, CONSERVATIVELY.
+ * Returns the surface aliases (original-cased variants) and normalized_terms
+ * (lowercased). The label's own normalized form is always included as a
+ * normalized term so the matcher has a baseline term to compare.
+ */
+export function deriveLabelTerms(
+  label: string,
+  config: AliasDerivationConfig = {},
+): { aliases: string[]; normalizedTerms: string[] } {
+  const honorifics = new Set((config.honorifics ?? DEFAULT_HONORIFICS).map((h) => h.toLowerCase()));
+  const surfaces = new Set<string>();
+  const base = String(label ?? "").trim();
+  if (!base) return { aliases: [], normalizedTerms: [] };
+
+  // Generate variants by applying strips in combination (conservative, finite).
+  const queue: string[] = [base];
+  const visited = new Set<string>([base]);
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const variant of [stripParenthetical(current), stripLeadingHonorific(current, honorifics)]) {
+      if (variant && variant !== base && !visited.has(variant)) {
+        visited.add(variant);
+        surfaces.add(variant);
+        queue.push(variant);
+      }
+    }
+  }
+
+  const aliases = Array.from(surfaces).sort((a, b) => a.localeCompare(b));
+  const normalizedTerms = Array.from(new Set([base, ...surfaces].map(normalizeTermLocal)))
+    .filter((t) => t.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  return { aliases, normalizedTerms };
+}
+
+/**
+ * (B) Derive `aliases` + `normalized_terms` for every node with a label.
+ * Idempotent: merges with (does not clobber) any pre-existing aliases/terms,
+ * and re-running yields the same union. Conservative — no fuzzy stemming.
+ */
+export function deriveAliasesAndNormalizedTerms(
+  extraction: Extraction,
+  config: AliasDerivationConfig = {},
+): Extraction {
+  const nodes = (extraction.nodes ?? []).map((node) => {
+    const label = typeof node.label === "string" ? node.label : "";
+    if (!label) return node;
+    const { aliases, normalizedTerms } = deriveLabelTerms(label, config);
+    const mergedAliases = unionStringArrays(node.aliases, aliases);
+    const mergedTerms = unionStringArrays(node.normalized_terms, normalizedTerms);
+    const next: GraphNode = { ...node };
+    if (mergedAliases.length > 0) next.aliases = mergedAliases;
+    if (mergedTerms.length > 0) (next as Record<string, unknown>).normalized_terms = mergedTerms;
+    return next;
+  });
+  return { ...extraction, nodes };
+}
+
+// ---------------------------------------------------------------------------
+// (D) De-orphan — finest-container appears_in derivation
+// ---------------------------------------------------------------------------
+
+export interface DeOrphanConfig {
+  /** Container node types, FINEST → coarsest. The first matching wins. */
+  containerTypesFinestFirst?: string[];
+  /** The coarsest fallback container type (the Work). */
+  workType?: string;
+}
+
+/** Default container ranking: chapter/scene/section first, Work last. */
+export const DEFAULT_CONTAINER_TYPES_FINEST_FIRST = [
+  "ChapterOrStory",
+  "Scene",
+  "Section",
+] as const;
+export const DEFAULT_WORK_TYPE = "Work";
+const APPEARS_IN = "appears_in";
+
+function edgeEndpoint(value: unknown): string {
+  if (value && typeof value === "object" && "id" in (value as Record<string, unknown>)) {
+    return String((value as Record<string, unknown>).id);
+  }
+  return String(value);
+}
+
+/** Derive the corpus path-slug of a source_file (the work directory stem). */
+function slugOfSourceFile(sourceFile: string | undefined): string | null {
+  if (!sourceFile) return null;
+  const parts = String(sourceFile).split("/").filter(Boolean);
+  return parts.length >= 2 ? parts[parts.length - 2]! : null;
+}
+
+function nodeSourceFiles(node: GraphNode): Set<string> {
+  const set = new Set<string>();
+  if (typeof node.source_file === "string" && node.source_file) set.add(node.source_file);
+  for (const c of asCitations(node.citations)) {
+    if (typeof c.source_file === "string" && c.source_file) set.add(c.source_file);
+  }
+  return set;
+}
+
+export interface DeOrphanResult {
+  extraction: Extraction;
+  orphansBefore: number;
+  orphansAfter: number;
+  appearsInAdded: number;
+  unresolved: number;
+}
+
+/**
+ * (D) Link each degree-0 entity node to its finest available container via a
+ * derived `appears_in` edge. Container resolution, per orphan:
+ *   1. a container node (finest type first) sharing the orphan's source_file
+ *      or source-file slug;
+ *   2. else the Work sharing the source_file / slug.
+ * Idempotent: skips nodes that already have any edge, never duplicates an
+ * `appears_in` pair it (or a prior run) already created.
+ */
+export function deOrphanByContainer(
+  extraction: Extraction,
+  config: DeOrphanConfig = {},
+): DeOrphanResult {
+  const containerTypes = config.containerTypesFinestFirst ?? [...DEFAULT_CONTAINER_TYPES_FINEST_FIRST];
+  const workType = config.workType ?? DEFAULT_WORK_TYPE;
+  const nodes = extraction.nodes ?? [];
+  const edges = extraction.edges ?? [];
+
+  const degree = new Map<string, number>(nodes.map((n) => [String(n.id), 0]));
+  const existingPair = new Set<string>();
+  for (const e of edges) {
+    const s = edgeEndpoint(e.source);
+    const t = edgeEndpoint(e.target);
+    if (degree.has(s)) degree.set(s, degree.get(s)! + 1);
+    if (degree.has(t)) degree.set(t, degree.get(t)! + 1);
+    existingPair.add(`${s} ${t}`);
+  }
+
+  // Build container indices by source_file and by slug, per container rank.
+  // rankOf: finest container types get the lowest rank number; Work is last.
+  const rankOf = new Map<string, number>();
+  containerTypes.forEach((t, i) => rankOf.set(t, i));
+  rankOf.set(workType, containerTypes.length);
+
+  // For each (rank) maintain source_file→id and slug→id (first-seen by id order).
+  const byRankSource: Array<Map<string, string>> = [];
+  const byRankSlug: Array<Map<string, string>> = [];
+  for (let i = 0; i <= containerTypes.length; i += 1) {
+    byRankSource.push(new Map());
+    byRankSlug.push(new Map());
+  }
+  const containerOrdered = [...nodes].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  for (const n of containerOrdered) {
+    const rank = rankOf.get(String(n.type));
+    if (rank === undefined) continue;
+    const srcMap = byRankSource[rank]!;
+    const slugMap = byRankSlug[rank]!;
+    if (typeof n.source_file === "string" && n.source_file && !srcMap.has(n.source_file)) {
+      srcMap.set(n.source_file, String(n.id));
+    }
+    // id-slug: container ids look like "chapter_<work-slug>_chN" or
+    // "work_<slug>" — index by the source_file slug AND the id-derived slug.
+    const sfSlug = slugOfSourceFile(typeof n.source_file === "string" ? n.source_file : undefined);
+    if (sfSlug && !slugMap.has(sfSlug)) slugMap.set(sfSlug, String(n.id));
+    const idSlug = String(n.id).replace(/^[a-z]+[_-]/, "");
+    if (idSlug && !slugMap.has(idSlug)) slugMap.set(idSlug, String(n.id));
+  }
+
+  const containerTypeSet = new Set([...containerTypes, workType]);
+  const orphans = nodes.filter((n) => (degree.get(String(n.id)) ?? 0) === 0);
+  const added: GraphEdge[] = [];
+  let unresolved = 0;
+
+  for (const orphan of orphans) {
+    // A container node that is itself an orphan has no parent of its own kind
+    // to link into (a Work has no Work parent). Leave it as-is.
+    if (containerTypeSet.has(String(orphan.type))) {
+      unresolved += 1;
+      continue;
+    }
+    const sources = nodeSourceFiles(orphan);
+    let linked = false;
+    // Resolve the FINEST container across all of the orphan's source files:
+    // sweep ranks finest→coarsest, take the first hit.
+    let containerId: string | undefined;
+    for (let rank = 0; rank <= containerTypes.length && !containerId; rank += 1) {
+      for (const sf of sources) {
+        const hit = byRankSource[rank]!.get(sf) ?? byRankSlug[rank]!.get(slugOfSourceFile(sf) ?? "");
+        if (hit && hit !== String(orphan.id)) {
+          containerId = hit;
+          break;
+        }
+      }
+    }
+    if (containerId) {
+      const key = `${String(orphan.id)} ${containerId}`;
+      if (!existingPair.has(key)) {
+        existingPair.add(key);
+        added.push({
+          source: String(orphan.id),
+          target: containerId,
+          relation: APPEARS_IN,
+          confidence: "INFERRED",
+          source_file: typeof orphan.source_file === "string" ? orphan.source_file : "",
+          derived: true,
+          derivation_method: "deorphan:finest-container",
+        } as GraphEdge);
+      }
+      linked = true;
+    }
+    if (!linked) unresolved += 1;
+  }
+
+  const nextExtraction: Extraction = { ...extraction, edges: [...edges, ...added] };
+
+  // Recompute orphans after.
+  const degreeAfter = new Map<string, number>(nodes.map((n) => [String(n.id), 0]));
+  for (const e of nextExtraction.edges) {
+    const s = edgeEndpoint(e.source);
+    const t = edgeEndpoint(e.target);
+    if (degreeAfter.has(s)) degreeAfter.set(s, degreeAfter.get(s)! + 1);
+    if (degreeAfter.has(t)) degreeAfter.set(t, degreeAfter.get(t)! + 1);
+  }
+  const orphansAfter = nodes.filter((n) => (degreeAfter.get(String(n.id)) ?? 0) === 0).length;
+
+  return {
+    extraction: nextExtraction,
+    orphansBefore: orphans.length,
+    orphansAfter,
+    appearsInAdded: added.length,
+    unresolved,
+  };
+}

--- a/src/build.ts
+++ b/src/build.ts
@@ -17,6 +17,28 @@ import { createGraph } from "./graph.js";
 import { assertGraphJsonFileSize } from "./graph-size-guard.js";
 import { cleanupStaleNodes } from "./semantic-cleanup.js";
 import { validateExtraction } from "./validate.js";
+import {
+  deOrphanByContainer,
+  deriveAliasesAndNormalizedTerms,
+  normalizeSchemaHygiene,
+  type AliasDerivationConfig,
+  type DeOrphanConfig,
+  type SchemaHygieneConfig,
+} from "./assembly-hygiene.js";
+
+/**
+ * Config-gated CORE assembly-hygiene pre-pass (default OFF). Each sub-step is
+ * an independent, deterministic, idempotent transform of the extraction before
+ * the graphology build:
+ *   - `schemaHygiene`: id-prefix + type canonicalization with merge-union (A)
+ *   - `deriveAliases`: alias / normalized_terms derivation (B)
+ *   - `deOrphan`: finest-container `appears_in` derivation (D)
+ */
+export interface AssemblyHygieneOptions {
+  schemaHygiene?: boolean | SchemaHygieneConfig;
+  deriveAliases?: boolean | AliasDerivationConfig;
+  deOrphan?: boolean | DeOrphanConfig;
+}
 
 export interface BuildOptions {
   directed?: boolean;
@@ -27,6 +49,45 @@ export interface BuildOptions {
    * paths, splitting nodes across two identities.
    */
   root?: string;
+  /**
+   * Config-gated CORE assembly-hygiene pre-pass (default OFF — opt-in per
+   * corpus). Runs schema-hygiene → alias-derivation → de-orphan on the
+   * extraction before the graphology build. See `applyAssemblyHygiene`.
+   */
+  assemblyHygiene?: AssemblyHygieneOptions;
+}
+
+/**
+ * Run the config-gated assembly-hygiene transforms on an extraction, in the
+ * fixed order schema-hygiene → alias-derivation → de-orphan. Pure + idempotent;
+ * each step is a no-op unless explicitly enabled. Exported so the CLI and
+ * offline tools can productionize the same pipeline the prototypes validated.
+ */
+export function applyAssemblyHygiene(
+  extraction: Extraction,
+  options?: AssemblyHygieneOptions,
+): Extraction {
+  if (!options) return extraction;
+  let current = extraction;
+  if (options.schemaHygiene) {
+    current = normalizeSchemaHygiene(
+      current,
+      typeof options.schemaHygiene === "object" ? options.schemaHygiene : {},
+    );
+  }
+  if (options.deriveAliases) {
+    current = deriveAliasesAndNormalizedTerms(
+      current,
+      typeof options.deriveAliases === "object" ? options.deriveAliases : {},
+    );
+  }
+  if (options.deOrphan) {
+    current = deOrphanByContainer(
+      current,
+      typeof options.deOrphan === "object" ? options.deOrphan : {},
+    ).extraction;
+  }
+  return current;
 }
 
 const CHUNK_SUFFIX = /_c\d+$/;
@@ -252,6 +313,9 @@ export function deduplicateByLabel(extraction: Extraction): Extraction {
 
 export function buildFromJson(extraction: Extraction, options?: BuildOptions): Graph {
   const root = rootForOptions(options);
+  // CORE assembly-hygiene pre-pass (config-gated, default OFF). Runs before
+  // validation so the build sees canonical ids/types and derived edges.
+  extraction = applyAssemblyHygiene(extraction, options?.assemblyHygiene);
   for (const node of extraction.nodes ?? []) {
     const legacySource = node.source as unknown;
     if (legacySource !== undefined && node.source_file === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,26 @@ export type {
   ProfileReportPdfArtifact,
 } from "./profile-report.js";
 export { validateExtraction, assertValid } from "./validate.js";
-export { buildFromJson, build, buildMerge, deduplicateByLabel } from "./build.js";
+export { buildFromJson, build, buildMerge, deduplicateByLabel, applyAssemblyHygiene } from "./build.js";
+export type { AssemblyHygieneOptions } from "./build.js";
+export {
+  normalizeSchemaHygiene,
+  deriveAliasesAndNormalizedTerms,
+  deriveLabelTerms,
+  deOrphanByContainer,
+  canonicalId,
+  canonicalType,
+  DEFAULT_ID_PREFIX_SYNONYMS,
+  DEFAULT_TYPE_SYNONYMS,
+  DEFAULT_HONORIFICS,
+  DEFAULT_CONTAINER_TYPES_FINEST_FIRST,
+} from "./assembly-hygiene.js";
+export type {
+  SchemaHygieneConfig,
+  AliasDerivationConfig,
+  DeOrphanConfig,
+  DeOrphanResult,
+} from "./assembly-hygiene.js";
 export { cleanupStaleNodes } from "./semantic-cleanup.js";
 export type { CleanupStaleNodesOptions, CleanupStaleNodesResult } from "./semantic-cleanup.js";
 export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,6 +278,16 @@ export type {
   DeOrphanConfig,
   DeOrphanResult,
 } from "./assembly-hygiene.js";
+export {
+  fuzzyMatchNodes,
+  DEFAULT_FUZZY_TOKEN_JACCARD_THRESHOLD,
+  DEFAULT_RECONCILIATION_CANDIDATE_CAP,
+  DEFAULT_FUZZY_EXCLUDE_TYPES,
+} from "./ontology-reconciliation.js";
+export type {
+  FuzzyMatchResult,
+  OntologyReconciliationCandidateTier,
+} from "./ontology-reconciliation.js";
 export { cleanupStaleNodes } from "./semantic-cleanup.js";
 export type { CleanupStaleNodesOptions, CleanupStaleNodesResult } from "./semantic-cleanup.js";
 export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -11,11 +11,16 @@ export const ONTOLOGY_RECONCILIATION_CANDIDATES_RESPONSE_SCHEMA =
 export type OntologyReconciliationCandidateKind = "entity_match";
 export type OntologyReconciliationCandidateStatus = "candidate";
 
+/** Matching tier that produced a candidate. */
+export type OntologyReconciliationCandidateTier = "exact" | "fuzzy";
+
 export interface OntologyReconciliationCandidate {
   id: string;
   kind: OntologyReconciliationCandidateKind;
   status: OntologyReconciliationCandidateStatus;
   score: number;
+  /** Which matching tier produced this candidate. Optional for back-compat. */
+  tier?: OntologyReconciliationCandidateTier;
   candidate_id: string;
   canonical_id: string;
   shared_terms: string[];
@@ -62,6 +67,20 @@ export interface OntologyReconciliationCandidatesResponse {
 
 export interface GenerateOntologyReconciliationCandidatesOptions {
   generatedAt?: string;
+  /**
+   * Enable the LOWER-confidence fuzzy tier (token-containment + token Jaccard,
+   * honorific-stripped) over the exact-normalized-label tier. Default true.
+   */
+  fuzzy?: boolean;
+  /** Token-Jaccard threshold for the fuzzy tier. */
+  fuzzyThreshold?: number;
+  /** Cap on the total number of emitted candidates (after ranking by score). */
+  cap?: number;
+  /**
+   * Node types excluded from the FUZZY tier (structural containers by default).
+   * The exact tier always runs on every type.
+   */
+  fuzzyExcludeTypes?: readonly string[];
 }
 
 function sha256(value: string): string {
@@ -82,6 +101,253 @@ function nodeTerms(node: OntologyPatchNode): string[] {
     ...(node.aliases ?? []).map(normalizeTerm),
     ...(node.normalized_terms ?? []).map(normalizeTerm),
   ]);
+}
+
+// --- Fuzzy tier ------------------------------------------------------------
+//
+// A LOWER-confidence tier over the exact-normalized-label tier. It compares
+// honorific-stripped token SETS across surface VARIANTS of each label/alias
+// (the full surface, the parenthetical-stripped surface, and the
+// parenthetical CONTENT on its own). Two entities are a fuzzy match when some
+// variant pair is token-set-EQUAL, or one variant's tokens are a strict subset
+// of the other's (≥ 2 meaningful tokens), or their best token Jaccard clears
+// the threshold. This surfaces genuine qualifier-variants
+// ("Hugo Oberstein" ↔ "Hugo Oberstein (spy)";
+//  "Devonshire (Exmoor estate)" ↔ "Exmoor estate") while rejecting siblings
+// ("Sir Henry" ↔ "Sir Charles"), regnal series ("Edward I/II/III"), generic
+// honorific collisions ("Inspector …"), and distinct "Château de …".
+
+/** Leading honorifics/titles stripped before fuzzy token comparison. */
+const FUZZY_HONORIFICS = new Set([
+  "dr",
+  "sir",
+  "colonel",
+  "col",
+  "inspector",
+  "mr",
+  "mrs",
+  "ms",
+  "miss",
+  "lord",
+  "lady",
+  "captain",
+  "capt",
+  "professor",
+  "prof",
+  "doctor",
+  "madame",
+  "madam",
+  "monsieur",
+  "m",
+  "mme",
+  "mlle",
+  "the",
+]);
+
+/** Default token-Jaccard threshold for the fuzzy tier. */
+export const DEFAULT_FUZZY_TOKEN_JACCARD_THRESHOLD = 0.6;
+/** Default cap on the number of emitted candidates (exact + fuzzy). */
+export const DEFAULT_RECONCILIATION_CANDIDATE_CAP = 200;
+/**
+ * Structural CONTAINER types excluded from the FUZZY tier by default. Fuzzy
+ * coreference is for ENTITIES (characters, places, objects); distinct chapters
+ * / works / sagas are never the "same real thing", and their formulaic titles
+ * ("Part I, Chapter II", "The Adventures of …") otherwise dominate the output
+ * with non-mergeable noise. The exact tier still runs on these types.
+ */
+export const DEFAULT_FUZZY_EXCLUDE_TYPES = [
+  "Work",
+  "ChapterOrStory",
+  "Scene",
+  "Section",
+  "Saga",
+] as const;
+
+const NON_WORD = /[^\p{L}\p{N}]+/gu;
+const PARENTHETICAL = /\([^)]*\)/gu;
+
+/**
+ * A variant is either the entity NAME (the full surface or its
+ * parenthetical-stripped form) or the PARENTHETICAL content alone. Tagging
+ * matters because a parenthetical is often a generic descriptor ("(servant)",
+ * "(mentioned)", "(Evidence)") that must NOT match another node's descriptor —
+ * only a node's real NAME. So `paren` variants are compared against `name`
+ * variants only, never `paren`↔`paren`.
+ */
+interface FuzzyVariant {
+  tokens: string[];
+  kind: "name" | "paren";
+}
+
+/** Honorific-stripped, NFKC-folded token list of a surface string. */
+function fuzzyTokens(variant: string): string[] {
+  return variant
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(NON_WORD, " ")
+    .split(/\s+/u)
+    .filter((t) => t.length > 0 && !FUZZY_HONORIFICS.has(t));
+}
+
+/** Tagged surface variants of a single term. The NAME is the parenthetical-
+ * STRIPPED surface (not the full surface — keeping the parenthetical tokens in
+ * a name variant would leak generic descriptors like "(murder weapon)" into
+ * name comparisons). The parenthetical content is a separate `paren` variant. */
+function surfaceVariants(term: string): FuzzyVariant[] {
+  const out: FuzzyVariant[] = [];
+  const noParen = fuzzyTokens(term.replace(PARENTHETICAL, " "));
+  if (noParen.length > 0) out.push({ tokens: noParen, kind: "name" });
+  for (const m of term.match(/\(([^)]*)\)/gu) ?? []) {
+    const paren = fuzzyTokens(m.slice(1, -1));
+    if (paren.length > 0) out.push({ tokens: paren, kind: "paren" });
+  }
+  return out;
+}
+
+/** All distinct tagged token sets across a node's terms + variants. */
+function fuzzyVariants(node: OntologyPatchNode): FuzzyVariant[] {
+  const seen = new Set<string>();
+  const variants: FuzzyVariant[] = [];
+  for (const term of nodeTerms(node)) {
+    for (const variant of surfaceVariants(term)) {
+      // Order-preserving dedup key: token SEQUENCE matters (so "Part I Chapter
+      // II" and "Part II Chapter I" stay distinct variants).
+      const key = `${variant.kind}:${variant.tokens.join(" ")}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      variants.push(variant);
+    }
+  }
+  return variants;
+}
+
+function tokenJaccard(a: string[], b: string[]): number {
+  const A = new Set(a);
+  const B = new Set(b);
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter += 1;
+  const union = new Set([...A, ...B]).size;
+  return union === 0 ? 0 : inter / union;
+}
+
+/** Order-preserving token-sequence equality (kills reordered-ordinal collisions). */
+function tokenSequenceEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+// Ordinal-ish tokens: roman numerals i–xx, plain digits, and single letters.
+// Two labels differing ONLY by these are a FORMULAIC SERIES — "Edward I/II/III",
+// "Part I, Chapter II", "Sir James / Sir Robert"(no — surnames differ) — and
+// must NOT fuzzy-match: a one-numeral delta is a DISTINCT member, not a variant.
+const ROMAN_NUMERAL = /^(?:x{0,3})(?:ix|iv|v?i{0,3})$/u;
+function isOrdinalToken(token: string): boolean {
+  if (/^\d+$/u.test(token)) return true;
+  if (token.length === 1) return true; // single letter (regnal, sub-section)
+  return token.length <= 4 && ROMAN_NUMERAL.test(token) && token !== "";
+}
+
+/**
+ * True when the two token sets share ≥1 token AND every token in their
+ * symmetric difference is ordinal-ish — i.e. they are the same template with a
+ * different serial number ("part i chapter ii" vs "part ii chapter i";
+ * "edward i" vs "edward ii"). Such pairs are formulaic-series false positives.
+ */
+function differsOnlyByOrdinal(a: string[], b: string[]): boolean {
+  const A = new Set(a);
+  const B = new Set(b);
+  let shared = 0;
+  const diff: string[] = [];
+  for (const x of A) (B.has(x) ? (shared += 1) : diff.push(x));
+  for (const x of B) if (!A.has(x)) diff.push(x);
+  if (shared === 0 || diff.length === 0) return false;
+  return diff.every(isOrdinalToken);
+}
+
+function tokenSubset(a: string[], b: string[]): boolean {
+  const A = new Set(a);
+  const B = new Set(b);
+  if (A.size === 0 || B.size === 0) return false;
+  const [small, big] = A.size <= B.size ? [A, B] : [B, A];
+  for (const x of small) if (!big.has(x)) return false;
+  return true;
+}
+
+export interface FuzzyMatchResult {
+  matched: boolean;
+  /** Best token Jaccard across all admissible variant pairs. */
+  jaccard: number;
+  /** True when some name↔name variant pair was token-set-equal. */
+  equal: boolean;
+  /** True when a ≥2-token strict containment held (incl. paren↔name). */
+  contained: boolean;
+}
+
+/**
+ * Fuzzy match between two nodes across honorific-stripped tagged variants.
+ * Deterministic; reads label/aliases/normalized_terms only.
+ *
+ * Admissibility:
+ *   - name↔name: equality / containment / Jaccard all eligible.
+ *   - paren↔name: only token-set EQUALITY or strict containment with ≥2 tokens
+ *     (captures "Exmoor estate" ⊆ "Devonshire (Exmoor estate)"), so a generic
+ *     ≥2-word descriptor never matches by mere Jaccard.
+ *   - paren↔paren: NEVER (generic-descriptor collision guard).
+ */
+export function fuzzyMatchNodes(
+  left: OntologyPatchNode,
+  right: OntologyPatchNode,
+  threshold: number = DEFAULT_FUZZY_TOKEN_JACCARD_THRESHOLD,
+): FuzzyMatchResult {
+  const leftSets = fuzzyVariants(left);
+  const rightSets = fuzzyVariants(right);
+  let best = 0;
+  let equal = false;
+  let contained = false;
+  for (const a of leftSets) {
+    for (const b of rightSets) {
+      // paren↔paren is never admissible (generic-descriptor collision guard).
+      if (a.kind === "paren" && b.kind === "paren") continue;
+      // A match needs ≥2 meaningful tokens on the smaller side so a single
+      // generic locator ("Greenford", "Seawood", "butler", "inn") cannot match
+      // every node that merely mentions it in a parenthetical.
+      const minLen = Math.min(a.tokens.length, b.tokens.length);
+      if (minLen < 2) continue;
+      // Formulaic-series guard: a one-numeral delta is a distinct member, not a
+      // variant ("Edward I/II"). Also reject a same-token-set pair whose
+      // sequences differ AND that carries ordinal tokens ("Part I, Chapter II"
+      // vs "Part II, Chapter I" share the token SET but swap the serials).
+      if (differsOnlyByOrdinal(a.tokens, b.tokens)) continue;
+      if (
+        !tokenSequenceEqual(a.tokens, b.tokens) &&
+        a.tokens.length === b.tokens.length &&
+        tokenSubset(a.tokens, b.tokens) &&
+        (a.tokens.some(isOrdinalToken) || b.tokens.some(isOrdinalToken))
+      ) {
+        continue;
+      }
+      const nameName = a.kind === "name" && b.kind === "name";
+      // Equality is SEQUENCE-equal (order preserved) so reordered ordinals
+      // do not collide.
+      if (tokenSequenceEqual(a.tokens, b.tokens)) equal = true;
+      if (tokenSubset(a.tokens, b.tokens)) contained = true;
+      // Jaccard-threshold matching is name↔name only (loose-similarity tier).
+      if (nameName) {
+        const j = tokenJaccard(a.tokens, b.tokens);
+        if (j > best) best = j;
+      }
+    }
+  }
+  const matched = equal || contained || best >= threshold;
+  return { matched, jaccard: best, equal, contained };
+}
+
+/** Fuzzy-tier score: equality > containment > threshold-only. Always < exact 1.0. */
+function fuzzyScore(result: FuzzyMatchResult): number {
+  if (result.equal) return 0.9;
+  if (result.contained) return 0.75;
+  return 0.7;
 }
 
 function statusRank(status: string | undefined): number {
@@ -115,8 +381,9 @@ function candidateScore(sharedTerms: string[], canonical: OntologyPatchNode, can
   const canonicalLabel = canonical.label ? normalizeTerm(canonical.label) : null;
   const candidateLabel = candidate.label ? normalizeTerm(candidate.label) : null;
   const exactLabelMatch = canonicalLabel !== null && canonicalLabel === candidateLabel && sharedTerms.includes(canonicalLabel);
-  const statusBoost = statusRank(canonical.status) > statusRank(candidate.status) ? 0.05 : 0;
-  return Math.min(exactLabelMatch ? 0.95 + statusBoost : 0.8 + statusBoost, 1);
+  // Exact normalized-label match is the top tier: score 1.0 (canonical pair).
+  // A shared non-label term (alias/normalized_term) is strong but sub-exact.
+  return exactLabelMatch ? 1 : 0.85;
 }
 
 function candidateId(canonical: OntologyPatchNode, candidate: OntologyPatchNode, sharedTerms: string[]): string {
@@ -215,7 +482,13 @@ export function generateOntologyReconciliationCandidates(
   context: OntologyPatchContext,
   options: GenerateOntologyReconciliationCandidatesOptions = {},
 ): OntologyReconciliationCandidateQueue {
+  const fuzzyEnabled = options.fuzzy ?? true;
+  const fuzzyThreshold = options.fuzzyThreshold ?? DEFAULT_FUZZY_TOKEN_JACCARD_THRESHOLD;
+  const cap = options.cap ?? DEFAULT_RECONCILIATION_CANDIDATE_CAP;
+  const fuzzyExcludeTypes = new Set(options.fuzzyExcludeTypes ?? DEFAULT_FUZZY_EXCLUDE_TYPES);
+
   const candidates: OntologyReconciliationCandidate[] = [];
+  const emittedPairs = new Set<string>();
   const comparableNodes = context.nodes
     .filter((node) => node.type && nodeTerms(node).length > 0)
     .sort((a, b) => a.id.localeCompare(b.id));
@@ -224,29 +497,68 @@ export function generateOntologyReconciliationCandidates(
     for (let j = i + 1; j < comparableNodes.length; j += 1) {
       const left = comparableNodes[i]!;
       const right = comparableNodes[j]!;
+      // Type-guard applies AFTER schema hygiene has canonicalized types.
       if (left.type !== right.type) continue;
 
       const leftTerms = new Set(nodeTerms(left));
       const sharedTerms = nodeTerms(right).filter((term) => leftTerms.has(term));
-      if (sharedTerms.length === 0) continue;
 
       const { canonical, candidate } = chooseCanonicalPair(left, right);
+      const pairKey = `${canonical.id}|${candidate.id}`;
       const evidenceRefs = uniqueSorted([
         ...(canonical.source_refs ?? []),
         ...(candidate.source_refs ?? []),
       ]);
+
+      if (sharedTerms.length > 0) {
+        // Exact tier: shared normalized term (label/alias/normalized_term).
+        emittedPairs.add(pairKey);
+        candidates.push({
+          id: candidateId(canonical, candidate, sharedTerms),
+          kind: "entity_match",
+          status: "candidate",
+          score: candidateScore(sharedTerms, canonical, candidate),
+          tier: "exact",
+          candidate_id: candidate.id,
+          canonical_id: canonical.id,
+          shared_terms: sharedTerms,
+          evidence_refs: evidenceRefs,
+          reasons: [
+            `same node type: ${canonical.type}`,
+            `shared normalized term(s): ${sharedTerms.join(", ")}`,
+          ],
+          proposed_patch_operation: "accept_match",
+        });
+        continue;
+      }
+
+      if (!fuzzyEnabled) continue;
+      // Fuzzy tier is for ENTITIES — skip structural container types (their
+      // formulaic titles are non-mergeable noise). Types are equal here.
+      if (fuzzyExcludeTypes.has(String(left.type))) continue;
+      // Fuzzy tier: honorific-stripped token containment / Jaccard.
+      const fuzzy = fuzzyMatchNodes(left, right, fuzzyThreshold);
+      if (!fuzzy.matched) continue;
+      if (emittedPairs.has(pairKey)) continue;
+      emittedPairs.add(pairKey);
+      const reasonDetail = fuzzy.equal
+        ? "token-set equal (honorific/parenthetical-stripped)"
+        : fuzzy.contained
+          ? "token containment (honorific/parenthetical-stripped)"
+          : `token Jaccard ${fuzzy.jaccard.toFixed(2)} ≥ ${fuzzyThreshold}`;
       candidates.push({
-        id: candidateId(canonical, candidate, sharedTerms),
+        id: candidateId(canonical, candidate, [reasonDetail]),
         kind: "entity_match",
         status: "candidate",
-        score: candidateScore(sharedTerms, canonical, candidate),
+        score: fuzzyScore(fuzzy),
+        tier: "fuzzy",
         candidate_id: candidate.id,
         canonical_id: canonical.id,
-        shared_terms: sharedTerms,
+        shared_terms: [],
         evidence_refs: evidenceRefs,
         reasons: [
           `same node type: ${canonical.type}`,
-          `shared normalized term(s): ${sharedTerms.join(", ")}`,
+          `fuzzy match: ${reasonDetail}`,
         ],
         proposed_patch_operation: "accept_match",
       });
@@ -254,13 +566,14 @@ export function generateOntologyReconciliationCandidates(
   }
 
   candidates.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  const capped = Number.isFinite(cap) && cap >= 0 ? candidates.slice(0, cap) : candidates;
   return {
     schema: ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA,
     graph_hash: context.graphHash,
     profile_hash: context.profile.profile_hash,
     generated_at: options.generatedAt ?? new Date().toISOString(),
-    candidate_count: candidates.length,
-    candidates,
+    candidate_count: capped.length,
+    candidates: capped,
   };
 }
 

--- a/tests/assembly-hygiene.test.ts
+++ b/tests/assembly-hygiene.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalId,
+  canonicalType,
+  deriveAliasesAndNormalizedTerms,
+  deriveLabelTerms,
+  deOrphanByContainer,
+  normalizeSchemaHygiene,
+} from "../src/assembly-hygiene.js";
+import { applyAssemblyHygiene, buildFromJson } from "../src/build.js";
+import type { Extraction, GraphEdge, GraphNode } from "../src/types.js";
+
+function node(partial: Partial<GraphNode> & { id: string }): GraphNode {
+  return {
+    label: partial.label ?? partial.id,
+    file_type: partial.file_type ?? "document",
+    source_file: partial.source_file ?? "",
+    ...partial,
+  };
+}
+
+function edge(partial: Partial<GraphEdge> & { source: string; target: string }): GraphEdge {
+  return {
+    relation: partial.relation ?? "related_to",
+    confidence: partial.confidence ?? "EXTRACTED",
+    source_file: partial.source_file ?? "",
+    ...partial,
+  };
+}
+
+function extraction(nodes: GraphNode[], edges: GraphEdge[] = []): Extraction {
+  return { nodes, edges, hyperedges: [], input_tokens: 0, output_tokens: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// (A) Schema hygiene
+// ---------------------------------------------------------------------------
+describe("normalizeSchemaHygiene (A)", () => {
+  it("canonicalizes id-prefixes and types", () => {
+    expect(canonicalId("location_british_museum", { location: "place" })).toBe("place_british_museum");
+    expect(canonicalId("org_eyres", { org: "organization" })).toBe("organization_eyres");
+    expect(canonicalId("character_holmes", { location: "place" })).toBe("character_holmes");
+    expect(canonicalType("place", { place: "Location" })).toBe("Location");
+    expect(canonicalType("character", {})).toBe("Character");
+    expect(canonicalType("ChapterOrStory", {})).toBe("ChapterOrStory");
+    expect(canonicalType("CrimeOrScheme", {})).toBe("CrimeOrScheme");
+  });
+
+  it("collapses a location_/place_ duplicate pair and unions edges + citations + attrs", () => {
+    const ex = extraction(
+      [
+        node({
+          id: "location_british_museum",
+          label: "British Museum",
+          type: "Location",
+          source_file: "corpus/w/text.txt",
+          citations: [{ source_file: "corpus/w/text.txt", section: "I", quote: "a" }],
+          description: "the museum",
+        }),
+        node({
+          id: "place_british_museum",
+          label: "British Museum (Egyptian Antiquities)",
+          type: "place",
+          citations: [{ source_file: "corpus/w/text.txt", section: "II", quote: "b" }],
+          community: 3,
+        }),
+        node({ id: "character_holmes", label: "Sherlock Holmes", type: "Character" }),
+      ],
+      [
+        edge({ source: "location_british_museum", target: "character_holmes", relation: "visited_by" }),
+        edge({ source: "place_british_museum", target: "character_holmes", relation: "near" }),
+      ],
+    );
+
+    const out = normalizeSchemaHygiene(ex);
+    const ids = out.nodes.map((n) => n.id).sort();
+    expect(ids).toEqual(["character_holmes", "place_british_museum"]);
+
+    const museum = out.nodes.find((n) => n.id === "place_british_museum")!;
+    expect(museum.type).toBe("Location"); // canonicalized from "place"
+    // Citation union: both sections survive (no last-write-wins drop).
+    expect(museum.citations).toHaveLength(2);
+    // First-seen scalar fill: description from one, community from the other.
+    expect(museum.description).toBe("the museum");
+    expect(museum.community).toBe(3);
+
+    // Two distinct relations between the same canonical pair both survive.
+    const rels = out.edges
+      .filter((e) => e.source === "place_british_museum" && e.target === "character_holmes")
+      .map((e) => e.relation)
+      .sort();
+    expect(rels).toEqual(["near", "visited_by"]);
+  });
+
+  it("is idempotent (re-running on its own output is a no-op)", () => {
+    const ex = extraction(
+      [
+        node({ id: "location_a", label: "A", type: "place", source_file: "w/text.txt" }),
+        node({ id: "place_a", label: "A", type: "Location", source_file: "w/text.txt" }),
+        node({ id: "org_x", label: "X", type: "organization" }),
+      ],
+      [edge({ source: "location_a", target: "org_x" })],
+    );
+    const once = normalizeSchemaHygiene(ex);
+    const twice = normalizeSchemaHygiene(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("drops self-loops created by a collapse", () => {
+    const ex = extraction(
+      [
+        node({ id: "location_a", label: "A", type: "Location" }),
+        node({ id: "place_a", label: "A", type: "Location" }),
+      ],
+      [edge({ source: "location_a", target: "place_a", relation: "same_as" })],
+    );
+    const out = normalizeSchemaHygiene(ex);
+    expect(out.nodes).toHaveLength(1);
+    expect(out.edges).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (B) Alias / normalized_terms derivation
+// ---------------------------------------------------------------------------
+describe("deriveAliasesAndNormalizedTerms (B)", () => {
+  it("strips parentheticals", () => {
+    const { aliases, normalizedTerms } = deriveLabelTerms("Hugo Oberstein (spy)");
+    expect(aliases).toContain("Hugo Oberstein");
+    expect(normalizedTerms).toContain("hugo oberstein");
+  });
+
+  it("strips leading honorifics", () => {
+    expect(deriveLabelTerms("Dr. Watson").aliases).toContain("Watson");
+    expect(deriveLabelTerms("Sir Henry Baskerville").aliases).toContain("Henry Baskerville");
+    expect(deriveLabelTerms("Inspector Lestrade").aliases).toContain("Lestrade");
+    expect(deriveLabelTerms("Professor Moriarty").normalizedTerms).toContain("moriarty");
+  });
+
+  it("combines honorific + parenthetical strips", () => {
+    const { aliases } = deriveLabelTerms("Colonel Sebastian Moran (sniper)");
+    expect(aliases).toContain("Sebastian Moran");
+    expect(aliases).toContain("Colonel Sebastian Moran");
+  });
+
+  it("does not over-generate for a bare name", () => {
+    const { aliases, normalizedTerms } = deriveLabelTerms("Sherlock Holmes");
+    expect(aliases).toEqual([]); // no honorific/parenthetical → no extra alias
+    expect(normalizedTerms).toEqual(["sherlock holmes"]);
+  });
+
+  it("populates node.aliases / node.normalized_terms idempotently", () => {
+    const ex = extraction([node({ id: "c_oberstein", label: "Hugo Oberstein (spy)", type: "Character" })]);
+    const once = deriveAliasesAndNormalizedTerms(ex);
+    const n = once.nodes[0]!;
+    expect(n.aliases).toContain("Hugo Oberstein");
+    expect(n.normalized_terms).toContain("hugo oberstein");
+    const twice = deriveAliasesAndNormalizedTerms(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("merges with pre-existing aliases without clobbering", () => {
+    const ex = extraction([
+      node({ id: "c_w", label: "Dr. Watson", type: "Character", aliases: ["Johnny"] }),
+    ]);
+    const out = deriveAliasesAndNormalizedTerms(ex);
+    expect(out.nodes[0]!.aliases).toEqual(expect.arrayContaining(["Johnny", "Watson"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (D) De-orphan
+// ---------------------------------------------------------------------------
+describe("deOrphanByContainer (D)", () => {
+  const work = node({
+    id: "work_w",
+    label: "The Work",
+    type: "Work",
+    source_file: "corpus/saga/the-work/text.txt",
+  });
+  const chapter = node({
+    id: "chapter_the-work_ch1",
+    label: "Chapter 1",
+    type: "ChapterOrStory",
+    source_file: "corpus/saga/the-work/text.txt",
+  });
+
+  it("links an orphan to the FINEST container (chapter, not Work) when available", () => {
+    const orphan = node({
+      id: "character_x",
+      label: "X",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, chapter, orphan], [
+      // keep work + chapter non-orphan so they are not themselves linked
+      edge({ source: "chapter_the-work_ch1", target: "work_w", relation: "part_of" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    const appears = out.extraction.edges.filter((e) => e.relation === "appears_in");
+    expect(appears).toHaveLength(1);
+    expect(appears[0]!.target).toBe("chapter_the-work_ch1"); // finest, not work_w
+    expect(appears[0]!.derived).toBe(true);
+    expect(out.orphansAfter).toBe(0);
+  });
+
+  it("falls back to the Work when no finer container shares provenance", () => {
+    const orphan = node({
+      id: "character_y",
+      label: "Y",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, orphan], [
+      // work must not be an orphan itself for this assertion to be about the orphan
+      edge({ source: "work_w", target: "work_w_anchor", relation: "noop" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    const appears = out.extraction.edges.filter((e) => e.relation === "appears_in");
+    expect(appears).toHaveLength(1);
+    expect(appears[0]!.target).toBe("work_w");
+  });
+
+  it("resolves the container via citation source_file when the node lacks one", () => {
+    const orphan = node({
+      id: "object_z",
+      label: "Z",
+      type: "Object",
+      source_file: "",
+      citations: [{ source_file: "corpus/saga/the-work/text.txt", section: "I", quote: "z" }],
+    });
+    const ex = extraction([work, chapter, orphan], [
+      edge({ source: "chapter_the-work_ch1", target: "work_w", relation: "part_of" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    const appears = out.extraction.edges.filter((e) => e.relation === "appears_in");
+    expect(appears[0]!.target).toBe("chapter_the-work_ch1");
+  });
+
+  it("is idempotent and respects pre-existing appears_in", () => {
+    const orphan = node({
+      id: "character_x",
+      label: "X",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, chapter, orphan], [
+      edge({ source: "chapter_the-work_ch1", target: "work_w", relation: "part_of" }),
+    ]);
+    const first = deOrphanByContainer(ex);
+    const second = deOrphanByContainer(first.extraction);
+    expect(second.appearsInAdded).toBe(0);
+    expect(second.extraction.edges).toEqual(first.extraction.edges);
+  });
+
+  it("does not double-add when an appears_in already exists", () => {
+    const orphan = node({
+      id: "character_x",
+      label: "X",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, chapter, orphan], [
+      edge({ source: "character_x", target: "chapter_the-work_ch1", relation: "appears_in" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    expect(out.appearsInAdded).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline wiring — config-gated, default OFF
+// ---------------------------------------------------------------------------
+describe("assembly-hygiene pipeline gate", () => {
+  const ex = extraction(
+    [
+      node({ id: "location_a", label: "Dr. Alpha (ghost)", type: "place", source_file: "corpus/w/the-w/text.txt" }),
+      node({ id: "place_a", label: "Alpha", type: "Location", source_file: "corpus/w/the-w/text.txt" }),
+      node({ id: "work_the-w", label: "The W", type: "Work", source_file: "corpus/w/the-w/text.txt" }),
+    ],
+    [],
+  );
+
+  it("is a no-op when assemblyHygiene is not set (default OFF)", () => {
+    const G = buildFromJson(ex);
+    expect(G.hasNode("location_a")).toBe(true);
+    expect(G.hasNode("place_a")).toBe(true);
+    expect(G.size).toBe(0); // no derived edges
+  });
+
+  it("runs all three steps when gated on", () => {
+    const G = buildFromJson(ex, {
+      assemblyHygiene: { schemaHygiene: true, deriveAliases: true, deOrphan: true },
+    });
+    // (A) location_a collapsed into place_a.
+    expect(G.hasNode("location_a")).toBe(false);
+    expect(G.hasNode("place_a")).toBe(true);
+    // (B) alias derived from the collapsed label "Dr. Alpha (ghost)".
+    const aliases = G.getNodeAttribute("place_a", "aliases") as string[];
+    expect(aliases).toEqual(expect.arrayContaining(["Alpha (ghost)", "Dr. Alpha"]));
+    // (D) the now-collapsed entity is de-orphaned to its Work.
+    expect(G.hasEdge("place_a", "work_the-w")).toBe(true);
+  });
+
+  it("applyAssemblyHygiene returns input unchanged with no options", () => {
+    expect(applyAssemblyHygiene(ex)).toBe(ex);
+  });
+});

--- a/tests/ontology-reconciliation-fuzzy.test.ts
+++ b/tests/ontology-reconciliation-fuzzy.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  fuzzyMatchNodes,
+  generateOntologyReconciliationCandidates,
+  type OntologyReconciliationCandidate,
+} from "../src/ontology-reconciliation.js";
+import type { OntologyPatchContext, OntologyPatchNode } from "../src/ontology-patch.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+
+const profile = { profile_hash: "h" } as unknown as NormalizedOntologyProfile;
+
+function ctx(nodes: OntologyPatchNode[]): OntologyPatchContext {
+  return {
+    rootDir: "/r",
+    stateDir: "/r/.graphify",
+    graphHash: "g",
+    profile,
+    profileState: {} as never,
+    nodes,
+    relations: [],
+    evidenceRefs: new Set(),
+  };
+}
+
+let counter = 0;
+function n(label: string, type = "Character"): OntologyPatchNode {
+  counter += 1;
+  return { id: `node_${counter}_${label.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`, label, type };
+}
+
+/** Did the generator emit a candidate pairing these two labels? */
+function pairsLabels(
+  candidates: OntologyReconciliationCandidate[],
+  nodes: OntologyPatchNode[],
+  a: string,
+  b: string,
+): boolean {
+  const byId = new Map(nodes.map((x) => [x.id, x.label]));
+  return candidates.some((c) => {
+    const labels = [byId.get(c.canonical_id), byId.get(c.candidate_id)].sort();
+    return labels[0] === [a, b].sort()[0] && labels[1] === [a, b].sort()[1];
+  });
+}
+
+describe("reconciliation fuzzy tier — precision on known mystery pairs", () => {
+  // MUST-surface genuine pairs (qualifier / parenthetical variants).
+  const genuine: Array<[string, string, string]> = [
+    ["Character", "Hugo Oberstein", "Hugo Oberstein (spy)"],
+    ["Location", "British Museum", "British Museum (Egyptian Antiquities)"],
+    ["Location", "Devonshire (Exmoor estate)", "Exmoor estate"],
+    ["Character", "Reuben Hornby", "Reuben Hornby (accused)"],
+    ["Character", "Gournay-Martin", "M. Gournay-Martin"],
+  ];
+  it.each(genuine)("surfaces genuine pair (%s): %s ↔ %s", (type, a, b) => {
+    const nodes = [n(a, type), n(b, type)];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t" });
+    expect(pairsLabels(queue.candidates, nodes, a, b)).toBe(true);
+  });
+
+  // MUST-reject false positives.
+  const falsePositives: Array<[string, string, string]> = [
+    ["Character", "Sir Henry Baskerville", "Sir Charles Baskerville"],
+    ["Character", "Edward I", "Edward II"],
+    ["Character", "Edward II", "Edward III"],
+    ["Character", "Inspector Lestrade", "Inspector Gregson"],
+    ["Character", "Inspector Bradstreet", "Inspector Lanner"],
+    ["Location", "Château de Blois", "Château de Chambord"],
+    ["Location", "Château de Blois", "Château de Chantilly"],
+    ["Location", "Château de Chambord", "Château de Chantilly"],
+  ];
+  it.each(falsePositives)("rejects false positive (%s): %s ↔ %s", (type, a, b) => {
+    const nodes = [n(a, type), n(b, type)];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t" });
+    expect(pairsLabels(queue.candidates, nodes, a, b)).toBe(false);
+  });
+
+  it("scores exact tier 1.0 and fuzzy tier strictly below", () => {
+    const nodes = [n("Hugo Oberstein"), n("Hugo Oberstein (spy)"), n("Watson"), n("Watson")];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t" });
+    const exact = queue.candidates.find((c) => c.tier === "exact");
+    const fuzzy = queue.candidates.find((c) => c.tier === "fuzzy");
+    expect(exact?.score).toBe(1);
+    expect(fuzzy).toBeDefined();
+    expect(fuzzy!.score).toBeLessThan(1);
+  });
+
+  it("applies the type-guard (no cross-type fuzzy match)", () => {
+    const nodes = [n("Hugo Oberstein", "Character"), n("Hugo Oberstein (place)", "Location")];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t" });
+    expect(queue.candidates).toHaveLength(0);
+  });
+
+  it("can disable the fuzzy tier (exact-only)", () => {
+    const nodes = [n("Hugo Oberstein"), n("Hugo Oberstein (spy)")];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t", fuzzy: false });
+    // labels differ → no exact shared term → no candidate without fuzzy.
+    expect(queue.candidates).toHaveLength(0);
+  });
+
+  it("caps the output and ranks exact above fuzzy", () => {
+    const nodes = [
+      n("Alpha"),
+      n("Alpha"), // exact pair, score 1.0
+      n("Beta Gamma"),
+      n("Beta Gamma (note)"), // fuzzy pair
+    ];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t", cap: 1 });
+    expect(queue.candidates).toHaveLength(1);
+    expect(queue.candidates[0]!.tier).toBe("exact");
+  });
+
+  it("is deterministic", () => {
+    const make = () => generateOntologyReconciliationCandidates(
+      ctx([n("Hugo Oberstein"), n("Hugo Oberstein (spy)")]),
+      { generatedAt: "t" },
+    );
+    // reset counter so ids match between runs
+    counter = 0;
+    const a = make();
+    counter = 0;
+    const b = make();
+    expect(a).toEqual(b);
+  });
+
+  it("fuzzyMatchNodes is a pure predicate over labels", () => {
+    expect(fuzzyMatchNodes(n("Hugo Oberstein"), n("Hugo Oberstein (spy)")).matched).toBe(true);
+    expect(fuzzyMatchNodes(n("Sir Henry Baskerville"), n("Sir Charles Baskerville")).matched).toBe(false);
+  });
+
+  it("rejects formulaic-series pairs (chapter/regnal ordinals)", () => {
+    expect(fuzzyMatchNodes(n("Part I, Chapter II"), n("Part II, Chapter I")).matched).toBe(false);
+    expect(fuzzyMatchNodes(n("Part I, Chapter I"), n("Part II, Chapter I")).matched).toBe(false);
+    expect(fuzzyMatchNodes(n("Edward I"), n("Edward III")).matched).toBe(false);
+  });
+
+  it("rejects generic single-token locator collisions via parentheticals", () => {
+    // name "Greenford" must not match the "(Greenford)" locator inside another label.
+    expect(fuzzyMatchNodes(n("Greenford"), n("Revival Mission (Greenford)")).matched).toBe(false);
+    // generic descriptor parens never collide.
+    expect(fuzzyMatchNodes(n("Bannister (Servant)"), n("Green (the servant)")).matched).toBe(false);
+    expect(fuzzyMatchNodes(n("Small hammer (murder weapon)"), n("Lift shaft (murder weapon)")).matched).toBe(false);
+  });
+
+  it("excludes structural container types from the fuzzy tier", () => {
+    const nodes = [
+      n("Part I, Chapter I", "ChapterOrStory"),
+      n("Part I, Chapter I: The Long Subtitle", "ChapterOrStory"),
+      n("The Adventures of Sherlock Holmes", "Work"),
+      n("The Memoirs of Sherlock Holmes", "Work"),
+    ];
+    const queue = generateOntologyReconciliationCandidates(ctx(nodes), { generatedAt: "t" });
+    expect(queue.candidates.filter((c) => c.tier === "fuzzy")).toHaveLength(0);
+    // But a custom empty exclude-set re-enables fuzzy on those types.
+    const queue2 = generateOntologyReconciliationCandidates(ctx(nodes), {
+      generatedAt: "t",
+      fuzzyExcludeTypes: [],
+    });
+    expect(queue2.candidates.some((c) => c.tier === "fuzzy")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

A cohesive **CORE "reconciliation + assembly hardening"** bundle (benefits every corpus), productionizing three of the four user-decided mystery-studio fixes (the 4th, studio label truncation, shipped in #160). All steps are deterministic, idempotent, NO-KEY by default, and never touch any live/published graph.

### (A) Schema hygiene — assembly normalization
New `src/assembly-hygiene.ts → normalizeSchemaHygiene`. Canonicalizes synonymous id-prefixes through an explicit extensible synonym map (`location_`→`place_`, `org_`→`organization_`) and normalizes node `type` to canonical Capitalized form (`place`→`Location`, `chapter`/`story`→`ChapterOrStory`, `character`→`Character`, …). When two nodes collapse onto one canonical id their **edges/attrs/citations are UNIONed** (reusing the 0.14.0 `unionCitations` posture — never last-write-wins-drop); collapse self-loops are dropped.

### (B) Alias / normalized_terms derivation
`deriveAliasesAndNormalizedTerms`. Every entity previously had 0 aliases + 0 normalized_terms (which is why the matcher was exact-label-only in practice). Conservatively derives them from the label: strips leading honorifics/titles and parentheticals, lowercases. No fuzzy stemming. Merges with — never clobbers — pre-existing values.

### (C) Reconciliation matcher fuzzy tier
`src/ontology-reconciliation.ts`. Adds a strictly-lower-confidence fuzzy tier below the exact-normalized-label tier (exact bumped to score 1.0). Token-sequence equality (0.9) / strict containment ≥2 tokens (0.75) / name-name Jaccard ≥ threshold (0.7), honorific-stripped, over tagged surface variants. Guard rails: ≥2-token minimum, never compare two parentheticals, formulaic-series guard (rejects Edward I/II/III + reordered chapter ordinals), structural container types excluded. Candidates carry a `tier` field; ranked + capped. Type-guard applies after schema hygiene.

### (D) De-orphan as a CORE assembly step
`deOrphanByContainer`. Links each degree-0 entity to its **finest** available container (ChapterOrStory/Scene/Section by provenance, else the Work) via a derived `appears_in` edge (`derived:true`). Finest-container avoids Work-hub degree inflation that distorts the force layout.

All three assembly steps are wired through `BuildOptions.assemblyHygiene` + `applyAssemblyHygiene` (config-gated, **default OFF** — base contract unchanged) and exported from the public API.

## Validation (on a COPY of the 2092-node mystery graph, through the productionized core)

| metric | value |
| --- | --- |
| orphans before → after | **705 → 0** |
| appears_in derived | 1909 (1876 → ChapterOrStory, 30 → Work) |
| nodes collapsed (dup-prefix) | 1 (british_museum place_/location_), 0 citation loss (2561 → 2561) |
| max **Work** degree (finest-container) | **47** vs **192** naive all-to-Work |
| Sherlock degree | **125** (beats every Work hub) |
| reconciliation candidates | 70 (40 exact + 30 fuzzy) |

Fuzzy precision pinned on the named cases: **surfaces** Hugo Oberstein (spy), British Museum (Egyptian Antiquities) [bridged across place_/location_ by hygiene], Devonshire (Exmoor estate)↔Exmoor estate, Reuben Hornby, Gournay-Martin — plus real reveals (Duke of Exmoor↔Isaac Green, Marquis of Marne↔Maurice Mair). **Rejects** Sir Henry/Sir Charles, Edward I/II/III, generic Inspector collisions, three distinct Châteaux, and chapter/work formulaic titles. Mystery fuzzy noise cut **160 → 30**.

## Tests
Full suite green: **1876 passed, 12 skipped, 0 failures** (`vitest run`). New: 23 assembly-hygiene + 25 reconciliation-fuzzy unit tests (collapse union, idempotency, alias derivation, de-orphan soundness/finest-container, fuzzy precision MUST-surface/MUST-reject). `tsc --noEmit` clean. (The 2 studio-scene self-graph tests time out at the default 30 s on a large local graph and pass at a higher timeout; they are pre-existing perf flakes unrelated to this change and skip in CI.)

## Specs
Extended `spec/SPEC_GRAPHIFY.md` (Assembly Hygiene pipeline) and `spec/SPEC_ONTOLOGY_RECONCILIATION_ALGORITHM.md` (implemented exact + fuzzy tiers, precision contract).
