### PR TITLE
feat(studio): nest Types facet as Domain → Sub-domain → Type accordions

### DIFF
--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -228,6 +228,10 @@
       sceneData = null;
       graph = result.graph ?? EMPTY_GRAPH;
     }
+    // EVOL: the Types facet renders a Domain → Sub-domain → Type accordion from
+    // the class taxonomy, so fetch class-hierarchies eagerly (not just on the
+    // class-display toggle). Cached; a no-op when the artifact is absent.
+    await ensureClassHierarchies();
   }
 
   /** Flip the active model and re-render the SAME studio in place. */
@@ -356,6 +360,7 @@
         <div class="col col-left">
           <LeftRail
             {graph}
+            {classHierarchies}
             query={viewerState.query}
             selection={viewerState.selection}
             showWeakLinks={viewerState.options.showWeakLinks}

--- a/studio/src/app.css
+++ b/studio/src/app.css
@@ -35,3 +35,22 @@ body {
 button {
   font: inherit;
 }
+
+/*
+ * Workaround for a @sentropic/design-system-svelte Collapsible bug: its chevron
+ * rotation rule `.st-collapsible--open .st-collapsible__icon` is a DESCENDANT
+ * selector, so an OPEN parent collapsible rotates EVERY nested icon — including
+ * collapsed sub-accordions (visible in the Types Domain → Sub-domain tree, where
+ * the collapsed domains showed an "up" chevron). Re-scope rotation to each
+ * collapsible's OWN trigger icon (the trigger is a direct child of the root;
+ * nested collapsibles live in the sibling __region, so `>` excludes them).
+ * Upstream one-line fix: scope that DS rule to `> .st-collapsible__trigger`.
+ */
+/* The DS rule uses :where() (specificity-neutral), so a plain override only ties
+ * and loses on source order — !important is required to win. */
+.st-collapsible > .st-collapsible__trigger .st-collapsible__icon {
+  transform: none !important;
+}
+.st-collapsible--open > .st-collapsible__trigger .st-collapsible__icon {
+  transform: rotate(180deg) !important;
+}

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -23,6 +23,7 @@
 
   let {
     graph,
+    classHierarchies = null,
     query = "",
     selection = { types: [], communities: [], entities: [] },
     showWeakLinks = true,
@@ -40,6 +41,45 @@
   const typeList = $derived(groupCounts(graph, nodeType));
   // Communities excluding degree-0 singletons (folded into `isolatedCount`).
   const communityInfo = $derived(communityStats(graph));
+
+  const typeSet = $derived(new Set(selection.types));
+  // EVOL: nested Domain → Sub-domain → Type tree from the ontology class
+  // taxonomy (class-hierarchies.json). Each leaf type keeps its live count and
+  // its toggle behaviour; when no taxonomy is loaded the Types facet falls back
+  // to the previous flat list.
+  const typeTree = $derived.by(() => {
+    const hs = classHierarchies?.hierarchies;
+    if (!hs) return null;
+    const h = hs[Object.keys(hs)[0]];
+    if (!h?.classes_by_id || !(h.root_class_ids?.length)) return null;
+    const classes = h.classes_by_id;
+    const countByType = new Map(typeList.map((t) => [t.key, t.count]));
+    const labelOf = (id) => classes[id]?.label || String(id).replace(/^class:/, "");
+    const seen = new Set();
+    const domains = h.root_class_ids
+      .map((rootId) => {
+        const subs = (classes[rootId]?.child_ids ?? [])
+          .map((subId) => {
+            const types = (classes[subId]?.member_node_types ?? []).map((t) => {
+              seen.add(t);
+              return { key: t, count: countByType.get(t) ?? 0 };
+            });
+            return { id: subId, label: labelOf(subId), types, count: types.reduce((n, t) => n + t.count, 0) };
+          })
+          .filter((s) => s.types.length);
+        return { id: rootId, label: labelOf(rootId), subs, count: subs.reduce((n, s) => n + s.count, 0) };
+      })
+      .filter((d) => d.subs.length);
+    // Types not covered by the taxonomy (and not synthetic class nodes) keep a
+    // home so nothing disappears from the facet.
+    const other = typeList.filter((t) => !seen.has(t.key) && t.key !== "OntologyClass");
+    if (other.length) {
+      const types = other.map((t) => ({ key: t.key, count: t.count }));
+      const count = types.reduce((n, t) => n + t.count, 0);
+      domains.push({ id: "__other__", label: "Other", count, subs: [{ id: "__other_sub__", label: "Ungrouped", types, count }] });
+    }
+    return domains;
+  });
 
   // Entities grouped by type (count) -> rows, filtered by the search query.
   // No cap: per-type accordions stay collapsed so all entities are reachable.
@@ -119,6 +159,49 @@
     {/snippet}
     {#if typeList.length === 0}
       <p class="rail-empty">No types.</p>
+    {:else if typeTree}
+      <!-- EVOL: nested Domain → Sub-domain → Type accordions (taxonomy-driven). -->
+      <ul class="rail-type-groups">
+        {#each typeTree as domain (domain.id)}
+          <li>
+            <Collapsible title={domain.label} open={false} size="sm">
+              {#snippet trailing()}
+                <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
+              {/snippet}
+              <ul class="rail-type-groups">
+                {#each domain.subs as sub (sub.id)}
+                  <li>
+                    <Collapsible title={sub.label} open={false} size="sm">
+                      {#snippet trailing()}
+                        <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
+                      {/snippet}
+                      <ul class="rail-list">
+                        {#each sub.types as t (t.key)}
+                          <li>
+                            <SelectableRow
+                              value={t.key}
+                              selected={typeSet.has(t.key)}
+                              onselect={() => onToggleType?.(t.key)}
+                            >
+                              {#snippet leading()}
+                                <TypeShapeGlyph type={t.key} />
+                              {/snippet}
+                              {t.key}
+                              {#snippet trailing()}
+                                <Badge shape="circle" size="sm" tone="neutral">{t.count}</Badge>
+                              {/snippet}
+                            </SelectableRow>
+                          </li>
+                        {/each}
+                      </ul>
+                    </Collapsible>
+                  </li>
+                {/each}
+              </ul>
+            </Collapsible>
+          </li>
+        {/each}
+      </ul>
     {:else}
       <SelectableList
         class="rail-list"


### PR DESCRIPTION
Drives the left-rail Types facet from the ontology class taxonomy: nested Domain → Sub-domain → Type accordions (glyph + count + click-to-filter preserved), flat-list fallback. Also fixes a DS Collapsible chevron bug (descendant-selector rotation) via an app.css override. Verified at the rendered level. 165 studio tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)