### PR TITLE
feat(assembly): CORE schema-hygiene + alias derivation + de-orphan (config-gated, default-OFF)

### DIFF
--- a/spec/SPEC_GRAPHIFY.md
+++ b/spec/SPEC_GRAPHIFY.md
@@ -83,6 +83,14 @@ Legacy compatibility:
 
 Every edge keeps provenance confidence: EXTRACTED, INFERRED, or AMBIGUOUS, with scores where available.
 
+### Assembly Hygiene (CORE, config-gated, default OFF)
+
+Between step 6 (merge AST + semantic) and step 7 (build the graph), an optional, deterministic, idempotent, NO-KEY pre-pass canonicalizes the assembled extraction. It is gated through `BuildOptions.assemblyHygiene` (and exposed standalone as `applyAssemblyHygiene`), default OFF so the base non-profile contract is unchanged. The three sub-steps run in fixed order and benefit any corpus (`src/assembly-hygiene.ts`):
+
+1. **Schema hygiene (`normalizeSchemaHygiene`).** Canonicalizes synonymous id-prefixes through an explicit, extensible synonym map (defaults `location_`→`place_`, `org_`→`organization_`) and normalizes the node `type` to its canonical Capitalized form (default overrides `place`→`Location`, `chapter`/`story`→`ChapterOrStory`; bare lowercase types fold to Capitalize, e.g. `character`→`Character`). When two nodes collapse onto the same canonical id their edges, string-array fields, and citations are **UNIONed** (the 0.14.0 citation-union-at-merge posture — never last-write-wins-dropped); scalar attrs are filled first-seen by sorted id order. Self-loops created by a collapse are dropped. Re-running on its own output is a no-op.
+2. **Alias / normalized_terms derivation (`deriveAliasesAndNormalizedTerms`).** Derives `aliases` + `normalized_terms` from the label CONSERVATIVELY: strips leading honorifics/titles (Dr., Sir, Colonel, Inspector, Mr., Mrs., Lord, Lady, Captain, Professor, …) and parentheticals (`Hugo Oberstein (spy)`→alias `Hugo Oberstein`), lowercases the normalized terms. No fuzzy stemming (no invented collisions). Merges with — never clobbers — any pre-existing aliases/terms; idempotent.
+3. **De-orphan (`deOrphanByContainer`).** Links each degree-0 entity node to its FINEST available container — a ChapterOrStory/Scene/Section sharing its provenance (`source_file` or path slug), else the Work — through a derived `appears_in` edge (`derived:true`, `derivation_method:"deorphan:finest-container"`, `confidence:"INFERRED"`). Finest-container is chosen over straight-to-Work because all-orphans→Work inflates Work-node degree (Work hubs outrank protagonists) and distorts the force layout. Idempotent: respects pre-existing `appears_in`, never double-adds, never links a container node into itself.
+
 ## Configured Ontology Dataprep Profiles
 
 Configured ontology dataprep profiles are an additive layer over the existing pipeline. They activate only through a discovered project config (`graphify.yaml`, `graphify.yml`, `.graphify/config.yaml`, `.graphify/config.yml`) or an explicit `--config`/`--profile` option. Without that activation, the normal non-profile graphify behavior and base `validateExtraction()` contract remain unchanged.

