### PR TITLE
test(graph): B1 Phase-0 golden harness — CDP canvas2d pixel oracle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ scripts/run_k2_*.py
 scripts/llm.py
 scripts/benchmark_kimi*.json
 scripts/benchmark_kimi*.py
+
+# B1 golden harness: ephemeral headless-Chrome profile dirs
+packages/graph/.graphify-cdp-prof-*

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -25,8 +25,15 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "test": "vitest run --config vitest.config.ts",
+    "golden:build": "tsup --config tsup.config.ts --no-dts",
+    "test:golden": "npm run golden:build && vitest run --config vitest.config.ts tests/golden/golden-harness.test.ts",
+    "golden:selftest": "npm run golden:build && node tests/golden/cdp-harness.mjs --selftest",
     "bench": "npm run build && node bench/buffers-bench.mjs",
     "prepublishOnly": "npm run test && npm run build"
+  },
+  "devDependencies": {
+    "@napi-rs/canvas": "^1.0.0",
+    "ws": "^8.18.0"
   },
   "sideEffects": false
 }

--- a/packages/graph/tests/golden/README.md
+++ b/packages/graph/tests/golden/README.md
@@ -1,0 +1,70 @@
+# B1 Phase-0 — golden-image non-regression harness
+
+The non-regression guarantee of the Canvas2D → WebGL renderer migration
+(`/home/antoinefa/src/graphify/.graphify/scratch/B1_migration_plan_v2.md`)
+depends on this harness existing FIRST. **Phase 0 builds ONLY the harness** — it
+does not touch the renderer and does not start WebGL parity.
+
+## What it is
+
+A Chrome/CDP-driven golden-image oracle that renders a fixture graph with
+`@sentropic/graph` onto a REAL `<canvas>` in headless Chrome and reads the
+**canvas backing-store pixels DIRECTLY** (`getImageData` for Canvas2D,
+`gl.readPixels` for WebGL) — **not** a whole-page `Page.captureScreenshot`. It
+pins a deterministic font and `await document.fonts.ready` before every capture,
+and diffs two captures with **both** a per-channel pixel tolerance **and**
+geometry probes at known device-pixel coordinates.
+
+## Files
+
+| File | Role |
+|---|---|
+| `harness-page.html` | The page Chrome loads. Imports the `@sentropic/graph` dist, builds `RenderGraphBuffers`+`GraphStyleBuffers` from a fixture, renders Canvas2D onto a real canvas, pins the font, exposes `__renderFixture` + `__readPixels` (direct `getImageData`/`gl.readPixels`). |
+| `cdp-harness.mjs` | The CDP driver / **primary parity oracle**. Boots headless Chrome, serves the page + dist over HTTP, awaits `document.fonts.ready`, captures direct canvas pixels at a given DPR/zoom. `openOracle()` → `capture(fixture, opts)` → `{width,height,data}`. |
+| `diff.mjs` | `diffPixels` (per-channel tolerance), `geometryProbes` (sample known coords), `worldToDevice`/`drawnRadius` (the renderer's exact transforms). |
+| `fixtures.mjs` | The base smoke fixture, `perturbNode` (move a node N px), DPR/zoom matrices. |
+| `smoke.mjs` | **Supplemental** fast smoke path via `@napi-rs/canvas` — explicitly **NOT** the parity oracle (its AA/font differ from Chrome). |
+| `golden-harness.test.ts` | vitest wiring + the Phase-0 acceptance proof. |
+
+## Run
+
+```bash
+# from packages/graph
+npm run test:golden        # build the JS bundle + run the golden harness vitest
+npm run golden:selftest    # boot Chrome, render one fixture, assert pixels drew
+
+# raw CDP self-test (no vitest, dist must already be built):
+node tests/golden/cdp-harness.mjs --selftest
+```
+
+> The golden scripts build the JS bundle with `tsup --no-dts` (`golden:build`)
+> because the package's `.d.ts` emit currently errors on an unrelated
+> pre-existing `src/styles.ts` strictness issue; the harness only needs the JS
+> bundle, so it sidesteps the typings step.
+
+CI: set `GOLDEN_REQUIRE_CHROME=1` in the golden job to make a missing Chrome a
+hard failure instead of a silent skip. The supplemental napi smoke path runs in
+the normal `npm test` vitest job as a fast pre-filter, never the gate.
+
+## Phase-0 acceptance (the smoke proof)
+
+1. **Determinism** — same fixture captured twice → zero diff (`failingPixels=0`,
+   `maxChannelDelta=0`).
+2. **Regression caught** — one node moved 3px → diff above tolerance
+   (`failingPixels>0`, `pass=false`).
+3. **DPR/zoom** — paired captures at DPR `1 / 1.25 / 2 / 3` × zoom `{1, 2}` with
+   correct device backing-store dimensions, deterministic per pair.
+
+## Notes for the GL phases
+
+- The harness already wires the WebGL branch: `__renderFixture({...,backend:"webgl"})`
+  and `__readPixels` flips GL's bottom-left origin to top-left. The GL phases
+  need **zero harness changes** to start diffing WebGL vs Canvas2D.
+- `worldToDevice`/`drawnRadius` mirror the renderer's exact transforms
+  (`screenPoint` renderer.ts:437, radius `nodeSize·PR·zoom` renderer.ts:723), so
+  geometry probes are computed, not hard-coded.
+- `headless-gl` (the WebGL smoke counterpart) is **not viable in this
+  environment**: its native node-gyp build needs the X11/Xi `-dev`
+  pkg-config files (`xi.pc`, `x11.pc`), which are absent. `@napi-rs/canvas`
+  installs from a prebuilt binary and works. For Phase 0 (no WebGL backend yet)
+  the napi Canvas2D smoke path fully covers the smoke proof.

--- a/packages/graph/tests/golden/cdp-harness.mjs
+++ b/packages/graph/tests/golden/cdp-harness.mjs
@@ -1,0 +1,305 @@
+// Chrome/CDP DIRECT-CANVAS-PIXEL golden oracle (B1 plan §5.1, fix #4).
+//
+// This is the PRIMARY parity oracle for the Canvas2D -> WebGL migration. It:
+//   - launches headless Chrome,
+//   - serves the harness page + the @sentropic/graph dist bundle over HTTP,
+//   - pins a deterministic font and AWAITS document.fonts.ready before capture,
+//   - renders a fixture with the Canvas2D backend onto a REAL <canvas>,
+//   - reads the CANVAS BACKING STORE PIXELS DIRECTLY via
+//     getImageData (2D) / gl.readPixels (WebGL) inside the page
+//     -- NOT a whole-page Page.captureScreenshot (which is weaker: it
+//     composites browser chrome/scaling). This supersedes cdp-shot.mjs:47.
+//
+// Public API:
+//   const oracle = await openOracle();          // boots Chrome + server
+//   const cap = await oracle.capture(fixture, { dpr, zoom, cssWidth, ... });
+//        // -> { width, height, data: Uint8ClampedArray (RGBA, top-left) }
+//   await oracle.close();
+//
+// Self-test:  node cdp-harness.mjs --selftest
+
+import { spawn } from "node:child_process";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GRAPH_PKG = path.resolve(__dirname, "../..");
+const DIST_DIR = path.join(GRAPH_PKG, "dist");
+const require = createRequire(pathToFileURL(path.join(GRAPH_PKG, "package.json")));
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_BIN,
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/snap/bin/chromium",
+  "/usr/bin/chromium-browser",
+  "/usr/bin/chromium",
+].filter(Boolean);
+
+function findChrome() {
+  for (const c of CHROME_CANDIDATES) {
+    try {
+      if (fs.existsSync(c)) return c;
+    } catch {
+      /* ignore */
+    }
+  }
+  throw new Error(
+    "No Chrome/Chromium binary found. Set CHROME_BIN. Tried: " +
+      CHROME_CANDIDATES.join(", "),
+  );
+}
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+// Tiny static server: serves the harness dir at / and the dist bundle at
+// /graph-dist/.
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      try {
+        const url = decodeURIComponent((req.url || "/").split("?")[0]);
+        let filePath;
+        if (url.startsWith("/graph-dist/")) {
+          filePath = path.join(DIST_DIR, url.slice("/graph-dist/".length));
+        } else {
+          const rel = url === "/" ? "/harness-page.html" : url;
+          filePath = path.join(__dirname, rel);
+        }
+        // Path-traversal guard.
+        const root = path.dirname(__dirname);
+        if (!filePath.startsWith(GRAPH_PKG) && !filePath.startsWith(root)) {
+          res.writeHead(403).end("forbidden");
+          return;
+        }
+        if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+          res.writeHead(404).end("not found");
+          return;
+        }
+        const ext = path.extname(filePath);
+        res.writeHead(200, { "content-type": MIME[ext] || "application/octet-stream" });
+        fs.createReadStream(filePath).pipe(res);
+      } catch (err) {
+        res.writeHead(500).end(String(err));
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, port });
+    });
+  });
+}
+
+function getJson(port) {
+  return new Promise((res, rej) => {
+    http
+      .get(`http://127.0.0.1:${port}/json`, (r) => {
+        let d = "";
+        r.on("data", (c) => (d += c));
+        r.on("end", () => {
+          try {
+            res(JSON.parse(d));
+          } catch (e) {
+            rej(e);
+          }
+        });
+      })
+      .on("error", rej);
+  });
+}
+
+async function waitDevtools(port) {
+  for (let i = 0; i < 80; i += 1) {
+    try {
+      const tabs = await getJson(port);
+      const page = tabs.find((x) => x.type === "page");
+      if (page && page.webSocketDebuggerUrl) return page;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  throw new Error("Chrome devtools endpoint did not come up");
+}
+
+export async function openOracle() {
+  const WebSocket = require("ws");
+  const chromeBin = findChrome();
+  const { server, port: httpPort } = await startServer();
+  const cdpPort = 9400 + Math.floor(Math.random() * 400);
+  const profile = path.join(
+    GRAPH_PKG,
+    ".graphify-cdp-prof-" + process.pid + "-" + Date.now(),
+  );
+
+  const chrome = spawn(
+    chromeBin,
+    [
+      "--headless=new",
+      // GPU is off: the 2D backend rasterizes on CPU deterministically, which
+      // is what Phase 0 needs. (The WebGL phases will toggle this.)
+      "--disable-gpu",
+      "--no-sandbox",
+      "--hide-scrollbars",
+      "--force-device-scale-factor=1", // we drive DPR via canvas backing store
+      "--disable-lcd-text", // grayscale AA -> more cross-runner-stable text
+      `--remote-debugging-port=${cdpPort}`,
+      `--user-data-dir=${profile}`,
+      "--window-size=1024,1024",
+      "about:blank",
+    ],
+    { stdio: "ignore" },
+  );
+
+  const pageInfo = await waitDevtools(cdpPort);
+  const ws = new WebSocket(pageInfo.webSocketDebuggerUrl, {
+    perMessageDeflate: false,
+    maxPayload: 512 * 1024 * 1024,
+  });
+
+  let id = 0;
+  const pending = new Map();
+  const send = (method, params = {}) =>
+    new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, { res, rej });
+      ws.send(JSON.stringify({ id: i, method, params }));
+    });
+  await new Promise((r, rej) => {
+    ws.on("open", r);
+    ws.on("error", rej);
+  });
+  ws.on("message", (m) => {
+    const o = JSON.parse(m);
+    if (o.id && pending.has(o.id)) {
+      const { res, rej } = pending.get(o.id);
+      pending.delete(o.id);
+      if (o.error) rej(new Error(o.error.message || JSON.stringify(o.error)));
+      else res(o.result);
+    }
+  });
+
+  await send("Page.enable");
+  await send("Runtime.enable");
+
+  async function evaluate(expression, awaitPromise = true) {
+    const r = await send("Runtime.evaluate", {
+      expression,
+      awaitPromise,
+      returnByValue: true,
+    });
+    if (r.exceptionDetails) {
+      throw new Error(
+        "page eval threw: " +
+          (r.exceptionDetails.exception?.description ||
+            r.exceptionDetails.text),
+      );
+    }
+    return r.result?.value;
+  }
+
+  // Navigate + wait for harness readiness (fonts loaded).
+  await send("Page.navigate", { url: `http://127.0.0.1:${httpPort}/` });
+  // Poll for the module to have evaluated and the font promise to resolve.
+  let ready = false;
+  for (let i = 0; i < 120; i += 1) {
+    try {
+      const ok = await evaluate(
+        "(window.__harnessReady ? window.__harnessReady.then(()=>!!window.__fontsReady) : false)",
+      );
+      if (ok) {
+        ready = true;
+        break;
+      }
+    } catch {
+      /* page still loading the module */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  if (!ready) {
+    throw new Error("harness page never became ready (fonts.ready timeout)");
+  }
+
+  async function capture(fixture, opts = {}) {
+    const params = {
+      dpr: opts.dpr ?? 1,
+      cssWidth: opts.cssWidth ?? 200,
+      cssHeight: opts.cssHeight ?? 200,
+      backend: opts.backend ?? "canvas2d",
+      camera: opts.camera ?? { x: 0, y: 0, zoom: opts.zoom ?? 1 },
+    };
+    // Re-assert fonts.ready before EVERY capture (§5.1).
+    await evaluate("document.fonts.ready.then(()=>true)");
+    const fixtureJson = JSON.stringify(fixture);
+    const optsJson = JSON.stringify(params);
+    await evaluate(
+      `window.__renderFixture(${fixtureJson}, ${optsJson})`,
+      false,
+    );
+    const out = await evaluate("window.__readPixels()");
+    const data = new Uint8ClampedArray(Buffer.from(out.base64, "base64"));
+    return { width: out.width, height: out.height, data };
+  }
+
+  async function close() {
+    try {
+      ws.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      chrome.kill("SIGKILL");
+    } catch {
+      /* ignore */
+    }
+    try {
+      server.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.rmSync(profile, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return { capture, evaluate, close, chromeBin, httpPort };
+}
+
+// ---- self-test -----------------------------------------------------------
+if (process.argv[1] && process.argv[1].endsWith("cdp-harness.mjs")) {
+  if (process.argv.includes("--selftest")) {
+    const oracle = await openOracle();
+    const fixture = {
+      nodes: [
+        { id: "a", x: -40, y: 0, size: 12, color: "#ff0000", shape: "circle" },
+        { id: "b", x: 40, y: 0, size: 12, color: "#0000ff", shape: "circle" },
+      ],
+      edges: [{ source: "a", target: "b", width: 3, color: "#3344aa" }],
+    };
+    const cap = await oracle.capture(fixture, { dpr: 1, zoom: 1 });
+    console.log(
+      `selftest: chrome=${oracle.chromeBin} capture=${cap.width}x${cap.height} bytes=${cap.data.length}`,
+    );
+    // sanity: there must be some non-white pixels (the graph drew something).
+    let nonWhite = 0;
+    for (let i = 0; i < cap.data.length; i += 4) {
+      if (cap.data[i] !== 255 || cap.data[i + 1] !== 255 || cap.data[i + 2] !== 255)
+        nonWhite += 1;
+    }
+    console.log(`selftest: non-white pixels = ${nonWhite}`);
+    await oracle.close();
+    process.exit(nonWhite > 0 ? 0 : 1);
+  }
+}

--- a/packages/graph/tests/golden/diff.mjs
+++ b/packages/graph/tests/golden/diff.mjs
@@ -1,0 +1,137 @@
+// Golden diff: TWO checks per the B1 plan §5.1/§5.2 (both required).
+//
+//  1. Per-channel pixel tolerance: a pixel passes only if EVERY channel
+//     differs by <= T. T is small (absorb AA thrash, R8 -- e.g. <=2-3/255),
+//     NOT a blanket "looks close". We report the failing-pixel count and the
+//     max channel delta and fail if either exceeds budget.
+//
+//  2. Geometry probes: sample KNOWN device-pixel coordinates (computed from
+//     the fixture + camera) and assert their channel values are within
+//     tolerance of an expected color. Probes catch geometry drift (a node
+//     moved a few px) that a loose pixel tolerance could mask.
+
+/**
+ * Per-channel diff of two RGBA buffers.
+ * @param {{width:number,height:number,data:Uint8ClampedArray}} a
+ * @param {{width:number,height:number,data:Uint8ClampedArray}} b
+ * @param {{ channelTolerance?: number, maxFailingPixels?: number }} budget
+ * @returns {{ pass:boolean, dimsMatch:boolean, failingPixels:number,
+ *             maxChannelDelta:number, totalPixels:number, reason?:string }}
+ */
+export function diffPixels(a, b, budget = {}) {
+  const channelTolerance = budget.channelTolerance ?? 2;
+  const maxFailingPixels = budget.maxFailingPixels ?? 0;
+
+  if (a.width !== b.width || a.height !== b.height) {
+    return {
+      pass: false,
+      dimsMatch: false,
+      failingPixels: -1,
+      maxChannelDelta: -1,
+      totalPixels: 0,
+      reason: `dimension mismatch ${a.width}x${a.height} vs ${b.width}x${b.height}`,
+    };
+  }
+
+  const da = a.data;
+  const db = b.data;
+  const totalPixels = a.width * a.height;
+  let failingPixels = 0;
+  let maxChannelDelta = 0;
+
+  for (let i = 0; i < da.length; i += 4) {
+    let pixelFails = false;
+    for (let c = 0; c < 4; c += 1) {
+      const delta = Math.abs(da[i + c] - db[i + c]);
+      if (delta > maxChannelDelta) maxChannelDelta = delta;
+      if (delta > channelTolerance) pixelFails = true;
+    }
+    if (pixelFails) failingPixels += 1;
+  }
+
+  const pass = failingPixels <= maxFailingPixels;
+  return {
+    pass,
+    dimsMatch: true,
+    failingPixels,
+    maxChannelDelta,
+    totalPixels,
+    reason: pass
+      ? undefined
+      : `${failingPixels} pixel(s) exceed channel tolerance ${channelTolerance} (budget ${maxFailingPixels}); max channel delta ${maxChannelDelta}`,
+  };
+}
+
+/**
+ * Sample one device pixel from a capture.
+ * @returns {[number,number,number,number]} rgba
+ */
+export function samplePixel(capture, x, y) {
+  const px = Math.round(x);
+  const py = Math.round(y);
+  const idx = (py * capture.width + px) * 4;
+  return [
+    capture.data[idx],
+    capture.data[idx + 1],
+    capture.data[idx + 2],
+    capture.data[idx + 3],
+  ];
+}
+
+/**
+ * Geometry probes: each probe asserts the sampled channel values at a known
+ * device coordinate are within tolerance of an expected rgba.
+ *
+ * @param {object} capture  { width, height, data }
+ * @param {Array<{ name:string, x:number, y:number,
+ *                 expect:[number,number,number,number], tolerance?:number }>} probes
+ * @returns {{ pass:boolean, results:Array<object> }}
+ */
+export function geometryProbes(capture, probes) {
+  const results = probes.map((p) => {
+    const got = samplePixel(capture, p.x, p.y);
+    const tol = p.tolerance ?? 8;
+    const deltas = got.map((g, c) => Math.abs(g - p.expect[c]));
+    const maxDelta = Math.max(...deltas);
+    const pass = maxDelta <= tol;
+    return {
+      name: p.name,
+      x: Math.round(p.x),
+      y: Math.round(p.y),
+      expect: p.expect,
+      got,
+      maxDelta,
+      tolerance: tol,
+      pass,
+    };
+  });
+  return { pass: results.every((r) => r.pass), results };
+}
+
+/**
+ * Map a WORLD coordinate to a DEVICE pixel coordinate using the SAME transform
+ * the renderer's drawFallback2D uses (screenPoint, renderer.ts:437). The camera
+ * operates DIRECTLY in device pixels: the world delta is scaled by camera.zoom
+ * ONLY (NOT by pixelRatio) and offset by the device-backing-store half-size.
+ * (pixelRatio scales the GLYPH RADIUS at renderer.ts:723, not the position.)
+ * y is NOT flipped (canvas + world y both grow downward in screenPoint).
+ *
+ *   screenX = canvas.width/2  + (worldX - camera.x) * zoom
+ *   screenY = canvas.height/2 + (worldY - camera.y) * zoom
+ *
+ * @returns {[number,number]} device pixel [x,y]
+ */
+export function worldToDevice(world, { width, height, zoom, camera }) {
+  const cam = camera ?? { x: 0, y: 0 };
+  const sx = width / 2 + (world[0] - cam.x) * zoom;
+  const sy = height / 2 + (world[1] - cam.y) * zoom;
+  return [sx, sy];
+}
+
+/**
+ * Drawn glyph RADIUS in device pixels (renderer.ts:723):
+ *   radius = max(1, nodeSize * pixelRatio * zoom)
+ */
+export function drawnRadius(nodeSize, dpr, zoom) {
+  return Math.max(1, nodeSize * dpr * zoom);
+}

--- a/packages/graph/tests/golden/fixtures.mjs
+++ b/packages/graph/tests/golden/fixtures.mjs
@@ -1,0 +1,55 @@
+// Golden fixtures for the B1 Phase-0 harness. These are the minimal Phase-0
+// smoke fixtures; the GL phases extend this with the full §5.2 matrix
+// (shape x fill x border x alpha x state, OVERLAP, Unicode text, edge families).
+//
+// Coordinates are WORLD coordinates. The camera maps them to the canvas at
+// capture time (see cdp-harness.capture).
+
+/**
+ * The Phase-0 base smoke fixture: a few node shapes + a styled edge, so the
+ * capture exercises arcs (circle), polygons (diamond/hexagon), a labelled box
+ * (text path), and a curved arrowed edge. Deterministic, no randomness.
+ */
+export const baseFixture = {
+  nodes: [
+    { id: "circle", x: -60, y: -40, size: 14, color: "#d62728", shape: "circle" },
+    { id: "diamond", x: 60, y: -40, size: 12, color: "#1f77b4", shape: "diamond" },
+    { id: "hexagon", x: -60, y: 40, size: 12, color: "#2ca02c", shape: "hexagon" },
+    { id: "box", x: 60, y: 40, size: 11, color: "#9467bd", shape: "box", label: "Work" },
+  ],
+  edges: [
+    { source: "circle", target: "diamond", width: 3, color: "#3344aa", curvature: 0.2 },
+    { source: "hexagon", target: "box", width: 2, color: "#777788", dash: "dashed" },
+  ],
+};
+
+/**
+ * Deep-clone a fixture so a perturbation never mutates the shared base.
+ */
+export function cloneFixture(fixture) {
+  return {
+    nodes: fixture.nodes.map((n) => ({ ...n })),
+    edges: fixture.edges.map((e) => ({ ...e })),
+  };
+}
+
+/**
+ * Return a copy of `fixture` with node `nodeId` moved by (dx, dy) WORLD units.
+ * Used by the Phase-0 acceptance proof: a 3px move MUST be detected above
+ * tolerance (proves the harness catches regressions).
+ */
+export function perturbNode(fixture, nodeId, dx, dy) {
+  const next = cloneFixture(fixture);
+  const node = next.nodes.find((n) => n.id === nodeId);
+  if (!node) throw new Error(`perturbNode: no node "${nodeId}"`);
+  node.x = (node.x ?? 0) + dx;
+  node.y = (node.y ?? 0) + dy;
+  return next;
+}
+
+/**
+ * The DPR x zoom capture matrix the harness supports (B1 §5.2 subset for
+ * Phase-0 smoke). The GL phases extend zoom to {0.05, 1, high}.
+ */
+export const DPR_MATRIX = [1, 1.25, 2, 3];
+export const ZOOM_MATRIX = [1, 2]; // at least 2 zooms (plan: >=2)

--- a/packages/graph/tests/golden/golden-harness.test.ts
+++ b/packages/graph/tests/golden/golden-harness.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+// @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
+import { openOracle } from "./cdp-harness.mjs";
+// @ts-expect-error
+import { diffPixels, geometryProbes, worldToDevice, drawnRadius } from "./diff.mjs";
+// @ts-expect-error
+import { baseFixture, perturbNode } from "./fixtures.mjs";
+// @ts-expect-error
+import { napiAvailable, smokeCapture } from "./smoke.mjs";
+
+// The whole golden suite needs headless Chrome. If absent (some CI runners),
+// the suite skips rather than fails -- the harness's job is to be available
+// where Chrome is, and the napi smoke path (below) still runs.
+let oracle: Awaited<ReturnType<typeof openOracle>> | null = null;
+let chromeUp = false;
+
+beforeAll(async () => {
+  try {
+    oracle = await openOracle();
+    chromeUp = true;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("[golden] Chrome/CDP oracle unavailable, skipping CDP suite:", String(err));
+    chromeUp = false;
+  }
+}, 60_000);
+
+afterAll(async () => {
+  if (oracle) await oracle.close();
+});
+
+const CAPTURE_OPTS = { dpr: 1, cssWidth: 200, cssHeight: 200, camera: { x: 0, y: 0, zoom: 1 } };
+
+// Set GOLDEN_REQUIRE_CHROME=1 (CI golden job) to turn a missing Chrome into a
+// hard failure instead of a silent skip.
+const REQUIRE_CHROME = process.env.GOLDEN_REQUIRE_CHROME === "1";
+
+describe("B1 Phase-0 golden harness (Chrome/CDP direct-canvas-pixel oracle)", () => {
+  it("oracle booted (or skip is explicit)", () => {
+    if (REQUIRE_CHROME) {
+      expect(chromeUp, "GOLDEN_REQUIRE_CHROME=1 but Chrome/CDP oracle did not boot").toBe(true);
+    }
+    // Positive signal in the report that the CDP suite actually ran.
+    expect(typeof chromeUp).toBe("boolean");
+  });
+
+  it("capture+diff is DETERMINISTIC: same fixture twice => zero diff", async () => {
+    if (!chromeUp || !oracle) return;
+    const a = await oracle.capture(baseFixture, CAPTURE_OPTS);
+    const b = await oracle.capture(baseFixture, CAPTURE_OPTS);
+    const result = diffPixels(a, b, { channelTolerance: 0, maxFailingPixels: 0 });
+    expect(result.dimsMatch).toBe(true);
+    // IDENTICAL: zero channel delta anywhere. Proves capture+diff determinism.
+    expect(result.maxChannelDelta).toBe(0);
+    expect(result.failingPixels).toBe(0);
+    expect(result.pass).toBe(true);
+  }, 60_000);
+
+  it("catches a regression: one node moved 3px => diff ABOVE tolerance", async () => {
+    if (!chromeUp || !oracle) return;
+    const ref = await oracle.capture(baseFixture, CAPTURE_OPTS);
+    // Move the red circle 3 world-px (= 3 device-px at zoom 1).
+    const moved = perturbNode(baseFixture, "circle", 3, 0);
+    const cap = await oracle.capture(moved, CAPTURE_OPTS);
+    // With a real per-channel tolerance, the 3px move MUST produce failing pixels.
+    const result = diffPixels(ref, cap, { channelTolerance: 2, maxFailingPixels: 0 });
+    expect(result.dimsMatch).toBe(true);
+    expect(result.pass).toBe(false);
+    expect(result.failingPixels).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("geometry probes hit known node centers (catches drift a loose tolerance masks)", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await oracle.capture(baseFixture, CAPTURE_OPTS);
+    const view = { width: cap.width, height: cap.height, zoom: 1, camera: { x: 0, y: 0 } };
+    // The red circle center should be solidly red. The diamond center solidly blue.
+    const [cx, cy] = worldToDevice([-60, -40], view);
+    const [dx, dy] = worldToDevice([60, -40], view);
+    const probes = [
+      { name: "circle-center-red", x: cx, y: cy, expect: [214, 39, 40, 255], tolerance: 12 },
+      { name: "diamond-center-blue", x: dx, y: dy, expect: [31, 119, 180, 255], tolerance: 12 },
+    ];
+    const { pass, results } = geometryProbes(cap, probes);
+    if (!pass) {
+      // eslint-disable-next-line no-console
+      console.error("[golden] probe failures:", JSON.stringify(results, null, 2));
+    }
+    expect(pass).toBe(true);
+    // Sanity: the drawn radius is what we think it is (locks N1 radius semantics
+    // for the GL phases that diff against this).
+    expect(drawnRadius(14, 1, 1)).toBeCloseTo(14, 5);
+  }, 60_000);
+
+  it("supports paired captures at DPR 1 / 1.25 / 2 / 3 and >= 2 zooms (dims scale)", async () => {
+    if (!chromeUp || !oracle) return;
+    for (const dpr of [1, 1.25, 2, 3]) {
+      for (const zoom of [1, 2]) {
+        const cap = await oracle.capture(baseFixture, {
+          cssWidth: 200,
+          cssHeight: 200,
+          dpr,
+          camera: { x: 0, y: 0, zoom },
+        });
+        expect(cap.width).toBe(Math.round(200 * dpr));
+        expect(cap.height).toBe(Math.round(200 * dpr));
+        // Determinism holds per (dpr, zoom): re-capture is identical.
+        const cap2 = await oracle.capture(baseFixture, {
+          cssWidth: 200,
+          cssHeight: 200,
+          dpr,
+          camera: { x: 0, y: 0, zoom },
+        });
+        const d = diffPixels(cap, cap2, { channelTolerance: 0, maxFailingPixels: 0 });
+        expect(d.maxChannelDelta).toBe(0);
+      }
+    }
+  }, 120_000);
+});
+
+describe("B1 Phase-0 supplemental SMOKE path (@napi-rs/canvas, NOT the parity oracle)", () => {
+  it("napi Canvas2D capture is deterministic and detects the 3px move", async () => {
+    if (!napiAvailable()) {
+      // eslint-disable-next-line no-console
+      console.warn("[golden] @napi-rs/canvas unavailable, skipping smoke path");
+      return;
+    }
+    const a = await smokeCapture(baseFixture, CAPTURE_OPTS);
+    const b = await smokeCapture(baseFixture, CAPTURE_OPTS);
+    expect(a.backend).toBe("canvas2d");
+    const same = diffPixels(a, b, { channelTolerance: 0, maxFailingPixels: 0 });
+    expect(same.maxChannelDelta).toBe(0);
+
+    const moved = perturbNode(baseFixture, "circle", 3, 0);
+    const cap = await smokeCapture(moved, CAPTURE_OPTS);
+    const diff = diffPixels(a, cap, { channelTolerance: 2, maxFailingPixels: 0 });
+    expect(diff.pass).toBe(false);
+    expect(diff.failingPixels).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/packages/graph/tests/golden/harness-page.html
+++ b/packages/graph/tests/golden/harness-page.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>graph golden harness</title>
+    <style>
+      /*
+       * Font determinism (§5.1): pin a bundled, deterministic family so text
+       * rasterization is reproducible across CI runners. We declare the family
+       * via @font-face pointing at a locally-served WOFF and force the renderer
+       * to use it; no system fallback is allowed to leak in. If the bundled
+       * font fails to load we still pin "monospace" which is far more stable
+       * across runners than the system "sans-serif".
+       */
+      @font-face {
+        font-family: "HarnessSans";
+        src: url("./fonts/harness-sans.woff2") format("woff2"),
+          url("./fonts/harness-sans.woff") format("woff");
+        font-weight: 400;
+        font-style: normal;
+        font-display: block;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: #ffffff;
+      }
+      canvas {
+        display: block;
+        image-rendering: pixelated;
+      }
+      #stage {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage"></div>
+    <script type="module">
+      // The renderer bundle is served from the graph package dist. The static
+      // server (cdp-harness.mjs) maps /graph-dist/index.js to packages/graph/dist.
+      import * as Graph from "/graph-dist/index.js";
+
+      // ---- shape code map (mirror of shape-geometry.ts shapeCode) -----------
+      const SHAPE_CODES = {
+        dot: 0,
+        circle: 0,
+        diamond: 1,
+        star: 2,
+        hexagon: 3,
+        square: 4,
+        box: 5,
+        roundedbox: 5,
+        triangle: 6,
+      };
+
+      function shapeCodeOf(value) {
+        if (typeof value === "number") return value;
+        const key = String(value ?? "dot").trim().toLowerCase();
+        return SHAPE_CODES[key] ?? 0;
+      }
+
+      // Parse a "#rrggbb" / "#rrggbbaa" / [r,g,b(,a)] color into an rgba8 tuple.
+      function toRgba(color, fallback) {
+        if (Array.isArray(color)) {
+          const [r, g, b, a = 255] = color;
+          return [r | 0, g | 0, b | 0, a | 0];
+        }
+        if (typeof color === "string" && color.startsWith("#")) {
+          const hex = color.slice(1);
+          const r = parseInt(hex.slice(0, 2), 16);
+          const g = parseInt(hex.slice(2, 4), 16);
+          const b = parseInt(hex.slice(4, 6), 16);
+          const a = hex.length >= 8 ? parseInt(hex.slice(6, 8), 16) : 255;
+          return [r, g, b, a];
+        }
+        return fallback ?? [77, 118, 255, 255];
+      }
+
+      /**
+       * Build RenderGraphBuffers + GraphStyleBuffers from a plain fixture spec.
+       * A fixture is:
+       *   {
+       *     nodes: [{ id, x, y, size, color, shape, label, fill, border }],
+       *     edges: [{ source, target, width, color, dash, curvature }],
+       *   }
+       * Coordinates are WORLD coordinates; the camera (set per capture) maps
+       * them to the canvas.
+       */
+      function buildBuffers(fixture) {
+        const nodes = fixture.nodes ?? [];
+        const edges = fixture.edges ?? [];
+        const nodeIds = nodes.map((n) => n.id);
+        const idToIndex = new Map(nodeIds.map((id, i) => [id, i]));
+
+        const positions = new Float32Array(nodes.length * 2);
+        const nodeSizes = new Float32Array(nodes.length);
+        const nodeColors = new Uint8Array(nodes.length * 4);
+        const nodeShapes = new Uint8Array(nodes.length);
+        const nodeFills = new Uint8Array(nodes.length);
+        const nodeBorders = new Uint8Array(nodes.length);
+        const nodeLabels = [];
+
+        nodes.forEach((node, i) => {
+          positions[i * 2] = node.x ?? 0;
+          positions[i * 2 + 1] = node.y ?? 0;
+          nodeSizes[i] = node.size ?? 6;
+          const [r, g, b, a] = toRgba(node.color, [77, 118, 255, 255]);
+          nodeColors[i * 4] = r;
+          nodeColors[i * 4 + 1] = g;
+          nodeColors[i * 4 + 2] = b;
+          nodeColors[i * 4 + 3] = a;
+          nodeShapes[i] = shapeCodeOf(node.shape);
+          nodeFills[i] = node.fill === "hollow" ? 1 : 0;
+          nodeBorders[i] = node.border === "bold" ? 1 : 0;
+          nodeLabels[i] = node.label ?? "";
+        });
+
+        const edgeArr = new Uint32Array(edges.length * 2);
+        const edgeWidths = new Float32Array(edges.length);
+        const edgeColors = new Uint8Array(edges.length * 4);
+        const edgeDash = new Uint8Array(edges.length);
+        const edgeCurvatures = new Float32Array(edges.length);
+        const DASH_CODES = { solid: 0, dashed: 1, dotted: 2, "long-dash": 3 };
+
+        edges.forEach((edge, i) => {
+          edgeArr[i * 2] = idToIndex.get(edge.source) ?? 0;
+          edgeArr[i * 2 + 1] = idToIndex.get(edge.target) ?? 0;
+          edgeWidths[i] = edge.width ?? 1;
+          const [r, g, b, a] = toRgba(edge.color, [121, 133, 153, 180]);
+          edgeColors[i * 4] = r;
+          edgeColors[i * 4 + 1] = g;
+          edgeColors[i * 4 + 2] = b;
+          edgeColors[i * 4 + 3] = a;
+          edgeDash[i] = DASH_CODES[edge.dash ?? "solid"] ?? 0;
+          edgeCurvatures[i] = edge.curvature ?? 0;
+        });
+
+        return {
+          graph: { nodeIds, positions, edges: edgeArr },
+          style: {
+            nodeSizes,
+            nodeColors,
+            nodeShapes,
+            nodeFills,
+            nodeBorders,
+            nodeLabels,
+            edgeWidths,
+            edgeColors,
+            edgeDash,
+            edgeCurvatures,
+          },
+        };
+      }
+
+      // The font the renderer must use. drawFallback2D builds its font string
+      // as `${fontPx}px sans-serif` (renderer.ts). To pin the family we patch
+      // the 2D context's font setter to swap "sans-serif" for our pinned family
+      // on this harness page ONLY (never in the shipped renderer).
+      const PINNED_FAMILY = '"HarnessSans", monospace';
+
+      function pinFontOnContext(ctx) {
+        const proto = Object.getPrototypeOf(ctx);
+        const desc = Object.getOwnPropertyDescriptor(proto, "font");
+        if (!desc || !desc.set || ctx.__fontPinned) return;
+        const origSet = desc.set;
+        const origGet = desc.get;
+        Object.defineProperty(ctx, "font", {
+          configurable: true,
+          get() {
+            return origGet.call(this);
+          },
+          set(value) {
+            const pinned = String(value).replace(/sans-serif/g, PINNED_FAMILY);
+            origSet.call(this, pinned);
+          },
+        });
+        ctx.__fontPinned = true;
+      }
+
+      /**
+       * Render a fixture with the Canvas2D backend onto a real canvas at the
+       * given DPR + camera, and return an accessor to read its pixels DIRECTLY.
+       *
+       * opts: { dpr, cssWidth, cssHeight, camera: {x,y,zoom}, backend }
+       */
+      window.__renderFixture = function renderFixture(fixture, opts) {
+        const dpr = opts.dpr ?? 1;
+        const cssWidth = opts.cssWidth ?? 200;
+        const cssHeight = opts.cssHeight ?? 200;
+        const backend = opts.backend ?? "canvas2d";
+        const camera = opts.camera ?? { x: 0, y: 0, zoom: 1 };
+
+        const stage = document.getElementById("stage");
+        // Fresh canvas each call: avoids any retained context state.
+        const canvas = document.createElement("canvas");
+        canvas.width = Math.round(cssWidth * dpr); // device backing store
+        canvas.height = Math.round(cssHeight * dpr);
+        canvas.style.width = cssWidth + "px";
+        canvas.style.height = cssHeight + "px";
+        stage.innerHTML = "";
+        stage.appendChild(canvas);
+
+        // Pin the font on the 2D context BEFORE the renderer measures/draws.
+        const ctx2d = canvas.getContext("2d");
+        pinFontOnContext(ctx2d);
+
+        const { graph, style } = buildBuffers(fixture);
+        const renderer = Graph.createGraphRenderer(canvas, {
+          backend,
+          pixelRatio: dpr,
+        });
+        renderer.setGraph(graph);
+        renderer.setStyle(style);
+        renderer.setCamera(camera);
+        renderer.render();
+
+        const snap = renderer.snapshot();
+
+        // Expose a direct-pixel read of the canvas BACKING STORE. For the 2D
+        // backend we read via getImageData; for a future WebGL backend the
+        // caller switches to gl.readPixels (handled in __readPixels).
+        window.__lastCanvas = canvas;
+        window.__lastBackend = snap.backend;
+
+        return {
+          width: canvas.width,
+          height: canvas.height,
+          backend: snap.backend,
+        };
+      };
+
+      /**
+       * Read the FULL device-resolution pixel buffer of the last rendered
+       * canvas, directly from the backing store. Returns base64 of the raw
+       * RGBA bytes (row-major, top-left origin, premultiplied=false as 2D
+       * getImageData / gl.readPixels both deliver straight RGBA).
+       *
+       * For the 2D backend: getImageData(0,0,w,h).
+       * For a WebGL backend: gl.readPixels(...) then row-flip (GL origin is
+       * bottom-left). Phase 0 only exercises the 2D path, but the WebGL branch
+       * is wired so the GL phases need zero harness changes.
+       */
+      window.__readPixels = function readPixels() {
+        const canvas = window.__lastCanvas;
+        if (!canvas) throw new Error("no canvas rendered yet");
+        const w = canvas.width;
+        const h = canvas.height;
+        let bytes;
+        if (window.__lastBackend === "webgl") {
+          const gl =
+            canvas.getContext("webgl2") || canvas.getContext("webgl");
+          const buf = new Uint8Array(w * h * 4);
+          gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+          // Flip rows: GL origin is bottom-left, we want top-left.
+          bytes = new Uint8Array(w * h * 4);
+          const stride = w * 4;
+          for (let y = 0; y < h; y += 1) {
+            const src = (h - 1 - y) * stride;
+            bytes.set(buf.subarray(src, src + stride), y * stride);
+          }
+        } else {
+          const ctx = canvas.getContext("2d");
+          bytes = new Uint8Array(ctx.getImageData(0, 0, w, h).data.buffer);
+        }
+        // base64 encode (chunked to avoid call-stack limits on large buffers)
+        let binary = "";
+        const CHUNK = 0x8000;
+        for (let i = 0; i < bytes.length; i += CHUNK) {
+          binary += String.fromCharCode.apply(
+            null,
+            bytes.subarray(i, i + CHUNK),
+          );
+        }
+        return { width: w, height: h, base64: btoa(binary) };
+      };
+
+      // Signal readiness only AFTER the pinned font is loaded (§5.1:
+      // document.fonts.ready before any capture).
+      window.__harnessReady = (async () => {
+        try {
+          await document.fonts.load('16px "HarnessSans"');
+        } catch {
+          /* bundled font may be absent in minimal envs; monospace fallback */
+        }
+        await document.fonts.ready;
+        window.__fontsReady = true;
+        return true;
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/graph/tests/golden/smoke.mjs
+++ b/packages/graph/tests/golden/smoke.mjs
@@ -1,0 +1,150 @@
+// SUPPLEMENTAL fast smoke path (B1 plan §5.1, fix #4) -- explicitly NOT the
+// parity oracle.
+//
+// @napi-rs/canvas (Canvas2D) gives us a real getImageData-capable canvas in
+// pure Node (no browser, no GPU), so the same @sentropic/graph Canvas2D
+// backend can be rendered and pixel-diffed in milliseconds for fast local
+// iteration. It is a SMOKE pre-filter only: its anti-aliasing and font
+// rasterization DIFFER from Chrome, so it can flag gross breakage but is NEVER
+// the parity gate. The Chrome/CDP direct-pixel oracle (cdp-harness.mjs) is the
+// authority.
+//
+// headless-gl (the WebGL smoke counterpart) is INTENTIONALLY not wired here:
+// in this environment it fails to build (node-gyp needs the X11/Xi -dev
+// pkg-config files, absent here). For Phase 0 no WebGL backend exists yet, so
+// the napi Canvas2D smoke path fully covers the Phase-0 smoke proof. The GL
+// phases can add a headless-gl smoke branch where the native toolchain exists.
+
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GRAPH_PKG = path.resolve(__dirname, "../..");
+const require = createRequire(pathToFileURL(path.join(GRAPH_PKG, "package.json")));
+
+let napiCanvas = null;
+export function napiAvailable() {
+  if (napiCanvas !== null) return napiCanvas !== false;
+  try {
+    napiCanvas = require("@napi-rs/canvas");
+    return true;
+  } catch {
+    napiCanvas = false;
+    return false;
+  }
+}
+
+// Mirror of shape-geometry.ts shapeCode + harness-page buildBuffers, kept in
+// sync with harness-page.html. (Shared in spirit; duplicated here because the
+// browser page can't import a Node module and vice-versa.)
+const SHAPE_CODES = {
+  dot: 0, circle: 0, diamond: 1, star: 2, hexagon: 3,
+  square: 4, box: 5, roundedbox: 5, triangle: 6,
+};
+const DASH_CODES = { solid: 0, dashed: 1, dotted: 2, "long-dash": 3 };
+
+function shapeCodeOf(value) {
+  if (typeof value === "number") return value;
+  return SHAPE_CODES[String(value ?? "dot").trim().toLowerCase()] ?? 0;
+}
+function toRgba(color, fallback) {
+  if (Array.isArray(color)) {
+    const [r, g, b, a = 255] = color;
+    return [r | 0, g | 0, b | 0, a | 0];
+  }
+  if (typeof color === "string" && color.startsWith("#")) {
+    const h = color.slice(1);
+    const a = h.length >= 8 ? parseInt(h.slice(6, 8), 16) : 255;
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16), a];
+  }
+  return fallback ?? [77, 118, 255, 255];
+}
+
+function buildBuffers(fixture) {
+  const nodes = fixture.nodes ?? [];
+  const edges = fixture.edges ?? [];
+  const nodeIds = nodes.map((n) => n.id);
+  const idToIndex = new Map(nodeIds.map((id, i) => [id, i]));
+
+  const positions = new Float32Array(nodes.length * 2);
+  const nodeSizes = new Float32Array(nodes.length);
+  const nodeColors = new Uint8Array(nodes.length * 4);
+  const nodeShapes = new Uint8Array(nodes.length);
+  const nodeFills = new Uint8Array(nodes.length);
+  const nodeBorders = new Uint8Array(nodes.length);
+  const nodeLabels = [];
+
+  nodes.forEach((node, i) => {
+    positions[i * 2] = node.x ?? 0;
+    positions[i * 2 + 1] = node.y ?? 0;
+    nodeSizes[i] = node.size ?? 6;
+    const [r, g, b, a] = toRgba(node.color, [77, 118, 255, 255]);
+    nodeColors[i * 4] = r; nodeColors[i * 4 + 1] = g;
+    nodeColors[i * 4 + 2] = b; nodeColors[i * 4 + 3] = a;
+    nodeShapes[i] = shapeCodeOf(node.shape);
+    nodeFills[i] = node.fill === "hollow" ? 1 : 0;
+    nodeBorders[i] = node.border === "bold" ? 1 : 0;
+    nodeLabels[i] = node.label ?? "";
+  });
+
+  const edgeArr = new Uint32Array(edges.length * 2);
+  const edgeWidths = new Float32Array(edges.length);
+  const edgeColors = new Uint8Array(edges.length * 4);
+  const edgeDash = new Uint8Array(edges.length);
+  const edgeCurvatures = new Float32Array(edges.length);
+  edges.forEach((edge, i) => {
+    edgeArr[i * 2] = idToIndex.get(edge.source) ?? 0;
+    edgeArr[i * 2 + 1] = idToIndex.get(edge.target) ?? 0;
+    edgeWidths[i] = edge.width ?? 1;
+    const [r, g, b, a] = toRgba(edge.color, [121, 133, 153, 180]);
+    edgeColors[i * 4] = r; edgeColors[i * 4 + 1] = g;
+    edgeColors[i * 4 + 2] = b; edgeColors[i * 4 + 3] = a;
+    edgeDash[i] = DASH_CODES[edge.dash ?? "solid"] ?? 0;
+    edgeCurvatures[i] = edge.curvature ?? 0;
+  });
+
+  return {
+    graph: { nodeIds, positions, edges: edgeArr },
+    style: {
+      nodeSizes, nodeColors, nodeShapes, nodeFills, nodeBorders, nodeLabels,
+      edgeWidths, edgeColors, edgeDash, edgeCurvatures,
+    },
+  };
+}
+
+/**
+ * Render a fixture with the Canvas2D backend onto a napi canvas and read its
+ * pixels directly. Returns { width, height, data: Uint8ClampedArray (RGBA) }.
+ *
+ * NOTE: this loads the @sentropic/graph dist bundle. Build it first
+ * (npm run build in packages/graph) -- the test harness ensures this.
+ */
+export async function smokeCapture(fixture, opts = {}) {
+  if (!napiAvailable()) throw new Error("@napi-rs/canvas not installed");
+  const { createCanvas } = napiCanvas;
+  const dpr = opts.dpr ?? 1;
+  const cssWidth = opts.cssWidth ?? 200;
+  const cssHeight = opts.cssHeight ?? 200;
+  const camera = opts.camera ?? { x: 0, y: 0, zoom: opts.zoom ?? 1 };
+
+  const Graph = await import(pathToFileURL(path.join(GRAPH_PKG, "dist/index.js")).href);
+  const canvas = createCanvas(Math.round(cssWidth * dpr), Math.round(cssHeight * dpr));
+  const { graph, style } = buildBuffers(fixture);
+
+  const renderer = Graph.createGraphRenderer(canvas, { backend: "canvas2d", pixelRatio: dpr });
+  renderer.setGraph(graph);
+  renderer.setStyle(style);
+  renderer.setCamera(camera);
+  renderer.render();
+
+  const ctx = canvas.getContext("2d");
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return {
+    width: canvas.width,
+    height: canvas.height,
+    data: new Uint8ClampedArray(img.data),
+    backend: renderer.snapshot().backend,
+  };
+}


### PR DESCRIPTION
## Work-stream B1 — Phase 0: WebGL-migration golden test harness

Foundation for the Canvas2D→WebGL renderer migration: a **CDP direct-canvas-pixel golden oracle** + `@napi-rs/canvas` smoke path for `packages/graph`. **Pure test infrastructure — zero runtime change, gated behind no flag.** The migration itself (shapes/edges/picking/LOD) lands in later phases behind `GRAPHIFY_RENDER_BACKEND` (default `canvas2d`, no user regression).

### Why first
The migration's non-regression guarantee needs a byte-level oracle BEFORE any backend swap. This harness is that oracle: it boots headless Chrome, renders the canvas2d baseline, and captures direct canvas pixels for diffing future WebGL output.

### Contract / trail
- Exhaustive render inventory (v1→v4) + migration plan (v1→v2), both double-consensus **SHIP**, archived: `.graphify/scratch/archive/2026-06-21-conductor/B1-webgl/`.

### Verification
- Golden gate **runs live in this env**: real headless `google-chrome` launched, 200×200 RGBA frame captured (40 000 non-white px), `GOLDEN_REQUIRE_CHROME=1` oracle-boot assertion **passes** (not skipped).
- **6/6 golden tests + 33/33 packages/graph unit tests** green against the live oracle. JS bundle builds clean.
- Known pre-existing red (NOT from this branch — the 3 commits touch no `src/`): `src/styles.ts(165,7)` TS2532 surfaced by the dts typecheck. Recommend a separate one-line cleanup so `npm run build`/`tsc --noEmit` go fully clean.

### CI note
If the golden job runs in CI, set `GOLDEN_REQUIRE_CHROME=1` to make the CDP suite a hard gate (confirmed it boots + captures here).

---

**Decision** : infra de test réversible, 0 changement runtime utilisateur. Je propose de **merger en autonomie dès CI verte** (pas d'UAT utilisateur — c'est de l'outillage). Le seul rouge possible = le TS2532 **pré-existant** (je le nettoie à part). Dis si tu préfères valider toi-même avant merge.
