### PR TITLE
feat(qa): add target manifest QA gate

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,55 @@
+# codex/quality-target-qa
+
+## Objective
+
+- [ ] Implement `SPEC_EVOL_TARGET_CONFIGURATION_QA`: persisted quality targets, resolved run manifest, deterministic `graphify qa`, and publication preflight gates.
+- [ ] Preserve the validated distinction between exhaustive citation extraction and bounded inline `top_k` display.
+- [ ] Reject the Opus incident class: scratch provenance, bounded/minimum citation producer, partial sidecar, zero reconciliation, stale QA report.
+
+## Scope / Guardrails
+
+- [ ] Allowed: `src/types.ts`, `src/project-config.ts`, `src/cli.ts`, `src/citations.ts`, `src/workspace-manifest*.ts`, new `src/quality-target*.ts`, new `src/qa*.ts`, focused tests under `tests/`, `spec/SPEC_EVOL_TARGET_CONFIGURATION_QA.md`.
+- [ ] Forbidden: `Makefile`, `docker-compose*.yml`, `.cursor/rules/**`, unrelated studio UI redesign, Mystery pack data regeneration, provider/network extraction.
+- [ ] Conditional BR-EX1: `src/ontology-studio*.ts` only if a local publication/preflight command already exists there and needs target gating.
+- [ ] Conditional BR-EX2: `.track/**` only via `track branch import` bookkeeping, not staged in feature commits unless explicitly requested.
+
+## Lot 0 - Spec And Branch Plan
+
+- [ ] Commit validated EVOL spec and this branch plan.
+- [ ] Verify spec has two-pass xhigh validation log and implementation status.
+- [ ] Gate: `git diff --cached --stat` contains only `BRANCH.md` and `spec/SPEC_EVOL_TARGET_CONFIGURATION_QA.md`.
+
+## Lot 1 - Target Config And Contract Model
+
+- [ ] Add quality target types and target-only loader that can parse `quality.targets` without requiring `profile.path` or `inputs.corpus`.
+- [ ] Add structured citation extraction contract canonicalization and hash validation.
+- [ ] Add unit tests for target parsing, invalid target shape, contract hash mismatch, unknown/bounded citation mode, extraction-unit coverage.
+- [ ] Gate: targeted vitest for quality-target tests and `npm run lint`.
+
+## Lot 2 - Manifest And QA Evaluators
+
+- [ ] Add resolved target manifest model with structured artifact provenance and extraction units.
+- [ ] Add pure QA evaluators for manifest, graph counts, citation sidecar coverage, reconciliation completeness, data-only chrome tree hashes.
+- [ ] Add fixture tests for scratch provenance rejection, sidecar partial/stale rejection, truncated reconciliation response rejection, stale QA report hash rejection.
+- [ ] Gate: targeted vitest for QA evaluator tests and `npm run lint`.
+
+## Lot 3 - CLI Surface
+
+- [ ] Add `graphify qa --target <id> --bundle <path> [--config <path>] [--write-report] [--fail-on-error]`.
+- [ ] Emit deterministic JSON QA report and human-readable failure summary.
+- [ ] Add CLI tests for pass/fail exit behavior and report writing.
+- [ ] Gate: targeted vitest for CLI QA tests and `npm run lint`.
+
+## Lot 4 - Publication Preflight And Final Review
+
+- [ ] Wire QA preflight into any existing targetable bundle/publication path that serves/copies/pushes a studio bundle.
+- [ ] Add final regression fixture representing the Opus incident failure class.
+- [ ] Run `npm test`, `npm run lint`, and `npm run build`.
+- [ ] Run double xhigh implementation review and resolve blocking findings.
+- [ ] Run `npx graphify hook-rebuild` after code edits.
+- [ ] Gate: PR opened only after tests, review, graph rebuild, and clean intended diff.
+
+## Feedback Loop
+
+- [ ] BLOCKER: no existing publication command may exist; if so, implement `graphify qa` first and defer preflight wiring to the nearest existing command with explicit note.
+- [ ] BLOCKER: deploy/merge requires GitHub permissions and CI green.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -15,16 +15,16 @@
 
 ## Lot 0 - Spec And Branch Plan
 
-- [ ] Commit validated EVOL spec and this branch plan.
-- [ ] Verify spec has two-pass xhigh validation log and implementation status.
-- [ ] Gate: `git diff --cached --stat` contains only `BRANCH.md` and `spec/SPEC_EVOL_TARGET_CONFIGURATION_QA.md`.
+- [x] Commit validated EVOL spec and this branch plan.
+- [x] Verify spec has two-pass xhigh validation log and implementation status.
+- [x] Gate: `git diff --cached --stat` contains only `BRANCH.md` and `spec/SPEC_EVOL_TARGET_CONFIGURATION_QA.md`.
 
 ## Lot 1 - Target Config And Contract Model
 
-- [ ] Add quality target types and target-only loader that can parse `quality.targets` without requiring `profile.path` or `inputs.corpus`.
-- [ ] Add structured citation extraction contract canonicalization and hash validation.
-- [ ] Add unit tests for target parsing, invalid target shape, contract hash mismatch, unknown/bounded citation mode, extraction-unit coverage.
-- [ ] Gate: targeted vitest for quality-target tests and `npm run lint`.
+- [x] Add quality target types and target-only loader that can parse `quality.targets` without requiring `profile.path` or `inputs.corpus`.
+- [x] Add structured citation extraction contract canonicalization and hash validation.
+- [x] Add unit tests for target parsing, invalid target shape, contract hash mismatch, unknown/bounded citation mode, extraction-unit coverage.
+- [x] Gate: targeted vitest for quality-target tests and `npm run lint`.
 
 ## Lot 2 - Manifest And QA Evaluators
 

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -42,14 +42,14 @@
 
 ## Lot 4 - Publication Preflight And Final Review
 
-- [ ] Wire QA preflight into any existing targetable bundle/publication path that serves/copies/pushes a studio bundle.
-- [ ] Add final regression fixture representing the Opus incident failure class.
-- [ ] Run `npm test`, `npm run lint`, and `npm run build`.
-- [ ] Run double xhigh implementation review and resolve blocking findings.
-- [ ] Run `npx graphify hook-rebuild` after code edits.
-- [ ] Gate: PR opened only after tests, review, graph rebuild, and clean intended diff.
+- [x] Wire QA preflight into any existing targetable bundle/publication path that serves/copies/pushes a studio bundle.
+- [x] Add final regression fixture representing the Opus incident failure class.
+- [x] Run `npm test`, `npm run lint`, and `npm run build`.
+- [x] Run double xhigh implementation review and resolve blocking findings.
+- [x] Run `npx graphify hook-rebuild` after code edits.
+- [x] Gate: PR opened only after tests, review, graph rebuild, and clean intended diff.
 
 ## Feedback Loop
 
-- [ ] BLOCKER: no existing publication command may exist; if so, implement `graphify qa` first and defer preflight wiring to the nearest existing command with explicit note.
+- [x] BLOCKER: no existing publication command may exist; if so, implement `graphify qa` first and defer preflight wiring to the nearest existing command with explicit note.
 - [ ] BLOCKER: deploy/merge requires GitHub permissions and CI green.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -35,10 +35,10 @@
 
 ## Lot 3 - CLI Surface
 
-- [ ] Add `graphify qa --target <id> --bundle <path> [--config <path>] [--write-report] [--fail-on-error]`.
-- [ ] Emit deterministic JSON QA report and human-readable failure summary.
-- [ ] Add CLI tests for pass/fail exit behavior and report writing.
-- [ ] Gate: targeted vitest for CLI QA tests and `npm run lint`.
+- [x] Add `graphify qa --target <id> --bundle <path> [--config <path>] [--write-report] [--fail-on-error]`.
+- [x] Emit deterministic JSON QA report and human-readable failure summary.
+- [x] Add CLI tests for pass/fail exit behavior and report writing.
+- [x] Gate: targeted vitest for CLI QA tests and `npm run lint`.
 
 ## Lot 4 - Publication Preflight And Final Review
 

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -28,10 +28,10 @@
 
 ## Lot 2 - Manifest And QA Evaluators
 
-- [ ] Add resolved target manifest model with structured artifact provenance and extraction units.
-- [ ] Add pure QA evaluators for manifest, graph counts, citation sidecar coverage, reconciliation completeness, data-only chrome tree hashes.
-- [ ] Add fixture tests for scratch provenance rejection, sidecar partial/stale rejection, truncated reconciliation response rejection, stale QA report hash rejection.
-- [ ] Gate: targeted vitest for QA evaluator tests and `npm run lint`.
+- [x] Add resolved target manifest model with structured artifact provenance and extraction units.
+- [x] Add pure QA evaluators for manifest, graph counts, citation sidecar coverage, reconciliation completeness, data-only chrome tree hashes.
+- [x] Add fixture tests for scratch provenance rejection, sidecar partial/stale rejection, truncated reconciliation response rejection, stale QA report hash rejection.
+- [x] Gate: targeted vitest for QA evaluator tests and `npm run lint`.
 
 ## Lot 3 - CLI Surface
 

--- a/scripts/build-studio-demo.mjs
+++ b/scripts/build-studio-demo.mjs
@@ -25,12 +25,23 @@
  *
  * Usage:
  *   node scripts/build-studio-demo.mjs --state <dir> --out <dir> [--profile <p>]
+ *     [--qa-target <id> [--qa-config <path>] [--qa-manifest <path>]
+ *      [--qa-report <path>] [--qa-fail-on-error]]
  *
  *   --state    graphify state dir (default: .graphify). Must contain graph.json.
  *   --out      target export dir (default: docs/studio). Created if missing.
  *   --profile  profile path/dir for reconciliation context. Optional: when
  *              omitted the reconciliation candidates are emitted from the state's
  *              candidates.json as-is (no profile-hash staleness check).
+ *
+ *   --qa-target        quality.targets.<id> preflight to run after bundle emit.
+ *   --qa-config        graphify.yaml / .graphify/config.yaml containing target.
+ *                      Defaults to discovery from the current working dir.
+ *   --qa-manifest      resolved-target manifest JSON. Required for targets
+ *                      that require producer proof or batch coverage; otherwise
+ *                      defaults to generated <out>/resolved-target.json.
+ *   --qa-report        report path. Defaults to <out>/quality-qa-report.json.
+ *   --qa-fail-on-error fail even when the target is advisory/non-blocking.
  *
  * Requires the server build (dist/) and the SPA build (dist/studio-app). Run
  * `npm run build` first, or `node scripts/build-studio-app.mjs` for just the SPA.
