### PR TITLE
feat(viz): aggregate large surfaces by community for HTML export (WP11)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4263,6 +4263,7 @@ export async function main(): Promise<void> {
 
   exportCommand
     .command("html")
+    .description("Export standalone graph.html; large graphs are aggregated by community")
     .option("--graph <path>", "Path to graph.json", resolveGraphInputPath())
     .option("--out <path>", "Path to write graph.html")
     .option("--no-viz", "Skip HTML export and remove any stale output")
@@ -4273,6 +4274,10 @@ export async function main(): Promise<void> {
     .option(
       "--descriptions <path>",
       "Optional wiki description sidecar index JSON; node descriptions render in the node-info panel (Track G G-studio-lot4)",
+    )
+    .addHelpText(
+      "after",
+      "\nLarge graphs: Graphs over 5000 nodes render as aggregated community nodes.\n",
     )
     .action(async (opts) => {
       try {

--- a/src/export.ts
+++ b/src/export.ts
@@ -186,6 +186,7 @@ export function inferEdgeDashes(relation: string, confidenceTier: string): boole
 }
 
 const MAX_NODES_FOR_VIZ = 5_000;
+const MAX_COMMUNITIES_FOR_AGGREGATED_VIZ = 500;
 
 const CONFIDENCE_SCORE_DEFAULTS: Record<string, number> = {
   EXTRACTED: 1.0,
@@ -358,6 +359,31 @@ function lookupNodeDescription(
   if (!entry || entry.status !== "generated") return null;
   const text = typeof entry.description === "string" ? entry.description.trim() : "";
   return text ? text : null;
+}
+
+function summarizeRepoCounts(repoCounts: Map<string, number> | undefined): string {
+  if (!repoCounts || repoCounts.size === 0) return "";
+  const entries = [...repoCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const visible = entries
+    .slice(0, 4)
+    .map(([repo, count]) => `${sanitizeLabel(repo)} (${count})`);
+  const remaining = entries.length - visible.length;
+  return remaining > 0
+    ? `${visible.join(", ")} +${remaining} more`
+    : visible.join(", ");
+}
+
+function dominantRelationLabel(relationCounts: Map<string, number>): string {
+  if (relationCounts.size === 0) return "links";
+  const [relation, count] = [...relationCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]!;
+  return count > 1 ? `${relation} x${count}` : relation;
+}
+
+function communityColor(cid: number): string {
+  const index = ((cid % COMMUNITY_COLORS.length) + COMMUNITY_COLORS.length) % COMMUNITY_COLORS.length;
+  return COMMUNITY_COLORS[index]!;
 }
 
 /**
@@ -1321,12 +1347,7 @@ export function buildGraphHtml(
   const studioMode = normalizeStudioMode(communityLabelsOrOptions);
   const descriptions = normalizeDescriptions(communityLabelsOrOptions);
   const workspaceTheme = getWorkspaceTokens();
-  if (G.order > MAX_NODES_FOR_VIZ) {
-    throw new Error(
-      `Graph has ${G.order} nodes - too large for HTML viz. ` +
-      `Use --no-viz or reduce input size.`,
-    );
-  }
+  const useCommunityAggregation = G.order > MAX_NODES_FOR_VIZ;
 
   const nodeComm = nodeCommunityMap(communityMap);
   const degree = new Map<string, number>();
@@ -1353,64 +1374,6 @@ export function buildGraphHtml(
     /** G-studio-lot4 (#7): generated wiki description, omitted when absent. */
     description?: string;
   }
-  const visNodes: VisNode[] = [];
-  G.forEachNode((nodeId, data) => {
-    const cid = nodeComm.get(nodeId) ?? 0;
-    const paletteColor = COMMUNITY_COLORS[cid % COMMUNITY_COLORS.length]!;
-    const label = sanitizeLabel((data.label as string) ?? nodeId);
-    const deg = degree.get(nodeId) ?? 1;
-    const memberCount = memberCounts?.get(cid) ?? 1;
-    const size = memberCounts
-      ? 10 + 30 * (memberCount / maxMemberCount)
-      : 10 + 30 * (deg / maxDeg);
-    const fontSize = memberCounts ? 12 : (deg >= maxDeg * 0.15 ? 12 : 0);
-    const sourceFile = (data.source_file as string) ?? "";
-    const fileType = (data.file_type as string) ?? "";
-    // Track C-3.5: read node_type (canonical attribute on ontology graphs;
-    // legacy `type` is tolerated as fallback) and resolve shape + color
-    // via the profile first, with file_type/community palette as fallback.
-    const nodeType = (data.node_type as string) ?? (data.type as string) ?? "";
-    const shape = resolveNodeShape({ nodeType, fileType, sourceFile, profile });
-    const color = resolveNodeColor({ nodeType, profile, fallback: paletteColor });
-    // C-final-1 / G-studio-lot1 #2: shape "box" (document/paper/concept)
-    // renders "hollow" — coloured border, but a SEMI-OPAQUE WHITE fill
-    // (~50%) rather than a fully transparent one. Arrows leave from the box
-    // centre, so a 0-alpha fill leaves the label unreadable over crossing
-    // edges; a 50% white fill keeps the text legible while still looking
-    // hollow. It stays visually distinct from "square" (test), which is
-    // solid-filled. Consistent whether `box` comes from inferNodeShape or
-    // from a profile visual_encoding override.
-    const isOutlinedShape = shape === "box";
-    const outlinedFill = "rgba(255,255,255,0.5)";
-    // O1 contract: pass node.description attr so lookupNodeDescription prefers
-    // the canonical graph attribute over a sidecar entry (gap-fill only).
-    const nodeAttrDescription = typeof data.description === "string" ? data.description : undefined;
-    const description = lookupNodeDescription(descriptions, nodeId, nodeAttrDescription);
-    const visNode: VisNode = {
-      id: nodeId,
-      label,
-      color: {
-        background: isOutlinedShape ? outlinedFill : color,
-        border: color,
-        highlight: { background: workspaceTheme.colour.surface, border: color },
-      },
-      size: Math.round(size * 10) / 10,
-      font: { size: fontSize, color: workspaceTheme.colour.text },
-      title: label,
-      community: cid,
-      community_name: sanitizeLabel(communityLabels?.get(cid) ?? `Community ${cid}`),
-      source_file: sanitizeLabel(sourceFile),
-      file_type: fileType,
-      shape,
-      degree: deg,
-    };
-    // G-studio-lot4 (#7): attach the generated description only when present;
-    // insufficient_evidence / missing entries leave the field off entirely.
-    if (description) visNode.description = sanitizeLabel(description);
-    visNodes.push(visNode);
-  });
-
-  // Build edges list
   interface VisEdge {
     from: string;
     to: string;
@@ -1422,42 +1385,257 @@ export function buildGraphHtml(
     confidence: string;
     relation: string;
   }
-  const visEdges: VisEdge[] = [];
-  G.forEachEdge((_edge, data, u, v) => {
-    const confidence = (data.confidence as string) ?? "EXTRACTED";
-    const relation = (data.relation as string) ?? "";
-    visEdges.push({
-      from: u,
-      to: v,
-      label: relation,
-      title: `${relation} [${confidence}]`,
-      dashes: inferEdgeDashes(relation, confidence),
-      width: confidence === "EXTRACTED" ? 2 : 1,
-      color: {
-        color: workspaceTheme.colour["text-muted"],
-        highlight: workspaceTheme.colour.accent,
-        hover: workspaceTheme.colour.accent,
-        opacity: confidence === "EXTRACTED" ? 0.7 : 0.35,
-      },
-      confidence,
-      relation,
-    });
-  });
-
-  // Build community legend data
   interface LegendEntry {
     cid: number;
     color: string;
     label: string;
     count: number;
   }
+
+  const communityLabel = (cid: number): string =>
+    sanitizeLabel(communityLabels?.get(cid) ?? `Community ${cid}`);
+  const visNodes: VisNode[] = [];
+  const visEdges: VisEdge[] = [];
   const legendData: LegendEntry[] = [];
-  const labelKeys = communityLabels ? [...communityLabels.keys()].sort((a, b) => a - b) : [];
-  for (const cid of labelKeys) {
-    const color = COMMUNITY_COLORS[cid % COMMUNITY_COLORS.length]!;
-    const lbl = escapeHtml(sanitizeLabel(communityLabels?.get(cid) ?? `Community ${cid}`));
-    const n = memberCounts?.get(cid) ?? communityMap.get(cid)?.length ?? 0;
-    legendData.push({ cid, color, label: lbl, count: n });
+  let groupedAggregateCommunityCount = 0;
+
+  if (useCommunityAggregation) {
+    const membersByCommunity = new Map<number, string[]>();
+    const repoCountsByCommunity = new Map<number, Map<string, number>>();
+    G.forEachNode((nodeId, data) => {
+      const cid = nodeComm.get(nodeId) ?? 0;
+      const members = membersByCommunity.get(cid) ?? [];
+      members.push(nodeId);
+      membersByCommunity.set(cid, members);
+      const repo = typeof data.repo === "string" ? data.repo.trim() : "";
+      if (repo) {
+        const repoCounts = repoCountsByCommunity.get(cid) ?? new Map<string, number>();
+        repoCounts.set(repo, (repoCounts.get(repo) ?? 0) + 1);
+        repoCountsByCommunity.set(cid, repoCounts);
+      }
+    });
+
+    const originalCommunityIds = [...membersByCommunity.keys()].sort((a, b) => a - b);
+    let otherCommunityId = -1;
+    while (membersByCommunity.has(otherCommunityId)) otherCommunityId -= 1;
+    let visibleOriginalCommunityIds = new Set(originalCommunityIds);
+    if (originalCommunityIds.length > MAX_COMMUNITIES_FOR_AGGREGATED_VIZ) {
+      const topCommunityIds = [...originalCommunityIds]
+        .sort((a, b) => (membersByCommunity.get(b)?.length ?? 0) - (membersByCommunity.get(a)?.length ?? 0) || a - b)
+        .slice(0, MAX_COMMUNITIES_FOR_AGGREGATED_VIZ - 1);
+      visibleOriginalCommunityIds = new Set(topCommunityIds);
+      groupedAggregateCommunityCount = originalCommunityIds.length - visibleOriginalCommunityIds.size;
+    }
+    const renderCommunityId = (cid: number): number =>
+      visibleOriginalCommunityIds.has(cid) ? cid : otherCommunityId;
+    const aggregateCommunityLabel = (cid: number): string =>
+      groupedAggregateCommunityCount > 0 && cid === otherCommunityId
+        ? "Other communities"
+        : communityLabel(cid);
+
+    const renderedMembersByCommunity = new Map<number, string[]>();
+    const renderedRepoCountsByCommunity = new Map<number, Map<string, number>>();
+    for (const originalCid of originalCommunityIds) {
+      const renderedCid = renderCommunityId(originalCid);
+      const targetMembers = renderedMembersByCommunity.get(renderedCid) ?? [];
+      targetMembers.push(...(membersByCommunity.get(originalCid) ?? []));
+      renderedMembersByCommunity.set(renderedCid, targetMembers);
+
+      const originalRepoCounts = repoCountsByCommunity.get(originalCid);
+      if (originalRepoCounts) {
+        const targetRepoCounts = renderedRepoCountsByCommunity.get(renderedCid) ?? new Map<string, number>();
+        for (const [repo, count] of originalRepoCounts) {
+          targetRepoCounts.set(repo, (targetRepoCounts.get(repo) ?? 0) + count);
+        }
+        renderedRepoCountsByCommunity.set(renderedCid, targetRepoCounts);
+      }
+    }
+
+    const communityIds = [...renderedMembersByCommunity.keys()]
+      .sort((a, b) => {
+        if (a === otherCommunityId) return 1;
+        if (b === otherCommunityId) return -1;
+        return a - b;
+      });
+    const maxCommunitySize = Math.max(1, ...communityIds.map((cid) => renderedMembersByCommunity.get(cid)?.length ?? 0));
+    const communityEdgeCounts = new Map<number, number>();
+    const directed = isDirectedGraph(G);
+    const aggregatedEdges = new Map<string, {
+      fromCid: number;
+      toCid: number;
+      weight: number;
+      relations: Map<string, number>;
+    }>();
+
+    G.forEachEdge((_edge, data, source, target) => {
+      const sourceCid = renderCommunityId(nodeComm.get(source) ?? 0);
+      const targetCid = renderCommunityId(nodeComm.get(target) ?? 0);
+      communityEdgeCounts.set(sourceCid, (communityEdgeCounts.get(sourceCid) ?? 0) + 1);
+      if (targetCid !== sourceCid) {
+        communityEdgeCounts.set(targetCid, (communityEdgeCounts.get(targetCid) ?? 0) + 1);
+      }
+      if (sourceCid === targetCid) return;
+
+      const fromCid = directed ? sourceCid : Math.min(sourceCid, targetCid);
+      const toCid = directed ? targetCid : Math.max(sourceCid, targetCid);
+      const key = directed ? `${fromCid}->${toCid}` : `${fromCid}--${toCid}`;
+      const relation = sanitizeLabel((data.relation as string) ?? "") || "links";
+      const bucket = aggregatedEdges.get(key) ?? {
+        fromCid,
+        toCid,
+        weight: 0,
+        relations: new Map<string, number>(),
+      };
+      bucket.weight += 1;
+      bucket.relations.set(relation, (bucket.relations.get(relation) ?? 0) + 1);
+      aggregatedEdges.set(key, bucket);
+    });
+
+    for (const cid of communityIds) {
+      const color = communityColor(cid);
+      const label = aggregateCommunityLabel(cid);
+      const memberCount = renderedMembersByCommunity.get(cid)?.length ?? 0;
+      const repoSummary = summarizeRepoCounts(renderedRepoCountsByCommunity.get(cid));
+      const size = 18 + 34 * Math.sqrt(memberCount / maxCommunitySize);
+      const description = [
+        groupedAggregateCommunityCount > 0 && cid === otherCommunityId
+          ? `Aggregated ${groupedAggregateCommunityCount} smaller community(ies) with ${memberCount} member node(s).`
+          : `Aggregated community with ${memberCount} member node(s).`,
+        repoSummary ? `Repos: ${repoSummary}.` : "",
+      ].filter(Boolean).join(" ");
+      visNodes.push({
+        id: `community:${cid}`,
+        label,
+        color: {
+          background: color,
+          border: color,
+          highlight: { background: workspaceTheme.colour.surface, border: color },
+        },
+        size: Math.round(size * 10) / 10,
+        font: { size: 12, color: workspaceTheme.colour.text },
+        title: repoSummary ? `${label} (${memberCount} members) - ${repoSummary}` : `${label} (${memberCount} members)`,
+        community: cid,
+        community_name: label,
+        source_file: repoSummary ? `repos: ${repoSummary}` : "",
+        file_type: "community",
+        shape: "dot",
+        degree: communityEdgeCounts.get(cid) ?? 0,
+        description: sanitizeLabel(description),
+      });
+      legendData.push({
+        cid,
+        color,
+        label: escapeHtml(label),
+        count: memberCount,
+      });
+    }
+
+    for (const bucket of [...aggregatedEdges.values()].sort((a, b) => a.fromCid - b.fromCid || a.toCid - b.toCid)) {
+      const relation = dominantRelationLabel(bucket.relations);
+      const title = `${bucket.weight} link(s): ${aggregateCommunityLabel(bucket.fromCid)} -> ${aggregateCommunityLabel(bucket.toCid)} (${relation})`;
+      const width = Math.round((1 + Math.min(8, Math.log2(bucket.weight + 1))) * 10) / 10;
+      visEdges.push({
+        from: `community:${bucket.fromCid}`,
+        to: `community:${bucket.toCid}`,
+        label: `${bucket.weight}`,
+        title,
+        dashes: false,
+        width,
+        color: {
+          color: workspaceTheme.colour["text-muted"],
+          highlight: workspaceTheme.colour.accent,
+          hover: workspaceTheme.colour.accent,
+          opacity: 0.65,
+        },
+        confidence: "AGGREGATED",
+        relation,
+      });
+    }
+  } else {
+    G.forEachNode((nodeId, data) => {
+      const cid = nodeComm.get(nodeId) ?? 0;
+      const paletteColor = COMMUNITY_COLORS[cid % COMMUNITY_COLORS.length]!;
+      const label = sanitizeLabel((data.label as string) ?? nodeId);
+      const deg = degree.get(nodeId) ?? 1;
+      const memberCount = memberCounts?.get(cid) ?? 1;
+      const size = memberCounts
+        ? 10 + 30 * (memberCount / maxMemberCount)
+        : 10 + 30 * (deg / maxDeg);
+      const fontSize = memberCounts ? 12 : (deg >= maxDeg * 0.15 ? 12 : 0);
+      const sourceFile = (data.source_file as string) ?? "";
+      const fileType = (data.file_type as string) ?? "";
+      // Track C-3.5: read node_type (canonical attribute on ontology graphs;
+      // legacy `type` is tolerated as fallback) and resolve shape + color
+      // via the profile first, with file_type/community palette as fallback.
+      const nodeType = (data.node_type as string) ?? (data.type as string) ?? "";
+      const shape = resolveNodeShape({ nodeType, fileType, sourceFile, profile });
+      const color = resolveNodeColor({ nodeType, profile, fallback: paletteColor });
+      // C-final-1 / G-studio-lot1 #2: shape "box" (document/paper/concept)
+      // renders "hollow" — coloured border, but a SEMI-OPAQUE WHITE fill
+      // (~50%) rather than a fully transparent one. Arrows leave from the box
+      // centre, so a 0-alpha fill leaves the label unreadable over crossing
+      // edges; a 50% white fill keeps the text legible while still looking
+      // hollow. It stays visually distinct from "square" (test), which is
+      // solid-filled. Consistent whether `box` comes from inferNodeShape or
+      // from a profile visual_encoding override.
+      const isOutlinedShape = shape === "box";
+      const outlinedFill = "rgba(255,255,255,0.5)";
+      // O1 contract: pass node.description attr so lookupNodeDescription prefers
+      // the canonical graph attribute over a sidecar entry (gap-fill only).
+      const nodeAttrDescription = typeof data.description === "string" ? data.description : undefined;
+      const description = lookupNodeDescription(descriptions, nodeId, nodeAttrDescription);
+      const visNode: VisNode = {
+        id: nodeId,
+        label,
+        color: {
+          background: isOutlinedShape ? outlinedFill : color,
+          border: color,
+          highlight: { background: workspaceTheme.colour.surface, border: color },
+        },
+        size: Math.round(size * 10) / 10,
+        font: { size: fontSize, color: workspaceTheme.colour.text },
+        title: label,
+        community: cid,
+        community_name: communityLabel(cid),
+        source_file: sanitizeLabel(sourceFile),
+        file_type: fileType,
+        shape,
+        degree: deg,
+      };
+      // G-studio-lot4 (#7): attach the generated description only when present;
+      // insufficient_evidence / missing entries leave the field off entirely.
+      if (description) visNode.description = sanitizeLabel(description);
+      visNodes.push(visNode);
+    });
+
+    G.forEachEdge((_edge, data, u, v) => {
+      const confidence = (data.confidence as string) ?? "EXTRACTED";
+      const relation = (data.relation as string) ?? "";
+      visEdges.push({
+        from: u,
+        to: v,
+        label: relation,
+        title: `${relation} [${confidence}]`,
+        dashes: inferEdgeDashes(relation, confidence),
+        width: confidence === "EXTRACTED" ? 2 : 1,
+        color: {
+          color: workspaceTheme.colour["text-muted"],
+          highlight: workspaceTheme.colour.accent,
+          hover: workspaceTheme.colour.accent,
+          opacity: confidence === "EXTRACTED" ? 0.7 : 0.35,
+        },
+        confidence,
+        relation,
+      });
+    });
+
+    const labelKeys = communityLabels ? [...communityLabels.keys()].sort((a, b) => a - b) : [];
+    for (const cid of labelKeys) {
+      const color = COMMUNITY_COLORS[cid % COMMUNITY_COLORS.length]!;
+      const lbl = escapeHtml(communityLabel(cid));
+      const n = memberCounts?.get(cid) ?? communityMap.get(cid)?.length ?? 0;
+      legendData.push({ cid, color, label: lbl, count: n });
+    }
   }
 
   const nodesJson = JSON.stringify(visNodes);
@@ -1466,8 +1644,12 @@ export function buildGraphHtml(
   const rawHyperedges = (G.getAttribute("hyperedges") as Hyperedge[] | undefined) ?? [];
   const hyperedgesJson = JSON.stringify(rawHyperedges);
   const title = escapeHtml(sanitizeLabel(basename(outputPath)));
-  const stats =
-    `${G.order} nodes &middot; ${G.size} edges &middot; ${communityMap.size} communities`;
+  const aggregateGroupingStats = groupedAggregateCommunityCount > 0
+    ? ` &middot; ${groupedAggregateCommunityCount} smaller communities grouped into Other`
+    : "";
+  const stats = useCommunityAggregation
+    ? `${G.order} nodes &middot; ${G.size} edges &middot; ${visNodes.length} rendered communities &middot; rendered as ${visNodes.length} community nodes${aggregateGroupingStats}`
+    : `${G.order} nodes &middot; ${G.size} edges &middot; ${communityMap.size} communities`;
 
   const html = `<!DOCTYPE html>
 <html lang="en">

--- a/tests/cli-runtime.test.ts
+++ b/tests/cli-runtime.test.ts
@@ -178,6 +178,47 @@ async function runCli(args: string[], cwd: string, options: { interceptExit?: bo
   return runMain(() => main(), ["node", "graphify", ...args], cwd, options);
 }
 
+async function commandHelp(args: string[], cwd: string): Promise<string> {
+  const { main } = await import("../src/cli.js");
+  const previousArgv = process.argv;
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalExit = process.exit;
+  const output: string[] = [];
+
+  console.log = (...values: unknown[]) => { output.push(values.join(" ")); };
+  process.stdout.write = ((chunk: unknown) => {
+    output.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  process.exit = ((code?: string | number | null): never => {
+    throw new Error(`process.exit ${code ?? 0}`);
+  }) as typeof process.exit;
+  process.argv = ["node", "graphify", ...args, "--help"];
+  process.chdir(cwd);
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("process.exit ")) throw error;
+  } finally {
+    process.argv = previousArgv;
+    process.chdir(previousCwd);
+    console.log = originalLog;
+    process.stdout.write = originalWrite;
+    process.exit = originalExit;
+  }
+
+  return output.join("\n");
+}
+
+function readHtmlRawNodes(html: string): unknown[] {
+  const match = html.match(/const RAW_NODES = ([\s\S]*?);\nconst RAW_EDGES = /);
+  if (!match) throw new Error("Could not find RAW_NODES in HTML export");
+  return JSON.parse(match[1]!) as unknown[];
+}
+
 async function runSkillRuntime(args: string[], cwd: string, options: { interceptExit?: boolean } = {}) {
   const { main } = await import("../src/skill-runtime.js");
   return runMain(() => main(["node", "skill-runtime", ...args]), ["node", "skill-runtime", ...args], cwd, options);
@@ -381,6 +422,12 @@ describe("public CLI runtime command parity", () => {
     expect(noViz.exitCode).toBe(0);
     expect(noViz.logs.join("\n")).toContain("HTML export skipped");
     expect(existsSync(htmlPath)).toBe(false);
+  });
+
+  it("documents automatic community aggregation in export html help", async () => {
+    const help = await commandHelp(["export", "html"], tempProject());
+
+    expect(help).toContain("Graphs over 5000 nodes render as aggregated community nodes");
   });
 
   it("supports export wiki and obsidian vault generation", async () => {
@@ -1201,17 +1248,23 @@ describe("public CLI runtime command parity", () => {
     expect(existsSync(join(dir, ".graphify", "graph.html"))).toBe(true);
   });
 
-  it("supports cluster-only on oversized graphs by skipping HTML export", async () => {
+  it("supports cluster-only on oversized graphs with bounded aggregated HTML export", async () => {
     const dir = tempProject();
     writeLargeGraph(dir);
 
     const result = await runCli(["cluster-only", dir], dir);
+    const htmlPath = join(dir, ".graphify", "graph.html");
 
     expect(result.exitCode).toBe(0);
-    expect(result.warnings.join("\n")).toContain("HTML export skipped");
+    expect(result.warnings.join("\n")).not.toContain("HTML export skipped");
     expect(existsSync(join(dir, ".graphify", "GRAPH_REPORT.md"))).toBe(true);
     expect(existsSync(join(dir, ".graphify", "graph.json"))).toBe(true);
-    expect(existsSync(join(dir, ".graphify", "graph.html"))).toBe(false);
+    expect(existsSync(htmlPath)).toBe(true);
+
+    const html = readFileSync(htmlPath, "utf-8");
+    const renderedNodes = readHtmlRawNodes(html);
+    expect(renderedNodes.length).toBeLessThanOrEqual(500);
+    expect(html).toContain("rendered as");
   });
 
   it("update --no-cluster skips Louvain and writes graph.json without communities", async () => {

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -6,6 +6,13 @@ import Graph from "graphology";
 import { inferEdgeDashes, inferNodeShape, toHtml } from "../src/export.js";
 import { safeToHtml } from "../src/html-export.js";
 
+function readInlineJsonArray<T>(html: string, name: "RAW_NODES" | "RAW_EDGES"): T[] {
+  const nextConst = name === "RAW_NODES" ? "RAW_EDGES" : "LEGEND";
+  const match = html.match(new RegExp(`const ${name} = ([\\s\\S]*?);\\nconst ${nextConst} = `));
+  if (!match) throw new Error(`Could not find ${name} in HTML export`);
+  return JSON.parse(match[1]!) as T[];
+}
+
 describe("safeToHtml", () => {
   it("does not leak the absolute output path in the document title", () => {
     const dir = mkdtempSync(join(tmpdir(), "graphify-html-export-"));
@@ -116,6 +123,66 @@ describe("safeToHtml", () => {
 
     expect(() => toHtml(G, communities, htmlPath)).not.toThrow();
     expect(readFileSync(htmlPath, "utf-8")).toContain("\"source_file\":\"\"");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("automatically collapses graphs over the vis cap into community aggregates", () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-html-large-"));
+    const htmlPath = join(dir, "graph.html");
+
+    const G = new Graph();
+    const communityCount = 24;
+    const nodesPerCommunity = 230;
+    const communities = new Map<number, string[]>();
+    const labels = new Map<number, string>();
+
+    for (let cid = 0; cid < communityCount; cid++) {
+      labels.set(cid, `Community ${cid}`);
+      const members: string[] = [];
+      for (let index = 0; index < nodesPerCommunity; index++) {
+        const nodeId = `c${cid}-node-${index}`;
+        members.push(nodeId);
+        G.addNode(nodeId, {
+          label: `Node ${cid}.${index}`,
+          source_file: `src/community-${cid}/node-${index}.ts`,
+          file_type: "code",
+          repo: index % 2 === 0 ? "repo:github.com/acme/graphify" : "repo:github.com/acme/sentropic",
+        });
+        if (index > 0) {
+          G.addUndirectedEdge(`c${cid}-node-${index - 1}`, nodeId, {
+            relation: "calls",
+            confidence: "EXTRACTED",
+          });
+        }
+      }
+      communities.set(cid, members);
+    }
+
+    for (let cid = 0; cid < communityCount; cid++) {
+      const next = (cid + 1) % communityCount;
+      G.addUndirectedEdge(`c${cid}-node-0`, `c${next}-node-0`, {
+        relation: "imports",
+        confidence: "EXTRACTED",
+      });
+    }
+
+    toHtml(G, communities, htmlPath, { communityLabels: labels });
+
+    const html = readFileSync(htmlPath, "utf-8");
+    const renderedNodes = readInlineJsonArray<{ id: string; source_file: string }>(html, "RAW_NODES");
+    const renderedEdges = readInlineJsonArray<{ from: string; to: string; relation: string }>(html, "RAW_EDGES");
+
+    expect(G.order).toBeGreaterThan(5000);
+    expect(renderedNodes).toHaveLength(communityCount);
+    expect(renderedNodes.length).toBeLessThanOrEqual(100);
+    expect(renderedEdges.length).toBeLessThanOrEqual(communityCount);
+    expect(renderedNodes.every((node) => node.id.startsWith("community:"))).toBe(true);
+    expect(renderedNodes[0]?.source_file).toContain("repo:github.com/acme/graphify");
+    expect(renderedNodes[0]?.source_file).toContain("repo:github.com/acme/sentropic");
+    expect(html).toContain(`${G.order} nodes &middot; ${G.size} edges`);
+    expect(html).toContain(`rendered as ${communityCount} community nodes`);
+    expect(html).toContain(`"count":${nodesPerCommunity}`);
 
     rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
Lève le mur des **5000 nœuds** de `export html` pour rendre les **surfaces multi-repo** visualisables (scope graphify, sous MANDATE-graphify ; exécuté par codex détaché, vérifié par le conducteur **contre le vrai graphify**).

**Mécanisme** : au-delà de `MAX_NODES_FOR_VIZ=5000`, l'export bascule **auto** vers une **vue agrégée par communauté** — un super-nœud par communauté (taille ∝ nb de membres), arêtes inter-communautés agrégées, cap `MAX_COMMUNITIES_FOR_AGGREGATED_VIZ=500` (top-par-taille + bucket « other »). **< 5000 nœuds : rendu identique** (aucune régression). Aide CLI mise à jour.

**Vérif conducteur (vrai outil au gate)** : `graphify merge-graphs graphify+sentropic` = **10851 nœuds** → l'export, qui **levait** « too large for HTML viz », produit désormais un **viewer agrégé de 630 Ko**. Tests touchés **74/74**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)