### PR TITLE
feat(studio/recon): rail redesign (group-by-type, score bubble, two-line, batch) + depth-3 focal neighbourhood

### DIFF
--- a/studio/src/components/ReconciliationView.svelte
+++ b/studio/src/components/ReconciliationView.svelte
@@ -8,6 +8,7 @@
    * On a loopback --write server no token is needed (SVELTE-7 server change).
    */
   import { onMount } from "svelte";
+  import { SvelteSet } from "svelte/reactivity";
 
   import { Badge, Collapsible } from "@sentropic/design-system-svelte";
 
@@ -24,13 +25,19 @@
     indexNodes,
     nodeLabel,
     nodeType,
+    RECON_SUBGRAPH_DEPTH,
+    RECON_SUBGRAPH_MAX_NODES,
   } from "../lib/graphAdapter.js";
 
   // BUG-1: `labelMaxChars` parameterizes the DRAWN focal-box label length. The
   // two recon entities are pinned close together; a long name (e.g. "Dr. John H.
   // Watson") otherwise sizes an over-wide box that overflows the slot. The full
   // name remains on hover (GraphCanvas tooltip) and in the rail/detail `title`s.
-  let { graph, onOpenEntity, labelMaxChars = 22 } = $props();
+  // #4.1: `reconDepth` controls how far the focal pair's neighbourhood is
+  // expanded (default 3 — see RECON_SUBGRAPH_DEPTH). Fan-out is capped at
+  // RECON_SUBGRAPH_MAX_NODES inside candidateSubgraph so a deep ball around a
+  // high-degree hub can't explode into an unreadable hairball.
+  let { graph, onOpenEntity, labelMaxChars = 22, reconDepth = RECON_SUBGRAPH_DEPTH } = $props();
 
   let candidates = $state([]);
   let total = $state(0);
@@ -61,6 +68,48 @@
     );
   });
 
+  // #4 (a): GROUP the candidate list by entity TYPE (Character, Location, Work…)
+  // so the rail reads as typed sections with headers. The type is the candidate
+  // node's type from the graph (typeOf); we fall back to the canonical side, then
+  // to "Other" when neither node is in the loaded graph (stale ids). Within a
+  // group, candidates stay in their incoming (score-desc) order.
+  const grouped = $derived.by(() => {
+    const buckets = new Map();
+    for (const c of filtered) {
+      const t = typeOf(c.candidate_id) ?? typeOf(c.canonical_id) ?? "Other";
+      if (!buckets.has(t)) buckets.set(t, []);
+      buckets.get(t).push(c);
+    }
+    // Largest groups first; ties alphabetical so order is stable and meaningful.
+    return [...buckets.entries()]
+      .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+      .map(([type, items]) => ({ type, items }));
+  });
+
+  // #4 (d): batch-selection state. A Set of candidate ids ticked for bulk action.
+  let selected = $state(new SvelteSet());
+  // Only ids still present in the (filtered) queue count toward bulk actions.
+  const selectedCount = $derived(
+    filtered.reduce((n, c) => (selected.has(c.id) ? n + 1 : n), 0),
+  );
+  const allFilteredSelected = $derived(
+    filtered.length > 0 && filtered.every((c) => selected.has(c.id)),
+  );
+  // Bulk progress feedback (e.g. "Validated 4 of 6 — 2 failed").
+  let bulkResult = $state(null);
+
+  function toggleSelected(id) {
+    if (selected.has(id)) selected.delete(id);
+    else selected.add(id);
+  }
+  function toggleSelectAll() {
+    if (allFilteredSelected) {
+      for (const c of filtered) selected.delete(c.id);
+    } else {
+      for (const c of filtered) selected.add(c.id);
+    }
+  }
+
   // Center graph: subgraph around the two candidate entities (focused context).
   // The twins usually have no direct edge, so we (a) pin them side by side and
   // (b) add a bold synthetic "reconcile" edge so they read as a pair.
