### PR TITLE
feat(track-f): .slnx solution file extractor (F-0832, upstream 29e57cd #1189)

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -28,11 +28,12 @@ export const CODE_EXTENSIONS = new Set([
   // Tree-sitter TypeScript already handles .ets AST extraction; detect just
   // needed to recognize the extension. Port of upstream safishamsi 52d75bd / #926.
   ".ets",
-  // .NET project files — port of upstream safishamsi 8bcfffd / #515.
-  // Regex-backed extractors (extractSln, extractCsproj) handle these; no tree-sitter
-  // grammar required. .props/.targets are MSBuild SDK extension files that share the
-  // same XML schema as .csproj and are dispatched to extractCsproj.
-  ".sln", ".csproj", ".fsproj", ".vbproj", ".props", ".targets",
+  // .NET project files — port of upstream safishamsi 8bcfffd / #515 / 29e57cd.
+  // Regex-backed extractors (extractSln, extractSlnx, extractCsproj) handle these; no
+  // tree-sitter grammar required. .props/.targets are MSBuild SDK extension files that
+  // share the same XML schema as .csproj and are dispatched to extractCsproj. .slnx is
+  // the XML-based VS 2022 17.13+ replacement for .sln, dispatched to extractSlnx.
+  ".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".props", ".targets",
 ]);
 
 /**

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -4895,9 +4895,121 @@ export function extractSln(filePath: string, _rootDir?: string): ExtractionResul
   return { nodes, edges };
 }
 
+// XML-based .slnx solution files (VS 2022 17.13+ replacement for .sln).
+const _SLNX_PROJECT_RE = /<Project\s[^>]*Path="([^"]+)"[^>]*\/?>/gi;
+const _SLNX_BUILDDEP_RE = /<BuildDependency\s[^>]*Project="([^"]+)"[^>]*\/?>/gi;
+
+/**
+ * Extract projects and inter-project dependencies from a .slnx file.
+ *
+ * `.slnx` is the XML-based replacement for the legacy `.sln` format. Projects
+ * are listed as `<Project Path="..."/>` elements (optionally nested inside
+ * `<Folder>` elements) and build-order dependencies as `<BuildDependency
+ * Project="..."/>` children. Unlike `.sln` there are no GUIDs — projects are
+ * identified by their (resolved) path.
+ *
+ * XML guard (ad3f3b2): size cap + DOCTYPE/ENTITY rejection before any parse.
+ * Extraction: regex over raw text (no XML parser), safe after the guard —
+ * mirrors `extractCsproj`. Port of upstream extract_slnx (29e57cd, #1189).
+ */
+export function extractSlnx(filePath: string, _rootDir?: string): ExtractionResult {
+  let src: Buffer;
+  try {
+    src = readFileSync(filePath) as Buffer;
+  } catch (e: unknown) {
+    return { nodes: [], edges: [], error: String(e) };
+  }
+
+  // --- XML DoS guard (ad3f3b2) — same as extractCsproj ---
+  if (src.length > _PROJECT_XML_MAX_BYTES) {
+    return { nodes: [], edges: [], error: "project file too large (>2 MiB)" };
+  }
+  if (!_projectXmlIsSafe(src)) {
+    return { nodes: [], edges: [], error: "refusing XML with DOCTYPE/ENTITY declaration (billion-laughs guard)" };
+  }
+
+  const text = src.toString("utf-8");
+  const fileNid = _makeId(resolve(filePath));
+  const nodes: GraphNode[] = [{
+    id: fileNid,
+    label: basename(filePath),
+    file_type: "code",
+    source_file: filePath,
+    source_location: "L1",
+  }];
+  const edges: GraphEdge[] = [];
+  const seenIds = new Set([fileNid]);
+  const projectNids = new Set<string>();
+
+  function resolveProj(projPath: string): string {
+    const norm = projPath.replace(/\\/g, "/");
+    try {
+      return resolve(dirname(filePath), norm);
+    } catch {
+      return norm;
+    }
+  }
+
+  // First pass: collect projects (anywhere in the tree, including <Folder>).
+  _SLNX_PROJECT_RE.lastIndex = 0;
+  for (const m of text.matchAll(_SLNX_PROJECT_RE)) {
+    const projPath = m[1]!;
+    const absProj = resolveProj(projPath);
+    const projNid = _makeId(absProj);
+    if (!projNid) continue;
+    if (!seenIds.has(projNid)) {
+      seenIds.add(projNid);
+      nodes.push({
+        id: projNid,
+        label: basename(projPath.replace(/\\/g, "/")).replace(/\.[^.]+$/, ""),
+        file_type: "code",
+        source_file: absProj,
+      });
+      edges.push({
+        source: fileNid,
+        target: projNid,
+        relation: "contains",
+        confidence: "EXTRACTED",
+        source_file: filePath,
+        weight: 1.0,
+      });
+    }
+    projectNids.add(projNid);
+  }
+
+  // Second pass: build-order dependencies between known projects.
+  // Walk each <Project ...> ... </Project> block and read its <BuildDependency>.
+  const _PROJECT_BLOCK_RE = /<Project\s[^>]*Path="([^"]+)"[^>]*>([\s\S]*?)<\/Project>/gi;
+  _PROJECT_BLOCK_RE.lastIndex = 0;
+  for (const block of text.matchAll(_PROJECT_BLOCK_RE)) {
+    const fromNid = _makeId(resolveProj(block[1]!));
+    if (!fromNid) continue;
+    const inner = block[2]!;
+    _SLNX_BUILDDEP_RE.lastIndex = 0;
+    for (const dep of inner.matchAll(_SLNX_BUILDDEP_RE)) {
+      const toNid = _makeId(resolveProj(dep[1]!));
+      if (fromNid && toNid && fromNid !== toNid && projectNids.has(toNid)) {
+        edges.push({
+          source: fromNid,
+          target: toNid,
+          relation: "imports",
+          confidence: "EXTRACTED",
+          source_file: filePath,
+          weight: 1.0,
+        });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
 // Async wrappers so they fit the ExtractorFn signature expected by _DISPATCH.
 async function _extractSlnAsync(filePath: string, rootDir?: string): Promise<ExtractionResult> {
   return extractSln(filePath, rootDir);
+}
+async function _extractSlnxAsync(filePath: string, rootDir?: string): Promise<ExtractionResult> {
+  return extractSlnx(filePath, rootDir);
 }
 async function _extractCsprojAsync(filePath: string, rootDir?: string): Promise<ExtractionResult> {
   return extractCsproj(filePath, rootDir);
@@ -5161,8 +5273,9 @@ const _DISPATCH: Record<string, ExtractorFn> = {
   ".f95": extractRegexBackedCode,
   ".f03": extractRegexBackedCode,
   ".f08": extractRegexBackedCode,
-  // .NET project files — port of upstream 8bcfffd / ad3f3b2
+  // .NET project files — port of upstream 8bcfffd / ad3f3b2 / 29e57cd
   ".sln": _extractSlnAsync,
+  ".slnx": _extractSlnxAsync,
   ".csproj": _extractCsprojAsync,
   ".fsproj": _extractCsprojAsync,
   ".vbproj": _extractCsprojAsync,
@@ -5378,8 +5491,8 @@ const _EXTENSIONS = new Set([
   ".vue", ".svelte", ".astro", ".dart", ".groovy", ".gradle", ".v", ".sv", ".svh", ".ejs",
   ".md", ".mdx", ".qmd",
   ".luau", ".r", ".R", ".f", ".F", ".f90", ".F90", ".f95", ".F95", ".f03", ".F03", ".f08", ".F08",
-  // .NET project files (8bcfffd / ad3f3b2)
-  ".sln", ".csproj", ".fsproj", ".vbproj", ".props", ".targets",
+  // .NET project files (8bcfffd / ad3f3b2 / 29e57cd)
+  ".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".props", ".targets",
 ]);
 
 /**

--- a/tests/extract-dotnet.test.ts
+++ b/tests/extract-dotnet.test.ts
@@ -22,7 +22,7 @@ import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CODE_EXTENSIONS } from "../src/detect.js";
-import { extractSln, extractCsproj, __testing } from "../src/extract.js";
+import { extractSln, extractSlnx, extractCsproj, __testing } from "../src/extract.js";
 
 const { getExtractor } = __testing;
 
@@ -73,6 +73,77 @@ describe("F-0819-M extractSln", () => {
   it("returns error for a missing file", () => {
     const r = extractSln("/nonexistent/missing.sln");
     expect(r.error).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .slnx extractor (F-0832 — upstream 29e57cd / #1189)
+// ---------------------------------------------------------------------------
+describe("F-0832 extractSlnx", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-slnx-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("returns no error for sample.slnx", () => {
+    const r = extractSlnx(fixture("sample.slnx"));
+    expect(r.error).toBeUndefined();
+  });
+
+  it("extracts a file node for the .slnx itself", () => {
+    const r = extractSlnx(fixture("sample.slnx"));
+    expect(r.nodes.length).toBeGreaterThanOrEqual(1);
+    expect(r.nodes[0]!.label).toBe("sample.slnx");
+  });
+
+  it("extracts project nodes (incl. ones nested in <Folder>): WebApi, Domain, Tests", () => {
+    const r = extractSlnx(fixture("sample.slnx"));
+    const labels = r.nodes.map((n) => n.label);
+    expect(labels).toContain("WebApi");
+    expect(labels).toContain("Domain");
+    expect(labels).toContain("Tests");
+  });
+
+  it("emits contains edges from slnx to each project", () => {
+    const r = extractSlnx(fixture("sample.slnx"));
+    const containsEdges = r.edges.filter((e) => e.relation === "contains");
+    expect(containsEdges.length).toBe(3);
+  });
+
+  it("emits an imports edge for a BuildDependency between known projects", () => {
+    const r = extractSlnx(fixture("sample.slnx"));
+    const importsEdges = r.edges.filter((e) => e.relation === "imports");
+    expect(importsEdges.length).toBe(1);
+    // WebApi -> Domain
+    const webApi = r.nodes.find((n) => n.label === "WebApi");
+    const domain = r.nodes.find((n) => n.label === "Domain");
+    expect(importsEdges[0]!.source).toBe(webApi!.id);
+    expect(importsEdges[0]!.target).toBe(domain!.id);
+  });
+
+  it("returns error for a missing file", () => {
+    const r = extractSlnx("/nonexistent/missing.slnx");
+    expect(r.error).toBeDefined();
+  });
+
+  it("rejects a DOCTYPE/ENTITY billion-laughs payload (XML guard reused)", () => {
+    const payload = [
+      "<?xml version=\"1.0\"?>",
+      "<!DOCTYPE lolz [<!ENTITY lol \"lol\">]>",
+      "<Solution><Project Path=\"a/a.csproj\" /></Solution>",
+    ].join("\n");
+    const p = join(dir, "evil.slnx");
+    writeFileSync(p, payload, "utf-8");
+    const r = extractSlnx(p);
+    expect(r.error).toBeDefined();
+    expect(r.error).toMatch(/DOCTYPE|ENTITY/i);
+  });
+
+  it("rejects input larger than 2 MiB", () => {
+    const p = join(dir, "huge.slnx");
+    writeFileSync(p, Buffer.alloc(2 * 1024 * 1024 + 1, 0x20));
+    const r = extractSlnx(p);
+    expect(r.error).toBeDefined();
+    expect(r.error).toMatch(/too large/i);
   });
 });
 
@@ -208,7 +279,7 @@ describe("F-0819-M XML DoS guard (ad3f3b2)", () => {
 // Dispatch table
 // ---------------------------------------------------------------------------
 describe("F-0819-M dispatch table", () => {
-  it.each([".sln", ".csproj", ".fsproj", ".vbproj", ".props", ".targets"])(
+  it.each([".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".props", ".targets"])(
     "routes %s to a .NET extractor",
     (ext) => {
       const fn = getExtractor(`foo${ext}`);
@@ -221,7 +292,7 @@ describe("F-0819-M dispatch table", () => {
 // CODE_EXTENSIONS
 // ---------------------------------------------------------------------------
 describe("F-0819-M CODE_EXTENSIONS", () => {
-  it.each([".sln", ".csproj", ".fsproj", ".vbproj", ".props", ".targets"])(
+  it.each([".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".props", ".targets"])(
     "contains %s",
     (ext) => {
       expect(CODE_EXTENSIONS.has(ext)).toBe(true);

--- a/tests/fixtures/sample.slnx
+++ b/tests/fixtures/sample.slnx
@@ -1,0 +1,11 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/WebApi/WebApi.csproj">
+      <BuildDependency Project="src/Domain/Domain.csproj" />
+    </Project>
+    <Project Path="src/Domain/Domain.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Tests/Tests.csproj" />
+  </Folder>
+</Solution>


### PR DESCRIPTION
## What

Ports upstream safishamsi **29e57cd (#1189)** — support for the XML-based `.slnx` solution format (the VS 2022 17.13+ replacement for `.sln`). This is the first lot of the **post-cadrage `v0.8.32+` upstream drift** (the `v0.8.18..v0.8.31` window was already closed by the F-0819/F-0820-0827/F-0831 lots; this `.slnx` commit is the lowest-risk item in the newer window).

## Why this lot first

- **Mechanical & additive**: a new file extension only — no change to existing `.sln`/`.csproj` behaviour, no graph-schema change, no new dependencies.
- **Pairs cleanly** with the already-merged `.NET` project-file extractor (F-0819-M, PR #114): reuses the existing `_PROJECT_XML_MAX_BYTES` size cap and `_projectXmlIsSafe` DOCTYPE/ENTITY billion-laughs guard.
- **Fully testable** with the existing `tests/extract-dotnet.test.ts` harness.

## Changes

- `src/extract.ts`: new `extractSlnx` (regex over clean XML, no XML parser, guard-first). Emits a file node, one project node per `<Project Path="..."/>` (incl. projects nested in `<Folder>`), `contains` edges to each project, and `imports` edges for `<BuildDependency Project="..."/>` between known projects. Wired into `_DISPATCH` + `_EXTENSIONS`.
- `src/detect.ts`: `.slnx` added to `CODE_EXTENSIONS`.
- `tests/extract-dotnet.test.ts`: fixture `sample.slnx` + 8 new tests (nodes, folder-nested project, contains/imports edges, missing-file error, DOCTYPE/ENTITY rejection, 2 MiB size cap). Dispatch + `CODE_EXTENSIONS` `it.each` tables extended to include `.slnx`.

## Verification

- `tsc --noEmit` — clean (exit 0).
- `vitest run tests/extract-dotnet.test.ts` — **41 passed** (33 existing + 8 new).
- `vitest run tests/extract-dotnet.test.ts tests/detect.test.ts` — **113 passed**.

## Follow-up (NOT in this PR — needs a Track-F decision)

The newer upstream window **`v0.8.32`..`v0.8.45`** (and a fresh `v1.0.0` lightweight tag) is **~162 commits** past the last cadrage head (`fff1c98`, 2026-06-05) and has **not** been triaged. It contains real correctness/security work (FalkorDB export, Streamable-HTTP MCP, Terraform/HCL, several dedup/cache/global-graph fixes, `bandit`/`pip-audit` CI). A proper Track-F cadrage bilan of that window should pick the next lots and the release vehicle. See `.graphify/scratch/UPSTREAM_SYNC_ANALYSIS.md`.