--- a/src/assembly-hygiene.ts
+++ b/src/assembly-hygiene.ts
@@ -1,0 +1,505 @@
+/**
+ * Assembly hygiene — deterministic, idempotent, NO-KEY normalization that runs
+ * on the assembled extraction (node/edge dicts) BEFORE the graphology build.
+ *
+ * Three CORE assembly steps (each independently config-gated, each a pure
+ * transform of an `Extraction` → `Extraction`):
+ *
+ *   (A) `normalizeSchemaHygiene` — canonicalize synonymous id-prefixes
+ *       (`location_`→`place_`, `org_`→`organization_`, …) and normalize the
+ *       node `type` to its canonical Capitalized form. When two nodes collapse
+ *       onto the same canonical id, their edges/attrs/citations are UNIONed (the
+ *       0.14.0 citation-union-at-merge posture), never last-write-wins-dropped.
+ *
+ *   (B) `deriveAliasesAndNormalizedTerms` — derive `aliases` +
+ *       `normalized_terms` conservatively from the label: strip leading
+ *       honorifics/titles, strip parentheticals, lowercase. No fuzzy stemming
+ *       (no invented collisions).
+ *
+ *   (D) `deOrphanByContainer` — link every degree-0 entity node to its FINEST
+ *       available container (ChapterOrStory/Scene/Section matching provenance,
+ *       else the Work) via a derived `appears_in` edge. Idempotent: respects
+ *       pre-existing `appears_in`, never double-adds. Finest-container (not
+ *       straight-to-Work) keeps Work hubs from outranking real protagonists.
+ *
+ * Everything here is deterministic and replayable: no LLM, no network, no
+ * secrets, stable ordering, and re-running on its own output is a no-op.
+ */
+import type { Extraction, GraphEdge, GraphNode, OntologyCitation } from "./types.js";
+import { unionCitations } from "./citations.js";
+
+// ---------------------------------------------------------------------------
+// (A) Schema hygiene — id-prefix + type canonicalization with merge-union
+// ---------------------------------------------------------------------------
+
+/**
+ * Config for schema hygiene. Both maps are extensible/overridable per corpus.
+ *
+ * `idPrefixSynonyms`: maps a synonymous id-prefix to its canonical prefix
+ * (without the trailing underscore). e.g. `{ location: "place", org:
+ * "organization" }` rewrites `location_british_museum` → `place_british_museum`.
+ *
+ * `typeSynonyms`: maps a (lowercased) type token to its canonical form. The
+ * default also folds bare lowercase types to their Capitalized counterpart, so
+ * `character`→`Character`. Entries here override the default Capitalize rule
+ * (e.g. `place`→`Location`, `chapter`→`ChapterOrStory`).
+ */
+export interface SchemaHygieneConfig {
+  idPrefixSynonyms?: Record<string, string>;
+  typeSynonyms?: Record<string, string>;
+}
+
+/** Default id-prefix synonym map (canonical ← synonym). */
+export const DEFAULT_ID_PREFIX_SYNONYMS: Record<string, string> = {
+  location: "place",
+  org: "organization",
+};
+
+/**
+ * Default type synonym map. Keyed by the LOWERCASED type token. Only entries
+ * whose canonical form is NOT the simple Capitalize need listing; bare
+ * lowercase types (`character`→`Character`) are folded by the Capitalize rule.
+ */
+export const DEFAULT_TYPE_SYNONYMS: Record<string, string> = {
+  place: "Location",
+  chapter: "ChapterOrStory",
+  story: "ChapterOrStory",
+};
+
+function capitalize(value: string): string {
+  if (!value) return value;
+  return value[0]!.toUpperCase() + value.slice(1);
+}
+
+/**
+ * Canonical form of a node `type`. A type that already starts with an
+ * uppercase letter is treated as canonical and returned unchanged (so
+ * `ChapterOrStory`, `CrimeOrScheme` survive). A lowercase type is mapped
+ * through the synonym map, falling back to a plain Capitalize.
+ */
+export function canonicalType(type: string | undefined, synonyms: Record<string, string>): string | undefined {
+  if (typeof type !== "string" || type.length === 0) return type;
+  // Already canonical (starts uppercase) — leave compound canonical types intact.
+  if (type[0] === type[0]!.toUpperCase() && type[0] !== type[0]!.toLowerCase()) return type;
+  const key = type.toLowerCase();
+  if (synonyms[key]) return synonyms[key];
+  return capitalize(type);
+}
+
+/**
+ * Canonical id: rewrites a synonymous id-prefix to its canonical prefix.
+ * `location_british_museum` → `place_british_museum`. Ids without a known
+ * synonym prefix are returned unchanged.
+ */
+export function canonicalId(id: string, prefixSynonyms: Record<string, string>): string {
+  const match = /^([a-z]+)_(.*)$/.exec(id);
+  if (!match) return id;
+  const [, prefix, rest] = match;
+  const canonical = prefixSynonyms[prefix!];
+  if (!canonical || canonical === prefix) return id;
+  return `${canonical}_${rest}`;
+}
+
+function asCitations(value: unknown): OntologyCitation[] {
+  return Array.isArray(value) ? (value as OntologyCitation[]) : [];
+}
+
+function unionStringArrays(a: unknown, b: unknown): string[] {
+  const out = new Set<string>();
+  for (const v of Array.isArray(a) ? a : []) if (typeof v === "string" && v) out.add(v);
+  for (const v of Array.isArray(b) ? b : []) if (typeof v === "string" && v) out.add(v);
+  return Array.from(out).sort((x, y) => x.localeCompare(y));
+}
+
+const UNION_STRING_ARRAY_FIELDS = ["aliases", "normalized_terms", "registry_refs", "evidence_refs"] as const;
+
+/**
+ * Merge `incoming` into `kept` when two nodes collapse onto one canonical id.
+ * Citations + string-array fields are UNIONed (never dropped); scalar attrs are
+ * filled only where `kept` is missing them (first-seen, deterministic by sorted
+ * iteration order), so a non-empty value never silently loses to a later empty.
+ */
+function unionNodeInto(kept: GraphNode, incoming: GraphNode): void {
+  // Citations: deduped union by identity (0.14.0 posture).
+  const keptCites = asCitations(kept.citations);
+  const incCites = asCitations(incoming.citations);
+  if (keptCites.length > 0 || incCites.length > 0) {
+    kept.citations = unionCitations([keptCites, incCites]);
+  }
+  // String-array fields: deduped union.
+  for (const field of UNION_STRING_ARRAY_FIELDS) {
+    const merged = unionStringArrays(kept[field], incoming[field]);
+    if (merged.length > 0) (kept as Record<string, unknown>)[field] = merged;
+  }
+  // Scalar attrs: fill only where kept is missing (preserve first-seen non-empty).
+  for (const [key, value] of Object.entries(incoming)) {
+    if (key === "id" || key === "citations" || (UNION_STRING_ARRAY_FIELDS as readonly string[]).includes(key)) continue;
+    const current = (kept as Record<string, unknown>)[key];
+    const currentEmpty = current === undefined || current === null || current === "";
+    const incomingPresent = value !== undefined && value !== null && value !== "";
+    if (currentEmpty && incomingPresent) (kept as Record<string, unknown>)[key] = value;
+  }
+}
+
+/**
+ * (A) Normalize id-prefixes + types, collapsing duplicate nodes via union.
+ *
+ * Deterministic + idempotent: re-running on the output is a no-op (canonical
+ * ids/types are stable fixed points). Edges are rewritten through the same
+ * id-remap; self-loops created by a collapse are dropped.
+ */
+export function normalizeSchemaHygiene(
+  extraction: Extraction,
+  config: SchemaHygieneConfig = {},
+): Extraction {
+  const prefixSynonyms = { ...DEFAULT_ID_PREFIX_SYNONYMS, ...(config.idPrefixSynonyms ?? {}) };
+  const typeSynonyms = { ...DEFAULT_TYPE_SYNONYMS, ...(config.typeSynonyms ?? {}) };
+
+  const nodes = extraction.nodes ?? [];
+  // Process nodes in a stable id order so the first-seen winner of a collapse
+  // is deterministic regardless of extraction order.
+  const ordered = [...nodes].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+  const remap = new Map<string, string>();
+  const canonicalById = new Map<string, GraphNode>();
+  const result: GraphNode[] = [];
+
+  for (const node of ordered) {
+    const newId = canonicalId(String(node.id), prefixSynonyms);
+    const newType = canonicalType(node.type as string | undefined, typeSynonyms);
+    if (newId !== node.id) remap.set(String(node.id), newId);
+
+    const existing = canonicalById.get(newId);
+    if (!existing) {
+      const normalized: GraphNode = { ...node, id: newId };
+      if (newType !== undefined) (normalized as Record<string, unknown>).type = newType;
+      canonicalById.set(newId, normalized);
+      result.push(normalized);
+      continue;
+    }
+    // Collapse: union the incoming node into the surviving canonical node.
+    const incoming: GraphNode = { ...node, id: newId };
+    if (newType !== undefined) (incoming as Record<string, unknown>).type = newType;
+    unionNodeInto(existing, incoming);
+  }
+
+  // Stable output node order by canonical id so re-running is a byte-stable
+  // fixed point (a collapse changes push-order vs. a second no-collapse pass).
+  result.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+  if (remap.size === 0) {
+    // No id remap, but types may still have changed; result already carries
+    // normalized types. Edges/hyperedges are untouched by id rewriting.
+    return { ...extraction, nodes: result };
+  }
+
+  const resolve = (id: string): string => remap.get(id) ?? id;
+  const seenEdge = new Set<string>();
+  const edges: GraphEdge[] = [];
+  for (const edge of extraction.edges ?? []) {
+    const source = resolve(String(edge.source));
+    const target = resolve(String(edge.target));
+    if (source === target) continue; // self-loop from collapse
+    const key = `${source} ${target} ${edge.relation ?? ""}`;
+    if (seenEdge.has(key)) continue;
+    seenEdge.add(key);
+    edges.push({ ...edge, source, target });
+  }
+
+  const hyperedges = (extraction.hyperedges ?? []).map((h) => ({
+    ...h,
+    nodes: h.nodes.map(resolve),
+  }));
+
+  return { ...extraction, nodes: result, edges, hyperedges };
+}
+
+// ---------------------------------------------------------------------------
+// (B) Alias / normalized_terms derivation
+// ---------------------------------------------------------------------------
+
+/** Leading honorifics/titles stripped to derive a bare-name alias. */
+export const DEFAULT_HONORIFICS = [
+  "dr",
+  "sir",
+  "colonel",
+  "col",
+  "inspector",
+  "mr",
+  "mrs",
+  "ms",
+  "miss",
+  "lord",
+  "lady",
+  "captain",
+  "capt",
+  "professor",
+  "prof",
+  "doctor",
+  "madame",
+  "madam",
+  "monsieur",
+  "the",
+] as const;
+
+export interface AliasDerivationConfig {
+  honorifics?: readonly string[];
+}
+
+/** Lowercase a candidate term to its normalized form (trim + collapse spaces). */
+function normalizeTermLocal(value: string): string {
+  return value.trim().replace(/\s+/gu, " ").toLowerCase();
+}
+
+/**
+ * Strip a single leading honorific (with optional trailing period) from a name.
+ * Returns the stripped name, or null when nothing was stripped.
+ */
+function stripLeadingHonorific(name: string, honorifics: Set<string>): string | null {
+  const match = /^([A-Za-zÀ-ÖØ-öø-ÿ]+)\.?\s+(.+)$/u.exec(name.trim());
+  if (!match) return null;
+  const [, head, rest] = match;
+  if (!honorifics.has(head!.toLowerCase())) return null;
+  return rest!.trim();
+}
+
+/** Strip trailing/embedded parentheticals: "Hugo Oberstein (spy)" → "Hugo Oberstein". */
+function stripParenthetical(name: string): string | null {
+  const stripped = name.replace(/\s*\([^)]*\)\s*/gu, " ").replace(/\s+/gu, " ").trim();
+  if (stripped && stripped !== name.trim()) return stripped;
+  return null;
+}
+
+/**
+ * Derive alias + normalized-term candidates for a single label, CONSERVATIVELY.
+ * Returns the surface aliases (original-cased variants) and normalized_terms
+ * (lowercased). The label's own normalized form is always included as a
+ * normalized term so the matcher has a baseline term to compare.
+ */
+export function deriveLabelTerms(
+  label: string,
+  config: AliasDerivationConfig = {},
+): { aliases: string[]; normalizedTerms: string[] } {
+  const honorifics = new Set((config.honorifics ?? DEFAULT_HONORIFICS).map((h) => h.toLowerCase()));
+  const surfaces = new Set<string>();
+  const base = String(label ?? "").trim();
+  if (!base) return { aliases: [], normalizedTerms: [] };
+
+  // Generate variants by applying strips in combination (conservative, finite).
+  const queue: string[] = [base];
+  const visited = new Set<string>([base]);
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const variant of [stripParenthetical(current), stripLeadingHonorific(current, honorifics)]) {
+      if (variant && variant !== base && !visited.has(variant)) {
+        visited.add(variant);
+        surfaces.add(variant);
+        queue.push(variant);
+      }
+    }
+  }
+
+  const aliases = Array.from(surfaces).sort((a, b) => a.localeCompare(b));
+  const normalizedTerms = Array.from(new Set([base, ...surfaces].map(normalizeTermLocal)))
+    .filter((t) => t.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  return { aliases, normalizedTerms };
+}
+
+/**
+ * (B) Derive `aliases` + `normalized_terms` for every node with a label.
+ * Idempotent: merges with (does not clobber) any pre-existing aliases/terms,
+ * and re-running yields the same union. Conservative — no fuzzy stemming.
+ */
+export function deriveAliasesAndNormalizedTerms(
+  extraction: Extraction,
+  config: AliasDerivationConfig = {},
+): Extraction {
+  const nodes = (extraction.nodes ?? []).map((node) => {
+    const label = typeof node.label === "string" ? node.label : "";
+    if (!label) return node;
+    const { aliases, normalizedTerms } = deriveLabelTerms(label, config);
+    const mergedAliases = unionStringArrays(node.aliases, aliases);
+    const mergedTerms = unionStringArrays(node.normalized_terms, normalizedTerms);
+    const next: GraphNode = { ...node };
+    if (mergedAliases.length > 0) next.aliases = mergedAliases;
+    if (mergedTerms.length > 0) (next as Record<string, unknown>).normalized_terms = mergedTerms;
+    return next;
+  });
+  return { ...extraction, nodes };
+}
+
+// ---------------------------------------------------------------------------
+// (D) De-orphan — finest-container appears_in derivation
+// ---------------------------------------------------------------------------
+
+export interface DeOrphanConfig {
+  /** Container node types, FINEST → coarsest. The first matching wins. */
+  containerTypesFinestFirst?: string[];
+  /** The coarsest fallback container type (the Work). */
+  workType?: string;
+}
+
+/** Default container ranking: chapter/scene/section first, Work last. */
+export const DEFAULT_CONTAINER_TYPES_FINEST_FIRST = [
+  "ChapterOrStory",
+  "Scene",
+  "Section",
+] as const;
+export const DEFAULT_WORK_TYPE = "Work";
+const APPEARS_IN = "appears_in";
+
+function edgeEndpoint(value: unknown): string {
+  if (value && typeof value === "object" && "id" in (value as Record<string, unknown>)) {
+    return String((value as Record<string, unknown>).id);
+  }
+  return String(value);
+}
+
+/** Derive the corpus path-slug of a source_file (the work directory stem). */
+function slugOfSourceFile(sourceFile: string | undefined): string | null {
+  if (!sourceFile) return null;
+  const parts = String(sourceFile).split("/").filter(Boolean);
+  return parts.length >= 2 ? parts[parts.length - 2]! : null;
+}
+
+function nodeSourceFiles(node: GraphNode): Set<string> {
+  const set = new Set<string>();
+  if (typeof node.source_file === "string" && node.source_file) set.add(node.source_file);
+  for (const c of asCitations(node.citations)) {
+    if (typeof c.source_file === "string" && c.source_file) set.add(c.source_file);
+  }
+  return set;
+}
+
+export interface DeOrphanResult {
+  extraction: Extraction;
+  orphansBefore: number;
+  orphansAfter: number;
+  appearsInAdded: number;
+  unresolved: number;
+}
+
+/**
+ * (D) Link each degree-0 entity node to its finest available container via a
+ * derived `appears_in` edge. Container resolution, per orphan:
+ *   1. a container node (finest type first) sharing the orphan's source_file
+ *      or source-file slug;
+ *   2. else the Work sharing the source_file / slug.
+ * Idempotent: skips nodes that already have any edge, never duplicates an
+ * `appears_in` pair it (or a prior run) already created.
+ */
+export function deOrphanByContainer(
+  extraction: Extraction,
+  config: DeOrphanConfig = {},
+): DeOrphanResult {
+  const containerTypes = config.containerTypesFinestFirst ?? [...DEFAULT_CONTAINER_TYPES_FINEST_FIRST];
+  const workType = config.workType ?? DEFAULT_WORK_TYPE;
+  const nodes = extraction.nodes ?? [];
+  const edges = extraction.edges ?? [];
+
+  const degree = new Map<string, number>(nodes.map((n) => [String(n.id), 0]));
+  const existingPair = new Set<string>();
+  for (const e of edges) {
+    const s = edgeEndpoint(e.source);
+    const t = edgeEndpoint(e.target);
+    if (degree.has(s)) degree.set(s, degree.get(s)! + 1);
+    if (degree.has(t)) degree.set(t, degree.get(t)! + 1);
+    existingPair.add(`${s} ${t}`);
+  }
+
+  // Build container indices by source_file and by slug, per container rank.
+  // rankOf: finest container types get the lowest rank number; Work is last.
+  const rankOf = new Map<string, number>();
+  containerTypes.forEach((t, i) => rankOf.set(t, i));
+  rankOf.set(workType, containerTypes.length);
+
+  // For each (rank) maintain source_file→id and slug→id (first-seen by id order).
+  const byRankSource: Array<Map<string, string>> = [];
+  const byRankSlug: Array<Map<string, string>> = [];
+  for (let i = 0; i <= containerTypes.length; i += 1) {
+    byRankSource.push(new Map());
+    byRankSlug.push(new Map());
+  }
+  const containerOrdered = [...nodes].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  for (const n of containerOrdered) {
+    const rank = rankOf.get(String(n.type));
+    if (rank === undefined) continue;
+    const srcMap = byRankSource[rank]!;
+    const slugMap = byRankSlug[rank]!;
+    if (typeof n.source_file === "string" && n.source_file && !srcMap.has(n.source_file)) {
+      srcMap.set(n.source_file, String(n.id));
+    }
+    // id-slug: container ids look like "chapter_<work-slug>_chN" or
+    // "work_<slug>" — index by the source_file slug AND the id-derived slug.
+    const sfSlug = slugOfSourceFile(typeof n.source_file === "string" ? n.source_file : undefined);
+    if (sfSlug && !slugMap.has(sfSlug)) slugMap.set(sfSlug, String(n.id));
+    const idSlug = String(n.id).replace(/^[a-z]+[_-]/, "");
+    if (idSlug && !slugMap.has(idSlug)) slugMap.set(idSlug, String(n.id));
+  }
+
+  const containerTypeSet = new Set([...containerTypes, workType]);
+  const orphans = nodes.filter((n) => (degree.get(String(n.id)) ?? 0) === 0);
+  const added: GraphEdge[] = [];
+  let unresolved = 0;
+
+  for (const orphan of orphans) {
+    // A container node that is itself an orphan has no parent of its own kind
+    // to link into (a Work has no Work parent). Leave it as-is.
+    if (containerTypeSet.has(String(orphan.type))) {
+      unresolved += 1;
+      continue;
+    }
+    const sources = nodeSourceFiles(orphan);
+    let linked = false;
+    // Resolve the FINEST container across all of the orphan's source files:
+    // sweep ranks finest→coarsest, take the first hit.
+    let containerId: string | undefined;
+    for (let rank = 0; rank <= containerTypes.length && !containerId; rank += 1) {
+      for (const sf of sources) {
+        const hit = byRankSource[rank]!.get(sf) ?? byRankSlug[rank]!.get(slugOfSourceFile(sf) ?? "");
+        if (hit && hit !== String(orphan.id)) {
+          containerId = hit;
+          break;
+        }
+      }
+    }
+    if (containerId) {
+      const key = `${String(orphan.id)} ${containerId}`;
+      if (!existingPair.has(key)) {
+        existingPair.add(key);
+        added.push({
+          source: String(orphan.id),
+          target: containerId,
+          relation: APPEARS_IN,
+          confidence: "INFERRED",
+          source_file: typeof orphan.source_file === "string" ? orphan.source_file : "",
+          derived: true,
+          derivation_method: "deorphan:finest-container",
+        } as GraphEdge);
+      }
+      linked = true;
+    }
+    if (!linked) unresolved += 1;
+  }
+
+  const nextExtraction: Extraction = { ...extraction, edges: [...edges, ...added] };
+
+  // Recompute orphans after.
+  const degreeAfter = new Map<string, number>(nodes.map((n) => [String(n.id), 0]));
+  for (const e of nextExtraction.edges) {
+    const s = edgeEndpoint(e.source);
+    const t = edgeEndpoint(e.target);
+    if (degreeAfter.has(s)) degreeAfter.set(s, degreeAfter.get(s)! + 1);
+    if (degreeAfter.has(t)) degreeAfter.set(t, degreeAfter.get(t)! + 1);
+  }
+  const orphansAfter = nodes.filter((n) => (degreeAfter.get(String(n.id)) ?? 0) === 0).length;
+
+  return {
+    extraction: nextExtraction,
+    orphansBefore: orphans.length,
+    orphansAfter,
+    appearsInAdded: added.length,
+    unresolved,
+  };
+}

