### PR TITLE
fix(studio): truncate long box labels on the MAIN graph (BUG-1 regression)

### DIFF
--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -270,16 +270,27 @@ export function buildGraphRendererPayload(scene, options = {}) {
   // view sets the flag; main-view scenes never do, so the god-class gate is
   // untouched there. Applied to baseStyle BEFORE buildConnectedDimStyle so
   // the label survives dim / merge re-styling (cloneStyle copies nodeLabels).
-  for (const node of nodes) {
-    if (node.forceBoxLabel !== true || !isBoxShape(node.shape)) continue;
-    const index = nodeIndexById.get(node.id);
-    if (!Number.isInteger(index)) continue;
-    // BUG-1: the renderer sizes the box to the drawn label width, so a long
-    // entity name overflows the compact recon focal slot. Cap the DRAWN text
-    // (parameterizable via labelMaxChars; default DEFAULT_LABEL_MAX_CHARS). The
-    // full name stays reachable on hover (GraphCanvas tooltip uses node.label,
-    // which is left untouched on the payload node) and in the recon rail/detail.
-    baseStyle.nodeLabels[index] = truncateLabel(node.label || String(node.id), labelMaxChars);
+  // BUG-1 (regression fix): the renderer sizes a box glyph to its DRAWN label
+  // width, so a long entity / chapter name (e.g. "Part I, Chapter I: Being a
+  // Reprint of the Reminiscences of John H. Watson, M.D., …") overflows far past
+  // the box — on the MAIN graph, not just the recon focal slot. Truncation must
+  // cover EVERY box node, not only the `forceBoxLabel` recon pair. We truncate
+  // the SOURCE label (never an already-clipped string, so no double ellipsis);
+  // the full name stays on node.label for the hover tooltip + recon rail/detail.
+  if (baseStyle.nodeLabels) {
+    for (const node of nodes) {
+      if (!isBoxShape(node.shape)) continue;
+      const index = nodeIndexById.get(node.id);
+      if (!Number.isInteger(index)) continue;
+      const forced = node.forceBoxLabel === true;
+      const existing = baseStyle.nodeLabels[index];
+      const hasExisting = typeof existing === "string" && existing.length > 0;
+      // forceBoxLabel nodes always get a label; main-graph box nodes only carry
+      // one when buildStyleBuffers' label gate already set it. Skip the rest.
+      if (!forced && !hasExisting) continue;
+      const source = forced ? (node.label || String(node.id)) : existing;
+      baseStyle.nodeLabels[index] = truncateLabel(source, labelMaxChars);
+    }
   }
   const renderedEdges = Array.from(renderGraph.edgeInputIndices ?? [], (inputIndex) => edges[inputIndex]);
 

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -221,6 +221,44 @@ describe("buildGraphRendererPayload focal-box label truncation", () => {
   });
 });
 
+// --- BUG-1 REGRESSION: main-graph box labels must truncate too (not only the
+// recon focal pair — #160 fixed only forceBoxLabel; the chapter/work boxes on
+// the ordinary graph still overflowed). ---
+describe("buildGraphRendererPayload main-graph box label truncation (regression)", () => {
+  const longChapter =
+    "Part I, Chapter I: Being a Reprint of the Reminiscences of John H. Watson, M.D., Late of the Army Medical Department";
+  // A box-shaped god-node (highest degree → boxed by the label gate) WITHOUT any
+  // forceBoxLabel flag: exactly the main/workspace graph path where the bug lived.
+  const makeMainScene = () => {
+    const nodes = [
+      { id: "chap", label: longChapter, type: "ChapterOrStory", shape: "roundedbox", x: 0, y: 0, weight: 1 },
+    ];
+    const edges = [];
+    for (let i = 0; i < 12; i += 1) {
+      nodes.push({ id: `e${i}`, label: `E${i}`, type: "Character", shape: "diamond", x: i, y: 40, weight: 1 });
+      edges.push({ source: "chap", target: `e${i}` });
+    }
+    return { nodes, edges };
+  };
+
+  it("truncates a long main-graph box label (no forceBoxLabel) while keeping node.label full", () => {
+    const payload = buildGraphRendererPayload(makeMainScene(), { nodeRadius: 3 });
+    const idx = payload.nodeIndexById.get("chap");
+    const drawn = payload.baseStyle.nodeLabels[idx];
+    expect(drawn).toBeTruthy();
+    expect(drawn.endsWith("…")).toBe(true);
+    expect([...drawn].length).toBeLessThanOrEqual(DEFAULT_LABEL_MAX_CHARS + 1);
+    // full name preserved on the payload node for the hover tooltip
+    expect(payload.nodeById.get("chap").label).toBe(longChapter);
+  });
+
+  it("honours labelMaxChars on main-graph box nodes", () => {
+    const payload = buildGraphRendererPayload(makeMainScene(), { nodeRadius: 3, labelMaxChars: 8 });
+    const idx = payload.nodeIndexById.get("chap");
+    expect([...payload.baseStyle.nodeLabels[idx]].length).toBeLessThanOrEqual(9);
+  });
+});
+
 // --- legacy box parity: box nodes own their label (single text per box) ---
 describe("isBoxShape", () => {
   it("recognises the box-category scene shapes (case-insensitive)", () => {


### PR DESCRIPTION
## BUG-1 regression (UAT-reported)

#160's `truncateLabel` ran **only** inside the `forceBoxLabel` loop — i.e. only the reconciliation focal pair. Main-graph god-class **box** nodes (chapters/works) got their label straight from `buildStyleBuffers` with **no cap**, so long names like *"Part I, Chapter I: Being a Reprint of the Reminiscences of John H. Watson, M.D., Late of the Army Medical Department"* overflowed far past the box.

The renderer sizes a box glyph to its **drawn** label width, so the cap must cover **every** box node — truncate `baseStyle.nodeLabels` for all box-shaped nodes (forced *or* gate-labelled), from the SOURCE label (no double ellipsis). `node.label` stays full for the hover tooltip + recon detail.

## Proof (per the UAT-entry gate)
- **method:** dom-render-test (unit). **evidence:** 2 new tests in `studio/src/tests/graphRendererPayload.test.js` on a main-graph box god-node **without** `forceBoxLabel`: assert the drawn label is capped (`…`, ≤ DEFAULT_LABEL_MAX_CHARS+1) + `labelMaxChars` honored + `node.label` full.
- **result:** 31/31 `graphRendererPayload` tests pass.
- **captured_by:** claude:graphify (conductor, inline).

Still open on BUG-1: the "characters rendered as labelled boxes per spec" sub-point needs the exact display-mapping spec confirmed before I touch which node types box — flagged, not guessed. Visual confirmation pending a studio build/serve.