@@ -72,7 +121,11 @@
   // AROUND the centred, side-by-side pair (a compact, centred, twinned cluster).
   const scene = $derived.by(() => {
     if (!active) return buildScene({ nodes: [], links: [] });
-    const sub = candidateSubgraph(graph, active.candidate_id, active.canonical_id, 1);
+    // #4.1: expand each entity's neighbourhood to DEPTH reconDepth (default 3),
+    // capped at RECON_SUBGRAPH_MAX_NODES nodes (fan-out cap, see candidateSubgraph).
+    const sub = candidateSubgraph(graph, active.candidate_id, active.canonical_id, reconDepth, {
+      maxNodes: RECON_SUBGRAPH_MAX_NODES,
+    });
     const base = buildScene(sub, { showWeakLinks: true });
     const linked = withReconcileEdge(base, active.candidate_id, active.canonical_id);
     // Pin the two twins symmetrically near the centre so both stay in view. We
@@ -192,6 +245,56 @@
       busy = false;
     }
   }
+
+  // #4 (d): BATCH validation. Apply the same decision (accept | reject) to every
+  // ticked candidate. We snapshot the targets up front (the queue mutates as we
+  // remove decided rows), apply patches sequentially so the write server isn't
+  // hammered, count outcomes, then drop the succeeded ones and report a summary.
+  // No merge animation here — that single-pair flourish would serialise oddly
+  // across a bulk run; bulk is a queue-clearing action, not a focused merge.
+  async function decideBulk(decision) {
+    if (busy) return;
+    const targets = filtered.filter((c) => selected.has(c.id));
+    if (targets.length === 0) return;
+    busy = true;
+    bulkResult = null;
+    actionResult = null;
+    let ok = 0;
+    const failures = [];
+    try {
+      for (const cand of targets) {
+        try {
+          const patch = buildPatchFromCandidate(cand, decision, { graphHash, profileHash });
+          const res = await postPatchApply(patch);
+          if (res.ok && res.valid !== false) {
+            ok += 1;
+            selected.delete(cand.id);
+            candidates = candidates.filter((c) => c.id !== cand.id);
+            total = Math.max(0, total - 1);
+          } else {
+            const issues = (res.issues ?? []).map((i) => i.message).join("; ");
+            failures.push(`${cand.id}: ${issues || res.error || res.status}`);
+          }
+        } catch (err) {
+          failures.push(`${cand.id}: ${String(err)}`);
+        }
+      }
+    } finally {
+      busy = false;
+    }
+    // Keep the active selection valid after the queue shrank.
+    if (activeId && !candidates.some((c) => c.id === activeId)) {
+      activeId = candidates[0]?.id ?? null;
+    }
+    const verb = decision === "accept" ? "Validated" : "Rejected";
+    bulkResult = {
+      ok: failures.length === 0,
+      msg:
+        failures.length === 0
+          ? `${verb} ${ok} candidate(s).`
+          : `${verb} ${ok} of ${targets.length} — ${failures.length} failed: ${failures.join(" · ")}`,
+    };
+  }
 </script>
 
 <WorkspaceShell>
@@ -216,23 +319,79 @@
       {:else if filtered.length === 0}
         <p class="recon-empty">Reconciliation queue is empty.</p>
       {:else}
