### PR TITLE
fix(studio): right-rail CSS — wrap long content + contained internal scroll

### DIFF
--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -165,6 +165,13 @@
     background: var(--st-semantic-surface-default, #fff);
     overflow-y: auto;
     min-height: 0;
+    /* BUG A: the detail panel is nested inside the right rail's scroll
+       container (.sel). min-width:0 lets it shrink to the column width so a
+       long unbreakable token (Source path / description / quote) wraps inside
+       it; overflow-x:hidden guarantees the detail itself never produces a
+       horizontal scrollbar — content wraps, it does not scroll sideways. */
+    min-width: 0;
+    overflow-x: hidden;
     padding: 1rem 1.1rem 2rem;
   }
   .entity-empty,
@@ -201,7 +208,13 @@
   }
   .entity-meta > div {
     display: grid;
-    grid-template-columns: 6.5rem 1fr;
+    /* BUG A: the value track is `minmax(0, 1fr)` (not `1fr`) so it can shrink
+       below the intrinsic width of a long unbreakable token (e.g. a Source
+       path/locator). A bare `1fr` track has an implicit min-width of `auto`,
+       so a long path widens the grid past the panel and triggers a global
+       horizontal scrollbar. Combined with overflow-wrap:anywhere on the dd
+       (below), the path now wraps instead of clipping right. */
+    grid-template-columns: 6.5rem minmax(0, 1fr);
     gap: 0.5rem;
   }
   .entity-meta dt {
@@ -215,7 +228,13 @@
   .entity-meta dd {
     margin: 0;
     color: var(--st-semantic-text-primary, #0f172a);
+    /* BUG A: min-width:0 lets this grid cell shrink under a long token; pair it
+       with overflow-wrap:anywhere + word-break so a long unbreakable Source
+       path (e.g. `.graphify/converted/pdf/…_1eaf490f229c.md:Section 1.2.3 — Et
+       demain?`) breaks and wraps inside the panel instead of clipping right. */
+    min-width: 0;
     overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .entity-src {
     font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
@@ -235,6 +254,11 @@
     line-height: 1.5;
     color: var(--st-semantic-text-primary, #0f172a);
     font-size: 0.9rem;
+    /* BUG A: a description can carry a long unbreakable token (URL / path /
+       identifier). min-width:0 + overflow-wrap:anywhere break it so the text
+       wraps inside the panel instead of widening it into a horizontal scroll. */
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
   .entity-relations {
     list-style: none;
@@ -302,6 +326,22 @@
     font-size: 0.74rem;
     font-weight: 600;
     color: var(--st-semantic-text-secondary, #475569);
+    /* BUG A: the passage locator (e.g. "Section 1.2.3 — Et demain?") wraps
+       inside the panel rather than clipping right. */
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+  /* BUG A: the citation FILE path renders as a DS Collapsible trigger title
+     (e.g. ".graphify/converted/pdf/CONTRIBUATION_AI_AERONAUTIQUE_…md"). Its
+     long unbreakable token must wrap, otherwise it widens the nested accordion
+     and the whole right rail into a horizontal scroll. Scope the wrap to the
+     citation-file triggers only so other (short) titles are unaffected. */
+  .entity-cite-files :global(.st-collapsible__trigger) {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    white-space: normal;
+    text-align: left;
   }
   .entity-cite-quote {
     margin: 0.2rem 0 0;
@@ -311,5 +351,9 @@
     font-size: 0.8rem;
     font-style: italic;
     line-height: 1.4;
+    /* BUG A: a citation quote can contain a long unbreakable token; wrap it so
+       the blockquote never widens the panel into a horizontal scroll. */
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 </style>

--- a/studio/src/components/SelectionPanel.svelte
+++ b/studio/src/components/SelectionPanel.svelte
@@ -161,8 +161,19 @@
 <style>
   .sel {
     background: var(--st-semantic-surface-default, #fff);
-    overflow-y: auto;
+    /* BUG B: the right rail must scroll INSIDE its column like the left rail
+       (.rail), not spill its overflow to the page. The left rail pins
+       height:100% + scrollbar-gutter:stable so `overflow-y:auto` engages
+       against the column height instead of growing the document; mirror that
+       exact pattern here. Without height:100% the panel is content-sized, the
+       column height bound is never reached, and a tall selection/detail pushes
+       the whole document into an external scrollbar. */
+    height: 100%;
     min-height: 0;
+    overflow-y: auto;
+    /* Reserve the gutter so the content width is identical with or without the
+       scrollbar (no reflow when a long detail expands). */
+    scrollbar-gutter: stable;
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary

Two CSS bugs in the graphify studio **right rail** (SELECTION → Entities → entity detail: COMMUNITY / SOURCE / DESCRIPTION / Relations / Citations). Field report from ia-aero (h2a `env:1782138210029:f6d9`), studio SPA 0.15.1. Rides the next 0.15.2 batched release.

### BUG A — horizontal overflow not handled in the detail panel
A long unbreakable token (Source path/locator, description, citation file path/quote) widened the label/value grid past the panel and triggered a global horizontal scrollbar that clipped content on the right. The value grid track was a bare `1fr` (implicit `min-width:auto`), so it could not shrink below the token's intrinsic width.

**`studio/src/components/EntityPanel.svelte`:**
- `.entity-meta > div` value track `1fr` → `minmax(0, 1fr)` so the cell can shrink under a long token.
- `.entity-meta dd` (Source / Community): `min-width:0` + `overflow-wrap:anywhere` + `word-break:break-word`.
- `.entity-description`: `min-width:0` + `overflow-wrap:anywhere`.
- `.entity-cite-quote`: `min-width:0` + `overflow-wrap:anywhere`.
- `.entity-cite-section` (passage locator, e.g. `Section 1.2.3 — Et demain?`): wrap.
- Citation FILE-path Collapsible title (e.g. `.graphify/converted/pdf/CONTRIBUATION_AI_AERONAUTIQUE_…md`): scoped `:global(.st-collapsible__trigger)` wrap inside `.entity-cite-files`.
- `.entity` container: `min-width:0` + `overflow-x:hidden` — content wraps, never scrolls sideways. **No `overflow-x:auto`** (wrap is preferred, per the report).

### BUG B — vertical scroll inconsistent right vs left
The left rail scrolls INSIDE its column; the right rail had only `overflow-y:auto; min-height:0` (no height bound), so a tall selection/detail spilled into an external page scrollbar — inconsistent and ugly.

**`studio/src/components/SelectionPanel.svelte`** — mirror the left-rail (`LeftRail.svelte` `.rail`) contained pattern on `.sel`: `height:100%` + `min-height:0` + `overflow-y:auto` + `scrollbar-gutter:stable` → contained internal scroll, identical both sides.

> Class-hash map (the field report's scoped hashes): `.svelte-i76rms` = SelectionPanel `.sel` (right-rail container), `.svelte-1ycopz` = EntityPanel `.entity` (detail/citations, monospace `.entity-src`/`.entity-id`), `.svelte-lgosa7` = LeftRail `.rail` (reference contained pattern).

## Verification
- `npx vite build` — green (only pre-existing LeftRail a11y warnings, untouched here).
- `npx vitest run` — **231/231 pass** (18 files). Changes are CSS-only; no JS touched.
- Confirmed compiled into the bundle: two `scrollbar-gutter:stable` rules, the `minmax(0,1fr)` grid track, the `overflow-wrap:anywhere` rules.

## How to validate visually (user)
This is a visual fix — please confirm in the browser:
\`\`\`
cd studio && npm install && npx vite build
node ../scripts/static-serve.js studio/dist   # or any static server on studio/dist
\`\`\`
Open the app, pick an entity with a long Source path (e.g. a `.graphify/converted/pdf/…md:Section …` locator) into the right rail. Expect: Source / Description / Citations **wrap** inside the panel (no horizontal scrollbar, no right-clipping), and the right rail scrolls **inside itself** (no external page scrollbar), matching the left facets rail.