### PR TITLE
feat(gh): extract pull requests to Extraction (WP9)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2599,7 +2599,8 @@ export async function main(): Promise<void> {
     program.command(`${name} [selector]`)
       .description("Inspect local GitHub pull requests through gh and git worktree data")
       .option("--limit <n>", "Maximum PRs to list", String(30))
-      .option("--state <state>", "PR state for list/conflicts/worktrees", "open")
+      .option("--state <state>", "PR state for list/conflicts/worktrees/extract")
+      .option("--extract-gh", "Explicitly opt in to networked gh PR extraction")
       .action(async (selector: string | undefined, opts) => {
         const {
           formatPrWorktrees,
@@ -2612,8 +2613,17 @@ export async function main(): Promise<void> {
           listPullRequests,
         } = await import("./pr.js");
         const limit = parsePositiveIntegerOption(opts.limit, "--limit") ?? 30;
-        const state = opts.state;
         const command = selector ?? "list";
+        const state = opts.state ?? (command === "extract" ? "all" : "open");
+        if (command === "extract") {
+          if (opts.extractGh !== true) {
+            console.error("error: PR extraction requires the explicit --extract-gh opt-in flag");
+            process.exit(1);
+          }
+          const { extractPullRequests } = await import("./extract-gh.js");
+          console.log(JSON.stringify(extractPullRequests(".", { enabled: true, limit, state }), null, 2));
+          return;
+        }
         if (command === "list") {
           console.log(formatPullRequestList(listPullRequests({ limit, state })));
           return;
@@ -2628,7 +2638,7 @@ export async function main(): Promise<void> {
         }
         const parsedNumber = Number.parseInt(command, 10);
         if (!Number.isFinite(parsedNumber) || String(parsedNumber) !== command || parsedNumber <= 0) {
-          console.error("error: PR selector must be one of list, conflicts, worktrees, or a positive PR number");
+          console.error("error: PR selector must be one of list, conflicts, worktrees, extract, or a positive PR number");
           process.exit(1);
         }
         console.log(formatPullRequestDetails(getPullRequest(parsedNumber)));

--- a/src/extract-gh.ts
+++ b/src/extract-gh.ts
@@ -109,11 +109,14 @@ function positiveInteger(value: number | undefined, fallback: number): number {
   return Math.max(1, Math.floor(value));
 }
 
-function shortSha(value: string | undefined): string | undefined {
+// Returns the FULL commit sha (not truncated) so the commit: ids emitted here
+// join the git extractor's nodes, which use full shas (extract-git.ts uses
+// `git show -s --format=%H`). Truncating would break the cross-profile join.
+function commitSha(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   const match = trimmed.match(/[0-9a-f]{7,64}/i);
-  return match ? match[0]!.slice(0, 12) : undefined;
+  return match ? match[0]! : undefined;
 }
 
 function uniqueSorted(values: Array<string | undefined>): string[] {
@@ -228,15 +231,14 @@ export function extractPullRequests(root: string = ".", options: ExtractPullRequ
       edges.push(extractedEdge(id, branchId(repoKeyStr, details.baseRefName), "INTO_BRANCH", "gh_pr_ref"));
     }
 
-    const commits = uniqueSorted([
-      ...merge.commits.map(shortSha),
-      ...details.commits.map(shortSha),
-    ]);
+    // Source commit shas from the merge query (raw full oids), not from
+    // getPullRequest().commits which is a display string with 12-char oids.
+    const commits = uniqueSorted(merge.commits.map(commitSha));
     for (const sha of commits) {
       edges.push(extractedEdge(id, commitId(repoKeyStr, sha), "CONTAINS_COMMIT", "gh_pr_commits"));
     }
 
-    const mergeCommit = shortSha(merge.mergeCommit);
+    const mergeCommit = commitSha(merge.mergeCommit);
     if (mergeCommit) {
       edges.push(extractedEdge(id, commitId(repoKeyStr, mergeCommit), "MERGED_AS", "gh_pr_merge_commit"));
     }

--- a/src/extract-gh.ts
+++ b/src/extract-gh.ts
@@ -1,0 +1,263 @@
+import { createHash } from "node:crypto";
+
+import {
+  getPullRequest,
+  getPullRequestMerge,
+  listPullRequests,
+  type CommandRunner,
+  type PullRequestCheck,
+} from "./pr.js";
+import { branchId, commitId, prId, repoKey } from "./repo-key.js";
+import type { Extraction, GraphEdge, GraphNode, OntologyProfile } from "./types.js";
+
+export const GH_EXTRACT_ADAPTER_VERSION = "graphify-gh/1";
+export const GH_EXTRACTION_TTL = "PT4H";
+
+const DEFAULT_LIMIT = 30;
+const DEFAULT_STATE = "all";
+
+const PASSED_CHECKS = new Set(["SUCCESS", "PASSED", "PASS"]);
+const FAILED_CHECKS = new Set([
+  "ACTION_REQUIRED",
+  "CANCELLED",
+  "ERROR",
+  "FAILED",
+  "FAILURE",
+  "STARTUP_FAILURE",
+  "TIMED_OUT",
+]);
+const PENDING_CHECKS = new Set(["EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"]);
+
+export const GH_ONTOLOGY_PROFILE: OntologyProfile = {
+  id: "gh",
+  version: 1,
+  node_types: {
+    PullRequest: {
+      aliases: ["GitHub pull request", "PR"],
+      source_backed: true,
+    },
+    // Compatibility endpoint types for cross-profile references emitted as
+    // branch:/commit: ids. The extractor does not create these nodes.
+    Branch: {
+      aliases: ["git branch", "ref"],
+      source_backed: true,
+    },
+    Commit: {
+      aliases: ["git commit", "revision"],
+      source_backed: true,
+    },
+  },
+  relation_types: {
+    FROM_BRANCH: {
+      source: "PullRequest",
+      target: "Branch",
+      derivation_method: "gh_pr_ref",
+    },
+    INTO_BRANCH: {
+      source: "PullRequest",
+      target: "Branch",
+      derivation_method: "gh_pr_ref",
+    },
+    CONTAINS_COMMIT: {
+      source: "PullRequest",
+      target: "Commit",
+      derivation_method: "gh_pr_commits",
+    },
+    MERGED_AS: {
+      source: "PullRequest",
+      target: "Commit",
+      derivation_method: "gh_pr_merge_commit",
+    },
+  },
+};
+
+export interface ExtractPullRequestsOptions {
+  cwd?: string;
+  runner?: CommandRunner;
+  enabled?: boolean;
+  limit?: number;
+  state?: string;
+  observedAt?: string;
+  ttl?: string;
+}
+
+interface CheckAggregate {
+  checks_total: number;
+  checks_passed: number;
+  checks_failed: number;
+  checks_pending: number;
+  checks_other: number;
+  checks_conclusion: string;
+  check_runs?: PullRequestCheck[];
+}
+
+function emptyExtraction(): Extraction {
+  return {
+    nodes: [],
+    edges: [],
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.floor(value));
+}
+
+function shortSha(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const match = trimmed.match(/[0-9a-f]{7,64}/i);
+  return match ? match[0]!.slice(0, 12) : undefined;
+}
+
+function uniqueSorted(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))].sort();
+}
+
+function checkBucket(check: PullRequestCheck): "passed" | "failed" | "pending" | "other" {
+  const conclusion = check.conclusion.toUpperCase();
+  if (PASSED_CHECKS.has(conclusion)) return "passed";
+  if (FAILED_CHECKS.has(conclusion)) return "failed";
+  if (PENDING_CHECKS.has(conclusion)) return "pending";
+  return "other";
+}
+
+function normalizeCheck(check: PullRequestCheck): PullRequestCheck {
+  return {
+    name: check.name,
+    conclusion: check.conclusion.toUpperCase(),
+    ...(check.url ? { url: check.url } : {}),
+  };
+}
+
+function aggregateChecks(checks: PullRequestCheck[]): CheckAggregate {
+  const normalized = checks.map(normalizeCheck);
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  let other = 0;
+  for (const check of normalized) {
+    const bucket = checkBucket(check);
+    if (bucket === "passed") passed += 1;
+    else if (bucket === "failed") failed += 1;
+    else if (bucket === "pending") pending += 1;
+    else other += 1;
+  }
+
+  const total = normalized.length;
+  const conclusion =
+    total === 0 ? "NONE" : failed > 0 ? "FAILURE" : pending > 0 ? "PENDING" : other > 0 ? "MIXED" : "SUCCESS";
+  return {
+    checks_total: total,
+    checks_passed: passed,
+    checks_failed: failed,
+    checks_pending: pending,
+    checks_other: other,
+    checks_conclusion: conclusion,
+    ...(normalized.length > 0 ? { check_runs: normalized } : {}),
+  };
+}
+
+function prNode(repoKeyStr: string, pr: ReturnType<typeof getPullRequest>): GraphNode {
+  const checks = aggregateChecks(pr.checkRuns);
+  return {
+    id: prId(repoKeyStr, pr.number),
+    label: `#${pr.number} ${pr.title}`,
+    file_type: "concept",
+    source_file: "gh",
+    node_type: "PullRequest",
+    repo: repoKeyStr,
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    is_draft: pr.isDraft,
+    base_branch: pr.baseRefName,
+    head_branch: pr.headRefName,
+    ...(pr.author ? { author: pr.author } : {}),
+    ...(pr.url ? { url: pr.url } : {}),
+    ...(pr.reviewDecision ? { review_decision: pr.reviewDecision } : {}),
+    ...(pr.mergeStateStatus ?? pr.mergeable ? { merge_state: pr.mergeStateStatus ?? pr.mergeable } : {}),
+    ...(pr.updatedAt ? { updated_at: pr.updatedAt } : {}),
+    ...(pr.body ? { body_length: pr.body.length, body_hash: sha256(pr.body) } : {}),
+    ...checks,
+  };
+}
+
+function edgeKey(edge: GraphEdge): string {
+  return `${edge.source}\0${edge.target}\0${edge.relation}\0${String(edge.source_file ?? "")}`;
+}
+
+function extractedEdge(source: string, target: string, relation: string, derivationMethod: string): GraphEdge {
+  return {
+    source,
+    target,
+    relation,
+    confidence: "EXTRACTED",
+    source_file: "gh",
+    derivation_method: derivationMethod,
+  };
+}
+
+export function extractPullRequests(root: string = ".", options: ExtractPullRequestsOptions = {}): Extraction {
+  if (options.enabled !== true) return emptyExtraction();
+
+  const cwd = options.cwd ?? root;
+  const limit = positiveInteger(options.limit, DEFAULT_LIMIT);
+  const state = options.state ?? DEFAULT_STATE;
+  const repoKeyStr = repoKey(cwd, options.runner);
+  const summaries = listPullRequests({ cwd, runner: options.runner, limit, state });
+
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  for (const summary of summaries) {
+    const details = getPullRequest(summary.number, { cwd, runner: options.runner });
+    const merge = getPullRequestMerge(summary.number, { cwd, runner: options.runner });
+    const id = prId(repoKeyStr, details.number);
+    nodes.push(prNode(repoKeyStr, details));
+
+    if (details.headRefName) {
+      edges.push(extractedEdge(id, branchId(repoKeyStr, details.headRefName), "FROM_BRANCH", "gh_pr_ref"));
+    }
+    if (details.baseRefName) {
+      edges.push(extractedEdge(id, branchId(repoKeyStr, details.baseRefName), "INTO_BRANCH", "gh_pr_ref"));
+    }
+
+    const commits = uniqueSorted([
+      ...merge.commits.map(shortSha),
+      ...details.commits.map(shortSha),
+    ]);
+    for (const sha of commits) {
+      edges.push(extractedEdge(id, commitId(repoKeyStr, sha), "CONTAINS_COMMIT", "gh_pr_commits"));
+    }
+
+    const mergeCommit = shortSha(merge.mergeCommit);
+    if (mergeCommit) {
+      edges.push(extractedEdge(id, commitId(repoKeyStr, mergeCommit), "MERGED_AS", "gh_pr_merge_commit"));
+    }
+  }
+
+  const dedupedEdges = new Map<string, GraphEdge>();
+  for (const edge of edges) dedupedEdges.set(edgeKey(edge), edge);
+  const resultEdges = [...dedupedEdges.values()];
+
+  return {
+    provenance: {
+      source_owner: "gh",
+      source_id: repoKeyStr,
+      observed_at: options.observedAt ?? new Date().toISOString(),
+      source_hash: sha256(JSON.stringify({ repo: repoKeyStr, nodes, edges: resultEdges })),
+      adapter_version: GH_EXTRACT_ADAPTER_VERSION,
+      ttl: options.ttl ?? GH_EXTRACTION_TTL,
+    },
+    nodes,
+    edges: resultEdges,
+    input_tokens: 0,
+    output_tokens: 0,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,13 @@ export {
   extractGit,
   mergeExtractions,
 } from "./extract-git.js";
+export {
+  GH_EXTRACT_ADAPTER_VERSION,
+  GH_EXTRACTION_TTL,
+  GH_ONTOLOGY_PROFILE,
+  extractPullRequests,
+} from "./extract-gh.js";
+export type { ExtractPullRequestsOptions } from "./extract-gh.js";
 export { fileHash, loadCached, saveCached, checkSemanticCache, saveSemanticCache } from "./cache.js";
 export {
   MAX_SEMANTIC_FRAGMENT_BYTES,

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -20,11 +20,18 @@ export interface PullRequestSummary {
   updatedAt?: string;
 }
 
+export interface PullRequestCheck {
+  name: string;
+  conclusion: string;
+  url?: string;
+}
+
 export interface PullRequestDetails extends PullRequestSummary {
   body?: string;
   files: string[];
   commits: string[];
   checks: string[];
+  checkRuns: PullRequestCheck[];
 }
 
 export interface WorktreePrInfo {
@@ -101,6 +108,23 @@ function authorLogin(value: unknown): string | undefined {
   return normalizeString(login);
 }
 
+function checkUrl(value: Record<string, unknown>): string | undefined {
+  return normalizeString(value.detailsUrl) ?? normalizeString(value.targetUrl) ?? normalizeString(value.url);
+}
+
+function normalizeCheckRun(value: unknown): PullRequestCheck | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const item = value as Record<string, unknown>;
+  const name = normalizeString(item.name) ?? normalizeString(item.context);
+  const conclusion = normalizeString(item.conclusion) ?? normalizeString(item.state) ?? normalizeString(item.status);
+  if (!name || !conclusion) return undefined;
+  return {
+    name,
+    conclusion,
+    ...(checkUrl(item) ? { url: checkUrl(item) } : {}),
+  };
+}
+
 function parseJson<T>(raw: string, label: string): T {
   try {
     return JSON.parse(raw) as T;
@@ -163,23 +187,19 @@ function normalizePrDetails(value: unknown): PullRequestDetails {
       })
       .filter((commit): commit is string => Boolean(commit))
     : [];
-  const checks = Array.isArray(item.statusCheckRollup)
+  const checkRuns = Array.isArray(item.statusCheckRollup)
     ? item.statusCheckRollup
-      .map((check) => {
-        if (!check || typeof check !== "object") return undefined;
-        const c = check as Record<string, unknown>;
-        const name = normalizeString(c.name) ?? normalizeString(c.context);
-        const conclusion = normalizeString(c.conclusion) ?? normalizeString(c.state) ?? normalizeString(c.status);
-        return [name, conclusion].filter(Boolean).join(": ");
-      })
-      .filter((check): check is string => Boolean(check))
+      .map(normalizeCheckRun)
+      .filter((check): check is PullRequestCheck => Boolean(check))
     : [];
+  const checks = checkRuns.map((check) => [check.name, check.conclusion].filter(Boolean).join(": "));
   return {
     ...summary,
     body: normalizeString(item.body),
     files,
     commits,
     checks,
+    checkRuns,
   };
 }
 

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -249,7 +249,7 @@ export interface PrMergeInfo {
   headRefName?: string;
   /** Full sha of the commit that landed on the base branch, if merged. */
   mergeCommit?: string;
-  /** Abbreviated (12-char) shas of the PR's branch commits. */
+  /** Full shas of the PR's branch commits (joins the git extractor's commit: ids). */
   commits: string[];
 }
 
@@ -267,7 +267,6 @@ function normalizePrMerge(value: unknown): PrMergeInfo {
         ? normalizeString((commit as { oid?: unknown }).oid)
         : undefined)
       .filter((oid): oid is string => Boolean(oid))
-      .map((oid) => oid.slice(0, 12))
     : [];
   return {
     number,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -18,8 +18,13 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function isExternalReferenceId(value: unknown): boolean {
-  return typeof value === "string" && value.startsWith("commit:");
+// Cross-profile references: an edge endpoint may point at a node owned by
+// another extraction profile (a `commit:`/`branch:` id from extract-git, or a
+// `commit:` id from the conversations connector). These are legitimately absent
+// from this fragment's node set, so they are not dangling edges.
+export function isExternalReferenceId(value: unknown): boolean {
+  if (!isNonEmptyString(value)) return false;
+  return value.startsWith("commit:") || value.startsWith("branch:");
 }
 
 /**

--- a/tests/agent-stats-phase1.test.ts
+++ b/tests/agent-stats-phase1.test.ts
@@ -206,7 +206,10 @@ describe("pr.getPullRequestMerge (gh runner mock)", () => {
     expect(info.number).toBe(130);
     expect(info.headRefName).toBe("feat/agent-stats-mvp");
     expect(info.mergeCommit).toBe("613bf6100000000000000000000000000000abcd");
-    expect(info.commits).toEqual(["8f2fbf400000", "aaaaaaa00000"]);
+    expect(info.commits).toEqual([
+      "8f2fbf400000000000000000000000000000abcd",
+      "aaaaaaa00000000000000000000000000000abcd",
+    ]);
   });
 
   it("returns undefined mergeCommit for an unmerged PR", () => {

--- a/tests/extract-gh.test.ts
+++ b/tests/extract-gh.test.ts
@@ -164,7 +164,7 @@ describe("extractPullRequests", () => {
         }),
         expect.objectContaining({
           source: prId(KEY, 42),
-          target: commitId(KEY, headSha.slice(0, 12)),
+          target: commitId(KEY, headSha),
           relation: "CONTAINS_COMMIT",
         }),
       ]),
@@ -223,21 +223,34 @@ describe("extractPullRequests", () => {
       expect.arrayContaining([
         expect.objectContaining({
           source: prId(KEY, 77),
-          target: commitId(KEY, firstSha.slice(0, 12)),
+          target: commitId(KEY, firstSha),
           relation: "CONTAINS_COMMIT",
         }),
         expect.objectContaining({
           source: prId(KEY, 77),
-          target: commitId(KEY, secondSha.slice(0, 12)),
+          target: commitId(KEY, secondSha),
           relation: "CONTAINS_COMMIT",
         }),
         expect.objectContaining({
           source: prId(KEY, 77),
-          target: commitId(KEY, mergeSha.slice(0, 12)),
+          target: commitId(KEY, mergeSha),
           relation: "MERGED_AS",
         }),
       ]),
     );
+
+    // Interop with the git extractor (WP2): commit: ids MUST be the FULL sha,
+    // not truncated, or CONTAINS_COMMIT/MERGED_AS never join the Commit nodes
+    // emitted by extract-git (which uses `git show -s --format=%H`, full shas).
+    const commitTargets = extraction.edges
+      .filter((e) => e.relation === "CONTAINS_COMMIT" || e.relation === "MERGED_AS")
+      .map((e) => e.target);
+    expect(commitTargets).toContain(commitId(KEY, firstSha));
+    expect(commitTargets).toContain(commitId(KEY, mergeSha));
+    for (const target of commitTargets) {
+      const sha = target.split("@").at(-1)!;
+      expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    }
   });
 
   it("aggregates mixed check conclusions without storing logs", () => {

--- a/tests/extract-gh.test.ts
+++ b/tests/extract-gh.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+
+import { extractPullRequests, GH_ONTOLOGY_PROFILE } from "../src/extract-gh.js";
+import { normalizeOntologyProfile } from "../src/ontology-profile.js";
+import { branchId, commitId, prId } from "../src/repo-key.js";
+import { validateExtraction } from "../src/validate.js";
+import type { CommandRunner } from "../src/pr.js";
+
+const GH_LIST_FIELDS =
+  "number,title,state,isDraft,headRefName,baseRefName,author,url,mergeable,mergeStateStatus,reviewDecision,updatedAt";
+const GH_VIEW_FIELDS =
+  "number,title,state,isDraft,headRefName,baseRefName,author,url,mergeable,mergeStateStatus,reviewDecision,updatedAt,body,files,commits,statusCheckRollup";
+const GH_MERGE_FIELDS = "number,mergeCommit,commits,headRefName";
+const REMOTE = "https://github.com/rhanka/graphify.git";
+const KEY = "repo:github.com/rhanka/graphify";
+
+function fakeRunner(responses: Record<string, unknown>): CommandRunner & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    run(command: string, args: string[]): string {
+      const key = [command, ...args].join(" ");
+      calls.push(key);
+      if (!(key in responses)) {
+        throw new Error(`unexpected command: ${key}`);
+      }
+      const value = responses[key];
+      return typeof value === "string" ? value : JSON.stringify(value);
+    },
+  };
+}
+
+function listCommand(limit = 10): string {
+  return `gh pr list --repo rhanka/graphify --state all --limit ${limit} --json ${GH_LIST_FIELDS}`;
+}
+
+function viewCommand(number: number): string {
+  return `gh pr view ${number} --repo rhanka/graphify --json ${GH_VIEW_FIELDS}`;
+}
+
+function mergeCommand(number: number): string {
+  return `gh pr view ${number} --repo rhanka/graphify --json ${GH_MERGE_FIELDS}`;
+}
+
+describe("extractPullRequests", () => {
+  it("is disabled unless the caller opts in explicitly", () => {
+    const runner = fakeRunner({});
+
+    const extraction = extractPullRequests(".", { runner, enabled: false });
+
+    expect(extraction).toEqual({ nodes: [], edges: [], input_tokens: 0, output_tokens: 0 });
+    expect(runner.calls).toEqual([]);
+  });
+
+  it("extracts an open PR as a sanitized PullRequest node with branch and commit references", () => {
+    const headSha = "abc1234567890abc1234567890abc1234567890abc";
+    const runner = fakeRunner({
+      "git remote get-url origin": REMOTE,
+      [listCommand()]: [
+        {
+          number: 42,
+          title: "Add GH extraction",
+          state: "OPEN",
+          isDraft: false,
+          headRefName: "feature/wp9",
+          baseRefName: "main",
+          author: { login: "dev" },
+          url: "https://github.com/rhanka/graphify/pull/42",
+          mergeStateStatus: "CLEAN",
+          reviewDecision: "APPROVED",
+          updatedAt: "2026-06-15T10:00:00Z",
+        },
+      ],
+      [viewCommand(42)]: {
+        number: 42,
+        title: "Add GH extraction",
+        state: "OPEN",
+        isDraft: false,
+        headRefName: "feature/wp9",
+        baseRefName: "main",
+        author: { login: "dev" },
+        url: "https://github.com/rhanka/graphify/pull/42",
+        mergeStateStatus: "CLEAN",
+        reviewDecision: "APPROVED",
+        updatedAt: "2026-06-15T10:00:00Z",
+        body: "Implementation notes with ghp_body_secret_token and raw prose.",
+        commits: [{ oid: headSha, messageHeadline: "do not need headline in extraction" }],
+        statusCheckRollup: [
+          {
+            name: "unit",
+            conclusion: "SUCCESS",
+            detailsUrl: "https://github.com/rhanka/graphify/actions/runs/1",
+          },
+        ],
+      },
+      [mergeCommand(42)]: {
+        number: 42,
+        headRefName: "feature/wp9",
+        commits: [{ oid: headSha }],
+      },
+    });
+
+    const extraction = extractPullRequests(".", {
+      runner,
+      enabled: true,
+      limit: 10,
+      observedAt: "2026-06-15T12:00:00.000Z",
+    });
+
+    expect(validateExtraction(extraction)).toEqual([]);
+    expect(extraction.provenance).toMatchObject({
+      source_owner: "gh",
+      source_id: KEY,
+      observed_at: "2026-06-15T12:00:00.000Z",
+      adapter_version: "graphify-gh/1",
+      ttl: "PT4H",
+    });
+    expect(extraction.provenance?.source_hash).toMatch(/^[a-f0-9]{64}$/);
+
+    expect(extraction.nodes).toEqual([
+      expect.objectContaining({
+        id: prId(KEY, 42),
+        label: "#42 Add GH extraction",
+        node_type: "PullRequest",
+        number: 42,
+        title: "Add GH extraction",
+        state: "OPEN",
+        is_draft: false,
+        head_branch: "feature/wp9",
+        base_branch: "main",
+        author: "dev",
+        url: "https://github.com/rhanka/graphify/pull/42",
+        review_decision: "APPROVED",
+        merge_state: "CLEAN",
+        updated_at: "2026-06-15T10:00:00Z",
+        body_length: 62,
+        body_hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        checks_total: 1,
+        checks_passed: 1,
+        checks_failed: 0,
+        checks_conclusion: "SUCCESS",
+        check_runs: [
+          {
+            name: "unit",
+            conclusion: "SUCCESS",
+            url: "https://github.com/rhanka/graphify/actions/runs/1",
+          },
+        ],
+      }),
+    ]);
+    expect(extraction.nodes[0]).not.toHaveProperty("body");
+
+    expect(extraction.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: prId(KEY, 42),
+          target: branchId(KEY, "feature/wp9"),
+          relation: "FROM_BRANCH",
+        }),
+        expect.objectContaining({
+          source: prId(KEY, 42),
+          target: branchId(KEY, "main"),
+          relation: "INTO_BRANCH",
+        }),
+        expect.objectContaining({
+          source: prId(KEY, 42),
+          target: commitId(KEY, headSha.slice(0, 12)),
+          relation: "CONTAINS_COMMIT",
+        }),
+      ]),
+    );
+
+    const serialized = JSON.stringify(extraction);
+    expect(serialized).not.toContain("ghp_body_secret_token");
+    expect(serialized).not.toContain("raw prose");
+    expect(serialized).not.toContain("do not need headline");
+  });
+
+  it("adds MERGED_AS for a squash-merged PR and preserves original branch commits", () => {
+    const firstSha = "111111111111aaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const secondSha = "222222222222bbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const mergeSha = "999999999999cccccccccccccccccccccccccccc";
+    const runner = fakeRunner({
+      "git remote get-url origin": REMOTE,
+      [listCommand()]: [
+        {
+          number: 77,
+          title: "Squash me",
+          state: "MERGED",
+          isDraft: false,
+          headRefName: "feature/squash",
+          baseRefName: "main",
+          author: { login: "dev" },
+          url: "https://github.com/rhanka/graphify/pull/77",
+          mergeStateStatus: "CLEAN",
+          updatedAt: "2026-06-15T11:00:00Z",
+        },
+      ],
+      [viewCommand(77)]: {
+        number: 77,
+        title: "Squash me",
+        state: "MERGED",
+        isDraft: false,
+        headRefName: "feature/squash",
+        baseRefName: "main",
+        author: { login: "dev" },
+        url: "https://github.com/rhanka/graphify/pull/77",
+        mergeStateStatus: "CLEAN",
+        updatedAt: "2026-06-15T11:00:00Z",
+        commits: [{ oid: firstSha }, { oid: secondSha }],
+      },
+      [mergeCommand(77)]: {
+        number: 77,
+        headRefName: "feature/squash",
+        mergeCommit: { oid: mergeSha },
+        commits: [{ oid: firstSha }, { oid: secondSha }],
+      },
+    });
+
+    const extraction = extractPullRequests(".", { runner, enabled: true, limit: 10 });
+
+    expect(extraction.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: prId(KEY, 77),
+          target: commitId(KEY, firstSha.slice(0, 12)),
+          relation: "CONTAINS_COMMIT",
+        }),
+        expect.objectContaining({
+          source: prId(KEY, 77),
+          target: commitId(KEY, secondSha.slice(0, 12)),
+          relation: "CONTAINS_COMMIT",
+        }),
+        expect.objectContaining({
+          source: prId(KEY, 77),
+          target: commitId(KEY, mergeSha.slice(0, 12)),
+          relation: "MERGED_AS",
+        }),
+      ]),
+    );
+  });
+
+  it("aggregates mixed check conclusions without storing logs", () => {
+    const runner = fakeRunner({
+      "git remote get-url origin": REMOTE,
+      [listCommand()]: [
+        {
+          number: 5,
+          title: "Mixed checks",
+          state: "OPEN",
+          isDraft: false,
+          headRefName: "feature/checks",
+          baseRefName: "main",
+        },
+      ],
+      [viewCommand(5)]: {
+        number: 5,
+        title: "Mixed checks",
+        state: "OPEN",
+        isDraft: false,
+        headRefName: "feature/checks",
+        baseRefName: "main",
+        statusCheckRollup: [
+          { name: "unit", conclusion: "SUCCESS", detailsUrl: "https://example.test/unit" },
+          {
+            name: "lint",
+            conclusion: "FAILURE",
+            detailsUrl: "https://example.test/lint",
+            output: { text: "raw ci log with token ghp_ci_secret" },
+          },
+          { context: "deploy", state: "PENDING", targetUrl: "https://example.test/deploy" },
+        ],
+      },
+      [mergeCommand(5)]: {
+        number: 5,
+        headRefName: "feature/checks",
+        commits: [],
+      },
+    });
+
+    const extraction = extractPullRequests(".", { runner, enabled: true, limit: 10 });
+    const node = extraction.nodes[0]!;
+
+    expect(node).toMatchObject({
+      checks_total: 3,
+      checks_passed: 1,
+      checks_failed: 1,
+      checks_pending: 1,
+      checks_conclusion: "FAILURE",
+      check_runs: [
+        { name: "unit", conclusion: "SUCCESS", url: "https://example.test/unit" },
+        { name: "lint", conclusion: "FAILURE", url: "https://example.test/lint" },
+        { name: "deploy", conclusion: "PENDING", url: "https://example.test/deploy" },
+      ],
+    });
+    expect(JSON.stringify(extraction)).not.toContain("raw ci log");
+    expect(JSON.stringify(extraction)).not.toContain("ghp_ci_secret");
+  });
+
+  it("handles a PR without commits", () => {
+    const runner = fakeRunner({
+      "git remote get-url origin": REMOTE,
+      [listCommand()]: [
+        {
+          number: 9,
+          title: "Empty branch",
+          state: "OPEN",
+          isDraft: true,
+          headRefName: "empty",
+          baseRefName: "main",
+        },
+      ],
+      [viewCommand(9)]: {
+        number: 9,
+        title: "Empty branch",
+        state: "OPEN",
+        isDraft: true,
+        headRefName: "empty",
+        baseRefName: "main",
+        commits: [],
+      },
+      [mergeCommand(9)]: {
+        number: 9,
+        headRefName: "empty",
+        commits: [],
+      },
+    });
+
+    const extraction = extractPullRequests(".", { runner, enabled: true, limit: 10 });
+
+    expect(extraction.nodes).toHaveLength(1);
+    expect(extraction.edges.filter((edge) => edge.relation === "CONTAINS_COMMIT")).toEqual([]);
+  });
+
+  it("surfaces malformed gh JSON as a clean parse error", () => {
+    const runner = fakeRunner({
+      "git remote get-url origin": REMOTE,
+      [listCommand()]: "{not json",
+    });
+
+    expect(() => extractPullRequests(".", { runner, enabled: true, limit: 10 })).toThrow(
+      /failed to parse pull request list JSON/,
+    );
+  });
+
+  it("declares a focused gh ontology profile", () => {
+    const profile = normalizeOntologyProfile(GH_ONTOLOGY_PROFILE);
+
+    expect(Object.keys(profile.node_types).sort()).toEqual(["Branch", "Commit", "PullRequest"]);
+    expect(Object.keys(profile.relation_types).sort()).toEqual([
+      "CONTAINS_COMMIT",
+      "FROM_BRANCH",
+      "INTO_BRANCH",
+      "MERGED_AS",
+    ]);
+    expect(profile.relation_types.FROM_BRANCH.source_types).toEqual(["PullRequest"]);
+    expect(profile.relation_types.FROM_BRANCH.target_types).toEqual(["Branch"]);
+    expect(profile.relation_types.MERGED_AS.target_types).toEqual(["Commit"]);
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateExtraction, assertValid } from "../src/validate.js";
+import { validateExtraction, assertValid, isExternalReferenceId } from "../src/validate.js";
 
 describe("validateExtraction", () => {
   it("rejects non-object input", () => {
@@ -54,6 +54,33 @@ describe("validateExtraction", () => {
       edges: [{ source: "a", target: "missing", relation: "calls", confidence: "EXTRACTED", source_file: "f.py" }],
     });
     expect(errors.some((e) => e.includes("does not match any node id"))).toBe(true);
+  });
+
+  it("accepts whitelisted cross-profile commit and branch references", () => {
+    expect(isExternalReferenceId("commit:repo:github.com/rhanka/graphify@abc123456789")).toBe(true);
+    expect(isExternalReferenceId("branch:repo:github.com/rhanka/graphify#feature/wp9")).toBe(true);
+    expect(isExternalReferenceId("missing")).toBe(false);
+
+    const errors = validateExtraction({
+      nodes: [{ id: "pr:repo:github.com/rhanka/graphify#42", label: "#42", file_type: "concept", source_file: "gh" }],
+      edges: [
+        {
+          source: "pr:repo:github.com/rhanka/graphify#42",
+          target: "commit:repo:github.com/rhanka/graphify@abc123456789",
+          relation: "CONTAINS_COMMIT",
+          confidence: "EXTRACTED",
+          source_file: "gh",
+        },
+        {
+          source: "pr:repo:github.com/rhanka/graphify#42",
+          target: "branch:repo:github.com/rhanka/graphify#feature/wp9",
+          relation: "FROM_BRANCH",
+          confidence: "EXTRACTED",
+          source_file: "gh",
+        },
+      ],
+    });
+    expect(errors).toEqual([]);
   });
 
   it("accepts valid extraction", () => {


### PR DESCRIPTION
WP9 sous MANDATE-graphify. Exécuté par codex 5.5 xhigh headless (détaché), **vérifié + corrigé au gate + commité par le conducteur**.

**Fait** : adapter `gh` → `Extraction`. `src/extract-gh.ts` : nœud **PullRequest** (id `prId`), edges `FROM_BRANCH`/`INTO_BRANCH`→`branchId`, `CONTAINS_COMMIT`/`MERGED_AS`→`commitId` (refs cross-profil, **pas** de nœuds commit/branch redéfinis). Checks CI en **agrégats** sur le PR (`checks_*` + `check_runs` name/conclusion/url) — **aucun log brut**. Provenance TTL `PT4H`. Profil `GH_ONTOLOGY_PROFILE`. Helpers d'IDs WP1.

**Activation opt-in explicite** : `extractPullRequests` retourne vide sauf `enabled:true` ; commande CLI `extract` exige `--extract-gh`. Jamais dans un build standard offline.

**Redaction** (review Opus auditée) : body **jamais en clair** → `body_length`+`body_hash` (sha256) ; **aucun token gh** persisté (provenance = repoKey public + hash irréversible des nodes/edges assainis) ; headlines de commits droppées ; logs CI droppés.

**Bloquant review corrigé au gate** : extract-gh tronquait les SHA `commit:` à 12 alors qu'extract-git (WP2) émet le SHA **plein 40** → jointure cross-profil cassée. Fix : `pr.ts` garde les oids pleins (seul consommateur = extract-gh ; agent-stats utilise `mergeCommit`, déjà plein), extract-gh émet le SHA plein, + **test d'interop git↔gh** (sha = 40 hex).

**Vérif (hors sandbox)** : suite **1968 passed / 0 failed** (201 fichiers) ; lint (tsc) OK. graphify n'a pas de prettier en CI (point "format" de l'exécutant = non-sujet).

Rapport : `segmentation/wp/WP9-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)