--- a/src/build.ts
+++ b/src/build.ts
@@ -17,6 +17,28 @@ import { createGraph } from "./graph.js";
 import { assertGraphJsonFileSize } from "./graph-size-guard.js";
 import { cleanupStaleNodes } from "./semantic-cleanup.js";
 import { validateExtraction } from "./validate.js";
+import {
+  deOrphanByContainer,
+  deriveAliasesAndNormalizedTerms,
+  normalizeSchemaHygiene,
+  type AliasDerivationConfig,
+  type DeOrphanConfig,
+  type SchemaHygieneConfig,
+} from "./assembly-hygiene.js";
+
+/**
+ * Config-gated CORE assembly-hygiene pre-pass (default OFF). Each sub-step is
+ * an independent, deterministic, idempotent transform of the extraction before
+ * the graphology build:
+ *   - `schemaHygiene`: id-prefix + type canonicalization with merge-union (A)
+ *   - `deriveAliases`: alias / normalized_terms derivation (B)
+ *   - `deOrphan`: finest-container `appears_in` derivation (D)
+ */
+export interface AssemblyHygieneOptions {
+  schemaHygiene?: boolean | SchemaHygieneConfig;
+  deriveAliases?: boolean | AliasDerivationConfig;
+  deOrphan?: boolean | DeOrphanConfig;
+}
 
 export interface BuildOptions {
   directed?: boolean;
@@ -27,6 +49,45 @@ export interface BuildOptions {
    * paths, splitting nodes across two identities.
    */
   root?: string;
+  /**
+   * Config-gated CORE assembly-hygiene pre-pass (default OFF — opt-in per
+   * corpus). Runs schema-hygiene → alias-derivation → de-orphan on the
+   * extraction before the graphology build. See `applyAssemblyHygiene`.
+   */
+  assemblyHygiene?: AssemblyHygieneOptions;
+}
+
+/**
+ * Run the config-gated assembly-hygiene transforms on an extraction, in the
+ * fixed order schema-hygiene → alias-derivation → de-orphan. Pure + idempotent;
+ * each step is a no-op unless explicitly enabled. Exported so the CLI and
+ * offline tools can productionize the same pipeline the prototypes validated.
+ */
+export function applyAssemblyHygiene(
+  extraction: Extraction,
+  options?: AssemblyHygieneOptions,
+): Extraction {
+  if (!options) return extraction;
+  let current = extraction;
+  if (options.schemaHygiene) {
+    current = normalizeSchemaHygiene(
+      current,
+      typeof options.schemaHygiene === "object" ? options.schemaHygiene : {},
+    );
+  }
+  if (options.deriveAliases) {
+    current = deriveAliasesAndNormalizedTerms(
+      current,
+      typeof options.deriveAliases === "object" ? options.deriveAliases : {},
+    );
+  }
+  if (options.deOrphan) {
+    current = deOrphanByContainer(
+      current,
+      typeof options.deOrphan === "object" ? options.deOrphan : {},
+    ).extraction;
+  }
+  return current;
 }
 
 const CHUNK_SUFFIX = /_c\d+$/;
@@ -252,6 +313,9 @@ export function deduplicateByLabel(extraction: Extraction): Extraction {
 
 export function buildFromJson(extraction: Extraction, options?: BuildOptions): Graph {
   const root = rootForOptions(options);
+  // CORE assembly-hygiene pre-pass (config-gated, default OFF). Runs before
+  // validation so the build sees canonical ids/types and derived edges.
+  extraction = applyAssemblyHygiene(extraction, options?.assemblyHygiene);
   for (const node of extraction.nodes ?? []) {
     const legacySource = node.source as unknown;
     if (legacySource !== undefined && node.source_file === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,26 @@ export type {
   ProfileReportPdfArtifact,
 } from "./profile-report.js";
 export { validateExtraction, assertValid } from "./validate.js";
-export { buildFromJson, build, buildMerge, deduplicateByLabel } from "./build.js";
+export { buildFromJson, build, buildMerge, deduplicateByLabel, applyAssemblyHygiene } from "./build.js";
+export type { AssemblyHygieneOptions } from "./build.js";
+export {
+  normalizeSchemaHygiene,
+  deriveAliasesAndNormalizedTerms,
+  deriveLabelTerms,
+  deOrphanByContainer,
+  canonicalId,
+  canonicalType,
+  DEFAULT_ID_PREFIX_SYNONYMS,
+  DEFAULT_TYPE_SYNONYMS,
+  DEFAULT_HONORIFICS,
+  DEFAULT_CONTAINER_TYPES_FINEST_FIRST,
+} from "./assembly-hygiene.js";
+export type {
+  SchemaHygieneConfig,
+  AliasDerivationConfig,
+  DeOrphanConfig,
+  DeOrphanResult,
+} from "./assembly-hygiene.js";
 export { cleanupStaleNodes } from "./semantic-cleanup.js";
 export type { CleanupStaleNodesOptions, CleanupStaleNodesResult } from "./semantic-cleanup.js";
 export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";

--- a/tests/assembly-hygiene.test.ts
+++ b/tests/assembly-hygiene.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalId,
+  canonicalType,
+  deriveAliasesAndNormalizedTerms,
+  deriveLabelTerms,
+  deOrphanByContainer,
+  normalizeSchemaHygiene,
+} from "../src/assembly-hygiene.js";
+import { applyAssemblyHygiene, buildFromJson } from "../src/build.js";
+import type { Extraction, GraphEdge, GraphNode } from "../src/types.js";
+
+function node(partial: Partial<GraphNode> & { id: string }): GraphNode {
+  return {
+    label: partial.label ?? partial.id,
+    file_type: partial.file_type ?? "document",
+    source_file: partial.source_file ?? "",
+    ...partial,
+  };
+}
+
+function edge(partial: Partial<GraphEdge> & { source: string; target: string }): GraphEdge {
+  return {
+    relation: partial.relation ?? "related_to",
+    confidence: partial.confidence ?? "EXTRACTED",
+    source_file: partial.source_file ?? "",
+    ...partial,
+  };
+}
+
+function extraction(nodes: GraphNode[], edges: GraphEdge[] = []): Extraction {
+  return { nodes, edges, hyperedges: [], input_tokens: 0, output_tokens: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// (A) Schema hygiene
+// ---------------------------------------------------------------------------
+describe("normalizeSchemaHygiene (A)", () => {
+  it("canonicalizes id-prefixes and types", () => {
+    expect(canonicalId("location_british_museum", { location: "place" })).toBe("place_british_museum");
+    expect(canonicalId("org_eyres", { org: "organization" })).toBe("organization_eyres");
+    expect(canonicalId("character_holmes", { location: "place" })).toBe("character_holmes");
+    expect(canonicalType("place", { place: "Location" })).toBe("Location");
+    expect(canonicalType("character", {})).toBe("Character");
+    expect(canonicalType("ChapterOrStory", {})).toBe("ChapterOrStory");
+    expect(canonicalType("CrimeOrScheme", {})).toBe("CrimeOrScheme");
+  });
+
+  it("collapses a location_/place_ duplicate pair and unions edges + citations + attrs", () => {
+    const ex = extraction(
+      [
+        node({
+          id: "location_british_museum",
+          label: "British Museum",
+          type: "Location",
+          source_file: "corpus/w/text.txt",
+          citations: [{ source_file: "corpus/w/text.txt", section: "I", quote: "a" }],
+          description: "the museum",
+        }),
+        node({
+          id: "place_british_museum",
+          label: "British Museum (Egyptian Antiquities)",
+          type: "place",
+          citations: [{ source_file: "corpus/w/text.txt", section: "II", quote: "b" }],
+          community: 3,
+        }),
+        node({ id: "character_holmes", label: "Sherlock Holmes", type: "Character" }),
+      ],
+      [
+        edge({ source: "location_british_museum", target: "character_holmes", relation: "visited_by" }),
+        edge({ source: "place_british_museum", target: "character_holmes", relation: "near" }),
+      ],
+    );
+
+    const out = normalizeSchemaHygiene(ex);
+    const ids = out.nodes.map((n) => n.id).sort();
+    expect(ids).toEqual(["character_holmes", "place_british_museum"]);
+
+    const museum = out.nodes.find((n) => n.id === "place_british_museum")!;
+    expect(museum.type).toBe("Location"); // canonicalized from "place"
+    // Citation union: both sections survive (no last-write-wins drop).
+    expect(museum.citations).toHaveLength(2);
+    // First-seen scalar fill: description from one, community from the other.
+    expect(museum.description).toBe("the museum");
+    expect(museum.community).toBe(3);
+
+    // Two distinct relations between the same canonical pair both survive.
+    const rels = out.edges
+      .filter((e) => e.source === "place_british_museum" && e.target === "character_holmes")
+      .map((e) => e.relation)
+      .sort();
+    expect(rels).toEqual(["near", "visited_by"]);
+  });
+
+  it("is idempotent (re-running on its own output is a no-op)", () => {
+    const ex = extraction(
+      [
+        node({ id: "location_a", label: "A", type: "place", source_file: "w/text.txt" }),
+        node({ id: "place_a", label: "A", type: "Location", source_file: "w/text.txt" }),
+        node({ id: "org_x", label: "X", type: "organization" }),
+      ],
+      [edge({ source: "location_a", target: "org_x" })],
+    );
+    const once = normalizeSchemaHygiene(ex);
+    const twice = normalizeSchemaHygiene(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("drops self-loops created by a collapse", () => {
+    const ex = extraction(
+      [
+        node({ id: "location_a", label: "A", type: "Location" }),
+        node({ id: "place_a", label: "A", type: "Location" }),
+      ],
+      [edge({ source: "location_a", target: "place_a", relation: "same_as" })],
+    );
+    const out = normalizeSchemaHygiene(ex);
+    expect(out.nodes).toHaveLength(1);
+    expect(out.edges).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (B) Alias / normalized_terms derivation
+// ---------------------------------------------------------------------------
+describe("deriveAliasesAndNormalizedTerms (B)", () => {
+  it("strips parentheticals", () => {
+    const { aliases, normalizedTerms } = deriveLabelTerms("Hugo Oberstein (spy)");
+    expect(aliases).toContain("Hugo Oberstein");
+    expect(normalizedTerms).toContain("hugo oberstein");
+  });
+
+  it("strips leading honorifics", () => {
+    expect(deriveLabelTerms("Dr. Watson").aliases).toContain("Watson");
+    expect(deriveLabelTerms("Sir Henry Baskerville").aliases).toContain("Henry Baskerville");
+    expect(deriveLabelTerms("Inspector Lestrade").aliases).toContain("Lestrade");
+    expect(deriveLabelTerms("Professor Moriarty").normalizedTerms).toContain("moriarty");
+  });
+
+  it("combines honorific + parenthetical strips", () => {
+    const { aliases } = deriveLabelTerms("Colonel Sebastian Moran (sniper)");
+    expect(aliases).toContain("Sebastian Moran");
+    expect(aliases).toContain("Colonel Sebastian Moran");
+  });
+
+  it("does not over-generate for a bare name", () => {
+    const { aliases, normalizedTerms } = deriveLabelTerms("Sherlock Holmes");
+    expect(aliases).toEqual([]); // no honorific/parenthetical → no extra alias
+    expect(normalizedTerms).toEqual(["sherlock holmes"]);
+  });
+
+  it("populates node.aliases / node.normalized_terms idempotently", () => {
+    const ex = extraction([node({ id: "c_oberstein", label: "Hugo Oberstein (spy)", type: "Character" })]);
+    const once = deriveAliasesAndNormalizedTerms(ex);
+    const n = once.nodes[0]!;
+    expect(n.aliases).toContain("Hugo Oberstein");
+    expect(n.normalized_terms).toContain("hugo oberstein");
+    const twice = deriveAliasesAndNormalizedTerms(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("merges with pre-existing aliases without clobbering", () => {
+    const ex = extraction([
+      node({ id: "c_w", label: "Dr. Watson", type: "Character", aliases: ["Johnny"] }),
+    ]);
+    const out = deriveAliasesAndNormalizedTerms(ex);
+    expect(out.nodes[0]!.aliases).toEqual(expect.arrayContaining(["Johnny", "Watson"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (D) De-orphan
+// ---------------------------------------------------------------------------
+describe("deOrphanByContainer (D)", () => {
+  const work = node({
+    id: "work_w",
+    label: "The Work",
+    type: "Work",
+    source_file: "corpus/saga/the-work/text.txt",
+  });
+  const chapter = node({
+    id: "chapter_the-work_ch1",
+    label: "Chapter 1",
+    type: "ChapterOrStory",
+    source_file: "corpus/saga/the-work/text.txt",
+  });
+
+  it("links an orphan to the FINEST container (chapter, not Work) when available", () => {
+    const orphan = node({
+      id: "character_x",
+      label: "X",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, chapter, orphan], [
+      // keep work + chapter non-orphan so they are not themselves linked
+      edge({ source: "chapter_the-work_ch1", target: "work_w", relation: "part_of" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    const appears = out.extraction.edges.filter((e) => e.relation === "appears_in");
+    expect(appears).toHaveLength(1);
+    expect(appears[0]!.target).toBe("chapter_the-work_ch1"); // finest, not work_w
+    expect(appears[0]!.derived).toBe(true);
+    expect(out.orphansAfter).toBe(0);
+  });
+
+  it("falls back to the Work when no finer container shares provenance", () => {
+    const orphan = node({
+      id: "character_y",
+      label: "Y",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, orphan], [
+      // work must not be an orphan itself for this assertion to be about the orphan
+      edge({ source: "work_w", target: "work_w_anchor", relation: "noop" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    const appears = out.extraction.edges.filter((e) => e.relation === "appears_in");
+    expect(appears).toHaveLength(1);
+    expect(appears[0]!.target).toBe("work_w");
+  });
+
+  it("resolves the container via citation source_file when the node lacks one", () => {
+    const orphan = node({
+      id: "object_z",
+      label: "Z",
+      type: "Object",
+      source_file: "",
+      citations: [{ source_file: "corpus/saga/the-work/text.txt", section: "I", quote: "z" }],
+    });
+    const ex = extraction([work, chapter, orphan], [
+      edge({ source: "chapter_the-work_ch1", target: "work_w", relation: "part_of" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    const appears = out.extraction.edges.filter((e) => e.relation === "appears_in");
+    expect(appears[0]!.target).toBe("chapter_the-work_ch1");
+  });
+
+  it("is idempotent and respects pre-existing appears_in", () => {
+    const orphan = node({
+      id: "character_x",
+      label: "X",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, chapter, orphan], [
+      edge({ source: "chapter_the-work_ch1", target: "work_w", relation: "part_of" }),
+    ]);
+    const first = deOrphanByContainer(ex);
+    const second = deOrphanByContainer(first.extraction);
+    expect(second.appearsInAdded).toBe(0);
+    expect(second.extraction.edges).toEqual(first.extraction.edges);
+  });
+
+  it("does not double-add when an appears_in already exists", () => {
+    const orphan = node({
+      id: "character_x",
+      label: "X",
+      type: "Character",
+      source_file: "corpus/saga/the-work/text.txt",
+    });
+    const ex = extraction([work, chapter, orphan], [
+      edge({ source: "character_x", target: "chapter_the-work_ch1", relation: "appears_in" }),
+    ]);
+    const out = deOrphanByContainer(ex);
+    expect(out.appearsInAdded).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline wiring — config-gated, default OFF
+// ---------------------------------------------------------------------------
+describe("assembly-hygiene pipeline gate", () => {
+  const ex = extraction(
+    [
+      node({ id: "location_a", label: "Dr. Alpha (ghost)", type: "place", source_file: "corpus/w/the-w/text.txt" }),
+      node({ id: "place_a", label: "Alpha", type: "Location", source_file: "corpus/w/the-w/text.txt" }),
+      node({ id: "work_the-w", label: "The W", type: "Work", source_file: "corpus/w/the-w/text.txt" }),
+    ],
+    [],
+  );
+
+  it("is a no-op when assemblyHygiene is not set (default OFF)", () => {
+    const G = buildFromJson(ex);
+    expect(G.hasNode("location_a")).toBe(true);
+    expect(G.hasNode("place_a")).toBe(true);
+    expect(G.size).toBe(0); // no derived edges
+  });
+
+  it("runs all three steps when gated on", () => {
+    const G = buildFromJson(ex, {
+      assemblyHygiene: { schemaHygiene: true, deriveAliases: true, deOrphan: true },
+    });
+    // (A) location_a collapsed into place_a.
+    expect(G.hasNode("location_a")).toBe(false);
+    expect(G.hasNode("place_a")).toBe(true);
+    // (B) alias derived from the collapsed label "Dr. Alpha (ghost)".
+    const aliases = G.getNodeAttribute("place_a", "aliases") as string[];
+    expect(aliases).toEqual(expect.arrayContaining(["Alpha (ghost)", "Dr. Alpha"]));
+    // (D) the now-collapsed entity is de-orphaned to its Work.
+    expect(G.hasEdge("place_a", "work_the-w")).toBe(true);
+  });
+
+  it("applyAssemblyHygiene returns input unchanged with no options", () => {
+    expect(applyAssemblyHygiene(ex)).toBe(ex);
+  });
+});


### PR DESCRIPTION
Split from #164 (conductor decision): the **clean, ship-worthy** half. The reconciliation fuzzy/alias **matcher precision** iterates in a separate PR (the 70-candidate set is ~29% genuine — noise classes to guard).

## What's here (all config-gated via `BuildOptions.assemblyHygiene`, **default OFF ⇒ base contract byte-unchanged**)
- **Schema hygiene** (`src/assembly-hygiene.ts`): canonicalize synonymous id-prefixes (`location_`→`place_`, `org_`→`organization_`) + normalize `type` to canonical Capitalized form; on id-collapse, **UNION edges/attrs/citations** (no last-write-wins drop).
- **Alias / normalized_terms derivation**: conservative (honorific + parenthetical strip, lowercase). Data only — how the matcher *uses* it is governed by the follow-up precision PR.
- **De-orphan**: link each degree-0 entity to its **finest** container (ChapterOrStory/Scene else Work) via derived `appears_in`; idempotent.

## Validation (COPY of the 2092-node mystery graph) — two independent reviews
- orphans **705 → 0**; +703 `appears_in`; max Work degree **47** (finest-container) vs **192** naive-all-to-Work.
- schema hygiene: 1 clean node collapse, **zero citation loss**, idempotent.
- default-OFF reference pass-through verified byte-identical (adversarial challenger).
- 1876 root tests + lint green; the single full-suite 'failure' is a pre-existing load-induced timeout (passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)