### PR TITLE
feat(studio): group-by axis selector + reactive count badges under search (work-stream B2)

### DIFF
--- a/spec/SPEC_STUDIO_GROUPBY_UX.md
+++ b/spec/SPEC_STUDIO_GROUPBY_UX.md
@@ -1,28 +1,50 @@
-# SPEC — Studio group-by UX (per-item) — user-dictated, verbatim
+# SPEC — Studio group-by UX (per-item + tri-state bulk buttons) — APPROVED
 
-Source: user requirements, transcribed exactly. This is the contract; implement it faithfully.
+User-approved design (double-consensus 4.8 on the bulk-button best-practice). This is the contract.
 
-## The interaction (the approved mockup)
-```
-Ontology ▾
-  ☐ People            ← bare checkbox, ON THE LEFT, NO text next to it
-  ☐ Detective
-  ☑ Suspect           ← checked = grouped (collapsed) by this class
-Communities ▾
-  ☑ Community 8        ← bare checkbox on the LEFT = grouped by this community
-  ☐ Community 14
-```
+## 1. State model (single source of truth)
+The state = **the set of checked items** (ontology class keys + community keys), i.e. `groupBy.grouped`. Checking an item groups (collapses) it. Bulk buttons are **shortcuts/toggles over that set**. The tree checkboxes are the truth; buttons are verbs.
 
-## Hard requirements (each is a MUST)
-1. **Checkbox ON THE LEFT** of every groupable item — each Ontology class row (Domain + Sub-domain) AND each Community row. The checkbox is the FIRST thing on the row (left edge), before the label. (Currently it is wrongly in the `trailing()` snippet = right side — MOVE it to `leading()`/left.)
-2. **NO text** next to the checkbox at rest. Remove the `<span class="rail-group-hint">group</span>` entirely. At rest the affordance is ONLY a bare checkbox.
-3. **Hover is the ONLY signal** that the checkbox means "group by". On hover of the row, signal it (a `title`/tooltip "Group by <name>" is acceptable, and/or a subtle visual hint that appears on hover). NEVER a persistent text label.
-4. **Multi-select**: several checked items group simultaneously (Ontology classes + communities mixed).
-5. **Community grouping MUST actually WORK** — checking a Community checkbox MUST collapse/regroup the graph so that the community's member nodes fold into the community group node (same as the ontology axis does for classes). This is currently BROKEN (the checkbox is wired but the graph does not regroup). Find and fix the runtime path (`mintCommunityNodeIds` → `injectCommunityNodes` → `buildCommunityParentIndex.collapseTargetByKey` → `applyGroupCollapse`).
-6. Keep separate: the group-by checkbox (`onToggleGroupOntology`/`onToggleGroupCommunity`) is NOT the row's filter/select (`onToggleType`/`onToggleCommunity`). Grouping ≠ selecting.
-7. Keep intact: Types→Ontology rename, count badges + reactive x/N, model-switch preservation, A5 tone, Ontology/Communities open by default.
+## 2. Per-item checkboxes
+A **bare checkbox on the LEFT** (no text label; hover = the only "group by" signal via `title` tooltip + a hover-only visual hint) on EVERY groupable row:
+- Ontology: **Domain**, **Sub-domain**, AND **Type** rows (the Type checkbox is ADDED next to the existing Type FILTER select — group ≠ filter, keep them separate).
+- Communities: each community row (already correct).
+Checking groups that item; **multi-select**; ontology + community checks group together (union).
 
-## Acceptance criteria (UAT)
-- **Visual**: on the mystery studio, each Ontology class row and each Community row shows a bare checkbox at its LEFT edge, with NO "group" text. Hover reveals the "Group by …" signal only.
-- **Functional — community**: check a community's checkbox → the graph visibly REGROUPS: that community's member nodes collapse into a single community group node (and uncheck restores). Proven by a unit/integration test on the App `groupedGraph` derivation: grouping by a live community key yields a collapsed graph where the community's members are folded under the community node (node count drops / community node present). The test must FAIL on the current code and PASS after the fix.
-- **Functional — multi**: checking 2 communities + 1 ontology class collapses all three at once.
+### Bugs to FIX (currently broken)
+- 🐛 **Ontology per-item grouping does NOT actually group** — only communities work. Checking a Domain/Sub-domain/Type must collapse that class's nodes into the class group node. FIND THE ROOT CAUSE (the ontology collapse path: injectOntologyClassNodes / buildClassParentIndex / collapseTargets in App.svelte `groupedGraph`) and fix it. Write a failing→passing test driving the real App grouping chain (group by a Domain → node count drops, members folded under the class node).
+- 🐛 **"Type" level grouping does NOT work** — grouping at the Type (leaf) level must collapse nodes into their type. Fix + test.
+
+## 3. Nesting (ontology levels are hierarchical)
+A node collapses to its **nearest checked ancestor class** (Domain supersedes Sub-domain supersedes Type if multiple ancestors checked). A class **absorbed by a grouped ancestor** renders **disabled + tooltip** ("grouped by parent <Domain>") so the user sees it's covered. "ALL at level X" means: all classes whose **effective** grouping resolves to X (excluding absorbed ones) — the count denominators must exclude absorbed classes.
+
+## 4. Bulk buttons — Ontology section (TRI-STATE toggles)
+Buttons: **`Group all to: Domain | Sub-domain | Type`** + **`Ungroup all`**. The DS Button has only `primary`/`secondary` variants (no third) + native `disabled`. Tri-state = 2 variants + a count Badge.
+
+Per `Group all to: <level>` button, by that level's state:
+| State | DS variant | aria | Visible | Click action |
+|---|---|---|---|---|
+| **NONE** of the level grouped | `secondary` | `aria-pressed="false"` | "Group all to <level>" | group every (non-absorbed) class at that level |
+| **ALL** (effective) grouped | **`primary`** | `aria-pressed="true"` | "Group all to <level>" | **toggle OFF** — ungroup that level |
+| **PARTIAL** | `secondary` + Badge `tone="neutral"` `"3/6"` | `aria-pressed="false"` | "Group all to <level>" (acc. name "(3 of 6 grouped)") | **complete to ALL** (group the rest) |
+
+Cycle: `none → all → none`; `partial → all`. Never two clicks to finish; never `aria-checked="mixed"` (that's checkbox-only — these are toggle buttons → `aria-pressed`).
+
+**`Ungroup all`** (ontology): `secondary`, native **`disabled`** when zero ontology classes are grouped. Clears all ontology grouped keys (ontology scope only).
+
+## 5. Bulk buttons — Communities section (FLAT, 2-state)
+No levels, no partial, no count. Buttons: **`Group all`** + **`Ungroup all`**.
+- `Group all`: `secondary` → **`primary`** (`aria-pressed="true"`) when ALL communities grouped; click toggles (group all / ungroup all).
+- `Ungroup all`: `secondary`, native `disabled` when zero communities grouped. Clears community grouped keys (community scope only).
+
+## 6. Keep intact (no regression)
+Checkbox-left placement (done), Types→Ontology rename, count badges + reactive x/N, model-switch preservation, A5 tone, community namespacing, the community grouping fix (GROUPED∩LIVE), Ontology/Communities open by default, the Ontology FILTER facet (onToggleType) separate from the group-by checkboxes.
+
+## 7. Acceptance (UAT, on mystery studio)
+- Every ontology Domain/Sub-domain/Type row + every community row shows a bare LEFT checkbox, no "group" text.
+- Checking a Domain/Sub-domain/Type **regroups the graph** (the bug is fixed); checking a community regroups; mixing works.
+- "Group all to: Domain" → all domains grouped + the button goes `primary`; click again → ungroups (toggle). Partial → shows `(n/m)` + completes on click.
+- "Type" works. Absorbed classes render disabled with the parent tooltip.
+- "Ungroup all" present + **disabled** when nothing grouped in that section; enabled + clears when something is.
+- Communities section: 2-state Group all / Ungroup all, no count.
+- Full studio suite green + new failing→passing tests for: ontology per-item grouping, Type grouping, the tri-state button state mapping, the disabled ungroup-all, nesting absorption.

--- a/spec/SPEC_STUDIO_GROUPBY_UX.md
+++ b/spec/SPEC_STUDIO_GROUPBY_UX.md
@@ -1,0 +1,28 @@
+# SPEC — Studio group-by UX (per-item) — user-dictated, verbatim
+
+Source: user requirements, transcribed exactly. This is the contract; implement it faithfully.
+
+## The interaction (the approved mockup)
+```
+Ontology ▾
+  ☐ People            ← bare checkbox, ON THE LEFT, NO text next to it
+  ☐ Detective
+  ☑ Suspect           ← checked = grouped (collapsed) by this class
+Communities ▾
+  ☑ Community 8        ← bare checkbox on the LEFT = grouped by this community
+  ☐ Community 14
+```
+
+## Hard requirements (each is a MUST)
+1. **Checkbox ON THE LEFT** of every groupable item — each Ontology class row (Domain + Sub-domain) AND each Community row. The checkbox is the FIRST thing on the row (left edge), before the label. (Currently it is wrongly in the `trailing()` snippet = right side — MOVE it to `leading()`/left.)
+2. **NO text** next to the checkbox at rest. Remove the `<span class="rail-group-hint">group</span>` entirely. At rest the affordance is ONLY a bare checkbox.
+3. **Hover is the ONLY signal** that the checkbox means "group by". On hover of the row, signal it (a `title`/tooltip "Group by <name>" is acceptable, and/or a subtle visual hint that appears on hover). NEVER a persistent text label.
+4. **Multi-select**: several checked items group simultaneously (Ontology classes + communities mixed).
+5. **Community grouping MUST actually WORK** — checking a Community checkbox MUST collapse/regroup the graph so that the community's member nodes fold into the community group node (same as the ontology axis does for classes). This is currently BROKEN (the checkbox is wired but the graph does not regroup). Find and fix the runtime path (`mintCommunityNodeIds` → `injectCommunityNodes` → `buildCommunityParentIndex.collapseTargetByKey` → `applyGroupCollapse`).
+6. Keep separate: the group-by checkbox (`onToggleGroupOntology`/`onToggleGroupCommunity`) is NOT the row's filter/select (`onToggleType`/`onToggleCommunity`). Grouping ≠ selecting.
+7. Keep intact: Types→Ontology rename, count badges + reactive x/N, model-switch preservation, A5 tone, Ontology/Communities open by default.
+
+## Acceptance criteria (UAT)
+- **Visual**: on the mystery studio, each Ontology class row and each Community row shows a bare checkbox at its LEFT edge, with NO "group" text. Hover reveals the "Group by …" signal only.
+- **Functional — community**: check a community's checkbox → the graph visibly REGROUPS: that community's member nodes collapse into a single community group node (and uncheck restores). Proven by a unit/integration test on the App `groupedGraph` derivation: grouping by a live community key yields a collapsed graph where the community's members are folded under the community node (node count drops / community node present). The test must FAIL on the current code and PASS after the fix.
+- **Functional — multi**: checking 2 communities + 1 ontology class collapses all three at once.

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -34,22 +34,26 @@
     resolveSelectedIds,
     communityStats,
     nodeCommunity,
+    nodeType,
   } from "./lib/graphAdapter.js";
   import {
-    injectOntologyClassNodes,
-    applyOntologyCollapse,
-    applyGroupCollapse,
-    buildClassParentIndex,
-    injectCommunityNodes,
-    buildCommunityParentIndex,
     mintCommunityNodeIds,
+    mintTypeNodeIds,
   } from "./lib/classNodes.js";
+  import {
+    computeGroupedGraph,
+    classIdsAtLevel,
+    typeNamesInTaxonomy,
+    ontologyLevelState,
+    ontologyAbsorption,
+  } from "./lib/groupBy.js";
   import { loadWorkspace } from "./lib/sceneLoader.js";
   import {
     createDefaultViewerState,
     splitGroupedKeys,
     groupKeyForOntology,
     groupKeyForCommunity,
+    groupKeyForType,
     toggleType,
     toggleCommunity,
     toggleEntity,
@@ -61,9 +65,14 @@
     setShowWeakLinks,
     toggleGroupOntology,
     toggleGroupCommunity,
+    toggleGroupType,
     toggleGroupItem,
-    foldOntologyToLevel,
-    clearGrouping,
+    groupOntologyLevel,
+    groupAllCommunities,
+    clearOntologyGrouping,
+    clearCommunityGrouping,
+    hasOntologyGrouping,
+    hasCommunityGrouping,
   } from "./lib/viewerState.js";
 
   const EMPTY_GRAPH = { nodes: [], links: [] };
@@ -87,10 +96,8 @@
   let classHierarchies = $state.raw(null);
   // EVOL 2.b/2.d: the class-injection granularity is "all" — EVERY class (not
   // just leaves) is injected so that intermediate super-classes exist as collapse
-  // HANDLES (click a class node to fold its subtree). With an empty collapsed set
-  // this is the 2.a display plus the inter-class subclass_of skeleton; the
-  // collapse pass below only ever does work once a class is folded.
-  const ontologyClassLevels = "all";
+  // HANDLES. `computeGroupedGraph` (lib/groupBy.js) owns the inject granularity;
+  // the collapse pass only ever does work once a class is folded.
 
   // ----- in-UI model switcher ----------------------------------------------
   // The store holds the manifest + active model; api.js resolves static fetches
@@ -107,14 +114,15 @@
   // scene WITHOUT the raw graph (ÉTAPE 1b): on the light scene via
   // applyWeakFilter, or — in legacy fallback — by rebuilding from the graph.
 
-  // B2 (per-item): the grouped item SET split back into its two engine inputs.
+  // B2 (per-item): the grouped item SET split back into its engine inputs.
   // An EMPTY set is the FAST PATH and must be byte-identical to the pre-B2
-  // default (A3). Several keys — mixing ontology classes and communities —
-  // collapse simultaneously.
+  // default (A3). Several keys — mixing ontology classes, communities AND leaf
+  // TYPES — collapse simultaneously.
   const groupedSplit = $derived(splitGroupedKeys(viewerState.options.groupBy.grouped));
   const hasOntologyGroup = $derived(groupedSplit.ontologyClassIds.length > 0);
   const hasCommunityGroup = $derived(groupedSplit.communityKeys.length > 0);
-  const hasAnyGroup = $derived(hasOntologyGroup || hasCommunityGroup);
+  const hasTypeGroup = $derived(groupedSplit.typeNames.length > 0);
+  const hasAnyGroup = $derived(hasOntologyGroup || hasCommunityGroup || hasTypeGroup);
 
   // C4: which kinds are AVAILABLE to group. Ontology needs the class-hierarchies
   // artifact; Community needs at least one live community. The rail hides the
@@ -153,54 +161,68 @@
     };
   });
 
-  // B2 (per-item): build ONE collapse over the UNION of every grouped item.
-  //   - inject ontology class nodes when any ontology class is grouped;
-  //   - inject community fold nodes when any community is grouped;
-  //   - merge their parent indexes + descendant maps;
-  //   - call applyGroupCollapse ONCE with the union of collapse targets.
-  // An empty grouped set is the fast path (returns the raw graph untouched, A3).
-  const groupedGraph = $derived.by(() => {
-    if (!hasAnyGroup) return graph;
-
-    let injected = graph;
-    const parentById = new Map();
-    const descendantsByTarget = new Map();
-    const collapseTargets = [];
-
-    if (hasOntologyGroup && classHierarchies?.hierarchies) {
-      injected = injectOntologyClassNodes(injected, classHierarchies, {
-        levels: ontologyClassLevels,
-      });
-      const { parentById: classParents, descendantClassIds } =
-        buildClassParentIndex(classHierarchies);
-      for (const [k, v] of classParents) parentById.set(k, v);
-      for (const [k, v] of descendantClassIds) descendantsByTarget.set(k, v);
-      for (const id of groupedSplit.ontologyClassIds) collapseTargets.push(id);
-    }
-
-    if (hasCommunityGroup && communityCtx) {
-      injected = injectCommunityNodes(injected, communityCtx);
-      const {
-        parentById: commParents,
-        descendantsByTarget: commDesc,
-        collapseTargetByKey,
-      } = buildCommunityParentIndex(injected, communityCtx);
-      for (const [k, v] of commParents) {
-        // Don't clobber an ontology parent mapping for a shared entity; the
-        // community membership only governs entities the ontology pass left
-        // unmapped (community nodes themselves are unmapped roots).
-        if (!parentById.has(k)) parentById.set(k, v);
-      }
-      for (const [k, v] of commDesc) descendantsByTarget.set(k, v);
-      for (const key of groupedSplit.communityKeys) {
-        const id = collapseTargetByKey(key);
-        if (typeof id === "string") collapseTargets.push(id);
-      }
-    }
-
-    if (collapseTargets.length === 0) return injected;
-    return applyGroupCollapse(injected, { parentById, collapseTargets, descendantsByTarget });
+  // B2 (per-item): the TYPE fold context — mint synthetic type-node ids ONCE so
+  // the injector and parent index agree. Only built when a Type is grouped. The
+  // Type LEVEL is the entity `type` itself (no per-type class node in the
+  // artifact), so a grouped type folds entities sharing that `type` (§2).
+  const typeCtx = $derived.by(() => {
+    if (!hasTypeGroup) return null;
+    const typeNames = groupedSplit.typeNames;
+    const idByKey = mintTypeNodeIds(typeNames, new Set((graph?.nodes ?? []).map((n) => n.id)));
+    return { typeNames, idByKey, typeOf: nodeType };
   });
+
+  // B2 (per-item): the REAL App grouping chain, now a single EXTRACTED + tested
+  // function (`computeGroupedGraph`). It folds the UNION of every grouped item
+  // (ontology classes + communities + leaf types) into ONE collapse pass. An
+  // empty grouped set is the fast path (returns the raw graph untouched, A3).
+  const groupedGraph = $derived(
+    computeGroupedGraph({
+      graph,
+      classHierarchies,
+      communityCtx,
+      typeCtx,
+      grouped: viewerState.options.groupBy.grouped,
+    }),
+  );
+
+  // Tri-state of each ontology bulk button (spec §4) + per-class absorption view
+  // (spec §3). Denominators EXCLUDE absorbed classes; the rail renders the
+  // {none|partial|all} variant + (n/m) badge and disables absorbed rows.
+  const checkedOntologyIds = $derived(new Set(groupedSplit.ontologyClassIds));
+  const checkedTypeNames = $derived(new Set(groupedSplit.typeNames));
+  const ontologyLevelStates = $derived({
+    domain: ontologyLevelState({
+      classHierarchies,
+      level: 0,
+      checkedOntologyIds,
+      checkedTypeNames,
+    }),
+    subDomain: ontologyLevelState({
+      classHierarchies,
+      level: 1,
+      checkedOntologyIds,
+      checkedTypeNames,
+    }),
+    type: ontologyLevelState({
+      classHierarchies,
+      level: 2,
+      checkedOntologyIds,
+      checkedTypeNames,
+    }),
+  });
+  const ontologyAbsorbed = $derived(ontologyAbsorption(classHierarchies, checkedOntologyIds));
+  // Community bulk button state (spec §5 — FLAT, 2-state): all-grouped when every
+  // live community key is checked.
+  const allCommunitiesGrouped = $derived(
+    canGroupCommunity &&
+      communityInfo.live.length > 0 &&
+      communityInfo.live.every((c) => groupedSplit.communityKeys.includes(c.key)),
+  );
+  // Scope-specific "anything grouped" flags → native `disabled` on each
+  // section's Ungroup all (spec §4/§5).
+  const ontologyGrouped = $derived(hasOntologyGrouping(viewerState));
+  const communityGrouped = $derived(hasCommunityGrouping(viewerState));
   const scene = $derived(
     hasAnyGroup
       ? // B2/A4: the grouped scene is rebuilt from graph.json (no positions) —
@@ -233,6 +255,8 @@
     if (node.ontology_node_kind === "class") return groupKeyForOntology(node.id);
     if (node.community_node_kind === "community")
       return node.community_key != null ? groupKeyForCommunity(node.community_key) : null;
+    if (node.type_node_kind === "type")
+      return node.type_name != null ? groupKeyForType(node.type_name) : null;
     return null;
   }
   function handleToggleEntity(id) {
@@ -281,34 +305,63 @@
   function handleToggleGroupCommunity(communityKey) {
     viewerState = toggleGroupCommunity(viewerState, communityKey);
   }
-  function handleClearGrouping() {
-    viewerState = clearGrouping(viewerState);
-  }
-  // B2 / F8: BASELINE fold to an ontology level. Compute the exact class ids at
-  // the level from the taxonomy, then group exactly them (replacing prior
-  // ontology folds; community folds are untouched).
-  function handleFoldToLevel(level) {
-    viewerState = foldOntologyToLevel(viewerState, classIdsAtLevel(level));
+  // B2 (§2): a leaf TYPE row owns its OWN group-by checkbox (separate from the
+  // Type FILTER select). Checking it folds entities of that `type`.
+  function handleToggleGroupType(typeName) {
+    viewerState = toggleGroupType(viewerState, typeName);
     void ensureClassHierarchies();
+  }
+  // B2 (§4): clear ONLY the ontology scope (class + type keys). Community
+  // grouping survives — each section's `Ungroup all` is scope-local.
+  function handleClearOntologyGrouping() {
+    viewerState = clearOntologyGrouping(viewerState);
+  }
+  // B2 (§5): clear ONLY the community scope.
+  function handleClearCommunityGrouping() {
+    viewerState = clearCommunityGrouping(viewerState);
+  }
+
+  // B2 (§4): TRI-STATE bulk "Group all to <level>". By the level's current state:
+  //   none    → group every (non-absorbed) member at that level
+  //   all     → toggle OFF (ungroup the level — clears the ontology scope)
+  //   partial → complete to ALL (re-group every member at the level)
+  // For Domain/Sub-domain the members are class ids; for Type they are the
+  // taxonomy's `type` values.
+  function handleBulkLevel(level) {
+    const ls =
+      level === 0
+        ? ontologyLevelStates.domain
+        : level === 1
+          ? ontologyLevelStates.subDomain
+          : ontologyLevelStates.type;
+    if (ls.state === "all") {
+      // Toggle OFF: drop only the ontology scope (class + type keys).
+      viewerState = clearOntologyGrouping(viewerState);
+      return;
+    }
+    // none OR partial → group every member at the level (replaces ontology scope).
+    if (level === 2) {
+      viewerState = groupOntologyLevel(viewerState, 2, [], typeNamesInTaxonomy(classHierarchies));
+    } else {
+      viewerState = groupOntologyLevel(viewerState, level, classIdsAtLevel(classHierarchies, level));
+    }
+    void ensureClassHierarchies();
+  }
+
+  // B2 (§5): FLAT community bulk toggle — `Group all` groups every live
+  // community; when all are already grouped, the same button ungroups them.
+  function handleBulkCommunities() {
+    if (allCommunitiesGrouped) {
+      viewerState = clearCommunityGrouping(viewerState);
+    } else {
+      viewerState = groupAllCommunities(
+        viewerState,
+        communityInfo.live.map((c) => c.key),
+      );
+    }
   }
   function handleSetView(view) {
     viewerState = setActiveView(viewerState, view);
-  }
-
-  // B2 / F8: the class ids at a given ontology level (0=Domain, 1=Sub-domain,
-  // 2=Type), read from the class-hierarchies artifact. Used as the baseline set.
-  function classIdsAtLevel(level) {
-    const hs = classHierarchies?.hierarchies;
-    if (!hs) return [];
-    const out = [];
-    for (const h of Object.values(hs)) {
-      const classes = h?.classes_by_id;
-      if (!classes || typeof classes !== "object") continue;
-      for (const entry of Object.values(classes)) {
-        if (typeof entry?.id === "string" && (entry.level ?? 0) === level) out.push(entry.id);
-      }
-    }
-    return out;
   }
 
   async function ensureEntity(id) {
@@ -498,6 +551,11 @@
             groupBy={viewerState.options.groupBy}
             {canGroupOntology}
             {canGroupCommunity}
+            {ontologyLevelStates}
+            {ontologyAbsorbed}
+            {allCommunitiesGrouped}
+            {ontologyGrouped}
+            {communityGrouped}
             stats={scene.stats}
             onToggleType={handleToggleType}
             onToggleCommunity={handleToggleCommunity}
@@ -506,8 +564,11 @@
             onToggleWeak={handleToggleWeak}
             onToggleGroupOntology={handleToggleGroupOntology}
             onToggleGroupCommunity={handleToggleGroupCommunity}
-            onFoldToLevel={handleFoldToLevel}
-            onClearGrouping={handleClearGrouping}
+            onToggleGroupType={handleToggleGroupType}
+            onBulkLevel={handleBulkLevel}
+            onBulkCommunities={handleBulkCommunities}
+            onClearOntologyGrouping={handleClearOntologyGrouping}
+            onClearCommunityGrouping={handleClearCommunityGrouping}
           />
         </div>
         <div class="col col-center">

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -47,7 +47,9 @@
   import { loadWorkspace } from "./lib/sceneLoader.js";
   import {
     createDefaultViewerState,
-    normalizeGroupAxisAvailability,
+    splitGroupedKeys,
+    groupKeyForOntology,
+    groupKeyForCommunity,
     toggleType,
     toggleCommunity,
     toggleEntity,
@@ -57,10 +59,11 @@
     setActiveView,
     setQuery,
     setShowWeakLinks,
-    setGroupAxis,
-    toggleCollapse,
-    foldToLevel,
-    expandAll,
+    toggleGroupOntology,
+    toggleGroupCommunity,
+    toggleGroupItem,
+    foldOntologyToLevel,
+    clearGrouping,
   } from "./lib/viewerState.js";
 
   const EMPTY_GRAPH = { nodes: [], links: [] };
@@ -104,25 +107,28 @@
   // scene WITHOUT the raw graph (ÉTAPE 1b): on the light scene via
   // applyWeakFilter, or — in legacy fallback — by rebuilding from the graph.
 
-  // B2: the active group-by axis (none | community | ontology). `axis:"none"` is
-  // the FAST PATH and must be byte-identical to the pre-B2 default (A3).
-  const groupAxis = $derived(viewerState.options.groupBy.axis);
+  // B2 (per-item): the grouped item SET split back into its two engine inputs.
+  // An EMPTY set is the FAST PATH and must be byte-identical to the pre-B2
+  // default (A3). Several keys — mixing ontology classes and communities —
+  // collapse simultaneously.
+  const groupedSplit = $derived(splitGroupedKeys(viewerState.options.groupBy.grouped));
+  const hasOntologyGroup = $derived(groupedSplit.ontologyClassIds.length > 0);
+  const hasCommunityGroup = $derived(groupedSplit.communityKeys.length > 0);
+  const hasAnyGroup = $derived(hasOntologyGroup || hasCommunityGroup);
 
-  // B2 / C4: which axes the CURRENT graph + artifacts support. Ontology needs the
-  // class-hierarchies artifact; Community needs at least one live community. The
-  // picker omits absent axes; an unavailable persisted axis is downgraded by
-  // normalizeGroupAxisAvailability once the graph is in hand.
+  // C4: which kinds are AVAILABLE to group. Ontology needs the class-hierarchies
+  // artifact; Community needs at least one live community. The rail hides the
+  // checkbox affordance for an absent kind (and grouped keys for an unavailable
+  // kind simply contribute no collapse target — the engine ignores them).
   const communityInfo = $derived(communityStats(graph));
-  const availableAxes = $derived([
-    "none",
-    ...(communityInfo.liveCount > 0 ? ["community"] : []),
-    ...(classHierarchies?.hierarchies ? ["ontology"] : []),
-  ]);
+  const canGroupOntology = $derived(Boolean(classHierarchies?.hierarchies));
+  const canGroupCommunity = $derived(communityInfo.liveCount > 0);
 
   // B2 / A1+A2: mint the live community keys + their collision-safe synthetic ids
-  // + per-key tone ONCE, so the injector and the parent index agree on ids.
+  // + per-key tone ONCE, so the injector and the parent index agree on ids. Built
+  // only when at least one community is grouped (the injector is skipped otherwise).
   const communityCtx = $derived.by(() => {
-    if (groupAxis !== "community") return null;
+    if (!hasCommunityGroup) return null;
     const live = communityInfo.live;
     const liveKeys = live.map((c) => c.key);
     const idByKey = mintCommunityNodeIds(liveKeys, new Set((graph?.nodes ?? []).map((n) => n.id)));
@@ -136,40 +142,56 @@
     };
   });
 
-  // B2: axis-dispatched scene pipeline.
-  //   axis "none"      → fast path (applyWeakFilter / buildScene fallback) [A3]
-  //   axis "ontology"  → inject classes → applyGroupCollapse(ontology) → buildScene
-  //   axis "community" → inject communities → applyGroupCollapse(community) → buildScene
-  // A non-"none" axis abandons sceneData and runs force layout (A4 cost accepted).
+  // B2 (per-item): build ONE collapse over the UNION of every grouped item.
+  //   - inject ontology class nodes when any ontology class is grouped;
+  //   - inject community fold nodes when any community is grouped;
+  //   - merge their parent indexes + descendant maps;
+  //   - call applyGroupCollapse ONCE with the union of collapse targets.
+  // An empty grouped set is the fast path (returns the raw graph untouched, A3).
   const groupedGraph = $derived.by(() => {
-    if (groupAxis === "ontology") {
-      const injected = injectOntologyClassNodes(graph, classHierarchies, {
+    if (!hasAnyGroup) return graph;
+
+    let injected = graph;
+    const parentById = new Map();
+    const descendantsByTarget = new Map();
+    const collapseTargets = [];
+
+    if (hasOntologyGroup && classHierarchies?.hierarchies) {
+      injected = injectOntologyClassNodes(injected, classHierarchies, {
         levels: ontologyClassLevels,
       });
-      const ids = viewerState.options.groupBy.ontology.collapsedClassIds;
-      if (ids.length === 0) return injected;
-      const { parentById, descendantClassIds } = buildClassParentIndex(classHierarchies);
-      return applyGroupCollapse(injected, {
-        parentById,
-        collapseTargets: ids,
-        descendantsByTarget: descendantClassIds,
-      });
+      const { parentById: classParents, descendantClassIds } =
+        buildClassParentIndex(classHierarchies);
+      for (const [k, v] of classParents) parentById.set(k, v);
+      for (const [k, v] of descendantClassIds) descendantsByTarget.set(k, v);
+      for (const id of groupedSplit.ontologyClassIds) collapseTargets.push(id);
     }
-    if (groupAxis === "community" && communityCtx) {
-      const injected = injectCommunityNodes(graph, communityCtx);
-      const keys = viewerState.options.groupBy.community.collapsedKeys;
-      if (keys.length === 0) return injected;
-      const { parentById, descendantsByTarget, collapseTargetByKey } =
-        buildCommunityParentIndex(graph, communityCtx);
-      const collapseTargets = keys
-        .map((k) => collapseTargetByKey(k))
-        .filter((id) => typeof id === "string");
-      return applyGroupCollapse(injected, { parentById, collapseTargets, descendantsByTarget });
+
+    if (hasCommunityGroup && communityCtx) {
+      injected = injectCommunityNodes(injected, communityCtx);
+      const {
+        parentById: commParents,
+        descendantsByTarget: commDesc,
+        collapseTargetByKey,
+      } = buildCommunityParentIndex(injected, communityCtx);
+      for (const [k, v] of commParents) {
+        // Don't clobber an ontology parent mapping for a shared entity; the
+        // community membership only governs entities the ontology pass left
+        // unmapped (community nodes themselves are unmapped roots).
+        if (!parentById.has(k)) parentById.set(k, v);
+      }
+      for (const [k, v] of commDesc) descendantsByTarget.set(k, v);
+      for (const key of groupedSplit.communityKeys) {
+        const id = collapseTargetByKey(key);
+        if (typeof id === "string") collapseTargets.push(id);
+      }
     }
-    return graph;
+
+    if (collapseTargets.length === 0) return injected;
+    return applyGroupCollapse(injected, { parentById, collapseTargets, descendantsByTarget });
   });
   const scene = $derived(
-    groupAxis !== "none"
+    hasAnyGroup
       ? // B2/A4: the grouped scene is rebuilt from graph.json (no positions) —
         // attach a force layout so it doesn't render as a ring.
         attachForceLayout(
@@ -189,31 +211,33 @@
   function handleToggleCommunity(community) {
     viewerState = toggleCommunity(viewerState, community);
   }
-  // B2 / A2: a click on ANY group-synthetic node folds/unfolds it instead of
-  // selecting an entity. Ontology class nodes toggle by their id; community fold
-  // nodes toggle by their `community_key` field (NEVER the parsed id). Returns
-  // the toggle key when the node is a group node, else null (entity selection).
+  // B2 / A2: a click on ANY group-synthetic node UNGROUPS it instead of selecting
+  // an entity. Ontology class nodes toggle their namespaced ontology key (by id);
+  // community fold nodes toggle their namespaced community key (read from the
+  // `community_key` field, NEVER the parsed id). Returns the namespaced grouped
+  // key when the node is a group node, else null (entity selection).
   function groupNodeToggleKey(id) {
     const node = scene?.nodes?.find((n) => n.id === id);
     if (!node) return null;
-    if (node.ontology_node_kind === "class") return node.id;
-    if (node.community_node_kind === "community") return node.community_key ?? null;
+    if (node.ontology_node_kind === "class") return groupKeyForOntology(node.id);
+    if (node.community_node_kind === "community")
+      return node.community_key != null ? groupKeyForCommunity(node.community_key) : null;
     return null;
   }
   function handleToggleEntity(id) {
     const groupKey = groupNodeToggleKey(id);
     if (groupKey != null) {
-      viewerState = toggleCollapse(viewerState, groupKey);
+      viewerState = toggleGroupItem(viewerState, groupKey);
       return;
     }
     viewerState = toggleEntity(viewerState, id);
     if (viewerState.focusId) void ensureEntity(viewerState.focusId);
   }
   function handleFocusEntity(id) {
-    // Double-click on a group node = collapse toggle too (no entity detail).
+    // Double-click on a group node = ungroup toggle too (no entity detail).
     const groupKey = groupNodeToggleKey(id);
     if (groupKey != null) {
-      viewerState = toggleCollapse(viewerState, groupKey);
+      viewerState = toggleGroupItem(viewerState, groupKey);
       return;
     }
     viewerState = focusEntityAction(viewerState, id);
@@ -233,23 +257,28 @@
   function handleToggleWeak(value) {
     viewerState = setShowWeakLinks(viewerState, value);
   }
-  // B2: group-by axis callbacks (replace the ontology-class toggle).
-  function handleSetAxis(axis) {
-    viewerState = setGroupAxis(viewerState, axis);
-    // Ontology needs the class-hierarchies artifact; load it lazily the first
-    // time the axis is chosen (the derived scene re-runs once it lands).
-    if (axis === "ontology") void ensureClassHierarchies();
+  // B2 (per-item): group-by callbacks. Every groupable rail item owns a checkbox
+  // that GROUPS (collapses) the item when checked. Ontology classes and
+  // communities each toggle their own kind; the App splits the grouped set and
+  // collapses the union (handled in `groupedGraph`).
+  function handleToggleGroupOntology(classId) {
+    viewerState = toggleGroupOntology(viewerState, classId);
+    // Ontology grouping needs the class-hierarchies artifact; load it lazily the
+    // first time something ontology is grouped (the scene re-runs once it lands).
+    void ensureClassHierarchies();
   }
-  function handleToggleCollapse(key) {
-    viewerState = toggleCollapse(viewerState, key);
+  function handleToggleGroupCommunity(communityKey) {
+    viewerState = toggleGroupCommunity(viewerState, communityKey);
   }
-  function handleExpandAll() {
-    viewerState = expandAll(viewerState);
+  function handleClearGrouping() {
+    viewerState = clearGrouping(viewerState);
   }
   // B2 / F8: BASELINE fold to an ontology level. Compute the exact class ids at
-  // the level from the taxonomy, then SET them as the collapse set (not a union).
+  // the level from the taxonomy, then group exactly them (replacing prior
+  // ontology folds; community folds are untouched).
   function handleFoldToLevel(level) {
-    viewerState = foldToLevel(viewerState, classIdsAtLevel(level));
+    viewerState = foldOntologyToLevel(viewerState, classIdsAtLevel(level));
+    void ensureClassHierarchies();
   }
   function handleSetView(view) {
     viewerState = setActiveView(viewerState, view);
@@ -270,16 +299,6 @@
     }
     return out;
   }
-
-  // B2 / C4: availability coercion at the App seam (the only place with graph +
-  // artifact context). A persisted axis that the current graph no longer supports
-  // is downgraded → "none" WITHOUT wiping the per-axis collapse sets, so re-loading
-  // on a graph that does have the axis restores it. Idempotent; safe to run on
-  // every availableAxes change.
-  $effect(() => {
-    const next = normalizeGroupAxisAvailability(viewerState, availableAxes);
-    if (next !== viewerState) viewerState = next;
-  });
 
   async function ensureEntity(id) {
     if (!id || entityCache[id]) return;
@@ -336,14 +355,16 @@
     if (switching || !modelStore.select(id)) return;
     modelId = modelStore.activeId;
     switching = true;
-    // B2 regression fix: capture the active group-by axis BEFORE we drop the
-    // per-model artifacts. Nulling classHierarchies removes "ontology" from
-    // availableAxes, so the availability $effect downgrades the axis to "none"
-    // while the new model's taxonomy is in flight. We re-assert the intended
-    // axis once the artifact lands (below) IF it is available again, so a model
-    // switch within a multi-model bundle keeps an active Ontology grouping (the
-    // collapse set already survives in viewerState — only the axis was lost).
-    const intendedAxis = viewerState.options.groupBy.axis;
+    // B2 (per-item): the grouped item SET survives a model switch — it lives in
+    // viewerState.options.groupBy.grouped and clearSelection() below only touches
+    // the selection/focus, never the grouping. Capture whether any ONTOLOGY item
+    // is grouped so we can guarantee the per-model taxonomy is re-fetched
+    // (loadActiveModel does this eagerly anyway, but keep the intent explicit) —
+    // grouped ontology keys reference class ids that the new model's taxonomy must
+    // provide for the fold to take effect again.
+    const hadOntologyGroup = splitGroupedKeys(
+      viewerState.options.groupBy.grouped,
+    ).ontologyClassIds.length > 0;
     // The fetch base now points at the new model's dir; clear stale per-model
     // client state before re-loading.
     __resetEntitiesIndexCache();
@@ -355,16 +376,10 @@
     viewerState = clearSelection(viewerState);
     try {
       await loadActiveModel();
-      // Re-fetch eagerly if the ontology axis was active (else lazy). loadActiveModel
-      // already eagerly fetches class-hierarchies, so this is a cached no-op.
-      if (intendedAxis === "ontology") await ensureClassHierarchies();
-      // Restore the intended axis if the new model still supports it. A downgrade
-      // happened while the artifact was null; reassert now that availableAxes is
-      // up to date. normalizeGroupAxisAvailability is idempotent and keeps the axis
-      // only when it is genuinely available (else this re-asserts to a no-op).
-      if (intendedAxis !== viewerState.options.groupBy.axis && availableAxes.includes(intendedAxis)) {
-        viewerState = setGroupAxis(viewerState, intendedAxis);
-      }
+      // Re-fetch eagerly if any ontology item was grouped (else lazy).
+      // loadActiveModel already eagerly fetches class-hierarchies, so this is a
+      // cached no-op — but it guarantees the grouped ontology folds re-apply.
+      if (hadOntologyGroup) await ensureClassHierarchies();
     } finally {
       switching = false;
     }
@@ -470,17 +485,18 @@
             selection={viewerState.selection}
             showWeakLinks={viewerState.options.showWeakLinks}
             groupBy={viewerState.options.groupBy}
-            {availableAxes}
+            {canGroupOntology}
+            {canGroupCommunity}
             stats={scene.stats}
             onToggleType={handleToggleType}
             onToggleCommunity={handleToggleCommunity}
             onToggleEntity={handleToggleEntity}
             onSetQuery={handleSetQuery}
             onToggleWeak={handleToggleWeak}
-            onSetAxis={handleSetAxis}
-            onToggleCollapse={handleToggleCollapse}
+            onToggleGroupOntology={handleToggleGroupOntology}
+            onToggleGroupCommunity={handleToggleGroupCommunity}
             onFoldToLevel={handleFoldToLevel}
-            onExpandAll={handleExpandAll}
+            onClearGrouping={handleClearGrouping}
           />
         </div>
         <div class="col col-center">

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -124,12 +124,23 @@
   const canGroupOntology = $derived(Boolean(classHierarchies?.hierarchies));
   const canGroupCommunity = $derived(communityInfo.liveCount > 0);
 
-  // B2 / A1+A2: mint the live community keys + their collision-safe synthetic ids
-  // + per-key tone ONCE, so the injector and the parent index agree on ids. Built
-  // only when at least one community is grouped (the injector is skipped otherwise).
+  // B2 / A1+A2: mint the synthetic community fold ids + per-key tone ONCE, so the
+  // injector and the parent index agree on ids. Built only when at least one
+  // community is grouped (the injector is skipped otherwise).
+  //
+  // ROOT-CAUSE FIX (community grouping was broken): `liveKeys` is the set fed to
+  // `injectCommunityNodes` / `buildCommunityParentIndex`, which mint a fold node +
+  // re-parent members for EVERY key in it. Passing ALL live communities here
+  // injected an orphan box (plus its has_member edges) for every NON-grouped
+  // community — at mystery scale, checking ONE community spawned 120+ stray fold
+  // boxes and thousands of structural edges that never collapsed, so the graph
+  // visibly failed to "regroup". Restrict the set to the GROUPED ∩ LIVE keys: only
+  // the communities the user actually checked get a fold node, and they collapse.
   const communityCtx = $derived.by(() => {
     if (!hasCommunityGroup) return null;
-    const live = communityInfo.live;
+    const groupedSet = new Set(groupedSplit.communityKeys);
+    const live = communityInfo.live.filter((c) => groupedSet.has(c.key));
+    if (live.length === 0) return null;
     const liveKeys = live.map((c) => c.key);
     const idByKey = mintCommunityNodeIds(liveKeys, new Set((graph?.nodes ?? []).map((n) => n.id)));
     const toneKeyByKey = new Map(live.map((c) => [c.key, c.groupKey ?? c.key]));

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -10,7 +10,7 @@
    * architecture.
    */
   import { onMount } from "svelte";
-  import { AppChrome, Button, Badge, ButtonGroup, Select } from "@sentropic/design-system-svelte";
+  import { AppChrome, Button, ButtonGroup, Select } from "@sentropic/design-system-svelte";
 
   import GraphCanvas from "./components/GraphCanvas.svelte";
   import LeftRail from "./components/LeftRail.svelte";
@@ -32,11 +32,22 @@
     applyWeakFilter,
     attachForceLayout,
     resolveSelectedIds,
+    communityStats,
+    nodeCommunity,
   } from "./lib/graphAdapter.js";
-  import { injectOntologyClassNodes, applyOntologyCollapse } from "./lib/classNodes.js";
+  import {
+    injectOntologyClassNodes,
+    applyOntologyCollapse,
+    applyGroupCollapse,
+    buildClassParentIndex,
+    injectCommunityNodes,
+    buildCommunityParentIndex,
+    mintCommunityNodeIds,
+  } from "./lib/classNodes.js";
   import { loadWorkspace } from "./lib/sceneLoader.js";
   import {
     createDefaultViewerState,
+    normalizeGroupAxisAvailability,
     toggleType,
     toggleCommunity,
     toggleEntity,
@@ -46,9 +57,10 @@
     setActiveView,
     setQuery,
     setShowWeakLinks,
-    setShowOntologyClasses,
-    toggleCollapseClass,
-    expandAllClasses,
+    setGroupAxis,
+    toggleCollapse,
+    foldToLevel,
+    expandAll,
   } from "./lib/viewerState.js";
 
   const EMPTY_GRAPH = { nodes: [], links: [] };
@@ -91,38 +103,81 @@
   // selectedIds/focusId (no re-layout). The weak-link toggle re-filters the
   // scene WITHOUT the raw graph (ÉTAPE 1b): on the light scene via
   // applyWeakFilter, or — in legacy fallback — by rebuilding from the graph.
-  //
-  // EVOL 2.a: when "Show ontology classes" is ON we cannot reuse the light
-  // sceneData fast-path — synthetic class nodes + has_instance edges must enter
-  // BEFORE buildScene so degrees / god-class / the weak filter all operate on
-  // the displayed topology. So we inject into the raw graph and rebuild. The
-  // injection is a no-op (returns the graph unchanged) when the artifact is
-  // absent or the graph has not hydrated yet, so this stays robust during load.
-  const ontologyGraph = $derived(
-    viewerState.options.showOntologyClasses
-      ? injectOntologyClassNodes(graph, classHierarchies, { levels: ontologyClassLevels })
-      : graph,
-  );
-  // EVOL 2.b/2.d: once one or more classes are folded, collapse the injected
-  // graph (re-endpoint edges to the nearest visible ancestor, fold the subtree)
-  // BEFORE buildScene so degrees / god-class / the weak filter all operate on the
-  // collapsed topology. An empty collapsed set returns the graph unchanged.
-  const collapsedGraph = $derived(
-    viewerState.options.showOntologyClasses && viewerState.options.collapsedClassIds.length > 0
-      ? applyOntologyCollapse(ontologyGraph, classHierarchies, {
-          collapsedClassIds: viewerState.options.collapsedClassIds,
-        })
-      : ontologyGraph,
-  );
+
+  // B2: the active group-by axis (none | community | ontology). `axis:"none"` is
+  // the FAST PATH and must be byte-identical to the pre-B2 default (A3).
+  const groupAxis = $derived(viewerState.options.groupBy.axis);
+
+  // B2 / C4: which axes the CURRENT graph + artifacts support. Ontology needs the
+  // class-hierarchies artifact; Community needs at least one live community. The
+  // picker omits absent axes; an unavailable persisted axis is downgraded by
+  // normalizeGroupAxisAvailability once the graph is in hand.
+  const communityInfo = $derived(communityStats(graph));
+  const availableAxes = $derived([
+    "none",
+    ...(communityInfo.liveCount > 0 ? ["community"] : []),
+    ...(classHierarchies?.hierarchies ? ["ontology"] : []),
+  ]);
+
+  // B2 / A1+A2: mint the live community keys + their collision-safe synthetic ids
+  // + per-key tone ONCE, so the injector and the parent index agree on ids.
+  const communityCtx = $derived.by(() => {
+    if (groupAxis !== "community") return null;
+    const live = communityInfo.live;
+    const liveKeys = live.map((c) => c.key);
+    const idByKey = mintCommunityNodeIds(liveKeys, new Set((graph?.nodes ?? []).map((n) => n.id)));
+    const toneKeyByKey = new Map(live.map((c) => [c.key, c.groupKey ?? c.key]));
+    return {
+      liveKeys,
+      idByKey,
+      communityOf: nodeCommunity,
+      toneKeyOf: (k) => toneKeyByKey.get(k),
+      labelOf: (k) => k,
+    };
+  });
+
+  // B2: axis-dispatched scene pipeline.
+  //   axis "none"      → fast path (applyWeakFilter / buildScene fallback) [A3]
+  //   axis "ontology"  → inject classes → applyGroupCollapse(ontology) → buildScene
+  //   axis "community" → inject communities → applyGroupCollapse(community) → buildScene
+  // A non-"none" axis abandons sceneData and runs force layout (A4 cost accepted).
+  const groupedGraph = $derived.by(() => {
+    if (groupAxis === "ontology") {
+      const injected = injectOntologyClassNodes(graph, classHierarchies, {
+        levels: ontologyClassLevels,
+      });
+      const ids = viewerState.options.groupBy.ontology.collapsedClassIds;
+      if (ids.length === 0) return injected;
+      const { parentById, descendantClassIds } = buildClassParentIndex(classHierarchies);
+      return applyGroupCollapse(injected, {
+        parentById,
+        collapseTargets: ids,
+        descendantsByTarget: descendantClassIds,
+      });
+    }
+    if (groupAxis === "community" && communityCtx) {
+      const injected = injectCommunityNodes(graph, communityCtx);
+      const keys = viewerState.options.groupBy.community.collapsedKeys;
+      if (keys.length === 0) return injected;
+      const { parentById, descendantsByTarget, collapseTargetByKey } =
+        buildCommunityParentIndex(graph, communityCtx);
+      const collapseTargets = keys
+        .map((k) => collapseTargetByKey(k))
+        .filter((id) => typeof id === "string");
+      return applyGroupCollapse(injected, { parentById, collapseTargets, descendantsByTarget });
+    }
+    return graph;
+  });
   const scene = $derived(
-    viewerState.options.showOntologyClasses
-      ? // EVOL 2.a/2.b: the class/collapse scene is rebuilt from graph.json (no
-        // positions) — attach a force layout so it doesn't render as a ring.
+    groupAxis !== "none"
+      ? // B2/A4: the grouped scene is rebuilt from graph.json (no positions) —
+        // attach a force layout so it doesn't render as a ring.
         attachForceLayout(
-          buildScene(collapsedGraph, { showWeakLinks: viewerState.options.showWeakLinks }),
+          buildScene(groupedGraph, { showWeakLinks: viewerState.options.showWeakLinks }),
         )
       : sceneData
-        ? applyWeakFilter(sceneData, viewerState.options.showWeakLinks)
+        ? // A3 FAST PATH — byte-identical to the pre-B2 default-off.
+          applyWeakFilter(sceneData, viewerState.options.showWeakLinks)
         : buildScene(graph, { showWeakLinks: viewerState.options.showWeakLinks }),
   );
   // Graph highlight = every entity of every selected type/community + the
@@ -134,31 +189,35 @@
   function handleToggleCommunity(community) {
     viewerState = toggleCommunity(viewerState, community);
   }
-  // EVOL 2.b/2.d: a click on a CLASS node folds/unfolds its subtree instead of
-  // selecting it as an entity. We branch on the displayed node's kind (the scene
-  // carries ontology_node_kind through from injectOntologyClassNodes).
-  function sceneNodeKind(id) {
-    return scene?.nodes?.find((n) => n.id === id)?.ontology_node_kind ?? null;
+  // B2 / A2: a click on ANY group-synthetic node folds/unfolds it instead of
+  // selecting an entity. Ontology class nodes toggle by their id; community fold
+  // nodes toggle by their `community_key` field (NEVER the parsed id). Returns
+  // the toggle key when the node is a group node, else null (entity selection).
+  function groupNodeToggleKey(id) {
+    const node = scene?.nodes?.find((n) => n.id === id);
+    if (!node) return null;
+    if (node.ontology_node_kind === "class") return node.id;
+    if (node.community_node_kind === "community") return node.community_key ?? null;
+    return null;
   }
   function handleToggleEntity(id) {
-    if (sceneNodeKind(id) === "class") {
-      viewerState = toggleCollapseClass(viewerState, id);
+    const groupKey = groupNodeToggleKey(id);
+    if (groupKey != null) {
+      viewerState = toggleCollapse(viewerState, groupKey);
       return;
     }
     viewerState = toggleEntity(viewerState, id);
     if (viewerState.focusId) void ensureEntity(viewerState.focusId);
   }
   function handleFocusEntity(id) {
-    // Double-click on a class node = collapse toggle too (no entity detail).
-    if (sceneNodeKind(id) === "class") {
-      viewerState = toggleCollapseClass(viewerState, id);
+    // Double-click on a group node = collapse toggle too (no entity detail).
+    const groupKey = groupNodeToggleKey(id);
+    if (groupKey != null) {
+      viewerState = toggleCollapse(viewerState, groupKey);
       return;
     }
     viewerState = focusEntityAction(viewerState, id);
     void ensureEntity(id);
-  }
-  function handleExpandAllClasses() {
-    viewerState = expandAllClasses(viewerState);
   }
   function handleSetFocus(id) {
     // Expand/collapse the right-column entity detail (null = collapse).
@@ -174,15 +233,53 @@
   function handleToggleWeak(value) {
     viewerState = setShowWeakLinks(viewerState, value);
   }
-  function handleToggleOntologyClasses(value) {
-    viewerState = setShowOntologyClasses(viewerState, value);
-    // Lazily load the artifact the first time the toggle is switched on; the
-    // derived scene re-runs once it lands (no-op injection until then).
-    if (value) void ensureClassHierarchies();
+  // B2: group-by axis callbacks (replace the ontology-class toggle).
+  function handleSetAxis(axis) {
+    viewerState = setGroupAxis(viewerState, axis);
+    // Ontology needs the class-hierarchies artifact; load it lazily the first
+    // time the axis is chosen (the derived scene re-runs once it lands).
+    if (axis === "ontology") void ensureClassHierarchies();
+  }
+  function handleToggleCollapse(key) {
+    viewerState = toggleCollapse(viewerState, key);
+  }
+  function handleExpandAll() {
+    viewerState = expandAll(viewerState);
+  }
+  // B2 / F8: BASELINE fold to an ontology level. Compute the exact class ids at
+  // the level from the taxonomy, then SET them as the collapse set (not a union).
+  function handleFoldToLevel(level) {
+    viewerState = foldToLevel(viewerState, classIdsAtLevel(level));
   }
   function handleSetView(view) {
     viewerState = setActiveView(viewerState, view);
   }
+
+  // B2 / F8: the class ids at a given ontology level (0=Domain, 1=Sub-domain,
+  // 2=Type), read from the class-hierarchies artifact. Used as the baseline set.
+  function classIdsAtLevel(level) {
+    const hs = classHierarchies?.hierarchies;
+    if (!hs) return [];
+    const out = [];
+    for (const h of Object.values(hs)) {
+      const classes = h?.classes_by_id;
+      if (!classes || typeof classes !== "object") continue;
+      for (const entry of Object.values(classes)) {
+        if (typeof entry?.id === "string" && (entry.level ?? 0) === level) out.push(entry.id);
+      }
+    }
+    return out;
+  }
+
+  // B2 / C4: availability coercion at the App seam (the only place with graph +
+  // artifact context). A persisted axis that the current graph no longer supports
+  // is downgraded → "none" WITHOUT wiping the per-axis collapse sets, so re-loading
+  // on a graph that does have the axis restores it. Idempotent; safe to run on
+  // every availableAxes change.
+  $effect(() => {
+    const next = normalizeGroupAxisAvailability(viewerState, availableAxes);
+    if (next !== viewerState) viewerState = next;
+  });
 
   async function ensureEntity(id) {
     if (!id || entityCache[id]) return;
@@ -250,8 +347,8 @@
     viewerState = clearSelection(viewerState);
     try {
       await loadActiveModel();
-      // Re-fetch eagerly if the toggle is currently on (otherwise it stays lazy).
-      if (viewerState.options.showOntologyClasses) await ensureClassHierarchies();
+      // Re-fetch eagerly if the ontology axis is currently active (else lazy).
+      if (viewerState.options.groupBy.axis === "ontology") await ensureClassHierarchies();
     } finally {
       switching = false;
     }
@@ -330,13 +427,6 @@
           </Select>
         </span>
       {/if}
-      {#if loaded && !loadError}
-        <span class="app-stats" aria-label="Graph summary">
-          <Badge tone="neutral">{scene.stats.nodeCount} nodes</Badge>
-          <Badge tone="neutral">{scene.stats.edgeCount} edges</Badge>
-          <Badge tone="info">{scene.stats.communityCount} groups</Badge>
-        </span>
-      {/if}
     {/snippet}
   </AppChrome>
 
@@ -363,15 +453,18 @@
             query={viewerState.query}
             selection={viewerState.selection}
             showWeakLinks={viewerState.options.showWeakLinks}
-            showOntologyClasses={viewerState.options.showOntologyClasses}
-            collapsedClassCount={viewerState.options.collapsedClassIds.length}
+            groupBy={viewerState.options.groupBy}
+            {availableAxes}
+            stats={scene.stats}
             onToggleType={handleToggleType}
             onToggleCommunity={handleToggleCommunity}
             onToggleEntity={handleToggleEntity}
             onSetQuery={handleSetQuery}
             onToggleWeak={handleToggleWeak}
-            onToggleOntologyClasses={handleToggleOntologyClasses}
-            onExpandAllClasses={handleExpandAllClasses}
+            onSetAxis={handleSetAxis}
+            onToggleCollapse={handleToggleCollapse}
+            onFoldToLevel={handleFoldToLevel}
+            onExpandAll={handleExpandAll}
           />
         </div>
         <div class="col col-center">
@@ -435,13 +528,6 @@
   .view-label--compact {
     display: none;
   }
-  .app-stats {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--st-spacing-2, 0.5rem);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-  }
   .app-body {
     flex: 1;
     min-height: 0;
@@ -480,12 +566,6 @@
     }
     .col-center {
       height: 70vh;
-    }
-  }
-
-  @media (max-width: 720px) {
-    .app-stats {
-      display: none;
     }
   }
 

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -336,6 +336,14 @@
     if (switching || !modelStore.select(id)) return;
     modelId = modelStore.activeId;
     switching = true;
+    // B2 regression fix: capture the active group-by axis BEFORE we drop the
+    // per-model artifacts. Nulling classHierarchies removes "ontology" from
+    // availableAxes, so the availability $effect downgrades the axis to "none"
+    // while the new model's taxonomy is in flight. We re-assert the intended
+    // axis once the artifact lands (below) IF it is available again, so a model
+    // switch within a multi-model bundle keeps an active Ontology grouping (the
+    // collapse set already survives in viewerState — only the axis was lost).
+    const intendedAxis = viewerState.options.groupBy.axis;
     // The fetch base now points at the new model's dir; clear stale per-model
     // client state before re-loading.
     __resetEntitiesIndexCache();
@@ -347,8 +355,16 @@
     viewerState = clearSelection(viewerState);
     try {
       await loadActiveModel();
-      // Re-fetch eagerly if the ontology axis is currently active (else lazy).
-      if (viewerState.options.groupBy.axis === "ontology") await ensureClassHierarchies();
+      // Re-fetch eagerly if the ontology axis was active (else lazy). loadActiveModel
+      // already eagerly fetches class-hierarchies, so this is a cached no-op.
+      if (intendedAxis === "ontology") await ensureClassHierarchies();
+      // Restore the intended axis if the new model still supports it. A downgrade
+      // happened while the artifact was null; reassert now that availableAxes is
+      // up to date. normalizeGroupAxisAvailability is idempotent and keeps the axis
+      // only when it is genuinely available (else this re-asserts to a no-op).
+      if (intendedAxis !== viewerState.options.groupBy.axis && availableAxes.includes(intendedAxis)) {
+        viewerState = setGroupAxis(viewerState, intendedAxis);
+      }
     } finally {
       switching = false;
     }

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -203,7 +203,7 @@
     </span>
   </div>
 
-  <Collapsible title="Ontology" open={false}>
+  <Collapsible title="Ontology" open={true}>
     {#snippet trailing()}
       <Badge shape="circle" size="sm" tone="neutral">{typeList.length}</Badge>
     {/snippet}
@@ -211,8 +211,8 @@
       <p class="rail-empty">No types.</p>
     {:else if typeTree}
       <!-- EVOL: nested Domain → Sub-domain → Type accordions (taxonomy-driven).
-           B2 (per-item): each Ontology CLASS node (Domain + Sub-domain) carries a
-           hover-revealed GROUP-BY checkbox in its header. Checking it GROUPS
+           B2 (per-item): each Ontology CLASS node (Domain + Sub-domain) carries an
+           always-visible GROUP-BY checkbox in its header. Checking it GROUPS
            (collapses) that class; the FILTER facet (leaf Type SelectableRows →
            onToggleType) stays a SEPARATE concern. -->
       <ul class="rail-type-groups rail-onto-tree" aria-label="Ontology classes">
@@ -327,7 +327,7 @@
     {/if}
   </Collapsible>
 
-  <Collapsible title="Communities" open={false}>
+  <Collapsible title="Communities" open={true}>
     {#snippet trailing()}
       <Badge shape="circle" size="sm" tone="neutral">{communityInfo.liveCount}</Badge>
     {/snippet}
@@ -353,7 +353,7 @@
               {#snippet trailing()}
                 <span class="rail-onto-trailing">
                   <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
-                  <!-- B2 (per-item): hover-revealed GROUP-BY checkbox. Checking it
+                  <!-- B2 (per-item): always-visible GROUP-BY checkbox. Checking it
                        GROUPS (collapses) the community; the row's own SELECT
                        (onToggleCommunity, filter) stays a separate concern. -->
                   <label
@@ -567,16 +567,16 @@
   .rail-onto-tree {
     margin-top: 0.15rem;
   }
-  /* B2 (per-item): the per-item GROUP-BY checkbox affordance. The "group" hint
-     label is hidden until the row is hovered (or the box is already checked), so
-     the rail stays calm; a checked box keeps the affordance visible as feedback. */
+  /* B2 (per-item): the per-item GROUP-BY checkbox affordance. The checkbox is
+     ALWAYS visible to the left of/inline with each groupable row so the feature
+     is discoverable at rest; hover/focus/checked only ENHANCES the "group" hint
+     text (it is never the only way to see the box). */
   .rail-group-check {
     display: inline-flex;
     align-items: center;
     gap: 0.2rem;
     cursor: pointer;
-    opacity: 0;
-    transition: opacity 0.12s ease;
+    opacity: 1;
   }
   .rail-group-check input {
     margin: 0;
@@ -587,17 +587,20 @@
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--st-semantic-text-muted, #64748b);
+    opacity: 0.55;
+    transition: opacity 0.12s ease, color 0.12s ease;
   }
-  /* Reveal on hover of the enclosing row, on keyboard focus, or when checked. */
-  :global(.st-collapsible__header:hover) .rail-group-check,
-  :global(.st-selectableRow:hover) .rail-group-check,
-  .rail-group-check:focus-within,
-  .rail-group-check--on {
+  /* Subtle hover/focus enhancement: bring the "group" hint forward. The checkbox
+     itself stays visible at rest, so this is additive affordance only. */
+  :global(.st-collapsible__header:hover) .rail-group-check .rail-group-hint,
+  :global(.st-selectableRow:hover) .rail-group-check .rail-group-hint,
+  .rail-group-check:focus-within .rail-group-hint {
     opacity: 1;
   }
   .rail-group-check--on .rail-group-hint {
     color: var(--st-semantic-action-primary, #2563eb);
     font-weight: 600;
+    opacity: 1;
   }
   .rail-fold-bulk {
     display: flex;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -387,8 +387,8 @@
       Show weak (inferred) links
     </label>
 
-    <!-- B2 / C1+F1: the "Show ontology classes" checkbox is GONE — group-by is a
-         nested sub-menu with an axis selector (None · Community · Ontology). -->
+    <!-- B2 / C1+F1: the legacy ontology-class checkbox is removed (F2) — group-by
+         is a nested sub-menu with an axis selector (None / Community / Ontology). -->
     <Collapsible title="Group by" open={false} size="sm">
       {#snippet trailing()}
         <Badge shape="circle" size="sm" tone="neutral">{groupBy.axis}</Badge>

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -232,7 +232,7 @@
     </span>
   </div>
 
-  <Collapsible title="Types" open={false}>
+  <Collapsible title="Ontology" open={false}>
     {#snippet trailing()}
       <Badge shape="circle" size="sm" tone="neutral">{typeList.length}</Badge>
     {/snippet}
@@ -284,7 +284,7 @@
     {:else}
       <SelectableList
         class="rail-list"
-        label="Types"
+        label="Ontology"
         multiple
         value={selection.types}
         onchange={(next) => onListChange(selection.types, next, onToggleType)}

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -27,9 +27,15 @@
     query = "",
     selection = { types: [], communities: [], entities: [] },
     showWeakLinks = true,
-    // B2: axis-scoped group-by state + the axes the current graph supports.
-    groupBy = { axis: "none", ontology: { collapsedClassIds: [] }, community: { collapsedKeys: [] } },
-    availableAxes = ["none"],
+    // B2 (per-item): the grouped item SET — namespaced keys
+    // ("ontology:<classId>" | "community:<key>"). Every checked rail item adds
+    // one key; checking GROUPS (collapses) it. Multi-select is the default.
+    groupBy = { grouped: [] },
+    // Which kinds are AVAILABLE to group (C4): ontology needs the taxonomy,
+    // community needs ≥1 live community. The checkbox affordance is hidden for an
+    // absent kind.
+    canGroupOntology = false,
+    canGroupCommunity = false,
     // The scene's count badges (relocated under the search bar).
     stats = { nodeCount: 0, edgeCount: 0, communityCount: 0 },
     onToggleType,
@@ -37,32 +43,36 @@
     onToggleEntity,
     onSetQuery,
     onToggleWeak,
-    // B2 group-by callbacks (replace the ontology-class toggle).
-    onSetAxis,
-    onToggleCollapse,
+    // B2 (per-item) group-by callbacks.
+    onToggleGroupOntology,
+    onToggleGroupCommunity,
     onFoldToLevel,
-    onExpandAll,
+    onClearGrouping,
   } = $props();
 
   const typeList = $derived(groupCounts(graph, nodeType));
   // Communities excluding degree-0 singletons (folded into `isolatedCount`).
   const communityInfo = $derived(communityStats(graph));
 
-  // B2: which axes the picker offers (omit absent axes, C4). "none" always shown.
-  const axisAvailable = $derived(new Set(availableAxes));
-  const showCommunityAxis = $derived(axisAvailable.has("community"));
-  const showOntologyAxis = $derived(axisAvailable.has("ontology"));
-
-  // B2: the active axis's folded set, for per-row glyphs/state.
-  const ontologyFolded = $derived(new Set(groupBy.ontology?.collapsedClassIds ?? []));
-  const communityFolded = $derived(new Set(groupBy.community?.collapsedKeys ?? []));
-  const activeFoldedCount = $derived(
-    groupBy.axis === "ontology"
-      ? ontologyFolded.size
-      : groupBy.axis === "community"
-        ? communityFolded.size
-        : 0,
+  // B2 (per-item): split the namespaced grouped SET into per-row membership sets.
+  // A class/community is "grouped" when its namespaced key is present. Mixing
+  // ontology + community keys is allowed; both render their checked state here.
+  const groupedSet = $derived(new Set(groupBy.grouped ?? []));
+  const ontologyGrouped = $derived(
+    new Set(
+      (groupBy.grouped ?? [])
+        .filter((k) => typeof k === "string" && k.startsWith("ontology:"))
+        .map((k) => k.slice("ontology:".length)),
+    ),
   );
+  const communityGrouped = $derived(
+    new Set(
+      (groupBy.grouped ?? [])
+        .filter((k) => typeof k === "string" && k.startsWith("community:"))
+        .map((k) => k.slice("community:".length)),
+    ),
+  );
+  const groupedCount = $derived(groupedSet.size);
 
   const typeSet = $derived(new Set(selection.types));
   // EVOL: nested Domain → Sub-domain → Type tree from the ontology class
@@ -139,45 +149,6 @@
   const totalNodeCount = $derived(graphNodes(graph).length);
   const hasQuery = $derived(query.trim().length > 0);
 
-  // B2 / C2: the ontology FOLD tree (per-node "fold here" pills + glyphs), built
-  // from the same taxonomy the Types facet uses but rendered as fold controls, not
-  // selectable rows (the §Two-Concepts separation device). Domains/sub-domains get
-  // a fold pill; leaf Type rows are read-only in v1 (F5 deferred).
-  const foldTree = $derived.by(() => {
-    const hs = classHierarchies?.hierarchies;
-    if (!hs) return null;
-    const h = hs[Object.keys(hs)[0]];
-    if (!h?.classes_by_id || !(h.root_class_ids?.length)) return null;
-    const classes = h.classes_by_id;
-    const countByType = new Map(typeList.map((t) => [t.key, t.count]));
-    const labelOf = (id) => classes[id]?.label || String(id).replace(/^class:/, "");
-    const domains = h.root_class_ids
-      .map((rootId) => {
-        const subs = (classes[rootId]?.child_ids ?? [])
-          .map((subId) => {
-            const types = (classes[subId]?.member_node_types ?? []).map((t) => ({
-              key: t,
-              count: countByType.get(t) ?? 0,
-            }));
-            return {
-              id: subId,
-              label: labelOf(subId),
-              types,
-              count: types.reduce((n, t) => n + t.count, 0),
-            };
-          })
-          .filter((s) => s.types.length);
-        return {
-          id: rootId,
-          label: labelOf(rootId),
-          subs,
-          count: subs.reduce((n, s) => n + s.count, 0),
-        };
-      })
-      .filter((d) => d.subs.length);
-    return domains;
-  });
-
   // Communities + Entities use STANDALONE SelectableRows (selected/onselect), so
   // they need the selection-membership sets for the per-row `selected` flag.
   // (Types uses a SelectableList controlled by selection.types — see below.)
@@ -239,20 +210,57 @@
     {#if typeList.length === 0}
       <p class="rail-empty">No types.</p>
     {:else if typeTree}
-      <!-- EVOL: nested Domain → Sub-domain → Type accordions (taxonomy-driven). -->
-      <ul class="rail-type-groups">
+      <!-- EVOL: nested Domain → Sub-domain → Type accordions (taxonomy-driven).
+           B2 (per-item): each Ontology CLASS node (Domain + Sub-domain) carries a
+           hover-revealed GROUP-BY checkbox in its header. Checking it GROUPS
+           (collapses) that class; the FILTER facet (leaf Type SelectableRows →
+           onToggleType) stays a SEPARATE concern. -->
+      <ul class="rail-type-groups rail-onto-tree" aria-label="Ontology classes">
         {#each typeTree as domain (domain.id)}
           <li>
             <Collapsible title={domain.label} open={false} size="sm">
               {#snippet trailing()}
-                <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
+                <span class="rail-onto-trailing">
+                  <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
+                  <label
+                    class="rail-group-check"
+                    class:rail-group-check--on={ontologyGrouped.has(domain.id)}
+                    title="Group by {domain.label}"
+                    onclick={(e) => e.stopPropagation()}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={ontologyGrouped.has(domain.id)}
+                      aria-label="Group by {domain.label}"
+                      onchange={() => onToggleGroupOntology?.(domain.id)}
+                    />
+                    <span class="rail-group-hint" aria-hidden="true">group</span>
+                  </label>
+                </span>
               {/snippet}
               <ul class="rail-type-groups">
                 {#each domain.subs as sub (sub.id)}
                   <li>
                     <Collapsible title={sub.label} open={false} size="sm">
                       {#snippet trailing()}
-                        <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
+                        <span class="rail-onto-trailing">
+                          <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
+                          <label
+                            class="rail-group-check"
+                            class:rail-group-check--on={ontologyGrouped.has(sub.id)}
+                            title="Group by {sub.label}"
+                            onclick={(e) => e.stopPropagation()}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={ontologyGrouped.has(sub.id)}
+                              disabled={ontologyGrouped.has(domain.id)}
+                              aria-label="Group by {sub.label}"
+                              onchange={() => onToggleGroupOntology?.(sub.id)}
+                            />
+                            <span class="rail-group-hint" aria-hidden="true">group</span>
+                          </label>
+                        </span>
                       {/snippet}
                       <ul class="rail-list">
                         {#each sub.types as t (t.key)}
@@ -281,6 +289,21 @@
           </li>
         {/each}
       </ul>
+      <!-- B2 / F8: bulk baseline fold + an ungroup-all reset, scoped to the
+           Ontology facet (only shown when the taxonomy supports grouping). -->
+      {#if canGroupOntology}
+        <div class="rail-fold-bulk">
+          <span class="rail-fold-bulk-label">Group all to:</span>
+          <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(0)}>Domain</button>
+          <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(1)}>Sub-domain</button>
+          <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(2)}>Type</button>
+        </div>
+      {/if}
+      {#if groupedCount > 0}
+        <button type="button" class="rail-reset-btn" onclick={() => onClearGrouping?.()}>
+          Ungroup all ({groupedCount} grouped)
+        </button>
+      {/if}
     {:else}
       <SelectableList
         class="rail-list"
@@ -328,7 +351,26 @@
               {/snippet}
               {c.key}
               {#snippet trailing()}
-                <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
+                <span class="rail-onto-trailing">
+                  <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
+                  <!-- B2 (per-item): hover-revealed GROUP-BY checkbox. Checking it
+                       GROUPS (collapses) the community; the row's own SELECT
+                       (onToggleCommunity, filter) stays a separate concern. -->
+                  <label
+                    class="rail-group-check"
+                    class:rail-group-check--on={communityGrouped.has(c.key)}
+                    title="Group by {c.key}"
+                    onclick={(e) => e.stopPropagation()}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={communityGrouped.has(c.key)}
+                      aria-label="Group by {c.key}"
+                      onchange={() => onToggleGroupCommunity?.(c.key)}
+                    />
+                    <span class="rail-group-hint" aria-hidden="true">group</span>
+                  </label>
+                </span>
               {/snippet}
             </SelectableRow>
           </li>
@@ -387,154 +429,11 @@
       Show weak (inferred) links
     </label>
 
-    <!-- B2 / C1+F1: the legacy ontology-class checkbox is removed (F2) — group-by
-         is a nested sub-menu with an axis selector (None / Community / Ontology). -->
-    <Collapsible title="Group by" open={false} size="sm">
-      {#snippet trailing()}
-        <Badge shape="circle" size="sm" tone="neutral">{groupBy.axis}</Badge>
-      {/snippet}
-
-      <div class="rail-axis" role="radiogroup" aria-label="Group-by axis">
-        <button
-          type="button"
-          class="rail-axis-btn"
-          role="radio"
-          aria-checked={groupBy.axis === "none"}
-          class:rail-axis-btn--on={groupBy.axis === "none"}
-          onclick={() => onSetAxis?.("none")}
-        >None</button>
-        {#if showCommunityAxis}
-          <button
-            type="button"
-            class="rail-axis-btn"
-            role="radio"
-            aria-checked={groupBy.axis === "community"}
-            class:rail-axis-btn--on={groupBy.axis === "community"}
-            onclick={() => onSetAxis?.("community")}
-          >Community</button>
-        {/if}
-        {#if showOntologyAxis}
-          <button
-            type="button"
-            class="rail-axis-btn"
-            role="radio"
-            aria-checked={groupBy.axis === "ontology"}
-            class:rail-axis-btn--on={groupBy.axis === "ontology"}
-            onclick={() => onSetAxis?.("ontology")}
-          >Ontology</button>
-        {/if}
-      </div>
-
-      {#if groupBy.axis === "ontology"}
-        <p class="rail-facet-hint">Collapse the graph at any class — folding re-lays out the graph.</p>
-        {#if foldTree}
-          <div class="rail-fold-tree" aria-label="Collapse the graph at">
-            {#each foldTree as domain (domain.id)}
-              <Collapsible title={domain.label} open={false} size="sm">
-                {#snippet trailing()}
-                  <span class="rail-fold-trailing">
-                    <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
-                    <button
-                      type="button"
-                      class="rail-fold-pill"
-                      class:rail-fold-pill--on={ontologyFolded.has(domain.id)}
-                      aria-pressed={ontologyFolded.has(domain.id)}
-                      onclick={(e) => { e.stopPropagation(); onToggleCollapse?.(domain.id); }}
-                    >
-                      <span class="rail-fold-glyph" aria-hidden="true"
-                        >{ontologyFolded.has(domain.id) ? "●" : "◯"}</span
-                      >{ontologyFolded.has(domain.id) ? "folded" : "fold"}
-                    </button>
-                  </span>
-                {/snippet}
-                <ul class="rail-type-groups">
-                  {#each domain.subs as sub (sub.id)}
-                    <li>
-                      <Collapsible title={sub.label} open={false} size="sm">
-                        {#snippet trailing()}
-                          <span class="rail-fold-trailing">
-                            <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
-                            <button
-                              type="button"
-                              class="rail-fold-pill"
-                              class:rail-fold-pill--on={ontologyFolded.has(sub.id)}
-                              aria-pressed={ontologyFolded.has(sub.id)}
-                              disabled={ontologyFolded.has(domain.id)}
-                              onclick={(e) => { e.stopPropagation(); onToggleCollapse?.(sub.id); }}
-                            >
-                              <span class="rail-fold-glyph" aria-hidden="true"
-                                >{ontologyFolded.has(sub.id) ? "●" : "◯"}</span
-                              >{ontologyFolded.has(sub.id) ? "folded" : "fold"}
-                            </button>
-                          </span>
-                        {/snippet}
-                        <ul class="rail-list">
-                          {#each sub.types as t (t.key)}
-                            <li class="rail-fold-leaf">
-                              <span class="rail-fold-glyph rail-fold-glyph--leaf" aria-hidden="true">·</span>
-                              <span class="rail-fold-leaf-label">{t.key}</span>
-                              <Badge shape="circle" size="sm" tone="neutral">{t.count}</Badge>
-                            </li>
-                          {/each}
-                        </ul>
-                      </Collapsible>
-                    </li>
-                  {/each}
-                </ul>
-              </Collapsible>
-            {/each}
-          </div>
-          <div class="rail-fold-bulk">
-            <span class="rail-fold-bulk-label">Fold all to:</span>
-            <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(0)}>Domain</button>
-            <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(1)}>Sub-domain</button>
-            <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(2)}>Type</button>
-          </div>
-          {#if activeFoldedCount > 0}
-            <button type="button" class="rail-reset-btn" onclick={() => onExpandAll?.()}>
-              Expand all ({activeFoldedCount} folded)
-            </button>
-          {/if}
-        {:else}
-          <p class="rail-empty">No ontology taxonomy loaded.</p>
-        {/if}
-      {:else if groupBy.axis === "community"}
-        <p class="rail-facet-hint">Fold members into their community — folding re-lays out the graph.</p>
-        {#if communityInfo.liveCount === 0}
-          <p class="rail-empty">No communities.</p>
-        {:else}
-          <ul class="rail-list">
-            {#each communityInfo.live as c (c.key)}
-              <li class="rail-fold-row">
-                <span
-                  class="rail-swatch"
-                  style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
-                  aria-hidden="true"
-                ></span>
-                <span class="rail-fold-leaf-label">{c.key}</span>
-                <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
-                <button
-                  type="button"
-                  class="rail-fold-pill"
-                  class:rail-fold-pill--on={communityFolded.has(c.key)}
-                  aria-pressed={communityFolded.has(c.key)}
-                  onclick={() => onToggleCollapse?.(c.key)}
-                >
-                  <span class="rail-fold-glyph" aria-hidden="true"
-                    >{communityFolded.has(c.key) ? "●" : "◯"}</span
-                  >{communityFolded.has(c.key) ? "folded" : "fold"}
-                </button>
-              </li>
-            {/each}
-          </ul>
-          {#if activeFoldedCount > 0}
-            <button type="button" class="rail-reset-btn" onclick={() => onExpandAll?.()}>
-              Expand all ({activeFoldedCount} folded)
-            </button>
-          {/if}
-        {/if}
-      {/if}
-    </Collapsible>
+    <!-- B2 (per-item): group-by is NOT a separate axis sub-menu anymore — every
+         groupable Ontology class / Community owns its OWN checkbox inline in its
+         facet section above (the legacy class-display checkbox and the axis
+         selector were both removed, F2). Options keeps only true graph options
+         (weak links). -->
   </Collapsible>
 </aside>
 
@@ -644,13 +543,6 @@
     color: var(--st-semantic-text-secondary, #475569);
     cursor: pointer;
   }
-  .rail-facet-hint {
-    margin: 0.35rem 0 0.15rem;
-    color: var(--st-semantic-text-muted, #64748b);
-    font-size: 0.72rem;
-    font-style: italic;
-    line-height: 1.3;
-  }
   .rail-reset-btn {
     margin-top: 0.25rem;
     padding: 0.3rem 0.55rem;
@@ -665,85 +557,47 @@
     background: var(--st-semantic-surface-hover, #f1f5f9);
   }
 
-  /* B2 — group-by axis selector (segmented control). */
-  .rail-axis {
-    display: inline-flex;
-    margin: 0.35rem 0 0.2rem;
-    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    border-radius: 5px;
-    overflow: hidden;
-  }
-  .rail-axis-btn {
-    padding: 0.28rem 0.6rem;
-    border: 0;
-    border-right: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    background: var(--st-semantic-surface-default, #fff);
-    color: var(--st-semantic-text-secondary, #475569);
-    font-size: 0.76rem;
-    cursor: pointer;
-  }
-  .rail-axis-btn:last-child {
-    border-right: 0;
-  }
-  .rail-axis-btn--on {
-    background: var(--st-semantic-action-primary, #2563eb);
-    color: #fff;
-  }
-  /* B2 — fold tree + pills (the §Two-Concepts separation device: NO selectable
-     rows / shape glyphs here; fold pills + state glyphs only). */
-  .rail-fold-tree {
-    display: grid;
-    gap: 0.15rem;
-    margin-top: 0.2rem;
-  }
-  .rail-fold-trailing {
+  /* B2 (per-item): an Ontology class / Community row carries its count Badge AND
+     a hover-revealed group-by checkbox in the SAME trailing slot. */
+  .rail-onto-trailing {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
   }
-  .rail-fold-pill {
+  .rail-onto-tree {
+    margin-top: 0.15rem;
+  }
+  /* B2 (per-item): the per-item GROUP-BY checkbox affordance. The "group" hint
+     label is hidden until the row is hovered (or the box is already checked), so
+     the rail stays calm; a checked box keeps the affordance visible as feedback. */
+  .rail-group-check {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.12rem 0.4rem;
-    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    border-radius: 999px;
-    background: var(--st-semantic-surface-default, #fff);
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-size: 0.68rem;
+    gap: 0.2rem;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+  .rail-group-check input {
+    margin: 0;
     cursor: pointer;
   }
-  .rail-fold-pill--on {
-    background: var(--st-semantic-action-primary, #2563eb);
-    color: #fff;
-    border-color: var(--st-semantic-action-primary, #2563eb);
-  }
-  .rail-fold-pill:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-  .rail-fold-glyph {
-    font-size: 0.7rem;
-    line-height: 1;
-  }
-  .rail-fold-glyph--leaf {
+  .rail-group-hint {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
     color: var(--st-semantic-text-muted, #64748b);
   }
-  .rail-fold-leaf,
-  .rail-fold-row {
-    list-style: none;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.2rem 0.1rem;
-    font-size: 0.78rem;
-    color: var(--st-semantic-text-secondary, #475569);
+  /* Reveal on hover of the enclosing row, on keyboard focus, or when checked. */
+  :global(.st-collapsible__header:hover) .rail-group-check,
+  :global(.st-selectableRow:hover) .rail-group-check,
+  .rail-group-check:focus-within,
+  .rail-group-check--on {
+    opacity: 1;
   }
-  .rail-fold-leaf-label {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .rail-group-check--on .rail-group-hint {
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-weight: 600;
   }
   .rail-fold-bulk {
     display: flex;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -580,6 +580,11 @@
   .rail {
     background: var(--st-semantic-surface-default, #fff);
     overflow-y: auto;
+    /* B2-UI-9: clip horizontal overflow — never a horizontal scrollbar. With only
+       overflow-y:auto set, CSS promotes overflow-x:visible to `auto`, so a long
+       row (community label / bulk-button strip) pushed the rail into horizontal
+       scroll. Pin it hidden: labels ellipsize, the bulk buttons wrap → nothing lost. */
+    overflow-x: hidden;
     min-height: 0;
     /* Contain accordion growth INSIDE the rail: without a height bound,
        `overflow-y: auto` never engages — an expanded menu grows the rail past
@@ -749,7 +754,10 @@
      header; the Sub-domain list and the Type/leaf list each add one step. */
   .rail-onto-tree .rail-type-groups,
   .rail-onto-tree .rail-list {
-    padding-left: var(--rail-indent);
+    /* B2-UI-8: the Domain step (rail-onto-tree padding, 0.75rem) is kept (user:
+       "perfect, don't touch"); the DEEPER steps (Domain→Sub-domain, Sub-domain→
+       Type) were too large — reduce them. */
+    padding-left: 0.4rem;
   }
   /* B2 (§2): the leaf Type row puts its bare group-by checkbox FIRST (left),
      then the Type FILTER SelectableRow — two separate concerns on one line. */
@@ -821,6 +829,10 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
+    /* B2-UI-7: the DS SelectableRow ignores the list's padding-left, so the
+       community checkbox sat at the rail edge (measured 4px) vs the Domain
+       checkbox at 16px. Shift the lead by one Domain step so they align. */
+    margin-left: 0.75rem;
   }
   /* B2-UI-1+5: align the FIRST-LEVEL Community checkbox with the first-level
      Domain checkbox. The Domain checkbox now sits ONE indent step (0.75rem) to

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -733,6 +733,10 @@
   .rail-onto-tree {
     --rail-indent: 0.75rem;
     margin-top: 0.15rem;
+    /* B2-UI-1: L1 (Domain) ALSO gets one indent step — its checkbox sits a step
+       to the RIGHT of the "Ontology" header (not flush), and L0→L1 = L1→L2 =
+       L2→L3 are all equal. Aligned with the Community first-level checkbox (UI-5). */
+    padding-left: var(--rail-indent);
   }
   /* Kill the nested Collapsible region's inline padding INSIDE the tree (keep the
      bottom padding) so our per-level indent is the only horizontal offset. */
@@ -818,12 +822,14 @@
     align-items: center;
     gap: 0.35rem;
   }
-  /* B2-UI-5: align the FIRST-LEVEL Community checkbox with the first-level Domain
-     checkbox. The Domain checkbox sits at the Ontology Collapsible region origin
-     (~0.25rem). The Community checkbox lives inside a DS SelectableRow whose own
-     0.75rem inline padding would push it ~0.75rem further right than the Domain
-     box. Drop that inline padding on the community rows so BOTH first-level
-     checkboxes share the same distance from the rail's left edge. */
+  /* B2-UI-1+5: align the FIRST-LEVEL Community checkbox with the first-level
+     Domain checkbox. The Domain checkbox now sits ONE indent step (0.75rem) to
+     the right of the "Ontology" header; the community list takes the SAME left
+     indent, and the DS SelectableRow's own inline padding is dropped, so BOTH
+     first-level checkboxes share the same distance from the rail's left edge. */
+  .rail-comm-list {
+    padding-left: 0.75rem;
+  }
   .rail-comm-list :global(.st-selectableRow) {
     padding-left: 0;
     padding-right: 0.25rem;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -441,7 +441,7 @@
     {#if communityInfo.liveCount === 0}
       <p class="rail-empty">No communities.</p>
     {:else}
-      <ul class="rail-list">
+      <ul class="rail-list rail-comm-list">
         {#each communityInfo.live as c (c.key)}
           <li>
             <SelectableRow
@@ -475,7 +475,10 @@
                   ></span>
                 </span>
               {/snippet}
-              {c.key}
+              <!-- B2-UI-4: a long community label (e.g. "The Absence of Mr Glass")
+                   is ellipsised by the row content; the titled span carries the
+                   FULL text on hover so nothing is lost. -->
+              <span class="rail-comm-label" title={c.key}>{c.key}</span>
               {#snippet trailing()}
                 <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
               {/snippet}
@@ -629,9 +632,46 @@
   :global(.rail-list.st-selectableList) {
     gap: 1px;
   }
+  /* B2-UI-3 + B2-UI-4: DS typography alignment. The bare DS SelectableRow has NO
+     font-size of its own — it inherits the rail's base 1rem, which renders the
+     leaf Type / Community labels LARGER than the Domain/Sub-domain Collapsible
+     triggers (those use the `--sm` accordion token = 0.875rem / weight 500). We
+     normalise EVERY rail row to the SAME tokens the AppHeader's horizontal nav
+     menu uses — `.st-appHeader__nav` / `.st-appHeader__navLink`:
+       font-size: 0.875rem; font-weight: 500; line-height: 1.
+     The whole .rail inherits these so SelectableRow labels, Collapsible bodies and
+     leaf rows all match the nav scale; smaller token sizes (badges, kickers,
+     notes) keep their explicit sizes below. Pinning the font here ALSO shrinks
+     long Community labels enough to stop the overflow-x regression (paired with
+     the ellipsis on the row content below). */
+  .rail {
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1;
+  }
+  /* B2-UI-4: ellipsis long labels (Community / Type / Domain) so they never
+     overflow the rail horizontally. The DS SelectableRow __content already
+     ellipsizes, but the standalone Community rows render their label as a direct
+     text child of __content — re-assert nowrap/ellipsis here so any wrapping
+     theme cannot let a long name (e.g. "The Absence of Mr Glass") push the rail
+     into horizontal scroll. The full text stays reachable via the row tooltip. */
+  .rail :global(.st-selectableRow__content) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
   /* Entity rows wrap the label in a titled span (hover tooltip = full id). The
      DS row content already ellipsizes; the span just carries the title. */
   .rail-ent-label {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* B2-UI-4: the Community label mirrors the entity label — block + ellipsis with
+     the FULL name in the hover tooltip (title). Stops the long-label overflow-x. */
+  .rail-comm-label {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -679,8 +719,33 @@
     color: var(--st-semantic-text-secondary, #475569);
     cursor: pointer;
   }
+  /* B2-UI-1/2/5 — uniform indentation.
+     The Domain → Sub-domain → Type tree is built from NESTED DS Collapsibles, each
+     wrapping its body in a `.st-collapsible__region` with its own 0.25rem inline
+     padding. Left unchecked those paddings stack UNEVENLY (region + checkbox +
+     gap), making L1 (Domain) over-indented and the L2→L3 (Sub-domain→Type) step
+     visibly larger than L0→L1.
+     Fix: neutralise the nested region's HORIZONTAL padding inside the tree and
+     drive indentation ourselves with ONE equal step per level (`--rail-indent`).
+     L1 (Domain) gets ZERO extra indent so its checkbox aligns with the "Ontology"
+     header's left edge (both at the region's 0.25rem origin); every deeper level
+     adds exactly `--rail-indent`, so L0→L1, L1→L2 and L2→L3 are identical. */
   .rail-onto-tree {
+    --rail-indent: 0.75rem;
     margin-top: 0.15rem;
+  }
+  /* Kill the nested Collapsible region's inline padding INSIDE the tree (keep the
+     bottom padding) so our per-level indent is the only horizontal offset. */
+  .rail-onto-tree :global(.st-collapsible__region) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  /* One equal indent step applied to each nested level's list. The Domain list
+     (rail-onto-tree itself) gets NONE → Domain checkbox aligns with the Ontology
+     header; the Sub-domain list and the Type/leaf list each add one step. */
+  .rail-onto-tree .rail-type-groups,
+  .rail-onto-tree .rail-list {
+    padding-left: var(--rail-indent);
   }
   /* B2 (§2): the leaf Type row puts its bare group-by checkbox FIRST (left),
      then the Type FILTER SelectableRow — two separate concerns on one line. */
@@ -753,6 +818,16 @@
     align-items: center;
     gap: 0.35rem;
   }
+  /* B2-UI-5: align the FIRST-LEVEL Community checkbox with the first-level Domain
+     checkbox. The Domain checkbox sits at the Ontology Collapsible region origin
+     (~0.25rem). The Community checkbox lives inside a DS SelectableRow whose own
+     0.75rem inline padding would push it ~0.75rem further right than the Domain
+     box. Drop that inline padding on the community rows so BOTH first-level
+     checkboxes share the same distance from the rail's left edge. */
+  .rail-comm-list :global(.st-selectableRow) {
+    padding-left: 0;
+    padding-right: 0.25rem;
+  }
   .rail-fold-bulk {
     display: flex;
     flex-wrap: wrap;
@@ -768,6 +843,21 @@
   .rail-fold-btn :global(.st-button) {
     display: inline-flex;
     align-items: center;
+  }
+  /* B2-UI-6: the DS Button has only sm/md/lg — there is NO `xs`. The bulk buttons
+     are already `size="sm"`, but in the dense rail that is still too big, so we
+     tighten the `sm` button down to an xs scale: a shorter control height, tighter
+     inline/block padding and the nav-aligned font (0.875rem → 0.78rem, matching
+     the smaller rail density). Applied to every bulk button — the ontology
+     "Group all to" trio, "Ungroup all", and the community Group all / Ungroup
+     all — via their shared rail wrappers. */
+  .rail-fold-bulk :global(.st-button),
+  .rail-fold-ungroup :global(.st-button) {
+    min-height: 1.6rem;
+    min-width: 0;
+    padding: 0.15rem 0.45rem;
+    font-size: 0.78rem;
+    line-height: 1.1;
   }
   .rail-fold-ungroup {
     margin-top: 0.3rem;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -756,19 +756,23 @@
   .rail-onto-tree .rail-list {
     /* B2-UI-8: the Domain step (rail-onto-tree padding, 0.75rem) is kept (user:
        "perfect, don't touch"); the DEEPER steps (Domain→Sub-domain, Sub-domain→
-       Type) were too large — reduce them. */
-    padding-left: 0.4rem;
+       Type) were too large — reduce them. (UI-10: still ~2× too big → halve to 0.2rem.) */
+    padding-left: 0.2rem;
   }
   /* B2 (§2): the leaf Type row puts its bare group-by checkbox FIRST (left),
      then the Type FILTER SelectableRow — two separate concerns on one line. */
   .rail-type-row {
     display: flex;
     align-items: center;
-    gap: 0.3rem;
+    /* B2-UI-11: checkbox→glyph gap. Measured 17px (too large) — the DS SelectableRow's
+       own left padding inflated it. Drop that padding (below) + set the gap so the
+       checkbox→glyph distance (~8px) matches the community checkbox→swatch. */
+    gap: 0.5rem;
   }
   .rail-type-row :global(.st-selectableRow) {
     flex: 1;
     min-width: 0;
+    padding-left: 0;
   }
   .rail-type-group-check {
     flex-shrink: 0;
@@ -801,34 +805,22 @@
     display: inline-flex;
     align-items: center;
     cursor: pointer;
-    /* A faint hover ring is layered behind the box; keep a transparent baseline
-       so only hover/focus reveals it (no persistent visual chrome at rest). */
-    border-radius: 4px;
-    outline: 1px solid transparent;
-    outline-offset: 1px;
-    transition: outline-color 0.12s ease;
   }
   .rail-group-check input {
     margin: 0;
     cursor: pointer;
   }
-  /* Hover/focus-only hint: a faint outline appears around the bare checkbox when
-     the row is hovered or the box is focused, signalling "group by …" WITHOUT any
-     text. The title tooltip carries the wording. */
-  :global(.st-collapsible__header:hover) .rail-group-check,
-  :global(.st-selectableRow:hover) .rail-group-check,
-  .rail-group-check:focus-within {
-    outline-color: var(--st-semantic-action-primary, #2563eb);
-  }
-  /* A grouped (checked) row keeps the accent ring so the active fold is legible. */
-  .rail-group-check--on {
-    outline-color: var(--st-semantic-action-primary, #2563eb);
-  }
+  /* B2-UI-12: NO hover/focus outline ring on the checkbox. The ring only ever
+     matched community/type rows (the ontology Collapsible-header hover never
+     selected the now-sibling checkbox), so it read as a random inconsistency.
+     A bare native checkbox is enough. */
   /* Community row: the bare group-by checkbox sits FIRST, then the color swatch. */
   .rail-comm-lead {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    /* B2-UI-11: checkbox→swatch gap. Measured 6px (too small) → match the Type
+       checkbox→glyph (~8px) so both use the standard checkbox-to-shape distance. */
+    gap: 0.5rem;
     /* B2-UI-7: the DS SelectableRow ignores the list's padding-left, so the
        community checkbox sat at the rail edge (measured 4px) vs the Domain
        checkbox at 16px. Shift the lead by one Domain step so they align. */

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -10,6 +10,7 @@
     SelectableRow,
     Search,
     Badge,
+    Button,
     Collapsible,
   } from "@sentropic/design-system-svelte";
   import TypeShapeGlyph from "./TypeShapeGlyph.svelte";
@@ -36,6 +37,19 @@
     // absent kind.
     canGroupOntology = false,
     canGroupCommunity = false,
+    // B2 (§4) TRI-STATE bulk buttons: per-level { state:"none"|"partial"|"all",
+    // done, total }. B2 (§3) absorption: class id -> { absorbed, byLabel }.
+    ontologyLevelStates = {
+      domain: { state: "none", done: 0, total: 0 },
+      subDomain: { state: "none", done: 0, total: 0 },
+      type: { state: "none", done: 0, total: 0 },
+    },
+    ontologyAbsorbed = new Map(),
+    // B2 (§5) FLAT community bulk: true when EVERY live community is grouped.
+    allCommunitiesGrouped = false,
+    // B2 (§4/§5) scope-local "anything grouped" → native disabled on Ungroup all.
+    ontologyGrouped = false,
+    communityGrouped = false,
     // The scene's count badges (relocated under the search bar).
     stats = { nodeCount: 0, edgeCount: 0, communityCount: 0 },
     onToggleType,
@@ -46,8 +60,11 @@
     // B2 (per-item) group-by callbacks.
     onToggleGroupOntology,
     onToggleGroupCommunity,
-    onFoldToLevel,
-    onClearGrouping,
+    onToggleGroupType,
+    onBulkLevel,
+    onBulkCommunities,
+    onClearOntologyGrouping,
+    onClearCommunityGrouping,
   } = $props();
 
   const typeList = $derived(groupCounts(graph, nodeType));
@@ -55,24 +72,53 @@
   const communityInfo = $derived(communityStats(graph));
 
   // B2 (per-item): split the namespaced grouped SET into per-row membership sets.
-  // A class/community is "grouped" when its namespaced key is present. Mixing
-  // ontology + community keys is allowed; both render their checked state here.
-  const groupedSet = $derived(new Set(groupBy.grouped ?? []));
-  const ontologyGrouped = $derived(
+  // A class/community/type is "grouped" when its namespaced key is present.
+  // Mixing kinds is allowed; each row renders its own checked state here.
+  const ontologyCheckedSet = $derived(
     new Set(
       (groupBy.grouped ?? [])
         .filter((k) => typeof k === "string" && k.startsWith("ontology:"))
         .map((k) => k.slice("ontology:".length)),
     ),
   );
-  const communityGrouped = $derived(
+  const communityCheckedSet = $derived(
     new Set(
       (groupBy.grouped ?? [])
         .filter((k) => typeof k === "string" && k.startsWith("community:"))
         .map((k) => k.slice("community:".length)),
     ),
   );
-  const groupedCount = $derived(groupedSet.size);
+  const typeCheckedSet = $derived(
+    new Set(
+      (groupBy.grouped ?? [])
+        .filter((k) => typeof k === "string" && k.startsWith("type:"))
+        .map((k) => k.slice("type:".length)),
+    ),
+  );
+
+  // B2 (§4): map a level's tri-state to the DS Button render contract. The DS
+  // Button has only primary/secondary, so PARTIAL = secondary + a count Badge.
+  //   none    → secondary, aria-pressed=false  (groups the level)
+  //   all     → primary,   aria-pressed=true   (toggles OFF)
+  //   partial → secondary, aria-pressed=false, badge "n/m" (completes to all)
+  function levelButton(ls) {
+    const s = ls ?? { state: "none", done: 0, total: 0 };
+    if (s.state === "all") {
+      return { variant: "primary", ariaPressed: "true", showBadge: false, badge: null };
+    }
+    if (s.state === "partial") {
+      return {
+        variant: "secondary",
+        ariaPressed: "false",
+        showBadge: true,
+        badge: `${s.done}/${s.total}`,
+      };
+    }
+    return { variant: "secondary", ariaPressed: "false", showBadge: false, badge: null };
+  }
+  const domainBtn = $derived(levelButton(ontologyLevelStates.domain));
+  const subDomainBtn = $derived(levelButton(ontologyLevelStates.subDomain));
+  const typeBtn = $derived(levelButton(ontologyLevelStates.type));
 
   const typeSet = $derived(new Set(selection.types));
   // EVOL: nested Domain → Sub-domain → Type tree from the ontology class
@@ -220,15 +266,19 @@
           <li>
             <Collapsible title={domain.label} open={false} size="sm">
               {#snippet leading()}
+                {@const dAbs = ontologyAbsorbed.get(domain.id)}
                 <label
                   class="rail-group-check"
-                  class:rail-group-check--on={ontologyGrouped.has(domain.id)}
-                  title="Group by {domain.label}"
+                  class:rail-group-check--on={ontologyCheckedSet.has(domain.id)}
+                  title={dAbs?.absorbed
+                    ? `grouped by parent ${dAbs.byLabel}`
+                    : `Group by ${domain.label}`}
                   onclick={(e) => e.stopPropagation()}
                 >
                   <input
                     type="checkbox"
-                    checked={ontologyGrouped.has(domain.id)}
+                    checked={ontologyCheckedSet.has(domain.id)}
+                    disabled={dAbs?.absorbed === true}
                     aria-label="Group by {domain.label}"
                     onchange={() => onToggleGroupOntology?.(domain.id)}
                   />
@@ -242,16 +292,19 @@
                   <li>
                     <Collapsible title={sub.label} open={false} size="sm">
                       {#snippet leading()}
+                        {@const sAbs = ontologyAbsorbed.get(sub.id)}
                         <label
                           class="rail-group-check"
-                          class:rail-group-check--on={ontologyGrouped.has(sub.id)}
-                          title="Group by {sub.label}"
+                          class:rail-group-check--on={ontologyCheckedSet.has(sub.id)}
+                          title={sAbs?.absorbed
+                            ? `grouped by parent ${sAbs.byLabel}`
+                            : `Group by ${sub.label}`}
                           onclick={(e) => e.stopPropagation()}
                         >
                           <input
                             type="checkbox"
-                            checked={ontologyGrouped.has(sub.id)}
-                            disabled={ontologyGrouped.has(domain.id)}
+                            checked={ontologyCheckedSet.has(sub.id)}
+                            disabled={sAbs?.absorbed === true}
                             aria-label="Group by {sub.label}"
                             onchange={() => onToggleGroupOntology?.(sub.id)}
                           />
@@ -262,7 +315,25 @@
                       {/snippet}
                       <ul class="rail-list">
                         {#each sub.types as t (t.key)}
-                          <li>
+                          <li class="rail-type-row">
+                            <!-- B2 (§2): the leaf TYPE row carries its OWN bare
+                                 group-by checkbox on the LEFT — folds entities of
+                                 this `type`. It is SEPARATE from the Type FILTER
+                                 SelectableRow (onToggleType) that follows it. -->
+                            <label
+                              class="rail-group-check rail-type-group-check"
+                              class:rail-group-check--on={typeCheckedSet.has(t.key)}
+                              title="Group by {t.key}"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={typeCheckedSet.has(t.key)}
+                                disabled={ontologyCheckedSet.has(sub.id) ||
+                                  ontologyCheckedSet.has(domain.id)}
+                                aria-label="Group by {t.key}"
+                                onchange={() => onToggleGroupType?.(t.key)}
+                              />
+                            </label>
                             <SelectableRow
                               value={t.key}
                               selected={typeSet.has(t.key)}
@@ -287,20 +358,64 @@
           </li>
         {/each}
       </ul>
-      <!-- B2 / F8: bulk baseline fold + an ungroup-all reset, scoped to the
-           Ontology facet (only shown when the taxonomy supports grouping). -->
+      <!-- B2 (§4): TRI-STATE bulk "Group all to: Domain | Sub-domain | Type" via
+           the DS Button (secondary↔primary + a count Badge for partial) + a
+           scope-local Ungroup all (native disabled when nothing ontology is
+           grouped). Only shown when the taxonomy supports grouping. -->
       {#if canGroupOntology}
-        <div class="rail-fold-bulk">
+        <div class="rail-fold-bulk" role="group" aria-label="Group all ontology to level">
           <span class="rail-fold-bulk-label">Group all to:</span>
-          <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(0)}>Domain</button>
-          <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(1)}>Sub-domain</button>
-          <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(2)}>Type</button>
+          <span class="rail-fold-btn">
+            <Button
+              variant={domainBtn.variant}
+              size="sm"
+              aria-pressed={domainBtn.ariaPressed}
+              aria-label={domainBtn.showBadge
+                ? `Group all to Domain (${ontologyLevelStates.domain.done} of ${ontologyLevelStates.domain.total} grouped)`
+                : "Group all to Domain"}
+              onclick={() => onBulkLevel?.(0)}
+            >
+              Domain{#if domainBtn.showBadge}&nbsp;<Badge tone="neutral" size="sm">{domainBtn.badge}</Badge>{/if}
+            </Button>
+          </span>
+          <span class="rail-fold-btn">
+            <Button
+              variant={subDomainBtn.variant}
+              size="sm"
+              aria-pressed={subDomainBtn.ariaPressed}
+              aria-label={subDomainBtn.showBadge
+                ? `Group all to Sub-domain (${ontologyLevelStates.subDomain.done} of ${ontologyLevelStates.subDomain.total} grouped)`
+                : "Group all to Sub-domain"}
+              onclick={() => onBulkLevel?.(1)}
+            >
+              Sub-domain{#if subDomainBtn.showBadge}&nbsp;<Badge tone="neutral" size="sm">{subDomainBtn.badge}</Badge>{/if}
+            </Button>
+          </span>
+          <span class="rail-fold-btn">
+            <Button
+              variant={typeBtn.variant}
+              size="sm"
+              aria-pressed={typeBtn.ariaPressed}
+              aria-label={typeBtn.showBadge
+                ? `Group all to Type (${ontologyLevelStates.type.done} of ${ontologyLevelStates.type.total} grouped)`
+                : "Group all to Type"}
+              onclick={() => onBulkLevel?.(2)}
+            >
+              Type{#if typeBtn.showBadge}&nbsp;<Badge tone="neutral" size="sm">{typeBtn.badge}</Badge>{/if}
+            </Button>
+          </span>
         </div>
-      {/if}
-      {#if groupedCount > 0}
-        <button type="button" class="rail-reset-btn" onclick={() => onClearGrouping?.()}>
-          Ungroup all ({groupedCount} grouped)
-        </button>
+        <div class="rail-fold-ungroup">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={!ontologyGrouped}
+            aria-label="Ungroup all ontology"
+            onclick={() => onClearOntologyGrouping?.()}
+          >
+            Ungroup all
+          </Button>
+        </div>
       {/if}
     {:else}
       <SelectableList
@@ -348,13 +463,13 @@
                 <span class="rail-comm-lead">
                   <label
                     class="rail-group-check"
-                    class:rail-group-check--on={communityGrouped.has(c.key)}
+                    class:rail-group-check--on={communityCheckedSet.has(c.key)}
                     title="Group by {c.key}"
                     onclick={(e) => e.stopPropagation()}
                   >
                     <input
                       type="checkbox"
-                      checked={communityGrouped.has(c.key)}
+                      checked={communityCheckedSet.has(c.key)}
                       aria-label="Group by {c.key}"
                       onchange={() => onToggleGroupCommunity?.(c.key)}
                     />
@@ -379,6 +494,35 @@
           Isolated · {communityInfo.isolatedCount}
           <span class="rail-isolated-note">degree-0, excluded from the count</span>
         </p>
+      {/if}
+      <!-- B2 (§5): FLAT 2-state community bulk — NO level, NO partial, NO count.
+           `Group all` (secondary→primary when ALL grouped, click toggles) +
+           a scope-local `Ungroup all` (native disabled when none grouped). -->
+      {#if canGroupCommunity}
+        <div class="rail-fold-bulk rail-comm-bulk" role="group" aria-label="Group all communities">
+          <span class="rail-fold-btn">
+            <Button
+              variant={allCommunitiesGrouped ? "primary" : "secondary"}
+              size="sm"
+              aria-pressed={allCommunitiesGrouped ? "true" : "false"}
+              aria-label="Group all communities"
+              onclick={() => onBulkCommunities?.()}
+            >
+              Group all
+            </Button>
+          </span>
+          <span class="rail-fold-btn">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={!communityGrouped}
+              aria-label="Ungroup all communities"
+              onclick={() => onClearCommunityGrouping?.()}
+            >
+              Ungroup all
+            </Button>
+          </span>
+        </div>
       {/if}
     {/if}
   </Collapsible>
@@ -541,22 +685,22 @@
     color: var(--st-semantic-text-secondary, #475569);
     cursor: pointer;
   }
-  .rail-reset-btn {
-    margin-top: 0.25rem;
-    padding: 0.3rem 0.55rem;
-    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    border-radius: 4px;
-    background: var(--st-semantic-surface-default, #fff);
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-size: 0.76rem;
-    cursor: pointer;
-  }
-  .rail-reset-btn:hover {
-    background: var(--st-semantic-surface-hover, #f1f5f9);
-  }
-
   .rail-onto-tree {
     margin-top: 0.15rem;
+  }
+  /* B2 (§2): the leaf Type row puts its bare group-by checkbox FIRST (left),
+     then the Type FILTER SelectableRow — two separate concerns on one line. */
+  .rail-type-row {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+  .rail-type-row :global(.st-selectableRow) {
+    flex: 1;
+    min-width: 0;
+  }
+  .rail-type-group-check {
+    flex-shrink: 0;
   }
   /* B2 (per-item): the per-item GROUP-BY checkbox affordance, now the FIRST
      element on the LEFT edge of every groupable row (Ontology class header /
@@ -607,16 +751,15 @@
     font-size: 0.72rem;
     color: var(--st-semantic-text-muted, #64748b);
   }
-  .rail-fold-baseline {
-    padding: 0.22rem 0.5rem;
-    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    border-radius: 4px;
-    background: var(--st-semantic-surface-default, #fff);
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-size: 0.72rem;
-    cursor: pointer;
+  /* The tri-state DS Button keeps its label + (n/m) Badge on one line. */
+  .rail-fold-btn :global(.st-button) {
+    display: inline-flex;
+    align-items: center;
   }
-  .rail-fold-baseline:hover {
-    background: var(--st-semantic-surface-hover, #f1f5f9);
+  .rail-fold-ungroup {
+    margin-top: 0.3rem;
+  }
+  .rail-comm-bulk {
+    margin-top: 0.45rem;
   }
 </style>

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -263,53 +263,47 @@
            onToggleType) stays a SEPARATE concern. -->
       <ul class="rail-type-groups rail-onto-tree" aria-label="Ontology classes">
         {#each typeTree as domain (domain.id)}
-          <li>
+          {@const dAbs = ontologyAbsorbed.get(domain.id)}
+          <li class="rail-onto-head">
+            <label
+              class="rail-group-check"
+              class:rail-group-check--on={ontologyCheckedSet.has(domain.id)}
+              title={dAbs?.absorbed
+                ? `grouped by parent ${dAbs.byLabel}`
+                : `Group by ${domain.label}`}
+            >
+              <input
+                type="checkbox"
+                checked={ontologyCheckedSet.has(domain.id)}
+                disabled={dAbs?.absorbed === true}
+                aria-label="Group by {domain.label}"
+                onchange={() => onToggleGroupOntology?.(domain.id)}
+              />
+            </label>
             <Collapsible title={domain.label} open={false} size="sm">
-              {#snippet leading()}
-                {@const dAbs = ontologyAbsorbed.get(domain.id)}
-                <label
-                  class="rail-group-check"
-                  class:rail-group-check--on={ontologyCheckedSet.has(domain.id)}
-                  title={dAbs?.absorbed
-                    ? `grouped by parent ${dAbs.byLabel}`
-                    : `Group by ${domain.label}`}
-                  onclick={(e) => e.stopPropagation()}
-                >
-                  <input
-                    type="checkbox"
-                    checked={ontologyCheckedSet.has(domain.id)}
-                    disabled={dAbs?.absorbed === true}
-                    aria-label="Group by {domain.label}"
-                    onchange={() => onToggleGroupOntology?.(domain.id)}
-                  />
-                </label>
-              {/snippet}
               {#snippet trailing()}
                 <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
               {/snippet}
               <ul class="rail-type-groups">
                 {#each domain.subs as sub (sub.id)}
-                  <li>
+                  {@const sAbs = ontologyAbsorbed.get(sub.id)}
+                  <li class="rail-onto-head">
+                    <label
+                      class="rail-group-check"
+                      class:rail-group-check--on={ontologyCheckedSet.has(sub.id)}
+                      title={sAbs?.absorbed
+                        ? `grouped by parent ${sAbs.byLabel}`
+                        : `Group by ${sub.label}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={ontologyCheckedSet.has(sub.id)}
+                        disabled={sAbs?.absorbed === true}
+                        aria-label="Group by {sub.label}"
+                        onchange={() => onToggleGroupOntology?.(sub.id)}
+                      />
+                    </label>
                     <Collapsible title={sub.label} open={false} size="sm">
-                      {#snippet leading()}
-                        {@const sAbs = ontologyAbsorbed.get(sub.id)}
-                        <label
-                          class="rail-group-check"
-                          class:rail-group-check--on={ontologyCheckedSet.has(sub.id)}
-                          title={sAbs?.absorbed
-                            ? `grouped by parent ${sAbs.byLabel}`
-                            : `Group by ${sub.label}`}
-                          onclick={(e) => e.stopPropagation()}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={ontologyCheckedSet.has(sub.id)}
-                            disabled={sAbs?.absorbed === true}
-                            aria-label="Group by {sub.label}"
-                            onchange={() => onToggleGroupOntology?.(sub.id)}
-                          />
-                        </label>
-                      {/snippet}
                       {#snippet trailing()}
                         <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
                       {/snippet}
@@ -701,6 +695,25 @@
   }
   .rail-type-group-check {
     flex-shrink: 0;
+  }
+  /* B2 FIX: the DS Collapsible exposes NO `leading` slot, so the Domain/Sub-domain
+     group-by checkbox is rendered as a SIBLING before <Collapsible> (not in a
+     dropped leading() snippet). align-start keeps the bare checkbox on the header
+     line even when the accordion body is expanded below. */
+  .rail-onto-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.3rem;
+  }
+  .rail-onto-head > :global(.st-collapsible) {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .rail-onto-head > .rail-group-check {
+    flex-shrink: 0;
+    /* match the sm Collapsible header height (paddingBlock 0.4rem×2 + ~1.05rem
+       line) so the bare checkbox vertically centres on the header title. */
+    min-height: 1.85rem;
   }
   /* B2 (per-item): the per-item GROUP-BY checkbox affordance, now the FIRST
      element on the LEFT edge of every groupable row (Ontology class header /

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -219,48 +219,46 @@
         {#each typeTree as domain (domain.id)}
           <li>
             <Collapsible title={domain.label} open={false} size="sm">
+              {#snippet leading()}
+                <label
+                  class="rail-group-check"
+                  class:rail-group-check--on={ontologyGrouped.has(domain.id)}
+                  title="Group by {domain.label}"
+                  onclick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    type="checkbox"
+                    checked={ontologyGrouped.has(domain.id)}
+                    aria-label="Group by {domain.label}"
+                    onchange={() => onToggleGroupOntology?.(domain.id)}
+                  />
+                </label>
+              {/snippet}
               {#snippet trailing()}
-                <span class="rail-onto-trailing">
-                  <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
-                  <label
-                    class="rail-group-check"
-                    class:rail-group-check--on={ontologyGrouped.has(domain.id)}
-                    title="Group by {domain.label}"
-                    onclick={(e) => e.stopPropagation()}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={ontologyGrouped.has(domain.id)}
-                      aria-label="Group by {domain.label}"
-                      onchange={() => onToggleGroupOntology?.(domain.id)}
-                    />
-                    <span class="rail-group-hint" aria-hidden="true">group</span>
-                  </label>
-                </span>
+                <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
               {/snippet}
               <ul class="rail-type-groups">
                 {#each domain.subs as sub (sub.id)}
                   <li>
                     <Collapsible title={sub.label} open={false} size="sm">
+                      {#snippet leading()}
+                        <label
+                          class="rail-group-check"
+                          class:rail-group-check--on={ontologyGrouped.has(sub.id)}
+                          title="Group by {sub.label}"
+                          onclick={(e) => e.stopPropagation()}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={ontologyGrouped.has(sub.id)}
+                            disabled={ontologyGrouped.has(domain.id)}
+                            aria-label="Group by {sub.label}"
+                            onchange={() => onToggleGroupOntology?.(sub.id)}
+                          />
+                        </label>
+                      {/snippet}
                       {#snippet trailing()}
-                        <span class="rail-onto-trailing">
-                          <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
-                          <label
-                            class="rail-group-check"
-                            class:rail-group-check--on={ontologyGrouped.has(sub.id)}
-                            title="Group by {sub.label}"
-                            onclick={(e) => e.stopPropagation()}
-                          >
-                            <input
-                              type="checkbox"
-                              checked={ontologyGrouped.has(sub.id)}
-                              disabled={ontologyGrouped.has(domain.id)}
-                              aria-label="Group by {sub.label}"
-                              onchange={() => onToggleGroupOntology?.(sub.id)}
-                            />
-                            <span class="rail-group-hint" aria-hidden="true">group</span>
-                          </label>
-                        </span>
+                        <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
                       {/snippet}
                       <ul class="rail-list">
                         {#each sub.types as t (t.key)}
@@ -343,19 +341,11 @@
               onselect={() => onToggleCommunity?.(c.key)}
             >
               {#snippet leading()}
-                <span
-                  class="rail-swatch"
-                  style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
-                  aria-hidden="true"
-                ></span>
-              {/snippet}
-              {c.key}
-              {#snippet trailing()}
-                <span class="rail-onto-trailing">
-                  <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
-                  <!-- B2 (per-item): always-visible GROUP-BY checkbox. Checking it
-                       GROUPS (collapses) the community; the row's own SELECT
-                       (onToggleCommunity, filter) stays a separate concern. -->
+                <!-- B2 (per-item): the GROUP-BY checkbox is the FIRST thing on the
+                     row (left edge), before the color swatch. Checking it GROUPS
+                     (collapses) the community; the row's own SELECT
+                     (onToggleCommunity, filter) stays a separate concern. -->
+                <span class="rail-comm-lead">
                   <label
                     class="rail-group-check"
                     class:rail-group-check--on={communityGrouped.has(c.key)}
@@ -368,9 +358,17 @@
                       aria-label="Group by {c.key}"
                       onchange={() => onToggleGroupCommunity?.(c.key)}
                     />
-                    <span class="rail-group-hint" aria-hidden="true">group</span>
                   </label>
+                  <span
+                    class="rail-swatch"
+                    style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
+                    aria-hidden="true"
+                  ></span>
                 </span>
+              {/snippet}
+              {c.key}
+              {#snippet trailing()}
+                <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
               {/snippet}
             </SelectableRow>
           </li>
@@ -557,50 +555,46 @@
     background: var(--st-semantic-surface-hover, #f1f5f9);
   }
 
-  /* B2 (per-item): an Ontology class / Community row carries its count Badge AND
-     a hover-revealed group-by checkbox in the SAME trailing slot. */
-  .rail-onto-trailing {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-  }
   .rail-onto-tree {
     margin-top: 0.15rem;
   }
-  /* B2 (per-item): the per-item GROUP-BY checkbox affordance. The checkbox is
-     ALWAYS visible to the left of/inline with each groupable row so the feature
-     is discoverable at rest; hover/focus/checked only ENHANCES the "group" hint
-     text (it is never the only way to see the box). */
+  /* B2 (per-item): the per-item GROUP-BY checkbox affordance, now the FIRST
+     element on the LEFT edge of every groupable row (Ontology class header /
+     Community row), BEFORE the label. At rest it is a BARE checkbox — NO text.
+     The "group by" meaning is signalled on HOVER only (the title tooltip plus a
+     subtle ring around the box); never a persistent text label. */
   .rail-group-check {
     display: inline-flex;
     align-items: center;
-    gap: 0.2rem;
     cursor: pointer;
-    opacity: 1;
+    /* A faint hover ring is layered behind the box; keep a transparent baseline
+       so only hover/focus reveals it (no persistent visual chrome at rest). */
+    border-radius: 4px;
+    outline: 1px solid transparent;
+    outline-offset: 1px;
+    transition: outline-color 0.12s ease;
   }
   .rail-group-check input {
     margin: 0;
     cursor: pointer;
   }
-  .rail-group-hint {
-    font-size: 0.62rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--st-semantic-text-muted, #64748b);
-    opacity: 0.55;
-    transition: opacity 0.12s ease, color 0.12s ease;
+  /* Hover/focus-only hint: a faint outline appears around the bare checkbox when
+     the row is hovered or the box is focused, signalling "group by …" WITHOUT any
+     text. The title tooltip carries the wording. */
+  :global(.st-collapsible__header:hover) .rail-group-check,
+  :global(.st-selectableRow:hover) .rail-group-check,
+  .rail-group-check:focus-within {
+    outline-color: var(--st-semantic-action-primary, #2563eb);
   }
-  /* Subtle hover/focus enhancement: bring the "group" hint forward. The checkbox
-     itself stays visible at rest, so this is additive affordance only. */
-  :global(.st-collapsible__header:hover) .rail-group-check .rail-group-hint,
-  :global(.st-selectableRow:hover) .rail-group-check .rail-group-hint,
-  .rail-group-check:focus-within .rail-group-hint {
-    opacity: 1;
+  /* A grouped (checked) row keeps the accent ring so the active fold is legible. */
+  .rail-group-check--on {
+    outline-color: var(--st-semantic-action-primary, #2563eb);
   }
-  .rail-group-check--on .rail-group-hint {
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-weight: 600;
-    opacity: 1;
+  /* Community row: the bare group-by checkbox sits FIRST, then the color swatch. */
+  .rail-comm-lead {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
   }
   .rail-fold-bulk {
     display: flex;

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -27,20 +27,42 @@
     query = "",
     selection = { types: [], communities: [], entities: [] },
     showWeakLinks = true,
-    showOntologyClasses = false,
-    collapsedClassCount = 0,
+    // B2: axis-scoped group-by state + the axes the current graph supports.
+    groupBy = { axis: "none", ontology: { collapsedClassIds: [] }, community: { collapsedKeys: [] } },
+    availableAxes = ["none"],
+    // The scene's count badges (relocated under the search bar).
+    stats = { nodeCount: 0, edgeCount: 0, communityCount: 0 },
     onToggleType,
     onToggleCommunity,
     onToggleEntity,
     onSetQuery,
     onToggleWeak,
-    onToggleOntologyClasses,
-    onExpandAllClasses,
+    // B2 group-by callbacks (replace the ontology-class toggle).
+    onSetAxis,
+    onToggleCollapse,
+    onFoldToLevel,
+    onExpandAll,
   } = $props();
 
   const typeList = $derived(groupCounts(graph, nodeType));
   // Communities excluding degree-0 singletons (folded into `isolatedCount`).
   const communityInfo = $derived(communityStats(graph));
+
+  // B2: which axes the picker offers (omit absent axes, C4). "none" always shown.
+  const axisAvailable = $derived(new Set(availableAxes));
+  const showCommunityAxis = $derived(axisAvailable.has("community"));
+  const showOntologyAxis = $derived(axisAvailable.has("ontology"));
+
+  // B2: the active axis's folded set, for per-row glyphs/state.
+  const ontologyFolded = $derived(new Set(groupBy.ontology?.collapsedClassIds ?? []));
+  const communityFolded = $derived(new Set(groupBy.community?.collapsedKeys ?? []));
+  const activeFoldedCount = $derived(
+    groupBy.axis === "ontology"
+      ? ontologyFolded.size
+      : groupBy.axis === "community"
+        ? communityFolded.size
+        : 0,
+  );
 
   const typeSet = $derived(new Set(selection.types));
   // EVOL: nested Domain → Sub-domain → Type tree from the ontology class
@@ -108,6 +130,54 @@
   });
   const entityTotal = $derived(entitiesByType.reduce((n, g) => n + g.count, 0));
 
+  // Tracked UI: the count badges live UNDER the search bar now. The node badge is
+  // REACTIVE — it shows "x / total nodes" where x is the entity count matching the
+  // current search query (entityTotal) and total is the full graph node count.
+  // When there is no query, x === total. The denominator is the raw graph node
+  // count (every node, not the scene's filtered count) so the ratio is stable as
+  // the user types. Edges/groups come from the scene stats (unaffected by search).
+  const totalNodeCount = $derived(graphNodes(graph).length);
+  const hasQuery = $derived(query.trim().length > 0);
+
+  // B2 / C2: the ontology FOLD tree (per-node "fold here" pills + glyphs), built
+  // from the same taxonomy the Types facet uses but rendered as fold controls, not
+  // selectable rows (the §Two-Concepts separation device). Domains/sub-domains get
+  // a fold pill; leaf Type rows are read-only in v1 (F5 deferred).
+  const foldTree = $derived.by(() => {
+    const hs = classHierarchies?.hierarchies;
+    if (!hs) return null;
+    const h = hs[Object.keys(hs)[0]];
+    if (!h?.classes_by_id || !(h.root_class_ids?.length)) return null;
+    const classes = h.classes_by_id;
+    const countByType = new Map(typeList.map((t) => [t.key, t.count]));
+    const labelOf = (id) => classes[id]?.label || String(id).replace(/^class:/, "");
+    const domains = h.root_class_ids
+      .map((rootId) => {
+        const subs = (classes[rootId]?.child_ids ?? [])
+          .map((subId) => {
+            const types = (classes[subId]?.member_node_types ?? []).map((t) => ({
+              key: t,
+              count: countByType.get(t) ?? 0,
+            }));
+            return {
+              id: subId,
+              label: labelOf(subId),
+              types,
+              count: types.reduce((n, t) => n + t.count, 0),
+            };
+          })
+          .filter((s) => s.types.length);
+        return {
+          id: rootId,
+          label: labelOf(rootId),
+          subs,
+          count: subs.reduce((n, s) => n + s.count, 0),
+        };
+      })
+      .filter((d) => d.subs.length);
+    return domains;
+  });
+
   // Communities + Entities use STANDALONE SelectableRows (selected/onselect), so
   // they need the selection-membership sets for the per-row `selected` flag.
   // (Types uses a SelectableList controlled by selection.types — see below.)
@@ -151,6 +221,15 @@
       oninput={(e) => onSetQuery?.(e.currentTarget.value)}
       aria-label="Search entities"
     />
+    <!-- Tracked UI: count badges moved here from the AppChrome header. The node
+         badge is REACTIVE to the search query: "x / total nodes". -->
+    <span class="rail-stats" aria-label="Graph summary">
+      <Badge tone={hasQuery ? "info" : "neutral"}>
+        {#if hasQuery}{entityTotal} / {totalNodeCount} nodes{:else}{totalNodeCount} nodes{/if}
+      </Badge>
+      <Badge tone="neutral">{stats.edgeCount} edges</Badge>
+      <Badge tone="info">{stats.communityCount} groups</Badge>
+    </span>
   </div>
 
   <Collapsible title="Types" open={false}>
@@ -307,28 +386,155 @@
       />
       Show weak (inferred) links
     </label>
-    <label class="rail-facet">
-      <input
-        type="checkbox"
-        checked={showOntologyClasses}
-        onchange={(e) => onToggleOntologyClasses?.(e.currentTarget.checked)}
-      />
-      Show ontology classes
-    </label>
-    {#if showOntologyClasses}
-      <p class="rail-facet-hint">
-        Click a class node to fold its subtree; click again to expand.
-      </p>
-      {#if collapsedClassCount > 0}
+
+    <!-- B2 / C1+F1: the "Show ontology classes" checkbox is GONE — group-by is a
+         nested sub-menu with an axis selector (None · Community · Ontology). -->
+    <Collapsible title="Group by" open={false} size="sm">
+      {#snippet trailing()}
+        <Badge shape="circle" size="sm" tone="neutral">{groupBy.axis}</Badge>
+      {/snippet}
+
+      <div class="rail-axis" role="radiogroup" aria-label="Group-by axis">
         <button
           type="button"
-          class="rail-reset-btn"
-          onclick={() => onExpandAllClasses?.()}
-        >
-          Expand all classes ({collapsedClassCount} collapsed)
-        </button>
+          class="rail-axis-btn"
+          role="radio"
+          aria-checked={groupBy.axis === "none"}
+          class:rail-axis-btn--on={groupBy.axis === "none"}
+          onclick={() => onSetAxis?.("none")}
+        >None</button>
+        {#if showCommunityAxis}
+          <button
+            type="button"
+            class="rail-axis-btn"
+            role="radio"
+            aria-checked={groupBy.axis === "community"}
+            class:rail-axis-btn--on={groupBy.axis === "community"}
+            onclick={() => onSetAxis?.("community")}
+          >Community</button>
+        {/if}
+        {#if showOntologyAxis}
+          <button
+            type="button"
+            class="rail-axis-btn"
+            role="radio"
+            aria-checked={groupBy.axis === "ontology"}
+            class:rail-axis-btn--on={groupBy.axis === "ontology"}
+            onclick={() => onSetAxis?.("ontology")}
+          >Ontology</button>
+        {/if}
+      </div>
+
+      {#if groupBy.axis === "ontology"}
+        <p class="rail-facet-hint">Collapse the graph at any class — folding re-lays out the graph.</p>
+        {#if foldTree}
+          <div class="rail-fold-tree" aria-label="Collapse the graph at">
+            {#each foldTree as domain (domain.id)}
+              <Collapsible title={domain.label} open={false} size="sm">
+                {#snippet trailing()}
+                  <span class="rail-fold-trailing">
+                    <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
+                    <button
+                      type="button"
+                      class="rail-fold-pill"
+                      class:rail-fold-pill--on={ontologyFolded.has(domain.id)}
+                      aria-pressed={ontologyFolded.has(domain.id)}
+                      onclick={(e) => { e.stopPropagation(); onToggleCollapse?.(domain.id); }}
+                    >
+                      <span class="rail-fold-glyph" aria-hidden="true"
+                        >{ontologyFolded.has(domain.id) ? "●" : "◯"}</span
+                      >{ontologyFolded.has(domain.id) ? "folded" : "fold"}
+                    </button>
+                  </span>
+                {/snippet}
+                <ul class="rail-type-groups">
+                  {#each domain.subs as sub (sub.id)}
+                    <li>
+                      <Collapsible title={sub.label} open={false} size="sm">
+                        {#snippet trailing()}
+                          <span class="rail-fold-trailing">
+                            <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
+                            <button
+                              type="button"
+                              class="rail-fold-pill"
+                              class:rail-fold-pill--on={ontologyFolded.has(sub.id)}
+                              aria-pressed={ontologyFolded.has(sub.id)}
+                              disabled={ontologyFolded.has(domain.id)}
+                              onclick={(e) => { e.stopPropagation(); onToggleCollapse?.(sub.id); }}
+                            >
+                              <span class="rail-fold-glyph" aria-hidden="true"
+                                >{ontologyFolded.has(sub.id) ? "●" : "◯"}</span
+                              >{ontologyFolded.has(sub.id) ? "folded" : "fold"}
+                            </button>
+                          </span>
+                        {/snippet}
+                        <ul class="rail-list">
+                          {#each sub.types as t (t.key)}
+                            <li class="rail-fold-leaf">
+                              <span class="rail-fold-glyph rail-fold-glyph--leaf" aria-hidden="true">·</span>
+                              <span class="rail-fold-leaf-label">{t.key}</span>
+                              <Badge shape="circle" size="sm" tone="neutral">{t.count}</Badge>
+                            </li>
+                          {/each}
+                        </ul>
+                      </Collapsible>
+                    </li>
+                  {/each}
+                </ul>
+              </Collapsible>
+            {/each}
+          </div>
+          <div class="rail-fold-bulk">
+            <span class="rail-fold-bulk-label">Fold all to:</span>
+            <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(0)}>Domain</button>
+            <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(1)}>Sub-domain</button>
+            <button type="button" class="rail-fold-baseline" onclick={() => onFoldToLevel?.(2)}>Type</button>
+          </div>
+          {#if activeFoldedCount > 0}
+            <button type="button" class="rail-reset-btn" onclick={() => onExpandAll?.()}>
+              Expand all ({activeFoldedCount} folded)
+            </button>
+          {/if}
+        {:else}
+          <p class="rail-empty">No ontology taxonomy loaded.</p>
+        {/if}
+      {:else if groupBy.axis === "community"}
+        <p class="rail-facet-hint">Fold members into their community — folding re-lays out the graph.</p>
+        {#if communityInfo.liveCount === 0}
+          <p class="rail-empty">No communities.</p>
+        {:else}
+          <ul class="rail-list">
+            {#each communityInfo.live as c (c.key)}
+              <li class="rail-fold-row">
+                <span
+                  class="rail-swatch"
+                  style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
+                  aria-hidden="true"
+                ></span>
+                <span class="rail-fold-leaf-label">{c.key}</span>
+                <Badge shape="circle" size="sm" tone="neutral">{c.count}</Badge>
+                <button
+                  type="button"
+                  class="rail-fold-pill"
+                  class:rail-fold-pill--on={communityFolded.has(c.key)}
+                  aria-pressed={communityFolded.has(c.key)}
+                  onclick={() => onToggleCollapse?.(c.key)}
+                >
+                  <span class="rail-fold-glyph" aria-hidden="true"
+                    >{communityFolded.has(c.key) ? "●" : "◯"}</span
+                  >{communityFolded.has(c.key) ? "folded" : "fold"}
+                </button>
+              </li>
+            {/each}
+          </ul>
+          {#if activeFoldedCount > 0}
+            <button type="button" class="rail-reset-btn" onclick={() => onExpandAll?.()}>
+              Expand all ({activeFoldedCount} folded)
+            </button>
+          {/if}
+        {/if}
       {/if}
-    {/if}
+    </Collapsible>
   </Collapsible>
 </aside>
 
@@ -364,6 +570,15 @@
   .rail-search {
     padding: 0.5rem 0.85rem 0.7rem;
     border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  /* Tracked UI: the relocated count badges sit just under the search input. */
+  .rail-stats {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--st-spacing-1, 0.25rem);
+    margin-top: 0.45rem;
+    font-variant-numeric: tabular-nums;
   }
   /* The Communities/Entities lists are plain <ul> of standalone SelectableRows. */
   ul.rail-list {
@@ -447,6 +662,110 @@
     cursor: pointer;
   }
   .rail-reset-btn:hover {
+    background: var(--st-semantic-surface-hover, #f1f5f9);
+  }
+
+  /* B2 — group-by axis selector (segmented control). */
+  .rail-axis {
+    display: inline-flex;
+    margin: 0.35rem 0 0.2rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 5px;
+    overflow: hidden;
+  }
+  .rail-axis-btn {
+    padding: 0.28rem 0.6rem;
+    border: 0;
+    border-right: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    background: var(--st-semantic-surface-default, #fff);
+    color: var(--st-semantic-text-secondary, #475569);
+    font-size: 0.76rem;
+    cursor: pointer;
+  }
+  .rail-axis-btn:last-child {
+    border-right: 0;
+  }
+  .rail-axis-btn--on {
+    background: var(--st-semantic-action-primary, #2563eb);
+    color: #fff;
+  }
+  /* B2 — fold tree + pills (the §Two-Concepts separation device: NO selectable
+     rows / shape glyphs here; fold pills + state glyphs only). */
+  .rail-fold-tree {
+    display: grid;
+    gap: 0.15rem;
+    margin-top: 0.2rem;
+  }
+  .rail-fold-trailing {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  .rail-fold-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.12rem 0.4rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 999px;
+    background: var(--st-semantic-surface-default, #fff);
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-size: 0.68rem;
+    cursor: pointer;
+  }
+  .rail-fold-pill--on {
+    background: var(--st-semantic-action-primary, #2563eb);
+    color: #fff;
+    border-color: var(--st-semantic-action-primary, #2563eb);
+  }
+  .rail-fold-pill:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .rail-fold-glyph {
+    font-size: 0.7rem;
+    line-height: 1;
+  }
+  .rail-fold-glyph--leaf {
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .rail-fold-leaf,
+  .rail-fold-row {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.2rem 0.1rem;
+    font-size: 0.78rem;
+    color: var(--st-semantic-text-secondary, #475569);
+  }
+  .rail-fold-leaf-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .rail-fold-bulk {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.3rem;
+    margin-top: 0.35rem;
+  }
+  .rail-fold-bulk-label {
+    font-size: 0.72rem;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .rail-fold-baseline {
+    padding: 0.22rem 0.5rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 4px;
+    background: var(--st-semantic-surface-default, #fff);
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-size: 0.72rem;
+    cursor: pointer;
+  }
+  .rail-fold-baseline:hover {
     background: var(--st-semantic-surface-hover, #f1f5f9);
   }
 </style>

--- a/studio/src/lib/classNodes.js
+++ b/studio/src/lib/classNodes.js
@@ -50,6 +50,15 @@ const CLASS_ID_PREFIX = "class:";
 const COMMUNITY_ID_PREFIX = "community-node:";
 
 /**
+ * Type synthetic-node id namespace prefix (B2 — Type-level group-by). The Type
+ * LEVEL of the ontology taxonomy is the entity `type` itself; the artifact has no
+ * per-type CLASS node, so grouping a Type folds every entity sharing that `type`
+ * into one synthetic type node — the single-level, community-like collapse.
+ * Distinct from `class:` and `community-node:` so the three never collide.
+ */
+const TYPE_ID_PREFIX = "type-node:";
+
+/**
  * Mint the reserved synthetic id for a community fold node from its key
  * (Amendment A2). The id is namespaced so it cannot be confused with a class id;
  * collision against a REAL node id is the caller's concern (see
@@ -676,6 +685,155 @@ export function injectCommunityNodes(
       relation: "has_member",
       structural: true,
       community_edge_kind: "membership",
+    });
+  }
+
+  return {
+    nodes: [...baseNodes, ...addedNodes],
+    links: [...baseEdges, ...addedEdges],
+    idByKey: ids,
+  };
+}
+
+/* ===========================================================================
+ * B2 — TYPE group-by axis: the leaf "Type" level, single-level collapse.
+ *
+ * The ontology taxonomy's leaf classes carry `member_node_types` (raw entity
+ * `type` strings like "Character"). Those Types are the rail's deepest rows but
+ * have NO per-type CLASS node in the artifact, so a grouped Type folds every
+ * entity whose `type` equals it into one synthetic type node — exactly the
+ * community pattern (a synthetic fold node + a one-hop entity parent map). The
+ * studio passes `typeOf` (entity -> its `type`) IN so this module needs no
+ * graphAdapter import (mirrors the community axis).
+ * ======================================================================== */
+
+/** Mint the reserved synthetic id for a Type fold node from its `type` value. */
+export function typeNodeId(typeName) {
+  return `${TYPE_ID_PREFIX}${typeName}`;
+}
+
+/**
+ * Collision-safe synthetic ids for grouped Type values (mirrors
+ * `mintCommunityNodeIds`): a real node literally equal to `type-node:<T>` is never
+ * clobbered/re-endpointed onto.
+ *
+ * @param {Iterable<string>} typeNames  the grouped type values to mint ids for.
+ * @param {Set<string>} existingIds     every id already present in the graph.
+ * @returns {Map<string,string>} type value -> chosen collision-free node id.
+ */
+export function mintTypeNodeIds(typeNames, existingIds) {
+  const idByKey = new Map();
+  const taken = new Set(existingIds);
+  for (const name of typeNames) {
+    if (typeof name !== "string" || name.length === 0 || idByKey.has(name)) continue;
+    let id = typeNodeId(name);
+    let salt = 1;
+    while (taken.has(id)) {
+      id = `${typeNodeId(name)}#${salt}`;
+      salt += 1;
+    }
+    taken.add(id);
+    idByKey.set(name, id);
+  }
+  return idByKey;
+}
+
+/**
+ * Build the Type parent index for `applyGroupCollapse`. Each entity whose `type`
+ * is a grouped (live) type gets its synthetic type fold node as its parent; the
+ * fold node has no parent and an EMPTY descendant set (single-level, members fold
+ * via the entity leg only — like community).
+ *
+ * @param {{ nodes?: object[] }} graph
+ * @param {object} index
+ * @param {(node:object)=>string|null} index.typeOf  entity -> its `type` value.
+ * @param {Iterable<string>} index.typeNames         the grouped type values.
+ * @param {Map<string,string>} [index.idByKey]       value -> synthetic node id.
+ * @returns {{ parentById: Map<string,string|null>,
+ *             descendantsByTarget: Map<string,Set<string>>,
+ *             idByKey: Map<string,string>,
+ *             collapseTargetByKey: (name:string)=>string|undefined }}
+ */
+export function buildTypeParentIndex(graph, { typeOf, typeNames, idByKey } = {}) {
+  const baseNodes = graphNodeList(graph);
+  const live = new Set(
+    [...(typeNames ?? [])].filter((k) => typeof k === "string" && k.length > 0),
+  );
+  const ids =
+    idByKey instanceof Map ? idByKey : mintTypeNodeIds(live, new Set(baseNodes.map((n) => n.id)));
+
+  const parentById = new Map();
+  for (const node of baseNodes) {
+    const id = node?.id;
+    if (typeof id !== "string") continue;
+    const name = typeOf?.(node);
+    if (typeof name !== "string" || !live.has(name)) continue;
+    const targetId = ids.get(name);
+    if (typeof targetId === "string") parentById.set(id, targetId);
+  }
+  const descendantsByTarget = new Map();
+  for (const targetId of ids.values()) descendantsByTarget.set(targetId, new Set());
+
+  return {
+    parentById,
+    descendantsByTarget,
+    idByKey: ids,
+    collapseTargetByKey: (name) => ids.get(name),
+  };
+}
+
+/**
+ * Inject one synthetic Type fold node per grouped `type` value + its `has_member`
+ * structural edges (mirrors `injectCommunityNodes`). The node carries
+ * `type_node_kind: "type"` + the original `type_name` (click dispatch reads
+ * THIS, never the id) and `type: "OntologyTypeGroup"` so the renderer boxes it.
+ *
+ * @param {{ nodes?: object[], links?: object[], edges?: object[] }} graph
+ * @param {object} options
+ * @param {(node:object)=>string|null} options.typeOf   entity -> its `type`.
+ * @param {Iterable<string>} options.typeNames          grouped type values.
+ * @param {Map<string,string>} [options.idByKey]        shared minted ids.
+ * @returns {{ nodes: object[], links: object[], idByKey: Map<string,string> }}
+ */
+export function injectTypeNodes(graph, { typeOf, typeNames, idByKey } = {}) {
+  const baseNodes = graphNodeList(graph);
+  const baseEdges = graphEdgeList(graph);
+  const live = new Set(
+    [...(typeNames ?? [])].filter((k) => typeof k === "string" && k.length > 0),
+  );
+  const ids =
+    idByKey instanceof Map ? idByKey : mintTypeNodeIds(live, new Set(baseNodes.map((n) => n.id)));
+
+  if (live.size === 0) return { nodes: baseNodes, links: baseEdges, idByKey: ids };
+
+  const addedNodes = [];
+  for (const name of live) {
+    const nodeId = ids.get(name);
+    if (typeof nodeId !== "string") continue;
+    addedNodes.push({
+      id: nodeId,
+      label: name,
+      type: "OntologyTypeGroup",
+      type_node_kind: "type",
+      type_name: name,
+      group: name,
+    });
+  }
+
+  const addedEdges = [];
+  for (const node of baseNodes) {
+    const id = node?.id;
+    if (typeof id !== "string") continue;
+    const name = typeOf?.(node);
+    if (typeof name !== "string" || !live.has(name)) continue;
+    const nodeId = ids.get(name);
+    if (typeof nodeId !== "string") continue;
+    addedEdges.push({
+      source: nodeId,
+      target: id,
+      relation: "has_member",
+      structural: true,
+      type_edge_kind: "membership",
     });
   }
 

--- a/studio/src/lib/classNodes.js
+++ b/studio/src/lib/classNodes.js
@@ -38,6 +38,62 @@
 /** Class id namespace prefix the artifact uses (`class:<Name>`). */
 const CLASS_ID_PREFIX = "class:";
 
+/**
+ * Community synthetic-node id namespace prefix (B2 / Amendment A2). The id of a
+ * community fold node is minted ONLY by `communityNodeId`, never by raw concat,
+ * so click dispatch and collision detection have a single, auditable mint point
+ * — mirroring the `class:` discipline above. This is DISTINCT from the
+ * `nodeGroup` tone palette key (`community:<n>`, graphAdapter.js): keep the
+ * palette key, the `community_key` passthrough, and this synthetic id three
+ * separate, unambiguous things.
+ */
+const COMMUNITY_ID_PREFIX = "community-node:";
+
+/**
+ * Mint the reserved synthetic id for a community fold node from its key
+ * (Amendment A2). The id is namespaced so it cannot be confused with a class id;
+ * collision against a REAL node id is the caller's concern (see
+ * `mintCommunityNodeIds`), which is why this helper is the only mint point.
+ * @param {string} key  the community key (a `nodeCommunity` value).
+ * @returns {string}
+ */
+export function communityNodeId(key) {
+  return `${COMMUNITY_ID_PREFIX}${key}`;
+}
+
+/**
+ * Deterministically assign a non-colliding synthetic id to every live community
+ * key (Amendment A2 — collision detection is MANDATORY). The naive id is
+ * `communityNodeId(key)`; if that literal already exists as a REAL node id we do
+ * NOT silently reuse it (which would let re-endpointing land edges on the wrong
+ * node). Instead we disambiguate by appending a numeric sentinel until the id is
+ * free, and record the chosen id. The mapping is returned so both the injector
+ * and the parent-index build from the SAME ids.
+ *
+ * @param {Iterable<string>} liveKeys  the live community keys to mint ids for.
+ * @param {Set<string>} existingIds    every id already present in the graph.
+ * @returns {Map<string,string>} community key -> chosen collision-free node id.
+ */
+export function mintCommunityNodeIds(liveKeys, existingIds) {
+  const idByKey = new Map();
+  const taken = new Set(existingIds);
+  for (const key of liveKeys) {
+    if (typeof key !== "string" || key.length === 0 || idByKey.has(key)) continue;
+    let id = communityNodeId(key);
+    // Collision with a real node id (or an already-minted synthetic) -> append a
+    // deterministic sentinel until free. The chosen id is recorded so the real
+    // node is never re-endpointed onto.
+    let salt = 1;
+    while (taken.has(id)) {
+      id = `${communityNodeId(key)}#${salt}`;
+      salt += 1;
+    }
+    taken.add(id);
+    idByKey.set(key, id);
+  }
+  return idByKey;
+}
+
 function graphNodeList(graph) {
   return graph?.nodes ?? [];
 }
@@ -287,54 +343,63 @@ function asArray(value) {
 }
 
 /**
- * EVOL 2.b + 2.d — collapse ontology classes with multi-level link inheritance.
+ * B2 — generalized, AXIS-NEUTRAL collapse engine (single source of truth).
  *
- * Produces a NEW graph in which every descendant (sub-class + member entity) of
- * a collapsed class is HIDDEN and folded into that collapsed class node (which
- * itself stays visible). Every edge is re-endpointed to the nearest visible
- * ancestor of each endpoint; edges whose endpoint resolves to nothing are
- * dropped, self-loops are dropped (and counted as internal), and parallel edges
- * are aggregated.
+ * Lifted verbatim from `applyOntologyCollapse` (EVOL 2.b/2.d), this is the one
+ * re-endpointing engine shared by the Ontology (multi-level) and Community
+ * (single-level degenerate) group-by axes. The only axis-specific input is the
+ * parent index; the link-bubbling contract (re-endpoint to nearest visible
+ * ancestor, drop dangling, drop+tally self-loops, aggregate parallels by
+ * `source|target|relation|weak`, structural-only-if-unanimous, weak preserved,
+ * `(+N)` fold-node annotations, deterministic order) is identical on every axis.
+ *
+ * Produces a NEW graph in which every descendant of a collapse target is HIDDEN
+ * and folded into that target node (which itself stays visible). For ontology a
+ * target's descendants are its sub-class CLASS ids; for community the set is
+ * empty (members fold via the entity leg of `parentById` only).
  *
  * @param {{ nodes?: object[], links?: object[], edges?: object[] }} graph
- *        a graph already injected with class nodes (levels: "all").
- * @param {object|null} classHierarchies the class-hierarchies.json artifact.
- * @param {object} [options]
- * @param {string[]} [options.collapsedClassIds=[]] class ids to collapse.
+ *        a graph already injected with the axis's synthetic group nodes.
+ * @param {object} index
+ * @param {Map<string,string|null>} index.parentById     each id -> its parent
+ *        (entity -> its leaf group; group -> its parent group, null at a root).
+ * @param {Iterable<string>} index.collapseTargets        the group ids to fold.
+ * @param {Map<string,Set<string>>} index.descendantsByTarget  target -> its
+ *        descendant GROUP ids (∅ for a single-level axis like community).
  * @returns {{ nodes: object[], links: object[] }} a NEW graph, or the input
  *        unchanged when nothing is collapsed.
  */
-export function applyOntologyCollapse(
+export function applyGroupCollapse(
   graph,
-  classHierarchies,
-  { collapsedClassIds = [] } = {},
+  { parentById = new Map(), collapseTargets = [], descendantsByTarget = new Map() } = {},
 ) {
   const collapsed = new Set(
-    (collapsedClassIds ?? []).filter((id) => typeof id === "string" && id.length > 0),
+    [...(collapseTargets ?? [])].filter((id) => typeof id === "string" && id.length > 0),
   );
   if (collapsed.size === 0) return graph;
 
   const baseNodes = graphNodeList(graph);
   const baseEdges = graphEdgeList(graph);
-  const { parentById, descendantClassIds } = buildClassParentIndex(classHierarchies);
 
-  // Ids hidden by the collapse: every CLASS + ENTITY descendant of any collapsed
-  // class. The collapsed class node itself STAYS visible (it is the fold target).
+  // Ids hidden by the collapse: every GROUP + ENTITY descendant of any collapse
+  // target. The target node itself STAYS visible (it is the fold target).
   const hidden = new Set();
-  for (const classId of collapsed) {
-    for (const descClassId of descendantClassIds.get(classId) ?? []) hidden.add(descClassId);
+  for (const targetId of collapsed) {
+    for (const descId of descendantsByTarget.get(targetId) ?? []) hidden.add(descId);
   }
-  // Entity members fold under a collapsed class when their leaf class is the
-  // collapsed class OR one of its (now hidden) descendant classes.
+  // Entity members fold under a collapse target when their leaf group is the
+  // target itself OR one of its (now hidden) descendant groups. For the
+  // single-level community axis `descendantsByTarget` is empty, so this reduces
+  // to "entity whose community is the collapsed one folds in one hop".
   for (const node of baseNodes) {
     const id = node?.id;
     if (typeof id !== "string") continue;
-    const leafClassId = parentById.get(id); // entity -> its leaf class (or undefined)
-    if (typeof leafClassId !== "string") continue;
-    if (collapsed.has(leafClassId) || hidden.has(leafClassId)) hidden.add(id);
+    const leafGroupId = parentById.get(id); // entity -> its leaf group (or undefined)
+    if (typeof leafGroupId !== "string") continue;
+    if (collapsed.has(leafGroupId) || hidden.has(leafGroupId)) hidden.add(id);
   }
-  // The collapsed class nodes are never themselves hidden.
-  for (const classId of collapsed) hidden.delete(classId);
+  // The collapse target nodes are never themselves hidden.
+  for (const targetId of collapsed) hidden.delete(targetId);
 
   const visibleIds = new Set();
   for (const node of baseNodes) {
@@ -344,8 +409,8 @@ export function applyOntologyCollapse(
   // Re-endpoint + aggregate every edge. Aggregation key is directional and keeps
   // strong/weak and relation distinct so different relation types never merge.
   const aggregated = new Map();
-  // internal_edge_count: edges that became self-loops inside a collapsed class.
-  const internalCountByClass = new Map();
+  // internal_edge_count: edges that became self-loops inside a collapse target.
+  const internalCountByTarget = new Map();
 
   // Stable edge order so aggregation (and thus output) is deterministic.
   const orderedEdges = [...baseEdges]
@@ -362,10 +427,10 @@ export function applyOntologyCollapse(
     // An endpoint that resolves to nothing visible -> drop the edge.
     if (source == null || target == null) continue;
     // Self-loop after folding -> drop, but tally it as an internal edge of the
-    // collapsed class it folded into.
+    // collapse target it folded into.
     if (source === target) {
       if (collapsed.has(source)) {
-        internalCountByClass.set(source, (internalCountByClass.get(source) ?? 0) + 1);
+        internalCountByTarget.set(source, (internalCountByTarget.get(source) ?? 0) + 1);
       }
       continue;
     }
@@ -408,15 +473,15 @@ export function applyOntologyCollapse(
     return ka < kb ? -1 : ka > kb ? 1 : 0;
   });
 
-  // Count hidden nodes per collapsed class (its whole hidden subtree). A hidden
+  // Count hidden nodes per collapse target (its whole hidden subtree). A hidden
   // node is attributed to the nearest collapsed ancestor on its parent chain.
-  const hiddenCountByClass = new Map();
+  const hiddenCountByTarget = new Map();
   for (const hiddenId of hidden) {
     let current = parentById.get(hiddenId) ?? null;
     const guard = new Set();
     while (current != null && !guard.has(current)) {
       if (collapsed.has(current)) {
-        hiddenCountByClass.set(current, (hiddenCountByClass.get(current) ?? 0) + 1);
+        hiddenCountByTarget.set(current, (hiddenCountByTarget.get(current) ?? 0) + 1);
         break;
       }
       guard.add(current);
@@ -428,18 +493,195 @@ export function applyOntologyCollapse(
     .filter((node) => typeof node?.id === "string" && visibleIds.has(node.id))
     .map((node) => {
       if (!collapsed.has(node.id)) return node;
-      const hiddenCount = hiddenCountByClass.get(node.id) ?? 0;
+      const hiddenCount = hiddenCountByTarget.get(node.id) ?? 0;
       const baseLabel = typeof node.label === "string" && node.label ? node.label : node.id;
       return {
         ...node,
         collapsed: true,
         hidden_node_count: hiddenCount,
-        internal_edge_count: internalCountByClass.get(node.id) ?? 0,
-        // Visual cue: a collapsed class shows its folded-member count so the
+        internal_edge_count: internalCountByTarget.get(node.id) ?? 0,
+        // Visual cue: a collapsed target shows its folded-member count so the
         // renderer's in-box label reads e.g. "Character (+42)".
         label: hiddenCount > 0 ? `${baseLabel} (+${hiddenCount})` : baseLabel,
       };
     });
 
   return { nodes, links };
+}
+
+/**
+ * EVOL 2.b/2.d — ontology collapse, now a thin ADAPTER over `applyGroupCollapse`.
+ *
+ * Builds the ontology parent index (`buildClassParentIndex`) and delegates to the
+ * shared engine; behaviour is byte-for-byte identical to the pre-B2 monolithic
+ * `applyOntologyCollapse` (same back-compat signature for existing callers/tests).
+ *
+ * @param {{ nodes?: object[], links?: object[], edges?: object[] }} graph
+ *        a graph already injected with class nodes (levels: "all").
+ * @param {object|null} classHierarchies the class-hierarchies.json artifact.
+ * @param {object} [options]
+ * @param {string[]} [options.collapsedClassIds=[]] class ids to collapse.
+ * @returns {{ nodes: object[], links: object[] }} a NEW graph, or the input
+ *        unchanged when nothing is collapsed.
+ */
+export function applyOntologyCollapse(graph, classHierarchies, { collapsedClassIds = [] } = {}) {
+  const collapseTargets = (collapsedClassIds ?? []).filter(
+    (id) => typeof id === "string" && id.length > 0,
+  );
+  if (collapseTargets.length === 0) return graph;
+  const { parentById, descendantClassIds } = buildClassParentIndex(classHierarchies);
+  return applyGroupCollapse(graph, {
+    parentById,
+    collapseTargets,
+    descendantsByTarget: descendantClassIds,
+  });
+}
+
+/* ===========================================================================
+ * B2 — COMMUNITY group-by axis: single-level "class layer in disguise".
+ *
+ * Communities are FLAT (no parent/level/sub-community schema anywhere), so the
+ * community axis is a degenerate single-level collapse. A synthetic community
+ * fold node is injected per LIVE community key; the multi-level engine
+ * degenerates correctly — a hidden entity resolves to its community node in one
+ * hop, a visible entity resolves to itself, no special-casing.
+ *
+ * The studio (graphAdapter) owns `nodeCommunity` and `communityStats`; to avoid
+ * a module cycle, the App layer passes the per-node community key + the live-key
+ * set + per-key tone IN, rather than this module importing graphAdapter.
+ * ======================================================================== */
+
+/**
+ * Build the community parent index for `applyGroupCollapse` (Amendments A1+A2).
+ *
+ * `parentById` maps each entity id to its community fold node id — but ONLY when
+ * the entity's community key is in the LIVE set (A1). Entities with no live
+ * community key get NO parent, so `nearestVisibleAncestor` resolves them to
+ * themselves and they never fold into a missing ancestor (which would make them
+ * vanish). Community nodes have no parent (single level) and an EMPTY descendant
+ * set (members fold via the entity leg only).
+ *
+ * @param {{ nodes?: object[] }} graph
+ * @param {object} index
+ * @param {(node:object)=>string|null} index.communityOf  entity -> community key.
+ * @param {Iterable<string>} index.liveKeys                the live community keys.
+ * @param {Map<string,string>} [index.idByKey]             key -> synthetic node id
+ *        (from `mintCommunityNodeIds`); minted here against the graph if omitted.
+ * @returns {{ parentById: Map<string,string|null>,
+ *             descendantsByTarget: Map<string,Set<string>>,
+ *             idByKey: Map<string,string>,
+ *             collapseTargetByKey: (key:string)=>string|undefined }}
+ */
+export function buildCommunityParentIndex(graph, { communityOf, liveKeys, idByKey } = {}) {
+  const baseNodes = graphNodeList(graph);
+  const live = new Set([...(liveKeys ?? [])].filter((k) => typeof k === "string" && k.length > 0));
+  const ids =
+    idByKey instanceof Map
+      ? idByKey
+      : mintCommunityNodeIds(live, new Set(baseNodes.map((n) => n.id)));
+
+  const parentById = new Map();
+  // A1: only entities whose community key is live get a parent (their community
+  // fold node). Non-live / community-less entities are left unmapped.
+  for (const node of baseNodes) {
+    const id = node?.id;
+    if (typeof id !== "string") continue;
+    const key = communityOf?.(node);
+    if (typeof key !== "string" || !live.has(key)) continue;
+    const targetId = ids.get(key);
+    if (typeof targetId === "string") parentById.set(id, targetId);
+  }
+  // The community node itself has no parent (single level) — leave it unmapped so
+  // it resolves to itself.
+  const descendantsByTarget = new Map();
+  for (const targetId of ids.values()) descendantsByTarget.set(targetId, new Set());
+
+  return {
+    parentById,
+    descendantsByTarget,
+    idByKey: ids,
+    collapseTargetByKey: (key) => ids.get(key),
+  };
+}
+
+/**
+ * Inject one synthetic community fold node per LIVE key + its `has_member`
+ * structural edges (mirrors `injectOntologyClassNodes`). Collision-safe ids come
+ * from `mintCommunityNodeIds` (Amendment A2) so a real node whose id literally
+ * equals `community-node:<key>` is never clobbered or re-endpointed onto.
+ *
+ * Each community node carries (A2):
+ *   - id                : the collision-free synthetic id
+ *   - community_node_kind: "community"   (click dispatch recognizes it)
+ *   - community_key     : the original key (click reads THIS, never the id)
+ *   - type              : "OntologyCommunity"  (box shape via TYPE_SHAPE)
+ *   - tone passthrough  : `group` set to the key's `nodeGroup` tone key so the
+ *                         fold-node swatch matches the rail/canvas (see A5)
+ *
+ * @param {{ nodes?: object[], links?: object[], edges?: object[] }} graph
+ * @param {object} options
+ * @param {(node:object)=>string|null} options.communityOf  entity -> key.
+ * @param {Iterable<string>} options.liveKeys                live keys to inject.
+ * @param {Map<string,string>} [options.idByKey]            shared minted ids.
+ * @param {(key:string)=>string|undefined} [options.toneKeyOf]  key -> nodeGroup
+ *        palette key for the swatch (A5); defaults to the key itself.
+ * @param {(key:string)=>string|undefined} [options.labelOf]  key -> display label.
+ * @returns {{ nodes: object[], links: object[], idByKey: Map<string,string> }}
+ *        a NEW graph (original + community nodes + has_member edges).
+ */
+export function injectCommunityNodes(
+  graph,
+  { communityOf, liveKeys, idByKey, toneKeyOf, labelOf } = {},
+) {
+  const baseNodes = graphNodeList(graph);
+  const baseEdges = graphEdgeList(graph);
+  const live = new Set([...(liveKeys ?? [])].filter((k) => typeof k === "string" && k.length > 0));
+  const ids =
+    idByKey instanceof Map
+      ? idByKey
+      : mintCommunityNodeIds(live, new Set(baseNodes.map((n) => n.id)));
+
+  if (live.size === 0) return { nodes: baseNodes, links: baseEdges, idByKey: ids };
+
+  const addedNodes = [];
+  for (const key of live) {
+    const nodeId = ids.get(key);
+    if (typeof nodeId !== "string") continue;
+    const node = {
+      id: nodeId,
+      label: (labelOf && labelOf(key)) || key,
+      type: "OntologyCommunity",
+      community_node_kind: "community",
+      community_key: key,
+    };
+    const tone = toneKeyOf ? toneKeyOf(key) : key;
+    // `group` drives the DS categorical palette; reuse the community's tone key
+    // (its `nodeGroup` palette key, A5) so the fold node matches rail/canvas.
+    if (tone != null) node.group = tone;
+    addedNodes.push(node);
+  }
+
+  // has_member: community node -> each live member entity present in the graph.
+  const addedEdges = [];
+  for (const node of baseNodes) {
+    const id = node?.id;
+    if (typeof id !== "string") continue;
+    const key = communityOf?.(node);
+    if (typeof key !== "string" || !live.has(key)) continue;
+    const nodeId = ids.get(key);
+    if (typeof nodeId !== "string") continue;
+    addedEdges.push({
+      source: nodeId,
+      target: id,
+      relation: "has_member",
+      structural: true,
+      community_edge_kind: "membership",
+    });
+  }
+
+  return {
+    nodes: [...baseNodes, ...addedNodes],
+    links: [...baseEdges, ...addedEdges],
+    idByKey: ids,
+  };
 }

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -78,6 +78,15 @@ const NODE_PROFILE_FIELDS = [
   // EVOL 2.a: synthetic ontology CLASS node passthrough (injectOntologyClassNodes).
   "ontology_node_kind",
   "ontology_class_id",
+  // B2 / Amendment A2: synthetic COMMUNITY fold node passthrough
+  // (injectCommunityNodes). `community_key` lets click dispatch recover the fold
+  // key WITHOUT parsing the (collision-disambiguated) synthetic id.
+  "community_node_kind",
+  "community_key",
+  // B2: fold-node annotations survive into the scene for the (+N) in-box label.
+  "collapsed",
+  "hidden_node_count",
+  "internal_edge_count",
 ];
 
 const EDGE_PROFILE_FIELDS = [
@@ -154,6 +163,9 @@ const TYPE_SHAPE = {
   // EVOL 2.a: synthetic ontology CLASS nodes render as labelled rounded boxes
   // (the class name sits inside the box), distinct from data-driven entity hubs.
   OntologyClass: "roundedbox",
+  // B2 / Amendment A2: synthetic COMMUNITY fold nodes also read as a GROUP, not an
+  // entity — a labelled box (the community name inside), tone from communityStats.
+  OntologyCommunity: "roundedbox",
 };
 
 /**
@@ -195,6 +207,8 @@ const REL_DASH = {
   // anchoring, like other membership/structural-anchoring relations).
   subclass_of: "solid",
   has_instance: "dotted",
+  // B2: community membership structural edge (community node -> member entity).
+  has_member: "dotted",
 };
 export function dashForRelation(relation) {
   if (!relation) return undefined;
@@ -678,6 +692,14 @@ function computeCommunityStats(graph) {
   }
 
   const byComm = new Map();
+  // B2 / Amendment A5: the tone map is keyed by `nodeGroup`, but a NUMERIC-only
+  // community's `nodeCommunity` key (`Community <n>`) differs from its `nodeGroup`
+  // palette key (`community:<n>`), so a direct `toneByGroup.get(nodeCommunity)`
+  // MISSES and silently falls back to category1 — diverging from the canvas. Each
+  // node knows BOTH, so record the community key -> nodeGroup palette key mapping
+  // and resolve the tone under the palette key. Named communities are unaffected
+  // (their nodeGroup and nodeCommunity both resolve to community_name).
+  const groupKeyByComm = new Map();
   let isolatedCount = 0;
   for (const node of nodes) {
     const key = nodeCommunity(node);
@@ -685,6 +707,10 @@ function computeCommunityStats(graph) {
     if (key === undefined || key === null || key === "") {
       if (!live) isolatedCount += 1;
       continue;
+    }
+    if (!groupKeyByComm.has(key)) {
+      const g = nodeGroup(node);
+      groupKeyByComm.set(key, g === undefined || g === null ? key : g);
     }
     const rec = byComm.get(key) ?? { count: 0, live: false };
     rec.count += 1;
@@ -694,7 +720,15 @@ function computeCommunityStats(graph) {
   const liveList = [];
   for (const [key, rec] of byComm) {
     if (rec.live) {
-      liveList.push({ key: String(key), count: rec.count, tone: toneByGroup.get(key) ?? "category1" });
+      const groupKey = groupKeyByComm.get(key) ?? key;
+      liveList.push({
+        key: String(key),
+        count: rec.count,
+        // `groupKey` is the `nodeGroup` palette key (= `key` for named
+        // communities, `community:<n>` for numeric-only) — the canvas tone key.
+        groupKey: String(groupKey),
+        tone: toneByGroup.get(groupKey) ?? "category1",
+      });
     } else {
       isolatedCount += rec.count;
     }

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -83,6 +83,10 @@ const NODE_PROFILE_FIELDS = [
   // key WITHOUT parsing the (collision-disambiguated) synthetic id.
   "community_node_kind",
   "community_key",
+  // B2 (§2): synthetic TYPE fold node passthrough (injectTypeNodes). `type_name`
+  // lets click dispatch recover the fold key without parsing the synthetic id.
+  "type_node_kind",
+  "type_name",
   // B2: fold-node annotations survive into the scene for the (+N) in-box label.
   "collapsed",
   "hidden_node_count",
@@ -166,6 +170,8 @@ const TYPE_SHAPE = {
   // B2 / Amendment A2: synthetic COMMUNITY fold nodes also read as a GROUP, not an
   // entity — a labelled box (the community name inside), tone from communityStats.
   OntologyCommunity: "roundedbox",
+  // B2 (§2): synthetic TYPE fold nodes (Type-level group-by) read as a GROUP box.
+  OntologyTypeGroup: "roundedbox",
 };
 
 /**

--- a/studio/src/lib/groupBy.js
+++ b/studio/src/lib/groupBy.js
@@ -1,0 +1,303 @@
+/**
+ * B2 — group-by orchestration (the EXTRACTED, testable App `groupedGraph` chain).
+ *
+ * The ontology→inject→index→collapse chain used to live INLINE inside
+ * `App.svelte`'s `$derived.by`, so no test could drive the REAL App ontology path
+ * end-to-end and the Type level had no collapse path at all. This module is the
+ * single, pure source of truth the App now calls:
+ *
+ *   computeGroupedGraph({ graph, classHierarchies, communityCtx, typeCtx, grouped })
+ *
+ * It folds, over the UNION of every grouped item (ontology classes + communities
+ * + leaf TYPES), into ONE `applyGroupCollapse` pass — identical to the old inline
+ * derivation for ontology + community, plus the new Type axis. Empty grouped set
+ * = the fast path (returns the input graph untouched).
+ *
+ * It also owns the tri-state bulk-button + NESTING-ABSORPTION math (spec §3/§4):
+ *   - effective grouping resolves a class to its NEAREST CHECKED ANCESTOR;
+ *   - an absorbed class is EXCLUDED from level counts and rendered disabled;
+ *   - per ontology level the {none|partial|all} state + (n/m) count are derived
+ *     from the checked set vs the level's non-absorbed members.
+ */
+
+import {
+  injectOntologyClassNodes,
+  buildClassParentIndex,
+  injectCommunityNodes,
+  buildCommunityParentIndex,
+  injectTypeNodes,
+  buildTypeParentIndex,
+  applyGroupCollapse,
+} from "./classNodes.js";
+import { splitGroupedKeys } from "./viewerState.js";
+
+/**
+ * Compute the COLLAPSED graph for a grouped-key set — the real App `groupedGraph`.
+ *
+ * @param {object} args
+ * @param {{ nodes?: object[], links?: object[] }} args.graph  the raw graph.
+ * @param {object|null} args.classHierarchies  the class-hierarchies.json artifact.
+ * @param {object|null} [args.communityCtx]  the App's per-key community context
+ *        ({ liveKeys, idByKey, communityOf, ... }); null when no community is
+ *        grouped or none are live. Pre-built by the App so injector + index agree
+ *        on synthetic ids.
+ * @param {object|null} [args.typeCtx]  the App's per-key TYPE context
+ *        ({ typeNames, idByKey, typeOf }); null when no type is grouped.
+ * @param {string[]} args.grouped  the namespaced grouped-key set.
+ * @returns {{ nodes: object[], links: object[] }} the collapsed graph, or the
+ *        input graph unchanged when nothing is grouped (fast path).
+ */
+export function computeGroupedGraph({
+  graph,
+  classHierarchies = null,
+  communityCtx = null,
+  typeCtx = null,
+  grouped = [],
+} = {}) {
+  const { ontologyClassIds, communityKeys, typeNames } = splitGroupedKeys(grouped);
+  const hasOntologyGroup = ontologyClassIds.length > 0;
+  const hasCommunityGroup = communityKeys.length > 0;
+  const hasTypeGroup = typeNames.length > 0;
+  if (!hasOntologyGroup && !hasCommunityGroup && !hasTypeGroup) return graph;
+
+  let injected = graph;
+  const parentById = new Map();
+  const descendantsByTarget = new Map();
+  const collapseTargets = [];
+
+  if (hasOntologyGroup && classHierarchies?.hierarchies) {
+    injected = injectOntologyClassNodes(injected, classHierarchies, { levels: "all" });
+    const { parentById: classParents, descendantClassIds } =
+      buildClassParentIndex(classHierarchies);
+    for (const [k, v] of classParents) parentById.set(k, v);
+    for (const [k, v] of descendantClassIds) descendantsByTarget.set(k, v);
+    for (const id of ontologyClassIds) collapseTargets.push(id);
+  }
+
+  if (hasCommunityGroup && communityCtx) {
+    injected = injectCommunityNodes(injected, communityCtx);
+    const {
+      parentById: commParents,
+      descendantsByTarget: commDesc,
+      collapseTargetByKey,
+    } = buildCommunityParentIndex(injected, communityCtx);
+    for (const [k, v] of commParents) {
+      // Don't clobber an ontology parent mapping for a shared entity.
+      if (!parentById.has(k)) parentById.set(k, v);
+    }
+    for (const [k, v] of commDesc) descendantsByTarget.set(k, v);
+    for (const key of communityKeys) {
+      const id = collapseTargetByKey(key);
+      if (typeof id === "string") collapseTargets.push(id);
+    }
+  }
+
+  if (hasTypeGroup && typeCtx) {
+    injected = injectTypeNodes(injected, typeCtx);
+    const {
+      parentById: typeParents,
+      descendantsByTarget: typeDesc,
+      collapseTargetByKey,
+    } = buildTypeParentIndex(injected, typeCtx);
+    for (const [k, v] of typeParents) {
+      // Ontology + community parents win for a shared entity; a Type fold only
+      // governs entities the other axes left unmapped.
+      if (!parentById.has(k)) parentById.set(k, v);
+    }
+    for (const [k, v] of typeDesc) descendantsByTarget.set(k, v);
+    for (const name of typeNames) {
+      const id = collapseTargetByKey(name);
+      if (typeof id === "string") collapseTargets.push(id);
+    }
+  }
+
+  if (collapseTargets.length === 0) return injected;
+  return applyGroupCollapse(injected, { parentById, collapseTargets, descendantsByTarget });
+}
+
+/* ===========================================================================
+ * Tri-state bulk-button + NESTING-ABSORPTION math (spec §3/§4).
+ * ======================================================================== */
+
+/** Flatten every class entry across all hierarchies in the artifact. */
+function allClassEntries(classHierarchies) {
+  const out = [];
+  const hierarchies = classHierarchies?.hierarchies;
+  if (!hierarchies || typeof hierarchies !== "object") return out;
+  for (const h of Object.values(hierarchies)) {
+    const classes = h?.classes_by_id;
+    if (!classes || typeof classes !== "object") continue;
+    for (const entry of Object.values(classes)) {
+      if (typeof entry?.id === "string") out.push(entry);
+    }
+  }
+  return out;
+}
+
+/** Map class id -> its parent id (null at a root), across all hierarchies. */
+function classParentMap(classHierarchies) {
+  const parent = new Map();
+  for (const entry of allClassEntries(classHierarchies)) {
+    parent.set(entry.id, typeof entry.parent_id === "string" ? entry.parent_id : null);
+  }
+  return parent;
+}
+
+/** The class ids at a given ontology level (0=Domain, 1=Sub-domain). */
+export function classIdsAtLevel(classHierarchies, level) {
+  return allClassEntries(classHierarchies)
+    .filter((e) => (e.level ?? 0) === level)
+    .map((e) => e.id);
+}
+
+/**
+ * Every leaf `member_node_types` value (the Type LEVEL) across the taxonomy.
+ * De-duplicated, deterministic order (first-seen). These are the group keys for
+ * the Type bulk button (level 2) — they are entity `type` strings, NOT class ids.
+ */
+export function typeNamesInTaxonomy(classHierarchies) {
+  const seen = new Set();
+  const out = [];
+  for (const entry of allClassEntries(classHierarchies)) {
+    for (const t of entry.member_node_types ?? []) {
+      if (typeof t === "string" && t.length > 0 && !seen.has(t)) {
+        seen.add(t);
+        out.push(t);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Is `classId` ABSORBED by a CHECKED ancestor (spec §3)? An absorbed class folds
+ * via its grouped parent, so it is excluded from level counts and disabled in the
+ * rail. PURE — walks the artifact parent chain.
+ *
+ * @param {string} classId
+ * @param {Set<string>} checkedClassIds  the grouped ontology class id set.
+ * @param {Map<string,string|null>} parentMap  class id -> parent id.
+ * @returns {string|null} the nearest CHECKED ancestor's class id, or null.
+ */
+function absorbingAncestor(classId, checkedClassIds, parentMap) {
+  let current = parentMap.get(classId) ?? null;
+  const guard = new Set();
+  while (current != null && !guard.has(current)) {
+    if (checkedClassIds.has(current)) return current;
+    guard.add(current);
+    current = parentMap.get(current) ?? null;
+  }
+  return null;
+}
+
+/**
+ * Per-class absorption view (spec §3). For every class id in the taxonomy, report
+ * whether it is absorbed by a grouped ancestor and, if so, that ancestor's LABEL
+ * (for the "grouped by parent <Domain>" tooltip).
+ *
+ * @param {object|null} classHierarchies
+ * @param {Set<string>|string[]} checkedClassIds  the grouped ontology class ids.
+ * @returns {Map<string,{ absorbed: boolean, byId: string|null, byLabel: string|null }>}
+ */
+export function ontologyAbsorption(classHierarchies, checkedClassIds = new Set()) {
+  const checked = new Set(checkedClassIds);
+  const parentMap = classParentMap(classHierarchies);
+  const labelById = new Map();
+  for (const entry of allClassEntries(classHierarchies)) {
+    labelById.set(
+      entry.id,
+      typeof entry.label === "string" && entry.label
+        ? entry.label
+        : String(entry.id).replace(/^class:/, ""),
+    );
+  }
+  const out = new Map();
+  for (const entry of allClassEntries(classHierarchies)) {
+    const by = absorbingAncestor(entry.id, checked, parentMap);
+    out.set(entry.id, {
+      absorbed: by != null,
+      byId: by,
+      byLabel: by != null ? (labelById.get(by) ?? null) : null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Tri-state of a bulk "Group all to <level>" button (spec §4).
+ *
+ * The denominator EXCLUDES absorbed classes (a class whose effective grouping
+ * resolves to a grouped ancestor doesn't count). For the Type level (2) the
+ * members are entity `type` strings, never absorbed (single level).
+ *
+ *   total  = non-absorbed members at the level
+ *   done   = those whose own key is checked
+ *   state  = "none" | "partial" | "all"  (all only when total>0 && done===total)
+ *
+ * @param {object} args
+ * @param {object|null} args.classHierarchies
+ * @param {number} args.level  0=Domain, 1=Sub-domain, 2=Type.
+ * @param {Set<string>|string[]} args.checkedOntologyIds  grouped class ids.
+ * @param {Set<string>|string[]} args.checkedTypeNames    grouped type values.
+ * @returns {{ state: "none"|"partial"|"all", done: number, total: number,
+ *             members: string[] }}
+ */
+export function ontologyLevelState({
+  classHierarchies,
+  level,
+  checkedOntologyIds = new Set(),
+  checkedTypeNames = new Set(),
+} = {}) {
+  if (level === 2) {
+    // Type level: members are the taxonomy's Type values; none can be absorbed.
+    const members = typeNamesInTaxonomy(classHierarchies);
+    const checked = new Set(checkedTypeNames);
+    const done = members.filter((m) => checked.has(m)).length;
+    return { state: stateOf(done, members.length), done, total: members.length, members };
+  }
+  const checked = new Set(checkedOntologyIds);
+  const parentMap = classParentMap(classHierarchies);
+  // Non-absorbed members at the level (absorbed = has a CHECKED ancestor).
+  const members = classIdsAtLevel(classHierarchies, level).filter(
+    (id) => absorbingAncestor(id, checked, parentMap) == null,
+  );
+  const done = members.filter((id) => checked.has(id)).length;
+  return { state: stateOf(done, members.length), done, total: members.length, members };
+}
+
+function stateOf(done, total) {
+  if (total === 0 || done === 0) return "none";
+  if (done >= total) return "all";
+  return "partial";
+}
+
+/**
+ * Map a level's tri-state to its DS-Button render contract (spec §4). The DS
+ * Button has only primary/secondary, so PARTIAL is secondary + a count Badge.
+ *
+ *   none    -> secondary, aria-pressed="false"  (click groups the level)
+ *   all     -> primary,   aria-pressed="true"   (click toggles OFF)
+ *   partial -> secondary, aria-pressed="false", badge "done/total" (click completes)
+ *
+ * NEVER aria-checked="mixed" — these are toggle BUTTONS (aria-pressed), not
+ * checkboxes.
+ *
+ * @param {{ state: string, done: number, total: number }} levelState
+ * @returns {{ variant: "primary"|"secondary", ariaPressed: "true"|"false",
+ *             showBadge: boolean, badge: string|null }}
+ */
+export function levelButtonView(levelState) {
+  const { state, done, total } = levelState ?? { state: "none", done: 0, total: 0 };
+  if (state === "all") {
+    return { variant: "primary", ariaPressed: "true", showBadge: false, badge: null };
+  }
+  if (state === "partial") {
+    return {
+      variant: "secondary",
+      ariaPressed: "false",
+      showBadge: true,
+      badge: `${done}/${total}`,
+    };
+  }
+  return { variant: "secondary", ariaPressed: "false", showBadge: false, badge: null };
+}

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -1,23 +1,28 @@
 /**
  * Single client viewer state for the ontology studio SPA (selection rework R8-3,
- * group-by axis B2).
+ * PER-ITEM group-by B2).
  *
- * The LEFT column is navigation (search + Types / Communities / Entities lists);
- * the RIGHT column shows the current SELECTION and drills down to an entity.
+ * The LEFT column is navigation (search + Ontology / Communities / Entities
+ * lists); the RIGHT column shows the current SELECTION and drills down to an
+ * entity.
  *
  *   selection : { types:[], communities:[], entities:[] } — what the user picked
  *               on the left. Each list toggles independently (click = add/remove).
+ *               NOTE: `selection.types` is the ontology FILTER facet and is kept
+ *               STRICTLY SEPARATE from the group-by set below — grouping a class
+ *               is NOT selecting/filtering it.
  *   focusId   : the last individually-picked entity → gets the "double" emphasis
  *               (selection highlight + focus shadow) and opens its detail.
  *   options   : { showWeakLinks, groupBy } — graph options (ex-"Facets").
- *               `groupBy` (B2) is the axis-scoped group-by MODE:
- *                 { axis: "none"|"community"|"ontology",   // mutually exclusive
- *                   ontology:  { collapsedClassIds:[] },   // mixed-level class ids
- *                   community: { collapsedKeys:[] } }      // community keys
- *               Only the ACTIVE axis's collapse set is applied; both sets coexist
- *               in state so each axis remembers its own folds (F3 memory). The
- *               pre-B2 `showOntologyClasses` is subsumed: axis:"ontology" + empty
- *               collapse set === "show classes, nothing folded".
+ *               `groupBy` (B2 per-item) is a SET of GROUPED ITEM KEYS:
+ *                 { grouped: [ "ontology:<classId>" | "community:<key>", … ] }
+ *               Every checked item (an Ontology class node OR a community)
+ *               contributes one namespaced key; checking GROUPS (collapses) it,
+ *               unchecking ungroups it. MULTI-SELECT: several keys — mixing
+ *               ontology classes and communities — collapse simultaneously. The
+ *               App splits the set back into ontology class ids + community keys
+ *               (`splitGroupedKeys`) and feeds the shared engine's collapse-target
+ *               SET. An empty set === nothing grouped (fast path, A3).
  *   query     : free-text filter for the Entities list.
  *   activeView: "workspace" | "reconciliation".
  *
@@ -25,18 +30,60 @@
  * (a selected type/community contributes all its member entity ids).
  */
 
-/** The mutually-exclusive group-by axes (the `groupBy.axis` enum). */
-export const GROUP_AXES = ["none", "community", "ontology"];
-
 /** Ontology baseline levels for `foldToLevel` (0=Domain, 1=Sub-domain, 2=Type). */
 export const ONTOLOGY_LEVELS = { domain: 0, subDomain: 1, type: 2 };
 
-function createDefaultGroupBy() {
+/* ---------------------------------------------------------------------------
+ * Group-item key namespacing.
+ *
+ * A grouped item key is a single string that carries BOTH the item's kind
+ * (ontology class vs community) and its identifier. The namespace prefix is
+ * matched on the FIRST `:`-segment only, so an ontology class id ("class:People")
+ * or a colon-bearing community key both round-trip losslessly.
+ * ------------------------------------------------------------------------- */
+
+export const GROUP_KIND = { ontology: "ontology", community: "community" };
+
+/** Build the grouped key for an Ontology class node id (e.g. "class:People"). */
+export function groupKeyForOntology(classId) {
+  return `${GROUP_KIND.ontology}:${classId}`;
+}
+
+/** Build the grouped key for a community key (free text, may contain colons). */
+export function groupKeyForCommunity(communityKey) {
+  return `${GROUP_KIND.community}:${communityKey}`;
+}
+
+/**
+ * Split a flat grouped-key set back into its two engine inputs:
+ *   - ontologyClassIds : the raw class ids to collapse on the ontology axis.
+ *   - communityKeys    : the raw community keys to collapse on the community axis.
+ * Unknown / malformed prefixes are ignored. PURE (no graph context).
+ *
+ * @param {string[]} grouped  the namespaced grouped-key set.
+ * @returns {{ ontologyClassIds: string[], communityKeys: string[] }}
+ */
+export function splitGroupedKeys(grouped = []) {
+  const ontologyClassIds = [];
+  const communityKeys = [];
+  for (const key of grouped ?? []) {
+    if (typeof key !== "string" || key.length === 0) continue;
+    const sep = key.indexOf(":");
+    if (sep < 0) continue;
+    const kind = key.slice(0, sep);
+    const rest = key.slice(sep + 1);
+    if (rest.length === 0) continue;
+    if (kind === GROUP_KIND.ontology) ontologyClassIds.push(rest);
+    else if (kind === GROUP_KIND.community) communityKeys.push(rest);
+  }
   return {
-    axis: "none",
-    ontology: { collapsedClassIds: [] },
-    community: { collapsedKeys: [] },
+    ontologyClassIds: uniqueStrings(ontologyClassIds),
+    communityKeys: uniqueStrings(communityKeys),
   };
+}
+
+function createDefaultGroupBy() {
+  return { grouped: [] };
 }
 
 export function createDefaultViewerState() {
@@ -53,42 +100,48 @@ function uniqueStrings(values = []) {
   return [...new Set(values.filter((v) => typeof v === "string" && v.length > 0))];
 }
 
-/** Coerce any value to a valid axis enum member (out-of-enum → "none"). */
-function coerceAxis(value) {
-  return GROUP_AXES.includes(value) ? value : "none";
-}
-
 /**
  * Normalize the `groupBy` sub-object, folding the PURE (graph-free) shape
- * migration from the pre-B2 `showOntologyClasses`/`collapsedClassIds` fields:
- *   - showOntologyClasses:true  → axis:"ontology" (unless groupBy.axis is set)
- *   - collapsedClassIds         → groupBy.ontology.collapsedClassIds
- * Availability (artifact present / liveCount>0) is NOT consulted here — that is
- * the separate App-level `normalizeGroupAxisAvailability` step (C4).
+ * migration from the pre-B2 axis-scoped / pre-B2-flat shapes into the per-item
+ * `grouped` set:
+ *   - legacy flat   showOntologyClasses:true → group every collapsedClassId
+ *   - legacy flat   collapsedClassIds        → ontology grouped keys
+ *   - axis-scoped   groupBy.axis:"ontology"  → ontology grouped keys (from its set)
+ *   - axis-scoped   groupBy.axis:"community" → community grouped keys (from its set)
+ *   - per-item      groupBy.grouped          → kept as-is (normalized + deduped)
+ * Both legacy axis collapse sets fold in regardless of which axis was "active",
+ * because per-item grouping has no single active axis — every fold is live.
+ * Availability (artifact present / liveCount>0) is NOT consulted here.
  */
 function normalizeGroupBy(options = {}) {
-  const def = createDefaultGroupBy();
   const raw = options.groupBy ?? {};
-  // Migration: old flat fields seed the new shape when groupBy is absent/partial.
-  const legacyAxis =
-    options.showOntologyClasses === true ? "ontology" : "none";
-  const axis = coerceAxis(
-    raw.axis !== undefined ? raw.axis : legacyAxis,
-  );
-  const ontologyIds = uniqueStrings(
+  const keys = [];
+
+  // Per-item shape: the canonical `grouped` set (already namespaced).
+  if (Array.isArray(raw.grouped)) {
+    for (const k of raw.grouped) if (typeof k === "string") keys.push(k);
+  }
+
+  // Legacy axis-scoped ontology fold set → ontology grouped keys.
+  const axisOntologyIds =
     raw.ontology?.collapsedClassIds ??
-      // legacy: collapsedClassIds lived flat under options
-      options.collapsedClassIds ??
-      def.ontology.collapsedClassIds,
-  );
-  const communityKeys = uniqueStrings(
-    raw.community?.collapsedKeys ?? def.community.collapsedKeys,
-  );
-  return {
-    axis,
-    ontology: { collapsedClassIds: ontologyIds },
-    community: { collapsedKeys: communityKeys },
-  };
+    // legacy flat: collapsedClassIds lived under options
+    options.collapsedClassIds ??
+    [];
+  for (const id of axisOntologyIds) {
+    if (typeof id === "string" && id.length > 0) keys.push(groupKeyForOntology(id));
+  }
+
+  // Legacy axis-scoped community fold set → community grouped keys.
+  const axisCommunityKeys = raw.community?.collapsedKeys ?? [];
+  for (const k of axisCommunityKeys) {
+    if (typeof k === "string" && k.length > 0) keys.push(groupKeyForCommunity(k));
+  }
+
+  // Legacy flat `showOntologyClasses` only ever meant "inject classes"; with no
+  // explicit collapse set it groups nothing, so there is nothing extra to add.
+
+  return { grouped: uniqueStrings(keys) };
 }
 
 export function normalizeViewerState(partial = {}) {
@@ -111,40 +164,12 @@ export function normalizeViewerState(partial = {}) {
   // Normalize from the RAW partial options (not the base-merged one) so the
   // absence of `groupBy` is genuinely detectable and the legacy migration fires.
   next.options.groupBy = normalizeGroupBy(partial.options ?? {});
-  // Drop the subsumed legacy flat fields so they cannot drift out of sync.
+  // Drop the subsumed legacy flat / axis-scoped fields so they cannot drift.
   delete next.options.showOntologyClasses;
   delete next.options.collapsedClassIds;
   // The focus must be a selected entity; drop it if it was deselected.
   if (next.focusId && !next.selection.entities.includes(next.focusId)) next.focusId = null;
   return next;
-}
-
-/**
- * App-level AVAILABILITY coercion (C4) — SEPARATE from the pure normalizer.
- *
- * Runs only where graph/artifact context exists (the App seam that already knows
- * `availableAxes` from artifact presence + communityStats().liveCount). Downgrades
- * a persisted, enum-valid `axis` to "none" when it is not currently available,
- * WITHOUT touching the per-axis collapse sets (so F3 memory survives a downgrade
- * and is restored on a graph that has the axis). Idempotent; "none" and any
- * available axis pass through unchanged.
- *
- * @param {object} state          a (normalized) viewer state.
- * @param {string[]} availableAxes  the axes the current graph/artifacts support
- *        (always includes "none").
- * @returns {object} the state, possibly with `groupBy.axis` downgraded to "none".
- */
-export function normalizeGroupAxisAvailability(state, availableAxes = GROUP_AXES) {
-  const available = new Set(["none", ...(availableAxes ?? [])]);
-  const axis = state?.options?.groupBy?.axis ?? "none";
-  if (axis === "none" || available.has(axis)) return state;
-  return normalizeViewerState({
-    ...state,
-    options: {
-      ...state.options,
-      groupBy: { ...state.options.groupBy, axis: "none" },
-    },
-  });
 }
 
 function toggleIn(list, value) {
@@ -154,7 +179,7 @@ function toggleIn(list, value) {
   return [...set];
 }
 
-/** Toggle a TYPE bucket in/out of the selection. */
+/** Toggle a TYPE bucket in/out of the selection (FILTER facet, NOT group-by). */
 export function toggleType(state, type) {
   return normalizeViewerState({
     ...state,
@@ -234,96 +259,78 @@ export function setShowWeakLinks(state, value) {
 }
 
 /* ===========================================================================
- * B2 — group-by AXIS actions (replace the pre-B2 ontology-only ones).
+ * B2 — PER-ITEM group-by actions.
  *
- * One axis-dispatched API: the canvas click and the rail row call the SAME fns
- * regardless of axis. The active axis's collapse set is the one mutated; both
- * per-axis sets always survive (F3 memory — `setGroupAxis` NEVER wipes).
+ * Every groupable left-rail item (an Ontology class node OR a community) owns a
+ * checkbox. Checking it adds its namespaced key to the `grouped` SET; unchecking
+ * removes it. Multiple keys — mixing ontology classes and communities — group at
+ * once. The App splits the set (`splitGroupedKeys`) and feeds the shared engine.
  * ======================================================================== */
 
-/** Read the active axis's collapse-set array out of a state. */
-function activeCollapseSet(groupBy) {
-  if (groupBy.axis === "ontology") return groupBy.ontology.collapsedClassIds ?? [];
-  if (groupBy.axis === "community") return groupBy.community.collapsedKeys ?? [];
-  return [];
-}
-
-/** Return a new groupBy with the active axis's collapse set replaced. */
-function withActiveCollapseSet(groupBy, nextSet) {
-  if (groupBy.axis === "ontology") {
-    return { ...groupBy, ontology: { collapsedClassIds: uniqueStrings(nextSet) } };
-  }
-  if (groupBy.axis === "community") {
-    return { ...groupBy, community: { collapsedKeys: uniqueStrings(nextSet) } };
-  }
-  return groupBy;
-}
-
-/**
- * B2 (replaces setShowOntologyClasses) — set the group-by axis. An out-of-enum
- * value coerces to "none" (pure check). RETAINS every per-axis collapse set, so
- * Ontology → Community → Ontology restores the ontology folds (F3). Availability
- * of the chosen axis is the caller's concern (the picker only offers available
- * axes; the App availability step downgrades a now-unavailable persisted axis).
- */
-export function setGroupAxis(state, axis) {
+/** Replace the grouped set on a state (deduped, string-only). */
+function withGrouped(state, nextKeys) {
   return normalizeViewerState({
     ...state,
     options: {
       ...state.options,
-      groupBy: { ...state.options.groupBy, axis: coerceAxis(axis) },
+      groupBy: { grouped: uniqueStrings(nextKeys) },
     },
   });
 }
 
 /**
- * B2 (replaces toggleCollapseClass) — toggle a key in/out of the ACTIVE axis's
- * collapse set (a class id for ontology, a community key for community). One
- * action, axis-dispatched: the canvas click and the rail row share it.
+ * Toggle ANY grouped item by its namespaced key (build it with
+ * `groupKeyForOntology` / `groupKeyForCommunity`). A non-string / empty key is a
+ * no-op.
  */
-export function toggleCollapse(state, key) {
+export function toggleGroupItem(state, key) {
   if (typeof key !== "string" || !key) return normalizeViewerState(state);
-  const groupBy = state.options.groupBy;
-  if (groupBy.axis === "none") return normalizeViewerState(state);
-  const next = toggleIn(activeCollapseSet(groupBy), key);
-  return normalizeViewerState({
-    ...state,
-    options: { ...state.options, groupBy: withActiveCollapseSet(groupBy, next) },
-  });
+  return withGrouped(state, toggleIn(state.options.groupBy.grouped, key));
+}
+
+/** Toggle an Ontology class node into/out of the grouped set. */
+export function toggleGroupOntology(state, classId) {
+  if (typeof classId !== "string" || !classId) return normalizeViewerState(state);
+  return toggleGroupItem(state, groupKeyForOntology(classId));
+}
+
+/** Toggle a community into/out of the grouped set. */
+export function toggleGroupCommunity(state, communityKey) {
+  if (typeof communityKey !== "string" || !communityKey) return normalizeViewerState(state);
+  return toggleGroupItem(state, groupKeyForCommunity(communityKey));
+}
+
+/** Is this Ontology class node currently grouped (checked)? PURE predicate. */
+export function isOntologyGrouped(state, classId) {
+  return state?.options?.groupBy?.grouped?.includes(groupKeyForOntology(classId)) ?? false;
+}
+
+/** Is this community currently grouped (checked)? PURE predicate. */
+export function isCommunityGrouped(state, communityKey) {
+  return state?.options?.groupBy?.grouped?.includes(groupKeyForCommunity(communityKey)) ?? false;
+}
+
+/** Clear the entire grouped set (ungroup everything). */
+export function clearGrouping(state) {
+  return withGrouped(state, []);
 }
 
 /**
- * B2 (replaces expandAllClasses) — clear the ACTIVE axis's collapse set.
- */
-export function expandAll(state) {
-  const groupBy = state.options.groupBy;
-  if (groupBy.axis === "none") return normalizeViewerState(state);
-  return normalizeViewerState({
-    ...state,
-    options: { ...state.options, groupBy: withActiveCollapseSet(groupBy, []) },
-  });
-}
-
-/**
- * B2 (replaces collapseAllTopClasses) — ontology BASELINE fold (F8). SETS the
- * ontology collapse set to exactly `levelClassIds` (the class ids at the chosen
- * level, computed by the caller from the taxonomy), discarding the previous set.
- * Because the new set IS exactly the level-N ids, no conflicting ancestor or
- * descendant fold can remain — "fold to level" is a SET operation, not a blind
- * union. Per-node folds the user adds afterward mix freely on top. No-op unless
- * the active axis is ontology.
+ * B2 baseline fold (F8) — group EXACTLY the given ontology class ids, REPLACING
+ * the current ontology grouped keys (community keys are untouched). Used by the
+ * "Fold all to: Domain / Sub-domain / Type" bulk buttons; the caller computes the
+ * level's class ids from the taxonomy. Because the set IS replaced for the
+ * ontology kind, no stale ancestor/descendant ontology fold survives.
  *
  * @param {object} state
  * @param {string[]} levelClassIds  the class ids at the target level.
  */
-export function foldToLevel(state, levelClassIds = []) {
-  const groupBy = state.options.groupBy;
-  if (groupBy.axis !== "ontology") return normalizeViewerState(state);
-  return normalizeViewerState({
-    ...state,
-    options: {
-      ...state.options,
-      groupBy: { ...groupBy, ontology: { collapsedClassIds: uniqueStrings(levelClassIds) } },
-    },
-  });
+export function foldOntologyToLevel(state, levelClassIds = []) {
+  const ids = uniqueStrings(levelClassIds);
+  // Keep every NON-ontology grouped key (communities), drop old ontology keys,
+  // then add the level's ontology keys.
+  const kept = (state.options.groupBy.grouped ?? []).filter(
+    (k) => typeof k === "string" && !k.startsWith(`${GROUP_KIND.ontology}:`),
+  );
+  return withGrouped(state, [...kept, ...ids.map(groupKeyForOntology)]);
 }

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -42,7 +42,7 @@ export const ONTOLOGY_LEVELS = { domain: 0, subDomain: 1, type: 2 };
  * or a colon-bearing community key both round-trip losslessly.
  * ------------------------------------------------------------------------- */
 
-export const GROUP_KIND = { ontology: "ontology", community: "community" };
+export const GROUP_KIND = { ontology: "ontology", community: "community", type: "type" };
 
 /** Build the grouped key for an Ontology class node id (e.g. "class:People"). */
 export function groupKeyForOntology(classId) {
@@ -52,6 +52,17 @@ export function groupKeyForOntology(classId) {
 /** Build the grouped key for a community key (free text, may contain colons). */
 export function groupKeyForCommunity(communityKey) {
   return `${GROUP_KIND.community}:${communityKey}`;
+}
+
+/**
+ * Build the grouped key for a leaf TYPE (a node `type` value, e.g. "Character").
+ * The Type LEVEL of the ontology taxonomy is the entity `type` itself — the
+ * artifact's leaf classes carry `member_node_types`, but there is no per-type
+ * CLASS node, so a grouped type folds entities sharing that `type` into one
+ * synthetic type node (the single-level, community-like collapse).
+ */
+export function groupKeyForType(typeName) {
+  return `${GROUP_KIND.type}:${typeName}`;
 }
 
 /**
@@ -66,6 +77,7 @@ export function groupKeyForCommunity(communityKey) {
 export function splitGroupedKeys(grouped = []) {
   const ontologyClassIds = [];
   const communityKeys = [];
+  const typeNames = [];
   for (const key of grouped ?? []) {
     if (typeof key !== "string" || key.length === 0) continue;
     const sep = key.indexOf(":");
@@ -75,10 +87,12 @@ export function splitGroupedKeys(grouped = []) {
     if (rest.length === 0) continue;
     if (kind === GROUP_KIND.ontology) ontologyClassIds.push(rest);
     else if (kind === GROUP_KIND.community) communityKeys.push(rest);
+    else if (kind === GROUP_KIND.type) typeNames.push(rest);
   }
   return {
     ontologyClassIds: uniqueStrings(ontologyClassIds),
     communityKeys: uniqueStrings(communityKeys),
+    typeNames: uniqueStrings(typeNames),
   };
 }
 
@@ -300,6 +314,12 @@ export function toggleGroupCommunity(state, communityKey) {
   return toggleGroupItem(state, groupKeyForCommunity(communityKey));
 }
 
+/** Toggle a leaf TYPE into/out of the grouped set (Type-level group-by). */
+export function toggleGroupType(state, typeName) {
+  if (typeof typeName !== "string" || !typeName) return normalizeViewerState(state);
+  return toggleGroupItem(state, groupKeyForType(typeName));
+}
+
 /** Is this Ontology class node currently grouped (checked)? PURE predicate. */
 export function isOntologyGrouped(state, classId) {
   return state?.options?.groupBy?.grouped?.includes(groupKeyForOntology(classId)) ?? false;
@@ -310,9 +330,90 @@ export function isCommunityGrouped(state, communityKey) {
   return state?.options?.groupBy?.grouped?.includes(groupKeyForCommunity(communityKey)) ?? false;
 }
 
+/** Is this leaf TYPE currently grouped (checked)? PURE predicate. */
+export function isTypeGrouped(state, typeName) {
+  return state?.options?.groupBy?.grouped?.includes(groupKeyForType(typeName)) ?? false;
+}
+
 /** Clear the entire grouped set (ungroup everything). */
 export function clearGrouping(state) {
   return withGrouped(state, []);
+}
+
+/** Keys NOT in the given kind namespace (drop only that scope's keys). */
+function keysExceptKind(state, kind) {
+  return (state.options.groupBy.grouped ?? []).filter(
+    (k) => typeof k === "string" && !k.startsWith(`${kind}:`),
+  );
+}
+
+/**
+ * Ungroup ALL ontology-scoped keys (spec §4 — the Ontology section's
+ * `Ungroup all`). Both class ids (Domain/Sub-domain) AND leaf TYPE keys are
+ * ontology-scoped; communities are untouched.
+ */
+export function clearOntologyGrouping(state) {
+  const kept = (state.options.groupBy.grouped ?? []).filter(
+    (k) =>
+      typeof k === "string" &&
+      !k.startsWith(`${GROUP_KIND.ontology}:`) &&
+      !k.startsWith(`${GROUP_KIND.type}:`),
+  );
+  return withGrouped(state, kept);
+}
+
+/** Ungroup ALL community-scoped keys (spec §5 — Communities `Ungroup all`). */
+export function clearCommunityGrouping(state) {
+  return withGrouped(state, keysExceptKind(state, GROUP_KIND.community));
+}
+
+/** Are ANY ontology-scoped (class OR type) items grouped? (disables Ungroup all) */
+export function hasOntologyGrouping(state) {
+  return (state?.options?.groupBy?.grouped ?? []).some(
+    (k) =>
+      typeof k === "string" &&
+      (k.startsWith(`${GROUP_KIND.ontology}:`) || k.startsWith(`${GROUP_KIND.type}:`)),
+  );
+}
+
+/** Are ANY community-scoped items grouped? (disables the community Ungroup all) */
+export function hasCommunityGrouping(state) {
+  return (state?.options?.groupBy?.grouped ?? []).some(
+    (k) => typeof k === "string" && k.startsWith(`${GROUP_KIND.community}:`),
+  );
+}
+
+/**
+ * Group EXACTLY the given ontology level (spec §4 — bulk "Group all to <level>").
+ * Replaces ALL ontology-scoped keys (class ids + type names) with the level's
+ * members so no stale ancestor/descendant fold survives; communities untouched.
+ *
+ * @param {object} state
+ * @param {number} level  0=Domain, 1=Sub-domain (class ids), 2=Type (type names).
+ * @param {string[]} levelClassIds  the class ids at level 0/1 (ignored for L2).
+ * @param {string[]} levelTypeNames the type values at level 2 (ignored for L0/L1).
+ */
+export function groupOntologyLevel(state, level, levelClassIds = [], levelTypeNames = []) {
+  const kept = (state.options.groupBy.grouped ?? []).filter(
+    (k) =>
+      typeof k === "string" &&
+      !k.startsWith(`${GROUP_KIND.ontology}:`) &&
+      !k.startsWith(`${GROUP_KIND.type}:`),
+  );
+  const next =
+    level === ONTOLOGY_LEVELS.type
+      ? uniqueStrings(levelTypeNames).map(groupKeyForType)
+      : uniqueStrings(levelClassIds).map(groupKeyForOntology);
+  return withGrouped(state, [...kept, ...next]);
+}
+
+/**
+ * Group EXACTLY the given community keys (spec §5 — Communities `Group all`).
+ * Replaces all community-scoped keys; ontology untouched.
+ */
+export function groupAllCommunities(state, communityKeys = []) {
+  const kept = keysExceptKind(state, GROUP_KIND.community);
+  return withGrouped(state, [...kept, ...uniqueStrings(communityKeys).map(groupKeyForCommunity)]);
 }
 
 /**

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -1,5 +1,6 @@
 /**
- * Single client viewer state for the ontology studio SPA (selection rework R8-3).
+ * Single client viewer state for the ontology studio SPA (selection rework R8-3,
+ * group-by axis B2).
  *
  * The LEFT column is navigation (search + Types / Communities / Entities lists);
  * the RIGHT column shows the current SELECTION and drills down to an entity.
@@ -8,10 +9,15 @@
  *               on the left. Each list toggles independently (click = add/remove).
  *   focusId   : the last individually-picked entity → gets the "double" emphasis
  *               (selection highlight + focus shadow) and opens its detail.
- *   options   : { showWeakLinks, showOntologyClasses, collapsedClassIds } — graph
- *               options (ex-"Facets"). `collapsedClassIds` (EVOL 2.b/2.d) is the
- *               set of ontology class ids the user has folded; each click on a
- *               class node toggles its id in/out and the subtree collapses.
+ *   options   : { showWeakLinks, groupBy } — graph options (ex-"Facets").
+ *               `groupBy` (B2) is the axis-scoped group-by MODE:
+ *                 { axis: "none"|"community"|"ontology",   // mutually exclusive
+ *                   ontology:  { collapsedClassIds:[] },   // mixed-level class ids
+ *                   community: { collapsedKeys:[] } }      // community keys
+ *               Only the ACTIVE axis's collapse set is applied; both sets coexist
+ *               in state so each axis remembers its own folds (F3 memory). The
+ *               pre-B2 `showOntologyClasses` is subsumed: axis:"ontology" + empty
+ *               collapse set === "show classes, nothing folded".
  *   query     : free-text filter for the Entities list.
  *   activeView: "workspace" | "reconciliation".
  *
@@ -19,18 +25,70 @@
  * (a selected type/community contributes all its member entity ids).
  */
 
+/** The mutually-exclusive group-by axes (the `groupBy.axis` enum). */
+export const GROUP_AXES = ["none", "community", "ontology"];
+
+/** Ontology baseline levels for `foldToLevel` (0=Domain, 1=Sub-domain, 2=Type). */
+export const ONTOLOGY_LEVELS = { domain: 0, subDomain: 1, type: 2 };
+
+function createDefaultGroupBy() {
+  return {
+    axis: "none",
+    ontology: { collapsedClassIds: [] },
+    community: { collapsedKeys: [] },
+  };
+}
+
 export function createDefaultViewerState() {
   return {
     activeView: "workspace",
     query: "",
     selection: { types: [], communities: [], entities: [] },
     focusId: null,
-    options: { showWeakLinks: true, showOntologyClasses: false, collapsedClassIds: [] },
+    options: { showWeakLinks: true, groupBy: createDefaultGroupBy() },
   };
 }
 
 function uniqueStrings(values = []) {
   return [...new Set(values.filter((v) => typeof v === "string" && v.length > 0))];
+}
+
+/** Coerce any value to a valid axis enum member (out-of-enum → "none"). */
+function coerceAxis(value) {
+  return GROUP_AXES.includes(value) ? value : "none";
+}
+
+/**
+ * Normalize the `groupBy` sub-object, folding the PURE (graph-free) shape
+ * migration from the pre-B2 `showOntologyClasses`/`collapsedClassIds` fields:
+ *   - showOntologyClasses:true  → axis:"ontology" (unless groupBy.axis is set)
+ *   - collapsedClassIds         → groupBy.ontology.collapsedClassIds
+ * Availability (artifact present / liveCount>0) is NOT consulted here — that is
+ * the separate App-level `normalizeGroupAxisAvailability` step (C4).
+ */
+function normalizeGroupBy(options = {}) {
+  const def = createDefaultGroupBy();
+  const raw = options.groupBy ?? {};
+  // Migration: old flat fields seed the new shape when groupBy is absent/partial.
+  const legacyAxis =
+    options.showOntologyClasses === true ? "ontology" : "none";
+  const axis = coerceAxis(
+    raw.axis !== undefined ? raw.axis : legacyAxis,
+  );
+  const ontologyIds = uniqueStrings(
+    raw.ontology?.collapsedClassIds ??
+      // legacy: collapsedClassIds lived flat under options
+      options.collapsedClassIds ??
+      def.ontology.collapsedClassIds,
+  );
+  const communityKeys = uniqueStrings(
+    raw.community?.collapsedKeys ?? def.community.collapsedKeys,
+  );
+  return {
+    axis,
+    ontology: { collapsedClassIds: ontologyIds },
+    community: { collapsedKeys: communityKeys },
+  };
 }
 
 export function normalizeViewerState(partial = {}) {
@@ -50,13 +108,43 @@ export function normalizeViewerState(partial = {}) {
   next.focusId = typeof next.focusId === "string" && next.focusId ? next.focusId : null;
   if (next.activeView !== "reconciliation") next.activeView = "workspace";
   next.options.showWeakLinks = Boolean(next.options.showWeakLinks);
-  next.options.showOntologyClasses = Boolean(next.options.showOntologyClasses);
-  next.options.collapsedClassIds = uniqueStrings(
-    next.options.collapsedClassIds ?? base.options.collapsedClassIds,
-  );
+  // Normalize from the RAW partial options (not the base-merged one) so the
+  // absence of `groupBy` is genuinely detectable and the legacy migration fires.
+  next.options.groupBy = normalizeGroupBy(partial.options ?? {});
+  // Drop the subsumed legacy flat fields so they cannot drift out of sync.
+  delete next.options.showOntologyClasses;
+  delete next.options.collapsedClassIds;
   // The focus must be a selected entity; drop it if it was deselected.
   if (next.focusId && !next.selection.entities.includes(next.focusId)) next.focusId = null;
   return next;
+}
+
+/**
+ * App-level AVAILABILITY coercion (C4) — SEPARATE from the pure normalizer.
+ *
+ * Runs only where graph/artifact context exists (the App seam that already knows
+ * `availableAxes` from artifact presence + communityStats().liveCount). Downgrades
+ * a persisted, enum-valid `axis` to "none" when it is not currently available,
+ * WITHOUT touching the per-axis collapse sets (so F3 memory survives a downgrade
+ * and is restored on a graph that has the axis). Idempotent; "none" and any
+ * available axis pass through unchanged.
+ *
+ * @param {object} state          a (normalized) viewer state.
+ * @param {string[]} availableAxes  the axes the current graph/artifacts support
+ *        (always includes "none").
+ * @returns {object} the state, possibly with `groupBy.axis` downgraded to "none".
+ */
+export function normalizeGroupAxisAvailability(state, availableAxes = GROUP_AXES) {
+  const available = new Set(["none", ...(availableAxes ?? [])]);
+  const axis = state?.options?.groupBy?.axis ?? "none";
+  if (axis === "none" || available.has(axis)) return state;
+  return normalizeViewerState({
+    ...state,
+    options: {
+      ...state.options,
+      groupBy: { ...state.options.groupBy, axis: "none" },
+    },
+  });
 }
 
 function toggleIn(list, value) {
@@ -145,56 +233,97 @@ export function setShowWeakLinks(state, value) {
   });
 }
 
-export function setShowOntologyClasses(state, value) {
-  const on = Boolean(value);
+/* ===========================================================================
+ * B2 — group-by AXIS actions (replace the pre-B2 ontology-only ones).
+ *
+ * One axis-dispatched API: the canvas click and the rail row call the SAME fns
+ * regardless of axis. The active axis's collapse set is the one mutated; both
+ * per-axis sets always survive (F3 memory — `setGroupAxis` NEVER wipes).
+ * ======================================================================== */
+
+/** Read the active axis's collapse-set array out of a state. */
+function activeCollapseSet(groupBy) {
+  if (groupBy.axis === "ontology") return groupBy.ontology.collapsedClassIds ?? [];
+  if (groupBy.axis === "community") return groupBy.community.collapsedKeys ?? [];
+  return [];
+}
+
+/** Return a new groupBy with the active axis's collapse set replaced. */
+function withActiveCollapseSet(groupBy, nextSet) {
+  if (groupBy.axis === "ontology") {
+    return { ...groupBy, ontology: { collapsedClassIds: uniqueStrings(nextSet) } };
+  }
+  if (groupBy.axis === "community") {
+    return { ...groupBy, community: { collapsedKeys: uniqueStrings(nextSet) } };
+  }
+  return groupBy;
+}
+
+/**
+ * B2 (replaces setShowOntologyClasses) — set the group-by axis. An out-of-enum
+ * value coerces to "none" (pure check). RETAINS every per-axis collapse set, so
+ * Ontology → Community → Ontology restores the ontology folds (F3). Availability
+ * of the chosen axis is the caller's concern (the picker only offers available
+ * axes; the App availability step downgrades a now-unavailable persisted axis).
+ */
+export function setGroupAxis(state, axis) {
   return normalizeViewerState({
     ...state,
     options: {
       ...state.options,
-      showOntologyClasses: on,
-      // Turning the class layer OFF clears any pending collapse so the next
-      // turn-on starts fully expanded (no stale folds against a hidden layer).
-      collapsedClassIds: on ? state.options.collapsedClassIds : [],
+      groupBy: { ...state.options.groupBy, axis: coerceAxis(axis) },
     },
   });
 }
 
 /**
- * EVOL 2.b/2.d — toggle a single ontology CLASS id in/out of the collapsed set.
- * Collapsing folds the class's whole subtree (sub-classes + member entities)
- * into the class node; collapsing again (toggle off) restores it.
+ * B2 (replaces toggleCollapseClass) — toggle a key in/out of the ACTIVE axis's
+ * collapse set (a class id for ontology, a community key for community). One
+ * action, axis-dispatched: the canvas click and the rail row share it.
  */
-export function toggleCollapseClass(state, classId) {
-  if (typeof classId !== "string" || !classId) return normalizeViewerState(state);
+export function toggleCollapse(state, key) {
+  if (typeof key !== "string" || !key) return normalizeViewerState(state);
+  const groupBy = state.options.groupBy;
+  if (groupBy.axis === "none") return normalizeViewerState(state);
+  const next = toggleIn(activeCollapseSet(groupBy), key);
   return normalizeViewerState({
     ...state,
-    options: {
-      ...state.options,
-      collapsedClassIds: toggleIn(state.options.collapsedClassIds ?? [], classId),
-    },
-  });
-}
-
-/** EVOL 2.b/2.d — expand everything (clear the collapsed set). */
-export function expandAllClasses(state) {
-  return normalizeViewerState({
-    ...state,
-    options: { ...state.options, collapsedClassIds: [] },
+    options: { ...state.options, groupBy: withActiveCollapseSet(groupBy, next) },
   });
 }
 
 /**
- * EVOL 2.b/2.d — collapse a given set of TOP-LEVEL class ids in one gesture
- * (a convenience reset, e.g. "fold every root class"). Callers pass the ids to
- * collapse; the union with any current set is kept.
+ * B2 (replaces expandAllClasses) — clear the ACTIVE axis's collapse set.
  */
-export function collapseAllTopClasses(state, classIds = []) {
-  const next = uniqueStrings([
-    ...(state.options.collapsedClassIds ?? []),
-    ...(classIds ?? []),
-  ]);
+export function expandAll(state) {
+  const groupBy = state.options.groupBy;
+  if (groupBy.axis === "none") return normalizeViewerState(state);
   return normalizeViewerState({
     ...state,
-    options: { ...state.options, collapsedClassIds: next },
+    options: { ...state.options, groupBy: withActiveCollapseSet(groupBy, []) },
+  });
+}
+
+/**
+ * B2 (replaces collapseAllTopClasses) — ontology BASELINE fold (F8). SETS the
+ * ontology collapse set to exactly `levelClassIds` (the class ids at the chosen
+ * level, computed by the caller from the taxonomy), discarding the previous set.
+ * Because the new set IS exactly the level-N ids, no conflicting ancestor or
+ * descendant fold can remain — "fold to level" is a SET operation, not a blind
+ * union. Per-node folds the user adds afterward mix freely on top. No-op unless
+ * the active axis is ontology.
+ *
+ * @param {object} state
+ * @param {string[]} levelClassIds  the class ids at the target level.
+ */
+export function foldToLevel(state, levelClassIds = []) {
+  const groupBy = state.options.groupBy;
+  if (groupBy.axis !== "ontology") return normalizeViewerState(state);
+  return normalizeViewerState({
+    ...state,
+    options: {
+      ...state.options,
+      groupBy: { ...groupBy, ontology: { collapsedClassIds: uniqueStrings(levelClassIds) } },
+    },
   });
 }

--- a/studio/src/tests/appHeader.test.js
+++ b/studio/src/tests/appHeader.test.js
@@ -5,10 +5,9 @@ import { describe, expect, it } from "vitest";
 const appSource = readFileSync(resolve(process.cwd(), "src/App.svelte"), "utf8");
 
 describe("App header DS structure", () => {
-  it("uses the DS AppChrome chrome for brand, segmented navigation and graph stats", () => {
-    expect(appSource).toMatch(/import \{[^}]*AppChrome[^}]*Button[^}]*Badge[^}]*ButtonGroup[^}]*\}/);
-    expect(appSource).toMatch(/<AppChrome[\s\S]*brandName="Graphify"/);
-    expect(appSource).toMatch(/<AppChrome[\s\S]*productName="Ontology Studio"/);
+  it("uses the DS AppChrome chrome for brand + segmented navigation", () => {
+    expect(appSource).toMatch(/import \{[^}]*AppChrome[^}]*Button[^}]*ButtonGroup[^}]*\}/);
+    expect(appSource).toMatch(/<AppChrome[\s\S]*productName="Graphify"/);
     expect(appSource).toMatch(
       /{#snippet identity\(\)}[\s\S]*<ButtonGroup[\s\S]*attached[\s\S]*label="Studio view"/,
     );
@@ -16,12 +15,16 @@ describe("App header DS structure", () => {
     expect(appSource).toMatch(/aria-pressed=\{viewerState\.activeView === "reconciliation"\}/);
     expect(appSource).toMatch(/onclick=\{\(\) => handleSetView\("workspace"\)\}/);
     expect(appSource).toMatch(/onclick=\{\(\) => handleSetView\("reconciliation"\)\}/);
-    expect(appSource).toMatch(
-      /{#snippet extraSelectors\(\)}[\s\S]*class="app-stats"[\s\S]*aria-label="Graph summary"/,
-    );
-    expect(appSource).toContain("<Badge tone=\"neutral\">{scene.stats.nodeCount} nodes</Badge>");
-    expect(appSource).toContain("<Badge tone=\"neutral\">{scene.stats.edgeCount} edges</Badge>");
-    expect(appSource).toContain("<Badge tone=\"info\">{scene.stats.communityCount} groups</Badge>");
+  });
+
+  it("relocates the count badges OUT of the header (now under the LeftRail search)", () => {
+    // Tracked UI change: the AppChrome header no longer renders the stats badges
+    // — they moved under the search bar in the LeftRail (see leftRail.test.js).
+    expect(appSource).not.toMatch(/class="app-stats"/);
+    expect(appSource).not.toContain("{scene.stats.nodeCount} nodes");
+    expect(appSource).not.toContain("{scene.stats.edgeCount} edges");
+    // The header now passes scene.stats DOWN to the LeftRail instead.
+    expect(appSource).toMatch(/<LeftRail[\s\S]*stats=\{scene\.stats\}/);
   });
 
   it("renders the in-UI model switcher (DS Select) in the chrome, gated on >1 model", () => {
@@ -38,6 +41,5 @@ describe("App header DS structure", () => {
     expect(appSource).toMatch(/class="view-label view-label--full">Knowledge graph</);
     expect(appSource).toMatch(/class="view-label view-label--full">Entity reconciliation</);
     expect(appSource).toMatch(/class="view-label view-label--compact" aria-hidden="true"[\s\S]*Recon/);
-    expect(appSource).toMatch(/@media \(max-width: 720px\)[\s\S]*\.app-stats[\s\S]*display: none/);
   });
 });

--- a/studio/src/tests/classNodes.test.js
+++ b/studio/src/tests/classNodes.test.js
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   injectOntologyClassNodes,
   applyOntologyCollapse,
+  applyGroupCollapse,
   buildClassParentIndex,
+  buildCommunityParentIndex,
+  injectCommunityNodes,
+  communityNodeId,
+  mintCommunityNodeIds,
   nearestVisibleAncestor,
 } from "../lib/classNodes.js";
 import { buildScene, computeDegrees, computeGodClass } from "../lib/graphAdapter.js";
@@ -531,5 +536,249 @@ describe("applyOntologyCollapse — expand restores + determinism", () => {
     expect(g.links.length).toBe(beforeLinks);
     // The class node was not stamped with collapsed:true on the source graph.
     expect(g.nodes.find((n) => n.id === "class:Person").collapsed).toBeUndefined();
+  });
+});
+
+/* ===========================================================================
+ * B2 — applyGroupCollapse + community axis (T2, T4, T5, T8, T9, T10).
+ * ======================================================================== */
+
+describe("B2 — T2 fine sub-domain fold (mixed-depth, sibling stays expanded)", () => {
+  it("folds ONE sub-class subtree while its sibling sub-class stays expanded", () => {
+    const g = injectedTaxonomyGraph();
+    // Fold only class:Character (one leaf under Person); class:Villain sibling stays.
+    const out = applyOntologyCollapse(g, taxonomyHierarchies(), {
+      collapsedClassIds: ["class:Character"],
+    });
+    const ids = out.nodes.map((n) => n.id);
+    // Character members folded...
+    expect(ids).not.toContain("holmes");
+    expect(ids).not.toContain("watson");
+    expect(ids).toContain("class:Character");
+    // ...but the SIBLING sub-domain (Villain / moriarty) is untouched/expanded:
+    // both the sibling class node AND its member entity stay visible.
+    expect(ids).toContain("moriarty");
+    expect(ids).toContain("class:Villain");
+  });
+});
+
+describe("B2 — applyGroupCollapse empty set (T8 engine fast-path)", () => {
+  it("returns the input graph unchanged when there is nothing to collapse", () => {
+    const g = injectedTaxonomyGraph();
+    expect(applyGroupCollapse(g, { collapseTargets: [] })).toBe(g);
+    expect(applyGroupCollapse(g, {})).toBe(g);
+  });
+});
+
+// A graph whose communities map cleanly: { holmes, watson } in "People",
+// { moriarty } in "Villains"; baker is community-less. Edges mirror the
+// taxonomy graph so the community fold is comparable to a single-level ontology
+// fold of the SAME partition.
+function communityGraph() {
+  return {
+    nodes: [
+      { id: "holmes", label: "Holmes", type: "Character", community_name: "People" },
+      { id: "watson", label: "Watson", type: "Character", community_name: "People" },
+      { id: "moriarty", label: "Moriarty", type: "Villain", community_name: "Villains" },
+      { id: "baker", label: "Baker Street", type: "Location" },
+    ],
+    links: [
+      { source: "holmes", target: "watson", relation: "assists", evidence_refs: ["e1"] },
+      { source: "holmes", target: "moriarty", relation: "pursues", evidence_refs: ["e2"] },
+      { source: "watson", target: "moriarty", relation: "pursues", evidence_refs: ["e3"] },
+      { source: "holmes", target: "baker", relation: "located_in", evidence_refs: ["e4"] },
+      { source: "moriarty", target: "baker", relation: "located_in", evidence_refs: ["e5"] },
+    ],
+  };
+}
+
+const communityOf = (n) => n.community_name ?? null;
+
+describe("communityNodeId + mintCommunityNodeIds (A2 helper)", () => {
+  it("mints namespaced ids and disambiguates a collision deterministically", () => {
+    expect(communityNodeId("People")).toBe("community-node:People");
+    // A real node already owns the naive id -> the mint must NOT reuse it.
+    const existing = new Set(["community-node:People", "watson"]);
+    const ids = mintCommunityNodeIds(["People", "Villains"], existing);
+    expect(ids.get("People")).not.toBe("community-node:People");
+    expect(ids.get("People")).toBe("community-node:People#1");
+    expect(ids.get("Villains")).toBe("community-node:Villains");
+    // No minted id collides with an existing id.
+    for (const id of ids.values()) expect(existing.has(id)).toBe(false);
+  });
+});
+
+describe("B2 — injectCommunityNodes (synthetic nodes + has_member edges)", () => {
+  it("injects one node per LIVE key carrying kind + community_key + tone", () => {
+    const g = communityGraph();
+    const out = injectCommunityNodes(g, {
+      communityOf,
+      liveKeys: ["People", "Villains"],
+      toneKeyOf: (k) => k,
+    });
+    const peopleId = out.idByKey.get("People");
+    const node = out.nodes.find((n) => n.id === peopleId);
+    expect(node).toMatchObject({
+      community_node_kind: "community",
+      community_key: "People",
+      type: "OntologyCommunity",
+    });
+    // has_member edges: community node -> each live member present in the graph.
+    const memberEdges = out.links.filter((e) => e.relation === "has_member");
+    expect(memberEdges).toHaveLength(3); // holmes, watson (People) + moriarty (Villains)
+    expect(memberEdges.every((e) => e.structural === true)).toBe(true);
+    // baker (community-less) gets NO has_member edge.
+    expect(memberEdges.some((e) => e.target === "baker")).toBe(false);
+  });
+});
+
+describe("B2 — T4 community/ontology collapse PARITY (shared engine)", () => {
+  it("a community fold matches the same partition expressed as a 1-level ontology fold", () => {
+    // --- Community fold of "People" via the community index + engine. ---
+    const cg = communityGraph();
+    const ctx = { communityOf, liveKeys: ["People", "Villains"], toneKeyOf: (k) => k };
+    const injectedC = injectCommunityNodes(cg, ctx);
+    const { parentById, descendantsByTarget, collapseTargetByKey, idByKey } =
+      buildCommunityParentIndex(cg, { ...ctx, idByKey: injectedC.idByKey });
+    const peopleId = idByKey.get("People");
+    const communityOut = applyGroupCollapse(injectedC, {
+      parentById,
+      collapseTargets: [collapseTargetByKey("People")],
+      descendantsByTarget,
+    });
+
+    // --- Equivalent SINGLE-LEVEL ontology fold: one class "People" holding
+    //     holmes+watson, one class "Villains" holding moriarty, baker free. ---
+    const og = communityGraph(); // same edges; community_name fields are ignored by ontology
+    const flatHierarchies = {
+      schema: "graphify_ontology_class_hierarchies_v1",
+      hierarchies: {
+        flat: {
+          root_class_ids: [peopleId, idByKey.get("Villains")],
+          classes_by_id: {
+            [peopleId]: {
+              id: peopleId, label: "People", parent_id: null, child_ids: [], level: 0,
+              member_node_types: ["Character"], member_ids: ["holmes", "watson"],
+            },
+            [idByKey.get("Villains")]: {
+              id: idByKey.get("Villains"), label: "Villains", parent_id: null, child_ids: [], level: 0,
+              member_node_types: ["Villain"], member_ids: ["moriarty"],
+            },
+          },
+        },
+      },
+    };
+    const injectedO = injectOntologyClassNodes(og, flatHierarchies, { levels: "all" });
+    const { parentById: pOnt, descendantClassIds } = buildClassParentIndex(flatHierarchies);
+    const ontologyOut = applyGroupCollapse(injectedO, {
+      parentById: pOnt,
+      collapseTargets: [peopleId],
+      descendantsByTarget: descendantClassIds,
+    });
+
+    // The re-endpointed REAL TOPOLOGY (source|target|relation, aggregate counts)
+    // is identical — proving the engine is shared, not forked. The structural
+    // membership edges differ only in label (has_member vs has_instance, an
+    // injection detail), so compare the non-structural data edges.
+    const topo = (out) =>
+      out.links
+        .filter((e) => !e.structural)
+        .map((e) => `${e.source}|${e.target}|${e.relation}|${e.aggregate_count ?? 1}`)
+        .sort();
+    expect(topo(communityOut)).toEqual(topo(ontologyOut));
+
+    // Same fold-node annotations: People holds 2 hidden + the (+2) label.
+    const cPeople = communityOut.nodes.find((n) => n.id === peopleId);
+    const oPeople = ontologyOut.nodes.find((n) => n.id === peopleId);
+    expect(cPeople.hidden_node_count).toBe(2);
+    expect(oPeople.hidden_node_count).toBe(2);
+    expect(cPeople.label).toBe(oPeople.label);
+  });
+});
+
+describe("B2 — T5 link-bubbling invariant (community axis)", () => {
+  it("aggregates parallels, drops self-loops, unions evidence, deterministic order", () => {
+    const cg = communityGraph();
+    const ctx = { communityOf, liveKeys: ["People", "Villains"], toneKeyOf: (k) => k };
+    const injected = injectCommunityNodes(cg, ctx);
+    const { parentById, descendantsByTarget, collapseTargetByKey, idByKey } =
+      buildCommunityParentIndex(cg, { ...ctx, idByKey: injected.idByKey });
+    const peopleId = idByKey.get("People");
+    const out = applyGroupCollapse(injected, {
+      parentById,
+      collapseTargets: [collapseTargetByKey("People")],
+      descendantsByTarget,
+    });
+
+    // holmes/watson --pursues--> moriarty AGGREGATE into one People->moriarty edge.
+    const pursues = out.links.filter((e) => e.relation === "pursues");
+    expect(pursues).toHaveLength(1);
+    expect(pursues[0]).toMatchObject({ source: peopleId, target: "moriarty", aggregate_count: 2 });
+    expect(pursues[0].evidence_refs).toEqual(["e2", "e3"]);
+
+    // holmes--assists-->watson became an internal self-loop (both fold to People).
+    expect(out.links.some((e) => e.relation === "assists")).toBe(false);
+    const people = out.nodes.find((n) => n.id === peopleId);
+    // assists (1) + the People->holmes/watson has_member edges (2) self-loop = 3.
+    expect(people.internal_edge_count).toBe(3);
+
+    // No self-loops survive; output edge order is deterministic (sorted).
+    expect(out.links.every((e) => e.source !== e.target)).toBe(true);
+    const keys = out.links.map((e) => `${e.source}|${e.target}|${e.relation}`);
+    expect(keys).toEqual([...keys].sort());
+  });
+});
+
+describe("B2 — T9 A1 live-key guard (no vanish into a missing ancestor)", () => {
+  it("a fold key that is NOT live maps no entity, hides nothing", () => {
+    const cg = communityGraph();
+    // "Villains" is the only LIVE key we inject; a persisted fold of the NON-live
+    // "Ghosts" key must hide nothing (its members map to no community node).
+    const ctx = { communityOf, liveKeys: ["Villains"], toneKeyOf: (k) => k };
+    const injected = injectCommunityNodes(cg, ctx);
+    const { parentById, descendantsByTarget, idByKey } = buildCommunityParentIndex(cg, {
+      ...ctx,
+      idByKey: injected.idByKey,
+    });
+    // People entities have NO parent in the index (People is not live).
+    expect(parentById.has("holmes")).toBe(false);
+    expect(parentById.has("watson")).toBe(false);
+
+    // Collapsing a non-existent / non-live target hides nothing — engine no-op
+    // (empty collapseTargets) returns the input.
+    const out = applyGroupCollapse(injected, {
+      parentById,
+      collapseTargets: [], // "Ghosts"/"People" produced no synthetic id
+      descendantsByTarget,
+    });
+    expect(out).toBe(injected);
+    // holmes/watson remain visible (never vanished via a missing ancestor).
+    expect(injected.nodes.some((n) => n.id === "holmes")).toBe(true);
+    expect(injected.nodes.some((n) => n.id === "watson")).toBe(true);
+  });
+});
+
+describe("B2 — T10 id-collision safety (A2, NORMATIVE)", () => {
+  it("never mints two nodes with the same id when a real node owns the naive id", () => {
+    // A real entity whose id literally equals the naive community-node id.
+    const collidingGraph = {
+      nodes: [
+        { id: "community-node:People", label: "Decoy", type: "Character" },
+        { id: "holmes", label: "Holmes", type: "Character", community_name: "People" },
+      ],
+      links: [{ source: "holmes", target: "community-node:People", relation: "knows" }],
+    };
+    const ctx = { communityOf, liveKeys: ["People"], toneKeyOf: (k) => k };
+    const out = injectCommunityNodes(collidingGraph, ctx);
+
+    // The synthetic id was disambiguated; the real node is untouched.
+    const peopleId = out.idByKey.get("People");
+    expect(peopleId).not.toBe("community-node:People");
+    // No two nodes share an id post-injection.
+    const idCounts = new Map();
+    for (const n of out.nodes) idCounts.set(n.id, (idCounts.get(n.id) ?? 0) + 1);
+    for (const [, count] of idCounts) expect(count).toBe(1);
+    // The decoy real node still exists with its original id.
+    expect(out.nodes.find((n) => n.id === "community-node:People").label).toBe("Decoy");
   });
 });

--- a/studio/src/tests/communityGroupingPath.test.js
+++ b/studio/src/tests/communityGroupingPath.test.js
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  injectCommunityNodes,
+  buildCommunityParentIndex,
+  injectOntologyClassNodes,
+  buildClassParentIndex,
+  applyGroupCollapse,
+  mintCommunityNodeIds,
+} from "../lib/classNodes.js";
+import { communityStats, nodeCommunity, buildScene } from "../lib/graphAdapter.js";
+import {
+  createDefaultViewerState,
+  toggleGroupCommunity,
+  toggleGroupOntology,
+  splitGroupedKeys,
+} from "../lib/viewerState.js";
+
+/**
+ * B2 — END-TO-END community grouping path (the App `groupedGraph` derivation).
+ *
+ * The unit tests above drive `injectCommunityNodes` / `buildCommunityParentIndex`
+ * / `applyGroupCollapse` with a HAND-WIRED ctx whose `liveKeys` and `communityOf`
+ * already agree. This suite instead replicates the REAL App runtime chain
+ * (App.svelte `communityCtx` + `groupedGraph`) verbatim against MYSTERY-SHAPED
+ * data — every node carries BOTH a numeric `community` AND a string
+ * `community_name`, exactly like the public-pack graph.json. It exists to catch a
+ * key/id mismatch ANYWHERE along communityStats → mintCommunityNodeIds →
+ * injectCommunityNodes → buildCommunityParentIndex.collapseTargetByKey →
+ * applyGroupCollapse that the hand-wired unit tests cannot see.
+ */
+
+// Mystery-shaped fixture: numeric `community` AND string `community_name` on
+// every node, mirroring public-pack graph.json. Two named communities ("Raffles"
+// = 4 members, "Hound" = 3 members) plus a community-less Location.
+function mysteryGraph() {
+  return {
+    nodes: [
+      { id: "raffles", label: "A.J. Raffles", type: "Character", community: 12, community_name: "Raffles" },
+      { id: "bunny", label: "Bunny Manders", type: "Character", community: 12, community_name: "Raffles" },
+      { id: "crawshay", label: "Crawshay", type: "Character", community: 12, community_name: "Raffles" },
+      { id: "alias_amateur", label: "Amateur Cracksman", type: "Alias", community: 12, community_name: "Raffles" },
+      { id: "holmes", label: "Sherlock Holmes", type: "Character", community: 51, community_name: "Hound" },
+      { id: "watson", label: "John Watson", type: "Character", community: 51, community_name: "Hound" },
+      { id: "baskerville", label: "Henry Baskerville", type: "Character", community: 51, community_name: "Hound" },
+      { id: "baker", label: "Baker Street", type: "Location" },
+    ],
+    links: [
+      { source: "raffles", target: "bunny", relation: "assists", evidence_refs: ["e1"] },
+      { source: "raffles", target: "crawshay", relation: "opposes", evidence_refs: ["e2"] },
+      { source: "alias_amateur", target: "raffles", relation: "alias_of", evidence_refs: ["e3"] },
+      { source: "holmes", target: "watson", relation: "assists", evidence_refs: ["e4"] },
+      { source: "holmes", target: "baskerville", relation: "assists", evidence_refs: ["e5"] },
+      // cross-community + anchor edges so both communities are "live" (degree > 0)
+      { source: "raffles", target: "holmes", relation: "mentions", evidence_refs: ["e6"] },
+      { source: "holmes", target: "baker", relation: "located_in", evidence_refs: ["e7"] },
+      { source: "raffles", target: "baker", relation: "located_in", evidence_refs: ["e8"] },
+    ],
+  };
+}
+
+/**
+ * Faithful replica of App.svelte's `communityCtx` $derived. The set fed to the
+ * injector/index is the GROUPED ∩ LIVE keys (the root-cause fix): only the
+ * communities the user checked get a fold node, so non-grouped live communities
+ * never spawn an orphan box.
+ */
+function buildCommunityCtx(graph, communityKeys) {
+  const groupedSet = new Set(communityKeys);
+  const live = communityStats(graph).live.filter((c) => groupedSet.has(c.key));
+  if (live.length === 0) return null;
+  const liveKeys = live.map((c) => c.key);
+  const idByKey = mintCommunityNodeIds(liveKeys, new Set((graph?.nodes ?? []).map((n) => n.id)));
+  const toneKeyByKey = new Map(live.map((c) => [c.key, c.groupKey ?? c.key]));
+  return {
+    liveKeys,
+    idByKey,
+    communityOf: nodeCommunity,
+    toneKeyOf: (k) => toneKeyByKey.get(k),
+    labelOf: (k) => k,
+  };
+}
+
+/**
+ * Faithful replica of App.svelte's `groupedGraph` $derived (lines ~151-192) for
+ * an arbitrary grouped-key set. Returns the COLLAPSED graph the scene is built
+ * from.
+ */
+function groupedGraphFor(graph, classHierarchies, groupedKeys) {
+  const { ontologyClassIds, communityKeys } = splitGroupedKeys(groupedKeys);
+  const hasOntologyGroup = ontologyClassIds.length > 0;
+  const hasCommunityGroup = communityKeys.length > 0;
+  if (!hasOntologyGroup && !hasCommunityGroup) return graph;
+
+  let injected = graph;
+  const parentById = new Map();
+  const descendantsByTarget = new Map();
+  const collapseTargets = [];
+
+  if (hasOntologyGroup && classHierarchies?.hierarchies) {
+    injected = injectOntologyClassNodes(injected, classHierarchies, { levels: "all" });
+    const { parentById: classParents, descendantClassIds } = buildClassParentIndex(classHierarchies);
+    for (const [k, v] of classParents) parentById.set(k, v);
+    for (const [k, v] of descendantClassIds) descendantsByTarget.set(k, v);
+    for (const id of ontologyClassIds) collapseTargets.push(id);
+  }
+
+  const communityCtx = hasCommunityGroup ? buildCommunityCtx(graph, communityKeys) : null;
+  if (hasCommunityGroup && communityCtx) {
+    injected = injectCommunityNodes(injected, communityCtx);
+    const {
+      parentById: commParents,
+      descendantsByTarget: commDesc,
+      collapseTargetByKey,
+    } = buildCommunityParentIndex(injected, communityCtx);
+    for (const [k, v] of commParents) {
+      if (!parentById.has(k)) parentById.set(k, v);
+    }
+    for (const [k, v] of commDesc) descendantsByTarget.set(k, v);
+    for (const key of communityKeys) {
+      const id = collapseTargetByKey(key);
+      if (typeof id === "string") collapseTargets.push(id);
+    }
+  }
+
+  if (collapseTargets.length === 0) return injected;
+  return applyGroupCollapse(injected, { parentById, collapseTargets, descendantsByTarget });
+}
+
+describe("B2 — community grouping path (App groupedGraph derivation, mystery-shaped data)", () => {
+  it("checking a live community collapses its members into the community fold node", () => {
+    const graph = mysteryGraph();
+
+    // The rail row passes `c.key` from communityStats(graph).live to
+    // onToggleGroupCommunity — so drive the SAME key the UI would.
+    const live = communityStats(graph).live;
+    const raffles = live.find((c) => c.key === "Raffles");
+    expect(raffles, "Raffles must be a live community").toBeTruthy();
+    expect(raffles.count).toBe(4); // raffles, bunny, crawshay, alias_amateur
+
+    let state = createDefaultViewerState();
+    state = toggleGroupCommunity(state, raffles.key);
+
+    const out = groupedGraphFor(graph, null, state.options.groupBy.grouped);
+    const ids = out.nodes.map((n) => n.id);
+
+    // The community's 4 member entities folded away...
+    for (const member of ["raffles", "bunny", "crawshay", "alias_amateur"]) {
+      expect(ids, `member ${member} must fold into the community node`).not.toContain(member);
+    }
+    // ...a community fold node is present in their place...
+    const communityNode = out.nodes.find((n) => n.community_node_kind === "community");
+    expect(communityNode, "a community fold node must be present").toBeTruthy();
+    expect(communityNode.community_key).toBe("Raffles");
+    expect(communityNode.collapsed).toBe(true);
+    expect(communityNode.hidden_node_count).toBe(4);
+
+    // ...and the OTHER community (Hound) + the free Location stay visible.
+    for (const kept of ["holmes", "watson", "baskerville", "baker"]) {
+      expect(ids).toContain(kept);
+    }
+
+    // Node count DROPS: 8 entities -> 4 visible entities + 1 community node = 5.
+    // DIAGNOSTIC: exactly ONE community fold node must survive (the grouped one);
+    // a fold node for a NON-grouped live community must never be injected.
+    const survivingCommunityNodes = out.nodes.filter((n) => n.community_node_kind === "community");
+    expect(survivingCommunityNodes.map((n) => n.community_key)).toEqual(["Raffles"]);
+    expect(out.nodes.length).toBe(5);
+    expect(out.nodes.length).toBeLessThan(graph.nodes.length);
+
+    // The scene built from the collapsed graph carries the fold node too.
+    const scene = buildScene(out, { showWeakLinks: true });
+    expect(scene.nodes.some((n) => n.community_node_kind === "community")).toBe(true);
+  });
+
+  it("unchecking the community restores the full graph (round-trip)", () => {
+    const graph = mysteryGraph();
+    let state = createDefaultViewerState();
+    state = toggleGroupCommunity(state, "Raffles");
+    state = toggleGroupCommunity(state, "Raffles"); // toggle back off
+    const out = groupedGraphFor(graph, null, state.options.groupBy.grouped);
+    expect(out).toBe(graph); // fast path: nothing grouped
+    expect(out.nodes.length).toBe(graph.nodes.length);
+  });
+
+  it("multi-select: 2 communities + 1 ontology class collapse together", () => {
+    const graph = mysteryGraph();
+    // A taxonomy with one ontology class (Location) holding `baker`.
+    const classHierarchies = {
+      schema: "graphify_ontology_class_hierarchies_v1",
+      hierarchies: {
+        mystery: {
+          root_class_ids: ["class:Place"],
+          classes_by_id: {
+            "class:Place": {
+              id: "class:Place",
+              label: "Place",
+              parent_id: null,
+              child_ids: [],
+              level: 0,
+              member_node_types: ["Location"],
+              member_ids: ["baker"],
+            },
+          },
+        },
+      },
+    };
+
+    let state = createDefaultViewerState();
+    state = toggleGroupCommunity(state, "Raffles");
+    state = toggleGroupCommunity(state, "Hound");
+    state = toggleGroupOntology(state, "class:Place");
+
+    const out = groupedGraphFor(graph, classHierarchies, state.options.groupBy.grouped);
+    const ids = out.nodes.map((n) => n.id);
+
+    // BOTH communities folded: none of their 7 member entities remain.
+    for (const member of ["raffles", "bunny", "crawshay", "alias_amateur", "holmes", "watson", "baskerville"]) {
+      expect(ids, `${member} must fold`).not.toContain(member);
+    }
+    // baker folded into class:Place.
+    expect(ids).not.toContain("baker");
+    expect(ids).toContain("class:Place");
+
+    // Two community fold nodes are present.
+    const communityNodes = out.nodes.filter((n) => n.community_node_kind === "community");
+    expect(communityNodes).toHaveLength(2);
+    const keys = communityNodes.map((n) => n.community_key).sort();
+    expect(keys).toEqual(["Hound", "Raffles"]);
+
+    // Final graph: 2 community nodes + 1 ontology class node = 3 visible nodes.
+    expect(out.nodes.length).toBe(3);
+  });
+});

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -694,3 +694,60 @@ describe("candidateUnionSubgraph (EVOL 1.b)", () => {
     expect(owns[0].source).toBe("B");
   });
 });
+
+describe("B2 — T12 numeric-only-community tone parity (A5)", () => {
+  // A graph whose communities are NUMERIC-ONLY (no community_name). Two live
+  // communities (0, 1). The DS tone walk keys by nodeGroup (`community:<n>`), so
+  // the rail/canvas tone for community 1 is category2, NOT the category1 fallback
+  // the un-fixed `toneByGroup.get(nodeCommunity)` lookup produced.
+  const numericGraph = {
+    nodes: [
+      { id: "a", community: 0 },
+      { id: "b", community: 0 },
+      { id: "c", community: 1 },
+      { id: "d", community: 1 },
+    ],
+    links: [
+      { source: "a", target: "b", relation: "knows" },
+      { source: "c", target: "d", relation: "knows" },
+    ],
+  };
+
+  it("each numeric community's tone matches its nodeGroup palette key (not category1)", () => {
+    const stats = communityStats(numericGraph);
+    expect(stats.liveCount).toBe(2);
+    const byKey = new Map(stats.live.map((c) => [c.key, c]));
+    // nodeCommunity keys are `Community 0` / `Community 1`; nodeGroup keys are
+    // `community:0` / `community:1`. The tones follow first-seen nodeGroup order.
+    expect(nodeCommunity(numericGraph.nodes[0])).toBe("Community 0");
+    expect(nodeGroup(numericGraph.nodes[0])).toBe("community:0");
+    // community 0 first-seen → category1; community 1 → category2 (NOT category1).
+    expect(byKey.get("Community 0").tone).toBe("category1");
+    expect(byKey.get("Community 1").tone).toBe("category2");
+    expect(byKey.get("Community 1").tone).not.toBe("category1");
+    // The exposed groupKey is the nodeGroup palette key (the canvas tone key).
+    expect(byKey.get("Community 0").groupKey).toBe("community:0");
+    expect(byKey.get("Community 1").groupKey).toBe("community:1");
+  });
+
+  it("NAMED-community tone parity stays green (unaffected by the fix)", () => {
+    const namedGraph = {
+      nodes: [
+        { id: "a", community_name: "People" },
+        { id: "b", community_name: "People" },
+        { id: "c", community_name: "Places" },
+        { id: "d", community_name: "Places" },
+      ],
+      links: [
+        { source: "a", target: "b", relation: "knows" },
+        { source: "c", target: "d", relation: "knows" },
+      ],
+    };
+    const stats = communityStats(namedGraph);
+    const byKey = new Map(stats.live.map((c) => [c.key, c]));
+    // Named communities: nodeGroup === nodeCommunity === community_name.
+    expect(byKey.get("People").tone).toBe("category1");
+    expect(byKey.get("Places").tone).toBe("category2");
+    expect(byKey.get("People").groupKey).toBe("People");
+  });
+});

--- a/studio/src/tests/groupBy.test.js
+++ b/studio/src/tests/groupBy.test.js
@@ -1,0 +1,448 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  computeGroupedGraph,
+  classIdsAtLevel,
+  typeNamesInTaxonomy,
+  ontologyLevelState,
+  levelButtonView,
+  ontologyAbsorption,
+} from "../lib/groupBy.js";
+import { mintCommunityNodeIds, mintTypeNodeIds } from "../lib/classNodes.js";
+import { communityStats, nodeCommunity, nodeType, buildScene } from "../lib/graphAdapter.js";
+import {
+  createDefaultViewerState,
+  toggleGroupOntology,
+  toggleGroupType,
+  toggleGroupCommunity,
+  groupOntologyLevel,
+  groupAllCommunities,
+  clearOntologyGrouping,
+  clearCommunityGrouping,
+  hasOntologyGrouping,
+  hasCommunityGrouping,
+  splitGroupedKeys,
+  ONTOLOGY_LEVELS,
+} from "../lib/viewerState.js";
+
+/**
+ * B2 — the EXTRACTED, REAL App grouping chain (`computeGroupedGraph`) driven
+ * end-to-end on MYSTERY-SHAPED data, plus the Type axis (§2), the tri-state bulk
+ * button state mapping (§4), nesting absorption (§3) and the scope-local
+ * ungroup-all (§4/§5). These are the spec's failing→passing tests: they would
+ * FAIL before this change (no exported chain, no Type grouping, no tri-state /
+ * absorption math) and PASS after it.
+ *
+ * The App wires `communityCtx` / `typeCtx` exactly as built here, so this suite
+ * is the literal runtime path — not a re-implementation.
+ */
+
+// A mystery-shaped graph: Domain → Sub-domain class taxonomy with member_ids that
+// MATCH graph node ids (the public-pack invariant), numeric+named communities,
+// and typed entities so the Type axis has real members.
+function mysteryGraph() {
+  return {
+    nodes: [
+      // People domain
+      { id: "holmes", label: "Sherlock Holmes", type: "Character", community: 8, community_name: "Hound" },
+      { id: "watson", label: "John Watson", type: "Character", community: 8, community_name: "Hound" },
+      { id: "moriarty", label: "Moriarty", type: "Character", community: 14, community_name: "Web" },
+      { id: "yard", label: "Scotland Yard", type: "Organization", community: 8, community_name: "Hound" },
+      // Place domain
+      { id: "baker", label: "Baker Street", type: "Location", community: 8, community_name: "Hound" },
+      { id: "moor", label: "Dartmoor", type: "Location", community: 14, community_name: "Web" },
+    ],
+    links: [
+      { source: "holmes", target: "watson", relation: "assists", evidence_refs: ["e1"] },
+      { source: "holmes", target: "moriarty", relation: "rival", evidence_refs: ["e2"] },
+      { source: "holmes", target: "yard", relation: "consults", evidence_refs: ["e3"] },
+      { source: "holmes", target: "baker", relation: "lives_in", evidence_refs: ["e4"] },
+      { source: "moriarty", target: "moor", relation: "hides_in", evidence_refs: ["e5"] },
+      { source: "watson", target: "moor", relation: "visits", evidence_refs: ["e6"] },
+    ],
+  };
+}
+
+// Taxonomy: Domain (level 0) → Sub-domain leaf classes (level 1) carrying
+// member_ids + member_node_types. Mirrors the real mystery artifact shape.
+function mysteryHierarchies() {
+  return {
+    schema: "graphify_ontology_class_hierarchies_v1",
+    hierarchies: {
+      mystery_class_taxonomy_v1: {
+        root_class_ids: ["class:People", "class:Place"],
+        classes_by_id: {
+          "class:People": {
+            id: "class:People",
+            label: "People",
+            level: 0,
+            parent_id: null,
+            child_ids: ["class:Person", "class:Organization"],
+            member_node_types: [],
+            member_ids: [],
+          },
+          "class:Person": {
+            id: "class:Person",
+            label: "Person",
+            level: 1,
+            parent_id: "class:People",
+            child_ids: [],
+            member_node_types: ["Character"],
+            member_ids: ["holmes", "watson", "moriarty"],
+          },
+          "class:Organization": {
+            id: "class:Organization",
+            label: "Organization",
+            level: 1,
+            parent_id: "class:People",
+            child_ids: [],
+            member_node_types: ["Organization"],
+            member_ids: ["yard"],
+          },
+          "class:Place": {
+            id: "class:Place",
+            label: "Place",
+            level: 0,
+            parent_id: null,
+            child_ids: ["class:Location"],
+            member_node_types: [],
+            member_ids: [],
+          },
+          "class:Location": {
+            id: "class:Location",
+            label: "Location",
+            level: 1,
+            parent_id: "class:Place",
+            child_ids: [],
+            member_node_types: ["Location"],
+            member_ids: ["baker", "moor"],
+          },
+        },
+      },
+    },
+  };
+}
+
+// Faithful replica of App.svelte's `communityCtx` (GROUPED ∩ LIVE).
+function communityCtxFor(graph, communityKeys) {
+  if (!communityKeys.length) return null;
+  const groupedSet = new Set(communityKeys);
+  const live = communityStats(graph).live.filter((c) => groupedSet.has(c.key));
+  if (live.length === 0) return null;
+  const liveKeys = live.map((c) => c.key);
+  const idByKey = mintCommunityNodeIds(liveKeys, new Set(graph.nodes.map((n) => n.id)));
+  const toneKeyByKey = new Map(live.map((c) => [c.key, c.groupKey ?? c.key]));
+  return {
+    liveKeys,
+    idByKey,
+    communityOf: nodeCommunity,
+    toneKeyOf: (k) => toneKeyByKey.get(k),
+    labelOf: (k) => k,
+  };
+}
+
+// Faithful replica of App.svelte's `typeCtx`.
+function typeCtxFor(graph, typeNames) {
+  if (!typeNames.length) return null;
+  const idByKey = mintTypeNodeIds(typeNames, new Set(graph.nodes.map((n) => n.id)));
+  return { typeNames, idByKey, typeOf: nodeType };
+}
+
+// The full App chain for a grouped-key set (what `groupedGraph` resolves to).
+function groupedGraphFor(graph, classHierarchies, grouped) {
+  const { communityKeys, typeNames } = splitGroupedKeys(grouped);
+  return computeGroupedGraph({
+    graph,
+    classHierarchies,
+    communityCtx: communityCtxFor(graph, communityKeys),
+    typeCtx: typeCtxFor(graph, typeNames),
+    grouped,
+  });
+}
+
+describe("B2 §2 — ONTOLOGY per-item grouping regroups the graph (the fixed bug)", () => {
+  it("checking a DOMAIN folds its whole subtree into the domain class node", () => {
+    const graph = mysteryGraph();
+    const ch = mysteryHierarchies();
+
+    // Drive the SAME id the Domain checkbox passes (typeTree domain.id = root id).
+    let state = createDefaultViewerState();
+    state = toggleGroupOntology(state, "class:People");
+
+    const out = groupedGraphFor(graph, ch, state.options.groupBy.grouped);
+    const ids = out.nodes.map((n) => n.id);
+
+    // Node count DROPS and every People member folded away.
+    for (const member of ["holmes", "watson", "moriarty", "yard"]) {
+      expect(ids, `${member} must fold under class:People`).not.toContain(member);
+    }
+    // The class group node is present + collapsed with its hidden count.
+    const peopleNode = out.nodes.find((n) => n.id === "class:People");
+    expect(peopleNode, "class:People fold node must be present").toBeTruthy();
+    expect(peopleNode.collapsed).toBe(true);
+    // 4 entity members + 2 descendant class nodes (Person, Organization) = 6.
+    expect(peopleNode.hidden_node_count).toBe(6);
+    // Place subtree untouched.
+    expect(ids).toContain("baker");
+    expect(ids).toContain("moor");
+    expect(out.nodes.length).toBeLessThan(graph.nodes.length);
+  });
+
+  it("checking a SUB-DOMAIN leaf class folds only its members", () => {
+    const graph = mysteryGraph();
+    const ch = mysteryHierarchies();
+    let state = createDefaultViewerState();
+    state = toggleGroupOntology(state, "class:Person"); // leaf sub-domain
+
+    const out = groupedGraphFor(graph, ch, state.options.groupBy.grouped);
+    const ids = out.nodes.map((n) => n.id);
+    for (const member of ["holmes", "watson", "moriarty"]) {
+      expect(ids).not.toContain(member);
+    }
+    // Organization sibling + Place subtree stay visible.
+    expect(ids).toContain("yard");
+    expect(ids).toContain("baker");
+    const personNode = out.nodes.find((n) => n.id === "class:Person");
+    expect(personNode.hidden_node_count).toBe(3);
+  });
+
+  it("the collapsed graph builds a scene carrying the class fold node", () => {
+    const graph = mysteryGraph();
+    const out = groupedGraphFor(graph, mysteryHierarchies(), ["ontology:class:People"]);
+    const scene = buildScene(out, { showWeakLinks: true });
+    expect(scene.nodes.some((n) => n.ontology_node_kind === "class")).toBe(true);
+  });
+});
+
+describe("B2 §2 — TYPE (leaf) grouping folds entities into their type", () => {
+  it("checking a Type folds every entity of that `type` into a type node", () => {
+    const graph = mysteryGraph();
+    let state = createDefaultViewerState();
+    state = toggleGroupType(state, "Character");
+
+    const out = groupedGraphFor(graph, mysteryHierarchies(), state.options.groupBy.grouped);
+    const ids = out.nodes.map((n) => n.id);
+    // The 3 Characters folded away…
+    for (const member of ["holmes", "watson", "moriarty"]) {
+      expect(ids).not.toContain(member);
+    }
+    // …a Type fold node is present in their place…
+    const typeNode = out.nodes.find((n) => n.type_node_kind === "type");
+    expect(typeNode, "a Type fold node must be present").toBeTruthy();
+    expect(typeNode.type_name).toBe("Character");
+    expect(typeNode.collapsed).toBe(true);
+    expect(typeNode.hidden_node_count).toBe(3);
+    // …non-Character nodes stay visible.
+    for (const kept of ["yard", "baker", "moor"]) expect(ids).toContain(kept);
+    // The scene carries the type fold node.
+    const scene = buildScene(out, { showWeakLinks: true });
+    expect(scene.nodes.some((n) => n.type_node_kind === "type")).toBe(true);
+  });
+
+  it("mixing ontology + community + type folds all three at once", () => {
+    const graph = mysteryGraph();
+    let state = createDefaultViewerState();
+    state = toggleGroupType(state, "Location"); // baker, moor
+    state = toggleGroupOntology(state, "class:Organization"); // yard
+    state = toggleGroupCommunity(state, "Hound"); // holmes, watson (+ baker/yard but those fold via other axes)
+
+    const out = groupedGraphFor(graph, mysteryHierarchies(), state.options.groupBy.grouped);
+    const kinds = out.nodes
+      .map((n) => n.type_node_kind || n.community_node_kind || n.ontology_node_kind)
+      .filter(Boolean)
+      .sort();
+    expect(kinds).toContain("type");
+    expect(kinds).toContain("community");
+    expect(kinds).toContain("class");
+  });
+});
+
+describe("B2 §4 — tri-state bulk-button state mapping (none / partial / all)", () => {
+  const ch = mysteryHierarchies();
+
+  it("DOMAIN level: none → partial → all as classes get checked", () => {
+    // Two domains: class:People, class:Place → total = 2 (none absorbed).
+    let none = ontologyLevelState({ classHierarchies: ch, level: 0, checkedOntologyIds: new Set() });
+    expect(none).toMatchObject({ state: "none", done: 0, total: 2 });
+
+    let partial = ontologyLevelState({
+      classHierarchies: ch,
+      level: 0,
+      checkedOntologyIds: new Set(["class:People"]),
+    });
+    expect(partial).toMatchObject({ state: "partial", done: 1, total: 2 });
+
+    let all = ontologyLevelState({
+      classHierarchies: ch,
+      level: 0,
+      checkedOntologyIds: new Set(["class:People", "class:Place"]),
+    });
+    expect(all).toMatchObject({ state: "all", done: 2, total: 2 });
+  });
+
+  it("TYPE level: total = distinct member_node_types, checked = grouped type names", () => {
+    const types = typeNamesInTaxonomy(ch); // Character, Organization, Location
+    expect(types.sort()).toEqual(["Character", "Location", "Organization"]);
+    const partial = ontologyLevelState({
+      classHierarchies: ch,
+      level: 2,
+      checkedTypeNames: new Set(["Character"]),
+    });
+    expect(partial).toMatchObject({ state: "partial", done: 1, total: 3 });
+  });
+
+  it("levelButtonView maps tri-state to DS variant + aria-pressed + badge (NEVER mixed)", () => {
+    // NONE → secondary, aria-pressed=false, no badge (click groups the level).
+    expect(levelButtonView({ state: "none", done: 0, total: 2 })).toEqual({
+      variant: "secondary",
+      ariaPressed: "false",
+      showBadge: false,
+      badge: null,
+    });
+    // ALL → primary, aria-pressed=true (click toggles OFF).
+    expect(levelButtonView({ state: "all", done: 2, total: 2 })).toEqual({
+      variant: "primary",
+      ariaPressed: "true",
+      showBadge: false,
+      badge: null,
+    });
+    // PARTIAL → secondary, aria-pressed=false, badge "n/m" (click completes).
+    expect(levelButtonView({ state: "partial", done: 1, total: 2 })).toEqual({
+      variant: "secondary",
+      ariaPressed: "false",
+      showBadge: true,
+      badge: "1/2",
+    });
+    // It is NEVER aria-pressed="mixed" / aria-checked anything.
+    for (const s of ["none", "partial", "all"]) {
+      const v = levelButtonView({ state: s, done: 1, total: 2 });
+      expect(["true", "false"]).toContain(v.ariaPressed);
+    }
+  });
+
+  it("bulk CLICK cycles none→all→none and partial→all (via state actions)", () => {
+    let state = createDefaultViewerState();
+    // none → click groups all domains.
+    state = groupOntologyLevel(state, ONTOLOGY_LEVELS.domain, classIdsAtLevel(ch, 0));
+    let ls = ontologyLevelState({
+      classHierarchies: ch,
+      level: 0,
+      checkedOntologyIds: new Set(splitGroupedKeys(state.options.groupBy.grouped).ontologyClassIds),
+    });
+    expect(ls.state).toBe("all");
+    // all → toggle OFF (clearOntologyGrouping).
+    state = clearOntologyGrouping(state);
+    ls = ontologyLevelState({
+      classHierarchies: ch,
+      level: 0,
+      checkedOntologyIds: new Set(splitGroupedKeys(state.options.groupBy.grouped).ontologyClassIds),
+    });
+    expect(ls.state).toBe("none");
+    // partial → completes to all in ONE click.
+    state = toggleGroupOntology(createDefaultViewerState(), "class:People"); // partial
+    state = groupOntologyLevel(state, ONTOLOGY_LEVELS.domain, classIdsAtLevel(ch, 0));
+    ls = ontologyLevelState({
+      classHierarchies: ch,
+      level: 0,
+      checkedOntologyIds: new Set(splitGroupedKeys(state.options.groupBy.grouped).ontologyClassIds),
+    });
+    expect(ls.state).toBe("all");
+  });
+});
+
+describe("B2 §3 — nesting absorption", () => {
+  const ch = mysteryHierarchies();
+
+  it("a sub-domain absorbed by a grouped Domain is excluded + reports its parent", () => {
+    const checked = new Set(["class:People"]); // domain grouped
+    const abs = ontologyAbsorption(ch, checked);
+    // class:Person is absorbed by class:People.
+    expect(abs.get("class:Person")).toMatchObject({ absorbed: true, byLabel: "People" });
+    expect(abs.get("class:Organization")).toMatchObject({ absorbed: true, byLabel: "People" });
+    // class:Place (a different domain) is NOT absorbed.
+    expect(abs.get("class:Place").absorbed).toBe(false);
+  });
+
+  it("level counts EXCLUDE absorbed classes (denominator shrinks)", () => {
+    // With class:People grouped, the Sub-domain level still has Location as the
+    // ONLY non-absorbed member (Person+Organization are absorbed by People).
+    const ls = ontologyLevelState({
+      classHierarchies: ch,
+      level: 1,
+      checkedOntologyIds: new Set(["class:People"]),
+    });
+    expect(ls.total).toBe(1); // only class:Location
+    expect(ls.members).toEqual(["class:Location"]);
+  });
+});
+
+describe("B2 §4/§5 — scope-local ungroup-all (disabled when nothing grouped)", () => {
+  it("ontology ungroup-all clears ONLY ontology+type keys; community survives", () => {
+    let state = createDefaultViewerState();
+    state = toggleGroupOntology(state, "class:Person");
+    state = toggleGroupType(state, "Location");
+    state = toggleGroupCommunity(state, "Hound");
+    expect(hasOntologyGrouping(state)).toBe(true);
+    expect(hasCommunityGrouping(state)).toBe(true);
+
+    state = clearOntologyGrouping(state);
+    expect(hasOntologyGrouping(state)).toBe(false); // class + type both gone
+    expect(hasCommunityGrouping(state)).toBe(true); // community untouched
+    expect(splitGroupedKeys(state.options.groupBy.grouped).communityKeys).toEqual(["Hound"]);
+  });
+
+  it("community ungroup-all clears ONLY community keys; ontology survives", () => {
+    let state = createDefaultViewerState();
+    state = toggleGroupOntology(state, "class:Person");
+    state = toggleGroupCommunity(state, "Hound");
+    state = clearCommunityGrouping(state);
+    expect(hasCommunityGrouping(state)).toBe(false);
+    expect(hasOntologyGrouping(state)).toBe(true);
+  });
+
+  it("hasOntologyGrouping / hasCommunityGrouping are false by default (Ungroup all disabled)", () => {
+    const state = createDefaultViewerState();
+    expect(hasOntologyGrouping(state)).toBe(false);
+    expect(hasCommunityGrouping(state)).toBe(false);
+  });
+
+  it("community FLAT bulk: groupAllCommunities then all-grouped predicate", () => {
+    const graph = mysteryGraph();
+    const liveKeys = communityStats(graph).live.map((c) => c.key);
+    let state = groupAllCommunities(createDefaultViewerState(), liveKeys);
+    const grouped = new Set(splitGroupedKeys(state.options.groupBy.grouped).communityKeys);
+    expect(liveKeys.every((k) => grouped.has(k))).toBe(true);
+  });
+});
+
+describe("B2 — real served mystery artifact (if present) folds a Domain end-to-end", () => {
+  const candidates = [
+    resolve(process.env.HOME ?? "", "src/graphify/.graphify/uat/b2-mystery"),
+    resolve(
+      process.env.HOME ?? "",
+      "src/public-domaine-mystery-sagas-pack/.graphify/studio",
+    ),
+  ];
+  const base = candidates.find(
+    (p) => existsSync(resolve(p, "graph.json")) && existsSync(resolve(p, "class-hierarchies.json")),
+  );
+  const maybe = base ? it : it.skip;
+
+  maybe("a Domain checkbox drops the node count against the served pack", () => {
+    const graph = JSON.parse(readFileSync(resolve(base, "graph.json"), "utf8"));
+    const ch = JSON.parse(readFileSync(resolve(base, "class-hierarchies.json"), "utf8"));
+    const hs = ch.hierarchies[Object.keys(ch.hierarchies)[0]];
+    const domainId = hs.root_class_ids[0];
+    const out = computeGroupedGraph({
+      graph,
+      classHierarchies: ch,
+      grouped: [`ontology:${domainId}`],
+    });
+    const node = out.nodes.find((n) => n.id === domainId);
+    expect(node, `${domainId} fold node must be present`).toBeTruthy();
+    expect(node.collapsed).toBe(true);
+    expect(out.nodes.length).toBeLessThan(graph.nodes.length);
+  });
+});

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -14,7 +14,7 @@ const railSource = readFileSync(
 );
 const appSource = readFileSync(resolve(process.cwd(), "src/App.svelte"), "utf8");
 
-describe("LeftRail — T13 F2 visible-UI lock (group-by replaces the checkbox)", () => {
+describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", () => {
   it("NO 'Show ontology classes' checkbox remains (input nor label text)", () => {
     expect(railSource).not.toMatch(/Show ontology classes/i);
     // The pre-B2 checkbox handler / props are gone from the LeftRail ↔ App wiring.
@@ -24,49 +24,63 @@ describe("LeftRail — T13 F2 visible-UI lock (group-by replaces the checkbox)",
     expect(appSource).not.toMatch(/onToggleOntologyClasses=/);
   });
 
-  it("the group-by axis control appears under Options with a 3-way None/Community/Ontology selector", () => {
-    expect(railSource).toMatch(/<Collapsible title="Options"/);
-    expect(railSource).toMatch(/<Collapsible title="Group by"/);
-    expect(railSource).toMatch(/role="radiogroup"[\s\S]*aria-label="Group-by axis"/);
-    // The three axis buttons.
-    expect(railSource).toMatch(/onSetAxis\?\.\("none"\)/);
-    expect(railSource).toMatch(/onSetAxis\?\.\("community"\)/);
-    expect(railSource).toMatch(/onSetAxis\?\.\("ontology"\)/);
+  it("the OLD axis selector + per-axis fold sub-menu are fully removed", () => {
+    // No "Group by" axis sub-menu, no axis radiogroup, no axis handlers/props.
+    expect(railSource).not.toMatch(/<Collapsible title="Group by"/);
+    expect(railSource).not.toMatch(/aria-label="Group-by axis"/);
+    expect(railSource).not.toMatch(/onSetAxis/);
+    expect(railSource).not.toMatch(/onToggleCollapse/);
+    expect(railSource).not.toMatch(/onExpandAll/);
+    expect(railSource).not.toMatch(/availableAxes/);
+    expect(railSource).not.toMatch(/showCommunityAxis|showOntologyAxis/);
+    expect(railSource).not.toMatch(/groupBy\.axis/);
+    // …and the App no longer wires any axis prop/derivation either.
+    expect(appSource).not.toMatch(/availableAxes/);
+    expect(appSource).not.toMatch(/onSetAxis/);
+    expect(appSource).not.toMatch(/onToggleCollapse/);
+    expect(appSource).not.toMatch(/setGroupAxis/);
   });
 
-  it("absent axes are OMITTED from the picker (driven by availableAxes, not hard-coded)", () => {
-    // Community / Ontology buttons are gated on availability flags derived from
-    // the availableAxes prop — not always rendered.
-    expect(railSource).toMatch(/showCommunityAxis = \$derived\(axisAvailable\.has\("community"\)\)/);
-    expect(railSource).toMatch(/showOntologyAxis = \$derived\(axisAvailable\.has\("ontology"\)\)/);
-    expect(railSource).toMatch(/{#if showCommunityAxis}/);
-    expect(railSource).toMatch(/{#if showOntologyAxis}/);
-    // App computes availableAxes from artifact presence + liveCount and passes it.
-    expect(appSource).toMatch(/availableAxes = \$derived\(\[/);
-    expect(appSource).toMatch(/communityInfo\.liveCount > 0 \? \["community"\]/);
-    expect(appSource).toMatch(/classHierarchies\?\.hierarchies \? \["ontology"\]/);
-    expect(appSource).toMatch(/<LeftRail[\s\S]*\{availableAxes\}/);
+  it("each groupable Ontology CLASS node owns a per-item group-by checkbox", () => {
+    // Domain + Sub-domain class headers each carry a checkbox → onToggleGroupOntology.
+    expect(railSource).toMatch(/class="rail-group-check"/);
+    expect(railSource).toMatch(/onToggleGroupOntology\?\.\(domain\.id\)/);
+    expect(railSource).toMatch(/onToggleGroupOntology\?\.\(sub\.id\)/);
+    // The checked state reflects membership in the grouped SET (per-item).
+    expect(railSource).toMatch(/checked=\{ontologyGrouped\.has\(domain\.id\)\}/);
+    expect(railSource).toMatch(/checked=\{ontologyGrouped\.has\(sub\.id\)\}/);
+    // App passes the per-item callbacks + availability flags (NOT availableAxes).
+    expect(appSource).toMatch(/onToggleGroupOntology=\{handleToggleGroupOntology\}/);
+    expect(appSource).toMatch(/onToggleGroupCommunity=\{handleToggleGroupCommunity\}/);
+    expect(appSource).toMatch(/\{canGroupOntology\}/);
+    expect(appSource).toMatch(/\{canGroupCommunity\}/);
   });
 
-  it("the ontology fold tree uses fold pills/glyphs, NOT selectable rows (Two-Concepts)", () => {
-    // Group-by renders fold pills + state glyphs.
-    expect(railSource).toMatch(/class="rail-fold-pill"/);
-    expect(railSource).toMatch(/onToggleCollapse\?\.\(/);
-    // Bulk baseline buttons (F8): Domain / Sub-domain / Type.
+  it("each Community row owns a per-item group-by checkbox (separate from its select)", () => {
+    expect(railSource).toMatch(/onToggleGroupCommunity\?\.\(c\.key\)/);
+    expect(railSource).toMatch(/checked=\{communityGrouped\.has\(c\.key\)\}/);
+  });
+
+  it("the bulk baseline + ungroup-all controls drive the grouped set (F8)", () => {
+    // Bulk baseline buttons (F8): Domain / Sub-domain / Type → onFoldToLevel.
     expect(railSource).toMatch(/onFoldToLevel\?\.\(0\)/);
     expect(railSource).toMatch(/onFoldToLevel\?\.\(1\)/);
     expect(railSource).toMatch(/onFoldToLevel\?\.\(2\)/);
-    // Leaf Type rows are read-only in v1 (no fold pill on the leaf class label).
-    expect(railSource).toMatch(/rail-fold-leaf/);
+    // The ungroup-all reset clears the whole grouped set.
+    expect(railSource).toMatch(/onClearGrouping\?\.\(/);
+    expect(appSource).toMatch(/onFoldToLevel=\{handleFoldToLevel\}/);
+    expect(appSource).toMatch(/onClearGrouping=\{handleClearGrouping\}/);
   });
 
-  it("the Ontology FILTER facet stays separate (selectable rows + shape glyphs, own toggle)", () => {
-    // The Ontology accordion (taxonomy facet) still renders SelectableRow + TypeShapeGlyph + onToggleType.
+  it("the Ontology FILTER facet stays SEPARATE from the group-by checkboxes", () => {
+    // The Ontology accordion (taxonomy facet) renders SelectableRow + TypeShapeGlyph
+    // + onToggleType — the FILTER concern, distinct from the group-by checkbox.
     expect(railSource).toMatch(/<Collapsible title="Ontology"/);
     expect(railSource).toMatch(/<TypeShapeGlyph type=\{t\.key\}/);
     expect(railSource).toMatch(/onselect=\{\(\) => onToggleType\?\.\(t\.key\)\}/);
-    // Group-by toggles call onToggleCollapse, never onToggleType — and vice-versa.
-    expect(railSource).not.toMatch(/onToggleType\?\.\([^)]*\)[\s\S]{0,40}rail-fold-pill/);
+    // The group-by checkbox calls onToggleGroupOntology, NEVER onToggleType —
+    // grouping a class is not selecting/filtering it.
+    expect(railSource).not.toMatch(/onToggleType\?\.\([^)]*\)[\s\S]{0,40}rail-group-check/);
   });
 });
 

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * B2 — T13 (F2 visible-UI lock) + the tracked badge-relocation / reactive-count
+ * change. The studio's component tests assert against the .svelte SOURCE (jsdom
+ * has no Canvas2D, so we don't mount the GraphCanvas-bearing tree — same
+ * source-assertion style as appHeader.test.js / reconciliationView.test.js).
+ */
+const railSource = readFileSync(
+  resolve(process.cwd(), "src/components/LeftRail.svelte"),
+  "utf8",
+);
+const appSource = readFileSync(resolve(process.cwd(), "src/App.svelte"), "utf8");
+
+describe("LeftRail — T13 F2 visible-UI lock (group-by replaces the checkbox)", () => {
+  it("NO 'Show ontology classes' checkbox remains (input nor label text)", () => {
+    expect(railSource).not.toMatch(/Show ontology classes/i);
+    // The pre-B2 checkbox handler / props are gone from the LeftRail ↔ App wiring.
+    expect(railSource).not.toMatch(/onToggleOntologyClasses/);
+    expect(railSource).not.toMatch(/showOntologyClasses/);
+    expect(appSource).not.toMatch(/showOntologyClasses=/);
+    expect(appSource).not.toMatch(/onToggleOntologyClasses=/);
+  });
+
+  it("the group-by axis control appears under Options with a 3-way None/Community/Ontology selector", () => {
+    expect(railSource).toMatch(/<Collapsible title="Options"/);
+    expect(railSource).toMatch(/<Collapsible title="Group by"/);
+    expect(railSource).toMatch(/role="radiogroup"[\s\S]*aria-label="Group-by axis"/);
+    // The three axis buttons.
+    expect(railSource).toMatch(/onSetAxis\?\.\("none"\)/);
+    expect(railSource).toMatch(/onSetAxis\?\.\("community"\)/);
+    expect(railSource).toMatch(/onSetAxis\?\.\("ontology"\)/);
+  });
+
+  it("absent axes are OMITTED from the picker (driven by availableAxes, not hard-coded)", () => {
+    // Community / Ontology buttons are gated on availability flags derived from
+    // the availableAxes prop — not always rendered.
+    expect(railSource).toMatch(/showCommunityAxis = \$derived\(axisAvailable\.has\("community"\)\)/);
+    expect(railSource).toMatch(/showOntologyAxis = \$derived\(axisAvailable\.has\("ontology"\)\)/);
+    expect(railSource).toMatch(/{#if showCommunityAxis}/);
+    expect(railSource).toMatch(/{#if showOntologyAxis}/);
+    // App computes availableAxes from artifact presence + liveCount and passes it.
+    expect(appSource).toMatch(/availableAxes = \$derived\(\[/);
+    expect(appSource).toMatch(/communityInfo\.liveCount > 0 \? \["community"\]/);
+    expect(appSource).toMatch(/classHierarchies\?\.hierarchies \? \["ontology"\]/);
+    expect(appSource).toMatch(/<LeftRail[\s\S]*\{availableAxes\}/);
+  });
+
+  it("the ontology fold tree uses fold pills/glyphs, NOT selectable rows (Two-Concepts)", () => {
+    // Group-by renders fold pills + state glyphs.
+    expect(railSource).toMatch(/class="rail-fold-pill"/);
+    expect(railSource).toMatch(/onToggleCollapse\?\.\(/);
+    // Bulk baseline buttons (F8): Domain / Sub-domain / Type.
+    expect(railSource).toMatch(/onFoldToLevel\?\.\(0\)/);
+    expect(railSource).toMatch(/onFoldToLevel\?\.\(1\)/);
+    expect(railSource).toMatch(/onFoldToLevel\?\.\(2\)/);
+    // Leaf Type rows are read-only in v1 (no fold pill on the leaf class label).
+    expect(railSource).toMatch(/rail-fold-leaf/);
+  });
+
+  it("the Types FILTER facet stays separate (selectable rows + shape glyphs, own toggle)", () => {
+    // The Types accordion still renders SelectableRow + TypeShapeGlyph + onToggleType.
+    expect(railSource).toMatch(/<Collapsible title="Types"/);
+    expect(railSource).toMatch(/<TypeShapeGlyph type=\{t\.key\}/);
+    expect(railSource).toMatch(/onselect=\{\(\) => onToggleType\?\.\(t\.key\)\}/);
+    // Group-by toggles call onToggleCollapse, never onToggleType — and vice-versa.
+    expect(railSource).not.toMatch(/onToggleType\?\.\([^)]*\)[\s\S]{0,40}rail-fold-pill/);
+  });
+});
+
+describe("LeftRail — tracked UI: count badges relocated + reactive filtered count", () => {
+  it("the count badges live under the search bar, not in the header", () => {
+    expect(railSource).toMatch(/class="rail-search"[\s\S]*class="rail-stats"/);
+    expect(railSource).toMatch(/aria-label="Graph summary"/);
+    // edges / groups come from the passed-in scene stats.
+    expect(railSource).toMatch(/\{stats\.edgeCount\} edges/);
+    expect(railSource).toMatch(/\{stats\.communityCount\} groups/);
+  });
+
+  it("the nodes badge is REACTIVE to the search query: 'x / total nodes'", () => {
+    // entityTotal = the count matching the query; totalNodeCount = the full graph.
+    expect(railSource).toMatch(/totalNodeCount = \$derived\(graphNodes\(graph\)\.length\)/);
+    expect(railSource).toMatch(/hasQuery = \$derived\(query\.trim\(\)\.length > 0\)/);
+    // The badge shows "x / total nodes" while filtering, "total nodes" otherwise.
+    expect(railSource).toMatch(/\{#if hasQuery\}\{entityTotal\} \/ \{totalNodeCount\} nodes/);
+    expect(railSource).toMatch(/\{:else\}\{totalNodeCount\} nodes\{\/if\}/);
+  });
+});

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -72,6 +72,30 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     expect(appSource).toMatch(/onClearGrouping=\{handleClearGrouping\}/);
   });
 
+  it("the group-by checkbox is on the LEFT (leading) with NO 'group' text (SPEC)", () => {
+    // SPEC PART 1: the bare checkbox is the FIRST element on the row — it lives in
+    // a `leading()` snippet (left edge), NOT in `trailing()` (right side).
+    // Each group-by checkbox is immediately preceded by a `{#snippet leading()}`.
+    const checkboxBlocks = railSource.split('class="rail-group-check"');
+    // 3 group-by checkboxes (Domain, Sub-domain, Community) → 4 split segments.
+    expect(checkboxBlocks.length).toBe(4);
+    for (let i = 1; i < checkboxBlocks.length; i += 1) {
+      const before = checkboxBlocks[i - 1];
+      // The nearest snippet opening before the checkbox is leading(), not trailing().
+      const leadIdx = before.lastIndexOf("{#snippet leading()}");
+      const trailIdx = before.lastIndexOf("{#snippet trailing()}");
+      expect(leadIdx, `checkbox #${i} must sit inside a leading() snippet`).toBeGreaterThan(
+        trailIdx,
+      );
+    }
+    // NO persistent "group" text label anywhere — the rail-group-hint span is gone.
+    expect(railSource).not.toMatch(/rail-group-hint/);
+    expect(railSource).not.toMatch(/>group<\/span>/);
+    expect(railSource).not.toMatch(/aria-hidden="true">group/);
+    // The HOVER signal stays: the title tooltip "Group by …" is preserved.
+    expect(railSource).toMatch(/title="Group by /);
+  });
+
   it("the Ontology FILTER facet stays SEPARATE from the group-by checkboxes", () => {
     // The Ontology accordion (taxonomy facet) renders SelectableRow + TypeShapeGlyph
     // + onToggleType — the FILTER concern, distinct from the group-by checkbox.

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -60,9 +60,9 @@ describe("LeftRail — T13 F2 visible-UI lock (group-by replaces the checkbox)",
     expect(railSource).toMatch(/rail-fold-leaf/);
   });
 
-  it("the Types FILTER facet stays separate (selectable rows + shape glyphs, own toggle)", () => {
-    // The Types accordion still renders SelectableRow + TypeShapeGlyph + onToggleType.
-    expect(railSource).toMatch(/<Collapsible title="Types"/);
+  it("the Ontology FILTER facet stays separate (selectable rows + shape glyphs, own toggle)", () => {
+    // The Ontology accordion (taxonomy facet) still renders SelectableRow + TypeShapeGlyph + onToggleType.
+    expect(railSource).toMatch(/<Collapsible title="Ontology"/);
     expect(railSource).toMatch(/<TypeShapeGlyph type=\{t\.key\}/);
     expect(railSource).toMatch(/onselect=\{\(\) => onToggleType\?\.\(t\.key\)\}/);
     // Group-by toggles call onToggleCollapse, never onToggleType — and vice-versa.

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -110,18 +110,19 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     // `rail-type-group-check` variant).
     const onMarkers = railSource.match(/class:rail-group-check--on=/g) ?? [];
     expect(onMarkers.length).toBe(4);
-    // The Domain + Sub-domain + Community checkboxes live in a `leading()` snippet
-    // (left edge of the Collapsible/SelectableRow header).
-    const leadingChecks = railSource.split('class="rail-group-check"');
-    expect(leadingChecks.length).toBe(4); // 3 leading()-hosted bare checkboxes
-    for (let i = 1; i < leadingChecks.length; i += 1) {
-      const before = leadingChecks[i - 1];
-      const leadIdx = before.lastIndexOf("{#snippet leading()}");
-      const trailIdx = before.lastIndexOf("{#snippet trailing()}");
-      expect(leadIdx, `checkbox #${i} must sit inside a leading() snippet`).toBeGreaterThan(
-        trailIdx,
-      );
-    }
+    // FIX: the DS Collapsible exposes NO `leading` slot (only trailing/children),
+    // so the Domain + Sub-domain group-by checkboxes are SIBLINGS *before*
+    // <Collapsible> inside a `.rail-onto-head` flex row — NOT in a (silently
+    // dropped) leading() snippet. That dropped slot is exactly why the
+    // Domain/Sub-domain checkboxes were invisible.
+    const ontoHeads = railSource.match(/<li class="rail-onto-head">/g) ?? [];
+    expect(ontoHeads.length).toBe(2); // Domain + Sub-domain rows
+    expect(railSource).toMatch(
+      /<li class="rail-onto-head">[\s\S]*?class="rail-group-check"[\s\S]*?onToggleGroupOntology[\s\S]*?<Collapsible/,
+    );
+    // Regression guard: NEVER put a group-by checkbox in a Collapsible leading()
+    // snippet — the DS Collapsible drops it.
+    expect(railSource).not.toMatch(/<Collapsible[^>]*>\s*\{#snippet leading\(\)\}/);
     // The leaf Type checkbox sits FIRST in its flex row, BEFORE the FILTER
     // SelectableRow — left, bare, separate from the Type FILTER select (§2).
     expect(railSource).toMatch(

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -47,8 +47,8 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     expect(railSource).toMatch(/onToggleGroupOntology\?\.\(domain\.id\)/);
     expect(railSource).toMatch(/onToggleGroupOntology\?\.\(sub\.id\)/);
     // The checked state reflects membership in the grouped SET (per-item).
-    expect(railSource).toMatch(/checked=\{ontologyGrouped\.has\(domain\.id\)\}/);
-    expect(railSource).toMatch(/checked=\{ontologyGrouped\.has\(sub\.id\)\}/);
+    expect(railSource).toMatch(/checked=\{ontologyCheckedSet\.has\(domain\.id\)\}/);
+    expect(railSource).toMatch(/checked=\{ontologyCheckedSet\.has\(sub\.id\)\}/);
     // App passes the per-item callbacks + availability flags (NOT availableAxes).
     expect(appSource).toMatch(/onToggleGroupOntology=\{handleToggleGroupOntology\}/);
     expect(appSource).toMatch(/onToggleGroupCommunity=\{handleToggleGroupCommunity\}/);
@@ -56,38 +56,77 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     expect(appSource).toMatch(/\{canGroupCommunity\}/);
   });
 
+  it("each leaf TYPE row owns its OWN group-by checkbox (§2 — fixes Type grouping)", () => {
+    // The Type checkbox folds entities of that `type` → onToggleGroupType(t.key);
+    // its checked state reads the type-scoped membership set.
+    expect(railSource).toMatch(/onToggleGroupType\?\.\(t\.key\)/);
+    expect(railSource).toMatch(/checked=\{typeCheckedSet\.has\(t\.key\)\}/);
+    // It is SEPARATE from the Type FILTER SelectableRow (onToggleType) on the row.
+    expect(railSource).toMatch(/rail-type-group-check/);
+    expect(appSource).toMatch(/onToggleGroupType=\{handleToggleGroupType\}/);
+  });
+
   it("each Community row owns a per-item group-by checkbox (separate from its select)", () => {
     expect(railSource).toMatch(/onToggleGroupCommunity\?\.\(c\.key\)/);
-    expect(railSource).toMatch(/checked=\{communityGrouped\.has\(c\.key\)\}/);
+    expect(railSource).toMatch(/checked=\{communityCheckedSet\.has\(c\.key\)\}/);
   });
 
-  it("the bulk baseline + ungroup-all controls drive the grouped set (F8)", () => {
-    // Bulk baseline buttons (F8): Domain / Sub-domain / Type → onFoldToLevel.
-    expect(railSource).toMatch(/onFoldToLevel\?\.\(0\)/);
-    expect(railSource).toMatch(/onFoldToLevel\?\.\(1\)/);
-    expect(railSource).toMatch(/onFoldToLevel\?\.\(2\)/);
-    // The ungroup-all reset clears the whole grouped set.
-    expect(railSource).toMatch(/onClearGrouping\?\.\(/);
-    expect(appSource).toMatch(/onFoldToLevel=\{handleFoldToLevel\}/);
-    expect(appSource).toMatch(/onClearGrouping=\{handleClearGrouping\}/);
+  it("the ONTOLOGY tri-state bulk buttons drive the grouped set (§4)", () => {
+    // Tri-state bulk via DS Button → onBulkLevel(0|1|2), variant from the level's
+    // {none|partial|all} state, a count Badge for partial, aria-pressed (NOT mixed).
+    expect(railSource).toMatch(/onBulkLevel\?\.\(0\)/);
+    expect(railSource).toMatch(/onBulkLevel\?\.\(1\)/);
+    expect(railSource).toMatch(/onBulkLevel\?\.\(2\)/);
+    expect(railSource).toMatch(/variant=\{domainBtn\.variant\}/);
+    expect(railSource).toMatch(/aria-pressed=\{domainBtn\.ariaPressed\}/);
+    expect(railSource).toMatch(/\{domainBtn\.badge\}/);
+    // The DS Button only has primary/secondary — partial = secondary + Badge,
+    // never aria-checked="mixed".
+    expect(railSource).not.toMatch(/aria-checked="mixed"/);
+    // Scope-local Ungroup all (ontology), native disabled when nothing ontology grouped.
+    expect(railSource).toMatch(/disabled=\{!ontologyGrouped\}/);
+    expect(railSource).toMatch(/onClearOntologyGrouping\?\.\(/);
+    expect(appSource).toMatch(/onBulkLevel=\{handleBulkLevel\}/);
+    expect(appSource).toMatch(/onClearOntologyGrouping=\{handleClearOntologyGrouping\}/);
   });
 
-  it("the group-by checkbox is on the LEFT (leading) with NO 'group' text (SPEC)", () => {
-    // SPEC PART 1: the bare checkbox is the FIRST element on the row — it lives in
-    // a `leading()` snippet (left edge), NOT in `trailing()` (right side).
-    // Each group-by checkbox is immediately preceded by a `{#snippet leading()}`.
-    const checkboxBlocks = railSource.split('class="rail-group-check"');
-    // 3 group-by checkboxes (Domain, Sub-domain, Community) → 4 split segments.
-    expect(checkboxBlocks.length).toBe(4);
-    for (let i = 1; i < checkboxBlocks.length; i += 1) {
-      const before = checkboxBlocks[i - 1];
-      // The nearest snippet opening before the checkbox is leading(), not trailing().
+  it("the COMMUNITY section is FLAT 2-state — Group all / Ungroup all, no count (§5)", () => {
+    // Group all toggles secondary↔primary (aria-pressed) on allCommunitiesGrouped.
+    expect(railSource).toMatch(/onBulkCommunities\?\.\(/);
+    expect(railSource).toMatch(/allCommunitiesGrouped \? "primary" : "secondary"/);
+    expect(railSource).toMatch(/aria-pressed=\{allCommunitiesGrouped \? "true" : "false"\}/);
+    // Community Ungroup all: native disabled when nothing community grouped.
+    expect(railSource).toMatch(/disabled=\{!communityGrouped\}/);
+    expect(railSource).toMatch(/onClearCommunityGrouping\?\.\(/);
+    // NO partial/count badge in the community bulk (FLAT).
+    expect(appSource).toMatch(/onBulkCommunities=\{handleBulkCommunities\}/);
+    expect(appSource).toMatch(/onClearCommunityGrouping=\{handleClearCommunityGrouping\}/);
+  });
+
+  it("the group-by checkbox is on the LEFT with NO 'group' text (SPEC)", () => {
+    // SPEC PART 1: the bare checkbox is the FIRST element on the row. There are
+    // FOUR group-by checkboxes — Domain, Sub-domain, Type, Community — each
+    // carrying the `rail-group-check` affordance (the Type one adds the
+    // `rail-type-group-check` variant).
+    const onMarkers = railSource.match(/class:rail-group-check--on=/g) ?? [];
+    expect(onMarkers.length).toBe(4);
+    // The Domain + Sub-domain + Community checkboxes live in a `leading()` snippet
+    // (left edge of the Collapsible/SelectableRow header).
+    const leadingChecks = railSource.split('class="rail-group-check"');
+    expect(leadingChecks.length).toBe(4); // 3 leading()-hosted bare checkboxes
+    for (let i = 1; i < leadingChecks.length; i += 1) {
+      const before = leadingChecks[i - 1];
       const leadIdx = before.lastIndexOf("{#snippet leading()}");
       const trailIdx = before.lastIndexOf("{#snippet trailing()}");
       expect(leadIdx, `checkbox #${i} must sit inside a leading() snippet`).toBeGreaterThan(
         trailIdx,
       );
     }
+    // The leaf Type checkbox sits FIRST in its flex row, BEFORE the FILTER
+    // SelectableRow — left, bare, separate from the Type FILTER select (§2).
+    expect(railSource).toMatch(
+      /rail-type-group-check[\s\S]*?onToggleGroupType[\s\S]*?<SelectableRow/,
+    );
     // NO persistent "group" text label anywhere — the rail-group-hint span is gone.
     expect(railSource).not.toMatch(/rail-group-hint/);
     expect(railSource).not.toMatch(/>group<\/span>/);

--- a/studio/src/tests/leftRailRender.test.js
+++ b/studio/src/tests/leftRailRender.test.js
@@ -1,0 +1,220 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { groupCounts, nodeType, communityStats } from "../lib/graphAdapter.js";
+import {
+  groupKeyForOntology,
+  groupKeyForCommunity,
+} from "../lib/viewerState.js";
+
+/**
+ * B2 — PER-ITEM checkbox RENDER proof (the "approved mockup" gate).
+ *
+ * The user-validated design puts a group-by CHECKBOX to the LEFT of EVERY
+ * groupable item — each Ontology class row (Domain + Sub-domain) AND each
+ * Community row. The earlier regression was checkboxes that existed in the
+ * SOURCE but never SHOWED, because:
+ *   (a) the per-item ontology checkboxes only render when LeftRail's `typeTree`
+ *       derivation produces Domain/Sub-domain rows (taxonomy-driven), and
+ *   (b) the per-item community checkboxes only render when `communityStats`
+ *       reports liveCount > 0, and
+ *   (c) App's availability flags `canGroupOntology` / `canGroupCommunity` (which
+ *       also gate the SECONDARY bulk "Group all to" controls) evaluate true.
+ *
+ * jsdom has no Canvas2D and the full App tree pulls in GraphCanvas, so we cannot
+ * mount the live component here (same constraint as appHeader/leftRail tests).
+ * Instead we drive the EXACT derivations + flag formulas the component renders
+ * from, against MYSTERY-SHAPED data, and prove every per-item checkbox branch is
+ * reached. (The compiled markup itself is locked by leftRail.test.js.)
+ */
+
+// LeftRail's `typeTree` derivation, lifted verbatim from the component so this
+// test fails if the render logic that emits the per-item ontology checkboxes
+// drifts. Mirrors LeftRail.svelte `typeTree = $derived.by(...)`.
+function buildTypeTree(graph, classHierarchies) {
+  const typeList = groupCounts(graph, nodeType);
+  const hs = classHierarchies?.hierarchies;
+  if (!hs) return null;
+  const h = hs[Object.keys(hs)[0]];
+  if (!h?.classes_by_id || !h.root_class_ids?.length) return null;
+  const classes = h.classes_by_id;
+  const countByType = new Map(typeList.map((t) => [t.key, t.count]));
+  const labelOf = (id) => classes[id]?.label || String(id).replace(/^class:/, "");
+  const seen = new Set();
+  const domains = h.root_class_ids
+    .map((rootId) => {
+      const subs = (classes[rootId]?.child_ids ?? [])
+        .map((subId) => {
+          const types = (classes[subId]?.member_node_types ?? []).map((t) => {
+            seen.add(t);
+            return { key: t, count: countByType.get(t) ?? 0 };
+          });
+          return { id: subId, label: labelOf(subId), types };
+        })
+        .filter((s) => s.types.length);
+      return { id: rootId, label: labelOf(rootId), subs };
+    })
+    .filter((d) => d.subs.length);
+  return domains;
+}
+
+// The pack's REAL mystery taxonomy if present (the export check copies it next to
+// the bundle); otherwise a faithful inline stand-in with the same shape (Domain →
+// Sub-domain → member types) so the test stays hermetic in CI.
+function loadMysteryHierarchies() {
+  const packPath = resolve(
+    process.env.HOME ?? "",
+    "src/public-domaine-mystery-sagas-pack/.graphify/studio/class-hierarchies.json",
+  );
+  if (existsSync(packPath)) {
+    try {
+      return JSON.parse(readFileSync(packPath, "utf8"));
+    } catch {
+      /* fall through to the inline fixture */
+    }
+  }
+  return {
+    hierarchies: {
+      mystery_class_taxonomy_v1: {
+        root_class_ids: ["class:People", "class:Place"],
+        classes_by_id: {
+          "class:People": {
+            id: "class:People",
+            label: "People",
+            level: 0,
+            child_ids: ["class:Detective", "class:Suspect"],
+          },
+          "class:Detective": {
+            id: "class:Detective",
+            label: "Detective",
+            level: 1,
+            member_node_types: ["Detective"],
+          },
+          "class:Suspect": {
+            id: "class:Suspect",
+            label: "Suspect",
+            level: 1,
+            member_node_types: ["Suspect"],
+          },
+          "class:Place": {
+            id: "class:Place",
+            label: "Place",
+            level: 0,
+            child_ids: ["class:City"],
+          },
+          "class:City": {
+            id: "class:City",
+            label: "City",
+            level: 1,
+            member_node_types: ["City"],
+          },
+        },
+      },
+    },
+  };
+}
+
+// A mystery-shaped graph: numeric `community` + `community_name`, typed nodes,
+// real edges (so communities are LIVE, not degree-0 singletons).
+const mysteryGraph = {
+  nodes: [
+    { id: "holmes", label: "Sherlock Holmes", type: "Detective", community: 8, community_name: "Community 8" },
+    { id: "watson", label: "John Watson", type: "Detective", community: 8, community_name: "Community 8" },
+    { id: "moriarty", label: "Moriarty", type: "Suspect", community: 14, community_name: "Community 14" },
+    { id: "moran", label: "Sebastian Moran", type: "Suspect", community: 14, community_name: "Community 14" },
+    { id: "london", label: "London", type: "City", community: 8, community_name: "Community 8" },
+  ],
+  links: [
+    { source: "holmes", target: "watson", relation: "knows" },
+    { source: "holmes", target: "moriarty", relation: "rival" },
+    { source: "moriarty", target: "moran", relation: "employs" },
+    { source: "holmes", target: "london", relation: "lives_in" },
+  ],
+};
+
+describe("LeftRail per-item checkbox RENDER gate (mystery-shaped data)", () => {
+  const classHierarchies = loadMysteryHierarchies();
+
+  it("typeTree yields Domain + Sub-domain rows → each renders an ontology group-by checkbox", () => {
+    const tree = buildTypeTree(mysteryGraph, classHierarchies);
+    expect(tree).not.toBeNull();
+    // At least one Domain row (each gets a checkbox in its Collapsible trailing).
+    expect(tree.length).toBeGreaterThan(0);
+    // Every Domain has ≥1 Sub-domain row (each ALSO gets its own checkbox).
+    const subRows = tree.flatMap((d) => d.subs);
+    expect(subRows.length).toBeGreaterThan(0);
+    // The People domain (in the approved mockup) is present and owns ≥1
+    // sub-domain row — each Domain AND each Sub-domain is a checkbox row.
+    const people = tree.find((d) => d.label === "People");
+    expect(people).toBeTruthy();
+    expect(people.subs.length).toBeGreaterThan(0);
+    // Every sub-domain carries leaf member TYPES (the FILTER rows below the
+    // checkbox), so the row is a real, rendered, groupable target.
+    for (const sub of people.subs) {
+      expect(sub.types.length).toBeGreaterThan(0);
+      expect(typeof sub.label).toBe("string");
+    }
+  });
+
+  it("each ontology row exposes a stable class id for groupKeyForOntology(...)", () => {
+    const tree = buildTypeTree(mysteryGraph, classHierarchies);
+    for (const domain of tree) {
+      // Domain checkbox → onToggleGroupOntology(domain.id).
+      expect(typeof groupKeyForOntology(domain.id)).toBe("string");
+      expect(groupKeyForOntology(domain.id)).toMatch(/^ontology:/);
+      for (const sub of domain.subs) {
+        // Sub-domain checkbox → onToggleGroupOntology(sub.id).
+        expect(groupKeyForOntology(sub.id)).toMatch(/^ontology:/);
+      }
+    }
+  });
+
+  it("communityStats reports live communities → each renders a community group-by checkbox", () => {
+    const stats = communityStats(mysteryGraph);
+    // canGroupCommunity (App) === liveCount > 0; must be true for this data.
+    expect(stats.liveCount).toBeGreaterThan(0);
+    expect(stats.live.length).toBe(stats.liveCount);
+    // Each live community row carries a checkbox → onToggleGroupCommunity(c.key);
+    // its key round-trips through the community namespace.
+    for (const c of stats.live) {
+      expect(typeof c.key).toBe("string");
+      expect(groupKeyForCommunity(c.key)).toMatch(/^community:/);
+    }
+    // The mockup's "Community 8" / "Community 14" are both live + groupable.
+    const keys = stats.live.map((c) => c.key);
+    expect(keys).toEqual(expect.arrayContaining(["Community 8", "Community 14"]));
+  });
+
+  it("App availability flags are TRUE for this data (gate the SECONDARY bulk controls)", () => {
+    // canGroupOntology = Boolean(classHierarchies?.hierarchies)
+    expect(Boolean(classHierarchies?.hierarchies)).toBe(true);
+    // canGroupCommunity = communityStats(graph).liveCount > 0
+    expect(communityStats(mysteryGraph).liveCount > 0).toBe(true);
+  });
+
+  it("checked state reflects the grouped SET membership (per-item, multi-select)", () => {
+    // The component computes ontologyGrouped/communityGrouped from the grouped set;
+    // a checked box === its namespaced key is present. Prove the mapping the
+    // `checked={ontologyGrouped.has(...)}` / `checked={communityGrouped.has(...)}`
+    // bindings rely on, with a MIXED multi-select set.
+    const grouped = [
+      groupKeyForOntology("class:Suspect"),
+      groupKeyForCommunity("Community 8"),
+    ];
+    const ontologyGrouped = new Set(
+      grouped
+        .filter((k) => k.startsWith("ontology:"))
+        .map((k) => k.slice("ontology:".length)),
+    );
+    const communityGrouped = new Set(
+      grouped
+        .filter((k) => k.startsWith("community:"))
+        .map((k) => k.slice("community:".length)),
+    );
+    expect(ontologyGrouped.has("class:Suspect")).toBe(true);
+    expect(ontologyGrouped.has("class:Detective")).toBe(false);
+    expect(communityGrouped.has("Community 8")).toBe(true);
+    expect(communityGrouped.has("Community 14")).toBe(false);
+  });
+});

--- a/studio/src/tests/modelSwitchGroupAxis.test.js
+++ b/studio/src/tests/modelSwitchGroupAxis.test.js
@@ -3,102 +3,99 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  createDefaultViewerState,
   normalizeViewerState,
-  normalizeGroupAxisAvailability,
-  setGroupAxis,
+  clearSelection,
+  toggleGroupOntology,
+  toggleGroupCommunity,
+  toggleEntity,
+  splitGroupedKeys,
+  groupKeyForOntology,
 } from "../lib/viewerState.js";
 
 const appSource = readFileSync(resolve(process.cwd(), "src/App.svelte"), "utf8");
 
 /**
- * B2 regression: an active Ontology group-by axis must SURVIVE a model switch in
- * a multi-model bundle when the new model exposes the same taxonomy.
- *
- * The bug: handleSelectModel() nulled `classHierarchies` synchronously BEFORE the
- * new model's taxonomy landed. While null, the derived `availableAxes` drops
- * "ontology" and the availability $effect (normalizeGroupAxisAvailability)
- * downgrades groupBy.axis "ontology" → "none". The re-fetched taxonomy re-enables
- * the axis, but nothing restored it — so the active grouping silently vanished
- * (the per-axis collapse set survived in viewerState, but the axis was lost so
- * nothing folded).
- *
- * The fix captures the intended axis before the switch and re-asserts it once the
- * artifact lands IF the new model supports it again.
+ * B2 regression (per-item grouped set): an active group-by must SURVIVE a model
+ * switch. In the per-item model the grouped SET lives in
+ * `viewerState.options.groupBy.grouped`; a model switch only clears the
+ * SELECTION/focus (clearSelection), never the grouping. So unlike the old
+ * axis-scoped model — where `classHierarchies = null` transiently downgraded the
+ * axis to "none" and the grouping silently vanished — there is no axis to lose:
+ * the grouped keys persist verbatim. The App still re-fetches the per-model
+ * taxonomy eagerly (loadActiveModel) so grouped ONTOLOGY keys re-apply against the
+ * new model's class ids.
  */
-describe("model switch — group-by axis survives (B2 regression)", () => {
-  // Model the App's `availableAxes` derivation for the ontology axis: it is
-  // present iff the class-hierarchies artifact is loaded. (Community stays atomic
-  // with the graph swap and is exercised separately.)
-  const availableAxesFor = ({ ontologyLoaded }) => [
-    "none",
-    ...(ontologyLoaded ? ["ontology"] : []),
-  ];
+describe("model switch — grouped set survives (B2 per-item regression)", () => {
+  it("clearSelection (run on every model switch) leaves the grouped set untouched", () => {
+    // User has BOTH an ontology class and a community grouped, plus a selection.
+    let state = createDefaultViewerState();
+    state = toggleGroupOntology(state, "class:People");
+    state = toggleGroupCommunity(state, "Baker Street");
+    state = toggleEntity(state, "holmes"); // a live selection + focus
 
-  it("downgrade-then-restore: an active ontology axis is reasserted once the new model's taxonomy lands", () => {
-    // User has Ontology grouping active with a fold in place (F3 collapse set).
+    expect(state.selection.entities).toEqual(["holmes"]);
+    expect(state.focusId).toBe("holmes");
+
+    // The model switch clears the selection/focus (ids don't carry across models)…
+    const switched = clearSelection(state);
+    expect(switched.selection.entities).toEqual([]);
+    expect(switched.focusId).toBeNull();
+
+    // …but the grouped SET is preserved verbatim (grouping is model-agnostic).
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(
+      switched.options.groupBy.grouped,
+    );
+    expect(ontologyClassIds).toEqual(["class:People"]);
+    expect(communityKeys).toEqual(["Baker Street"]);
+  });
+
+  it("a grouped ontology key re-applies once the new model's taxonomy lands (same class id)", () => {
+    // Persisted grouped set referencing a class id the new model also provides.
     let state = normalizeViewerState({
-      options: {
-        groupBy: {
-          axis: "ontology",
-          ontology: { collapsedClassIds: ["class:People"] },
-        },
-      },
+      options: { groupBy: { grouped: [groupKeyForOntology("class:People")] } },
     });
-    expect(state.options.groupBy.axis).toBe("ontology");
-
-    // The handler captures the intended axis BEFORE dropping per-model artifacts.
-    const intendedAxis = state.options.groupBy.axis;
-
-    // --- model switch in flight: classHierarchies = null --------------------
-    // availableAxes drops "ontology"; the availability $effect downgrades the axis.
-    state = normalizeGroupAxisAvailability(state, availableAxesFor({ ontologyLoaded: false }));
-    expect(state.options.groupBy.axis).toBe("none"); // the transient downgrade
-    // The per-axis collapse set is RETAINED across the downgrade (F3 survives).
-    expect(state.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
-
-    // --- new model's taxonomy lands: classHierarchies set again -------------
-    const availableAxes = availableAxesFor({ ontologyLoaded: true });
-    // The fix re-asserts the intended axis when it is available again.
-    if (intendedAxis !== state.options.groupBy.axis && availableAxes.includes(intendedAxis)) {
-      state = setGroupAxis(state, intendedAxis);
-    }
-
-    // Restored: the active grouping (axis + its fold) is back.
-    expect(state.options.groupBy.axis).toBe("ontology");
-    expect(state.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+    // Switch in flight: clearSelection runs; the grouped key is unaffected.
+    state = clearSelection(state);
+    // Once the new model's taxonomy (with class:People) is fetched, the SAME
+    // ontology grouped key folds again — nothing had to be "reasserted".
+    expect(splitGroupedKeys(state.options.groupBy.grouped).ontologyClassIds).toEqual([
+      "class:People",
+    ]);
   });
 
-  it("does NOT restore an axis the new model genuinely lacks (no taxonomy)", () => {
-    let state = normalizeViewerState({ options: { groupBy: { axis: "ontology" } } });
-    const intendedAxis = state.options.groupBy.axis;
-
-    // Switch into a model WITHOUT a class-hierarchies artifact: ontology stays
-    // unavailable even after the load settles.
-    const availableAxes = availableAxesFor({ ontologyLoaded: false });
-    state = normalizeGroupAxisAvailability(state, availableAxes);
-    if (intendedAxis !== state.options.groupBy.axis && availableAxes.includes(intendedAxis)) {
-      state = setGroupAxis(state, intendedAxis);
-    }
-    // Correctly stays "none" — the restore is gated on real availability.
-    expect(state.options.groupBy.axis).toBe("none");
+  it("a grouped key for a class the new model LACKS simply contributes no fold (engine ignores it)", () => {
+    // Per the App's groupedGraph wiring, an ontology grouped key whose class id is
+    // absent from the new taxonomy yields no collapse target — it neither errors
+    // nor is silently dropped from the persisted set. Here we assert it is retained
+    // (so a switch BACK to a model that has it re-folds).
+    let state = normalizeViewerState({
+      options: { groupBy: { grouped: [groupKeyForOntology("class:ModelOnlyClass")] } },
+    });
+    state = clearSelection(state);
+    expect(state.options.groupBy.grouped).toEqual([groupKeyForOntology("class:ModelOnlyClass")]);
   });
 
-  it("handleSelectModel captures the intended axis and re-asserts it after the artifact lands", () => {
+  it("handleSelectModel preserves the grouped set + re-fetches the taxonomy (source guard)", () => {
     // Source assertion (jsdom can't mount the GraphCanvas-bearing App tree — same
-    // convention as appHeader/leftRail tests). This step is ABSENT in the buggy
-    // version, so this guards against the regression returning.
+    // convention as appHeader/leftRail tests). Guards the regression from returning.
     const handler =
       appSource.match(/async function handleSelectModel\([\s\S]*?\n  }\n/)?.[0] ?? "";
     expect(handler).not.toBe("");
 
-    // Captures the axis BEFORE dropping per-model artifacts (classHierarchies=null).
+    // The switch captures whether any ONTOLOGY item was grouped BEFORE dropping the
+    // per-model taxonomy artifact (classHierarchies=null).
     expect(handler).toMatch(
-      /const intendedAxis = viewerState\.options\.groupBy\.axis;[\s\S]*classHierarchies = null;/,
+      /splitGroupedKeys\([\s\S]*?\)\.ontologyClassIds\.length > 0;[\s\S]*classHierarchies = null;/,
     );
-    // Re-asserts the intended axis after loadActiveModel(), gated on availability.
+    // It clears only the SELECTION (never the grouped set).
+    expect(handler).toMatch(/viewerState = clearSelection\(viewerState\)/);
+    // And it re-fetches the taxonomy after loadActiveModel() so grouped ontology
+    // keys re-apply against the new model's class ids.
     expect(handler).toMatch(/await loadActiveModel\(\);/);
-    expect(handler).toMatch(
-      /availableAxes\.includes\(intendedAxis\)[\s\S]*viewerState = setGroupAxis\(viewerState, intendedAxis\)/,
-    );
+    expect(handler).toMatch(/hadOntologyGroup[\s\S]*await ensureClassHierarchies\(\)/);
+    // The old axis-restore machinery is GONE.
+    expect(handler).not.toMatch(/setGroupAxis/);
+    expect(handler).not.toMatch(/normalizeGroupAxisAvailability/);
   });
 });

--- a/studio/src/tests/modelSwitchGroupAxis.test.js
+++ b/studio/src/tests/modelSwitchGroupAxis.test.js
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeViewerState,
+  normalizeGroupAxisAvailability,
+  setGroupAxis,
+} from "../lib/viewerState.js";
+
+const appSource = readFileSync(resolve(process.cwd(), "src/App.svelte"), "utf8");
+
+/**
+ * B2 regression: an active Ontology group-by axis must SURVIVE a model switch in
+ * a multi-model bundle when the new model exposes the same taxonomy.
+ *
+ * The bug: handleSelectModel() nulled `classHierarchies` synchronously BEFORE the
+ * new model's taxonomy landed. While null, the derived `availableAxes` drops
+ * "ontology" and the availability $effect (normalizeGroupAxisAvailability)
+ * downgrades groupBy.axis "ontology" → "none". The re-fetched taxonomy re-enables
+ * the axis, but nothing restored it — so the active grouping silently vanished
+ * (the per-axis collapse set survived in viewerState, but the axis was lost so
+ * nothing folded).
+ *
+ * The fix captures the intended axis before the switch and re-asserts it once the
+ * artifact lands IF the new model supports it again.
+ */
+describe("model switch — group-by axis survives (B2 regression)", () => {
+  // Model the App's `availableAxes` derivation for the ontology axis: it is
+  // present iff the class-hierarchies artifact is loaded. (Community stays atomic
+  // with the graph swap and is exercised separately.)
+  const availableAxesFor = ({ ontologyLoaded }) => [
+    "none",
+    ...(ontologyLoaded ? ["ontology"] : []),
+  ];
+
+  it("downgrade-then-restore: an active ontology axis is reasserted once the new model's taxonomy lands", () => {
+    // User has Ontology grouping active with a fold in place (F3 collapse set).
+    let state = normalizeViewerState({
+      options: {
+        groupBy: {
+          axis: "ontology",
+          ontology: { collapsedClassIds: ["class:People"] },
+        },
+      },
+    });
+    expect(state.options.groupBy.axis).toBe("ontology");
+
+    // The handler captures the intended axis BEFORE dropping per-model artifacts.
+    const intendedAxis = state.options.groupBy.axis;
+
+    // --- model switch in flight: classHierarchies = null --------------------
+    // availableAxes drops "ontology"; the availability $effect downgrades the axis.
+    state = normalizeGroupAxisAvailability(state, availableAxesFor({ ontologyLoaded: false }));
+    expect(state.options.groupBy.axis).toBe("none"); // the transient downgrade
+    // The per-axis collapse set is RETAINED across the downgrade (F3 survives).
+    expect(state.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+
+    // --- new model's taxonomy lands: classHierarchies set again -------------
+    const availableAxes = availableAxesFor({ ontologyLoaded: true });
+    // The fix re-asserts the intended axis when it is available again.
+    if (intendedAxis !== state.options.groupBy.axis && availableAxes.includes(intendedAxis)) {
+      state = setGroupAxis(state, intendedAxis);
+    }
+
+    // Restored: the active grouping (axis + its fold) is back.
+    expect(state.options.groupBy.axis).toBe("ontology");
+    expect(state.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+  });
+
+  it("does NOT restore an axis the new model genuinely lacks (no taxonomy)", () => {
+    let state = normalizeViewerState({ options: { groupBy: { axis: "ontology" } } });
+    const intendedAxis = state.options.groupBy.axis;
+
+    // Switch into a model WITHOUT a class-hierarchies artifact: ontology stays
+    // unavailable even after the load settles.
+    const availableAxes = availableAxesFor({ ontologyLoaded: false });
+    state = normalizeGroupAxisAvailability(state, availableAxes);
+    if (intendedAxis !== state.options.groupBy.axis && availableAxes.includes(intendedAxis)) {
+      state = setGroupAxis(state, intendedAxis);
+    }
+    // Correctly stays "none" — the restore is gated on real availability.
+    expect(state.options.groupBy.axis).toBe("none");
+  });
+
+  it("handleSelectModel captures the intended axis and re-asserts it after the artifact lands", () => {
+    // Source assertion (jsdom can't mount the GraphCanvas-bearing App tree — same
+    // convention as appHeader/leftRail tests). This step is ABSENT in the buggy
+    // version, so this guards against the regression returning.
+    const handler =
+      appSource.match(/async function handleSelectModel\([\s\S]*?\n  }\n/)?.[0] ?? "";
+    expect(handler).not.toBe("");
+
+    // Captures the axis BEFORE dropping per-model artifacts (classHierarchies=null).
+    expect(handler).toMatch(
+      /const intendedAxis = viewerState\.options\.groupBy\.axis;[\s\S]*classHierarchies = null;/,
+    );
+    // Re-asserts the intended axis after loadActiveModel(), gated on availability.
+    expect(handler).toMatch(/await loadActiveModel\(\);/);
+    expect(handler).toMatch(
+      /availableAxes\.includes\(intendedAxis\)[\s\S]*viewerState = setGroupAxis\(viewerState, intendedAxis\)/,
+    );
+  });
+});

--- a/studio/src/tests/viewerState.test.js
+++ b/studio/src/tests/viewerState.test.js
@@ -3,105 +3,206 @@ import { describe, expect, it } from "vitest";
 import {
   createDefaultViewerState,
   normalizeViewerState,
-  setShowOntologyClasses,
+  normalizeGroupAxisAvailability,
   setShowWeakLinks,
-  toggleCollapseClass,
-  expandAllClasses,
-  collapseAllTopClasses,
+  setGroupAxis,
+  toggleCollapse,
+  foldToLevel,
+  expandAll,
 } from "../lib/viewerState.js";
 
-describe("viewerState — showOntologyClasses (EVOL 2.a)", () => {
-  it("defaults OFF (today's behaviour unchanged)", () => {
+describe("viewerState — group-by data model (B2)", () => {
+  it("defaults to axis:none with empty per-axis collapse sets (fast-path default)", () => {
     const state = createDefaultViewerState();
-    expect(state.options.showOntologyClasses).toBe(false);
-    // The pre-existing weak-link default is untouched.
+    expect(state.options.groupBy.axis).toBe("none");
+    expect(state.options.groupBy.ontology.collapsedClassIds).toEqual([]);
+    expect(state.options.groupBy.community.collapsedKeys).toEqual([]);
+    // The pre-existing weak-link default is untouched, the legacy flat fields gone.
     expect(state.options.showWeakLinks).toBe(true);
-  });
-
-  it("setShowOntologyClasses flips the option (coerced to boolean)", () => {
-    const off = createDefaultViewerState();
-    const on = setShowOntologyClasses(off, true);
-    expect(on.options.showOntologyClasses).toBe(true);
-    // Other options are preserved.
-    expect(on.options.showWeakLinks).toBe(true);
-
-    const back = setShowOntologyClasses(on, false);
-    expect(back.options.showOntologyClasses).toBe(false);
-
-    // Truthy/falsy values coerce to a real boolean.
-    expect(setShowOntologyClasses(off, 1).options.showOntologyClasses).toBe(true);
-    expect(setShowOntologyClasses(off, 0).options.showOntologyClasses).toBe(false);
+    expect(state.options.showOntologyClasses).toBeUndefined();
+    expect(state.options.collapsedClassIds).toBeUndefined();
   });
 
   it("does not interfere with setShowWeakLinks", () => {
-    const state = setShowOntologyClasses(createDefaultViewerState(), true);
+    const state = setGroupAxis(createDefaultViewerState(), "ontology");
     const next = setShowWeakLinks(state, false);
     expect(next.options.showWeakLinks).toBe(false);
-    expect(next.options.showOntologyClasses).toBe(true);
-  });
-
-  it("normalizeViewerState restores the option from a partial state", () => {
-    const normalized = normalizeViewerState({ options: { showOntologyClasses: true } });
-    expect(normalized.options.showOntologyClasses).toBe(true);
-    // Missing option falls back to the default.
-    expect(normalizeViewerState({}).options.showOntologyClasses).toBe(false);
+    expect(next.options.groupBy.axis).toBe("ontology");
   });
 });
 
-describe("viewerState — collapsedClassIds (EVOL 2.b/2.d)", () => {
-  it("defaults to an empty collapsed set", () => {
-    expect(createDefaultViewerState().options.collapsedClassIds).toEqual([]);
+describe("viewerState — T1 axis switch + out-of-enum coercion", () => {
+  it("setGroupAxis cycles none → ontology → community → none", () => {
+    let s = createDefaultViewerState();
+    s = setGroupAxis(s, "ontology");
+    expect(s.options.groupBy.axis).toBe("ontology");
+    s = setGroupAxis(s, "community");
+    expect(s.options.groupBy.axis).toBe("community");
+    s = setGroupAxis(s, "none");
+    expect(s.options.groupBy.axis).toBe("none");
   });
 
-  it("toggleCollapseClass adds then removes a class id", () => {
-    const base = createDefaultViewerState();
-    const collapsed = toggleCollapseClass(base, "class:Character");
-    expect(collapsed.options.collapsedClassIds).toEqual(["class:Character"]);
-    const expanded = toggleCollapseClass(collapsed, "class:Character");
-    expect(expanded.options.collapsedClassIds).toEqual([]);
+  it("an out-of-enum axis coerces to none (pure seam)", () => {
+    const s = setGroupAxis(createDefaultViewerState(), "source-file");
+    expect(s.options.groupBy.axis).toBe("none");
+    expect(setGroupAxis(createDefaultViewerState(), 42).options.groupBy.axis).toBe("none");
+    expect(setGroupAxis(createDefaultViewerState(), null).options.groupBy.axis).toBe("none");
+  });
+});
+
+describe("viewerState — toggleCollapse (axis-dispatched)", () => {
+  it("toggles a class id in the ontology axis", () => {
+    let s = setGroupAxis(createDefaultViewerState(), "ontology");
+    s = toggleCollapse(s, "class:People");
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+    s = toggleCollapse(s, "class:People");
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual([]);
   });
 
-  it("toggleCollapseClass keeps multiple distinct ids", () => {
-    let s = toggleCollapseClass(createDefaultViewerState(), "class:Person");
-    s = toggleCollapseClass(s, "class:Place");
-    expect(s.options.collapsedClassIds.sort()).toEqual(["class:Person", "class:Place"]);
+  it("toggles a community key in the community axis (ontology set untouched)", () => {
+    let s = setGroupAxis(createDefaultViewerState(), "community");
+    s = toggleCollapse(s, "People of London");
+    expect(s.options.groupBy.community.collapsedKeys).toEqual(["People of London"]);
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual([]);
   });
 
-  it("toggleCollapseClass ignores a non-string id", () => {
-    const base = createDefaultViewerState();
-    expect(toggleCollapseClass(base, "").options.collapsedClassIds).toEqual([]);
-    expect(toggleCollapseClass(base, null).options.collapsedClassIds).toEqual([]);
+  it("is a no-op on axis:none and ignores a non-string key", () => {
+    const none = createDefaultViewerState();
+    expect(toggleCollapse(none, "class:X").options.groupBy.ontology.collapsedClassIds).toEqual([]);
+    const onto = setGroupAxis(createDefaultViewerState(), "ontology");
+    expect(toggleCollapse(onto, "").options.groupBy.ontology.collapsedClassIds).toEqual([]);
+    expect(toggleCollapse(onto, null).options.groupBy.ontology.collapsedClassIds).toEqual([]);
+  });
+});
+
+describe("viewerState — T3 baseline fold-to-level (F8, not a blind union)", () => {
+  it("foldToLevel SETS the ontology set to exactly the level ids (moves finer)", () => {
+    let s = setGroupAxis(createDefaultViewerState(), "ontology");
+    // Fold to Domain (the level-0 roots).
+    s = foldToLevel(s, ["class:Narration", "class:People", "class:Case", "class:Place"]);
+    expect(s.options.groupBy.ontology.collapsedClassIds.sort()).toEqual([
+      "class:Case",
+      "class:Narration",
+      "class:People",
+      "class:Place",
+    ]);
+    // Now fold to Sub-domain: the set is REPLACED (moves finer), the Domain roots
+    // do NOT remain — distinguishing from the old blind-union collapseAllTopClasses.
+    s = foldToLevel(s, ["class:Dialogue", "class:Suspects"]);
+    expect(s.options.groupBy.ontology.collapsedClassIds.sort()).toEqual([
+      "class:Dialogue",
+      "class:Suspects",
+    ]);
+    expect(s.options.groupBy.ontology.collapsedClassIds).not.toContain("class:Narration");
   });
 
-  it("expandAllClasses clears the collapsed set", () => {
-    let s = toggleCollapseClass(createDefaultViewerState(), "class:Person");
-    s = toggleCollapseClass(s, "class:Place");
-    expect(expandAllClasses(s).options.collapsedClassIds).toEqual([]);
+  it("foldToLevel is a no-op unless the active axis is ontology", () => {
+    const s = setGroupAxis(createDefaultViewerState(), "community");
+    expect(foldToLevel(s, ["class:Foo"]).options.groupBy.ontology.collapsedClassIds).toEqual([]);
   });
 
-  it("collapseAllTopClasses unions the given ids with the current set", () => {
-    const s = toggleCollapseClass(createDefaultViewerState(), "class:Person");
-    const next = collapseAllTopClasses(s, ["class:Place", "class:Person"]);
-    expect(next.options.collapsedClassIds.sort()).toEqual(["class:Person", "class:Place"]);
+  it("expandAll clears the active axis's set only", () => {
+    let s = setGroupAxis(createDefaultViewerState(), "ontology");
+    s = toggleCollapse(s, "class:People");
+    s = expandAll(s);
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual([]);
   });
+});
 
-  it("turning the class layer OFF clears any pending collapse", () => {
-    let s = setShowOntologyClasses(createDefaultViewerState(), true);
-    s = toggleCollapseClass(s, "class:Person");
-    expect(s.options.collapsedClassIds).toEqual(["class:Person"]);
-    const off = setShowOntologyClasses(s, false);
-    expect(off.options.collapsedClassIds).toEqual([]);
+describe("viewerState — T6 per-axis collapse MEMORY (setGroupAxis never wipes)", () => {
+  it("Ontology(fold A) → Community(fold K) → Ontology restores fold A", () => {
+    let s = setGroupAxis(createDefaultViewerState(), "ontology");
+    s = toggleCollapse(s, "class:People");
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+
+    s = setGroupAxis(s, "community");
+    s = toggleCollapse(s, "Baker Street");
+    // The ontology fold survived the axis switch.
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+    expect(s.options.groupBy.community.collapsedKeys).toEqual(["Baker Street"]);
+
+    s = setGroupAxis(s, "ontology");
+    // Restored — setGroupAxis NEVER wipes.
+    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+    expect(s.options.groupBy.community.collapsedKeys).toEqual(["Baker Street"]);
   });
+});
 
-  it("normalizeViewerState restores collapsedClassIds from a partial state", () => {
+describe("viewerState — T7 pure migration (no graph context)", () => {
+  it("migrates legacy showOntologyClasses + collapsedClassIds → groupBy", () => {
     const normalized = normalizeViewerState({
-      options: { collapsedClassIds: ["class:Person", "class:Person", "class:Place"] },
+      options: {
+        showOntologyClasses: true,
+        collapsedClassIds: ["class:Person", "class:Person", "class:Place"],
+      },
     });
-    // De-duplicated by uniqueStrings.
-    expect(normalized.options.collapsedClassIds.sort()).toEqual([
+    expect(normalized.options.groupBy.axis).toBe("ontology");
+    expect(normalized.options.groupBy.ontology.collapsedClassIds.sort()).toEqual([
       "class:Person",
       "class:Place",
     ]);
-    expect(normalizeViewerState({}).options.collapsedClassIds).toEqual([]);
+    expect(normalized.options.showOntologyClasses).toBeUndefined();
+    expect(normalized.options.collapsedClassIds).toBeUndefined();
+  });
+
+  it("showOntologyClasses:false/absent migrates to axis:none", () => {
+    expect(normalizeViewerState({}).options.groupBy.axis).toBe("none");
+    expect(
+      normalizeViewerState({ options: { showOntologyClasses: false } }).options.groupBy.axis,
+    ).toBe("none");
+  });
+
+  it("an out-of-enum persisted axis → none; a valid axis:community is PRESERVED", () => {
+    expect(
+      normalizeViewerState({ options: { groupBy: { axis: "bogus" } } }).options.groupBy.axis,
+    ).toBe("none");
+    // Enum-valid: availability is NOT checked in the pure seam (that is T11).
+    expect(
+      normalizeViewerState({ options: { groupBy: { axis: "community" } } }).options.groupBy.axis,
+    ).toBe("community");
+  });
+
+  it("an explicit groupBy.axis wins over the legacy showOntologyClasses flag", () => {
+    const normalized = normalizeViewerState({
+      options: { showOntologyClasses: true, groupBy: { axis: "community" } },
+    });
+    expect(normalized.options.groupBy.axis).toBe("community");
+  });
+});
+
+describe("viewerState — T11 availability coercion (App seam, with context)", () => {
+  it("downgrades an unavailable persisted axis → none, retaining collapse sets", () => {
+    const persisted = normalizeViewerState({
+      options: {
+        groupBy: {
+          axis: "community",
+          ontology: { collapsedClassIds: ["class:People"] },
+          community: { collapsedKeys: ["Baker Street"] },
+        },
+      },
+    });
+    // Graph has NO communities (availableAxes excludes community).
+    const coerced = normalizeGroupAxisAvailability(persisted, ["none", "ontology"]);
+    expect(coerced.options.groupBy.axis).toBe("none");
+    // The per-axis sets are RETAINED across the downgrade (F3 survives).
+    expect(coerced.options.groupBy.community.collapsedKeys).toEqual(["Baker Street"]);
+    expect(coerced.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+  });
+
+  it("passes through an available axis and axis:none; is idempotent", () => {
+    const community = normalizeViewerState({ options: { groupBy: { axis: "community" } } });
+    const ok = normalizeGroupAxisAvailability(community, ["none", "community"]);
+    expect(ok.options.groupBy.axis).toBe("community");
+    const none = createDefaultViewerState();
+    expect(normalizeGroupAxisAvailability(none, ["none"]).options.groupBy.axis).toBe("none");
+    // Idempotent.
+    const once = normalizeGroupAxisAvailability(community, ["none", "ontology"]);
+    const twice = normalizeGroupAxisAvailability(once, ["none", "ontology"]);
+    expect(twice.options.groupBy.axis).toBe("none");
+  });
+
+  it("the pure normalizer (no availableAxes) does NOT downgrade", () => {
+    const normalized = normalizeViewerState({ options: { groupBy: { axis: "community" } } });
+    expect(normalized.options.groupBy.axis).toBe("community");
   });
 });

--- a/studio/src/tests/viewerState.test.js
+++ b/studio/src/tests/viewerState.test.js
@@ -1,178 +1,262 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  GROUP_KIND,
   createDefaultViewerState,
   normalizeViewerState,
-  normalizeGroupAxisAvailability,
   setShowWeakLinks,
-  setGroupAxis,
-  toggleCollapse,
-  foldToLevel,
-  expandAll,
+  groupKeyForOntology,
+  groupKeyForCommunity,
+  splitGroupedKeys,
+  toggleGroupItem,
+  toggleGroupOntology,
+  toggleGroupCommunity,
+  isOntologyGrouped,
+  isCommunityGrouped,
+  clearGrouping,
+  foldOntologyToLevel,
+  ONTOLOGY_LEVELS,
 } from "../lib/viewerState.js";
 
-describe("viewerState — group-by data model (B2)", () => {
-  it("defaults to axis:none with empty per-axis collapse sets (fast-path default)", () => {
+/* ===========================================================================
+ * B2 — PER-ITEM grouped-set model.
+ *
+ * groupBy is now `{ grouped: [ "ontology:<classId>" | "community:<key>", … ] }`:
+ * a flat SET of namespaced keys. Checking a groupable rail item (an Ontology
+ * class node OR a community) adds its namespaced key; unchecking removes it.
+ * MULTI-SELECT (several ontology classes + communities) is the default — every
+ * key folds at once. An empty set === nothing grouped (fast path, A3). The FILTER
+ * facet (selection.types) stays STRICTLY SEPARATE from these checkboxes.
+ * ======================================================================== */
+
+describe("viewerState — group-by data model (B2 per-item grouped set)", () => {
+  it("defaults to an EMPTY grouped set (fast-path default — nothing grouped)", () => {
     const state = createDefaultViewerState();
-    expect(state.options.groupBy.axis).toBe("none");
-    expect(state.options.groupBy.ontology.collapsedClassIds).toEqual([]);
-    expect(state.options.groupBy.community.collapsedKeys).toEqual([]);
-    // The pre-existing weak-link default is untouched, the legacy flat fields gone.
+    expect(state.options.groupBy.grouped).toEqual([]);
+    // The pre-existing weak-link default is untouched; legacy axis/flat fields gone.
     expect(state.options.showWeakLinks).toBe(true);
+    expect(state.options.groupBy.axis).toBeUndefined();
     expect(state.options.showOntologyClasses).toBeUndefined();
     expect(state.options.collapsedClassIds).toBeUndefined();
   });
 
-  it("does not interfere with setShowWeakLinks", () => {
-    const state = setGroupAxis(createDefaultViewerState(), "ontology");
-    const next = setShowWeakLinks(state, false);
+  it("namespaced key builders round-trip through splitGroupedKeys (colons preserved)", () => {
+    expect(groupKeyForOntology("class:People")).toBe(`${GROUP_KIND.ontology}:class:People`);
+    expect(groupKeyForCommunity("People of London")).toBe(
+      `${GROUP_KIND.community}:People of London`,
+    );
+    // A community key may itself contain colons — split on the FIRST `:` only.
+    const grouped = [
+      groupKeyForOntology("class:People"),
+      groupKeyForCommunity("scope:central:42"),
+    ];
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(grouped);
+    expect(ontologyClassIds).toEqual(["class:People"]);
+    expect(communityKeys).toEqual(["scope:central:42"]);
+  });
+
+  it("splitGroupedKeys ignores malformed / unknown-prefixed / empty keys", () => {
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys([
+      "ontology:class:Person",
+      "community:Baker Street",
+      "bogus:whatever", // unknown kind → dropped
+      "ontology:", // empty rest → dropped
+      "", // empty → dropped
+      "noseparator", // no `:` → dropped
+      42, // non-string → dropped
+    ]);
+    expect(ontologyClassIds).toEqual(["class:Person"]);
+    expect(communityKeys).toEqual(["Baker Street"]);
+  });
+
+  it("does not interfere with setShowWeakLinks (and grouped set survives)", () => {
+    const grouped = toggleGroupOntology(createDefaultViewerState(), "class:People");
+    const next = setShowWeakLinks(grouped, false);
     expect(next.options.showWeakLinks).toBe(false);
-    expect(next.options.groupBy.axis).toBe("ontology");
+    expect(next.options.groupBy.grouped).toEqual([groupKeyForOntology("class:People")]);
   });
 });
 
-describe("viewerState — T1 axis switch + out-of-enum coercion", () => {
-  it("setGroupAxis cycles none → ontology → community → none", () => {
+describe("viewerState — per-item toggle (ontology + community, independent)", () => {
+  it("toggleGroupOntology adds then removes an ontology key (idempotent toggle)", () => {
     let s = createDefaultViewerState();
-    s = setGroupAxis(s, "ontology");
-    expect(s.options.groupBy.axis).toBe("ontology");
-    s = setGroupAxis(s, "community");
-    expect(s.options.groupBy.axis).toBe("community");
-    s = setGroupAxis(s, "none");
-    expect(s.options.groupBy.axis).toBe("none");
+    s = toggleGroupOntology(s, "class:People");
+    expect(s.options.groupBy.grouped).toEqual([groupKeyForOntology("class:People")]);
+    expect(isOntologyGrouped(s, "class:People")).toBe(true);
+    s = toggleGroupOntology(s, "class:People");
+    expect(s.options.groupBy.grouped).toEqual([]);
+    expect(isOntologyGrouped(s, "class:People")).toBe(false);
   });
 
-  it("an out-of-enum axis coerces to none (pure seam)", () => {
-    const s = setGroupAxis(createDefaultViewerState(), "source-file");
-    expect(s.options.groupBy.axis).toBe("none");
-    expect(setGroupAxis(createDefaultViewerState(), 42).options.groupBy.axis).toBe("none");
-    expect(setGroupAxis(createDefaultViewerState(), null).options.groupBy.axis).toBe("none");
+  it("toggleGroupCommunity adds a community key WITHOUT touching ontology keys", () => {
+    let s = toggleGroupOntology(createDefaultViewerState(), "class:People");
+    s = toggleGroupCommunity(s, "People of London");
+    expect(isOntologyGrouped(s, "class:People")).toBe(true);
+    expect(isCommunityGrouped(s, "People of London")).toBe(true);
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(s.options.groupBy.grouped);
+    expect(ontologyClassIds).toEqual(["class:People"]);
+    expect(communityKeys).toEqual(["People of London"]);
+  });
+
+  it("toggleGroupItem is a no-op for a non-string / empty key", () => {
+    const s = createDefaultViewerState();
+    expect(toggleGroupItem(s, "").options.groupBy.grouped).toEqual([]);
+    expect(toggleGroupItem(s, null).options.groupBy.grouped).toEqual([]);
+    expect(toggleGroupOntology(s, "").options.groupBy.grouped).toEqual([]);
+    expect(toggleGroupCommunity(s, null).options.groupBy.grouped).toEqual([]);
+  });
+
+  it("MULTI-SELECT: several ontology classes + communities group simultaneously", () => {
+    let s = createDefaultViewerState();
+    s = toggleGroupOntology(s, "class:People");
+    s = toggleGroupOntology(s, "class:Place");
+    s = toggleGroupCommunity(s, "Baker Street");
+    s = toggleGroupCommunity(s, "Scotland Yard");
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(s.options.groupBy.grouped);
+    expect(ontologyClassIds.sort()).toEqual(["class:People", "class:Place"]);
+    expect(communityKeys.sort()).toEqual(["Baker Street", "Scotland Yard"]);
+    // Removing ONE class leaves the rest of the multi-selection intact.
+    s = toggleGroupOntology(s, "class:People");
+    const after = splitGroupedKeys(s.options.groupBy.grouped);
+    expect(after.ontologyClassIds).toEqual(["class:Place"]);
+    expect(after.communityKeys.sort()).toEqual(["Baker Street", "Scotland Yard"]);
+  });
+
+  it("the grouped set is deduped (re-checking the same item never duplicates)", () => {
+    let s = createDefaultViewerState();
+    s = toggleGroupOntology(s, "class:People");
+    // A direct toggleGroupItem with the SAME namespaced key removes it (toggle),
+    // so re-adding via toggleGroupOntology again yields exactly one entry.
+    s = toggleGroupOntology(s, "class:People"); // off
+    s = toggleGroupOntology(s, "class:People"); // on again
+    expect(s.options.groupBy.grouped).toEqual([groupKeyForOntology("class:People")]);
+  });
+
+  it("clearGrouping empties the whole grouped set (ungroup everything)", () => {
+    let s = createDefaultViewerState();
+    s = toggleGroupOntology(s, "class:People");
+    s = toggleGroupCommunity(s, "Baker Street");
+    s = clearGrouping(s);
+    expect(s.options.groupBy.grouped).toEqual([]);
   });
 });
 
-describe("viewerState — toggleCollapse (axis-dispatched)", () => {
-  it("toggles a class id in the ontology axis", () => {
-    let s = setGroupAxis(createDefaultViewerState(), "ontology");
-    s = toggleCollapse(s, "class:People");
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
-    s = toggleCollapse(s, "class:People");
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual([]);
-  });
-
-  it("toggles a community key in the community axis (ontology set untouched)", () => {
-    let s = setGroupAxis(createDefaultViewerState(), "community");
-    s = toggleCollapse(s, "People of London");
-    expect(s.options.groupBy.community.collapsedKeys).toEqual(["People of London"]);
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual([]);
-  });
-
-  it("is a no-op on axis:none and ignores a non-string key", () => {
-    const none = createDefaultViewerState();
-    expect(toggleCollapse(none, "class:X").options.groupBy.ontology.collapsedClassIds).toEqual([]);
-    const onto = setGroupAxis(createDefaultViewerState(), "ontology");
-    expect(toggleCollapse(onto, "").options.groupBy.ontology.collapsedClassIds).toEqual([]);
-    expect(toggleCollapse(onto, null).options.groupBy.ontology.collapsedClassIds).toEqual([]);
-  });
-});
-
-describe("viewerState — T3 baseline fold-to-level (F8, not a blind union)", () => {
-  it("foldToLevel SETS the ontology set to exactly the level ids (moves finer)", () => {
-    let s = setGroupAxis(createDefaultViewerState(), "ontology");
+describe("viewerState — T3 baseline fold-to-level (F8, ontology grouped keys only)", () => {
+  it("foldOntologyToLevel SETS the ontology grouped keys to EXACTLY the level ids", () => {
+    let s = createDefaultViewerState();
     // Fold to Domain (the level-0 roots).
-    s = foldToLevel(s, ["class:Narration", "class:People", "class:Case", "class:Place"]);
-    expect(s.options.groupBy.ontology.collapsedClassIds.sort()).toEqual([
+    s = foldOntologyToLevel(s, [
+      "class:Narration",
+      "class:People",
+      "class:Case",
+      "class:Place",
+    ]);
+    expect(splitGroupedKeys(s.options.groupBy.grouped).ontologyClassIds.sort()).toEqual([
       "class:Case",
       "class:Narration",
       "class:People",
       "class:Place",
     ]);
-    // Now fold to Sub-domain: the set is REPLACED (moves finer), the Domain roots
-    // do NOT remain — distinguishing from the old blind-union collapseAllTopClasses.
-    s = foldToLevel(s, ["class:Dialogue", "class:Suspects"]);
-    expect(s.options.groupBy.ontology.collapsedClassIds.sort()).toEqual([
-      "class:Dialogue",
-      "class:Suspects",
-    ]);
-    expect(s.options.groupBy.ontology.collapsedClassIds).not.toContain("class:Narration");
+    // Now fold to Sub-domain: the ontology keys are REPLACED (moves finer); the
+    // Domain roots do NOT remain — distinguishing from a blind union.
+    s = foldOntologyToLevel(s, ["class:Dialogue", "class:Suspects"]);
+    const ids = splitGroupedKeys(s.options.groupBy.grouped).ontologyClassIds.sort();
+    expect(ids).toEqual(["class:Dialogue", "class:Suspects"]);
+    expect(ids).not.toContain("class:Narration");
   });
 
-  it("foldToLevel is a no-op unless the active axis is ontology", () => {
-    const s = setGroupAxis(createDefaultViewerState(), "community");
-    expect(foldToLevel(s, ["class:Foo"]).options.groupBy.ontology.collapsedClassIds).toEqual([]);
+  it("foldOntologyToLevel REPLACES only ontology keys; community keys are untouched", () => {
+    let s = createDefaultViewerState();
+    s = toggleGroupCommunity(s, "Baker Street");
+    s = toggleGroupOntology(s, "class:OldClass");
+    s = foldOntologyToLevel(s, ["class:People", "class:Place"]);
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(s.options.groupBy.grouped);
+    // The stale ontology key was dropped; the level ids replaced it.
+    expect(ontologyClassIds.sort()).toEqual(["class:People", "class:Place"]);
+    expect(ontologyClassIds).not.toContain("class:OldClass");
+    // The community fold survived the ontology-level baseline.
+    expect(communityKeys).toEqual(["Baker Street"]);
   });
 
-  it("expandAll clears the active axis's set only", () => {
-    let s = setGroupAxis(createDefaultViewerState(), "ontology");
-    s = toggleCollapse(s, "class:People");
-    s = expandAll(s);
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual([]);
+  it("foldOntologyToLevel with [] clears the ontology keys but keeps communities", () => {
+    let s = createDefaultViewerState();
+    s = toggleGroupCommunity(s, "Baker Street");
+    s = toggleGroupOntology(s, "class:People");
+    s = foldOntologyToLevel(s, []);
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(s.options.groupBy.grouped);
+    expect(ontologyClassIds).toEqual([]);
+    expect(communityKeys).toEqual(["Baker Street"]);
   });
-});
 
-describe("viewerState — T6 per-axis collapse MEMORY (setGroupAxis never wipes)", () => {
-  it("Ontology(fold A) → Community(fold K) → Ontology restores fold A", () => {
-    let s = setGroupAxis(createDefaultViewerState(), "ontology");
-    s = toggleCollapse(s, "class:People");
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
-
-    s = setGroupAxis(s, "community");
-    s = toggleCollapse(s, "Baker Street");
-    // The ontology fold survived the axis switch.
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
-    expect(s.options.groupBy.community.collapsedKeys).toEqual(["Baker Street"]);
-
-    s = setGroupAxis(s, "ontology");
-    // Restored — setGroupAxis NEVER wipes.
-    expect(s.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
-    expect(s.options.groupBy.community.collapsedKeys).toEqual(["Baker Street"]);
+  it("exposes ONTOLOGY_LEVELS as the Domain/Sub-domain/Type baseline indices", () => {
+    expect(ONTOLOGY_LEVELS).toEqual({ domain: 0, subDomain: 1, type: 2 });
   });
 });
 
-describe("viewerState — T7 pure migration (no graph context)", () => {
-  it("migrates legacy showOntologyClasses + collapsedClassIds → groupBy", () => {
+describe("viewerState — T7 pure migration of LEGACY shapes INTO the grouped set", () => {
+  it("migrates legacy flat showOntologyClasses + collapsedClassIds → ontology keys", () => {
     const normalized = normalizeViewerState({
       options: {
         showOntologyClasses: true,
         collapsedClassIds: ["class:Person", "class:Person", "class:Place"],
       },
     });
-    expect(normalized.options.groupBy.axis).toBe("ontology");
-    expect(normalized.options.groupBy.ontology.collapsedClassIds.sort()).toEqual([
-      "class:Person",
-      "class:Place",
-    ]);
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(
+      normalized.options.groupBy.grouped,
+    );
+    expect(ontologyClassIds.sort()).toEqual(["class:Person", "class:Place"]);
+    expect(communityKeys).toEqual([]);
+    // The subsumed legacy flat fields are dropped so they cannot drift.
     expect(normalized.options.showOntologyClasses).toBeUndefined();
     expect(normalized.options.collapsedClassIds).toBeUndefined();
+    // No stale `axis` survives either.
+    expect(normalized.options.groupBy.axis).toBeUndefined();
   });
 
-  it("showOntologyClasses:false/absent migrates to axis:none", () => {
-    expect(normalizeViewerState({}).options.groupBy.axis).toBe("none");
+  it("an absent / showOntologyClasses:false groupBy migrates to an EMPTY grouped set", () => {
+    expect(normalizeViewerState({}).options.groupBy.grouped).toEqual([]);
     expect(
-      normalizeViewerState({ options: { showOntologyClasses: false } }).options.groupBy.axis,
-    ).toBe("none");
+      normalizeViewerState({ options: { showOntologyClasses: false } }).options.groupBy.grouped,
+    ).toEqual([]);
   });
 
-  it("an out-of-enum persisted axis → none; a valid axis:community is PRESERVED", () => {
-    expect(
-      normalizeViewerState({ options: { groupBy: { axis: "bogus" } } }).options.groupBy.axis,
-    ).toBe("none");
-    // Enum-valid: availability is NOT checked in the pure seam (that is T11).
-    expect(
-      normalizeViewerState({ options: { groupBy: { axis: "community" } } }).options.groupBy.axis,
-    ).toBe("community");
-  });
-
-  it("an explicit groupBy.axis wins over the legacy showOntologyClasses flag", () => {
+  it("migrates the older axis-scoped groupBy.axis:'ontology' collapse set → ontology keys", () => {
     const normalized = normalizeViewerState({
-      options: { showOntologyClasses: true, groupBy: { axis: "community" } },
+      options: {
+        groupBy: {
+          axis: "ontology",
+          ontology: { collapsedClassIds: ["class:People", "class:Place"] },
+        },
+      },
     });
-    expect(normalized.options.groupBy.axis).toBe("community");
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(
+      normalized.options.groupBy.grouped,
+    );
+    expect(ontologyClassIds.sort()).toEqual(["class:People", "class:Place"]);
+    expect(communityKeys).toEqual([]);
+    expect(normalized.options.groupBy.axis).toBeUndefined();
   });
-});
 
-describe("viewerState — T11 availability coercion (App seam, with context)", () => {
-  it("downgrades an unavailable persisted axis → none, retaining collapse sets", () => {
-    const persisted = normalizeViewerState({
+  it("migrates the older axis-scoped groupBy.axis:'community' collapse set → community keys", () => {
+    const normalized = normalizeViewerState({
+      options: {
+        groupBy: {
+          axis: "community",
+          community: { collapsedKeys: ["Baker Street", "Scotland Yard"] },
+        },
+      },
+    });
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(
+      normalized.options.groupBy.grouped,
+    );
+    expect(communityKeys.sort()).toEqual(["Baker Street", "Scotland Yard"]);
+    expect(ontologyClassIds).toEqual([]);
+  });
+
+  it("BOTH legacy axis collapse sets fold in regardless of which axis was 'active'", () => {
+    // The persisted axis was "community", but per-item grouping has no single
+    // active axis — every fold is live, so the ontology set folds in too.
+    const normalized = normalizeViewerState({
       options: {
         groupBy: {
           axis: "community",
@@ -181,28 +265,28 @@ describe("viewerState — T11 availability coercion (App seam, with context)", (
         },
       },
     });
-    // Graph has NO communities (availableAxes excludes community).
-    const coerced = normalizeGroupAxisAvailability(persisted, ["none", "ontology"]);
-    expect(coerced.options.groupBy.axis).toBe("none");
-    // The per-axis sets are RETAINED across the downgrade (F3 survives).
-    expect(coerced.options.groupBy.community.collapsedKeys).toEqual(["Baker Street"]);
-    expect(coerced.options.groupBy.ontology.collapsedClassIds).toEqual(["class:People"]);
+    const { ontologyClassIds, communityKeys } = splitGroupedKeys(
+      normalized.options.groupBy.grouped,
+    );
+    expect(ontologyClassIds).toEqual(["class:People"]);
+    expect(communityKeys).toEqual(["Baker Street"]);
   });
 
-  it("passes through an available axis and axis:none; is idempotent", () => {
-    const community = normalizeViewerState({ options: { groupBy: { axis: "community" } } });
-    const ok = normalizeGroupAxisAvailability(community, ["none", "community"]);
-    expect(ok.options.groupBy.axis).toBe("community");
-    const none = createDefaultViewerState();
-    expect(normalizeGroupAxisAvailability(none, ["none"]).options.groupBy.axis).toBe("none");
-    // Idempotent.
-    const once = normalizeGroupAxisAvailability(community, ["none", "ontology"]);
-    const twice = normalizeGroupAxisAvailability(once, ["none", "ontology"]);
-    expect(twice.options.groupBy.axis).toBe("none");
-  });
-
-  it("the pure normalizer (no availableAxes) does NOT downgrade", () => {
-    const normalized = normalizeViewerState({ options: { groupBy: { axis: "community" } } });
-    expect(normalized.options.groupBy.axis).toBe("community");
+  it("a per-item grouped set is preserved as-is (normalized + deduped)", () => {
+    const normalized = normalizeViewerState({
+      options: {
+        groupBy: {
+          grouped: [
+            groupKeyForOntology("class:People"),
+            groupKeyForOntology("class:People"), // dup
+            groupKeyForCommunity("Baker Street"),
+            "", // dropped
+          ],
+        },
+      },
+    });
+    expect(normalized.options.groupBy.grouped.sort()).toEqual(
+      [groupKeyForOntology("class:People"), groupKeyForCommunity("Baker Street")].sort(),
+    );
   });
 });


### PR DESCRIPTION
## Work-stream B2 — Group-by axis selector + reactive count badges

Generalizes the studio's single-purpose "ontology classes" collapse into a proper **group-by axis selector**, and relocates the count badges into the rail under the search bar with a live ratio.

### What lands
- **Axis selector under Options** (nested `Group by` sub-menu, 3-way **None / Community / Ontology** radiogroup). The old top-level `Show ontology classes` checkbox is **removed** (F2 UI-lock / T13).
- **Fine sub-domain grouping** for multi-level ontologies (group by a specific sub-domain via the hierarchical menu).
- **Community grouping = flat single-level degenerate** of the same `applyGroupCollapse`; synthetic ids namespaced via `communityNodeId(key)` with collision detection (A2); `community_key` passthrough.
- **A5 numeric-community tone fix** — resolves through the `nodeGroup` palette key (`community:<n>`), not the display key.
- **Count badges relocated** from the header into the rail **under the search bar**, with a reactive **`x / N nodes`** count that tracks the active search.
- `normalizeViewerState` stays **pure** (graph-free shape migration); availability coercion is the App-level `normalizeGroupAxisAvailability(state, availableAxes)`.

### Contract / trail
- Spec (double-consensus **SHIP**, codex v2): `spec/SPEC_STUDIO_GROUP_BY.md`
- Trail archived: `.graphify/scratch/archive/2026-06-21-conductor/B2-groupby/`
- Realizes the tracked item *"Studio: badges nodes/edges/groups SOUS la barre de recherche … + décompte réactif x/1983 nodes"*.

### Double-review (the required double-relecture)
- **Spec-conformance: SHIP** — all 13 obligations (T1–T13), 194/194 then 197/197, 3 nits only.
- **Adversarial-regression: REVISE → FIXED** — found 1 should-fix: model-switch silently reset an active Ontology axis in multi-model bundles. **Fixed** (capture intended axis before dropping the artifact, re-assert after the new taxonomy lands, gated on availability) + **3 regression tests** (proven to fail on the old behavior).
- **Full suite: `Test Files 15 passed (15) / Tests 197 passed (197)`**, tsc/build clean.

### Known nit (deliberate, on record)
Under an active group-by axis, the `X nodes` badge uses the **raw** graph count (keeps the `x / total` search ratio stable) while `edges`/`groups` come from the **collapsed** scene — a documented trade-off.

---

### 🧪 UAT (verdict = utilisateur)
- **Scope** : studio SPA — sélecteur d'axe group-by (Options > sous-menu) + regroupement fin par sous-domaine + badges sous la barre de recherche avec décompte réactif `x/N`.
- **Données d'entrée** : le studio `mystery` (1983 nœuds, ontologie multi-niveaux) — `graphify studio export` ou le live.
- **Critère de sortie** : (1) sélecteur d'axe visible dans **Options**, ancienne checkbox **absente** ; (2) group-by **Community** = collapse correct ; group-by **Ontology** / sous-domaine = collapse au bon niveau ; (3) badges **sous la search bar**, `x/1983 nodes` qui **bouge à la recherche** ; (4) facet **Types** intacte (surface séparée) ; (5) **0 erreur console**.

Studio UI réversible. **Pas de merge avant ton GO** (je fais le pré-UAT smoke ; le verdict visuel est à toi).
