### PR TITLE
fix(graph): pixel-fit box labels to a capped width on the MAIN graph (ellipsis)

### DIFF
--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -479,6 +479,18 @@ const BOX_BASE_HEIGHT_PX = 18; // box height in CSS px (× pixelRatio × zoom), 
 const BOX_MARGIN_RATIO = 5 / 22; // legacy margin per side (5 of a 22 box)
 const BOX_FONT_RATIO = 12 / 22; // legacy font size (12 of a 22 box) — text much smaller than the box
 const BOX_CORNER_RATIO = 1 / 4; // corner radius as a fraction of box height
+// Maximum box WIDTH, expressed as a multiple of the box height (so it scales
+// with pixelRatio × zoom exactly like the height — the cap reads the same at
+// any zoom). The box still grows in width to hug short labels, but a long
+// chapter / entity name is PIXEL-FITTED to this ceiling with an ellipsis so the
+// glyph can never balloon into an over-wide text card that overflows the layout.
+// ~10× a small box height keeps a comfortable line (≈ 30-ish narrow glyphs at
+// the legacy 12/22 font) while bounding the worst case. This is the SHARED,
+// backend-agnostic render-geometry fix: it covers EVERY box node (main-graph
+// chapter/work/god-class hubs AND the recon focal pair), not just one view.
+const BOX_MAX_WIDTH_RATIO = 10;
+// Single-character ellipsis appended when a box label is pixel-clipped to fit.
+const BOX_ELLIPSIS = "…";
 // Non-labelled (low-degree) box collapse, as a fraction of the box height:
 // legacy hidden-font boxes shrink to their two 5-unit margins of a 22-unit box.
 const BOX_EMPTY_RATIO = 10 / 22;
