### PR TITLE
feat(conversations): conversations connector (claude/codex/cursor/gemini) → Extraction (WP5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "unpdf": "^1.6.2"
       },
       "peerDependencies": {
+        "@sentropic/agent-stats-core": "^0.3.0",
         "faster-whisper-ts": "^1.2.1",
         "tree-sitter-c-sharp": "^0.23.1",
         "tree-sitter-elixir": "^0.3.5",
@@ -78,6 +79,9 @@
         "tree-sitter-zig": "^0.2.0"
       },
       "peerDependenciesMeta": {
+        "@sentropic/agent-stats-core": {
+          "optional": true
+        },
         "faster-whisper-ts": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "unpdf": "^1.6.2"
   },
   "peerDependencies": {
+    "@sentropic/agent-stats-core": "^0.3.0",
     "faster-whisper-ts": "^1.2.1",
     "tree-sitter-c-sharp": "^0.23.1",
     "tree-sitter-elixir": "^0.3.5",
@@ -135,6 +136,9 @@
     "tree-sitter-zig": "^0.2.0"
   },
   "peerDependenciesMeta": {
+    "@sentropic/agent-stats-core": {
+      "optional": true
+    },
     "faster-whisper-ts": {
       "optional": true
     },

--- a/src/conversations.ts
+++ b/src/conversations.ts
@@ -1,0 +1,457 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+import { commitId, repoKey as defaultRepoKey } from "./repo-key.js";
+import type { Extraction, GraphEdge, GraphNode, OntologyProfile } from "./types.js";
+
+export const CONVERSATIONS_ADAPTER_VERSION = "graphify-conversations/0.1.0";
+export const AGENT_STATS_CORE_VERSION = "0.3.0";
+
+export type ConversationTool = "claude" | "codex" | "cursor" | "gemini";
+export type ConversationSurface = "cli" | "vscode" | "exec" | "cursor";
+
+export interface ConversationUsage {
+  newInputTokens: number;
+  cachedInputTokens: number;
+  cacheWriteTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+}
+
+interface ConversationEventBase {
+  ts: string;
+  tool: ConversationTool;
+  sessionId: string;
+  projectCwd: string;
+}
+
+export interface ConversationSessionStartEvent extends ConversationEventBase {
+  kind: "session_start";
+  model?: string;
+  gitBranch?: string;
+  gitCommit?: string;
+  repoUrl?: string;
+  forkedFromId?: string;
+  agentNickname?: string;
+  cliVersion?: string;
+  surface?: ConversationSurface;
+  isSubagent: boolean;
+}
+
+export interface ConversationSessionEndEvent extends ConversationEventBase {
+  kind: "session_end";
+}
+
+export interface ConversationTurnEvent extends ConversationEventBase {
+  kind: "turn";
+  model: string;
+  usage: ConversationUsage;
+}
+
+export interface ConversationUserPromptEvent extends ConversationEventBase {
+  kind: "user_prompt";
+  textLength: number;
+  textHash: string;
+}
+
+export interface ConversationToolCallEvent extends ConversationEventBase {
+  kind: "tool_call";
+  name: string;
+  category: "bash" | "mcp" | "native" | "function" | "unknown";
+  durationMs?: number;
+  inputBytes?: number;
+  outputBytes?: number;
+  error?: boolean;
+}
+
+export interface ConversationSkillInvokeEvent extends ConversationEventBase {
+  kind: "skill_invoke";
+  name: string;
+}
+
+export interface ConversationCompactionEvent extends ConversationEventBase {
+  kind: "compaction";
+}
+
+export type ConversationsSessionEvent =
+  | ConversationSessionStartEvent
+  | ConversationSessionEndEvent
+  | ConversationTurnEvent
+  | ConversationUserPromptEvent
+  | ConversationToolCallEvent
+  | ConversationSkillInvokeEvent
+  | ConversationCompactionEvent;
+
+export interface ConversationSessionAggregate {
+  sessionId: string;
+  tool: ConversationTool;
+  surface?: ConversationSurface;
+  projectCwd: string;
+  model: string;
+  startTs: string;
+  endTs: string;
+  durationMs: number;
+  turns: number;
+  totalUsage: ConversationUsage;
+  gitBranch?: string;
+  gitCommit?: string;
+  repoUrl?: string;
+  isSubagent: boolean;
+  forkedFromId?: string;
+  agentNickname?: string;
+  toolCalls: number;
+  toolCallsByCategory: Record<string, number>;
+  toolCallsByName: Record<string, number>;
+  skillInvocations: number;
+  skillsByName: Record<string, number>;
+  compactions: number;
+  estimatedCost?: { codexCredits: number; claudeUsdCents: number; unknown: number };
+}
+
+export interface ConversationsCore {
+  VERSION?: string;
+  collect(opts: {
+    sources?: { claude?: boolean; codex?: boolean; cursor?: boolean; gemini?: boolean };
+    since?: Date;
+    until?: Date;
+    projectCwd?: string;
+    claudeProjectsDir?: string;
+    codexDbPath?: string;
+    cursorStateDir?: string;
+    geminiTmpDir?: string;
+  }): AsyncGenerator<ConversationsSessionEvent, void, unknown>;
+  aggregateSessions(
+    events: AsyncIterable<ConversationsSessionEvent> | Iterable<ConversationsSessionEvent>,
+  ): Promise<ConversationSessionAggregate[]>;
+}
+
+export interface ClaudeCommitResolveOptions {
+  repoRoot: string;
+  branch: string;
+  sessionStart: string;
+  sessionEnd: string;
+  windowMs?: number;
+  runner?: (repoRoot: string, args: string[]) => string;
+}
+
+export interface BuildConversationsExtractionOptions {
+  projectCwd?: string;
+  repoRoot: string;
+  sources?: { claude?: boolean; codex?: boolean; cursor?: boolean; gemini?: boolean };
+  since?: Date;
+  until?: Date;
+  claudeProjectsDir?: string;
+  codexDbPath?: string;
+  cursorStateDir?: string;
+  geminiTmpDir?: string;
+  observedAt?: string;
+  core?: ConversationsCore;
+  repoKey?: (repoRoot: string) => string;
+  claudeCommitResolver?: (session: ConversationSessionAggregate) => string | undefined;
+}
+
+export const CONVERSATIONS_ONTOLOGY_PROFILE: OntologyProfile = {
+  id: "conversations",
+  version: "1",
+  node_types: {
+    Conversation: {
+      aliases: ["conversation", "agent conversation"],
+      source_backed: true,
+    },
+    AgentSession: {
+      aliases: ["agent session", "assistant session"],
+      source_backed: true,
+    },
+  },
+  relation_types: {
+    contains_session: {
+      source: "Conversation",
+      target: "AgentSession",
+      requires_evidence: false,
+      assertion_basis: ["agent_stats_core"],
+      derivation_method: "session_aggregation",
+    },
+  },
+};
+
+function sha256short(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+async function loadAgentStatsCore(): Promise<ConversationsCore> {
+  try {
+    return await import("@sentropic/agent-stats-core") as ConversationsCore;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      "Conversations extraction requires the optional peer dependency " +
+        "@sentropic/agent-stats-core. Install it in the host project, for example: " +
+        "npm install @sentropic/agent-stats-core. Original import error: " + message,
+    );
+  }
+}
+
+function sumUsage(sessions: ConversationSessionAggregate[]): ConversationUsage {
+  return sessions.reduce(
+    (acc, session) => ({
+      newInputTokens: acc.newInputTokens + session.totalUsage.newInputTokens,
+      cachedInputTokens: acc.cachedInputTokens + session.totalUsage.cachedInputTokens,
+      cacheWriteTokens: acc.cacheWriteTokens + session.totalUsage.cacheWriteTokens,
+      outputTokens: acc.outputTokens + session.totalUsage.outputTokens,
+      reasoningTokens: acc.reasoningTokens + session.totalUsage.reasoningTokens,
+    }),
+    { newInputTokens: 0, cachedInputTokens: 0, cacheWriteTokens: 0, outputTokens: 0, reasoningTokens: 0 },
+  );
+}
+
+function mergeCounts(sessions: ConversationSessionAggregate[], field: "toolCallsByCategory" | "toolCallsByName" | "skillsByName"): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const session of sessions) {
+    for (const [key, value] of Object.entries(session[field])) {
+      counts[key] = (counts[key] ?? 0) + value;
+    }
+  }
+  return counts;
+}
+
+function sessionSourceFile(session: ConversationSessionAggregate): string {
+  return `conversations/${session.tool}/${session.sessionId}`;
+}
+
+function conversationId(projectCwd: string): string {
+  return `conversation:${sha256short(projectCwd)}`;
+}
+
+function sessionId(session: ConversationSessionAggregate): string {
+  return `agent-session:${session.tool}:${session.sessionId}`;
+}
+
+function collectPromptStats(events: ConversationsSessionEvent[]): Map<string, { textLength: number; textHashes: string[] }> {
+  const stats = new Map<string, { textLength: number; textHashes: string[] }>();
+  for (const event of events) {
+    if (event.kind !== "user_prompt") continue;
+    const current = stats.get(event.sessionId) ?? { textLength: 0, textHashes: [] };
+    current.textLength += event.textLength;
+    current.textHashes.push(event.textHash);
+    stats.set(event.sessionId, current);
+  }
+  return stats;
+}
+
+function runGitLog(repoRoot: string, args: string[]): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+/**
+ * Claude sessions expose branch + cwd but not a commit SHA. This helper keeps
+ * the heuristic explicit: choose the closest branch commit whose committer date
+ * falls inside the session time window plus a bounded tolerance.
+ */
+export function resolveClaudeCommit(opts: ClaudeCommitResolveOptions): string | undefined {
+  const windowMs = opts.windowMs ?? 15 * 60 * 1000;
+  const startMs = Date.parse(opts.sessionStart);
+  const endMs = Date.parse(opts.sessionEnd);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs) || opts.branch.trim().length === 0) {
+    return undefined;
+  }
+  const since = new Date(Math.max(0, startMs - windowMs)).toISOString();
+  const until = new Date(endMs + windowMs).toISOString();
+  let output = "";
+  try {
+    output = (opts.runner ?? runGitLog)(opts.repoRoot, [
+      "log",
+      opts.branch,
+      "--format=%H %cI",
+      "--since",
+      since,
+      "--until",
+      until,
+    ]);
+  } catch {
+    return undefined;
+  }
+  let best: { sha: string; distance: number } | undefined;
+  for (const line of output.split("\n")) {
+    const [sha, date] = line.trim().split(/\s+/, 2);
+    if (!sha || !date) continue;
+    const commitMs = Date.parse(date);
+    if (Number.isNaN(commitMs)) continue;
+    const distance = commitMs < startMs ? startMs - commitMs : commitMs > endMs ? commitMs - endMs : 0;
+    if (!best || distance < best.distance) best = { sha, distance };
+  }
+  return best?.sha;
+}
+
+function resolveSessionCommit(
+  session: ConversationSessionAggregate,
+  repoKeyValue: string,
+  opts: Pick<BuildConversationsExtractionOptions, "repoRoot" | "claudeCommitResolver">,
+): string | undefined {
+  if (session.gitCommit) return commitId(repoKeyValue, session.gitCommit);
+  if (session.tool !== "claude" || !session.gitBranch) return undefined;
+  const sha = opts.claudeCommitResolver
+    ? opts.claudeCommitResolver(session)
+    : resolveClaudeCommit({
+      repoRoot: opts.repoRoot,
+      branch: session.gitBranch,
+      sessionStart: session.startTs,
+      sessionEnd: session.endTs,
+    });
+  return sha ? commitId(repoKeyValue, sha) : undefined;
+}
+
+export async function buildConversationsExtraction(
+  opts: BuildConversationsExtractionOptions,
+): Promise<Extraction> {
+  if (!opts.projectCwd) {
+    throw new Error("projectCwd is required for conversations extraction to avoid global agent log ingestion.");
+  }
+
+  const core = opts.core ?? await loadAgentStatsCore();
+  const collected: ConversationsSessionEvent[] = [];
+  for await (const event of core.collect({
+    sources: opts.sources,
+    since: opts.since,
+    until: opts.until,
+    projectCwd: opts.projectCwd,
+    claudeProjectsDir: opts.claudeProjectsDir,
+    codexDbPath: opts.codexDbPath,
+    cursorStateDir: opts.cursorStateDir,
+    geminiTmpDir: opts.geminiTmpDir,
+  })) {
+    if (event.projectCwd !== opts.projectCwd && !opts.projectCwd.endsWith("/")) continue;
+    if (opts.projectCwd.endsWith("/") && !event.projectCwd.startsWith(opts.projectCwd)) continue;
+    collected.push(event);
+  }
+
+  const sessions = await core.aggregateSessions(collected);
+  const promptStats = collectPromptStats(collected);
+  const repoKeyValue = (opts.repoKey ?? defaultRepoKey)(opts.repoRoot);
+  const convId = conversationId(opts.projectCwd);
+  const observedAt = opts.observedAt ?? new Date().toISOString();
+  const sourceHash = sha256short(JSON.stringify({
+    projectCwd: opts.projectCwd,
+    since: opts.since?.toISOString(),
+    until: opts.until?.toISOString(),
+    sessions: sessions.map((session) => [session.tool, session.sessionId, session.startTs, session.endTs]),
+  }));
+
+  const conversationNode: GraphNode = {
+    id: convId,
+    label: `Conversations ${opts.projectCwd}`,
+    file_type: "rationale",
+    source_file: "conversations",
+    confidence: "EXTRACTED",
+    node_type: "Conversation",
+    profile_id: "conversations",
+    project_cwd: opts.projectCwd,
+    session_count: sessions.length,
+    tools: [...new Set(sessions.map((session) => session.tool))].sort(),
+    start_ts: sessions.map((session) => session.startTs).sort()[0] ?? observedAt,
+    end_ts: sessions.map((session) => session.endTs).sort().at(-1) ?? observedAt,
+    total_duration_ms: sessions.reduce((acc, session) => acc + session.durationMs, 0),
+    turns: sessions.reduce((acc, session) => acc + session.turns, 0),
+    total_usage: sumUsage(sessions),
+    tool_call_count: sessions.reduce((acc, session) => acc + session.toolCalls, 0),
+    tool_calls_by_category: mergeCounts(sessions, "toolCallsByCategory"),
+    tool_calls_by_name: mergeCounts(sessions, "toolCallsByName"),
+    skill_invocation_count: sessions.reduce((acc, session) => acc + session.skillInvocations, 0),
+    skills_by_name: mergeCounts(sessions, "skillsByName"),
+    compaction_count: sessions.reduce((acc, session) => acc + session.compactions, 0),
+  };
+
+  const nodes: GraphNode[] = [conversationNode];
+  const edges: GraphEdge[] = [];
+  const commitTargets = new Set<string>();
+
+  for (const session of sessions) {
+    const prompts = promptStats.get(session.sessionId) ?? { textLength: 0, textHashes: [] };
+    const sid = sessionId(session);
+    nodes.push({
+      id: sid,
+      label: `${session.tool} ${session.sessionId}`,
+      file_type: "rationale",
+      source_file: sessionSourceFile(session),
+      confidence: "EXTRACTED",
+      node_type: "AgentSession",
+      profile_id: "conversations",
+      vendor: session.tool,
+      surface: session.surface,
+      session_id: session.sessionId,
+      project_cwd: session.projectCwd,
+      model: session.model,
+      start_ts: session.startTs,
+      end_ts: session.endTs,
+      duration_ms: session.durationMs,
+      turns: session.turns,
+      total_usage: session.totalUsage,
+      git_branch: session.gitBranch,
+      repo_url_hash: session.repoUrl ? sha256short(session.repoUrl) : undefined,
+      is_subagent: session.isSubagent,
+      forked_from_id_hash: session.forkedFromId ? sha256short(session.forkedFromId) : undefined,
+      agent_nickname: session.agentNickname,
+      tool_call_count: session.toolCalls,
+      tool_calls_by_category: session.toolCallsByCategory,
+      tool_calls_by_name: session.toolCallsByName,
+      skill_invocation_count: session.skillInvocations,
+      skills_by_name: session.skillsByName,
+      compaction_count: session.compactions,
+      text_length_total: prompts.textLength,
+      text_hashes: prompts.textHashes,
+      estimated_cost: session.estimatedCost,
+    });
+    edges.push({
+      source: convId,
+      target: sid,
+      relation: "contains_session",
+      confidence: "EXTRACTED",
+      source_file: sessionSourceFile(session),
+      node_type: "Conversation",
+      target_node_type: "AgentSession",
+    });
+
+    const target = resolveSessionCommit(session, repoKeyValue, opts);
+    if (target) {
+      commitTargets.add(target);
+      edges.push({
+        source: sid,
+        target,
+        relation: "references_commit",
+        confidence: session.gitCommit ? "EXTRACTED" : "INFERRED",
+        source_file: sessionSourceFile(session),
+        assertion_basis: session.gitCommit ? "agent_stats_core_git_commit" : "claude_git_log_time_window",
+        derivation_method: session.gitCommit ? "codex_session_meta_git" : "claude_branch_time_window_git_log",
+      });
+    }
+  }
+
+  for (const target of commitTargets) {
+    edges.push({
+      source: convId,
+      target,
+      relation: "references_commit",
+      confidence: "INFERRED",
+      source_file: "conversations",
+      assertion_basis: "session_commit_aggregation",
+      derivation_method: "conversation_commit_rollup",
+    });
+  }
+
+  return {
+    provenance: {
+      source_owner: "conversations",
+      source_id: opts.projectCwd,
+      observed_at: observedAt,
+      source_hash: sourceHash,
+      adapter_version: `${CONVERSATIONS_ADAPTER_VERSION}; agent-stats-core/${core.VERSION ?? AGENT_STATS_CORE_VERSION}`,
+    },
+    nodes,
+    edges,
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,20 @@ export type {
   FuzzyMatchResult,
   OntologyReconciliationCandidateTier,
 } from "./ontology-reconciliation.js";
+export {
+  AGENT_STATS_CORE_VERSION,
+  CONVERSATIONS_ADAPTER_VERSION,
+  CONVERSATIONS_ONTOLOGY_PROFILE,
+  buildConversationsExtraction,
+  resolveClaudeCommit,
+} from "./conversations.js";
+export type {
+  BuildConversationsExtractionOptions,
+  ClaudeCommitResolveOptions,
+  ConversationSessionAggregate,
+  ConversationsCore,
+  ConversationsSessionEvent,
+} from "./conversations.js";
 export { cleanupStaleNodes } from "./semantic-cleanup.js";
 export type { CleanupStaleNodesOptions, CleanupStaleNodesResult } from "./semantic-cleanup.js";
 export { cloneRepo, defaultCloneDestination } from "./repo-clone.js";

--- a/src/types/optional-deps.d.ts
+++ b/src/types/optional-deps.d.ts
@@ -32,3 +32,9 @@ declare module "@sentropic/design-system/tokens" {
   const defaultTokens: WorkspaceThemedTokens;
   export default defaultTokens;
 }
+
+declare module "@sentropic/agent-stats-core" {
+  export const VERSION: string;
+  export function collect(opts?: unknown): AsyncGenerator<unknown, void, unknown>;
+  export function aggregateSessions(events: AsyncIterable<unknown> | Iterable<unknown>): Promise<unknown[]>;
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -18,6 +18,10 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function isExternalReferenceId(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith("commit:");
+}
+
 /**
  * Validate an extraction JSON dict against the graphify schema.
  * Returns a list of error strings - empty list means valid.
@@ -115,10 +119,10 @@ export function validateExtraction(data: unknown): string[] {
       if ("target" in edge && !isNonEmptyString(edge.target)) {
         errors.push(`Edge ${i} target must be a non-empty string`);
       }
-      if ("source" in edge && nodeIds.size > 0 && !nodeIds.has(edge.source as string)) {
+      if ("source" in edge && nodeIds.size > 0 && !nodeIds.has(edge.source as string) && !isExternalReferenceId(edge.source)) {
         errors.push(`Edge ${i} source '${edge.source}' does not match any node id`);
       }
-      if ("target" in edge && nodeIds.size > 0 && !nodeIds.has(edge.target as string)) {
+      if ("target" in edge && nodeIds.size > 0 && !nodeIds.has(edge.target as string) && !isExternalReferenceId(edge.target)) {
         errors.push(`Edge ${i} target '${edge.target}' does not match any node id`);
       }
     }

--- a/tests/conversations.test.ts
+++ b/tests/conversations.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildConversationsExtraction,
+  CONVERSATIONS_ONTOLOGY_PROFILE,
+  resolveClaudeCommit,
+  type ConversationsCore,
+  type ConversationsSessionEvent,
+} from "../src/conversations.js";
+import { validateExtraction } from "../src/validate.js";
+import { validateOntologyProfile } from "../src/ontology-profile.js";
+
+const repoRoot = "/home/u/src/demo";
+const repoKeyValue = "repo:github.com/acme/demo";
+const codexSha = "abcdef1234567890abcdef1234567890abcdef12";
+const claudeSha = "bbbbbb1234567890bbbbbb1234567890bbbbbb12";
+
+const events: ConversationsSessionEvent[] = [
+  {
+    kind: "session_start",
+    ts: "2026-05-18T10:00:00.000Z",
+    tool: "codex",
+    sessionId: "codex-session",
+    projectCwd: repoRoot,
+    model: "gpt-5.1-codex",
+    gitBranch: "wp5-conversations",
+    gitCommit: codexSha,
+    repoUrl: "https://github.com/acme/demo.git",
+    isSubagent: false,
+    surface: "cli",
+  },
+  {
+    kind: "user_prompt",
+    ts: "2026-05-18T10:00:02.000Z",
+    tool: "codex",
+    sessionId: "codex-session",
+    projectCwd: repoRoot,
+    textLength: 45,
+    textHash: "1111111111111111",
+  },
+  {
+    kind: "turn",
+    ts: "2026-05-18T10:00:10.000Z",
+    tool: "codex",
+    sessionId: "codex-session",
+    projectCwd: repoRoot,
+    model: "gpt-5.1-codex",
+    usage: {
+      newInputTokens: 100,
+      cachedInputTokens: 20,
+      cacheWriteTokens: 0,
+      outputTokens: 50,
+      reasoningTokens: 5,
+    },
+  },
+  {
+    kind: "tool_call",
+    ts: "2026-05-18T10:00:20.000Z",
+    tool: "codex",
+    sessionId: "codex-session",
+    projectCwd: repoRoot,
+    name: "exec_command",
+    category: "bash",
+    inputBytes: 12,
+    outputBytes: 8,
+  },
+  {
+    kind: "skill_invoke",
+    ts: "2026-05-18T10:00:25.000Z",
+    tool: "codex",
+    sessionId: "codex-session",
+    projectCwd: repoRoot,
+    name: "test-driven-development",
+  },
+  {
+    kind: "session_end",
+    ts: "2026-05-18T10:01:00.000Z",
+    tool: "codex",
+    sessionId: "codex-session",
+    projectCwd: repoRoot,
+  },
+  {
+    kind: "session_start",
+    ts: "2026-05-18T10:04:00.000Z",
+    tool: "claude",
+    sessionId: "claude-session",
+    projectCwd: repoRoot,
+    model: "claude-fable-5",
+    gitBranch: "wp5-conversations",
+    isSubagent: false,
+  },
+  {
+    kind: "user_prompt",
+    ts: "2026-05-18T10:04:02.000Z",
+    tool: "claude",
+    sessionId: "claude-session",
+    projectCwd: repoRoot,
+    textLength: 49,
+    textHash: "2222222222222222",
+  },
+  {
+    kind: "turn",
+    ts: "2026-05-18T10:04:10.000Z",
+    tool: "claude",
+    sessionId: "claude-session",
+    projectCwd: repoRoot,
+    model: "claude-fable-5",
+    usage: {
+      newInputTokens: 200,
+      cachedInputTokens: 30,
+      cacheWriteTokens: 10,
+      outputTokens: 80,
+      reasoningTokens: 0,
+    },
+  },
+  {
+    kind: "tool_call",
+    ts: "2026-05-18T10:04:30.000Z",
+    tool: "claude",
+    sessionId: "claude-session",
+    projectCwd: repoRoot,
+    name: "Read",
+    category: "native",
+  },
+  {
+    kind: "session_end",
+    ts: "2026-05-18T10:05:00.000Z",
+    tool: "claude",
+    sessionId: "claude-session",
+    projectCwd: repoRoot,
+  },
+];
+
+function fakeCore(): ConversationsCore {
+  return {
+    async *collect() {
+      yield* events;
+    },
+    async aggregateSessions(collected) {
+      const bySession = new Map<string, typeof events>();
+      for await (const event of collected) {
+        bySession.set(event.sessionId, [...(bySession.get(event.sessionId) ?? []), event]);
+      }
+      return [...bySession.values()].map((sessionEvents) => {
+        const start = sessionEvents.find((event) => event.kind === "session_start")!;
+        const end = sessionEvents[sessionEvents.length - 1]!;
+        const toolCalls = sessionEvents.filter((event) => event.kind === "tool_call");
+        const skills = sessionEvents.filter((event) => event.kind === "skill_invoke");
+        const turns = sessionEvents.filter((event) => event.kind === "turn");
+        const totalUsage = turns.reduce(
+          (acc, event) => ({
+            newInputTokens: acc.newInputTokens + event.usage.newInputTokens,
+            cachedInputTokens: acc.cachedInputTokens + event.usage.cachedInputTokens,
+            cacheWriteTokens: acc.cacheWriteTokens + event.usage.cacheWriteTokens,
+            outputTokens: acc.outputTokens + event.usage.outputTokens,
+            reasoningTokens: acc.reasoningTokens + event.usage.reasoningTokens,
+          }),
+          { newInputTokens: 0, cachedInputTokens: 0, cacheWriteTokens: 0, outputTokens: 0, reasoningTokens: 0 },
+        );
+        return {
+          sessionId: start.sessionId,
+          tool: start.tool,
+          surface: start.surface,
+          projectCwd: start.projectCwd,
+          model: start.model ?? "unknown",
+          startTs: start.ts,
+          endTs: end.ts,
+          durationMs: Date.parse(end.ts) - Date.parse(start.ts),
+          turns: turns.length,
+          totalUsage,
+          gitBranch: start.gitBranch,
+          gitCommit: start.gitCommit,
+          repoUrl: start.repoUrl,
+          isSubagent: start.isSubagent,
+          toolCalls: toolCalls.length,
+          toolCallsByCategory: Object.fromEntries(toolCalls.map((event) => [event.category, 1])),
+          toolCallsByName: Object.fromEntries(toolCalls.map((event) => [event.name, 1])),
+          skillInvocations: skills.length,
+          skillsByName: Object.fromEntries(skills.map((event) => [event.name, 1])),
+          compactions: 0,
+          estimatedCost: { codexCredits: 0, claudeUsdCents: 0, unknown: 0 },
+        };
+      });
+    },
+  };
+}
+
+describe("conversations connector", () => {
+  it("declares a conversations ontology profile for Conversation and AgentSession", () => {
+    expect(validateOntologyProfile(CONVERSATIONS_ONTOLOGY_PROFILE)).toEqual([]);
+    expect(Object.keys(CONVERSATIONS_ONTOLOGY_PROFILE.node_types).sort()).toEqual([
+      "AgentSession",
+      "Conversation",
+    ]);
+  });
+
+  it("builds a validateExtraction-compatible fragment with commit edges and redacted aggregates", async () => {
+    const extraction = await buildConversationsExtraction({
+      projectCwd: repoRoot,
+      repoRoot,
+      core: fakeCore(),
+      repoKey: () => repoKeyValue,
+      claudeCommitResolver: () => claudeSha,
+      observedAt: "2026-05-18T11:00:00.000Z",
+    });
+
+    expect(validateExtraction(extraction)).toEqual([]);
+    expect(extraction.provenance).toMatchObject({
+      source_owner: "conversations",
+      source_id: repoRoot,
+      observed_at: "2026-05-18T11:00:00.000Z",
+      adapter_version: "graphify-conversations/0.1.0; agent-stats-core/0.3.0",
+    });
+
+    const nodeTypes = extraction.nodes.map((node) => node.node_type).sort();
+    expect(nodeTypes).toEqual(["AgentSession", "AgentSession", "Conversation"]);
+    expect(extraction.nodes.every((node) => node.file_type === "rationale")).toBe(true);
+
+    const conversation = extraction.nodes.find((node) => node.node_type === "Conversation")!;
+    expect(conversation.session_count).toBe(2);
+    expect(conversation.tool_call_count).toBe(2);
+    expect(conversation.skill_invocation_count).toBe(1);
+
+    const codex = extraction.nodes.find((node) => node.id === "agent-session:codex:codex-session")!;
+    expect(codex.tool_call_count).toBe(1);
+    expect(codex.tool_calls_by_name).toEqual({ exec_command: 1 });
+    expect(codex.skill_invocation_count).toBe(1);
+    expect(codex.skills_by_name).toEqual({ "test-driven-development": 1 });
+    expect(codex.text_length_total).toBe(45);
+    expect(codex.text_hashes).toEqual(["1111111111111111"]);
+
+    const targets = extraction.edges.map((edge) => edge.target).sort();
+    expect(targets).toContain(`commit:${repoKeyValue}@${codexSha}`);
+    expect(targets).toContain(`commit:${repoKeyValue}@${claudeSha}`);
+
+    const json = JSON.stringify(extraction);
+    expect(json).not.toContain("Bonjour Claude");
+    expect(json).not.toContain("peux-tu");
+    expect(json).not.toContain("lister les fichiers");
+    expect(json).not.toContain("rawText");
+    expect(json).not.toContain("prompt");
+  });
+
+  it("requires projectCwd to avoid global agent log ingestion", async () => {
+    await expect(
+      buildConversationsExtraction({ repoRoot, core: fakeCore(), repoKey: () => repoKeyValue }),
+    ).rejects.toThrow(/projectCwd is required/i);
+  });
+
+  it("resolves Claude branch-only sessions from a time-windowed local git log", () => {
+    const sha = resolveClaudeCommit({
+      branch: "wp5-conversations",
+      sessionStart: "2026-05-18T10:04:00.000Z",
+      sessionEnd: "2026-05-18T10:05:00.000Z",
+      runner: () => [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 2026-05-18T09:00:00+00:00",
+        `${claudeSha} 2026-05-18T10:04:30+00:00`,
+      ].join("\n"),
+      repoRoot,
+    });
+
+    expect(sha).toBe(claudeSha);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "tsup";
 
 const optionalRuntimeDeps = [
   "@mixmark-io/domino",
+  "@sentropic/agent-stats-core",
+  "@sentropic/agent-stats-core/*",
   "@modelcontextprotocol/sdk",
   "@modelcontextprotocol/sdk/*",
   "chokidar",


### PR DESCRIPTION
WP5 sous MANDATE-graphify. Exécuté par codex headless (détaché), **vérifié + rebasé + commité par le conducteur**.

**Fait** : `src/conversations.ts` — connecteur conversations 4 vendeurs → `Extraction`. Nœuds **Conversation + AgentSession seulement** (ToolUse/SkillUse en agrégats). **agent-stats-core en peer dependency OPTIONNELLE** (peerDependenciesMeta.optional + await import() + external tsup ; pattern neo4j-driver). Jointure commit : codex direct (`git.commit_hash`), claude via `resolveClaudeCommit()` (git log ±15min) → `confidence=INFERRED`. Filtre `projectCwd` obligatoire. Provenance WP3. Profil `CONVERSATIONS_ONTOLOGY_PROFILE`.

**Redaction** (auditée) : `textLength`+`textHash` seulement, `repo_url_hash` (pas d'URL), aucun texte/args/stdout brut. `validateExtraction` accepte `commit:` comme réf cross-profil.

**Vérif (hors sandbox)** : suite **1834 passed / 0 failed** (196 fichiers) ; lint OK ; rebasé sur main (conflit index.ts résolu : exports conversations + assembly-hygiene/ontology-reconciliation conservés).

**Note conducteur** : endpoint cross-profil `references_commit` laissé au registre ontologie (non bloquant). Volumétrie : aucune instance ToolUse/SkillUse (les 10⁵-10⁶ events restent dans l'agrégation agent-stats-core).

Rapport : `segmentation/wp/WP5-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)