@@ -43,18 +54,32 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 function parseArgs(argv) {
-  const args = { state: ".graphify", out: "docs/studio", profile: null };
+  const args = {
+    state: ".graphify",
+    out: "docs/studio",
+    profile: null,
+    qaConfig: null,
+    qaFailOnError: false,
+    qaManifest: null,
+    qaReport: null,
+    qaTarget: null,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--state") args.state = argv[++i];
     else if (arg === "--out") args.out = argv[++i];
     else if (arg === "--profile") args.profile = argv[++i];
+    else if (arg === "--qa-config") args.qaConfig = argv[++i];
+    else if (arg === "--qa-fail-on-error") args.qaFailOnError = true;
+    else if (arg === "--qa-manifest") args.qaManifest = argv[++i];
+    else if (arg === "--qa-report") args.qaReport = argv[++i];
+    else if (arg === "--qa-target") args.qaTarget = argv[++i];
     else if (arg === "--help" || arg === "-h") args.help = true;
     else throw new Error(`unknown argument: ${arg}`);
   }
@@ -69,7 +94,7 @@ function die(msg) {
 const args = parseArgs(process.argv.slice(2));
 if (args.help) {
   console.log(
-    "Usage: node scripts/build-studio-demo.mjs --state <dir> --out <dir> [--profile <p>]",
+    "Usage: node scripts/build-studio-demo.mjs --state <dir> --out <dir> [--profile <p>] [--qa-target <id> [--qa-config <path>] [--qa-manifest <path>] [--qa-report <path>] [--qa-fail-on-error]]",
   );
   process.exit(0);
 }
@@ -93,6 +118,13 @@ let attachLayoutPositions;
 let buildEntitySidecar;
 let emitSceneHierarchies;
 let emitWorkspaceManifest;
+let discoverQualityTargetsConfig;
+let hashQualityTarget;
+let loadQualityTargetsConfig;
+let QA_REPORT_FILENAME;
+let RESOLVED_TARGET_MANIFEST_SCHEMA;
+let evaluateQualityBundle;
+let sha256File;
 let loadOntologyReconciliationCandidates;
 let queryOntologyReconciliationCandidates;
 try {
@@ -100,15 +132,139 @@ try {
     buildStudioScene,
     attachLayoutPositions,
     buildEntitySidecar,
+    discoverQualityTargetsConfig,
     emitSceneHierarchies,
     emitWorkspaceManifest,
+    evaluateQualityBundle,
+    hashQualityTarget,
+    loadQualityTargetsConfig,
     loadOntologyReconciliationCandidates,
+    QA_REPORT_FILENAME,
+    RESOLVED_TARGET_MANIFEST_SCHEMA,
     queryOntologyReconciliationCandidates,
+    sha256File,
   } = await import(join(root, "dist", "index.js")));
 } catch (err) {
   die(
     `could not import the server build (dist/index.js). Run \`npm run build:server\` first.\n  ${err instanceof Error ? err.message : String(err)}`,
   );
+}
+
+function toManifestPath(path) {
+  const rel = relative(process.cwd(), path).split(sep).join("/");
+  return rel && !rel.startsWith("../") && rel !== ".." ? rel : path;
+}
+
+function sameResolvedPath(left, right) {
+  return resolve(left) === resolve(right);
+}
+
+function artifactSourcePath(rel, context) {
+  if (rel === "graph.json") return context.graphPath;
+  if (rel === "scene.json") return context.graphPath;
+  if (rel === "scene-hierarchies.json") return join(context.stateDir, "ontology", "hierarchies.json");
+  if (rel === "reconciliation-candidates.json") return context.candidatesPath;
+  if (rel === "entities.json") return context.stateDir;
+  if (rel === "workspace-manifest.json") return join(context.outDir, "workspace-manifest.json");
+  if (rel === "ontology/citations.json") return join(context.stateDir, "ontology", "citations.json");
+  return join(context.outDir, rel);
+}
+
+function buildResolvedTargetManifest(target, targetHash, context) {
+  const artifacts = {};
+  for (const rel of target.publication.data_allowlist) {
+    const path = join(context.outDir, rel);
+    if (!existsSync(path)) continue;
+    artifacts[rel] = {
+      bundle_path: rel,
+      source_path: toManifestPath(artifactSourcePath(rel, context)),
+      source_kind: "generated",
+      sha256: sha256File(path),
+    };
+  }
+  return {
+    schema: RESOLVED_TARGET_MANIFEST_SCHEMA,
+    target_id: target.id,
+    target_hash: targetHash,
+    graphify_version: "0.14.0",
+    producer: {
+      command: "scripts/build-studio-demo.mjs",
+      cwd: process.cwd(),
+    },
+    artifacts,
+    resolved_policy: {
+      citations: {
+        extraction: {
+          mode: target.citations.extraction.mode,
+          ...(target.citations.extraction.contract_id
+            ? { contract_id: target.citations.extraction.contract_id }
+            : {}),
+        },
+        display: target.citations.display,
+        inline: target.citations.inline,
+        sidecar: { required: target.citations.require_sidecar },
+      },
+    },
+    inputs: {
+      state_dir: toManifestPath(context.stateDir),
+      graph_path: toManifestPath(context.graphPath),
+      bundle_path: toManifestPath(context.outDir),
+    },
+  };
+}
+
+function targetRequiresProducerManifest(target) {
+  return target.citations.extraction.require_producer_proof ||
+    target.citations.extraction.require_batch_coverage;
+}
+
+function loadQualityConfigForPreflight() {
+  const configPath = args.qaConfig
+    ? resolve(args.qaConfig)
+    : (() => {
+        const discovery = discoverQualityTargetsConfig(process.cwd());
+        return discovery.found ? discovery.path : null;
+      })();
+  if (!configPath) return null;
+  return { path: configPath, config: loadQualityTargetsConfig(configPath) };
+}
+
+function selectQualityTargetForPreflight(outDir) {
+  const loaded = loadQualityConfigForPreflight();
+  if (!loaded) {
+    if (args.qaTarget || args.qaConfig || args.qaManifest || args.qaReport || args.qaFailOnError) {
+      die("no graphify config found for quality target; pass --qa-config <path>.");
+    }
+    return null;
+  }
+  const matchingBlockingTargets = Object.values(loaded.config.targets).filter((target) =>
+    target.publication.blocking &&
+    target.resolvedBundlePath &&
+    sameResolvedPath(target.resolvedBundlePath, outDir)
+  );
+  if (args.qaTarget) {
+    const target = loaded.config.targets[String(args.qaTarget)];
+    if (!target) die(`quality target not found in ${loaded.path}: ${args.qaTarget}`);
+    const mismatchedBlockingTargets = matchingBlockingTargets.filter((blockingTarget) => blockingTarget.id !== target.id);
+    if (mismatchedBlockingTargets.length > 0) {
+      die(
+        `--out ${outDir} matches blocking quality target(s) ${mismatchedBlockingTargets.map((t) => t.id).join(", ")}; ` +
+          `refusing to validate only ${target.id}.`,
+      );
+    }
+    return { configPath: loaded.path, target };
+  }
+
+  if (matchingBlockingTargets.length === 1) {
+    return { configPath: loaded.path, target: matchingBlockingTargets[0] };
+  }
+  if (matchingBlockingTargets.length > 1) {
+    die(`multiple blocking quality targets match --out ${outDir}; pass --qa-target <id>.`);
+  }
+  if (args.qaConfig || args.qaManifest || args.qaReport || args.qaFailOnError) {
+    die("--qa-target is required unless a single blocking quality target matches --out.");
+  }
+  return null;
 }
 
 // --- 1. Copy the built SPA (index.html + assets) into the export dir. ---
@@ -121,6 +277,8 @@ for (const f of [
   "graph.json",
   "reconciliation-candidates.json",
   "entities.json",
+  "quality-qa-report.json",
+  "resolved-target.json",
   "workspace-manifest.json",
 ]) {
   rmSync(join(outDir, f), { force: true });
@@ -156,8 +314,9 @@ const hierarchiesResult = emitSceneHierarchies({
   sceneNodeIds: sceneRawIds,
 });
 
-// --- 4. reconciliation-candidates.json: mirror the SPA's request. ---
-// The SPA fetches /api/ontology/reconciliation/candidates?sort=score&order=desc&limit=50.
+// --- 4. reconciliation-candidates.json: publish the complete candidate set. ---
+// The SPA can page client-side from this static artifact. Publication QA must
+// see the full queue/response, not a UI page capped at 50.
 let candidatesResponse = { items: [], total: 0 };
 const candidatesPath = join(stateDir, "ontology", "reconciliation", "candidates.json");
 if (existsSync(candidatesPath)) {
@@ -166,7 +325,6 @@ if (existsSync(candidatesPath)) {
     candidatesResponse = queryOntologyReconciliationCandidates(queue, {
       sort: "score",
       order: "desc",
-      limit: 50,
       stale: false,
     });
   } catch (err) {
@@ -208,6 +366,50 @@ writeFileSync(join(outDir, "entities.json"), JSON.stringify(entities));
 // scene is OPTIONAL per F1, so a no-scene bundle stays valid).
 const manifestResult = emitWorkspaceManifest({ bundleDir: outDir });
 
+// --- 7. Quality target preflight. ---
+let qaReport = null;
+const selectedQualityTarget = selectQualityTargetForPreflight(outDir);
+if (selectedQualityTarget) {
+  const { target } = selectedQualityTarget;
+  const targetHash = hashQualityTarget(target);
+  const qaManifestPath = args.qaManifest ? resolve(args.qaManifest) : join(outDir, "resolved-target.json");
+  if (!args.qaManifest && targetRequiresProducerManifest(target)) {
+    die(
+      `--qa-manifest is required for quality target ${target.id} because it requires producer proof or extraction-unit coverage.`,
+    );
+  }
+  if (!args.qaManifest) {
+    writeFileSync(
+      qaManifestPath,
+      `${JSON.stringify(buildResolvedTargetManifest(target, targetHash, {
+        candidatesPath,
+        graphPath,
+        outDir,
+        stateDir,
+      }), null, 2)}\n`,
+    );
+  }
+  const resolvedTargetManifest = existsSync(qaManifestPath)
+    ? JSON.parse(readFileSync(qaManifestPath, "utf-8"))
+    : null;
+  qaReport = evaluateQualityBundle({
+    target,
+    bundleDir: outDir,
+    manifest: resolvedTargetManifest,
+    targetHash,
+  });
+  const qaReportPath = args.qaReport ? resolve(args.qaReport) : join(outDir, QA_REPORT_FILENAME);
+  writeFileSync(qaReportPath, `${JSON.stringify(qaReport, null, 2)}\n`);
+  if (qaReport.status === "failed" && (target.publication.blocking || args.qaFailOnError)) {
+    const failures = qaReport.checks
+      .filter((check) => check.severity === "error")
+      .slice(0, 10)
+      .map((check) => `    - ${check.id}: ${check.message}`)
+      .join("\n");
+    die(`QA failed for target ${target.id}; report written to ${qaReportPath}\n${failures}`);
+  }
+}
+
 // --- Summary. ---
 console.log(`build-studio-demo: wrote standalone studio export to ${outDir}`);
 console.log(`  nodes: ${nodes.length} | scene nodes: ${scene.nodes.length} | scene edges: ${scene.edges.length}`);
@@ -221,3 +423,8 @@ console.log(`  entities index: ${Object.keys(entities).length} ids (${withDescri
 console.log(
   `  workspace-manifest: ${manifestResult.manifest.present_count}/${manifestResult.manifest.artifacts.length} artifacts present (${manifestResult.path})`,
 );
+if (qaReport) {
+  console.log(
+    `  qa: ${qaReport.status} (${qaReport.summary.failed} errors, ${qaReport.summary.warned} warnings)`,
+  );
+}

--- a/spec/SPEC_EVOL_TARGET_CONFIGURATION_QA.md
+++ b/spec/SPEC_EVOL_TARGET_CONFIGURATION_QA.md
@@ -1,0 +1,761 @@
+# SPEC_EVOL_TARGET_CONFIGURATION_QA
+
+## Status
+
+- Product: Graphify TypeScript port
+- Scope: persisted target configuration, resolved run manifest, deterministic QA gate, and publication preflight
+- Ladder: EVOL validated for planning
+- Trigger: public mystery studio handover regression, 2026-06-17
+- Validation requirement: two independent 5.5 xhigh reviews before implementation planning
+- Validation status: PASS after remediation
+- Implementation status: not started
+
+## Validation Log
+
+- Manifest/exhaustive-citation review, 5.5 xhigh: first pass BLOCK because the
+  manifest proof was presence-based. Remediated with a structured citation
+  extraction contract, canonical contract hash allowlist, and extraction-unit
+  coverage. Second pass PASS.
+- QA/publication review, 5.5 xhigh: first pass BLOCK because partial sidecars,
+  scratch provenance, QA report binding, truncated reconciliation responses, and
+  chrome self-compare were under-specified. Remediated with full sidecar
+  coverage, artifact provenance, report hash binding, complete reconciliation
+  requirements, and non-self chrome references. Second pass BLOCK only on
+  precomputed report binding for data-only chrome. Remediated with data allowlist
+  and chrome/non-data tree hashes. Final pass PASS.
+
+## Incident Summary
+
+The public mystery studio handover served a scratch Opus comparison graph as a
+candidate publication bundle. The bundle kept the live SPA chrome but replaced
+the data with artifacts that did not satisfy the previously validated UAT
+contract:
+
+- `character_sherlock_holmes.citation_count`: expected at least the UAT value
+  `89`; served Opus bundle had `16`.
+- inline Sherlock citations: served bundle had `8` because the effective
+  citation policy resolved to `inlineTopK=8`.
+- reconciliation candidates: expected the UAT broad-ranked set around `31`;
+  served Opus bundle had `0`.
+- descriptions: UAT bundle had full coverage; served Opus bundle had a missing
+  description.
+- the source directory was documented as scratch/no-publish, but no QA gate
+  blocked serving it.
+
+The earlier Claude handover requirement was not ambiguous: for the mystery
+target the intended behavior is ALL extracted citations, with a lean inline
+preview and the full list served lazily. `inlineTopK=8` is only a display
+projection. A publishable target must therefore prove both:
+
+- the producing extraction/assembly run used the exhaustive citation contract;
+- the final bundle exposes the full citation set through `ontology/citations.json`
+  or another explicitly configured full store.
+
+This is not only a bad artifact choice. It exposes a product gap: once a target
+configuration is decided, Graphify does not persist that decision as an
+auditable target, does not stamp the resolved policy into a run manifest, and
+does not run deterministic QA against the final bundle.
+
+## Root Cause
+
+### Citation policy root cause
+
+`SPEC_CITATIONS` introduced a resolved policy with `inlineTopK=8` defaults for
+mixed, long-document, and entity-corpus builds. The implementation matches that
+spec:
+
+- `src/citation-policy.ts` sets the global default to `{ describeCap: 10,
+  inlineTopK: 8 }`.
+- long-document and entity-corpus defaults also set `inlineTopK: 8`.
+- `resolveCitationPolicyForRoot()` reads `.graphify_detect.json` and CLI flags,
+  then calls `resolveCitationPolicy()` with no project config tier.
+- the code comment explicitly says the config tier is inert in v1: the
+  `citations:` YAML block is not wired into the code-mode CLI.
+- the public mystery pack `graphify.yaml` declares `dataprep.citation_minimum:
+  section`, but no target citation surface such as full display via sidecar or
+  a project-specific top-K.
+
+On the public pack, the effective policy is therefore:
+
+```json
+{ "describeCap": "all", "inlineTopK": 8 }
+```
+
+This is not inherently wrong: `inlineTopK=8` is the bounded Level-1 preview from
+`SPEC_CITATIONS`. It becomes wrong only when a publication target requires full
+display but the run has no full sidecar and no proof that extraction captured
+all citations.
+
+The Opus reindex prompt lost the binding extraction contract. Its batch
+instructions required only "at least one `citations[]` entry" per entity, not
+ALL extracted citations, no `citation_count`, no `ontology/citations.json`, and
+no sidecar consistency check. The served graph had 8 inline Sherlock citations
+because of top-K display, but the more serious failure was upstream: the raw
+Opus graph had only 16 Sherlock citations available before trimming.
+
+### Reconciliation root cause
+
+The multimodel Opus harness is a scratch comparison lane. Its own README says
+`NO publish, NO live push`. Its `assemble.mjs` merges extraction batches,
+applies assembly hygiene, clusters, and writes `graph-<model>.json`. It does
+not generate `reconciliation-candidates.json`. The staged studio switch
+therefore had `{"total":0,"items":[]}` from the first served artifact, not from
+a UI rendering failure.
+
+### Publication root cause
+
+The last-mile operation copied live chrome and overlaid data files, which is the
+right shape for a data-only republish, but it had no formal data contract. A
+bundle could be served if files existed, even when it violated the intended UAT
+metrics.
+
+## Goals
+
+- Persist target configuration in project-owned files so decisions survive the
+  session that made them.
+- Stamp every producing run with the resolved target and resolved policy so
+  actual outputs can be compared with what was intended.
+- Provide a deterministic `graphify qa` command that evaluates the final bundle,
+  not only the intermediate `.graphify/graph.json`.
+- Make QA generic and project-configured; no Sherlock or mystery constants in
+  Graphify core.
+- Make publication/export commands able to fail closed when the target says QA
+  is blocking.
+- Keep the QA engine offline: no LLM, no network, no hidden sampling.
+
+## Non-Goals
+
+- Do not decide global Graphify citation defaults in this spec. The target layer
+  can override them per project/publication.
+- Do not add mention-level citation extraction. QA can detect an insufficient
+  count but cannot invent missing citations.
+- Do not hardcode mystery pack UAT thresholds in Graphify core.
+- Do not require every local experimental graph to pass publication QA. Blocking
+  applies only when a target is selected or a publication command opts into it.
+- Do not require semantic community labels unless the target config asks for
+  them.
+
+## Proposed Target Config
+
+Add a `quality.targets` block to `graphify.yaml` / `.graphify/config.yaml`.
+Each target is a named contract for a publishable surface.
+
+```yaml
+quality:
+  targets:
+    mystery_public_studio:
+      kind: studio-static-bundle
+      bundle_path: .graphify/studio
+      baseline_bundle_path: .graphify/baselines/public-studio-0.14.1
+      publication:
+        blocking: true
+        require_resolved_manifest: true
+        data_only_chrome: true
+        chrome_reference_path: .graphify/baselines/public-studio-0.14.1
+        deny_source_path_patterns:
+          - ".graphify/scratch/**"
+        data_allowlist:
+          - graph.json
+          - scene.json
+          - entities.json
+          - reconciliation-candidates.json
+          - workspace-manifest.json
+          - ontology/citations.json
+      citations:
+        extraction:
+          mode: all_extracted   # all_extracted | bounded_sample | unknown
+          require_producer_proof: true
+          contract_id: graphify_all_extracted_entity_citations_v1
+          allowed_contract_hashes:
+            - "sha256:..."
+          require_batch_coverage: true
+        display: full           # full | inline
+        inline:
+          mode: top_k           # full | top_k
+          top_k: 8              # required when mode=top_k
+        require_sidecar: true   # full display is served from ontology/citations.json
+        min_count_by_node:
+          character_sherlock_holmes: 89
+        no_shrink_by_node:
+          character_sherlock_holmes:
+            baseline_field: citation_count
+            max_drop: 0
+      graph:
+        min_nodes: 2091
+        min_edges: 3168
+        shrink_guard:
+          nodes:
+            max_drop: 0
+          edges:
+            max_drop: 0
+        max_missing_descriptions: 0
+        max_orphan_nodes: 0     # target-specific, not a global Graphify default
+      reconciliation:
+        min_candidates: 31
+        shrink_guard:
+          candidates:
+            max_drop: 0
+        require_groupable_by_type: true
+      communities:
+        require_semantic_labels: false
+```
+
+Rules:
+
+- Target config is source-controlled project data, not a transient CLI choice.
+- `citations.extraction.mode: all_extracted` means the producer must declare
+  and manifest that it asked for all extracted citations per entity and that the
+  assembly path unions same-entity citations instead of retaining a sample. QA
+  cannot infer this from an 8-item inline preview.
+- `citations.extraction.contract_id` and `allowed_contract_hashes` identify a
+  structured citation extraction contract, not arbitrary prompt text. For
+  blocking publication targets, QA must validate either a built-in canonical
+  contract by ID/hash or a manifest-embedded contract whose canonical JSON hash
+  is allowlisted by the target.
+- `require_batch_coverage: true` means every contributing extraction unit,
+  batch, or imported graph fragment must declare the same validated citation
+  contract. A single legacy/unknown/bounded batch fails the publication target.
+- `citations.display: full` means the published user-facing surface must have
+  the full citation set. The preferred storage is `inline.mode: top_k` plus
+  `require_sidecar: true`; `inline.mode: full` exists only for small/special
+  bundles that explicitly accept the eager payload cost.
+- `citations.inline.mode: top_k` means `node.citations.length <= top_k` and
+  `citation_count` / sidecar must carry the true count.
+- `require_groupable_by_type` is evaluated by resolving candidate endpoint IDs
+  against `graph.json` and reading `node_type` / `type`.
+- Baseline comparisons are optional for local QA but mandatory when any
+  `shrink_guard` or `no_shrink_by_node` rule is configured. Those rules are
+  blocking errors, not informational deltas.
+- `chrome_reference_path` must not resolve to the same directory as the bundle
+  being validated when `data_only_chrome` is true; otherwise the chrome hash
+  comparison is self-referential and fails closed.
+
+## Config Resolution
+
+- Config discovery follows the existing project config search order:
+  `graphify.yaml`, `graphify.yml`, `.graphify/config.yaml`,
+  `.graphify/config.yml`.
+- Relative paths in a target resolve from the config file directory.
+- `--target <id>` selects `quality.targets.<id>`.
+- `--bundle <path>` overrides the target `bundle_path` only for the QA input
+  under evaluation; it does not mutate the target or the resolved manifest.
+- If `publication.blocking: true`, `graphify qa --target <id>` exits non-zero
+  on any error even without `--fail-on-error`; `--fail-on-error` exists for
+  advisory targets and CI scripts that want strictness.
+- A QA-only target may omit producer fields, but a publication target may not.
+- `graphify qa` must not require the full normalized project config when the
+  file is used only as a target contract. The current project config loader
+  requires `profile.path` and `inputs.corpus`; QA therefore uses a tolerant
+  target loader that parses and validates only `quality.targets`. Producer
+  commands that also need corpus/profile settings still use the full existing
+  loader.
+
+## Structured Citation Extraction Contract
+
+The manifest cannot merely carry a free-form prompt hash. A hash proves bytes,
+not semantics. For publication QA, the cited producer contract must be
+structured and canonicalized:
+
+```json
+{
+  "schema": "graphify_citation_extraction_contract_v1",
+  "id": "graphify_all_extracted_entity_citations_v1",
+  "mode": "all_extracted",
+  "requirements": {
+    "emit_all_extracted_citations_per_entity": true,
+    "bounded_samples_allowed": false,
+    "minimum_one_citation_only_allowed": false,
+    "same_entity_merge": "union_by_citation_identity",
+    "inline_projection_is_not_storage": true,
+    "full_store_required_when_display_full": true
+  },
+  "citation_identity": ["source_file", "page", "section", "paragraph_id"]
+}
+```
+
+QA computes the sha256 over canonical JSON: sorted object keys, no insignificant
+whitespace, stable array order. A blocking target that sets
+`require_producer_proof: true` passes only when:
+
+- the manifest embeds this structured contract or references a Graphify built-in
+  contract ID known to the installed version;
+- the computed contract hash is present in
+  `citations.extraction.allowed_contract_hashes`;
+- the embedded/reference contract's `mode` matches the target mode;
+- every extraction unit listed in the manifest has the same validated contract
+  hash when `require_batch_coverage` is true.
+
+If a run imports external fragments and cannot prove every fragment's contract,
+the fragment contract is `unknown` and a blocking publication target fails. This
+is deliberate: scratch comparison graphs remain usable for analysis, but they
+cannot be served as a target publication without provenance.
+
+## Resolved Run Manifest
+
+Every target-selected command that writes a publication-targetable bundle must
+emit a manifest next to the output or under
+`.graphify/runs/<run-id>/resolved-target.json`. Non-target scratch commands may
+omit it, but then they cannot pass a blocking publication target.
+
+```json
+{
+  "schema": "graphify_resolved_target_v1",
+  "target_id": "mystery_public_studio",
+  "target_hash": "sha256:...",
+  "graphify_version": "0.14.x",
+  "producer": {
+    "command": "graphify studio bundle",
+    "cwd": "/path/to/project",
+    "git_head": "..."
+  },
+  "artifacts": {
+    "graph.json": {
+      "bundle_path": "graph.json",
+      "source_path": ".graphify/runs/2026-06-17/graph.json",
+      "source_kind": "generated",
+      "sha256": "sha256:..."
+    },
+    "scene.json": {
+      "bundle_path": "scene.json",
+      "source_path": ".graphify/runs/2026-06-17/scene.json",
+      "source_kind": "generated",
+      "sha256": "sha256:..."
+    },
+    "reconciliation-candidates.json": {
+      "bundle_path": "reconciliation-candidates.json",
+      "source_path": ".graphify/runs/2026-06-17/reconciliation-candidates.json",
+      "source_kind": "generated",
+      "sha256": "sha256:..."
+    },
+    "ontology/citations.json": {
+      "bundle_path": "ontology/citations.json",
+      "source_path": ".graphify/runs/2026-06-17/ontology/citations.json",
+      "source_kind": "generated",
+      "sha256": "sha256:..."
+    }
+  },
+  "resolved_policy": {
+    "corpus_type": "long-document",
+    "citations": {
+      "extraction": {
+        "mode": "all_extracted",
+        "contract_id": "graphify_all_extracted_entity_citations_v1",
+        "contract_hash": "sha256:...",
+        "contract": {
+          "schema": "graphify_citation_extraction_contract_v1",
+          "id": "graphify_all_extracted_entity_citations_v1",
+          "mode": "all_extracted"
+        },
+        "assembly": {
+          "same_entity_merge": "union_by_citation_identity",
+          "dedupe_key": ["source_file", "page", "section", "paragraph_id"]
+        }
+      },
+      "describeCap": "all",
+      "display": "full",
+      "inline": { "mode": "top_k", "topK": 8 },
+      "sidecar": { "required": true }
+    }
+  },
+  "inputs": {
+    "config_path": "graphify.yaml",
+    "graph_path": ".graphify/graph.json",
+    "bundle_path": ".graphify/studio"
+  },
+  "extraction_units": [
+    {
+      "id": "batch-000",
+      "source_path": ".graphify/extraction/batch-000.json",
+      "contract_id": "graphify_all_extracted_entity_citations_v1",
+      "contract_hash": "sha256:...",
+      "citation_mode": "all_extracted"
+    }
+  ]
+}
+```
+
+The `contract` object above is abbreviated for readability; a real embedded
+contract must contain the full canonical contract fields from
+`## Structured Citation Extraction Contract`, or reference a built-in contract
+ID/hash known to Graphify.
+
+The manifest is evidence, not the source of truth. QA verifies that the manifest
+matches the project target and that the final bundle matches the manifest. For a
+blocking publication target, the manifest is mandatory and these are errors:
+
+- missing manifest
+- `target_hash` not matching the current target config
+- `resolved_policy.citations.extraction.mode` missing, `unknown`, or not equal
+  to the target's `all_extracted` requirement
+- missing producer proof, such as the structured extraction contract,
+  contract hash, or assembly merge mode, when `require_producer_proof` is true
+- contract hash not present in the target's `allowed_contract_hashes`
+- embedded contract hash mismatch after canonicalization
+- extraction unit missing when `require_batch_coverage` is true
+- any extraction unit with `citation_mode` other than `all_extracted`, with an
+  unknown contract, or with a contract hash not allowlisted by the target
+- missing artifact provenance (`bundle_path`, `source_path`, `source_kind`,
+  `sha256`) for a required publication artifact
+- source path matching `publication.deny_source_path_patterns`
+- artifact hash mismatch
+- stale or mismatched precomputed QA report for the bundle being served, copied,
+  or pushed. A standalone `graphify qa` run produces the report and does not
+  require one to exist beforehand.
+
+The manifest must not claim exhaustive citations merely because
+`inlineTopK=8` was applied. Bounded inline projection and exhaustive extraction
+are separate facts and are validated separately.
+
+## QA Command
+
+Add:
+
+```bash
+graphify qa --target mystery_public_studio --bundle .graphify/studio
+graphify qa --target mystery_public_studio --bundle .graphify/studio --write-report
+graphify qa --target mystery_public_studio --bundle .graphify/studio --fail-on-error
+```
+
+Output:
+
+```json
+{
+  "schema": "graphify_qa_report_v1",
+  "target_id": "mystery_public_studio",
+  "target_hash": "sha256:...",
+  "manifest_hash": "sha256:...",
+  "bundle_path": ".graphify/studio",
+  "artifact_hashes": {
+    "graph.json": "sha256:...",
+    "scene.json": "sha256:...",
+    "reconciliation-candidates.json": "sha256:...",
+    "ontology/citations.json": "sha256:..."
+  },
+  "chrome": {
+    "data_only": true,
+    "data_allowlist_hash": "sha256:...",
+    "bundle_non_data_tree_hash": "sha256:...",
+    "chrome_reference_path": ".graphify/baselines/public-studio-0.14.1",
+    "chrome_reference_tree_hash": "sha256:..."
+  },
+  "status": "failed",
+  "summary": { "passed": 7, "failed": 2, "warned": 1 },
+  "checks": [
+    {
+      "id": "citations.min_count_by_node.character_sherlock_holmes",
+      "severity": "error",
+      "expected": ">= 89",
+      "actual": 16
+    },
+    {
+      "id": "reconciliation.min_candidates",
+      "severity": "error",
+      "expected": ">= 31",
+      "actual": 0
+    }
+  ]
+}
+```
+
+The QA reader loads the final bundle layout:
+
+- `graph.json`
+- `scene.json`
+- `entities.json`
+- `reconciliation-candidates.json`
+- optional `ontology/citations.json`
+- optional `workspace-manifest.json`
+- optional resolved target manifest
+
+The QA report is bound to the exact evaluation inputs: target hash, manifest
+hash, artifact hashes, bundle path, and, for `data_only_chrome`, the data
+allowlist hash plus both non-data tree hashes (`bundle_non_data_tree_hash` and
+`chrome_reference_tree_hash`). A publication command may either run QA
+in-process against the staged bundle or consume a precomputed report only if all
+hashes match the final staged bytes and the current chrome reference bytes. A
+changed artifact or changed chrome/reference tree invalidates the report.
+
+Accepted reconciliation file shapes:
+
+- response shape:
+  `graphify_ontology_reconciliation_candidates_response_v1`, counted from a
+  complete response only;
+- queue shape:
+  `graphify_ontology_reconciliation_candidates_v1`, counted from
+  `candidate_count` and `candidates[]`.
+
+The endpoint IDs used for type grouping are `candidate_id` and `canonical_id`.
+If a queue uses nested records in the future, the parser must normalize them
+into the same pair shape before checks run.
+
+For publication QA, reconciliation checks must run over a complete candidate
+array. A response-shape file is acceptable only when it proves `offset=0`,
+`items.length === total`, and any graph hash/staleness fields match the current
+`graph.json`. Otherwise QA treats the candidate count as unverifiable and fails
+closed. Queue shape is preferred for publication because it is already the full
+candidate set.
+
+## Check Families
+
+### Policy checks
+
+- target exists and validates
+- resolved run manifest exists when the target requires it
+- resolved citation policy matches the target
+- structured citation extraction contract validates against target mode and
+  allowed hashes when producer proof is required
+- all extraction units validate against the same allowed contract when batch
+  coverage is required
+- required artifact provenance fields exist and source paths do not match denied
+  patterns
+- data-only publication keeps every non-data file byte-identical to the
+  `chrome_reference_path` when requested
+- data allowlist is honored; any changed file outside it is an error for
+  `data_only_chrome`
+- source provenance is allowed by the target; scratch/no-publish sources are
+  rejected when denied
+
+### Graph checks
+
+- node/edge counts meet thresholds
+- no unexpected shrink versus baseline when configured; `max_drop: 0` is an
+  exact no-shrink guard
+- missing descriptions are within target limit
+- orphan nodes are within target limit
+- checked nodes exist by stable ID
+
+### Citation checks
+
+- producer manifest proves the configured extraction mode when required
+- per-node `citation_count` meets configured minimums
+- inline citation surface matches `full` or `top_k`
+- sidecar presence and count consistency match target
+- `citation_count` is never less than `citations.length`
+- `display: full` fails unless the full list is available either through the
+  sidecar or, explicitly, through full inline storage
+- when `display: full` and `require_sidecar` are true, the sidecar schema must
+  validate, its `graph_signature` / graph hash must match the current graph, and
+  every graph node with `citation_count > 0` must have a sidecar entry whose
+  `count` and `citations.length` match `graph.json` `citation_count`
+- configured `min_count_by_node` / `no_shrink_by_node` nodes are checked
+  explicitly even if they carry zero or missing citation counts, so a missing
+  sentinel cannot pass by absence
+- node-level no-shrink rules compare the configured field against the baseline
+
+### Reconciliation checks
+
+- candidate count meets target minimum
+- candidate endpoint IDs resolve in `graph.json`
+- candidates are groupable by type when requested
+- candidate schema is one of the accepted response/queue schemas
+- publication QA rejects paginated/truncated candidate responses whose full item
+  array cannot be verified
+- stale/hash fields, when present, must not contradict the current graph
+
+### Community checks
+
+- if semantic labels are required, generic `Community N` labels fail
+- if semantic labels are not required, generic labels are only informational
+
+## Publication Integration
+
+Publication-like commands must take a target and run QA on the final staged
+bundle before serving, copying, or pushing it.
+
+```bash
+graphify studio bundle --target mystery_public_studio --out .graphify/studio-next
+graphify qa --target mystery_public_studio --bundle .graphify/studio-next --fail-on-error
+```
+
+If `quality.targets.<id>.publication.blocking` is true, the publication command
+fails closed on QA errors and refuses to operate without:
+
+- selected target
+- resolved target manifest
+- QA executed in-process on the staged bundle, or a precomputed QA report whose
+  target hash, manifest hash, artifact hashes, and `data_only_chrome` tree
+  hashes match the final staged bytes and current chrome reference bytes
+- no provenance denial such as `.graphify/scratch/**`
+
+Experimental scratch commands may still run without a target, but they must not
+serve, copy, or push a bundle through a publication command.
+
+## Decisions
+
+### D1 - Target config location
+
+Recommendation: store target contracts in project config under
+`quality.targets`. This keeps the decision source-controlled and reviewable.
+Generated `.graphify/runs/*/resolved-target.json` files are evidence only.
+
+Alternative: store targets only under `.graphify/targets/*.json`. That is
+easier for generated state but weaker for review because `.graphify` may be
+ignored or overwritten.
+
+### D2 - Citation inline surface
+
+Recommendation: target config separates user-facing citation display from
+storage. Graphify defaults may remain bounded, but a publication target can
+require full display via `ontology/citations.json` and still keep
+`graph.json` lean with `inline.mode: top_k`. `inline.mode: full` remains
+available only as an explicit small-bundle choice.
+
+This addresses the incident directly: a decided target would have rejected an
+effective `inlineTopK=8` run if no full sidecar/display surface existed, and it
+would have rejected the Opus graph for shrinking Sherlock's `citation_count`
+from the baseline.
+
+It also rejects a graph whose producer prompt only asked for "at least one"
+citation per entity, even if the resulting graph happens to satisfy an inline
+top-K shape. The target's extraction requirement is part of the manifest
+contract, not a UI convention.
+
+### D3 - QA blocking semantics
+
+Recommendation: `graphify qa` is advisory for non-publication targets, blocking
+with `--fail-on-error`, and always blocking for targets whose
+`publication.blocking` is true. This keeps experiments cheap while making
+publish flows safe.
+
+### D4 - Domain thresholds
+
+Recommendation: thresholds live in the project target, not in Graphify code.
+Graphify provides generic predicates; the mystery pack supplies values like
+`character_sherlock_holmes >= 89` and `reconciliation >= 31`.
+
+### D5 - Evaluation surface
+
+Recommendation: QA reads the final bundle path. Intermediate graph state can be
+checked too, but it is not sufficient for publication because the incident was
+created by a last-mile bundle overlay.
+
+### D6 - Baseline shrink semantics
+
+Recommendation: baseline deltas are informational by default, but become
+blocking when a target config declares `shrink_guard` or `no_shrink_by_node`.
+This prevents a future graph from barely clearing an absolute minimum while
+silently regressing from the last accepted bundle.
+
+### D7 - QA config loader
+
+Recommendation: implement a target-only config parser for `graphify qa` and keep
+the existing strict project config loader for producer commands. This allows a
+repo to commit a minimal QA target without also declaring an ontology profile or
+corpus, while still letting full project builds validate their richer config.
+
+### D8 - Citation policy model boundary
+
+Recommendation: do not overload the existing `ResolvedCitationPolicy`
+(`describeCap`, numeric `inlineTopK`) with the target's display contract. Add a
+separate normalized target citation policy:
+
+```ts
+type TargetCitationDisplay = "inline" | "full";
+type TargetCitationInline = { mode: "top_k"; topK: number } | { mode: "full" };
+type TargetCitationExtraction = "all_extracted" | "bounded_sample" | "unknown";
+```
+
+Producer commands still resolve the implementation policy (`describeCap`,
+`inlineTopK`). QA compares the resolved implementation policy plus final bundle
+artifacts against the target display contract.
+
+### D9 - Producer proof for exhaustive citations
+
+Recommendation: publication targets may require producer proof. For citations,
+that proof is a structured citation extraction contract whose canonical hash is
+allowlisted by the target, plus the assembly merge mode that preserved it. The
+final bundle still carries the measured counts; the producer proof explains
+whether those counts came from the intended exhaustive process or from a bounded
+sample. This is what would have rejected the scratch Opus reindex prompt before
+serving.
+
+### D10 - Artifact provenance and QA report binding
+
+Recommendation: manifest artifacts are structured records, not bare hashes.
+Each required publication artifact records `bundle_path`, `source_path`,
+`source_kind`, and `sha256`. QA reports are bound to the exact target hash,
+manifest hash, artifact hashes, and, for data-only chrome publications, the
+data allowlist hash plus both non-data tree hashes. Publication commands either
+run QA in-process or verify that the precomputed report still matches the final
+staged bytes and current chrome reference bytes.
+
+### D11 - Full sidecar means full sidecar
+
+Recommendation: when a target says `display: full` and `require_sidecar: true`,
+QA validates the sidecar for every citation-bearing node, not only sentinel
+nodes. Sentinel thresholds such as Sherlock are additional UAT checks; they are
+not a substitute for full-store coverage.
+
+## Implementation Notes
+
+- Extend `GraphifyProjectConfig` / `NormalizedProjectConfig` with
+  `quality.targets`.
+- Add a target-only loader so `graphify qa` can read `quality.targets` without
+  requiring `profile.path` / `inputs.corpus`.
+- Wire target-selected citation knobs into `resolveCitationPolicyForRoot` only
+  for implementation fields that already exist (`describeCap`, numeric
+  `inlineTopK`); keep display/full-sidecar semantics in the target QA layer.
+- Add pure parsers and evaluators under a new `src/quality-target.ts` /
+  `src/qa.ts` split.
+- Add a canonical JSON hashing helper for structured citation extraction
+  contracts; do not hash raw prompt text as the only proof.
+- Extend target manifests so artifacts are structured provenance records.
+- Bind QA reports to target, manifest, and artifact hashes.
+- Add CLI command `graphify qa`.
+- Keep QA report writing deterministic and sorted.
+- Add fixture tests for:
+  - target config validation
+  - producer manifest rejection when target requires `all_extracted` but the
+    manifest says `bounded_sample`, `unknown`, or omits extraction proof
+  - contract hash rejection when the embedded structured contract hash is not in
+    `allowed_contract_hashes`
+  - extraction-unit coverage rejection when one batch/fragment is unknown or
+    bounded
+  - effective policy/display mismatch (`inlineTopK=8` with no full sidecar when
+    target says full display)
+  - sidecar count mismatch (`graph.json.citation_count` differs from
+    `ontology/citations.json.nodes[id].count` or `citations.length`)
+  - stale/mismatched citation sidecar graph signature
+  - missing sidecar entries for non-sentinel citation-bearing nodes
+  - Sherlock-like min-count check using synthetic IDs
+  - reconciliation total check
+  - truncated/paginated reconciliation response rejection
+  - groupable-by-type check
+  - artifact provenance rejection for denied `.graphify/scratch/**` sources
+  - stale QA report rejection after an artifact hash changes
+  - stale QA report rejection after the chrome reference tree or staged
+    non-data tree changes under `data_only_chrome`
+  - `data_only_chrome` rejection when `chrome_reference_path` self-compares with
+    the staged bundle
+  - data-only chrome hash check
+
+## Acceptance Criteria
+
+- A project can commit a target config that records citation, graph,
+  reconciliation, community, and publication expectations.
+- A publication target can require `citations.extraction.mode: all_extracted`;
+  QA fails if the resolved manifest cannot prove that contract.
+- QA validates exhaustive citation proof by structured contract hash allowlist,
+  not by accepting any manifest field named `all_extracted`.
+- Running a build with the wrong citation display/inline policy produces a QA
+  failure.
+- Running a build whose prompt/producer only requires one citation per entity
+  fails the target, even if the inline citations array has exactly top-K items.
+- Running QA against a bundle with a partial or stale `ontology/citations.json`
+  fails when the target requires full sidecar display.
+- Running QA against a bundle with zero reconciliation candidates fails when
+  `min_candidates` is positive.
+- Running QA against a paginated/truncated reconciliation response fails for a
+  publication target even if `total` is high enough.
+- Running QA against the Opus incident bundle fails for citation count and
+  reconciliation count, and for provenance if it is sourced from
+  `.graphify/scratch/**`.
+- Running QA against the previous UAT bundle passes the configured mystery
+  thresholds except any explicitly waived sidecar/community-label checks.
+- A blocking publication target cannot be served/copied/pushed without a
+  matching resolved manifest and passing QA run or matching precomputed QA
+  report, including matching chrome tree hashes when `data_only_chrome` is
+  enabled.
+- A data-only republish fails if any file outside the data allowlist changes
+  relative to the chrome reference bundle.
+- No LLM or network call is required for QA.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4162,6 +4162,67 @@ export async function main(): Promise<void> {
       );
     });
 
+  program
+    .command("qa")
+    .description("Evaluate a final Graphify bundle against a configured quality target")
+    .requiredOption("--target <id>", "quality.targets.<id> to evaluate")
+    .option("--config <path>", "graphify.yaml / .graphify/config.yaml containing quality.targets")
+    .option("--bundle <path>", "Final bundle directory; defaults to the target bundle_path")
+    .option("--manifest <path>", "Resolved target manifest JSON; defaults to <bundle>/resolved-target.json when present")
+    .option("--write-report [path]", "Write graphify_qa_report_v1 JSON; default <bundle>/quality-qa-report.json")
+    .option("--fail-on-error", "Exit non-zero when QA reports errors, even for advisory targets")
+    .action(async (opts) => {
+      const {
+        discoverQualityTargetsConfig,
+        loadQualityTargetsConfig,
+      } = await import("./quality-target.js");
+      const {
+        QA_REPORT_FILENAME,
+        evaluateQualityBundle,
+      } = await import("./qa.js");
+      type ResolvedTargetManifest = import("./qa.js").ResolvedTargetManifest;
+
+      const configPath = opts.config
+        ? resolve(opts.config)
+        : (() => {
+            const discovery = discoverQualityTargetsConfig(".");
+            return discovery.found ? discovery.path : null;
+          })();
+      if (!configPath) {
+        console.error("error: no graphify config found for quality target");
+        process.exit(1);
+      }
+      const config = loadQualityTargetsConfig(configPath);
+      const target = config.targets[String(opts.target)];
+      if (!target) {
+        console.error(`error: quality target not found: ${opts.target}`);
+        process.exit(1);
+      }
+      const bundleDir = resolve(opts.bundle ?? target.resolvedBundlePath ?? target.bundle_path ?? ".");
+      if (!existsSync(bundleDir) || !statSync(bundleDir).isDirectory()) {
+        console.error(`error: bundle directory not found: ${bundleDir}`);
+        process.exit(1);
+      }
+      const manifestPath = opts.manifest
+        ? resolve(opts.manifest)
+        : join(bundleDir, "resolved-target.json");
+      const manifest = existsSync(manifestPath)
+        ? readJson<ResolvedTargetManifest>(manifestPath)
+        : null;
+      const report = evaluateQualityBundle({ target, bundleDir, manifest });
+      const writeReport = opts.writeReport;
+      if (writeReport !== undefined) {
+        const reportPath = typeof writeReport === "string"
+          ? resolve(writeReport)
+          : join(bundleDir, QA_REPORT_FILENAME);
+        writeJson(reportPath, report);
+      }
+      console.log(JSON.stringify(report, null, 2));
+      if (report.status === "failed" && (opts.failOnError === true || target.publication.blocking)) {
+        process.exit(1);
+      }
+    });
+
   const wikiCommand = program
     .command("wiki")
     .description("Generate and maintain Graphify wiki artifacts");

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,56 @@ export {
   validateProjectConfig,
 } from "./project-config.js";
 export {
+  ALL_EXTRACTED_CITATION_CONTRACT,
+  ALL_EXTRACTED_CITATION_CONTRACT_ID,
+  CITATION_EXTRACTION_CONTRACT_SCHEMA,
+  QUALITY_TARGET_CONFIG_CANDIDATES,
+  canonicalJson,
+  discoverQualityTargetsConfig,
+  hashCitationExtractionContract,
+  hashQualityTarget,
+  loadQualityTargetsConfig,
+  normalizeQualityTarget,
+  normalizeQualityTargetsConfig,
+  parseQualityTargetsConfig,
+  sha256Prefixed,
+  validateCitationExtractionContractForTarget,
+  validateQualityTarget,
+} from "./quality-target.js";
+export type {
+  CitationExtractionContract,
+  NormalizedQualityTarget,
+  NormalizedQualityTargetsConfig,
+  QualityTargetCitationExtractionConfig,
+  QualityTargetCitationsConfig,
+  QualityTargetCommunitiesConfig,
+  QualityTargetDiscoveryResult,
+  QualityTargetGraphConfig,
+  QualityTargetPublicationConfig,
+  QualityTargetReconciliationConfig,
+  TargetCitationDisplay,
+  TargetCitationExtractionMode,
+  TargetCitationInline,
+} from "./quality-target.js";
+export {
+  QA_REPORT_FILENAME,
+  QA_REPORT_SCHEMA,
+  RESOLVED_TARGET_MANIFEST_SCHEMA,
+  computeDataOnlyChromeHashes,
+  computeGraphCitationSignatureFromJson,
+  evaluateQualityBundle,
+  sha256File,
+  validatePrecomputedQaReportBinding,
+} from "./qa.js";
+export type {
+  DataOnlyChromeHashes,
+  EvaluateQualityBundleOptions,
+  QualityQaCheck,
+  QualityQaReport,
+  ResolvedTargetArtifact,
+  ResolvedTargetManifest,
+} from "./qa.js";
+export {
   createAssistantTextJsonClient,
   createAssistantVisionJsonClient,
   createDirectTextJsonClient,

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -1,0 +1,626 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+import {
+  CITATION_EXTRACTION_CONTRACT_SCHEMA,
+  canonicalJson,
+  sha256Prefixed,
+  validateCitationExtractionContractForTarget,
+  validateQualityTarget,
+  type CitationExtractionContract,
+  type NormalizedQualityTarget,
+} from "./quality-target.js";
+
+export const RESOLVED_TARGET_MANIFEST_SCHEMA = "graphify_resolved_target_v1";
+export const QA_REPORT_SCHEMA = "graphify_qa_report_v1";
+export const QA_REPORT_FILENAME = "quality-qa-report.json";
+
+export interface ResolvedTargetArtifact {
+  bundle_path: string;
+  source_path: string;
+  source_kind: string;
+  sha256: string;
+}
+
+export interface ResolvedTargetManifest {
+  schema: typeof RESOLVED_TARGET_MANIFEST_SCHEMA;
+  target_id: string;
+  target_hash?: string;
+  graphify_version?: string;
+  producer?: Record<string, unknown>;
+  artifacts: Record<string, ResolvedTargetArtifact>;
+  resolved_policy?: {
+    corpus_type?: string;
+    citations?: {
+      extraction?: {
+        mode?: string;
+        contract_id?: string;
+        contract_hash?: string;
+        contract?: CitationExtractionContract;
+        assembly?: {
+          same_entity_merge?: string;
+          dedupe_key?: string[];
+        };
+      };
+      describeCap?: string | number;
+      display?: string;
+      inline?: Record<string, unknown>;
+      sidecar?: Record<string, unknown>;
+    };
+  };
+  inputs?: Record<string, unknown>;
+  extraction_units?: Array<{
+    id: string;
+    source_path?: string;
+    contract_id?: string;
+    contract_hash?: string;
+    citation_mode?: string;
+  }>;
+}
+
+export interface QualityQaCheck {
+  id: string;
+  severity: "error" | "warning" | "info";
+  message: string;
+  expected?: unknown;
+  actual?: unknown;
+}
+
+export interface QualityQaReport {
+  schema: typeof QA_REPORT_SCHEMA;
+  target_id: string;
+  target_hash: string | null;
+  manifest_hash: string | null;
+  bundle_path: string;
+  artifact_hashes: Record<string, string>;
+  chrome?: DataOnlyChromeHashes;
+  status: "passed" | "failed";
+  summary: { passed: number; failed: number; warned: number };
+  checks: QualityQaCheck[];
+}
+
+export interface DataOnlyChromeHashes {
+  data_only: true;
+  data_allowlist_hash: string;
+  bundle_non_data_tree_hash: string;
+  chrome_reference_path: string;
+  chrome_reference_tree_hash: string;
+}
+
+export interface EvaluateQualityBundleOptions {
+  target: NormalizedQualityTarget;
+  bundleDir: string;
+  manifest?: ResolvedTargetManifest | null;
+  targetHash?: string | null;
+}
+
+export function sha256File(path: string): string {
+  return sha256Prefixed(readFileSync(path));
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function normalizeSha(value: string): string {
+  return value.startsWith("sha256:") ? value : `sha256:${value}`;
+}
+
+function sortedJsonHash(value: unknown): string {
+  return sha256Prefixed(canonicalJson(value));
+}
+
+function relativePosix(root: string, path: string): string {
+  return relative(root, path).split(sep).join("/");
+}
+
+function listFiles(root: string): string[] {
+  if (!existsSync(root) || !statSync(root).isDirectory()) return [];
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const stat = statSync(path);
+      if (stat.isDirectory()) {
+        walk(path);
+      } else if (stat.isFile()) {
+        out.push(relativePosix(root, path));
+      }
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+function fileSetHash(root: string, files: string[]): string {
+  const entries = files.map((rel) => {
+    const path = join(root, rel);
+    return [rel, existsSync(path) && statSync(path).isFile() ? sha256File(path) : null] as const;
+  });
+  return sortedJsonHash(entries);
+}
+
+function treeHash(root: string, options: { exclude?: Set<string> } = {}): string {
+  const exclude = options.exclude ?? new Set<string>();
+  const files = listFiles(root).filter((rel) => !exclude.has(rel) && rel !== QA_REPORT_FILENAME);
+  return fileSetHash(root, files);
+}
+
+export function computeDataOnlyChromeHashes(
+  bundleDir: string,
+  chromeReferenceDir: string,
+  dataAllowlist: string[],
+): DataOnlyChromeHashes {
+  const allowlist = [...dataAllowlist].sort();
+  const exclude = new Set(allowlist);
+  return {
+    data_only: true,
+    data_allowlist_hash: sortedJsonHash(allowlist),
+    bundle_non_data_tree_hash: treeHash(bundleDir, { exclude }),
+    chrome_reference_path: chromeReferenceDir,
+    chrome_reference_tree_hash: treeHash(chromeReferenceDir, { exclude }),
+  };
+}
+
+function add(
+  checks: QualityQaCheck[],
+  failed: boolean,
+  id: string,
+  message: string,
+  details: Omit<QualityQaCheck, "id" | "message" | "severity"> = {},
+): void {
+  checks.push({
+    id,
+    severity: failed ? "error" : "info",
+    message,
+    ...details,
+  });
+}
+
+function addWarning(
+  checks: QualityQaCheck[],
+  id: string,
+  message: string,
+  details: Omit<QualityQaCheck, "id" | "message" | "severity"> = {},
+): void {
+  checks.push({ id, severity: "warning", message, ...details });
+}
+
+function globDenyMatch(pattern: string, path: string): boolean {
+  const normalizedPattern = pattern.split("\\").join("/");
+  const normalizedPath = path.split("\\").join("/");
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3);
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`);
+  }
+  return normalizedPath === normalizedPattern || normalizedPath.includes(normalizedPattern);
+}
+
+function artifactPathFor(target: NormalizedQualityTarget): string[] {
+  return [...target.publication.data_allowlist];
+}
+
+function loadBundleJson(bundleDir: string, rel: string): unknown | null {
+  const path = join(bundleDir, rel);
+  if (!existsSync(path) || !statSync(path).isFile()) return null;
+  return readJson(path);
+}
+
+function graphNodes(graph: unknown): Array<Record<string, unknown>> {
+  const nodes = asRecord(graph).nodes;
+  return Array.isArray(nodes) ? nodes.filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null) : [];
+}
+
+function graphEdges(graph: unknown): unknown[] {
+  const rec = asRecord(graph);
+  const links = rec.links ?? rec.edges;
+  return Array.isArray(links) ? links : [];
+}
+
+function nodeType(node: Record<string, unknown>): string | null {
+  const value = node.node_type ?? node.type;
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function computeGraphCitationSignatureFromJson(graph: unknown): string {
+  const projection: Record<string, unknown[]> = {};
+  for (const node of graphNodes(graph)) {
+    const id = typeof node.id === "string" ? node.id : null;
+    const citations = node.citations;
+    if (!id || !Array.isArray(citations) || citations.length === 0) continue;
+    projection[id] = citations;
+  }
+  const canonical = Object.keys(projection).sort().map((id) => [id, projection[id]] as const);
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+function evaluateTargetShape(target: NormalizedQualityTarget, checks: QualityQaCheck[]): void {
+  for (const issue of validateQualityTarget(target)) {
+    add(checks, true, "target.validate", issue);
+  }
+}
+
+function evaluateManifest(
+  target: NormalizedQualityTarget,
+  bundleDir: string,
+  manifest: ResolvedTargetManifest | null | undefined,
+  checks: QualityQaCheck[],
+): string | null {
+  if (!manifest) {
+    add(
+      checks,
+      target.publication.require_resolved_manifest,
+      "manifest.required",
+      "resolved target manifest is required",
+    );
+    return null;
+  }
+  const manifestHash = sortedJsonHash(manifest);
+  add(checks, manifest.schema !== RESOLVED_TARGET_MANIFEST_SCHEMA, "manifest.schema", "manifest schema must match", {
+    expected: RESOLVED_TARGET_MANIFEST_SCHEMA,
+    actual: manifest.schema,
+  });
+
+  const citationExtraction = manifest.resolved_policy?.citations?.extraction;
+  const expectedExtraction = target.citations.extraction;
+  add(
+    checks,
+    citationExtraction?.mode !== expectedExtraction.mode,
+    "manifest.citations.extraction.mode",
+    "manifest citation extraction mode must match target",
+    { expected: expectedExtraction.mode, actual: citationExtraction?.mode ?? null },
+  );
+
+  if (expectedExtraction.require_producer_proof) {
+    const contract = citationExtraction?.contract;
+    if (!contract) {
+      add(checks, true, "manifest.citations.contract", "structured citation extraction contract is required");
+    } else {
+      for (const issue of validateCitationExtractionContractForTarget(target, contract)) {
+        add(checks, true, "manifest.citations.contract", issue);
+      }
+      const hash = sortedJsonHash(contract);
+      add(
+        checks,
+        citationExtraction?.contract_hash !== hash,
+        "manifest.citations.contract_hash",
+        "manifest contract hash must match canonical contract",
+        { expected: hash, actual: citationExtraction?.contract_hash ?? null },
+      );
+      add(
+        checks,
+        contract.schema !== CITATION_EXTRACTION_CONTRACT_SCHEMA,
+        "manifest.citations.contract_schema",
+        "manifest contract schema must be structured citation contract",
+      );
+    }
+    add(
+      checks,
+      citationExtraction?.assembly?.same_entity_merge !== "union_by_citation_identity",
+      "manifest.citations.assembly",
+      "citation assembly must union same-entity citations",
+      { expected: "union_by_citation_identity", actual: citationExtraction?.assembly?.same_entity_merge ?? null },
+    );
+  }
+
+  const units = manifest.extraction_units ?? [];
+  if (expectedExtraction.require_batch_coverage) {
+    add(checks, units.length === 0, "manifest.extraction_units.present", "extraction units are required");
+    for (const unit of units) {
+      const badMode = unit.citation_mode !== expectedExtraction.mode;
+      add(checks, badMode, `manifest.extraction_units.${unit.id}.mode`, "extraction unit citation mode must match target", {
+        expected: expectedExtraction.mode,
+        actual: unit.citation_mode ?? null,
+      });
+      const badHash = !unit.contract_hash || !expectedExtraction.allowed_contract_hashes.includes(unit.contract_hash);
+      add(checks, badHash, `manifest.extraction_units.${unit.id}.contract_hash`, "extraction unit contract hash must be allowlisted", {
+        actual: unit.contract_hash ?? null,
+      });
+    }
+  }
+
+  for (const rel of artifactPathFor(target)) {
+    const artifact = manifest.artifacts?.[rel];
+    if (!artifact) {
+      add(checks, true, `manifest.artifacts.${rel}.present`, "required artifact provenance is missing");
+      continue;
+    }
+    for (const field of ["bundle_path", "source_path", "source_kind", "sha256"] as const) {
+      add(
+        checks,
+        typeof artifact[field] !== "string" || artifact[field].length === 0,
+        `manifest.artifacts.${rel}.${field}`,
+        `artifact ${field} is required`,
+      );
+    }
+    const denied = target.publication.deny_source_path_patterns.some((pattern) =>
+      globDenyMatch(pattern, artifact.source_path),
+    );
+    add(checks, denied, `manifest.artifacts.${rel}.source_path`, "artifact source path is denied", {
+      actual: artifact.source_path,
+    });
+    const bundlePath = join(bundleDir, rel);
+    if (existsSync(bundlePath) && statSync(bundlePath).isFile()) {
+      const actualHash = sha256File(bundlePath);
+      add(
+        checks,
+        normalizeSha(artifact.sha256) !== actualHash,
+        `manifest.artifacts.${rel}.sha256`,
+        "artifact hash must match bundle bytes",
+        { expected: normalizeSha(artifact.sha256), actual: actualHash },
+      );
+    }
+  }
+
+  return manifestHash;
+}
+
+function evaluateGraph(target: NormalizedQualityTarget, graph: unknown | null, checks: QualityQaCheck[]): void {
+  if (!graph) {
+    add(checks, true, "graph.present", "graph.json is required");
+    return;
+  }
+  const nodes = graphNodes(graph);
+  const edges = graphEdges(graph);
+  if (target.graph.min_nodes !== null) {
+    add(checks, nodes.length < target.graph.min_nodes, "graph.min_nodes", "graph node count must meet target", {
+      expected: `>= ${target.graph.min_nodes}`,
+      actual: nodes.length,
+    });
+  }
+  if (target.graph.min_edges !== null) {
+    add(checks, edges.length < target.graph.min_edges, "graph.min_edges", "graph edge count must meet target", {
+      expected: `>= ${target.graph.min_edges}`,
+      actual: edges.length,
+    });
+  }
+  if (target.graph.max_missing_descriptions !== null) {
+    const missing = nodes.filter((node) => typeof node.description !== "string" || !node.description.trim()).length;
+    add(
+      checks,
+      missing > target.graph.max_missing_descriptions,
+      "graph.max_missing_descriptions",
+      "missing descriptions must be within target",
+      { expected: `<= ${target.graph.max_missing_descriptions}`, actual: missing },
+    );
+  }
+}
+
+function evaluateCitations(
+  target: NormalizedQualityTarget,
+  graph: unknown | null,
+  sidecar: unknown | null,
+  checks: QualityQaCheck[],
+): void {
+  if (!graph) return;
+  const nodes = graphNodes(graph);
+  const nodeById = new Map(nodes.map((node) => [String(node.id), node]));
+  for (const [nodeId, min] of Object.entries(target.citations.min_count_by_node)) {
+    const node = nodeById.get(nodeId);
+    const count = typeof node?.citation_count === "number" ? node.citation_count : null;
+    add(checks, count === null || count < min, `citations.min_count_by_node.${nodeId}`, "citation count must meet target", {
+      expected: `>= ${min}`,
+      actual: count,
+    });
+  }
+
+  for (const node of nodes) {
+    const id = typeof node.id === "string" ? node.id : null;
+    if (!id) continue;
+    const inline = Array.isArray(node.citations) ? node.citations : [];
+    const count = typeof node.citation_count === "number" ? node.citation_count : 0;
+    add(
+      checks,
+      count < inline.length,
+      `citations.count_gte_inline.${id}`,
+      "citation_count must not be less than inline citations length",
+      { actual: { count, inline: inline.length } },
+    );
+    if (target.citations.inline.mode === "top_k") {
+      add(
+        checks,
+        inline.length > target.citations.inline.top_k,
+        `citations.inline.top_k.${id}`,
+        "inline citations must respect top_k",
+        { expected: `<= ${target.citations.inline.top_k}`, actual: inline.length },
+      );
+    }
+  }
+
+  if (!(target.citations.display === "full" && target.citations.require_sidecar)) return;
+  if (!sidecar) {
+    add(checks, true, "citations.sidecar.present", "ontology/citations.json is required for full citation display");
+    return;
+  }
+  const sidecarRecord = asRecord(sidecar);
+  add(
+    checks,
+    sidecarRecord.schema !== "graphify_ontology_citations_v1",
+    "citations.sidecar.schema",
+    "citation sidecar schema must match",
+    { expected: "graphify_ontology_citations_v1", actual: sidecarRecord.schema ?? null },
+  );
+  const expectedSignature = computeGraphCitationSignatureFromJson(graph);
+  add(
+    checks,
+    sidecarRecord.graph_signature !== expectedSignature,
+    "citations.sidecar.graph_signature",
+    "citation sidecar graph_signature must match graph inline citations",
+    { expected: expectedSignature, actual: sidecarRecord.graph_signature ?? null },
+  );
+  const sidecarNodes = asRecord(sidecarRecord.nodes);
+  for (const node of nodes) {
+    const id = typeof node.id === "string" ? node.id : null;
+    const count = typeof node.citation_count === "number" ? node.citation_count : 0;
+    if (!id || count <= 0) continue;
+    const entry = asRecord(sidecarNodes[id]);
+    const citations = entry.citations;
+    const actualCount = typeof entry.count === "number" ? entry.count : null;
+    const actualLength = Array.isArray(citations) ? citations.length : null;
+    add(checks, !entry || actualCount !== count || actualLength !== count, `citations.sidecar.node.${id}`, "sidecar entry must match citation_count", {
+      expected: count,
+      actual: { count: actualCount, citations_length: actualLength },
+    });
+  }
+}
+
+function candidateArrayFromReconciliation(reconciliation: unknown, graph: unknown | null, checks: QualityQaCheck[]): Array<Record<string, unknown>> {
+  const rec = asRecord(reconciliation);
+  if (rec.schema === "graphify_ontology_reconciliation_candidates_v1") {
+    const candidates = Array.isArray(rec.candidates) ? rec.candidates.filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null) : [];
+    add(
+      checks,
+      typeof rec.candidate_count === "number" && rec.candidate_count !== candidates.length,
+      "reconciliation.queue.count_consistency",
+      "candidate_count must match candidates length",
+      { expected: rec.candidate_count, actual: candidates.length },
+    );
+    return candidates;
+  }
+  if (rec.schema === "graphify_ontology_reconciliation_candidates_response_v1") {
+    const items = Array.isArray(rec.items) ? rec.items.filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null) : [];
+    const complete = rec.offset === 0 && rec.total === items.length && rec.stale === false;
+    add(
+      checks,
+      !complete,
+      "reconciliation.response.complete",
+      "publication reconciliation response must be complete, unpaginated, and non-stale",
+      { expected: { offset: 0, items_length: rec.total, stale: false }, actual: { offset: rec.offset, items_length: items.length, total: rec.total, stale: rec.stale } },
+    );
+    const graphHash = asRecord(graph).topology_signature;
+    if (typeof graphHash === "string" && typeof rec.graph_hash === "string") {
+      add(
+        checks,
+        rec.graph_hash !== graphHash,
+        "reconciliation.response.graph_hash",
+        "reconciliation response graph_hash must match graph",
+        { expected: graphHash, actual: rec.graph_hash },
+      );
+    }
+    return complete ? items : [];
+  }
+  add(checks, true, "reconciliation.schema", "reconciliation candidates schema is unsupported", {
+    actual: rec.schema ?? null,
+  });
+  return [];
+}
+
+function evaluateReconciliation(
+  target: NormalizedQualityTarget,
+  graph: unknown | null,
+  reconciliation: unknown | null,
+  checks: QualityQaCheck[],
+): void {
+  if (!reconciliation) {
+    if (target.reconciliation.min_candidates !== null && target.reconciliation.min_candidates > 0) {
+      add(checks, true, "reconciliation.present", "reconciliation-candidates.json is required");
+    }
+    return;
+  }
+  const candidates = candidateArrayFromReconciliation(reconciliation, graph, checks);
+  if (target.reconciliation.min_candidates !== null) {
+    add(
+      checks,
+      candidates.length < target.reconciliation.min_candidates,
+      "reconciliation.min_candidates",
+      "reconciliation candidate count must meet target",
+      { expected: `>= ${target.reconciliation.min_candidates}`, actual: candidates.length },
+    );
+  }
+  if (!graph) return;
+  const nodes = graphNodes(graph);
+  const nodeById = new Map(nodes.map((node) => [String(node.id), node]));
+  for (const candidate of candidates) {
+    const id = typeof candidate.id === "string" ? candidate.id : "unknown";
+    const candidateId = typeof candidate.candidate_id === "string" ? candidate.candidate_id : null;
+    const canonicalId = typeof candidate.canonical_id === "string" ? candidate.canonical_id : null;
+    const endpointsPresent = Boolean(candidateId && canonicalId && nodeById.has(candidateId) && nodeById.has(canonicalId));
+    add(checks, !endpointsPresent, `reconciliation.candidate.${id}.endpoints`, "candidate endpoints must resolve in graph");
+    if (target.reconciliation.require_groupable_by_type && endpointsPresent) {
+      const leftType = nodeType(nodeById.get(candidateId!)!);
+      const rightType = nodeType(nodeById.get(canonicalId!)!);
+      add(
+        checks,
+        !leftType || !rightType,
+        `reconciliation.candidate.${id}.types`,
+        "candidate endpoints must be groupable by type",
+        { actual: { candidate_type: leftType, canonical_type: rightType } },
+      );
+    }
+  }
+}
+
+function artifactHashes(bundleDir: string, rels: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rel of [...rels].sort()) {
+    const path = join(bundleDir, rel);
+    if (existsSync(path) && statSync(path).isFile()) out[rel] = sha256File(path);
+  }
+  return out;
+}
+
+export function evaluateQualityBundle(options: EvaluateQualityBundleOptions): QualityQaReport {
+  const checks: QualityQaCheck[] = [];
+  const { target, bundleDir, manifest = null } = options;
+  evaluateTargetShape(target, checks);
+  const manifestHash = evaluateManifest(target, bundleDir, manifest, checks);
+  const graph = loadBundleJson(bundleDir, "graph.json");
+  const sidecar = loadBundleJson(bundleDir, "ontology/citations.json");
+  const reconciliation = loadBundleJson(bundleDir, "reconciliation-candidates.json");
+  evaluateGraph(target, graph, checks);
+  evaluateCitations(target, graph, sidecar, checks);
+  evaluateReconciliation(target, graph, reconciliation, checks);
+
+  const chrome = target.publication.data_only_chrome && target.publication.resolvedChromeReferencePath
+    ? computeDataOnlyChromeHashes(bundleDir, target.publication.resolvedChromeReferencePath, target.publication.data_allowlist)
+    : undefined;
+  const failed = checks.filter((check) => check.severity === "error").length;
+  const warned = checks.filter((check) => check.severity === "warning").length;
+  const passed = checks.filter((check) => check.severity === "info").length;
+  return {
+    schema: QA_REPORT_SCHEMA,
+    target_id: target.id,
+    target_hash: options.targetHash ?? null,
+    manifest_hash: manifestHash,
+    bundle_path: bundleDir,
+    artifact_hashes: artifactHashes(bundleDir, target.publication.data_allowlist),
+    ...(chrome ? { chrome } : {}),
+    status: failed > 0 ? "failed" : "passed",
+    summary: { passed, failed, warned },
+    checks,
+  };
+}
+
+export function validatePrecomputedQaReportBinding(
+  report: QualityQaReport,
+  options: EvaluateQualityBundleOptions,
+): QualityQaCheck[] {
+  const checks: QualityQaCheck[] = [];
+  const current = evaluateQualityBundle(options);
+  add(checks, report.target_hash !== current.target_hash, "qa_report.target_hash", "QA report target hash must match", {
+    expected: current.target_hash,
+    actual: report.target_hash,
+  });
+  add(checks, report.manifest_hash !== current.manifest_hash, "qa_report.manifest_hash", "QA report manifest hash must match", {
+    expected: current.manifest_hash,
+    actual: report.manifest_hash,
+  });
+  add(checks, canonicalJson(report.artifact_hashes) !== canonicalJson(current.artifact_hashes), "qa_report.artifact_hashes", "QA report artifact hashes must match");
+  if (current.chrome) {
+    add(
+      checks,
+      canonicalJson(report.chrome ?? null) !== canonicalJson(current.chrome),
+      "qa_report.chrome",
+      "QA report chrome hashes must match staged bundle and current chrome reference",
+      { expected: current.chrome, actual: report.chrome ?? null },
+    );
+  }
+  return checks;
+}

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 
 import {
   CITATION_EXTRACTION_CONTRACT_SCHEMA,
   canonicalJson,
+  hashQualityTarget,
   sha256Prefixed,
   validateCitationExtractionContractForTarget,
   validateQualityTarget,
@@ -149,7 +150,9 @@ function fileSetHash(root: string, files: string[]): string {
 
 function treeHash(root: string, options: { exclude?: Set<string> } = {}): string {
   const exclude = options.exclude ?? new Set<string>();
-  const files = listFiles(root).filter((rel) => !exclude.has(rel) && rel !== QA_REPORT_FILENAME);
+  const files = listFiles(root).filter((rel) =>
+    !exclude.has(rel) && rel !== QA_REPORT_FILENAME && rel !== "resolved-target.json"
+  );
   return fileSetHash(root, files);
 }
 
@@ -247,10 +250,35 @@ function evaluateTargetShape(target: NormalizedQualityTarget, checks: QualityQaC
   }
 }
 
+function evaluateDataOnlyChromeTarget(
+  target: NormalizedQualityTarget,
+  bundleDir: string,
+  checks: QualityQaCheck[],
+): void {
+  if (!target.publication.data_only_chrome) return;
+  const referencePath = target.publication.resolvedChromeReferencePath;
+  if (!referencePath) return;
+  add(
+    checks,
+    resolve(bundleDir) === resolve(referencePath),
+    "publication.chrome_reference_path",
+    "chrome reference path must not resolve to the evaluated bundle path",
+    { actual: referencePath },
+  );
+  add(
+    checks,
+    !existsSync(referencePath) || !statSync(referencePath).isDirectory(),
+    "publication.chrome_reference_path.present",
+    "chrome reference path must exist as a directory",
+    { actual: referencePath },
+  );
+}
+
 function evaluateManifest(
   target: NormalizedQualityTarget,
   bundleDir: string,
   manifest: ResolvedTargetManifest | null | undefined,
+  targetHash: string,
   checks: QualityQaCheck[],
 ): string | null {
   if (!manifest) {
@@ -267,6 +295,17 @@ function evaluateManifest(
     expected: RESOLVED_TARGET_MANIFEST_SCHEMA,
     actual: manifest.schema,
   });
+  add(checks, manifest.target_id !== target.id, "manifest.target_id", "manifest target_id must match selected target", {
+    expected: target.id,
+    actual: manifest.target_id,
+  });
+  add(
+    checks,
+    manifest.target_hash !== targetHash,
+    "manifest.target_hash",
+    "manifest target_hash must match current target config",
+    { expected: targetHash, actual: manifest.target_hash ?? null },
+  );
 
   const citationExtraction = manifest.resolved_policy?.citations?.extraction;
   const expectedExtraction = target.citations.extraction;
@@ -569,8 +608,10 @@ function artifactHashes(bundleDir: string, rels: string[]): Record<string, strin
 export function evaluateQualityBundle(options: EvaluateQualityBundleOptions): QualityQaReport {
   const checks: QualityQaCheck[] = [];
   const { target, bundleDir, manifest = null } = options;
+  const targetHash = options.targetHash ?? hashQualityTarget(target);
   evaluateTargetShape(target, checks);
-  const manifestHash = evaluateManifest(target, bundleDir, manifest, checks);
+  evaluateDataOnlyChromeTarget(target, bundleDir, checks);
+  const manifestHash = evaluateManifest(target, bundleDir, manifest, targetHash, checks);
   const graph = loadBundleJson(bundleDir, "graph.json");
   const sidecar = loadBundleJson(bundleDir, "ontology/citations.json");
   const reconciliation = loadBundleJson(bundleDir, "reconciliation-candidates.json");
@@ -587,7 +628,7 @@ export function evaluateQualityBundle(options: EvaluateQualityBundleOptions): Qu
   return {
     schema: QA_REPORT_SCHEMA,
     target_id: target.id,
-    target_hash: options.targetHash ?? null,
+    target_hash: targetHash,
     manifest_hash: manifestHash,
     bundle_path: bundleDir,
     artifact_hashes: artifactHashes(bundleDir, target.publication.data_allowlist),
@@ -611,6 +652,10 @@ export function validatePrecomputedQaReportBinding(
   add(checks, report.manifest_hash !== current.manifest_hash, "qa_report.manifest_hash", "QA report manifest hash must match", {
     expected: current.manifest_hash,
     actual: report.manifest_hash,
+  });
+  add(checks, resolve(report.bundle_path) !== resolve(current.bundle_path), "qa_report.bundle_path", "QA report bundle_path must match", {
+    expected: current.bundle_path,
+    actual: report.bundle_path,
   });
   add(checks, canonicalJson(report.artifact_hashes) !== canonicalJson(current.artifact_hashes), "qa_report.artifact_hashes", "QA report artifact hashes must match");
   if (current.chrome) {

--- a/src/quality-target.ts
+++ b/src/quality-target.ts
@@ -1,0 +1,393 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export const QUALITY_TARGET_CONFIG_CANDIDATES = [
+  "graphify.yaml",
+  "graphify.yml",
+  join(".graphify", "config.yaml"),
+  join(".graphify", "config.yml"),
+] as const;
+
+export const CITATION_EXTRACTION_CONTRACT_SCHEMA = "graphify_citation_extraction_contract_v1";
+export const ALL_EXTRACTED_CITATION_CONTRACT_ID = "graphify_all_extracted_entity_citations_v1";
+
+export type TargetCitationExtractionMode = "all_extracted" | "bounded_sample" | "unknown";
+export type TargetCitationDisplay = "inline" | "full";
+export type TargetCitationInline =
+  | { mode: "top_k"; top_k: number }
+  | { mode: "full" };
+
+export interface CitationExtractionContract {
+  schema: typeof CITATION_EXTRACTION_CONTRACT_SCHEMA;
+  id: string;
+  mode: TargetCitationExtractionMode;
+  requirements: {
+    emit_all_extracted_citations_per_entity?: boolean;
+    bounded_samples_allowed?: boolean;
+    minimum_one_citation_only_allowed?: boolean;
+    same_entity_merge?: string;
+    inline_projection_is_not_storage?: boolean;
+    full_store_required_when_display_full?: boolean;
+    [key: string]: unknown;
+  };
+  citation_identity: string[];
+}
+
+export const ALL_EXTRACTED_CITATION_CONTRACT: CitationExtractionContract = {
+  schema: CITATION_EXTRACTION_CONTRACT_SCHEMA,
+  id: ALL_EXTRACTED_CITATION_CONTRACT_ID,
+  mode: "all_extracted",
+  requirements: {
+    emit_all_extracted_citations_per_entity: true,
+    bounded_samples_allowed: false,
+    minimum_one_citation_only_allowed: false,
+    same_entity_merge: "union_by_citation_identity",
+    inline_projection_is_not_storage: true,
+    full_store_required_when_display_full: true,
+  },
+  citation_identity: ["source_file", "page", "section", "paragraph_id"],
+};
+
+export interface QualityTargetPublicationConfig {
+  blocking: boolean;
+  require_resolved_manifest: boolean;
+  data_only_chrome: boolean;
+  chrome_reference_path: string | null;
+  resolvedChromeReferencePath: string | null;
+  deny_source_path_patterns: string[];
+  data_allowlist: string[];
+}
+
+export interface QualityTargetCitationExtractionConfig {
+  mode: TargetCitationExtractionMode;
+  require_producer_proof: boolean;
+  contract_id: string | null;
+  allowed_contract_hashes: string[];
+  require_batch_coverage: boolean;
+}
+
+export interface QualityTargetCitationsConfig {
+  extraction: QualityTargetCitationExtractionConfig;
+  display: TargetCitationDisplay;
+  inline: TargetCitationInline;
+  require_sidecar: boolean;
+  min_count_by_node: Record<string, number>;
+  no_shrink_by_node: Record<string, { baseline_field: string; max_drop: number }>;
+}
+
+export interface QualityTargetGraphConfig {
+  min_nodes: number | null;
+  min_edges: number | null;
+  shrink_guard: {
+    nodes?: { max_drop: number };
+    edges?: { max_drop: number };
+  };
+  max_missing_descriptions: number | null;
+  max_orphan_nodes: number | null;
+}
+
+export interface QualityTargetReconciliationConfig {
+  min_candidates: number | null;
+  shrink_guard: {
+    candidates?: { max_drop: number };
+  };
+  require_groupable_by_type: boolean;
+}
+
+export interface QualityTargetCommunitiesConfig {
+  require_semantic_labels: boolean;
+}
+
+export interface NormalizedQualityTarget {
+  id: string;
+  kind: string;
+  bundle_path: string | null;
+  resolvedBundlePath: string | null;
+  baseline_bundle_path: string | null;
+  resolvedBaselineBundlePath: string | null;
+  publication: QualityTargetPublicationConfig;
+  citations: QualityTargetCitationsConfig;
+  graph: QualityTargetGraphConfig;
+  reconciliation: QualityTargetReconciliationConfig;
+  communities: QualityTargetCommunitiesConfig;
+}
+
+export interface NormalizedQualityTargetsConfig {
+  sourcePath: string;
+  configDir: string;
+  targets: Record<string, NormalizedQualityTarget>;
+}
+
+export interface QualityTargetDiscoveryResult {
+  found: boolean;
+  path: string | null;
+  searched: string[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function asNonNegativeNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function asPositiveInteger(value: unknown, fallback: number): number {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : fallback;
+}
+
+function resolveMaybe(configDir: string, value: string | null): string | null {
+  return value ? resolve(configDir, value) : null;
+}
+
+function normalizeExtractionMode(value: unknown): TargetCitationExtractionMode {
+  return value === "all_extracted" || value === "bounded_sample" || value === "unknown"
+    ? value
+    : "unknown";
+}
+
+function normalizeDisplay(value: unknown): TargetCitationDisplay {
+  return value === "inline" ? "inline" : "full";
+}
+
+function normalizeInline(raw: Record<string, unknown>): TargetCitationInline {
+  const mode = raw.mode === "full" ? "full" : "top_k";
+  if (mode === "full") return { mode: "full" };
+  return { mode: "top_k", top_k: asPositiveInteger(raw.top_k ?? raw.topK, 8) };
+}
+
+function normalizeNoShrinkByNode(value: unknown): Record<string, { baseline_field: string; max_drop: number }> {
+  const out: Record<string, { baseline_field: string; max_drop: number }> = {};
+  for (const [id, rawRule] of Object.entries(asRecord(value))) {
+    const rule = asRecord(rawRule);
+    const baselineField = asString(rule.baseline_field) ?? "citation_count";
+    const maxDrop = asNonNegativeNumber(rule.max_drop) ?? 0;
+    out[id] = { baseline_field: baselineField, max_drop: maxDrop };
+  }
+  return out;
+}
+
+function normalizeMinCountByNode(value: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [id, rawCount] of Object.entries(asRecord(value))) {
+    const count = asNonNegativeNumber(rawCount);
+    if (count !== null) out[id] = count;
+  }
+  return out;
+}
+
+function normalizeMaxDrop(value: unknown): { max_drop: number } | undefined {
+  const maxDrop = asNonNegativeNumber(asRecord(value).max_drop);
+  return maxDrop === null ? undefined : { max_drop: maxDrop };
+}
+
+export function discoverQualityTargetsConfig(root: string = "."): QualityTargetDiscoveryResult {
+  const resolvedRoot = resolve(root);
+  const searched = QUALITY_TARGET_CONFIG_CANDIDATES.map((candidate) => join(resolvedRoot, candidate));
+  for (const candidate of searched) {
+    if (existsSync(candidate)) return { found: true, path: candidate, searched };
+  }
+  return { found: false, path: null, searched };
+}
+
+export function parseQualityTargetsConfig(raw: string, sourcePath: string): Record<string, unknown> {
+  const trimmed = raw.trim();
+  const parsed = sourcePath.endsWith(".json") || trimmed.startsWith("{")
+    ? JSON.parse(trimmed || "{}")
+    : parseYaml(trimmed || "{}");
+  return asRecord(parsed);
+}
+
+export function loadQualityTargetsConfig(configPath: string): NormalizedQualityTargetsConfig {
+  const resolved = resolve(configPath);
+  const raw = readFileSync(resolved, "utf-8");
+  return normalizeQualityTargetsConfig(parseQualityTargetsConfig(raw, resolved), resolved);
+}
+
+export function normalizeQualityTargetsConfig(
+  config: Record<string, unknown>,
+  sourcePath: string,
+): NormalizedQualityTargetsConfig {
+  const resolvedSourcePath = resolve(sourcePath);
+  const configDir = dirname(resolvedSourcePath);
+  const quality = asRecord(config.quality);
+  const targetsRaw = asRecord(quality.targets);
+  const targets: Record<string, NormalizedQualityTarget> = {};
+  for (const [id, rawTarget] of Object.entries(targetsRaw)) {
+    targets[id] = normalizeQualityTarget(id, asRecord(rawTarget), configDir);
+  }
+  return { sourcePath: resolvedSourcePath, configDir, targets };
+}
+
+export function normalizeQualityTarget(
+  id: string,
+  raw: Record<string, unknown>,
+  configDir: string,
+): NormalizedQualityTarget {
+  const publicationRaw = asRecord(raw.publication);
+  const citationsRaw = asRecord(raw.citations);
+  const extractionRaw = asRecord(citationsRaw.extraction);
+  const graphRaw = asRecord(raw.graph);
+  const reconciliationRaw = asRecord(raw.reconciliation);
+  const communitiesRaw = asRecord(raw.communities);
+  const bundlePath = asString(raw.bundle_path);
+  const baselineBundlePath = asString(raw.baseline_bundle_path);
+  const chromeReferencePath = asString(publicationRaw.chrome_reference_path);
+
+  const graphShrinkGuardRaw = asRecord(graphRaw.shrink_guard);
+  const reconciliationShrinkGuardRaw = asRecord(reconciliationRaw.shrink_guard);
+
+  return {
+    id,
+    kind: asString(raw.kind) ?? "studio-static-bundle",
+    bundle_path: bundlePath,
+    resolvedBundlePath: resolveMaybe(configDir, bundlePath),
+    baseline_bundle_path: baselineBundlePath,
+    resolvedBaselineBundlePath: resolveMaybe(configDir, baselineBundlePath),
+    publication: {
+      blocking: asBoolean(publicationRaw.blocking, false),
+      require_resolved_manifest: asBoolean(publicationRaw.require_resolved_manifest, false),
+      data_only_chrome: asBoolean(publicationRaw.data_only_chrome, false),
+      chrome_reference_path: chromeReferencePath,
+      resolvedChromeReferencePath: resolveMaybe(configDir, chromeReferencePath),
+      deny_source_path_patterns: asStringArray(publicationRaw.deny_source_path_patterns),
+      data_allowlist: asStringArray(publicationRaw.data_allowlist),
+    },
+    citations: {
+      extraction: {
+        mode: normalizeExtractionMode(extractionRaw.mode),
+        require_producer_proof: asBoolean(extractionRaw.require_producer_proof, false),
+        contract_id: asString(extractionRaw.contract_id),
+        allowed_contract_hashes: asStringArray(extractionRaw.allowed_contract_hashes),
+        require_batch_coverage: asBoolean(extractionRaw.require_batch_coverage, false),
+      },
+      display: normalizeDisplay(citationsRaw.display),
+      inline: normalizeInline(asRecord(citationsRaw.inline)),
+      require_sidecar: asBoolean(citationsRaw.require_sidecar, false),
+      min_count_by_node: normalizeMinCountByNode(citationsRaw.min_count_by_node),
+      no_shrink_by_node: normalizeNoShrinkByNode(citationsRaw.no_shrink_by_node),
+    },
+    graph: {
+      min_nodes: asNonNegativeNumber(graphRaw.min_nodes),
+      min_edges: asNonNegativeNumber(graphRaw.min_edges),
+      shrink_guard: {
+        nodes: normalizeMaxDrop(graphShrinkGuardRaw.nodes),
+        edges: normalizeMaxDrop(graphShrinkGuardRaw.edges),
+      },
+      max_missing_descriptions: asNonNegativeNumber(graphRaw.max_missing_descriptions),
+      max_orphan_nodes: asNonNegativeNumber(graphRaw.max_orphan_nodes),
+    },
+    reconciliation: {
+      min_candidates: asNonNegativeNumber(reconciliationRaw.min_candidates),
+      shrink_guard: {
+        candidates: normalizeMaxDrop(reconciliationShrinkGuardRaw.candidates),
+      },
+      require_groupable_by_type: asBoolean(reconciliationRaw.require_groupable_by_type, false),
+    },
+    communities: {
+      require_semantic_labels: asBoolean(communitiesRaw.require_semantic_labels, false),
+    },
+  };
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item));
+  if (typeof value !== "object" || value === null) return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = canonicalize((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
+export function sha256Prefixed(bytes: string | Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export function hashCitationExtractionContract(contract: CitationExtractionContract): string {
+  return sha256Prefixed(canonicalJson(contract));
+}
+
+export function validateCitationExtractionContractForTarget(
+  target: NormalizedQualityTarget,
+  contract: CitationExtractionContract,
+): string[] {
+  const errors: string[] = [];
+  const extraction = target.citations.extraction;
+  if (!extraction.require_producer_proof) return errors;
+  if (contract.schema !== CITATION_EXTRACTION_CONTRACT_SCHEMA) {
+    errors.push("citations.extraction.contract.schema must be graphify_citation_extraction_contract_v1");
+  }
+  if (contract.mode !== extraction.mode) {
+    errors.push(`citations.extraction.contract.mode must be ${extraction.mode}`);
+  }
+  if (extraction.contract_id !== null && contract.id !== extraction.contract_id) {
+    errors.push(`citations.extraction.contract.id must be ${extraction.contract_id}`);
+  }
+  const hash = hashCitationExtractionContract(contract);
+  if (!extraction.allowed_contract_hashes.includes(hash)) {
+    errors.push(`citations.extraction.contract hash ${hash} is not allowlisted`);
+  }
+  if (
+    extraction.mode === "all_extracted" &&
+    contract.requirements.minimum_one_citation_only_allowed !== false
+  ) {
+    errors.push("citations.extraction.contract must reject minimum-one-citation-only producers");
+  }
+  if (
+    extraction.mode === "all_extracted" &&
+    contract.requirements.bounded_samples_allowed !== false
+  ) {
+    errors.push("citations.extraction.contract must reject bounded samples");
+  }
+  return errors;
+}
+
+export function validateQualityTarget(target: NormalizedQualityTarget): string[] {
+  const errors: string[] = [];
+  const extraction = target.citations.extraction;
+  if (target.publication.blocking && target.publication.require_resolved_manifest !== true) {
+    errors.push("publication.require_resolved_manifest must be true for blocking targets");
+  }
+  if (target.publication.data_only_chrome && !target.publication.resolvedChromeReferencePath) {
+    errors.push("publication.chrome_reference_path is required when data_only_chrome is true");
+  }
+  if (
+    target.publication.data_only_chrome &&
+    target.resolvedBundlePath &&
+    target.publication.resolvedChromeReferencePath === target.resolvedBundlePath
+  ) {
+    errors.push("publication.chrome_reference_path must not resolve to the bundle path");
+  }
+  if (extraction.require_producer_proof) {
+    if (extraction.contract_id === null) errors.push("citations.extraction.contract_id is required");
+    if (extraction.allowed_contract_hashes.length === 0) {
+      errors.push("citations.extraction.allowed_contract_hashes must not be empty");
+    }
+  }
+  if (target.citations.display === "full" && target.citations.require_sidecar !== true) {
+    errors.push("citations.require_sidecar must be true when citations.display is full");
+  }
+  return errors;
+}

--- a/src/quality-target.ts
+++ b/src/quality-target.ts
@@ -329,6 +329,23 @@ export function hashCitationExtractionContract(contract: CitationExtractionContr
   return sha256Prefixed(canonicalJson(contract));
 }
 
+export function hashQualityTarget(target: NormalizedQualityTarget): string {
+  const {
+    resolvedBaselineBundlePath: _resolvedBaselineBundlePath,
+    resolvedBundlePath: _resolvedBundlePath,
+    publication,
+    ...targetForHash
+  } = target;
+  const {
+    resolvedChromeReferencePath: _resolvedChromeReferencePath,
+    ...publicationForHash
+  } = publication;
+  return sha256Prefixed(canonicalJson({
+    ...targetForHash,
+    publication: publicationForHash,
+  }));
+}
+
 export function validateCitationExtractionContractForTarget(
   target: NormalizedQualityTarget,
   contract: CitationExtractionContract,

--- a/tests/cli-qa.test.ts
+++ b/tests/cli-qa.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { main } from "../src/cli.js";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-cli-qa-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function write(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+}
+
+function writeJson(path: string, value: unknown): void {
+  write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+async function runCli(args: string[], cwd: string, options: { interceptExit?: boolean } = {}) {
+  const previousArgv = process.argv;
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const logs: string[] = [];
+  const errors: string[] = [];
+
+  console.log = (...items: unknown[]) => { logs.push(items.join(" ")); };
+  console.error = (...items: unknown[]) => { errors.push(items.join(" ")); };
+  if (options.interceptExit) {
+    process.exit = ((code?: string | number | null) => {
+      throw new Error(`process.exit ${code ?? 0}`);
+    }) as typeof process.exit;
+  }
+
+  process.argv = ["node", "graphify", ...args];
+  process.chdir(cwd);
+  try {
+    await main();
+    return { logs, errors, exitCode: 0 };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/^process\.exit (\d+)/);
+    if (match) return { logs, errors, exitCode: Number(match[1]) };
+    if (options.interceptExit) return { logs, errors: [...errors, message], exitCode: 1 };
+    throw error;
+  } finally {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+}
+
+function writeGraph(root: string): void {
+  writeJson(join(root, "bundle", "graph.json"), {
+    directed: false,
+    graph: {},
+    nodes: [
+      {
+        id: "a",
+        label: "A",
+        source_file: "a.md",
+        file_type: "document",
+        description: "A.",
+        citations: [],
+        citation_count: 0,
+      },
+    ],
+    links: [],
+  });
+}
+
+describe("graphify qa CLI", () => {
+  it("prints a passing JSON report for an advisory target", async () => {
+    const root = tempDir();
+    write(root + "/graphify.yaml", [
+      "quality:",
+      "  targets:",
+      "    advisory:",
+      "      kind: studio-static-bundle",
+      "      bundle_path: bundle",
+      "      publication:",
+      "        blocking: false",
+      "        require_resolved_manifest: false",
+      "        data_allowlist:",
+      "          - graph.json",
+      "      citations:",
+      "        display: inline",
+      "        inline:",
+      "          mode: top_k",
+      "          top_k: 8",
+      "      graph:",
+      "        min_nodes: 1",
+      "",
+    ].join("\n"));
+    writeGraph(root);
+
+    const result = await runCli(["qa", "--target", "advisory"], root);
+
+    expect(result.exitCode).toBe(0);
+    const report = JSON.parse(result.logs.join("\n"));
+    expect(report.schema).toBe("graphify_qa_report_v1");
+    expect(report.status).toBe("passed");
+  });
+
+  it("writes a report and exits non-zero for a failing blocking target", async () => {
+    const root = tempDir();
+    write(root + "/graphify.yaml", [
+      "quality:",
+      "  targets:",
+      "    public:",
+      "      kind: studio-static-bundle",
+      "      bundle_path: bundle",
+      "      publication:",
+      "        blocking: true",
+      "        require_resolved_manifest: true",
+      "        data_allowlist:",
+      "          - graph.json",
+      "      citations:",
+      "        display: inline",
+      "        inline:",
+      "          mode: top_k",
+      "          top_k: 8",
+      "      graph:",
+      "        min_nodes: 1",
+      "",
+    ].join("\n"));
+    writeGraph(root);
+
+    const result = await runCli(["qa", "--target", "public", "--write-report"], root, {
+      interceptExit: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+    const reportPath = join(root, "bundle", "quality-qa-report.json");
+    expect(existsSync(reportPath)).toBe(true);
+    const report = JSON.parse(readFileSync(reportPath, "utf-8"));
+    expect(report.status).toBe("failed");
+    expect(report.checks.some((check: { id: string }) => check.id === "manifest.required")).toBe(true);
+  });
+});

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -101,6 +101,11 @@ describe("public API compatibility", () => {
     expect(typeof api.defaultCloneDestination).toBe("function");
     expect(typeof api.mergeGraphsFromFiles).toBe("function");
     expect(typeof api.serializeGraph).toBe("function");
+    expect(typeof api.discoverQualityTargetsConfig).toBe("function");
+    expect(typeof api.hashQualityTarget).toBe("function");
+    expect(typeof api.loadQualityTargetsConfig).toBe("function");
+    expect(typeof api.evaluateQualityBundle).toBe("function");
+    expect(typeof api.validatePrecomputedQaReportBinding).toBe("function");
   });
 
   it("accepts object-style map inputs and option objects", () => {

--- a/tests/qa.test.ts
+++ b/tests/qa.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  ALL_EXTRACTED_CITATION_CONTRACT,
+  hashCitationExtractionContract,
+  loadQualityTargetsConfig,
+  type NormalizedQualityTarget,
+} from "../src/quality-target.js";
+import {
+  computeGraphCitationSignatureFromJson,
+  evaluateQualityBundle,
+  sha256File,
+  validatePrecomputedQaReportBinding,
+  type ResolvedTargetManifest,
+} from "../src/qa.js";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-qa-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function write(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, value, "utf-8");
+}
+
+function writeJson(path: string, value: unknown): void {
+  write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function targetYaml(contractHash = hashCitationExtractionContract(ALL_EXTRACTED_CITATION_CONTRACT)): string {
+  return [
+    "quality:",
+    "  targets:",
+    "    public_studio:",
+    "      kind: studio-static-bundle",
+    "      bundle_path: bundle",
+    "      baseline_bundle_path: baseline",
+    "      publication:",
+    "        blocking: true",
+    "        require_resolved_manifest: true",
+    "        data_only_chrome: true",
+    "        chrome_reference_path: chrome-reference",
+    "        deny_source_path_patterns:",
+    "          - .graphify/scratch/**",
+    "        data_allowlist:",
+    "          - graph.json",
+    "          - reconciliation-candidates.json",
+    "          - ontology/citations.json",
+    "      citations:",
+    "        extraction:",
+    "          mode: all_extracted",
+    "          require_producer_proof: true",
+    "          contract_id: graphify_all_extracted_entity_citations_v1",
+    "          allowed_contract_hashes:",
+    `            - ${contractHash}`,
+    "          require_batch_coverage: true",
+    "        display: full",
+    "        inline:",
+    "          mode: top_k",
+    "          top_k: 8",
+    "        require_sidecar: true",
+    "        min_count_by_node:",
+    "          a: 2",
+    "      graph:",
+    "        min_nodes: 2",
+    "        min_edges: 1",
+    "        max_missing_descriptions: 0",
+    "      reconciliation:",
+    "        min_candidates: 1",
+    "        require_groupable_by_type: true",
+    "",
+  ].join("\n");
+}
+
+function writeTarget(root: string): NormalizedQualityTarget {
+  const configPath = join(root, "graphify.yaml");
+  write(configPath, targetYaml());
+  return loadQualityTargetsConfig(configPath).targets.public_studio;
+}
+
+function graphFixture() {
+  return {
+    topology_signature: "graph-hash",
+    directed: false,
+    graph: {},
+    nodes: [
+      {
+        id: "a",
+        label: "A",
+        node_type: "Character",
+        source_file: "work.md",
+        file_type: "document",
+        description: "Alpha.",
+        citation_count: 2,
+        citations: [
+          { source_file: "work-1.md", section: "I" },
+          { source_file: "work-2.md", section: "II" },
+        ],
+      },
+      {
+        id: "b",
+        label: "B",
+        node_type: "Character",
+        source_file: "work.md",
+        file_type: "document",
+        description: "Beta.",
+        citation_count: 0,
+        citations: [],
+      },
+    ],
+    links: [{ source: "a", target: "b", relation: "KNOWS" }],
+  };
+}
+
+function reconciliationQueue() {
+  return {
+    schema: "graphify_ontology_reconciliation_candidates_v1",
+    graph_hash: "graph-hash",
+    profile_hash: "profile-hash",
+    generated_at: "2026-06-17T00:00:00.000Z",
+    candidate_count: 1,
+    candidates: [
+      {
+        id: "cand-1",
+        kind: "entity_match",
+        status: "candidate",
+        score: 0.9,
+        candidate_id: "a",
+        canonical_id: "b",
+        shared_terms: ["a"],
+        evidence_refs: [],
+        reasons: ["fixture"],
+        proposed_patch_operation: "accept_match",
+      },
+    ],
+  };
+}
+
+function writeValidBundle(root: string): { target: NormalizedQualityTarget; bundleDir: string; manifest: ResolvedTargetManifest } {
+  const target = writeTarget(root);
+  const bundleDir = join(root, "bundle");
+  const referenceDir = join(root, "chrome-reference");
+  const graph = graphFixture();
+  write(bundleDir + "/index.html", "<html>chrome</html>");
+  write(referenceDir + "/index.html", "<html>chrome</html>");
+  writeJson(join(bundleDir, "graph.json"), graph);
+  writeJson(join(bundleDir, "ontology", "citations.json"), {
+    schema: "graphify_ontology_citations_v1",
+    graph_signature: computeGraphCitationSignatureFromJson(graph),
+    nodes: {
+      a: {
+        count: 2,
+        citations: [
+          { source_file: "work-1.md", section: "I" },
+          { source_file: "work-2.md", section: "II" },
+        ],
+      },
+    },
+  });
+  writeJson(join(bundleDir, "reconciliation-candidates.json"), reconciliationQueue());
+
+  const contractHash = hashCitationExtractionContract(ALL_EXTRACTED_CITATION_CONTRACT);
+  const manifest: ResolvedTargetManifest = {
+    schema: "graphify_resolved_target_v1",
+    target_id: target.id,
+    target_hash: "sha256:target",
+    artifacts: {
+      "graph.json": {
+        bundle_path: "graph.json",
+        source_path: ".graphify/runs/run-1/graph.json",
+        source_kind: "generated",
+        sha256: sha256File(join(bundleDir, "graph.json")),
+      },
+      "reconciliation-candidates.json": {
+        bundle_path: "reconciliation-candidates.json",
+        source_path: ".graphify/runs/run-1/reconciliation-candidates.json",
+        source_kind: "generated",
+        sha256: sha256File(join(bundleDir, "reconciliation-candidates.json")),
+      },
+      "ontology/citations.json": {
+        bundle_path: "ontology/citations.json",
+        source_path: ".graphify/runs/run-1/ontology/citations.json",
+        source_kind: "generated",
+        sha256: sha256File(join(bundleDir, "ontology", "citations.json")),
+      },
+    },
+    resolved_policy: {
+      corpus_type: "long-document",
+      citations: {
+        extraction: {
+          mode: "all_extracted",
+          contract_id: "graphify_all_extracted_entity_citations_v1",
+          contract_hash: contractHash,
+          contract: ALL_EXTRACTED_CITATION_CONTRACT,
+          assembly: { same_entity_merge: "union_by_citation_identity" },
+        },
+      },
+    },
+    extraction_units: [
+      {
+        id: "batch-000",
+        source_path: ".graphify/extraction/batch-000.json",
+        contract_id: "graphify_all_extracted_entity_citations_v1",
+        contract_hash: contractHash,
+        citation_mode: "all_extracted",
+      },
+    ],
+  };
+  return { target, bundleDir, manifest };
+}
+
+function errorIds(reportOrChecks: { checks: Array<{ id: string; severity: string }> } | Array<{ id: string; severity: string }>): string[] {
+  const checks = Array.isArray(reportOrChecks) ? reportOrChecks : reportOrChecks.checks;
+  return checks.filter((check) => check.severity === "error").map((check) => check.id);
+}
+
+describe("evaluateQualityBundle", () => {
+  it("passes a complete bundle with manifest proof and full citation sidecar", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest, targetHash: "sha256:target" });
+
+    expect(report.status).toBe("passed");
+    expect(report.summary.failed).toBe(0);
+    expect(report.chrome?.bundle_non_data_tree_hash).toBe(report.chrome?.chrome_reference_tree_hash);
+  });
+
+  it("rejects scratch/no-publish artifact provenance", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    manifest.artifacts["graph.json"]!.source_path = ".graphify/scratch/reindex-multimodel/opus/graph.json";
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toContain("manifest.artifacts.graph.json.source_path");
+  });
+
+  it("rejects a partial full-citation sidecar", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    const sidecar = JSON.parse(readFileSync(join(bundleDir, "ontology", "citations.json"), "utf-8"));
+    sidecar.nodes = {};
+    writeJson(join(bundleDir, "ontology", "citations.json"), sidecar);
+    manifest.artifacts["ontology/citations.json"]!.sha256 = sha256File(join(bundleDir, "ontology", "citations.json"));
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toContain("citations.sidecar.node.a");
+  });
+
+  it("rejects a truncated reconciliation response even when total is high enough", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    writeJson(join(bundleDir, "reconciliation-candidates.json"), {
+      schema: "graphify_ontology_reconciliation_candidates_response_v1",
+      generated_at: "2026-06-17T00:00:00.000Z",
+      graph_hash: "graph-hash",
+      profile_hash: "profile-hash",
+      stale: false,
+      total: 31,
+      limit: 1,
+      offset: 0,
+      items: reconciliationQueue().candidates,
+    });
+    manifest.artifacts["reconciliation-candidates.json"]!.sha256 = sha256File(join(bundleDir, "reconciliation-candidates.json"));
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toContain("reconciliation.response.complete");
+    expect(errorIds(report)).toContain("reconciliation.min_candidates");
+  });
+
+  it("rejects a manifest whose extraction unit is unknown", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    manifest.extraction_units![0]!.citation_mode = "unknown";
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toContain("manifest.extraction_units.batch-000.mode");
+  });
+});
+
+describe("validatePrecomputedQaReportBinding", () => {
+  it("rejects a stale report after chrome reference bytes change", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    const report = evaluateQualityBundle({ target, bundleDir, manifest, targetHash: "sha256:target" });
+
+    write(join(root, "chrome-reference", "index.html"), "<html>new chrome</html>");
+    const checks = validatePrecomputedQaReportBinding(report, {
+      target,
+      bundleDir,
+      manifest,
+      targetHash: "sha256:target",
+    });
+
+    expect(errorIds(checks)).toContain("qa_report.chrome");
+  });
+});

--- a/tests/qa.test.ts
+++ b/tests/qa.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import {
   ALL_EXTRACTED_CITATION_CONTRACT,
   hashCitationExtractionContract,
+  hashQualityTarget,
   loadQualityTargetsConfig,
   type NormalizedQualityTarget,
 } from "../src/quality-target.js";
@@ -291,9 +292,98 @@ describe("evaluateQualityBundle", () => {
 
     expect(errorIds(report)).toContain("manifest.extraction_units.batch-000.mode");
   });
+
+  it("rejects a resolved manifest bound to another target or stale target hash", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    manifest.target_id = "other_target";
+    manifest.target_hash = "sha256:stale";
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toEqual(expect.arrayContaining([
+      "manifest.target_id",
+      "manifest.target_hash",
+    ]));
+  });
+
+  it("rejects runtime data-only chrome self-comparison after bundle override", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    target.publication.resolvedChromeReferencePath = bundleDir;
+    target.publication.chrome_reference_path = "bundle";
+    manifest.target_hash = hashQualityTarget(target);
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toContain("publication.chrome_reference_path");
+  });
+
+  it("rejects the Opus incident class before publication", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    target.citations.min_count_by_node.a = 89;
+    manifest.artifacts["graph.json"]!.source_path = ".graphify/scratch/reindex-multimodel/opus/graph.json";
+
+    const graph = graphFixture();
+    const sherlockCitations = Array.from({ length: 8 }, (_, index) => ({
+      source_file: `sherlock-${index + 1}.md`,
+      section: String(index + 1),
+    }));
+    graph.nodes[0]!.citations = sherlockCitations;
+    graph.nodes[0]!.citation_count = sherlockCitations.length;
+    writeJson(join(bundleDir, "graph.json"), graph);
+    manifest.artifacts["graph.json"]!.sha256 = sha256File(join(bundleDir, "graph.json"));
+
+    writeJson(join(bundleDir, "ontology", "citations.json"), {
+      schema: "graphify_ontology_citations_v1",
+      graph_signature: computeGraphCitationSignatureFromJson(graph),
+      nodes: {},
+    });
+    manifest.artifacts["ontology/citations.json"]!.sha256 = sha256File(join(bundleDir, "ontology", "citations.json"));
+
+    writeJson(join(bundleDir, "reconciliation-candidates.json"), {
+      schema: "graphify_ontology_reconciliation_candidates_response_v1",
+      generated_at: "2026-06-17T00:00:00.000Z",
+      graph_hash: "graph-hash",
+      profile_hash: "profile-hash",
+      stale: false,
+      total: 31,
+      limit: 8,
+      offset: 0,
+      items: [],
+    });
+    manifest.artifacts["reconciliation-candidates.json"]!.sha256 = sha256File(join(bundleDir, "reconciliation-candidates.json"));
+
+    const report = evaluateQualityBundle({ target, bundleDir, manifest });
+
+    expect(errorIds(report)).toEqual(expect.arrayContaining([
+      "manifest.artifacts.graph.json.source_path",
+      "citations.min_count_by_node.a",
+      "citations.sidecar.node.a",
+      "reconciliation.response.complete",
+      "reconciliation.min_candidates",
+    ]));
+  });
 });
 
 describe("validatePrecomputedQaReportBinding", () => {
+  it("rejects a report from a different bundle path even when hashes match", () => {
+    const root = tempDir();
+    const { target, bundleDir, manifest } = writeValidBundle(root);
+    const report = evaluateQualityBundle({ target, bundleDir, manifest, targetHash: "sha256:target" });
+    report.bundle_path = join(root, "other-bundle");
+
+    const checks = validatePrecomputedQaReportBinding(report, {
+      target,
+      bundleDir,
+      manifest,
+      targetHash: "sha256:target",
+    });
+
+    expect(errorIds(checks)).toContain("qa_report.bundle_path");
+  });
+
   it("rejects a stale report after chrome reference bytes change", () => {
     const root = tempDir();
     const { target, bundleDir, manifest } = writeValidBundle(root);

--- a/tests/quality-target.test.ts
+++ b/tests/quality-target.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  ALL_EXTRACTED_CITATION_CONTRACT,
+  canonicalJson,
+  discoverQualityTargetsConfig,
+  hashCitationExtractionContract,
+  loadQualityTargetsConfig,
+  validateCitationExtractionContractForTarget,
+  validateQualityTarget,
+} from "../src/quality-target.js";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-quality-target-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function write(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function targetYaml(contractHash = hashCitationExtractionContract(ALL_EXTRACTED_CITATION_CONTRACT)): string {
+  return [
+    "quality:",
+    "  targets:",
+    "    public_studio:",
+    "      kind: studio-static-bundle",
+    "      bundle_path: .graphify/studio-next",
+    "      baseline_bundle_path: .graphify/baselines/public-studio",
+    "      publication:",
+    "        blocking: true",
+    "        require_resolved_manifest: true",
+    "        data_only_chrome: true",
+    "        chrome_reference_path: .graphify/baselines/public-studio",
+    "        deny_source_path_patterns:",
+    "          - .graphify/scratch/**",
+    "        data_allowlist:",
+    "          - graph.json",
+    "          - ontology/citations.json",
+    "      citations:",
+    "        extraction:",
+    "          mode: all_extracted",
+    "          require_producer_proof: true",
+    "          contract_id: graphify_all_extracted_entity_citations_v1",
+    "          allowed_contract_hashes:",
+    `            - ${contractHash}`,
+    "          require_batch_coverage: true",
+    "        display: full",
+    "        inline:",
+    "          mode: top_k",
+    "          top_k: 8",
+    "        require_sidecar: true",
+    "        min_count_by_node:",
+    "          character_sherlock_holmes: 89",
+    "        no_shrink_by_node:",
+    "          character_sherlock_holmes:",
+    "            baseline_field: citation_count",
+    "            max_drop: 0",
+    "      graph:",
+    "        min_nodes: 2091",
+    "        min_edges: 3168",
+    "      reconciliation:",
+    "        min_candidates: 31",
+    "        require_groupable_by_type: true",
+    "      communities:",
+    "        require_semantic_labels: false",
+    "",
+  ].join("\n");
+}
+
+describe("quality target config", () => {
+  it("loads quality.targets without requiring profile.path or inputs.corpus", () => {
+    const root = tempDir();
+    const configPath = join(root, "graphify.yaml");
+    write(configPath, targetYaml());
+
+    const config = loadQualityTargetsConfig(configPath);
+    const target = config.targets.public_studio;
+
+    expect(target).toBeDefined();
+    expect(target.resolvedBundlePath).toBe(join(root, ".graphify", "studio-next"));
+    expect(target.resolvedBaselineBundlePath).toBe(join(root, ".graphify", "baselines", "public-studio"));
+    expect(target.publication.resolvedChromeReferencePath).toBe(
+      join(root, ".graphify", "baselines", "public-studio"),
+    );
+    expect(target.citations.extraction.mode).toBe("all_extracted");
+    expect(target.citations.inline).toEqual({ mode: "top_k", top_k: 8 });
+    expect(target.citations.min_count_by_node.character_sherlock_holmes).toBe(89);
+    expect(validateQualityTarget(target)).toEqual([]);
+  });
+
+  it("discovers the same target config filenames as project config", () => {
+    const root = tempDir();
+    mkdirSync(join(root, ".graphify"), { recursive: true });
+    writeFileSync(join(root, ".graphify", "config.yml"), "quality: {}\n", "utf-8");
+    writeFileSync(join(root, ".graphify", "config.yaml"), "quality: {}\n", "utf-8");
+    writeFileSync(join(root, "graphify.yml"), "quality: {}\n", "utf-8");
+    writeFileSync(join(root, "graphify.yaml"), "quality: {}\n", "utf-8");
+
+    const found = discoverQualityTargetsConfig(root);
+
+    expect(found.found).toBe(true);
+    expect(found.path).toBe(join(root, "graphify.yaml"));
+  });
+
+  it("rejects data-only chrome self comparison", () => {
+    const root = tempDir();
+    const configPath = join(root, "graphify.yaml");
+    write(configPath, targetYaml().replace(
+      "chrome_reference_path: .graphify/baselines/public-studio",
+      "chrome_reference_path: .graphify/studio-next",
+    ));
+
+    const target = loadQualityTargetsConfig(configPath).targets.public_studio;
+
+    expect(validateQualityTarget(target)).toContain(
+      "publication.chrome_reference_path must not resolve to the bundle path",
+    );
+  });
+});
+
+describe("structured citation extraction contract", () => {
+  it("canonicalizes object keys before hashing", () => {
+    const a = canonicalJson({ b: 1, a: { d: 4, c: 3 } });
+    const b = canonicalJson({ a: { c: 3, d: 4 }, b: 1 });
+
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":{"c":3,"d":4},"b":1}');
+  });
+
+  it("validates the built-in all-extracted contract against the target allowlist", () => {
+    const root = tempDir();
+    const configPath = join(root, "graphify.yaml");
+    write(configPath, targetYaml());
+    const target = loadQualityTargetsConfig(configPath).targets.public_studio;
+
+    expect(validateCitationExtractionContractForTarget(target, ALL_EXTRACTED_CITATION_CONTRACT)).toEqual([]);
+  });
+
+  it("rejects an unallowlisted contract hash", () => {
+    const root = tempDir();
+    const configPath = join(root, "graphify.yaml");
+    write(configPath, targetYaml("sha256:not-this-contract"));
+    const target = loadQualityTargetsConfig(configPath).targets.public_studio;
+
+    expect(validateCitationExtractionContractForTarget(target, ALL_EXTRACTED_CITATION_CONTRACT)).toEqual([
+      expect.stringMatching(/^citations\.extraction\.contract hash sha256:/),
+    ]);
+  });
+
+  it("rejects bounded or minimum-one citation contracts for all-extracted targets", () => {
+    const root = tempDir();
+    const configPath = join(root, "graphify.yaml");
+    const badContract = {
+      ...ALL_EXTRACTED_CITATION_CONTRACT,
+      requirements: {
+        ...ALL_EXTRACTED_CITATION_CONTRACT.requirements,
+        bounded_samples_allowed: true,
+        minimum_one_citation_only_allowed: true,
+      },
+    };
+    write(configPath, targetYaml(hashCitationExtractionContract(badContract)));
+    const target = loadQualityTargetsConfig(configPath).targets.public_studio;
+
+    expect(validateCitationExtractionContractForTarget(target, badContract)).toEqual([
+      "citations.extraction.contract must reject minimum-one-citation-only producers",
+      "citations.extraction.contract must reject bounded samples",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add persisted quality target hashing and stronger QA report/manifest binding
- wire `build-studio-demo` with blocking QA preflight for matching publication targets
- reject the Opus incident class: scratch provenance, truncated/zero reconciliation, partial citation sidecar, and stale/mismatched QA evidence

## Validation
- `npx vitest run tests/quality-target.test.ts tests/qa.test.ts tests/cli-qa.test.ts tests/public-api.test.ts`
- `npm run lint`
- `npm test` outside sandbox for 127.0.0.1 server tests
- `npm run build`
- double 5.5 xhigh implementation review: PASS/PASS after blockers resolved
- `node dist/cli.js hook-rebuild` completed; generated `.graphify` artifacts left unstaged to avoid polluting this feature PR

## Notes
- For targets requiring producer proof or extraction-unit coverage, `build-studio-demo` now requires `--qa-manifest` instead of synthesizing upstream proof.
- A blocking target whose `bundle_path` matches `--out` cannot be bypassed by validating a different advisory `--qa-target`.