-        <ul class="recon-rail-list">
-          {#each filtered as c (c.id)}
-            <li>
-              <button
-                class="recon-rail-row"
-                class:active={activeId === c.id}
-                onclick={() => { activeId = c.id; actionResult = null; }}
-              >
-                <span
-                  class="recon-rail-label"
-                  title={`${label(c.candidate_id)} ↔ ${label(c.canonical_id)}`}
-                >{label(c.candidate_id)} ↔ {label(c.canonical_id)}</span>
-                <span class="recon-rail-score">{Math.round((c.score ?? 0) * 100)}%</span>
-              </button>
-            </li>
+        <!-- #4 (d): batch validation bar — select all + bulk validate/reject. -->
+        <div class="recon-bulk-bar">
+          <label class="recon-bulk-all">
+            <input
+              type="checkbox"
+              checked={allFilteredSelected}
+              onchange={toggleSelectAll}
+              aria-label="Select all candidates"
+            />
+            <span>{selectedCount} selected</span>
+          </label>
+          <div class="recon-bulk-actions">
+            <button
+              class="recon-bulk-accept"
+              disabled={busy || selectedCount === 0}
+              onclick={() => decideBulk("accept")}
+            >Validate</button>
+            <button
+              class="recon-bulk-reject"
+              disabled={busy || selectedCount === 0}
+              onclick={() => decideBulk("reject")}
+            >Reject</button>
+          </div>
+        </div>
+        {#if bulkResult}
+          <p class="recon-bulk-result" class:ok={bulkResult.ok} class:err={!bulkResult.ok}>
+            {bulkResult.msg}
+          </p>
+        {/if}
+
+        <!-- #4 (a): candidates GROUPED by entity type, with type headers. -->
+        <div class="recon-rail-groups">
+          {#each grouped as group (group.type)}
+            <section class="recon-group">
+              <h3 class="recon-group-head">
+                <span class="recon-group-type">{group.type}</span>
+                <span class="recon-group-count">{group.items.length}</span>
+              </h3>
+              <ul class="recon-rail-list">
+                {#each group.items as c (c.id)}
+                  <li
+                    class="recon-rail-item"
+                    class:active={activeId === c.id}
+                    class:checked={selected.has(c.id)}
+                  >
+                    <!-- #4 (d): per-candidate checkbox for batch selection. -->
+                    <input
+                      class="recon-rail-check"
+                      type="checkbox"
+                      checked={selected.has(c.id)}
+                      onchange={() => toggleSelected(c.id)}
+                      aria-label={`Select ${label(c.candidate_id)} ↔ ${label(c.canonical_id)}`}
+                    />
+                    <button
+                      class="recon-rail-row"
+                      onclick={() => { activeId = c.id; actionResult = null; }}
+                    >
+                      <!-- #4 (c): the two entities on TWO separate lines. -->
+                      <span class="recon-rail-pair">
+                        <span class="recon-rail-line" title={label(c.candidate_id)}>{label(c.candidate_id)}</span>
+                        <span class="recon-rail-line recon-rail-canon" title={label(c.canonical_id)}>{label(c.canonical_id)}</span>
+                      </span>
+                      <!-- #4 (b): match score as a % bubble on the RIGHT. -->
+                      <span class="recon-score-bubble" title={`Match score ${Math.round((c.score ?? 0) * 100)}%`}>
+                        {Math.round((c.score ?? 0) * 100)}%
+                      </span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </section>
           {/each}
-        </ul>
+        </div>
       {/if}
     </aside>
   </div>
@@ -365,29 +524,109 @@
     color: var(--st-semantic-text-secondary, #475569);
     background: var(--st-semantic-surface-subtle, #f8fafc);
   }
-  .recon-rail-list { list-style: none; margin: 0; padding: 0 0.5rem; display: grid; gap: 2px; }
+  /* #4 (d): batch-validation bar. */
+  .recon-bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.4rem 0.85rem 0.5rem;
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .recon-bulk-all {
+    display: flex; align-items: center; gap: 0.4rem;
+    font-size: 0.76rem; color: var(--st-semantic-text-secondary, #475569);
+    cursor: pointer;
+  }
+  .recon-bulk-actions { display: flex; gap: 0.35rem; }
+  .recon-bulk-accept, .recon-bulk-reject {
+    border-radius: var(--st-radius-sm, 4px);
+    padding: 0.28rem 0.6rem;
+    font-size: 0.76rem; font-weight: 600; cursor: pointer;
+  }
+  .recon-bulk-accept {
+    border: 1px solid var(--st-semantic-action-primary, #2563eb);
+    background: var(--st-semantic-action-primary, #2563eb);
+    color: var(--st-semantic-action-primaryText, #fff);
+  }
+  .recon-bulk-reject {
+    border: 1px solid var(--st-semantic-border-strong, #94a3b8);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .recon-bulk-accept:disabled, .recon-bulk-reject:disabled { opacity: 0.5; cursor: not-allowed; }
+  .recon-bulk-result { margin: 0.4rem 0.85rem 0; font-size: 0.76rem; line-height: 1.35; }
+  .recon-bulk-result.ok { color: var(--st-semantic-feedback-success, #16a34a); }
+  .recon-bulk-result.err { color: var(--st-semantic-feedback-error, #dc2626); }
+
+  /* #4 (a): type-grouped sections. */
+  .recon-rail-groups { padding: 0.35rem 0; }
+  .recon-group { margin: 0 0 0.4rem; }
+  .recon-group-head {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.5rem; margin: 0; padding: 0.3rem 0.85rem 0.25rem;
+    position: sticky; top: 0; z-index: 1;
+    background: var(--st-semantic-surface-default, #fff);
+    text-transform: uppercase; letter-spacing: 0.05em;
+    font-size: 0.68rem; font-weight: 700;
+    color: var(--st-semantic-text-muted, #64748b);
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .recon-group-count {
+    font-variant-numeric: tabular-nums;
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-pill, 999px);
+    padding: 0 0.4rem; min-width: 1.4rem; text-align: center;
+  }
+
+  .recon-rail-list { list-style: none; margin: 0; padding: 0.15rem 0.5rem; display: grid; gap: 2px; }
+  /* #4 (d): row = checkbox + clickable body. */
+  .recon-rail-item {
+    display: flex; align-items: stretch; gap: 0.35rem;
+    border: 1px solid transparent;
+    border-radius: var(--st-radius-sm, 4px);
+  }
+  .recon-rail-item.active {
+    border-color: var(--st-semantic-action-primary, #2563eb);
+    box-shadow: inset 3px 0 0 var(--st-semantic-action-primary, #2563eb);
+  }
+  .recon-rail-item.checked { background: var(--st-semantic-surface-subtle, #f1f5f9); }
+  .recon-rail-check { margin: 0 0 0 0.35rem; align-self: center; cursor: pointer; }
   .recon-rail-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
-    width: 100%;
+    flex: 1; min-width: 0;
     text-align: left;
-    border: 1px solid transparent;
+    border: none;
     background: transparent;
     border-radius: var(--st-radius-sm, 4px);
     padding: 0.4rem 0.5rem;
     cursor: pointer;
-    font-size: 0.82rem;
     color: var(--st-semantic-text-primary, #0f172a);
   }
   .recon-rail-row:hover { background: var(--st-semantic-surface-subtle, #f8fafc); }
-  .recon-rail-row.active {
-    border-color: var(--st-semantic-action-primary, #2563eb);
-    box-shadow: inset 3px 0 0 var(--st-semantic-action-primary, #2563eb);
+  /* #4 (c): two entities, two lines. */
+  .recon-rail-pair { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
+  .recon-rail-line {
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-size: 0.82rem; line-height: 1.25;
   }
-  .recon-rail-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .recon-rail-score { font-variant-numeric: tabular-nums; color: var(--st-semantic-text-muted, #64748b); font-size: 0.74rem; }
+  .recon-rail-canon { color: var(--st-semantic-text-secondary, #475569); font-size: 0.78rem; }
+  /* #4 (b): score bubble, pinned right. */
+  .recon-score-bubble {
+    flex: none;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.72rem; font-weight: 700;
+    color: var(--st-semantic-action-primaryText, #fff);
+    background: var(--st-semantic-action-primary, #2563eb);
+    border-radius: var(--st-radius-pill, 999px);
+    padding: 0.1rem 0.45rem;
+    min-width: 2.4rem; text-align: center;
+    align-self: center;
+  }
   .recon-detail { padding: 1rem 1.1rem 2rem; }
   .recon-kicker {
     margin: 0; text-transform: uppercase; letter-spacing: 0.06em;

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -743,22 +743,44 @@ export function citationsByFile(node) {
  * and every edge whose endpoints are both in the kept set. Returns a graph
  * shaped like the full one ({ nodes, links }) so buildScene can consume it.
  */
-export function candidateSubgraph(graph, idA, idB, hops = 1) {
+// #4.1: default neighbourhood depth for the recon focal pair. The two entities
+// under comparison are expanded to DEPTH-3 so the operator can judge the match
+// from the surrounding context (shared neighbours, shared communities), not just
+// the bare twins. `maxNodes` CAPS the fan-out: a depth-3 ball around a
+// high-degree hub can pull in hundreds of nodes (an unreadable hairball that
+// also stalls the force layout), so once the kept set reaches the cap we stop
+// growing the frontier and return the partial ball. The two seed twins are
+// always kept (added before any cap check), so the pair can never be dropped.
+export const RECON_SUBGRAPH_DEPTH = 3;
+export const RECON_SUBGRAPH_MAX_NODES = 160;
+
+export function candidateSubgraph(
+  graph,
+  idA,
+  idB,
+  hops = 1,
+  { maxNodes = RECON_SUBGRAPH_MAX_NODES } = {},
+) {
   const idx = indexNodes(graph);
   const edges = graphEdges(graph);
   const keep = new Set();
   for (const a of [idA, idB]) {
     if (a != null && idx.has(a)) keep.add(a);
   }
+  const cap = Number.isFinite(maxNodes) ? Math.max(keep.size, maxNodes) : Infinity;
   let frontier = new Set(keep);
   for (let h = 0; h < Math.max(0, hops); h++) {
+    if (keep.size >= cap) break; // fan-out cap reached — stop expanding.
     const next = new Set();
     for (const e of edges) {
       const s = e?.source, t = e?.target;
       if (frontier.has(s) && t != null && idx.has(t) && !keep.has(t)) next.add(t);
       if (frontier.has(t) && s != null && idx.has(s) && !keep.has(s)) next.add(s);
     }
-    for (const n of next) keep.add(n);
+    for (const n of next) {
+      if (keep.size >= cap) break; // never exceed the cap (twins already kept).
+      keep.add(n);
+    }
     frontier = next;
     if (next.size === 0) break;
   }

--- a/studio/src/tests/reconciliationView.test.js
+++ b/studio/src/tests/reconciliationView.test.js
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  candidateSubgraph,
+  RECON_SUBGRAPH_DEPTH,
+  RECON_SUBGRAPH_MAX_NODES,
+} from "../lib/graphAdapter.js";
+
+/**
+ * TRACKED #4 / #4.1 — Reconciliation view redesign.
+ *
+ * The studio's component tests assert against the .svelte SOURCE (jsdom has no
+ * Canvas2D, so we don't mount the GraphCanvas-bearing component — see
+ * appHeader.test.js / entityPanel.test.js for the same source-assertion style).
+ * The behavioural half (#4.1 depth + fan-out cap) is proven against the real
+ * graphAdapter functions with a deterministic synthetic graph.
+ */
+const viewSource = readFileSync(
+  resolve(process.cwd(), "src/components/ReconciliationView.svelte"),
+  "utf8",
+);
+
+describe("ReconciliationView rail redesign (TRACKED #4)", () => {
+  it("(a) groups candidates by entity TYPE with type headers", () => {
+    // Derived buckets keyed by the candidate node's type (typeOf), header markup.
+    expect(viewSource).toMatch(/const grouped = \$derived\.by/);
+    expect(viewSource).toMatch(/typeOf\(c\.candidate_id\) \?\? typeOf\(c\.canonical_id\) \?\? "Other"/);
+    expect(viewSource).toMatch(/{#each grouped as group/);
+    expect(viewSource).toMatch(/class="recon-group-head"/);
+    expect(viewSource).toMatch(/class="recon-group-type">{group\.type}/);
+  });
+
+  it("(b) renders the match score as a % bubble on the RIGHT of each row", () => {
+    expect(viewSource).toMatch(/class="recon-score-bubble"/);
+    expect(viewSource).toMatch(/Math\.round\(\(c\.score \?\? 0\) \* 100\)}%/);
+    // The bubble sits after the two-line pair in the row (i.e. to its right) and
+    // is non-shrinking, pinned right via justify-content: space-between.
+    const rowStart = viewSource.indexOf('class="recon-rail-pair"');
+    const bubbleStart = viewSource.indexOf('class="recon-score-bubble"');
+    expect(rowStart).toBeGreaterThan(-1);
+    expect(bubbleStart).toBeGreaterThan(rowStart);
+    expect(viewSource).toMatch(/\.recon-score-bubble\s*{[\s\S]*flex:\s*none;[\s\S]*}/);
+    expect(viewSource).toMatch(/\.recon-rail-row\s*{[\s\S]*justify-content:\s*space-between;[\s\S]*}/);
+  });
+
+  it("(c) shows the two entities on TWO separate lines", () => {
+    expect(viewSource).toMatch(/class="recon-rail-pair"/);
+    // Two distinct line spans: candidate, then canonical.
+    expect(viewSource).toMatch(
+      /class="recon-rail-line"[^>]*>{label\(c\.candidate_id\)}/,
+    );
+    expect(viewSource).toMatch(
+      /class="recon-rail-line recon-rail-canon"[^>]*>{label\(c\.canonical_id\)}/,
+    );
+    // The pair container is a vertical flex column (the two lines stack).
+    expect(viewSource).toMatch(/\.recon-rail-pair\s*{[\s\S]*flex-direction:\s*column;[\s\S]*}/);
+  });
+
+  it("(d) gives each candidate a checkbox and supports batch validate/reject", () => {
+    // Per-row checkbox bound to a reactive selection set.
+    expect(viewSource).toMatch(/import { SvelteSet } from "svelte\/reactivity";/);
+    expect(viewSource).toMatch(/let selected = \$state\(new SvelteSet\(\)\)/);
+    expect(viewSource).toMatch(/class="recon-rail-check"\s*\n?\s*type="checkbox"/);
+    expect(viewSource).toMatch(/onchange={\(\) => toggleSelected\(c\.id\)}/);
+    // Select-all + bulk action buttons wired to decideBulk.
+    expect(viewSource).toMatch(/onchange={toggleSelectAll}/);
+    expect(viewSource).toMatch(/onclick={\(\) => decideBulk\("accept"\)}/);
+    expect(viewSource).toMatch(/onclick={\(\) => decideBulk\("reject"\)}/);
+    expect(viewSource).toMatch(/async function decideBulk\(decision\)/);
+  });
+});
+
+describe("ReconciliationView focal-pair depth (TRACKED #4.1)", () => {
+  it("calls candidateSubgraph at depth reconDepth (default 3), not 1", () => {
+    expect(viewSource).toMatch(/reconDepth = RECON_SUBGRAPH_DEPTH/);
+    expect(viewSource).toMatch(
+      /candidateSubgraph\(graph, active\.candidate_id, active\.canonical_id, reconDepth/,
+    );
+    // No lingering hard-coded 1-hop call.
+    expect(viewSource).not.toMatch(/candidateSubgraph\(graph, active\.candidate_id, active\.canonical_id, 1\)/);
+    expect(RECON_SUBGRAPH_DEPTH).toBe(3);
+  });
+
+  it("depth 3 expands the neighbourhood beyond 1 hop on a real chain", () => {
+    // A → n1 → n2 → n3 → n4 chain off the candidate; B isolated.
+    const graph = {
+      nodes: [
+        { id: "A" }, { id: "B" },
+        { id: "n1" }, { id: "n2" }, { id: "n3" }, { id: "n4" },
+      ],
+      links: [
+        { source: "A", target: "n1" },
+        { source: "n1", target: "n2" },
+        { source: "n2", target: "n3" },
+        { source: "n3", target: "n4" },
+      ],
+    };
+    const d1 = candidateSubgraph(graph, "A", "B", 1).nodes.map((n) => n.id).sort();
+    const d3 = candidateSubgraph(graph, "A", "B", 3).nodes.map((n) => n.id).sort();
+    expect(d1).toEqual(["A", "B", "n1"]); // 1 hop: only the immediate neighbour.
+    expect(d3).toEqual(["A", "B", "n1", "n2", "n3"]); // 3 hops reach n3, not n4.
+    expect(d3.length).toBeGreaterThan(d1.length);
+  });
+
+  it("caps fan-out at maxNodes while always keeping both seed twins", () => {
+    // A hub with 500 leaves; depth 1 alone would pull all 500 + B.
+    const nodes = [{ id: "A" }, { id: "B" }];
+    const links = [];
+    for (let i = 0; i < 500; i++) {
+      nodes.push({ id: `leaf${i}` });
+      links.push({ source: "A", target: `leaf${i}` });
+    }
+    const sub = candidateSubgraph({ nodes, links }, "A", "B", 3, { maxNodes: 50 });
+    const ids = sub.nodes.map((n) => n.id);
+    expect(ids.length).toBeLessThanOrEqual(50);
+    // The two twins under comparison are never dropped by the cap.
+    expect(ids).toContain("A");
+    expect(ids).toContain("B");
+    expect(RECON_SUBGRAPH_MAX_NODES).toBe(160);
+  });
+});


### PR DESCRIPTION
## Reconciliation view redesign (TRACKED #4 / #4.1)

Redesigns the studio reconciliation candidate rail and deepens the focal-pair
neighbourhood. `studio/src/components/ReconciliationView.svelte` +
`studio/src/lib/graphAdapter.js`.

### TRACKED #4 — candidate rail
- **(a) Group by entity TYPE** — sticky type headers with counts (Character,
  Object, Location, CrimeOrScheme, Event, Organization on the mystery pack).
- **(b) Score % bubble on the RIGHT** — non-shrinking pill pinned right of each row.
- **(c) Two entities on TWO lines** — candidate on line 1, canonical on line 2
  (was the inline `A ↔ B`).
- **(d) Per-candidate checkbox + batch validation** — select-all + per-row
  checkboxes feed a bulk **Validate** / **Reject** that applies patches
  sequentially and reports a summary.

### TRACKED #4.1 — depth-3 focal neighbourhood
- `candidateSubgraph(...)` now expands to **DEPTH 3** (`reconDepth` prop, default
  `RECON_SUBGRAPH_DEPTH = 3`) instead of ~1 hop.
- **Fan-out cap** `RECON_SUBGRAPH_MAX_NODES = 160` stops a deep ball around a
  high-degree hub from exploding into an unreadable hairball; the two seed twins
  are always kept before any cap check.

### Proof (real republish-0.14.1 bundle, 31 candidates)
- Grouping over the real 31 candidates: `Character 14, Object 9, Location 4,
  CrimeOrScheme 2, Organization 1, Event 1`.
- Depth 1 → depth 3 across all 31 pairs: `sum nodes 158 → 4001`; **31/31 pairs
  grew**; the cap engaged on **21/31** high-degree pairs.
- Headless Chrome (Playwright) against the served build: 6 type groups, 31 rows,
  31 score bubbles, 31 checkboxes, 62 rail lines (2 per pair), bulk bar updates to
  "2 selected" on checking two rows, **zero page errors**. Screenshots captured.

### Tests
`studio` suite green: **122 passed** (115 baseline + 7 new in
`reconciliationView.test.js`).
