### PR TITLE
fix(studio): build the offline single-file studio.html (was no-op'd by stale studio deps)

### DIFF
--- a/scripts/build-studio-app.mjs
+++ b/scripts/build-studio-app.mjs
@@ -49,8 +49,19 @@ if (!existsSync(join(studio, "package.json"))) {
   process.exit(0);
 }
 
-// Install the SPA's own deps if missing.
-if (!existsSync(join(studio, "node_modules", "vite"))) {
+// Install the SPA's own deps if missing. We probe a SET of packages, not just
+// `vite`: a node_modules tree installed from an OLDER lockfile (before a dep was
+// added to studio/package.json) still has `vite` but is missing newer deps like
+// `vite-plugin-singlefile`. Without that package the gated single-file Vite pass
+// dies with `ERR_MODULE_NOT_FOUND` (the dynamic `import("vite-plugin-singlefile")`
+// in vite.config.js), the offline studio.html never builds, and the multi-file
+// build silently no-ops it. Probing the single-file plugin too forces a
+// lockfile-faithful reinstall so the offline export stays buildable.
+const REQUIRED_STUDIO_DEPS = ["vite", "vite-plugin-singlefile"];
+const missingDep = REQUIRED_STUDIO_DEPS.find(
+  (dep) => !existsSync(join(studio, "node_modules", dep)),
+);
+if (missingDep) {
   const installed =
     (existsSync(join(studio, "package-lock.json")) && run("npm", ["ci"], studio)) ||
     run("npm", ["install"], studio);


### PR DESCRIPTION
## Problem

`graphify studio export --single-file` / `--full-offline` could never produce a working offline `studio.html`. The build printed:

```
build-studio-app: single-file build failed (offline studio.html will no-op) — skipping SPA
```

with an `ERR_MODULE_NOT_FOUND` ESM loader error (`at node:internal/modules/esm/loader:622:32`). The **multi-file** studio built fine. This blocked ia-aero's `--full-offline` export.

## Root cause

The single-file build is a separate, flag-gated Vite pass (`GRAPHIFY_STUDIO_SINGLEFILE=1`) whose `vite.config.js` dynamically `import("vite-plugin-singlefile")`. That plugin is a (correctly-listed) devDependency of `studio/package.json` and is present in `studio/package-lock.json`.

The bug was in `scripts/build-studio-app.mjs`: the dependency-install guard probed **only** `node_modules/vite`. A `studio/node_modules` tree installed from an **older** lockfile (before `vite-plugin-singlefile` was added) still has `vite` but is missing the single-file plugin — so the install step was skipped, the gated Vite pass died on the dynamic import (`Cannot find package 'vite-plugin-singlefile'`), `studio-template.html` was never produced, and the exporter's best-effort single-file emit no-op'd.

## Fix

Probe a **set** of required studio deps (`vite` **and** `vite-plugin-singlefile`) and force a lockfile-faithful `npm ci` reinstall when any is missing, so the offline export stays buildable on a stale `node_modules`. One-file change, no behavior change for the multi-file build.

## Verification

- Single-file Vite pass builds a self-contained `dist/studio-app/studio-template.html` (JS + CSS inlined, zero external `src`/`href` refs).
- `graphify studio export <out> --full-offline` on the real `.graphify` graph (6002 nodes) emits a 45 MB `studio.html` with `scene.json` + `graph.json` + `entities.json` inlined as `window.__GRAPHIFY_BUNDLE__` (scene positions x/y + fx/fy preserved, not the degenerate circle), bundle script injected before the boot module — **not** the no-op stub.
- Default scene-only `studio export` also emits a valid single-file `studio.html`.
- **T1 CDP `file://` render test** (`studio-export-offline-render.test.ts`) — previously *perma-skipped* because the template never existed — now **runs and passes**: the graph canvas paints from the inlined bundle in real headless Chrome with **zero** `Network.loadingFailed`.
- `tsc --noEmit` clean.
- `studio-export-offline`, `studio-export-offline-render`, `studio-assets`, `studio-export-migration`, `studio-scene` suites green (49 passed / 1 skipped).
- Studio SPA suite green (231/231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)