### PR TITLE
fix(studio): static-studio facets type/community + shapes per type (BUG A) + single-source community colors (BUG B)

### DIFF
--- a/src/studio-assets.ts
+++ b/src/studio-assets.ts
@@ -331,6 +331,19 @@ function loadCitationsForNode(stateDir: string, id: string): CitationSidecarEntr
 
 export interface EntitySidecarResponse {
   id: string;
+  /**
+   * Ontology / file type of the node (node_type → type → kind → file_type, the
+   * same precedence the scene + SPA `nodeType` use). Carried on the entity
+   * sidecar so the Types facet + per-entity badge populate from `entities.json`
+   * even when the heavy graph.json has not hydrated (the default scene-only
+   * `studio.html`, or a multi-file bundle opened over `file://`). `null` when the
+   * node has no type. Bug A fix.
+   */
+  type?: string | null;
+  /** Numeric community id, when the node carries one (Bug A — facet source). */
+  community?: number;
+  /** Human community label (named, then "Community N"), when present (Bug A). */
+  community_name?: string | null;
   description: { status: string; description: string | null } | null;
   occurrences: unknown;
   /**
@@ -343,6 +356,36 @@ export interface EntitySidecarResponse {
 }
 
 /**
+ * Loose graph-node shape buildEntitySidecar reads type/community from. Mirrors
+ * the fields the SPA `nodeType`/`nodeCommunity` consult.
+ */
+export interface EntitySidecarNode {
+  node_type?: unknown;
+  type?: unknown;
+  kind?: unknown;
+  file_type?: unknown;
+  community?: unknown;
+  community_name?: unknown;
+}
+
+function sidecarDisplay(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+/** Node type with the SPA's precedence (node_type → type → kind → file_type). */
+function sidecarNodeType(node: EntitySidecarNode | undefined): string | null {
+  if (!node) return null;
+  return (
+    sidecarDisplay(node.node_type) ??
+    sidecarDisplay(node.type) ??
+    sidecarDisplay(node.kind) ??
+    sidecarDisplay(node.file_type)
+  );
+}
+
+/**
  * Build the `/api/ontology/entity/<id>` payload: the node description
  * (normalised to { status, description }) plus the occurrence record for this
  * node id, if any. Returns the shape the SPA's EntityPanel expects.
@@ -352,7 +395,11 @@ export interface EntitySidecarResponse {
  * graph whose nodes all carry descriptions reports them all here even without a
  * wiki sidecar present.
  */
-export function buildEntitySidecar(stateDir: string, id: string): EntitySidecarResponse {
+export function buildEntitySidecar(
+  stateDir: string,
+  id: string,
+  node?: EntitySidecarNode,
+): EntitySidecarResponse {
   let description: EntitySidecarResponse["description"] = null;
 
   // 1. graph.json node.description (the default WP11 source).
@@ -384,6 +431,13 @@ export function buildEntitySidecar(stateDir: string, id: string): EntitySidecarR
   const citations = loadCitationsForNode(stateDir, id);
 
   const response: EntitySidecarResponse = { id, description, occurrences };
+  // Bug A: surface type + community on the entity sidecar so the SPA facets can
+  // populate from entities.json alone (graph.json may be absent/unhydrated).
+  const type = sidecarNodeType(node);
+  if (type !== null) response.type = type;
+  if (typeof node?.community === "number") response.community = node.community;
+  const communityName = sidecarDisplay(node?.community_name);
+  if (communityName !== null) response.community_name = communityName;
   if (citations) response.citations = citations;
   return response;
 }

--- a/src/studio-export.ts
+++ b/src/studio-export.ts
@@ -47,7 +47,11 @@ import {
   queryOntologyReconciliationCandidates,
 } from "./ontology-reconciliation.js";
 import { emitSceneHierarchies } from "./scene-hierarchies-emitter.js";
-import { buildEntitySidecar, resolveStudioAppDir } from "./studio-assets.js";
+import {
+  buildEntitySidecar,
+  type EntitySidecarNode,
+  resolveStudioAppDir,
+} from "./studio-assets.js";
 import { buildStudioScene, type StudioSceneGraphLike } from "./studio-scene.js";
 import { emitWorkspaceManifest } from "./workspace-manifest-emitter.js";
 
@@ -310,7 +314,10 @@ export function buildStaticStudio(
   for (const node of nodes) {
     const id = (node as { id?: unknown }).id;
     if (typeof id !== "string" || !id) continue;
-    entities[id] = buildEntitySidecar(stateDir, id);
+    // Pass the graph node so the sidecar carries its type/community (Bug A):
+    // the SPA facets then populate from entities.json even when graph.json is
+    // not hydrated (scene-only studio.html / file:// multi-file bundle).
+    entities[id] = buildEntitySidecar(stateDir, id, node as EntitySidecarNode);
   }
 
   // reconciliation candidates source (read before cleanup).

--- a/src/studio-scene.ts
+++ b/src/studio-scene.ts
@@ -113,6 +113,13 @@ export interface StudioSceneStats {
 export interface StudioScene {
   nodes: StudioSceneNode[];
   edges: StudioSceneEdge[];
+  /**
+   * BUG B: the single source of truth community → colour map (community name →
+   * hex). Emitted in the scene so the legend, the canvas, and any downstream
+   * consumer read ONE mapping. Identical to the on-canvas node fill + the legend
+   * swatch (all resolve via colorForGroup over the same key).
+   */
+  communityColors: Record<string, string>;
   stats: StudioSceneStats;
 }
 
@@ -180,6 +187,15 @@ const NODE_PROFILE_FIELDS = [
   "entity_url",
   "source_file",
   "source_location",
+  // Community membership passthrough: the scene is the SPA's always-present
+  // mount payload, so carrying the raw `community`/`community_name` lets the
+  // Types/Communities facets + the community→colour legend resolve from the
+  // scene ALONE when the heavy graph.json has not (or cannot) hydrate — e.g. the
+  // default scene-only `studio.html`, or a multi-file bundle opened over
+  // `file://` (cross-origin fetch of a sibling graph.json is blocked). Without
+  // this the facets read an empty graph and render "No types / No communities".
+  "community",
+  "community_name",
   "parent_id",
   "child_ids",
   "level",
@@ -259,9 +275,41 @@ const TYPE_SHAPE: Record<string, string> = {
   Translator: "triangle",
 };
 
+/**
+ * Shape-per-type fallback ring for types NOT in the curated {@link TYPE_SHAPE}
+ * map. A non-profile graph (graphify's own corpus, the aero contribution pack,
+ * any `file_type`-typed graph) carries types like `code` / `concept` / `Commit`
+ * the narrative TYPE_SHAPE map never anticipated — they previously ALL fell back
+ * to the constant `dot`, so the canvas showed one glyph for every type and the
+ * legend had no shape-per-type key. Each unknown type now gets a STABLE shape by
+ * hashing its name into this ring, so distinct types render as distinct glyphs.
+ * Excludes the box family (reserved for god-class hubs / class nodes). Kept in
+ * lockstep with studio/src/lib/graphAdapter.js FALLBACK_TYPE_SHAPES (parity).
+ */
+const FALLBACK_TYPE_SHAPES = ["dot", "triangle", "square", "diamond", "hexagon", "star"];
+
+/** FNV-1a hash (mirrors graphRendererPayload.stableHash) for stable bucketing. */
+function stableTypeHash(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/** Stable scene shape for a type the curated {@link TYPE_SHAPE} map omits. */
+function fallbackShapeForType(type: string): string {
+  return FALLBACK_TYPE_SHAPES[stableTypeHash(type) % FALLBACK_TYPE_SHAPES.length] ?? "dot";
+}
+
 function shapeForType(node: StudioSceneGraphNode | undefined): string {
   const t = nodeType(node);
-  return (t && TYPE_SHAPE[t]) || "dot";
+  if (!t) return "dot";
+  // Curated narrative types keep their hand-picked glyph; everything else
+  // (file_type-based / non-profile types) gets a stable per-type shape so the
+  // canvas and legend distinguish them instead of collapsing to one dot.
+  return TYPE_SHAPE[t] ?? fallbackShapeForType(t);
 }
 
 /**
@@ -436,10 +484,52 @@ function isBoxSceneShape(shape: unknown): boolean {
 }
 
 /**
- * Community breakdown that EXCLUDES isolated singletons from the count. Mirrors
- * graphAdapter.js communityStats; only `liveCount` is consumed by buildScene.
+ * Group / community → colour palette and lookup. THE single source of truth for
+ * BUG B: both this build-time scene emitter AND the SPA canvas/legend resolve a
+ * group's colour through colorForGroup() over the SAME key, so the emitted
+ * scene.communityColors map, the on-canvas node fill, and the legend swatch are
+ * all identical. Kept in lockstep with studio/src/lib/graphRendererPayload.js
+ * GROUP_PALETTE / colorForGroup (the offline-render test cross-checks them).
  */
-function communityLiveCount(graph: StudioSceneGraphLike): number {
+const GROUP_PALETTE = [
+  "#4f7cac",
+  "#f59e0b",
+  "#10b981",
+  "#ef4444",
+  "#8b5cf6",
+  "#14b8a6",
+  "#f97316",
+  "#64748b",
+  "#ec4899",
+  "#22c55e",
+  "#3b82f6",
+  "#a855f7",
+] as const;
+
+function groupHash(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function colorForGroup(group: string | undefined): string {
+  return GROUP_PALETTE[groupHash(group ?? "default") % GROUP_PALETTE.length] ?? GROUP_PALETTE[0];
+}
+
+/**
+ * Community breakdown that EXCLUDES isolated singletons. Mirrors graphAdapter.js
+ * computeCommunityStats EXACTLY (same node order, same nodeGroup colour key,
+ * same descending-count/key sort) so the emitted `communityColors` map and the
+ * `communityCount` are byte-identical to the SPA's. Returns the live-count and
+ * the colour map (keyed by community name, descending-count order).
+ */
+function communityStats(graph: StudioSceneGraphLike): {
+  liveCount: number;
+  communityColors: Record<string, string>;
+} {
   const nodes = graphNodes(graph);
   const ids = new Set(nodes.map((n) => n.id));
   const deg = new Map<string, number>();
@@ -449,21 +539,26 @@ function communityLiveCount(graph: StudioSceneGraphLike): number {
     deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
   }
 
-  const byComm = new Map<string, { count: number; live: boolean }>();
+  const byComm = new Map<string, { count: number; live: boolean; group: string | undefined }>();
   for (const node of nodes) {
     const key = nodeCommunity(node);
     const live = (deg.get(node.id) ?? 0) > 0;
     if (key === undefined || key === null || key === "") continue;
-    const rec = byComm.get(key) ?? { count: 0, live: false };
+    const rec = byComm.get(key) ?? { count: 0, live: false, group: nodeGroup(node) };
     rec.count += 1;
     if (live) rec.live = true;
     byComm.set(key, rec);
   }
-  let liveCount = 0;
-  for (const rec of byComm.values()) {
-    if (rec.live) liveCount += 1;
+  const liveList: Array<{ key: string; count: number; color: string }> = [];
+  for (const [key, rec] of byComm) {
+    if (rec.live) {
+      liveList.push({ key: String(key), count: rec.count, color: colorForGroup(rec.group ?? key) });
+    }
   }
-  return liveCount;
+  liveList.sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+  const communityColors: Record<string, string> = {};
+  for (const c of liveList) communityColors[c.key] = c.color;
+  return { liveCount: liveList.length, communityColors };
 }
 
 // ---------------------------------------------------------------------------
@@ -559,14 +654,19 @@ export function buildStudioScene(
     return out;
   });
 
+  const cstats = communityStats(safeGraph);
   return {
     nodes,
     edges: sceneEdges,
+    // BUG B: emitted single source of truth community → colour map (see
+    // communityStats / colorForGroup). Byte-identical to the SPA buildScene
+    // output (parity test enforces it).
+    communityColors: cstats.communityColors,
     stats: {
       nodeCount: nodes.length,
       edgeCount: sceneEdges.length,
       weakEdgeCount: sceneEdges.filter((e) => e.weak).length,
-      communityCount: communityLiveCount(safeGraph),
+      communityCount: cstats.liveCount,
     },
   };
 }

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -125,9 +125,26 @@
         ? applyWeakFilter(sceneData, viewerState.options.showWeakLinks)
         : buildScene(graph, { showWeakLinks: viewerState.options.showWeakLinks }),
   );
+  // BUG A: facet / selection source. The left rail (Types / Communities /
+  // Entities), the selection panel, and the selected-id resolution all read a
+  // graph-like. Normally that is the hydrated raw `graph` (richest source). But
+  // when graph.json is NOT available — the default scene-only `studio.html`, or
+  // a multi-file static bundle opened over `file://` where a sibling fetch is
+  // blocked — `graph` stays EMPTY_GRAPH and EVERY facet renders empty ("No
+  // types / No communities"). The light scene IS always present and now carries
+  // `type` + `community`/`community_name` per node (+ its edges), so fall back to
+  // it: the facets populate from the scene alone. The scene's edges drive the
+  // community live/degree computation, identical to the graph path.
+  const facetGraph = $derived(
+    (graph?.nodes?.length ?? 0) > 0
+      ? graph
+      : scene
+        ? { nodes: scene.nodes, links: scene.edges }
+        : graph,
+  );
   // Graph highlight = every entity of every selected type/community + the
   // directly-selected entities (R8-3.B).
-  const selectedIds = $derived(resolveSelectedIds(graph, viewerState.selection));
+  const selectedIds = $derived(resolveSelectedIds(facetGraph, viewerState.selection));
   function handleToggleType(type) {
     viewerState = toggleType(viewerState, type);
   }
@@ -358,7 +375,7 @@
       <WorkspaceShell>
         <div class="col col-left">
           <LeftRail
-            {graph}
+            graph={facetGraph}
             {classHierarchies}
             query={viewerState.query}
             selection={viewerState.selection}
@@ -386,7 +403,7 @@
         </div>
         <div class="col col-right">
           <SelectionPanel
-            {graph}
+            graph={facetGraph}
             selection={viewerState.selection}
             focusId={viewerState.focusId}
             {entityCache}

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -243,7 +243,7 @@
               {#snippet leading()}
                 <span
                   class="rail-swatch"
-                  style="background: var(--st-semantic-data-{c.tone}, #94a3b8)"
+                  style="background: {c.color}"
                   aria-hidden="true"
                 ></span>
               {/snippet}

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -22,6 +22,13 @@
 
 import { computeLayout } from "@graphify/graph-layout";
 
+// Single source of truth for community/group → colour. The legend swatch
+// (computeCommunityStats below) and the canvas node fill (graphRendererPayload)
+// resolve a group's colour through this ONE function over the SAME key, so the
+// legend and the canvas never diverge (BUG B). graphRendererPayload imports only
+// from @sentropic/graph, so this back-reference creates no import cycle.
+import { colorForGroup } from "./graphRendererPayload.js";
+
 /** Graphify persists `links`; some adapters/tests pass `edges`. Accept both. */
 export function graphEdges(graph) {
   if (!graph) return [];
@@ -67,6 +74,13 @@ const NODE_PROFILE_FIELDS = [
   "entity_url",
   "source_file",
   "source_location",
+  // Community membership passthrough: the scene is the always-present mount
+  // payload, so carrying the raw `community`/`community_name` lets the
+  // Types/Communities facets + the community→colour legend resolve from the
+  // scene ALONE when graph.json has not (or cannot) hydrate. Kept in lockstep
+  // with src/studio-scene.ts NODE_PROFILE_FIELDS (parity test enforces this).
+  "community",
+  "community_name",
   "parent_id",
   "child_ids",
   "level",
@@ -200,9 +214,53 @@ export function dashForRelation(relation) {
   if (!relation) return undefined;
   return REL_DASH[String(relation)] ?? "solid";
 }
+
+/**
+ * Shape-per-type fallback ring for types NOT in the curated {@link TYPE_SHAPE}
+ * map. A non-profile graph (graphify's own corpus, the aero contribution pack,
+ * any `file_type`-typed graph) carries types like `code` / `concept` / `Commit`
+ * that the narrative TYPE_SHAPE map never anticipated — they previously ALL fell
+ * back to the constant `dot`, so the canvas showed one glyph for every type and
+ * the legend had no shape-per-type key. We now assign each unknown type a STABLE
+ * shape by hashing its name into this ring, so distinct types render as distinct
+ * glyphs (and the type-shape legend is meaningful) on profile-less graphs.
+ *
+ * The ring deliberately EXCLUDES the box family (`box`/`roundedbox`), reserved
+ * for god-class Character hubs + synthetic ontology class nodes, so an ordinary
+ * data type can never masquerade as a labelled hub box. Kept in lockstep with
+ * src/studio-scene.ts FALLBACK_TYPE_SHAPES (the parity test enforces this).
+ */
+const FALLBACK_TYPE_SHAPES = ["dot", "triangle", "square", "diamond", "hexagon", "star"];
+
+/** FNV-1a hash (mirrors graphRendererPayload.stableHash) for stable bucketing. */
+function stableTypeHash(value) {
+  const text = String(value ?? "");
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Stable scene shape for a type the curated {@link TYPE_SHAPE} map does not
+ * cover: hash the type name into {@link FALLBACK_TYPE_SHAPES}. Deterministic
+ * (same type ⇒ same shape across the canvas, legend, and re-exports).
+ */
+export function fallbackShapeForType(type) {
+  const t = displayValue(type);
+  if (!t) return "dot";
+  return FALLBACK_TYPE_SHAPES[stableTypeHash(t) % FALLBACK_TYPE_SHAPES.length];
+}
+
 export function shapeForType(node) {
   const t = nodeType(node);
-  return (t && TYPE_SHAPE[t]) || "dot";
+  if (!t) return "dot";
+  // Curated narrative types keep their hand-picked glyph; everything else
+  // (file_type-based / non-profile types) gets a stable per-type shape so the
+  // canvas and legend distinguish them instead of collapsing to one dot.
+  return TYPE_SHAPE[t] ?? fallbackShapeForType(t);
 }
 
 /**
@@ -435,17 +493,37 @@ export function buildScene(graph, options = {}) {
     return out;
   });
 
+  const cstats = communityStats(graph);
   return {
     nodes,
     edges: sceneEdges,
+    // BUG B: the SINGLE source of truth community → colour map, emitted in the
+    // scene so every consumer (legend, canvas, downstream tools) reads ONE
+    // mapping instead of recomputing it with a divergent scheme. Keyed by the
+    // live community name; the value is colorForGroup() over the canvas group
+    // key, so scene.communityColors[name] === the on-canvas fill of that
+    // community's nodes === the legend swatch. Kept in lockstep with
+    // src/studio-scene.ts (parity test enforces byte-equality).
+    communityColors: communityColorMap(cstats),
     stats: {
       nodeCount: nodes.length,
       edgeCount: sceneEdges.length,
       weakEdgeCount: sceneEdges.filter((e) => e.weak).length,
       // Isolated singletons (degree-0) are excluded from the community count.
-      communityCount: communityStats(graph).liveCount,
+      communityCount: cstats.liveCount,
     },
   };
+}
+
+/**
+ * Plain `{ communityName: color }` map from the live community stats — the
+ * scene's emitted single source of truth for BUG B. Insertion order follows the
+ * stats' descending-count order so the serialized map is deterministic.
+ */
+export function communityColorMap(cstats) {
+  const map = {};
+  for (const c of cstats?.live ?? []) map[c.key] = c.color;
+  return map;
 }
 
 /**
@@ -663,19 +741,6 @@ function computeCommunityStats(graph) {
     deg.set(e.source, (deg.get(e.source) ?? 0) + 1);
     deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
   }
-  // Reproduce the DS tone assignment: it walks scene nodes and assigns
-  // category1..8 to each new `group` in first-seen order. We mirror that here
-  // (same node order, same nodeGroup key) so the rail swatch matches the graph.
-  const TONES = [
-    "category1", "category2", "category3", "category4",
-    "category5", "category6", "category7", "category8",
-  ];
-  const toneByGroup = new Map();
-  for (const node of nodes) {
-    const g = nodeGroup(node);
-    if (g === undefined || g === null || toneByGroup.has(g)) continue;
-    toneByGroup.set(g, TONES[toneByGroup.size % TONES.length]);
-  }
 
   const byComm = new Map();
   let isolatedCount = 0;
@@ -686,7 +751,7 @@ function computeCommunityStats(graph) {
       if (!live) isolatedCount += 1;
       continue;
     }
-    const rec = byComm.get(key) ?? { count: 0, live: false };
+    const rec = byComm.get(key) ?? { count: 0, live: false, group: nodeGroup(node) };
     rec.count += 1;
     if (live) rec.live = true;
     byComm.set(key, rec);
@@ -694,7 +759,16 @@ function computeCommunityStats(graph) {
   const liveList = [];
   for (const [key, rec] of byComm) {
     if (rec.live) {
-      liveList.push({ key: String(key), count: rec.count, tone: toneByGroup.get(key) ?? "category1" });
+      // BUG B: the legend swatch resolves its colour through the SAME
+      // colorForGroup() the canvas uses, over the SAME key the canvas hashes
+      // (nodeGroup, captured in rec.group). So the legend dot and the node fill
+      // are guaranteed identical — no more independent DS-tone-by-sorted-
+      // position scheme diverging from the canvas hash.
+      liveList.push({
+        key: String(key),
+        count: rec.count,
+        color: colorForGroup(rec.group ?? key),
+      });
     } else {
       isolatedCount += rec.count;
     }

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -1,6 +1,16 @@
 import { buildRenderGraphBuffers, buildStyleBuffers } from "@sentropic/graph";
 
-const GROUP_PALETTE = [
+/**
+ * SINGLE source of truth for a group's (community / type) colour. Both the
+ * canvas node fill (`buildGraphRendererPayload`) AND the left-rail community
+ * legend swatch resolve a group's colour through {@link colorForGroup} over the
+ * SAME key (the group / community name). Previously the legend assigned a DS
+ * category token by sorted position while the canvas hashed the name into this
+ * palette — two independent schemes that diverged (the biggest community could
+ * render blue on the canvas but amber in the legend). Reusing one function over
+ * one key guarantees the legend dot and the node fill are byte-identical.
+ */
+export const GROUP_PALETTE = [
   "#4f7cac",
   "#f59e0b",
   "#10b981",
@@ -62,7 +72,12 @@ function stableHash(value) {
   return hash >>> 0;
 }
 
-function colorForGroup(group) {
+/**
+ * Resolve the palette colour for a group key (community / type name). Exported
+ * so the legend (LeftRail) reuses the EXACT same mapping as the canvas — the
+ * single source of truth for community→colour (BUG B fix).
+ */
+export function colorForGroup(group) {
   const index = stableHash(group ?? "default") % GROUP_PALETTE.length;
   return GROUP_PALETTE[index];
 }

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -312,15 +312,33 @@ describe("candidateSubgraph (SVELTE-7)", () => {
 });
 
 describe("shapeForType (SVELTE-4)", () => {
-  it("maps ontology types to DS shapes, defaulting to dot", async () => {
+  it("maps curated ontology types to their hand-picked DS shapes", async () => {
     const { shapeForType } = await import("../lib/graphAdapter.js");
     expect(shapeForType({ type: "Character" })).toBe("diamond");
     expect(shapeForType({ node_type: "Location" })).toBe("triangle");
     expect(shapeForType({ type: "Evidence" })).toBe("square");
     expect(shapeForType({ type: "Work" })).toBe("hexagon");
     expect(shapeForType({ type: "ChapterOrStory" })).toBe("dot");
-    expect(shapeForType({ type: "Unknownish" })).toBe("dot");
+    // A typeless node still falls back to the neutral dot.
     expect(shapeForType({})).toBe("dot");
+  });
+
+  it("gives a NON-profile (file_type) type a stable, distinct shape per type", async () => {
+    const { shapeForType, fallbackShapeForType } = await import("../lib/graphAdapter.js");
+    // Bug fix: unknown types used to ALL collapse to "dot" (one glyph for every
+    // file_type, no shape-per-type legend). Each now gets a stable ring shape.
+    expect(shapeForType({ type: "Unknownish" })).toBe("diamond");
+    expect(shapeForType({ file_type: "code" })).toBe("square");
+    expect(shapeForType({ file_type: "concept" })).toBe("star");
+    expect(shapeForType({ file_type: "rationale" })).toBe("hexagon");
+    // Deterministic: same type ⇒ same shape across canvas / legend / re-export.
+    expect(fallbackShapeForType("code")).toBe(shapeForType({ type: "code" }));
+    expect(fallbackShapeForType("code")).toBe("square");
+    // Never the box family (reserved for god-class hubs / class nodes).
+    for (const t of ["code", "concept", "rationale", "Commit", "Branch", "zzz"]) {
+      expect(["box", "roundedbox"]).not.toContain(fallbackShapeForType(t));
+    }
+    expect(fallbackShapeForType("")).toBe("dot");
   });
   it("buildScene attaches a shape to every node", async () => {
     const { buildScene } = await import("../lib/graphAdapter.js");
@@ -416,8 +434,12 @@ describe("computeGodClass — Character-gated box-label class", () => {
     expect(computeGodClass(flipped.nodes, degree, 2)).toBe(null);
     const s = buildScene(flipped);
     const byId = new Map(s.nodes.map((n) => [n.id, n]));
-    expect(byId.get("lab").shape).toBe("dot"); // non-Character hub keeps base shape
-    expect(byId.get("p1").shape).toBe("dot"); // unmapped type default
+    // The intent: a non-Character hub is NEVER box-labelled (boxes are reserved
+    // for Character god-class hubs). Each non-profile type still gets its own
+    // stable per-type glyph (Lab → dot, Paper → star) — never a box.
+    expect(["box", "roundedbox"]).not.toContain(byId.get("lab").shape);
+    expect(byId.get("lab").shape).toBe("dot");
+    expect(byId.get("p1").shape).toBe("star");
   });
 
   it("returns null with no edges or no typed nodes (no override applied)", async () => {

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -3,16 +3,66 @@ import { describe, expect, it } from "vitest";
 import {
   buildConnectedDimStyle,
   buildGraphRendererPayload,
+  colorForGroup,
   densityScale,
   DEFAULT_LABEL_MAX_CHARS,
   findNearestEdge,
   findNearestNode,
   findNearestNodeId,
+  GROUP_PALETTE,
   interpolateMergeStyle,
   interpolateMergePositions,
   isBoxShape,
   truncateLabel,
 } from "../lib/graphRendererPayload.js";
+import { buildScene, communityStats, nodeGroup } from "../lib/graphAdapter.js";
+
+// --- BUG B: single source of truth for community → colour ---
+// The legend swatch (communityStats[].color) and the canvas node fill
+// (buildGraphRendererPayload -> colorForGroup(node.group)) must resolve a
+// community to the SAME palette colour. Before the fix the legend assigned a
+// DS category token by sorted position while the canvas hashed the name into
+// GROUP_PALETTE — two independent schemes that diverged.
+describe("community colour single source (BUG B)", () => {
+  // 3 named communities of differing sizes so a sort-by-count legend would
+  // reorder them (and, with the old scheme, recolour them away from the canvas).
+  const GRAPH = {
+    nodes: [
+      { id: "a1", community_name: "Alpha big" },
+      { id: "a2", community_name: "Alpha big" },
+      { id: "a3", community_name: "Alpha big" },
+      { id: "b1", community_name: "Beta mid" },
+      { id: "b2", community_name: "Beta mid" },
+      { id: "g1", community_name: "Gamma small" },
+    ],
+    links: [
+      { source: "a1", target: "a2" },
+      { source: "a2", target: "a3" },
+      { source: "b1", target: "b2" },
+      { source: "a1", target: "g1" },
+    ],
+  };
+
+  it("colorForGroup is a stable palette lookup", () => {
+    expect(GROUP_PALETTE).toContain(colorForGroup("Alpha big"));
+    expect(colorForGroup("Alpha big")).toBe(colorForGroup("Alpha big"));
+  });
+
+  it("every legend swatch colour equals the canvas node fill for that community", () => {
+    const scene = buildScene(GRAPH);
+    const payload = buildGraphRendererPayload(scene, { nodeRadius: 3 });
+    const { live } = communityStats(GRAPH);
+    // The legend is sorted by descending count; the canvas is in node order.
+    // Regardless of ordering, each community's legend colour must equal the
+    // fill of EVERY one of its member nodes on the canvas.
+    for (const community of live) {
+      const memberNode = GRAPH.nodes.find((n) => n.community_name === community.key);
+      const canvasColor = payload.nodeById.get(memberNode.id).color;
+      expect(community.color, `legend ${community.key}`).toBe(canvasColor);
+      expect(community.color).toBe(colorForGroup(nodeGroup(memberNode)));
+    }
+  });
+});
 
 // --- Item 1: density-aware base node size ---
 describe("densityScale", () => {

--- a/tests/studio-scene.test.ts
+++ b/tests/studio-scene.test.ts
@@ -272,19 +272,32 @@ describe("buildStudioScene — parity with studio buildScene", () => {
     const graphPath = join(REPO_ROOT, ".graphify", "graph.json");
     const hasRealGraph = existsSync(graphPath);
 
-    it.runIf(hasRealGraph)("matches node-by-node and edge-by-edge", () => {
-      const realGraph = JSON.parse(readFileSync(graphPath, "utf-8"));
-      // Sanity: this is the heavy real graph, not a stub.
-      expect((realGraph.nodes ?? []).length).toBeGreaterThan(100);
-      expectGranularParity(realGraph);
-      expectParity(realGraph);
-    });
+    // Heavy: granular + full parity over the WHOLE real graph (can be thousands
+    // of nodes/edges), so per-element JSON.stringify dominates — give it a
+    // generous timeout so a large local graph / loaded CI box never flakes.
+    const HEAVY_PARITY_TIMEOUT_MS = 120_000;
 
-    it.runIf(hasRealGraph)("matches with weak links filtered out", () => {
-      const realGraph = JSON.parse(readFileSync(graphPath, "utf-8"));
-      expectGranularParity(realGraph, { showWeakLinks: false });
-      expectParity(realGraph, { showWeakLinks: false });
-    });
+    it.runIf(hasRealGraph)(
+      "matches node-by-node and edge-by-edge",
+      () => {
+        const realGraph = JSON.parse(readFileSync(graphPath, "utf-8"));
+        // Sanity: this is the heavy real graph, not a stub.
+        expect((realGraph.nodes ?? []).length).toBeGreaterThan(100);
+        expectGranularParity(realGraph);
+        expectParity(realGraph);
+      },
+      HEAVY_PARITY_TIMEOUT_MS,
+    );
+
+    it.runIf(hasRealGraph)(
+      "matches with weak links filtered out",
+      () => {
+        const realGraph = JSON.parse(readFileSync(graphPath, "utf-8"));
+        expectGranularParity(realGraph, { showWeakLinks: false });
+        expectParity(realGraph, { showWeakLinks: false });
+      },
+      HEAVY_PARITY_TIMEOUT_MS,
+    );
 
     it.skipIf(hasRealGraph)("real graph absent — synthetic parity still proven", () => {
       expect(hasRealGraph).toBe(false);


### PR DESCRIPTION
Upstream fix for 2 high-severity static-studio bugs reported by **contribution-ia-aeronautique** (fix_request env:1782088681723:f474, bug report env:…:f437) on any **non-profile** graph.

**BUG A — facets Types/Communities empty + no shape per type**
- entities.json now carries `type` (from file_type) + `community` + `community_name`; file_type/type harmonized so the SPA facet reader (`node_type ?? type`) populates.
- scene.shape derived **per type** (square/star/hexagon…), not constant 'dot' → shapes + shape legend.

**BUG B — community colors legend ≠ canvas**
- Single source of truth: `communityColors` emitted once at export (scene top-level) + reused IDENTICALLY in legend AND canvas (no more hash-vs-sorted-position divergence).

Verified on graphify's own non-profile graph (6002 nodes): entities carry type/community, shapes {square:5713, star:185, hexagon:104}, `communityColors` present. Studio tests 172/173 (the 1 fail = pre-existing `appHeader` brand test, fails on main too).

Closes the ia-aero static-compilation fix_request.