@@ -576,29 +588,80 @@ interface NodeGeometry {
 }
 
 /**
+ * PIXEL-FIT a label so its DRAWN width never exceeds `maxTextWidth`, appending a
+ * single ellipsis when it has to clip. Unlike a fixed character-count cap, this
+ * is glyph-width aware (a run of wide letters clips sooner than a run of "i"s),
+ * so the box that hugs the returned text is guaranteed to stay within the max.
+ *
+ * Binary search over the keep-length keeps it O(log n) measureText calls per
+ * over-long label (cheap, and only long labels pay it). When even the ellipsis
+ * alone does not fit (an absurdly tiny box) we still return the ellipsis so the
+ * caller draws SOMETHING rather than overflowing. The full text is unchanged on
+ * the node payload, so hover tooltips / detail panels keep the verbatim name.
+ */
+function fitLabelToWidth(
+  label: string,
+  maxTextWidth: number,
+  font: string,
+  measureLabelWidth: (text: string, font: string) => number,
+): string {
+  if (!label) return label;
+  if (maxTextWidth <= 0) return label;
+  if (measureLabelWidth(label, font) <= maxTextWidth) return label;
+
+  // Search the largest prefix length whose `prefix + …` still fits.
+  let low = 0;
+  let high = label.length;
+  let best = "";
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const candidate = label.slice(0, mid).replace(/\s+$/u, "") + BOX_ELLIPSIS;
+    if (measureLabelWidth(candidate, font) <= maxTextWidth) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  // Even a lone ellipsis overflowed the (degenerate) box — draw it anyway.
+  return best || BOX_ELLIPSIS;
+}
+
+/**
  * Legacy `shape:box` glyph dimensions. The box height is a fixed legacy base
  * (BOX_BASE_HEIGHT_PX, scaled by pixelRatio × zoom) — degree-INDEPENDENT, so a
  * high-degree Work box never inflates past its neighbours; the small font fits
  * that height minus a margin per side, and the box only grows in WIDTH to hug
  * the text plus margins. A non-labelled (low-degree) box collapses like the
  * legacy hidden-font (fontSize 0) box: a small square of BOX_EMPTY_RATIO × height.
+ *
+ * WIDTH IS CAPPED at BOX_MAX_WIDTH_RATIO × height: a label too long to hug
+ * within that ceiling is PIXEL-FITTED (see {@link fitLabelToWidth}) to the
+ * available text width with an ellipsis, so the box never balloons into an
+ * over-wide text card that overflows the layout. The returned `label` is the
+ * exact (possibly clipped) text the box was sized to — the draw path renders
+ * THAT string, so the box always hugs precisely what it shows.
  */
 function boxDimensions(
   height: number,
   label: string,
   measureLabelWidth: (text: string, font: string) => number,
-): { w: number; h: number; fontPx: number; corner: number } {
+): { w: number; h: number; fontPx: number; corner: number; label: string } {
   const margin = height * BOX_MARGIN_RATIO;
   const corner = height * BOX_CORNER_RATIO;
   const fontPx = height * BOX_FONT_RATIO;
 
   if (!label) {
     const side = height * BOX_EMPTY_RATIO;
-    return { w: side, h: side, fontPx, corner };
+    return { w: side, h: side, fontPx, corner, label };
   }
 
-  const textW = measureLabelWidth(label, `${fontPx}px sans-serif`);
-  return { w: textW + 2 * margin, h: height, fontPx, corner };
+  const font = `${fontPx}px sans-serif`;
+  // Text must fit inside the max box width minus a margin per side.
+  const maxTextWidth = Math.max(0, height * BOX_MAX_WIDTH_RATIO - 2 * margin);
+  const fitted = fitLabelToWidth(label, maxTextWidth, font, measureLabelWidth);
+  const textW = measureLabelWidth(fitted, font);
+  return { w: textW + 2 * margin, h: height, fontPx, corner, label: fitted };
 }
 
 /**
@@ -860,7 +923,10 @@ function drawFallback2D(
         dims.corner,
         dims.fontPx,
         pixelRatio,
-        label,
+        // The PIXEL-FITTED label (clipped + ellipsised to the capped box width),
+        // so the drawn text matches the box `dims` was sized to — never the raw,
+        // possibly-overflowing source label.
+        dims.label,
         nodeColor,
         alpha,
         boldBorder,

--- a/packages/graph/tests/renderer-api.test.ts
+++ b/packages/graph/tests/renderer-api.test.ts
@@ -432,6 +432,95 @@ describe("createGraphRenderer", () => {
     expect(Math.max(...labelledBoxCorners.map((corner) => corner.cy))).toBe(59);
   });
 
+  it("PIXEL-FITS a long box label to the capped box width (ellipsis, no overflow)", () => {
+    const context2d = createFakeCanvas2DContext();
+    const canvas = {
+      width: 1000,
+      height: 200,
+      getContext: (kind: string) => (kind === "2d" ? context2d : null),
+    };
+    const view = createGraphRenderer(canvas as unknown as HTMLCanvasElement, {
+      backend: "canvas2d",
+      pixelRatio: 1,
+    });
+    view.setGraph({
+      nodeIds: ["chapter"],
+      positions: new Float32Array([0, 0]),
+      edges: new Uint32Array([]),
+    });
+    // A long chapter title that, measured at 7px/char, would otherwise size a
+    // box ~440px wide — far past the layout. The renderer must clip it to fit.
+    const longLabel =
+      "Part I, Chapter I: Being a Reprint of the Reminiscences of John H. Watson, M.D.";
+    view.setStyle({
+      nodeSizes: new Float32Array([11]),
+      nodeShapes: new Uint8Array([5]),
+      nodeLabels: [longLabel],
+      nodeColors: new Uint8Array([255, 0, 0, 255]),
+      edgeWidths: new Float32Array([]),
+      edgeColors: new Uint8Array([]),
+      edgeDash: new Uint8Array([]),
+      edgeCurvatures: new Float32Array([]),
+    });
+    view.setCamera({ x: 0, y: 0, zoom: 1 });
+    view.render();
+
+    // Geometry: boxHeight = 18 (× pr1 × zoom1), margin = 18 × 5/22, max box
+    // width = 18 × BOX_MAX_WIDTH_RATIO(10) = 180, so the DRAWN text must fit
+    // within 180 − 2×margin. measureText stub = text.length × 7.
+    const boxHeight = 18;
+    const margin = boxHeight * (5 / 22);
+    const maxTextWidth = boxHeight * 10 - 2 * margin;
+
+    // Exactly one label drawn, and it is CLIPPED with a single trailing ellipsis.
+    expect(context2d.calls.fillText).toHaveLength(1);
+    const drawn = context2d.calls.fillText[0]!.text;
+    expect(drawn.endsWith("…")).toBe(true);
+    expect(drawn).not.toBe(longLabel);
+    expect(drawn.length).toBeLessThan(longLabel.length);
+    // Single ellipsis only (no "Foo……").
+    expect(drawn.endsWith("……")).toBe(false);
+    // The drawn text fits the capped width (stub width = length × 7).
+    expect(drawn.length * 7).toBeLessThanOrEqual(maxTextWidth);
+    // And it is the LARGEST such prefix: one more visible glyph would overflow.
+    expect((drawn.length + 1) * 7).toBeGreaterThan(maxTextWidth);
+  });
+
+  it("leaves a short box label untouched (no spurious ellipsis, no width cap)", () => {
+    const context2d = createFakeCanvas2DContext();
+    const canvas = {
+      width: 400,
+      height: 100,
+      getContext: (kind: string) => (kind === "2d" ? context2d : null),
+    };
+    const view = createGraphRenderer(canvas as unknown as HTMLCanvasElement, {
+      backend: "canvas2d",
+      pixelRatio: 1,
+    });
+    view.setGraph({
+      nodeIds: ["work"],
+      positions: new Float32Array([0, 0]),
+      edges: new Uint32Array([]),
+    });
+    view.setStyle({
+      nodeSizes: new Float32Array([11]),
+      nodeShapes: new Uint8Array([5]),
+      nodeLabels: ["Sherlock Holmes"],
+      nodeColors: new Uint8Array([255, 0, 0, 255]),
+      edgeWidths: new Float32Array([]),
+      edgeColors: new Uint8Array([]),
+      edgeDash: new Uint8Array([]),
+      edgeCurvatures: new Float32Array([]),
+    });
+    view.setCamera({ x: 0, y: 0, zoom: 1 });
+    view.render();
+
+    // Short label well within the cap: drawn verbatim, no ellipsis.
+    expect(context2d.calls.fillText).toEqual([
+      { text: "Sherlock Holmes", x: 200, y: 50, font: `${18 * (12 / 22)}px sans-serif` },
+    ]);
+  });
+
   it("measures and draws the box label at the zoom-scaled font (no base/scaled mismatch)", () => {
     const context2d = createFakeCanvas2DContext();
     const canvas = {


### PR DESCRIPTION
## Problem

On the **main graph view**, long `shape:box` labels (chapter / entity / Character-hub names) **overflow** the layout. The renderer sized a box glyph to its label's FULL drawn width with no ceiling, so a long name (e.g. *"Part I, Chapter I: Being a Reprint of the Reminiscences of John H. Watson, M.D., …"*) ballooned into an over-wide text card.

The studio's existing 22-char cap (#160 / BUG-1) only clips **length** and is glyph-width blind — a run of wide glyphs still overflows. #160 hard-fixed only the **recon focal box** (`forceBoxLabel`); chapter / entity / Character boxes on the ordinary graph still spilled. This is the tracked regression.

## Fix — in the shared, backend-agnostic render-geometry

All changes live in `packages/graph/src/renderer.ts` (the box-glyph draw path), so the fix covers **every** box node — main-graph chapter/work/god-class Character hubs **and** the recon focal pair — not a single view.

- **`BOX_MAX_WIDTH_RATIO`** (`packages/graph/src/renderer.ts`) caps the box width at 10× the (degree-independent) box height, scaled by `pixelRatio × zoom` like the height, so the cap reads the same at any zoom. Short labels still hug their text; only long ones hit the ceiling.
- **`fitLabelToWidth()`** pixel-fits the label to `maxWidth − 2·margin` via a binary search over `measureText`, appending a **single** ellipsis. Glyph-width aware, so the box that hugs the returned text is guaranteed to stay within the cap. No double ellipsis; degenerate tiny boxes still draw the ellipsis.
- **`boxDimensions()`** now returns the fitted label; the draw path renders **that** exact string, so the box always hugs precisely what it shows. The geometry pre-pass and the node pass use the same clamped width, so edge-clipping and drawing agree.

The full, untruncated name is untouched on the node payload — hover tooltip + recon rail/detail keep it verbatim.

### Character → labelled box
Data-driven Character **god-class hubs** already map to labelled `roundedbox` glyphs (`computeGodClass` → `buildScene` → styles label gate, per `spec/SPEC_STUDIO_NODE_LABELS.md`). This change guarantees those labels now **fit** their box instead of overflowing — consistent with the recon focal boxes.

## Tests
- 2 new `renderer-api` cases: a long label pixel-clips to the cap with a single ellipsis and is the **largest** fitting prefix; a short label is left untouched.
- **12/12** renderer-api, **35/35** `packages/graph`, **231/231** studio green. `npx vite build` (studio) OK; `packages/graph` JS build OK.

## How to serve it for the user
```
# from the worktree
cd packages/graph && npx tsup --no-dts        # rebuild dist consumed by dist users
cd ../../studio && npx vite build             # build the SPA bundle (dist/)
# the studio dev server reads @sentropic/graph from src via the vite alias:
cd studio && npm run dev                       # then open the printed localhost URL
```
Load a graph with long chapter/entity names (or the mystery pack) and zoom the main graph: box labels now clip with an ellipsis and never overflow the box; Character hubs read as labelled boxes.