### PR TITLE
feat(enrichment): default-on describe + citations in every finalization path (spec + phase 1)

### DIFF
--- a/spec/SPEC_GRAPHIFY.md
+++ b/spec/SPEC_GRAPHIFY.md
@@ -79,7 +79,11 @@ Legacy compatibility:
 7. Build a Graphology graph.
 8. Cluster with Louvain and compute cohesion.
 9. Label communities and compute analysis.
-10. Export graph.json, GRAPH_REPORT.md, graph.html, optional wiki and export formats.
+10. Describe entities — per-node descriptions (default-on enrichment, no-key assistant-emit; `--no-description` to skip).
+11. Project citations — deterministic union / true-count / tiering of the per-node citation locators emitted by step 4 (default-on, no LLM; `--no-citations` to skip).
+12. Export graph.json, GRAPH_REPORT.md, the static Ontology Studio, optional wiki and export formats.
+
+Steps 9–11 are **enrichment stages** governed by the shared policy in *Enrichment Stages* below; they run in EVERY graph-finalization path, not only `graphify update`.
 
 Every edge keeps provenance confidence: EXTRACTED, INFERRED, or AMBIGUOUS, with scores where available.
 
@@ -90,6 +94,39 @@ Between step 6 (merge AST + semantic) and step 7 (build the graph), an optional,
 1. **Schema hygiene (`normalizeSchemaHygiene`).** Canonicalizes synonymous id-prefixes through an explicit, extensible synonym map (defaults `location_`→`place_`, `org_`→`organization_`) and normalizes the node `type` to its canonical Capitalized form (default overrides `place`→`Location`, `chapter`/`story`→`ChapterOrStory`; bare lowercase types fold to Capitalize, e.g. `character`→`Character`). When two nodes collapse onto the same canonical id their edges, string-array fields, and citations are **UNIONed** (the 0.14.0 citation-union-at-merge posture — never last-write-wins-dropped); scalar attrs are filled first-seen by sorted id order. Self-loops created by a collapse are dropped. Re-running on its own output is a no-op.
 2. **Alias / normalized_terms derivation (`deriveAliasesAndNormalizedTerms`).** Derives `aliases` + `normalized_terms` from the label CONSERVATIVELY: strips leading honorifics/titles (Dr., Sir, Colonel, Inspector, Mr., Mrs., Lord, Lady, Captain, Professor, …) and parentheticals (`Hugo Oberstein (spy)`→alias `Hugo Oberstein`), lowercases the normalized terms. No fuzzy stemming (no invented collisions). Merges with — never clobbers — any pre-existing aliases/terms; idempotent.
 3. **De-orphan (`deOrphanByContainer`).** Links each degree-0 entity node to a container through a derived `appears_in` edge (`derived:true`, `confidence:"INFERRED"`), **steering the orphan into the giant connected component so it never forms a 2-node island**. Per orphan (giant mode, `preferGiantComponent` default ON): pick the FINEST container (ChapterOrStory/Scene/Section, then Work) sharing provenance (`source_file` or path slug) that is **itself in the giant component** (`derivation_method:"deorphan:giant-component"`); else fall back to the Work (the densely-connected anchor — "of two items one is necessarily the Work, and the Work is linked to many", `derivation_method:"deorphan:work-fallback"`) so the orphan joins the Work's subgraph rather than a degree-1↔degree-1 island; else the strict finest container as best-effort. Exactly ONE container is chosen per orphan, so no redundant entity→Work edge is added when a finer container already carries it toward the Work. Finest-in-giant is still chosen over straight-to-Work so Work hubs don't outrank protagonists. Set `preferGiantComponent:false` for the legacy strict-finest behavior (`derivation_method:"deorphan:finest-container"`). Idempotent: respects pre-existing `appears_in`, never double-adds, never links a container node into itself. **Honest residual:** de-orphan is a topology guardrail, not a density fix — on the public mystery-sagas corpus ~64.8% of entities carry ONLY an `appears_in` edge, which produces implausibly thin hub-spoke stars (e.g. a Father Brown chapter with ~184 degree-1 satellites) and a multi-work Thorndyke island that no container-linking strategy can merge into the giant without cross-work edges. That deeper low-density cause is the separate re-index work (TRACKED #5), not de-orphan.
+
+## Enrichment Stages — Labels, Descriptions, Citations
+
+Three pipeline stages enrich the clustered graph before export (steps 9–11). They share one policy resolver but split into two mechanics.
+
+**Target contract — NOT yet fully implemented.** These stages MUST run by default in every graph-finalization path — `graphify <path>` (first run), `graphify extract` (after semantic input is available), `graphify update` (code), and profile post-semantic finalization — through ONE shared finalization step. Today only `graphify update` (code) describes; `graphify extract` and `profile build` run labels/citations but never call `generateNodeDescriptions` (`src/cli.ts:3481-3528`, `src/cli.ts:2934`), and `buildProject` describes but only resolves existing community labels (`src/pipeline.ts:215-254`). Bringing `extract` / profile / `buildProject` / runtime onto the shared finalization step is the core change this spec mandates.
+
+### LLM/assistant stages — community labels + node descriptions
+
+Both require an LLM. The NO-KEY default is the assistant-emit contract: the stage emits instruction files for the host assistant (the running skill) to fill, then ingests the answers on the next run — never requiring an API key.
+
+- Labels emit `.graphify/label-instructions/`; the assistant writes the answers; the next run ingests and persists them (regardless of `assistant` vs `llm` source — neither path may drop assistant-ingested labels).
+- Descriptions emit `.graphify/description-instructions/batch-NNN.md`; the assistant writes `batch-NNN.json`; the next run ingests it before emitting new work and sets `node.description`.
+- Direct (keyed) execution is OPT-IN and EXPLICIT via `--label-mode direct` / `--description-mode direct`. The mere presence of an API key in the environment (e.g. a discovered `.env`) does NOT silently switch a stage to direct mode. *Required change:* today auto-mode resolves to **direct** whenever a backend/API key is detected (`src/node-descriptions.ts:1025-1033`, `src/community-labeling.ts:527-534`; the CLI also imports a local `.env`, `src/cli.ts:2201`) — auto must resolve to assistant/emit unless `direct` is explicitly requested.
+- Opt-out: `--no-label` / `--no-description`. `--no-cluster` also implies no labels.
+
+### Deterministic stage — citations
+
+Citation projection is deterministic and provider-neutral: NO LLM, network, or secrets. The citation LOCATORS (`{source_file, source_url?, page?, section?, paragraph_id?, figure_id?, bbox?}`, `src/types.ts:500`) are emitted PER NODE by the upstream semantic extraction (step 4) — when profile extraction is active, at the profile's `citation_policy.minimum_granularity` (`file | page | section | paragraph`; validation today enforces `source_file` always and `page` only when the minimum is `page`, `src/profile-validate.ts:66-77`); non-profile extraction preserves whatever locators the upstream extraction emitted. The citation stage only UNIONs/dedups the locators already on the nodes, sets the true degree-independent `citation_count`, and tiers them: an inline top-K in `graph.json` plus the full union lazily in `.graphify/ontology/citations.json`. It scans NO source text (no grep/regex). **Required invariant:** graph-finalization writers MUST route through `persistGraphWithCitations` (`src/export.ts:394`, `src/citations.ts:220`); today raw `toJson` writers still exist in non-finalization commands (fragment `build`, `label`, `describe`, `backfill-citations`, runtime reload — `src/cli.ts:3233,3937,4063,4118`) and each must be classified as a non-finalization rewrite that preserves/reprojects the existing sidecar, or migrated so no graph output can skip citation projection. Opt-out: `--no-citations`.
+
+### Cost-awareness policy (uniform across the three stages) — REQUIRED, not yet implemented
+
+None of the following exist in the CLI today (no `--batch`, no `CI=1` resolver, no impact-threshold warning, no `--description-top`/`--description-max-nodes`; describe default is full coverage, `DEFAULT_MAX_NODES = 0`, `src/node-descriptions.ts:261`). They are the target:
+
+- **Impact warning — *le cas échéant*.** Before a stage runs, if its workload exceeds a configurable threshold, warn with the concrete impact and the skip flag — describe: describable-node count → assistant-batch count; citations: estimated `citations.json` size (cost is bytes/time, not tokens — citation projection makes no provider calls). Below threshold: silent (no nag).
+- **Batch opt-out.** `--batch=skip|emit` is an umbrella across the stages; `CI=1` forces a deterministic posture (emit-only or skip, never direct). A non-TTY environment alone is NOT treated as batch (a scripted assistant run may legitimately want instruction files).
+- **Large-corpus threshold.** Configurable per stage. Above it the default is WARN + FULL coverage — NEVER a silent cap: an undescribed node has no sidecar fallback (unlike a citation, whose tail is preserved in `citations.json`, where an inline top-K is correct). A reduced pass is opt-in only (`--description-top <k>` / `--description-max-nodes <n>`, direct mode).
+
+### Migration
+
+On finalization paths that run the description stage, a graph with zero descriptions auto-emits description instructions on the next run; `--fill-missing` is the idempotent gap-fill for partially-described graphs. Citation-poor graphs are NOT auto re-extracted — exhaustive counts come from re-extraction or the opt-in `backfill-citations` path.
+
+`SPEC_WIKI_ENTITY_DESCRIPTIONS.md` (the older `--wiki-descriptions` opt-in framing) is SUPERSEDED by this default-on model for *generation*; its wiki-rendering consumption contract still applies.
 
 ## Configured Ontology Dataprep Profiles
 

--- a/spec/SPEC_ONTOLOGY_DATAPREP_PROFILES.md
+++ b/spec/SPEC_ONTOLOGY_DATAPREP_PROFILES.md
@@ -31,7 +31,7 @@ Graphify already performs substantial dataprep:
 - AST extraction for code
 - assistant-driven semantic extraction for documents, papers and images
 - extraction validation
-- graph build, clustering, reports, wiki and exports
+- graph build, clustering, reports, wiki and exports (the INTENDED finalization stack adds default-on node descriptions + citation projection per `SPEC_GRAPHIFY.md` § Enrichment Stages — not yet wired into the corpus `extract` path)
 
 The missing layer is not a separate dataprep product. The missing layer is a generic way for a project to declare:
 

--- a/spec/SPEC_WIKI_ENTITY_DESCRIPTIONS.md
+++ b/spec/SPEC_WIKI_ENTITY_DESCRIPTIONS.md
@@ -7,9 +7,9 @@
 - Spec state: baseline accepted; render-only sidecar consumption implemented; generation command/API contract specified; assistant-first generation core implemented; CLI wiring and direct provider creation remain open
 - Implemented activation: explicit `graphify export wiki|obsidian --descriptions <path>` render path
 - Planned activation: explicit generation command/config/skill options only
-- Default behavior: unchanged
+- Default behavior: **SUPERSEDED for generation** — per-node description *generation* is now a default-on enrichment stage across all build paths per `SPEC_GRAPHIFY.md` § *Enrichment Stages* (no-key assistant-emit). The `--wiki-descriptions` opt-in framing below is historical. The wiki render-only sidecar *consumption* contract still applies.
 
-This spec defines an optional enrichment layer for Graphify wiki output. It applies to both code graphs and document/knowledge-base graphs, and it must reuse the existing LLM execution ports: assistant, direct, batch and mesh.
+For *generation*, this historical opt-in model is SUPERSEDED by `SPEC_GRAPHIFY.md` § Enrichment Stages (default-on, no-key assistant-emit). The remaining contract here is wiki/obsidian *rendering* — consuming an existing `node.description` or the description sidecar — across both code and document/knowledge-base graphs, reusing the existing LLM execution ports (assistant, direct, batch, mesh) where direct generation is still explicitly invoked.
 
 ## Problem
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3248,6 +3248,10 @@ export async function main(): Promise<void> {
     .option("--concurrency <n>", "Direct backend semantic chunk concurrency", "4")
     .option("--token-budget <n>", "Approximate direct backend token budget per semantic chunk", "60000")
     .option("--no-cluster", "Write the raw merged extraction and skip graph clustering/reporting")
+    .option("--no-description", "Skip the node-description enrichment stage")
+    .option("--no-label", "Skip the salient community-label enrichment stage")
+    .option("--description-mode <mode>", "Description execution: 'assistant' (default, emit instructions, no key) or 'direct' (explicit, requires API key)")
+    .option("--label-mode <mode>", "Community-label execution: 'assistant' (default, emit instructions, no key) or 'direct' (explicit, requires API key)")
     .option("--citations-top-k <n>", "Inline Level-1 citations kept per node in graph.json (default: corpus-resolved; 3 code / 8 others)")
     .option("--scope <mode>", scopeOptionDescription())
     .option("--all", "Alias for --scope all")
@@ -3478,12 +3482,12 @@ export async function main(): Promise<void> {
           return;
         }
 
-        const [{ buildFromJson }, { cluster, scoreAll }, { godNodes, surprisingConnections, suggestQuestions }, { generate }, { persistGraphWithCitations }] = await Promise.all([
+        const [{ buildFromJson }, { cluster, scoreAll }, { godNodes, surprisingConnections, suggestQuestions }, { generate }, { finalizeEnrichedGraphBuild }] = await Promise.all([
           import("./build.js"),
           import("./cluster.js"),
           import("./analyze.js"),
           import("./report.js"),
-          import("./export.js"),
+          import("./finalize-enriched-graph.js"),
         ]);
 
         const G = buildFromJson(merged);
@@ -3503,8 +3507,40 @@ export async function main(): Promise<void> {
           labelsPath: paths.scratch.labels,
           graph: G,
         });
-        const questions = suggestQuestions(G, communities, labels);
         const tokenCost = { input: merged.input_tokens ?? 0, output: merged.output_tokens ?? 0 };
+        const extractCitationPolicy = resolveCitationPolicyForRoot(outputRoot, {
+          topKFlag: parseTopKFlag(opts.citationsTopK),
+        });
+        // SPEC_GRAPHIFY § Enrichment Stages: the corpus first-run path now routes
+        // through the SHARED finalization step. Previously it clustered, resolved
+        // existing labels and projected citations but NEVER described or generated
+        // salient labels — so a no-key corpus build emitted `label-instructions/`
+        // but no `description-instructions/`. Both stages now emit (assistant
+        // default, no key) and `persistGraphWithCitations` remains the writer.
+        //
+        // The finalizer runs BEFORE report/question generation: it mutates
+        // `labels` in place with the salient/ingested community names. Generating
+        // the report or the suggested questions first would bake GENERIC labels
+        // into both artifacts even when `--label-mode direct` (or an ingested
+        // answer) resolved real names.
+        await finalizeEnrichedGraphBuild({
+          graph: G,
+          communities,
+          labels,
+          graphPath: paths.graph,
+          stateDir: paths.stateDir,
+          labelsPath: paths.scratch.labels,
+          gods,
+          force: true,
+          citationsTopK: extractCitationPolicy.inlineTopK,
+          ...(opts.description === false ? { describe: false } : {}),
+          ...(opts.label === false ? { label: false } : {}),
+          ...(opts.descriptionMode ? { descriptionMode: opts.descriptionMode } : {}),
+          ...(opts.labelMode ? { labelMode: opts.labelMode } : {}),
+        });
+
+        // Report + suggested questions are derived from the FINALIZED labels.
+        const questions = suggestQuestions(G, communities, labels);
         const report = generate(
           G,
           communities,
@@ -3520,20 +3556,11 @@ export async function main(): Promise<void> {
             freshness: { builtFromCommit: safeGitRevParse(root, ["HEAD"]) },
           },
         );
-
         writeFileSync(paths.report, report, "utf-8");
-        const extractCitationPolicy = resolveCitationPolicyForRoot(outputRoot, {
-          topKFlag: parseTopKFlag(opts.citationsTopK),
-        });
-        persistGraphWithCitations(G, communities, paths.graph, {
-          communityLabels: labels,
-          force: true,
-          citations: { topK: extractCitationPolicy.inlineTopK },
-        });
+
         // Visual output: a self-contained static Ontology Studio (the
         // replacement for the former HTML graph export). Best-effort.
         await emitDefaultStaticStudio(paths.stateDir);
-        persistCommunityLabels(labels, paths.scratch.labels);
         writeJson(paths.scratch.analysis, {
           communities: Object.fromEntries([...communities.entries()].map(([key, value]) => [String(key), value])),
           cohesion: Object.fromEntries([...cohesion.entries()].map(([key, value]) => [String(key), value])),

--- a/src/community-labeling.ts
+++ b/src/community-labeling.ts
@@ -529,7 +529,12 @@ export async function generateCommunityLabels(
       ? "direct"
       : options.mode === "assistant"
         ? "assistant"
-        : provider !== null || Boolean(options.callLlm)
+        : // Auto (SPEC_GRAPHIFY § Enrichment Stages): resolve to ASSISTANT/emit
+          // unless `--label-mode direct` is EXPLICITLY requested. A detected
+          // backend / API key (incl. a discovered `.env`) must NOT silently
+          // switch to direct. An INJECTED `callLlm` is a programmatic direct
+          // opt-in and still resolves to direct; a detected `provider` does not.
+          options.callLlm
           ? "direct"
           : "assistant";
 

--- a/src/finalize-enriched-graph.ts
+++ b/src/finalize-enriched-graph.ts
@@ -1,0 +1,192 @@
+/**
+ * Shared enrichment-stage finalization (SPEC_GRAPHIFY § "Enrichment Stages").
+ *
+ * Steps 9–11 of the pipeline — community labels, node descriptions, citation
+ * projection — are enrichment stages that MUST run in EVERY graph-finalization
+ * path (`graphify <path>` first run, `graphify extract`, `graphify update`,
+ * profile post-semantic finalization), not only `graphify update`.
+ *
+ * This module is the single chokepoint those paths converge on. It runs, in
+ * fixed order:
+ *
+ *   1. Community labels — fold salient names into the resolved labels
+ *      (default-on, assistant-emit when no key; emits `<stateDir>/label-
+ *      instructions/`). Persisted so later runs reuse them.
+ *   2. Node descriptions — `generateNodeDescriptions` with an EXPLICIT
+ *      `instructionDir = <stateDir>/description-instructions` (default-on,
+ *      assistant-emit when no key; `--no-description` opts out).
+ *   3. Citation projection — `persistGraphWithCitations` IS the graph writer
+ *      (deterministic, no LLM). The required invariant is that finalization
+ *      writers route through `persistGraphWithCitations`, never raw `toJson`.
+ *
+ * Modeled on `watch.rebuildCode` (src/watch.ts) and `buildProject`
+ * (src/pipeline.ts), which previously each open-coded a partial subset of these
+ * stages.
+ */
+import { join } from "node:path";
+import type Graph from "graphology";
+
+import { applySalientCommunityLabels, type LabelMode } from "./community-labeling.js";
+import { persistCommunityLabels } from "./community-labels.js";
+import {
+  generateNodeDescriptions,
+  type DescriptionMode,
+  type CitationCap,
+} from "./node-descriptions.js";
+import { persistGraphWithCitations } from "./export.js";
+import type { CitationAggregateMap } from "./citations.js";
+import type { DirectLlmProvider } from "./llm-execution.js";
+import type { GodNodeEntry } from "./types.js";
+
+type CallLlmFn = (prompt: string, maxTokens?: number) => Promise<string>;
+
+export interface FinalizeEnrichedGraphBuildOptions {
+  /** In-memory graph to enrich + persist. */
+  graph: Graph;
+  /** Louvain communities (cid → node ids). */
+  communities: Map<number, string[]>;
+  /**
+   * Resolved community labels (cid → name). Mutated in place by salient
+   * labeling. The caller resolves existing labels first (resolveCommunityLabels)
+   * and passes them here.
+   */
+  labels: Map<number, string>;
+  /** Absolute path of the graph.json output. */
+  graphPath: string;
+  /** `.graphify/` state dir — anchors the label/description instruction dirs. */
+  stateDir: string;
+  /** Persisted-labels JSON path (`<stateDir>/.graphify_labels.json`). */
+  labelsPath: string;
+
+  /** God-node entries (improve salient labeling); empty when clustering is off. */
+  gods?: GodNodeEntry[];
+
+  // --- Stage gates (default-on; `false` opts out) -------------------------
+  /** `false` → skip salient community labels (`--no-label` / `--no-cluster`). */
+  label?: boolean;
+  /** `false` → skip node descriptions (`--no-description`). */
+  describe?: boolean;
+
+  // --- Label stage knobs ---------------------------------------------------
+  labelBackend?: DirectLlmProvider | string | null;
+  labelModel?: string;
+  labelMode?: LabelMode;
+  /**
+   * Injectable LLM caller for the LABEL stage only (tests / programmatic
+   * direct opt-in). An injected `callLlm` is a programmatic direct opt-in
+   * (community-labeling.ts:535), so this MUST stay separate from the
+   * description caller — a description-only callback must never drive the
+   * label stage into direct mode with label prompts.
+   */
+  labelCallLlm?: CallLlmFn;
+
+  // --- Description stage knobs --------------------------------------------
+  descriptionBackend?: DirectLlmProvider | string | null;
+  descriptionModel?: string;
+  descriptionMode?: DescriptionMode;
+  descriptionMaxNodes?: number;
+  descriptionOnlyMissing?: boolean;
+  citationCap?: CitationCap;
+  /** Injectable LLM caller for the DESCRIPTION stage only (tests). */
+  descriptionCallLlm?: CallLlmFn;
+
+  // --- Citation writer knobs ----------------------------------------------
+  /** Inline top-K cap for `graph.json` citations (default policy when omitted). */
+  citationsTopK?: number;
+  /**
+   * Prior FULL citation union (from `citations.json`) for update/merge paths,
+   * so a re-extracted node's count + top-K derive from `prior ∪ fresh` rather
+   * than the K-trimmed inline. Forwarded to `persistGraphWithCitations`.
+   */
+  citationsPriorSidecar?: CitationAggregateMap | null;
+  /** Force overwrite of a protected/curated graph. */
+  force?: boolean;
+}
+
+export interface FinalizeEnrichedGraphBuildResult {
+  /** Whether `persistGraphWithCitations` wrote graph.json. */
+  jsonWritten: boolean;
+  /** Source of the salient labels: "llm" | "assistant" | "placeholder". */
+  labelSource: string;
+  /** Every describable node now carries a description (false in assistant emit). */
+  descriptionsComplete: boolean;
+}
+
+/**
+ * Run the three enrichment stages (labels → descriptions → citations) and write
+ * graph.json through `persistGraphWithCitations`. The single finalization step
+ * every graph-finalization path is required to route through.
+ */
+export async function finalizeEnrichedGraphBuild(
+  options: FinalizeEnrichedGraphBuildOptions,
+): Promise<FinalizeEnrichedGraphBuildResult> {
+  const {
+    graph: G,
+    communities,
+    labels,
+    graphPath,
+    stateDir,
+    labelsPath,
+  } = options;
+
+  // --- Stage 9: salient community labels (default-on, assistant-emit no-key).
+  // The caller has already resolved existing labels into `labels`; here we fold
+  // in salient names. Skipped when clustering is off (no communities) or
+  // `label === false` (--no-label). Degrades to generic names + a stderr note
+  // when no LLM backend is configured.
+  let labelSource = "placeholder";
+  if (options.label !== false && communities.size > 0) {
+    const { source } = await applySalientCommunityLabels(G, communities, labels, {
+      provider: options.labelBackend ?? null,
+      ...(options.labelModel ? { model: options.labelModel } : {}),
+      ...(options.labelMode ? { mode: options.labelMode } : {}),
+      ...(options.labelCallLlm ? { callLlm: options.labelCallLlm } : {}),
+      gods: options.gods ?? [],
+      instructionDir: join(stateDir, "label-instructions"),
+    });
+    labelSource = source;
+    if (source === "llm") {
+      // Persist so subsequent cluster-only / update / hook runs reuse the
+      // salient names instead of regenerating them.
+      persistCommunityLabels(labels, labelsPath);
+    }
+  }
+
+  // --- Stage 10: node descriptions (default-on, assistant-emit no-key).
+  // Stamp `description` onto G before the JSON write. EXPLICIT instructionDir so
+  // a no-key build emits `<stateDir>/description-instructions/` (parity with the
+  // label instructions above). Skips gracefully (no throw) with no backend.
+  let descriptionsComplete = false;
+  if (options.describe !== false) {
+    const result = await generateNodeDescriptions(G, {
+      ...(options.descriptionBackend ? { provider: options.descriptionBackend } : {}),
+      ...(options.descriptionModel ? { model: options.descriptionModel } : {}),
+      ...(options.descriptionMaxNodes !== undefined ? { maxNodes: options.descriptionMaxNodes } : {}),
+      ...(options.descriptionOnlyMissing ? { onlyMissing: true } : {}),
+      ...(options.descriptionMode ? { mode: options.descriptionMode } : {}),
+      ...(options.citationCap !== undefined ? { citationCap: options.citationCap } : {}),
+      ...(options.descriptionCallLlm ? { callLlm: options.descriptionCallLlm } : {}),
+      instructionDir: join(stateDir, "description-instructions"),
+    });
+    descriptionsComplete = result.coverage.described >= result.coverage.describable;
+  }
+
+  // --- Stage 11: citation projection IS the graph writer. Deterministic union /
+  // true-count / tiering; no LLM. The required invariant is that finalization
+  // writers route through `persistGraphWithCitations` (never raw `toJson`).
+  const citationOptions = {
+    ...(options.citationsTopK !== undefined ? { topK: options.citationsTopK } : {}),
+    ...(options.citationsPriorSidecar ? { priorSidecar: options.citationsPriorSidecar } : {}),
+  };
+  const jsonWritten = persistGraphWithCitations(G, communities, graphPath, {
+    communityLabels: labels,
+    ...(options.force ? { force: true } : {}),
+    ...(Object.keys(citationOptions).length > 0 ? { citations: citationOptions } : {}),
+  });
+
+  // Persist the (possibly salient-updated) labels even on the assistant /
+  // placeholder path so cluster-only / update reuse the active set.
+  persistCommunityLabels(labels, labelsPath);
+
+  return { jsonWritten, labelSource, descriptionsComplete };
+}

--- a/src/node-descriptions.ts
+++ b/src/node-descriptions.ts
@@ -1027,8 +1027,13 @@ export async function generateNodeDescriptions(
       ? "direct"
       : options.mode === "assistant"
         ? "assistant"
-        : // Auto: use direct when a backend is available, assistant otherwise.
-          provider !== null || Boolean(options.callLlm)
+        : // Auto (SPEC_GRAPHIFY § Enrichment Stages): resolve to ASSISTANT/emit
+          // unless `--description-mode direct` is EXPLICITLY requested. The mere
+          // presence of a detected backend / API key (incl. a discovered `.env`)
+          // must NOT silently switch to direct. An INJECTED `callLlm` is a
+          // programmatic direct opt-in (tests / embedders) and still resolves
+          // to direct — a detected `provider` alone does not.
+          options.callLlm
           ? "direct"
           : "assistant";
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -14,14 +14,15 @@ import { buildFromJson } from "./build.js";
 import { cluster, scoreAll } from "./cluster.js";
 import { godNodes, surprisingConnections, suggestQuestions } from "./analyze.js";
 import { generate } from "./report.js";
-import { backupIfProtected, persistGraphWithCitations } from "./export.js";
+import { backupIfProtected } from "./export.js";
 import { buildStaticStudio, StudioSpaNotBuiltError, removeLegacyGraphViz } from "./studio-export.js";
 import { extractWithDiagnostics, type ExtractionDiagnostic } from "./extract.js";
 import { buildCodeFileNodeIdMap, extractGit, mergeExtractions } from "./extract-git.js";
 import { resolveGraphifyPaths } from "./paths.js";
 import { markLifecycleAnalyzed } from "./lifecycle.js";
-import { persistCommunityLabels, resolveCommunityLabels } from "./community-labels.js";
-import { generateNodeDescriptions, type GenerateNodeDescriptionsOptions } from "./node-descriptions.js";
+import { resolveCommunityLabels } from "./community-labels.js";
+import type { GenerateNodeDescriptionsOptions } from "./node-descriptions.js";
+import { finalizeEnrichedGraphBuild } from "./finalize-enriched-graph.js";
 import { safeGitRevParse } from "./git.js";
 import { toWiki } from "./wiki.js";
 import {
@@ -216,8 +217,42 @@ export async function buildProject(
     labelsPath: paths.scratch.labels,
     graph: G,
   });
-  const questions = suggestQuestions(G, communities, labels);
 
+  // Upstream 6939494 (#834): snapshot existing artifacts before overwrite if
+  // the previous graph cost real LLM tokens or has been human-curated.
+  backupIfProtected(paths.stateDir);
+
+  // SPEC_GRAPHIFY § Enrichment Stages: run the shared finalization step
+  // (salient labels → node descriptions → citation projection writer) so this
+  // path converges with `graphify update` / `extract`. Previously buildProject
+  // described but only resolved existing labels and never applied salient names.
+  //
+  // The finalizer runs BEFORE report/question generation: it mutates `labels`
+  // in place with the salient/ingested community names. Generating the report
+  // or the suggested questions first would bake GENERIC labels into both
+  // artifacts even when salient names (or an ingested answer) resolved.
+  await finalizeEnrichedGraphBuild({
+    graph: G,
+    communities,
+    labels,
+    graphPath,
+    stateDir: paths.stateDir,
+    labelsPath: paths.scratch.labels,
+    gods,
+    ...(options?.describe !== undefined ? { describe: options.describe } : {}),
+    ...(options?.descriptionBackend ? { descriptionBackend: options.descriptionBackend } : {}),
+    ...(options?.descriptionModel ? { descriptionModel: options.descriptionModel } : {}),
+    ...(options?.descriptionMaxNodes !== undefined ? { descriptionMaxNodes: options.descriptionMaxNodes } : {}),
+    // `describeCallLlm` is a DESCRIPTION-only caller; pass it solely to the
+    // description stage. An injected callLlm is a programmatic direct opt-in
+    // (community-labeling.ts:535), so handing it to the label stage too would
+    // silently drive labels into direct mode with label prompts. buildProject
+    // exposes no label caller, so the label stage stays assistant/auto here.
+    ...(options?.describeCallLlm ? { descriptionCallLlm: options.describeCallLlm } : {}),
+  });
+
+  // Report + suggested questions are derived from the FINALIZED labels.
+  const questions = suggestQuestions(G, communities, labels);
   const report = generate(
     G,
     communities,
@@ -233,26 +268,7 @@ export async function buildProject(
       freshness: { builtFromCommit: safeGitRevParse(rootResolved, ["HEAD"]) },
     },
   );
-
-  // Upstream 6939494 (#834): snapshot existing artifacts before overwrite if
-  // the previous graph cost real LLM tokens or has been human-curated.
-  backupIfProtected(paths.stateDir);
-
-  // WP11: generate node descriptions by default (entity + code symbols) and
-  // stamp them onto G so the next toJson() persists each `description` to
-  // graph.json. Skips gracefully (no throw) when no backend is configured.
-  if (options?.describe !== false) {
-    await generateNodeDescriptions(G, {
-      ...(options?.descriptionBackend ? { provider: options.descriptionBackend } : {}),
-      ...(options?.descriptionModel ? { model: options.descriptionModel } : {}),
-      ...(options?.descriptionMaxNodes !== undefined ? { maxNodes: options.descriptionMaxNodes } : {}),
-      ...(options?.describeCallLlm ? { callLlm: options.describeCallLlm } : {}),
-    });
-  }
-
   writeFileSync(reportPath, report, "utf-8");
-  persistGraphWithCitations(G, communities, graphPath, { communityLabels: labels });
-  persistCommunityLabels(labels, paths.scratch.labels);
 
   // Visual output: the self-contained static Ontology Studio bundle (the
   // replacement for the former HTML graph export). Best-effort — a missing

--- a/src/skill-runtime.ts
+++ b/src/skill-runtime.ts
@@ -454,6 +454,82 @@ function analyzeGraph(
   };
 }
 
+/**
+ * SPEC_GRAPHIFY § "Enrichment Stages" — route a RUNTIME finalization path
+ * through the shared `finalizeEnrichedGraphBuild` chokepoint.
+ *
+ * The runtime `finalize-build` / `finalize-update` / `analyze-build` paths
+ * previously resolved EXISTING labels (via `analyzeGraph`) and projected
+ * citations, but never ran salient community labels or node descriptions — so a
+ * no-key runtime/assistant build emitted neither `label-instructions/` nor
+ * `description-instructions/`. They now converge on the same finalizer
+ * `graphify extract` uses (cli.ts), giving every finalization path the same
+ * enrichment contract.
+ *
+ * The finalizer mutates `analyzed.labels` in place with the salient/ingested
+ * names AND writes graph.json (via `persistGraphWithCitations`, never raw
+ * `toJson`). Because `analyzeGraph` generated its report from the PRE-salient
+ * labels (FIX 2 ordering), this helper RE-generates the report + suggested
+ * questions from the finalized labels and returns them so the caller writes the
+ * enriched report/analysis, not the preliminary one.
+ */
+async function finalizeRuntimeBuild(args: {
+  graph: Graph;
+  detection: DetectionResult;
+  root: string;
+  tokenCost: { input: number; output: number };
+  graphOut: string;
+  labelsPath: string;
+  analyzed: ReturnType<typeof analyzeGraph>;
+  /** Prior FULL citation union (update/merge paths) — recovers the true union. */
+  priorSidecar?: CitationAggregateMap | null;
+  /** Force overwrite of a protected/curated graph (first-run builds). */
+  force?: boolean;
+}): Promise<{ report: string; questions: SuggestedQuestion[]; analysis: AnalysisFile }> {
+  const { finalizeEnrichedGraphBuild } = await import("./finalize-enriched-graph.js");
+  const { graph: G, detection, root, tokenCost, graphOut, labelsPath, analyzed } = args;
+  const stateDir = dirname(resolve(graphOut));
+
+  // Finalizer: salient labels (mutates `analyzed.labels`) → node descriptions →
+  // citation projection writer. This IS the graph.json writer for these paths.
+  await finalizeEnrichedGraphBuild({
+    graph: G,
+    communities: analyzed.communities,
+    labels: analyzed.labels,
+    graphPath: resolve(graphOut),
+    stateDir,
+    labelsPath,
+    gods: analyzed.gods,
+    ...(args.force ? { force: true } : {}),
+    ...(args.priorSidecar ? { citationsPriorSidecar: args.priorSidecar } : {}),
+  });
+
+  // Re-derive report + questions from the FINALIZED labels (FIX 2).
+  const questions = suggestQuestions(G, analyzed.communities, analyzed.labels);
+  const report = generate(
+    G,
+    analyzed.communities,
+    analyzed.cohesion,
+    analyzed.labels,
+    analyzed.gods,
+    analyzed.surprises,
+    detection,
+    tokenCost,
+    projectRootLabel(root),
+    {
+      suggestedQuestions: questions,
+      freshness: { builtFromCommit: safeGitRevParse(root, ["HEAD"]) },
+    },
+  );
+
+  const analysis: AnalysisFile = {
+    ...analyzed.analysis,
+    questions,
+    labels: mapToObject(analyzed.labels),
+  };
+  return { report, questions, analysis };
+}
+
 function placeholderDetection(root: string = "."): DetectionResult {
   return {
     files: { code: [], document: [], paper: [], image: [], video: [] },
@@ -1256,12 +1332,23 @@ export async function main(argv: string[] = process.argv): Promise<void> {
         { labelsPath },
       );
 
-      persistGraphWithCitations(G, analyzed.communities, resolve(opts.graphOut), {
-        communityLabels: analyzed.labels,
+      // SPEC_GRAPHIFY § Enrichment Stages: route through the SHARED finalizer
+      // (salient labels → descriptions → citation projection writer) so a no-key
+      // runtime build emits BOTH label- and description-instructions/, not just
+      // existing-label resolution. The finalizer writes graph.json + persists
+      // the (salient-updated) labels, and we re-derive the report/analysis from
+      // the finalized labels (FIX 2 ordering).
+      const finalized = await finalizeRuntimeBuild({
+        graph: G,
+        detection: portableDetection,
+        root,
+        tokenCost: { input: extraction.input_tokens ?? 0, output: extraction.output_tokens ?? 0 },
+        graphOut: opts.graphOut,
+        labelsPath,
+        analyzed,
       });
-      writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
-      writeJson(opts.analysisOut, analyzed.analysis);
-      persistCommunityLabels(analyzed.labels, labelsPath);
+      writeFileSync(resolve(opts.reportOut), finalized.report, "utf-8");
+      writeJson(opts.analysisOut, finalized.analysis);
       await emitSkillStaticStudio(dirname(resolve(opts.graphOut)));
       saveManifest(portableDetection.files, join(dirname(resolve(opts.graphOut)), "manifest.json"), { root });
       const cost = updateCostFile(extraction, portableDetection, opts.costOut);
@@ -1338,19 +1425,28 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const finalizePriorSidecar: CitationAggregateMap | null = readCitationsSidecar(
         dirname(resolve(opts.graphOut)),
       );
-      persistGraphWithCitations(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
-        communityLabels: analyzed.labels,
-        ...(finalizePriorSidecar ? { citations: { priorSidecar: finalizePriorSidecar } } : {}),
+      // SPEC_GRAPHIFY § Enrichment Stages: route the update finalization through
+      // the SHARED finalizer (salient labels → descriptions → citation writer),
+      // forwarding the prior FULL citation sidecar so the union/count stay
+      // correct. Re-derive report/analysis from the finalized labels (FIX 2).
+      const finalized = await finalizeRuntimeBuild({
+        graph: mergedGraph,
+        detection: portableDetection,
+        root,
+        tokenCost: { input: extraction.input_tokens ?? 0, output: extraction.output_tokens ?? 0 },
+        graphOut: opts.graphOut,
+        labelsPath,
+        analyzed,
+        ...(finalizePriorSidecar ? { priorSidecar: finalizePriorSidecar } : {}),
       });
-      writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
-      writeJson(opts.analysisOut, analyzed.analysis);
-      persistCommunityLabels(analyzed.labels, labelsPath);
+      writeFileSync(resolve(opts.reportOut), finalized.report, "utf-8");
+      writeJson(opts.analysisOut, finalized.analysis);
       await emitSkillStaticStudio(dirname(resolve(opts.graphOut)));
       saveManifest(portableDetection.files, join(dirname(resolve(opts.graphOut)), "manifest.json"), { root });
       const cost = updateCostFile(extraction, portableDetection, opts.costOut);
 
       console.log(`Merged: ${mergedGraph.order} nodes, ${mergedGraph.size} edges`);
-      console.log(analyzed.analysis.diff.summary);
+      console.log(finalized.analysis.diff!.summary);
       console.log(`This run: ${(extraction.input_tokens ?? 0).toLocaleString()} input tokens, ${(extraction.output_tokens ?? 0).toLocaleString()} output tokens`);
       console.log(`All time: ${cost.total_input_tokens.toLocaleString()} input, ${cost.total_output_tokens.toLocaleString()} output (${cost.runs.length} runs)`);
     });
@@ -1364,7 +1460,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .requiredOption("--report-out <path>")
     .requiredOption("--analysis-out <path>")
     .option("--directed", "Build a directed graph (preserves source->target)")
-    .action((opts) => {
+    .action(async (opts) => {
       const root = resolve(opts.root);
       const extraction = makeExtractionPortable(ensureExtractionShape(readJson<Partial<Extraction>>(opts.extract)), root);
       const detection = makeDetectionPortable(readJson<DetectionResult>(opts.detect), root);
@@ -1384,12 +1480,21 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       );
 
       mkdirSync(dirname(resolve(opts.graphOut)), { recursive: true });
-      persistGraphWithCitations(G, analyzed.communities, resolve(opts.graphOut), {
-        communityLabels: analyzed.labels,
+      // SPEC_GRAPHIFY § Enrichment Stages: route through the SHARED finalizer so
+      // a no-key analyze-build emits BOTH label- and description-instructions/
+      // (was existing-label resolution + citations only). Report/analysis derive
+      // from the finalized labels (FIX 2).
+      const finalized = await finalizeRuntimeBuild({
+        graph: G,
+        detection,
+        root,
+        tokenCost: { input: extraction.input_tokens ?? 0, output: extraction.output_tokens ?? 0 },
+        graphOut: opts.graphOut,
+        labelsPath,
+        analyzed,
       });
-      writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
-      writeJson(opts.analysisOut, analyzed.analysis);
-      persistCommunityLabels(analyzed.labels, labelsPath);
+      writeFileSync(resolve(opts.reportOut), finalized.report, "utf-8");
+      writeJson(opts.analysisOut, finalized.analysis);
       saveManifest(detection.files, join(dirname(resolve(opts.graphOut)), "manifest.json"), { root });
       console.log(`Graph: ${G.order} nodes, ${G.size} edges, ${analyzed.communities.size} communities`);
     });
@@ -1585,7 +1690,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .requiredOption("--report-out <path>")
     .requiredOption("--analysis-out <path>")
     .option("--directed", "Build a directed graph (preserves source->target)")
-    .action((opts) => {
+    .action(async (opts) => {
       const root = resolve(opts.root);
       const oldGraph = makeGraphPortable(loadGraph(opts.existingGraph), root);
       const mergedGraph = makeGraphPortable(loadGraph(opts.existingGraph), root);
@@ -1614,17 +1719,26 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       const mergeUpdatePriorSidecar: CitationAggregateMap | null = readCitationsSidecar(
         dirname(resolve(opts.graphOut)),
       );
-      persistGraphWithCitations(mergedGraph, analyzed.communities, resolve(opts.graphOut), {
-        communityLabels: analyzed.labels,
-        ...(mergeUpdatePriorSidecar ? { citations: { priorSidecar: mergeUpdatePriorSidecar } } : {}),
+      // SPEC_GRAPHIFY § Enrichment Stages: mirrors finalize-update — route the
+      // re-extraction merge through the SHARED finalizer (salient labels →
+      // descriptions → citation writer with the prior sidecar). Report/analysis
+      // derive from the finalized labels (FIX 2).
+      const finalized = await finalizeRuntimeBuild({
+        graph: mergedGraph,
+        detection,
+        root,
+        tokenCost: { input: extraction.input_tokens ?? 0, output: extraction.output_tokens ?? 0 },
+        graphOut: opts.graphOut,
+        labelsPath,
+        analyzed,
+        ...(mergeUpdatePriorSidecar ? { priorSidecar: mergeUpdatePriorSidecar } : {}),
       });
-      writeFileSync(resolve(opts.reportOut), analyzed.report, "utf-8");
-      writeJson(opts.analysisOut, analyzed.analysis);
-      persistCommunityLabels(analyzed.labels, labelsPath);
+      writeFileSync(resolve(opts.reportOut), finalized.report, "utf-8");
+      writeJson(opts.analysisOut, finalized.analysis);
       saveManifest(detection.files, join(dirname(resolve(opts.graphOut)), "manifest.json"), { root });
 
       console.log(`Merged: ${mergedGraph.order} nodes, ${mergedGraph.size} edges`);
-      console.log(analyzed.analysis.diff.summary);
+      console.log(finalized.analysis.diff!.summary);
     });
 
   program

--- a/tests/build-project-report-finalized-labels.test.ts
+++ b/tests/build-project-report-finalized-labels.test.ts
@@ -1,0 +1,141 @@
+/**
+ * SPEC_GRAPHIFY § "Enrichment Stages" — PHASE 1, ordering invariant.
+ *
+ * REGRESSION (FIX 2): `buildProject` generated GRAPH_REPORT.md + suggested
+ * questions BEFORE the shared finalizer mutated the community labels, so when
+ * salient/ingested names resolved, the emitted report still showed the GENERIC
+ * `Community N` placeholders. The finalizer now runs FIRST and the report is
+ * derived from the FINALIZED labels.
+ *
+ * This test ingests an assistant label answer (the no-key default path) and
+ * asserts the resulting report reflects the ingested name, not `Community N`.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const cleanupDirs: string[] = [];
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-report-labels-"));
+  cleanupDirs.push(dir);
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(join(dir, "src", "sample.ts"), "export function demo() { return 1; }\n", "utf-8");
+  return dir;
+}
+
+/** A multi-node code extraction so clustering yields at least one community. */
+function mockExtract(dir: string): void {
+  const file = join(dir, "src", "sample.ts");
+  const node = (id: string, label: string) => ({
+    id,
+    label,
+    file_type: "code",
+    source_file: file,
+  });
+  const edge = (source: string, target: string) => ({
+    source,
+    target,
+    relation: "calls",
+    confidence: "EXTRACTED" as const,
+    source_file: file,
+  });
+  vi.doMock("../src/extract.js", async () => {
+    const actual = await vi.importActual<typeof import("../src/extract.js")>("../src/extract.js");
+    return {
+      ...actual,
+      extractWithDiagnostics: vi.fn(async () => ({
+        extraction: {
+          nodes: [
+            node("alpha_fn", "alpha()"),
+            node("beta_fn", "beta()"),
+            node("gamma_fn", "gamma()"),
+            node("delta_fn", "delta()"),
+          ],
+          edges: [
+            edge("alpha_fn", "beta_fn"),
+            edge("beta_fn", "gamma_fn"),
+            edge("gamma_fn", "delta_fn"),
+            edge("delta_fn", "alpha_fn"),
+          ],
+          input_tokens: 0,
+          output_tokens: 0,
+        },
+        diagnostics: [],
+      })),
+    };
+  });
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("../src/extract.js");
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+const INGESTED_NAME = "Demo Salient Layer";
+
+describe("buildProject GRAPH_REPORT.md reflects FINALIZED community labels", () => {
+  it("renders the ingested label, not the generic Community N placeholder", async () => {
+    const dir = makeProjectDir();
+    mockExtract(dir);
+
+    const noDescribe = {
+      html: false,
+      describe: false as const,
+      // never called (describe:false) — guards against an accidental call.
+      describeCallLlm: async () => {
+        throw new Error("LLM must not be called when describe:false");
+      },
+    };
+
+    const { buildProject } = await import("../src/pipeline.js");
+
+    // Run 1: no answer yet → the label stage emits label-instructions/.
+    await buildProject(dir, noDescribe);
+
+    const labelDir = join(dir, ".graphify", "label-instructions");
+    const instruction = readFileSync(join(labelDir, "communities.md"), "utf-8");
+    // The instruction file lists "Community <cid>: ..." for each labeled cid.
+    const cids = [...instruction.matchAll(/^Community (\d+):/gmu)].map((m) => Number(m[1]));
+    expect(cids.length).toBeGreaterThan(0);
+
+    // The first run's report still shows the generic placeholder (no answer yet).
+    const reportPath = join(dir, ".graphify", "GRAPH_REPORT.md");
+    const firstReport = readFileSync(reportPath, "utf-8");
+    expect(firstReport).toMatch(/Community 0/u);
+
+    // Simulate the assistant answering: map every labeled cid to a salient name.
+    const answer = Object.fromEntries(cids.map((cid) => [String(cid), INGESTED_NAME]));
+    writeFileSync(join(labelDir, "communities.json"), JSON.stringify(answer), "utf-8");
+
+    // Run 2: the finalizer ingests the answer into `labels` BEFORE the report is
+    // generated, so the emitted report must carry the ingested salient name.
+    await buildProject(dir, noDescribe);
+
+    const finalReport = readFileSync(reportPath, "utf-8");
+    expect(finalReport).toContain(`- "${INGESTED_NAME}"`);
+    // The community whose name we ingested is no longer rendered as generic.
+    expect(finalReport).not.toMatch(/### Community 0 - "Community 0"/u);
+
+    // The persisted labels JSON also carries the ingested name (the report and
+    // the labels store agree).
+    const labelsJson = JSON.parse(
+      readFileSync(join(dir, ".graphify", ".graphify_labels.json"), "utf-8"),
+    ) as Record<string, string>;
+    expect(Object.values(labelsJson)).toContain(INGESTED_NAME);
+
+    // Sanity: the instruction dir name we relied on actually exists.
+    expect(readdirSync(join(dir, ".graphify")).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/finalize-enriched-graph.test.ts
+++ b/tests/finalize-enriched-graph.test.ts
@@ -1,0 +1,339 @@
+/**
+ * SPEC_GRAPHIFY § "Enrichment Stages" — PHASE 1.
+ *
+ * The shared `finalizeEnrichedGraphBuild(...)` is the single chokepoint every
+ * graph-finalization path routes through. These tests pin its contract:
+ *
+ *   1. A no-key build emits BOTH `label-instructions/` AND
+ *      `description-instructions/` (description parity with labels — the gap the
+ *      corpus `extract` path previously had).
+ *   2. The description stage actually RUNS in the shared path (assistant ingest
+ *      + injected callLlm direct).
+ *   3. Auto-mode stays assistant-emit when an API key is present but `direct`
+ *      was NOT explicitly requested (detected key must NOT auto-switch).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Graph from "graphology";
+import { mkdtempSync, mkdirSync, readdirSync, existsSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { finalizeEnrichedGraphBuild } from "../src/finalize-enriched-graph.js";
+import { generateNodeDescriptions, type CallLlmFn } from "../src/node-descriptions.js";
+import { generateCommunityLabels } from "../src/community-labeling.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+const PROVIDER_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "MISTRAL_API_KEY",
+  "COHERE_API_KEY",
+];
+
+function clearProviderKeys(): void {
+  for (const key of PROVIDER_KEYS) delete process.env[key];
+}
+
+/** Code-symbol graph: every node is describable (isCodeNode). */
+function mkCodeGraph(): Graph {
+  const G = new Graph({ type: "undirected" });
+  G.addNode("src_a_resolveconfig", {
+    label: "resolveConfig()",
+    file_type: "code",
+    source_file: "src/a.ts",
+    source_location: "L42",
+  });
+  G.addNode("src_a_buildgraph", {
+    label: "buildGraph()",
+    file_type: "code",
+    source_file: "src/a.ts",
+    source_location: "L60",
+  });
+  G.addNode("src_b_const", {
+    label: "MAX_NODES",
+    file_type: "code",
+    source_file: "src/b.ts",
+    source_location: "L3",
+  });
+  G.addUndirectedEdge("src_a_resolveconfig", "src_a_buildgraph", { relation: "calls" });
+  G.addUndirectedEdge("src_a_buildgraph", "src_b_const", { relation: "references" });
+  return G;
+}
+
+/** A single generic-labeled community spanning all nodes. */
+function singleCommunity(G: Graph): Map<number, string[]> {
+  return new Map([[0, G.nodes()]]);
+}
+
+/** Generic ("Community N") labels so the salient label stage actually emits. */
+function genericLabels(communities: Map<number, string[]>): Map<number, string> {
+  const labels = new Map<number, string>();
+  for (const cid of communities.keys()) labels.set(cid, `Community ${cid}`);
+  return labels;
+}
+
+function mkStateDir(): string {
+  return mkdtempSync(join(tmpdir(), "graphify-finalize-test-"));
+}
+
+/** mockCallLlm: echoes a deterministic description per node id in the prompt. */
+function mockCallLlm(describeFn: (id: string) => string): CallLlmFn {
+  return async (prompt: string) => {
+    const ids = [...prompt.matchAll(/^- "([^"]+)":/gmu)].map((m) => m[1]!);
+    const map: Record<string, string> = {};
+    for (const id of ids) map[id] = describeFn(id);
+    return JSON.stringify(map);
+  };
+}
+
+describe("finalizeEnrichedGraphBuild — no-key emit parity", () => {
+  it("emits description-instructions/ AND label-instructions/ in a no-key build (parity)", async () => {
+    clearProviderKeys();
+    const G = mkCodeGraph();
+    const communities = singleCommunity(G);
+    const labels = genericLabels(communities);
+    const stateDir = mkStateDir();
+    const graphPath = join(stateDir, "graph.json");
+
+    const result = await finalizeEnrichedGraphBuild({
+      graph: G,
+      communities,
+      labels,
+      graphPath,
+      stateDir,
+      labelsPath: join(stateDir, ".graphify_labels.json"),
+      force: true,
+    });
+
+    // graph.json was written through persistGraphWithCitations.
+    expect(result.jsonWritten).toBe(true);
+    expect(existsSync(graphPath)).toBe(true);
+
+    // PARITY: both instruction dirs exist with at least one batch file.
+    const labelDir = join(stateDir, "label-instructions");
+    const descDir = join(stateDir, "description-instructions");
+    expect(existsSync(labelDir)).toBe(true);
+    expect(existsSync(descDir)).toBe(true);
+
+    const labelFiles = readdirSync(labelDir);
+    const descFiles = readdirSync(descDir);
+    expect(labelFiles.some((f) => f.endsWith(".md"))).toBe(true);
+    expect(descFiles.some((f) => f.endsWith(".md"))).toBe(true);
+
+    // No-key → assistant emit, nothing described yet.
+    expect(result.labelSource).toBe("assistant");
+    expect(result.descriptionsComplete).toBe(false);
+    expect(G.hasNodeAttribute("src_a_resolveconfig", "description")).toBe(false);
+  });
+
+  it("ingests assistant description answers in the shared path on the next run", async () => {
+    clearProviderKeys();
+    const G = mkCodeGraph();
+    const communities = singleCommunity(G);
+    const labels = genericLabels(communities);
+    const stateDir = mkStateDir();
+    const descDir = join(stateDir, "description-instructions");
+    mkdirSync(descDir, { recursive: true });
+
+    // Simulate the assistant having answered the emitted batch.
+    writeFileSync(
+      join(descDir, "batch-000.json"),
+      JSON.stringify({
+        src_a_resolveconfig: "Resolves the configuration for the code graph.",
+        src_a_buildgraph: "Builds the code knowledge graph from extracted nodes.",
+        src_b_const: "Maximum node count constant used by the graph builder.",
+      }),
+      "utf-8",
+    );
+
+    const result = await finalizeEnrichedGraphBuild({
+      graph: G,
+      communities,
+      labels,
+      graphPath: join(stateDir, "graph.json"),
+      stateDir,
+      labelsPath: join(stateDir, ".graphify_labels.json"),
+      force: true,
+    });
+
+    expect(result.jsonWritten).toBe(true);
+    expect(result.descriptionsComplete).toBe(true);
+    expect(G.getNodeAttribute("src_a_resolveconfig", "description")).toBe(
+      "Resolves the configuration for the code graph.",
+    );
+    // Persisted graph.json carries the description.
+    const persisted = JSON.parse(readFileSync(join(stateDir, "graph.json"), "utf-8"));
+    const node = persisted.nodes.find((n: { id: string }) => n.id === "src_a_resolveconfig");
+    expect(node.description).toBe("Resolves the configuration for the code graph.");
+  });
+
+  it("runs the description stage (direct) in the shared path with an injected callLlm", async () => {
+    clearProviderKeys();
+    const G = mkCodeGraph();
+    const communities = singleCommunity(G);
+    const labels = genericLabels(communities);
+    const stateDir = mkStateDir();
+
+    const result = await finalizeEnrichedGraphBuild({
+      graph: G,
+      communities,
+      labels,
+      graphPath: join(stateDir, "graph.json"),
+      stateDir,
+      labelsPath: join(stateDir, ".graphify_labels.json"),
+      force: true,
+      descriptionCallLlm: mockCallLlm((id) => `Describes ${id}.`),
+    });
+
+    expect(result.jsonWritten).toBe(true);
+    // describe RAN in the shared path: every describable node now has a description.
+    expect(result.descriptionsComplete).toBe(true);
+    expect(G.getNodeAttribute("src_a_resolveconfig", "description")).toBe(
+      "Describes src_a_resolveconfig.",
+    );
+  });
+
+  it("a description-only callback does NOT drive the LABEL stage into direct", async () => {
+    // FIX 3: `descriptionCallLlm` is forwarded ONLY to the description stage.
+    // An injected callLlm is a programmatic direct opt-in (community-labeling),
+    // so a description-only caller must NOT flip labels to direct or feed the
+    // label stage description prompts. With no `labelCallLlm` + no key the label
+    // stage stays assistant-emit while descriptions run direct via the caller.
+    clearProviderKeys();
+    const G = mkCodeGraph();
+    const communities = singleCommunity(G);
+    const labels = genericLabels(communities);
+    const stateDir = mkStateDir();
+    const graphPath = join(stateDir, "graph.json");
+
+    // A label-shaped caller would mark its prompt so we can prove it was NEVER
+    // invoked for labels: this fn throws if handed a label prompt.
+    const descCalls: string[] = [];
+    const descriptionCallLlm: CallLlmFn = async (prompt: string) => {
+      descCalls.push(prompt);
+      const ids = [...prompt.matchAll(/^- "([^"]+)":/gmu)].map((m) => m[1]!);
+      return JSON.stringify(Object.fromEntries(ids.map((id) => [id, `Describes ${id}.`])));
+    };
+
+    const result = await finalizeEnrichedGraphBuild({
+      graph: G,
+      communities,
+      labels,
+      graphPath,
+      stateDir,
+      labelsPath: join(stateDir, ".graphify_labels.json"),
+      force: true,
+      descriptionCallLlm,
+    });
+
+    // Labels stayed assistant-emit (NOT "llm"): the description caller did not
+    // drive the label stage into direct mode.
+    expect(result.labelSource).toBe("assistant");
+    expect(existsSync(join(stateDir, "label-instructions"))).toBe(true);
+    // The labels map still carries the generic names (no direct labeling ran).
+    expect(labels.get(0)).toBe("Community 0");
+
+    // Descriptions DID run direct through the description-only caller.
+    expect(result.descriptionsComplete).toBe(true);
+    expect(G.getNodeAttribute("src_a_resolveconfig", "description")).toBe(
+      "Describes src_a_resolveconfig.",
+    );
+
+    // The injected caller was only ever handed description prompts (node ids),
+    // never a community-label prompt.
+    expect(descCalls.length).toBeGreaterThan(0);
+    expect(descCalls.every((p) => !/community/iu.test(p) || /^- "/mu.test(p))).toBe(true);
+  });
+
+  it("--no-description skips the description stage but still writes the graph", async () => {
+    clearProviderKeys();
+    const G = mkCodeGraph();
+    const communities = singleCommunity(G);
+    const labels = genericLabels(communities);
+    const stateDir = mkStateDir();
+
+    const result = await finalizeEnrichedGraphBuild({
+      graph: G,
+      communities,
+      labels,
+      graphPath: join(stateDir, "graph.json"),
+      stateDir,
+      labelsPath: join(stateDir, ".graphify_labels.json"),
+      force: true,
+      describe: false,
+    });
+
+    expect(result.jsonWritten).toBe(true);
+    expect(existsSync(join(stateDir, "description-instructions"))).toBe(false);
+    expect(G.hasNodeAttribute("src_a_resolveconfig", "description")).toBe(false);
+  });
+});
+
+describe("auto-mode: detected API key must NOT auto-switch to direct", () => {
+  it("generateNodeDescriptions stays assistant-emit when a key is present but direct is not requested", async () => {
+    clearProviderKeys();
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-fake-key";
+    const G = mkCodeGraph();
+    const instructionDir = mkStateDir();
+
+    // No `mode`, no injected callLlm — only a detected key. Must resolve to
+    // assistant/emit, NOT direct (which would attempt a real network call).
+    const result = await generateNodeDescriptions(G, { instructionDir, quiet: true });
+
+    expect(result.source).toBe("assistant");
+    expect(result.describedCount).toBe(0);
+    const files = readdirSync(instructionDir);
+    expect(files.some((f) => f.endsWith(".md"))).toBe(true);
+    expect(G.hasNodeAttribute("src_a_resolveconfig", "description")).toBe(false);
+  });
+
+  it("generateCommunityLabels stays assistant-emit when a key is present but direct is not requested", async () => {
+    clearProviderKeys();
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-fake-key";
+    const G = mkCodeGraph();
+    const communities = singleCommunity(G);
+    const instructionDir = mkStateDir();
+
+    const result = await generateCommunityLabels(G, communities, { instructionDir, quiet: true });
+
+    // Detected key alone must NOT flip to direct (source "llm").
+    expect(result.source).toBe("assistant");
+    const files = readdirSync(instructionDir);
+    expect(files.some((f) => f.endsWith(".md"))).toBe(true);
+  });
+
+  it("explicit --description-mode direct still honors the detected key path (skips with fake key)", async () => {
+    clearProviderKeys();
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-fake-key";
+    const G = mkCodeGraph();
+    // mode:"direct" is the EXPLICIT opt-in. With no real backend reachable the
+    // injected callLlm is what proves direct ran; here we inject it.
+    const result = await generateNodeDescriptions(G, {
+      mode: "direct",
+      callLlm: mockCallLlm((id) => `Direct ${id}.`),
+      quiet: true,
+    });
+    expect(result.describedCount).toBeGreaterThan(0);
+    expect(G.getNodeAttribute("src_a_resolveconfig", "description")).toBe("Direct src_a_resolveconfig.");
+  });
+
+  it("auto-mode WITH an injected callLlm (programmatic opt-in) still resolves to direct", async () => {
+    clearProviderKeys();
+    const G = mkCodeGraph();
+    // No `mode`, but callLlm injected — programmatic direct opt-in, not an env key.
+    const result = await generateNodeDescriptions(G, {
+      callLlm: mockCallLlm((id) => `Injected ${id}.`),
+      quiet: true,
+    });
+    expect(result.describedCount).toBeGreaterThan(0);
+    expect(G.getNodeAttribute("src_a_resolveconfig", "description")).toBe("Injected src_a_resolveconfig.");
+  });
+});

--- a/tests/skill-runtime-finalize-enrichment.test.ts
+++ b/tests/skill-runtime-finalize-enrichment.test.ts
@@ -1,0 +1,213 @@
+/**
+ * SPEC_GRAPHIFY § "Enrichment Stages" — PHASE 1, RUNTIME finalization.
+ *
+ * REGRESSION (FIX 1): the runtime `analyze-build` / `finalize-build` paths
+ * resolved EXISTING community labels and projected citations, but never ran the
+ * salient-label or node-description stages — so a no-key runtime/assistant build
+ * emitted neither `label-instructions/` NOR `description-instructions/`. They now
+ * route through the shared `finalizeEnrichedGraphBuild` chokepoint exactly like
+ * `graphify extract`, so "every finalization path" enriches.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+const cleanupDirs: string[] = [];
+
+function tempRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-runtime-enrich-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+const PROVIDER_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "MISTRAL_API_KEY",
+  "COHERE_API_KEY",
+];
+
+async function withApiKeysCleared<T>(fn: () => Promise<T>): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of PROVIDER_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function runRuntime(args: string[]): Promise<void> {
+  const { main } = await import("../src/skill-runtime.js");
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalErr = console.error;
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    await main(["node", "skill-runtime", ...args]);
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalErr;
+  }
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+/** A multi-node CODE extraction so clustering yields a labelable community. */
+function writeExtract(stateDir: string, file: string): string {
+  const node = (id: string, label: string) => ({
+    id,
+    label,
+    file_type: "code",
+    source_file: file,
+    source_location: "L1",
+  });
+  const extractPath = join(stateDir, "extract.json");
+  writeFileSync(
+    extractPath,
+    JSON.stringify({
+      nodes: [
+        node("alpha_fn", "alpha()"),
+        node("beta_fn", "beta()"),
+        node("gamma_fn", "gamma()"),
+        node("delta_fn", "delta()"),
+      ],
+      edges: [
+        { source: "alpha_fn", target: "beta_fn", relation: "calls", source_file: file },
+        { source: "beta_fn", target: "gamma_fn", relation: "calls", source_file: file },
+        { source: "gamma_fn", target: "delta_fn", relation: "calls", source_file: file },
+        { source: "delta_fn", target: "alpha_fn", relation: "calls", source_file: file },
+      ],
+      input_tokens: 0,
+      output_tokens: 0,
+    }),
+    "utf-8",
+  );
+  return extractPath;
+}
+
+function writeDetect(stateDir: string, file: string): string {
+  const detectPath = join(stateDir, "detect.json");
+  writeFileSync(
+    detectPath,
+    JSON.stringify({
+      files: { code: [file], document: [], paper: [], image: [], video: [] },
+      total_files: 1,
+      total_words: 100,
+      needs_graph: false,
+      skipped_sensitive: [],
+      graphifyignore_patterns: 0,
+    }),
+    "utf-8",
+  );
+  return detectPath;
+}
+
+describe("runtime analyze-build routes through the shared finalizer (no-key)", () => {
+  it("emits BOTH label-instructions/ AND description-instructions/ in a no-key build", async () => {
+    await withApiKeysCleared(async () => {
+      const root = tempRoot();
+      const stateDir = join(root, ".graphify");
+      mkdirSync(stateDir, { recursive: true });
+      const file = join(root, "src", "sample.ts");
+      const extractPath = writeExtract(stateDir, file);
+      const detectPath = writeDetect(stateDir, file);
+      const graphPath = join(stateDir, "graph.json");
+
+      await runRuntime([
+        "analyze-build",
+        "--extract", extractPath,
+        "--detect", detectPath,
+        "--root", root,
+        "--graph-out", graphPath,
+        "--report-out", join(stateDir, "report.md"),
+        "--analysis-out", join(stateDir, "analysis.json"),
+      ]);
+
+      // graph.json written through the finalizer (persistGraphWithCitations).
+      expect(existsSync(graphPath)).toBe(true);
+
+      // FIX 1 PARITY: both instruction dirs now exist with at least one .md.
+      const labelDir = join(stateDir, "label-instructions");
+      const descDir = join(stateDir, "description-instructions");
+      expect(existsSync(labelDir)).toBe(true);
+      expect(existsSync(descDir)).toBe(true);
+      expect(readdirSync(descDir).some((f) => f.endsWith(".md"))).toBe(true);
+      expect(readdirSync(labelDir).some((f) => f.endsWith(".md"))).toBe(true);
+
+      // No-key → assistant emit; nothing described into graph.json yet.
+      const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+        nodes: Array<{ id: string; description?: string }>;
+      };
+      expect(graph.nodes.every((n) => n.description === undefined)).toBe(true);
+    });
+  });
+
+  it("ingests assistant description answers on the next analyze-build run", async () => {
+    await withApiKeysCleared(async () => {
+      const root = tempRoot();
+      const stateDir = join(root, ".graphify");
+      mkdirSync(stateDir, { recursive: true });
+      const file = join(root, "src", "sample.ts");
+      const extractPath = writeExtract(stateDir, file);
+      const detectPath = writeDetect(stateDir, file);
+      const graphPath = join(stateDir, "graph.json");
+
+      const args = [
+        "analyze-build",
+        "--extract", extractPath,
+        "--detect", detectPath,
+        "--root", root,
+        "--graph-out", graphPath,
+        "--report-out", join(stateDir, "report.md"),
+        "--analysis-out", join(stateDir, "analysis.json"),
+      ];
+
+      // Run 1 emits the description-instructions batch.
+      await runRuntime(args);
+      const descDir = join(stateDir, "description-instructions");
+
+      // Simulate the assistant answering every emitted node.
+      writeFileSync(
+        join(descDir, "batch-000.json"),
+        JSON.stringify({
+          alpha_fn: "Alpha entry point.",
+          beta_fn: "Beta helper.",
+          gamma_fn: "Gamma helper.",
+          delta_fn: "Delta helper.",
+        }),
+        "utf-8",
+      );
+
+      // Run 2 ingests the answers and stamps them onto graph.json.
+      await runRuntime(args);
+      const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+        nodes: Array<{ id: string; description?: string }>;
+      };
+      const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+      expect(byId.get("alpha_fn")?.description).toBe("Alpha entry point.");
+    });
+  });
+});


### PR DESCRIPTION
## Problem
`describe` (entity descriptions) was default-on only in `graphify update` (code). The corpus / first-run flow (`graphify <path>`, `graphify extract`, profile + runtime finalization) ran community labels (no-key assistant-emit) but **never `describe`** — so a no-key corpus build shipped a Studio with empty entity descriptions (observed on a real project: a 620-node graph with **0 descriptions, 596 rationales**). The canonical pipeline spec had labels as a stage but **no describe/citations stage**.

## Spec (commit `d13eed9`)
New "Enrichment Stages" section in `SPEC_GRAPHIFY.md`: pipeline steps 9–12 (label → describe → project citations → export) + the shared policy, framed as the **TARGET contract** with the current-vs-target gap made explicit (file:line-cited). describe + labels = no-key assistant-emit (mirror labels); **citations = deterministic locator projection (no LLM)**. Supersedes the wiki-descriptions opt-in model; aligns the dataprep spec. Reconciled via a 4.8 + 5.5xhigh double review.

## Phase 1 impl (commit `143b277`)
- New `src/finalize-enriched-graph.ts` — shared `finalizeEnrichedGraphBuild`: community labels → node descriptions (no-key assistant-emit, explicit instructionDir) → `persistGraphWithCitations`.
- Wired into **every finalization path**: `graphify extract` (the corpus first-run path that previously skipped describe), `buildProject`, and the runtime `finalize-build` / `finalize-update` / `analyze-build` / `merge-update`. A no-key corpus/runtime build now emits `description-instructions/` exactly like `label-instructions/`.
- Auto-mode resolves to **assistant/emit unless `--description-mode` / `--label-mode direct` is EXPLICIT** — a detected `.env`/API key no longer silently switches to direct.
- Report + suggested questions generated **after** label finalization (reflect ingested/finalized names, not generic `Community N`).
- Separate `labelCallLlm` / `descriptionCallLlm` (a description-only callback no longer drives the label stage).
- `cluster-only` deliberately kept on raw `toJson` (reload-only re-cluster of an already-K-trimmed graph — a "non-finalization rewrite" per the spec).

## Deferred to phase 2
Cost controls (`--batch`, `CI=1`, large-corpus impact warning, `--description-top`) and the broad `toJson` → `persistGraphWithCitations` chokepoint migration. The spec marks these as required-but-unbuilt.

## Review & tests
- **Double-consensus**: codex 5.5xhigh → REVISE (3 findings: runtime path not routed, report/label ordering, label/description callback coupling) → all 3 fixed + 4 new tests.
- `npx tsc --noEmit` clean. Full suite: **2007 tests, 1994 pass / 12 skip / 1 pre-existing `cluster-only` timeout flake** (passes isolated with a generous timeout; fails identically on baseline — not a regression).