### PR TITLE
feat(studio): ia-aero entities-export — 0%-coverage warning + rationale fallback + Step 5 describe-required

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4542,6 +4542,11 @@ export async function main(): Promise<void> {
             `  nodes: ${result.nodeCount} | scene nodes: ${result.sceneNodeCount} | scene edges: ${result.sceneEdgeCount}`,
           );
           console.log(`  entities index: ${result.entityCount} | reconciliation candidates: ${result.reconciliationCount}`);
+          {
+            const cov = result.descriptionCoverage;
+            const provisionalNote = cov.provisional > 0 ? ` (+${cov.provisional} provisional from rationale)` : "";
+            console.log(`  descriptions: ${cov.described}/${cov.total} real${provisionalNote}`);
+          }
           console.log(
             `  workspace-manifest: ${result.manifestPresentCount}/${result.manifestArtifactCount} artifacts present`,
           );

--- a/src/skills/skill.md
+++ b/src/skills/skill.md
@@ -487,6 +487,15 @@ graphify update .
 
 **Opt out of either step**: `--no-description` / `--no-label`.
 
+> **REQUIRED before the studio/wiki export — `describe` is NOT optional for a populated studio.** There is an asymmetry to know about: the default `graphify update` flow wires the community-**labels** pass automatically, but the node-**descriptions** pass only fills `graph.json` when you actually complete the assistant two-step (or run with a key). If you skip it, every node ships with `description: null` and the **static studio / wiki export shows empty entity panels silently** (field report ia-aero: 620/620 null descriptions). The export now *warns* on ~0% description coverage and *provisionally* backfills entity panels from each node's extractor `rationale` (clearly marked "provisional" in the studio) — but that is a stop-gap, not a real description.
+>
+> So, for non-null descriptions, the explicit order is:
+>
+> 1. `graphify update .` (emits `.graphify/description-instructions/` + `.graphify/label-instructions/`).
+> 2. Fill **both** the `batch-NNN.json` description answers **and** `communities.json` labels.
+> 3. `graphify update .` again to ingest — OR, on an already-built/curated graph, `graphify describe .` (descriptions) + `graphify label .` (labels) non-destructively.
+> 4. **Then** generate the static Ontology Studio (Step 6). Confirm descriptions landed: a 0%-description studio means Step 5 was skipped — go back and run `describe`.
+
 **Language attention (per source).** Descriptions and community names are written in the **language of each node's SOURCE document**, detected per node from its label + citations (and the community's sampled node names). A 100%-French corpus yields French descriptions and French community names; a mixed corpus gets each node's description in its own source language — never a random FR/EN mix left to the backend's whim. The directive is injected into **every** prompt: the assistant `batch-NNN.md` files (look for the `Write every description in <Language>` line, or per-node `lang=` markers on a mixed batch) AND the direct API path. When you (the host assistant) fill an instruction file, **honor that language directive** — answer in the language the instruction states, per node.
 
 - Default is `--description-lang auto` / `--label-lang auto` (detect per source).

--- a/src/studio-assets.ts
+++ b/src/studio-assets.ts
@@ -176,9 +176,16 @@ interface GraphNodeDescriptionCacheEntry {
 }
 
 const graphDescriptionCache = new Map<string, GraphNodeDescriptionCacheEntry>();
+// Parallel index of node `rationale` (the extractor's 1-2 sentence justification),
+// used as a CLEARLY-MARKED provisional fallback when a node has no description.
+const graphRationaleCache = new Map<string, GraphNodeDescriptionCacheEntry>();
 
 interface GraphFileShape {
   nodes?: Array<{ id?: unknown; description?: unknown }>;
+}
+
+interface GraphFileShapeWithRationale {
+  nodes?: Array<{ id?: unknown; rationale?: unknown }>;
 }
 
 /**
@@ -214,9 +221,45 @@ function loadGraphNodeDescriptions(stateDir: string): Map<string, string> {
   return byId;
 }
 
-/** Test seam: drop the cached graph.json node-description index. */
+/**
+ * Map of node id -> trimmed non-empty `rationale` from `<stateDir>/graph.json`.
+ * The extractor fills `rationale` (a 1-2 sentence justification) on most nodes
+ * even when `describe` has NOT run, so this is the provisional fallback source
+ * for {@link buildEntitySidecar}. Same mtime-keyed caching as the description
+ * index. Returns an empty map when graph.json is missing/unreadable.
+ */
+function loadGraphNodeRationales(stateDir: string): Map<string, string> {
+  const graphPath = join(stateDir, "graph.json");
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(graphPath).mtimeMs;
+  } catch {
+    graphRationaleCache.delete(stateDir);
+    return new Map();
+  }
+  const cached = graphRationaleCache.get(stateDir);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.byId;
+
+  const byId = new Map<string, string>();
+  const graph = loadJsonSafe<GraphFileShapeWithRationale>(graphPath);
+  if (graph && Array.isArray(graph.nodes)) {
+    for (const node of graph.nodes) {
+      const id = node?.id;
+      if (typeof id !== "string" || !id) continue;
+      const rationale = node?.rationale;
+      if (typeof rationale !== "string") continue;
+      const trimmed = rationale.trim();
+      if (trimmed) byId.set(id, trimmed);
+    }
+  }
+  graphRationaleCache.set(stateDir, { mtimeMs, byId });
+  return byId;
+}
+
+/** Test seam: drop the cached graph.json node-description + rationale indexes. */
 export function __resetGraphDescriptionCache(): void {
   graphDescriptionCache.clear();
+  graphRationaleCache.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -329,6 +372,29 @@ function loadCitationsForNode(stateDir: string, id: string): CitationSidecarEntr
   return { count, citations };
 }
 
+/**
+ * Normalised per-node description for the entity panel.
+ *
+ * `source` records WHERE the text came from so a provisional fallback can never
+ * masquerade as a real `describe` output:
+ *   - `"description"` — the node's own `graph.json` description, or the opt-in
+ *     wiki sidecar (a real, generated description). `provisional` is omitted.
+ *   - `"rationale"` — a CLEARLY-MARKED fallback: the node had no description but
+ *     carried an extractor `rationale`, surfaced so the studio is never empty.
+ *     `provisional: true` flags it so consumers (and the user) know `describe`
+ *     is still recommended for a proper description. `status` stays `"generated"`
+ *     so the SPA renders the text, but the marking keeps the "run describe"
+ *     signal alive (the 0%-coverage warning counts only REAL descriptions).
+ */
+export interface EntitySidecarDescription {
+  status: string;
+  description: string | null;
+  /** Where the description text came from (omitted = the default `"description"`). */
+  source?: "description" | "rationale";
+  /** True only for the `rationale` fallback — a provisional, describe-still-recommended fill. */
+  provisional?: boolean;
+}
+
 export interface EntitySidecarResponse {
   id: string;
   /**
@@ -344,7 +410,7 @@ export interface EntitySidecarResponse {
   community?: number;
   /** Human community label (named, then "Community N"), when present (Bug A). */
   community_name?: string | null;
-  description: { status: string; description: string | null } | null;
+  description: EntitySidecarDescription | null;
   occurrences: unknown;
   /**
    * Level-2 full per-entity citation list, lazily served (SPEC_CITATIONS.md).
@@ -394,6 +460,14 @@ function sidecarNodeType(node: EntitySidecarNode | undefined): string | null {
  * the opt-in wiki sidecar index is consulted only when the node has none. So a
  * graph whose nodes all carry descriptions reports them all here even without a
  * wiki sidecar present.
+ *
+ * Rationale fallback (field report ia-aero): when a node has NO real description
+ * (node + wiki both empty) but carries an extractor `rationale`, the rationale
+ * is surfaced as a CLEARLY-MARKED provisional description (`source: "rationale"`,
+ * `provisional: true`) so the studio is never empty when the data already
+ * exists — avoiding a costly 2nd LLM pass for a good-enough result. The marking
+ * means it never masks the "run `describe`" signal: it counts as ungrounded for
+ * the 0%-coverage warning, which still recommends `describe`.
  */
 export function buildEntitySidecar(
   stateDir: string,
@@ -405,7 +479,7 @@ export function buildEntitySidecar(
   // 1. graph.json node.description (the default WP11 source).
   const nodeDescription = loadGraphNodeDescriptions(stateDir).get(id);
   if (nodeDescription) {
-    description = { status: "generated", description: nodeDescription };
+    description = { status: "generated", description: nodeDescription, source: "description" };
   } else {
     // 2. Fall back to the opt-in wiki description sidecar.
     const index = loadDescriptionIndex(stateDir);
@@ -413,8 +487,24 @@ export function buildEntitySidecar(
     if (entry) {
       description =
         entry.status === "generated"
-          ? { status: "generated", description: entry.description ?? null }
-          : { status: "insufficient_evidence", description: null };
+          ? { status: "generated", description: entry.description ?? null, source: "description" }
+          : { status: "insufficient_evidence", description: null, source: "description" };
+    }
+  }
+
+  // 3. Provisional rationale fallback: only when no REAL description text was
+  //    found (no node/wiki "generated" string). An insufficient_evidence wiki
+  //    entry is still treated as "no description text", so the rationale fills
+  //    it — clearly marked provisional so `describe` stays recommended.
+  if (!description || (description.status !== "generated" || !description.description)) {
+    const rationale = loadGraphNodeRationales(stateDir).get(id);
+    if (rationale) {
+      description = {
+        status: "generated",
+        description: rationale,
+        source: "rationale",
+        provisional: true,
+      };
     }
   }
 

--- a/src/studio-export.ts
+++ b/src/studio-export.ts
@@ -50,6 +50,7 @@ import { emitSceneHierarchies } from "./scene-hierarchies-emitter.js";
 import {
   buildEntitySidecar,
   type EntitySidecarNode,
+  type EntitySidecarResponse,
   resolveStudioAppDir,
 } from "./studio-assets.js";
 import { buildStudioScene, type StudioSceneGraphLike } from "./studio-scene.js";
@@ -99,6 +100,8 @@ export interface BuildStaticStudioResult {
   sceneNodeCount: number;
   sceneEdgeCount: number;
   entityCount: number;
+  /** Per-node description coverage (field report ia-aero); drives the low-coverage hint. */
+  descriptionCoverage: StudioDescriptionCoverage;
   reconciliationCount: number;
   sceneHierarchiesPath: string | null;
   classHierarchiesPath: string | null;
@@ -132,6 +135,61 @@ const GENERATED_DATA_FILES = [
 
 /** Stale directories a previous (possibly multi-model) export may have left. */
 const GENERATED_DATA_DIRS = ["assets", "ontology", "models"];
+
+/**
+ * Below this fraction of real descriptions (per describable node), the export
+ * emits a `describe`-pipeline hint (field report ia-aero). A ~0%-description
+ * graph is almost always an incomplete pipeline (`describe` was never run).
+ */
+const LOW_DESCRIPTION_COVERAGE_THRESHOLD = 0.02;
+
+/** Per-node description coverage of a static studio export. */
+export interface StudioDescriptionCoverage {
+  /** Nodes the export built an entity sidecar for. */
+  total: number;
+  /**
+   * Nodes with a REAL description — a generated, non-provisional description
+   * (the node's own graph.json description or a generated wiki entry).
+   * Provisional rationale fallbacks are deliberately EXCLUDED so the warning
+   * still fires when only rationales exist.
+   */
+  described: number;
+  /** Nodes filled by the provisional rationale fallback (source: "rationale"). */
+  provisional: number;
+}
+
+/** True when a sidecar description is a real, generated (non-provisional) one. */
+function isRealDescription(description: EntitySidecarResponse["description"]): boolean {
+  return (
+    !!description &&
+    description.status === "generated" &&
+    typeof description.description === "string" &&
+    description.description.trim().length > 0 &&
+    description.source !== "rationale"
+  );
+}
+
+/**
+ * Build the low-description-coverage hint (field report ia-aero), or null when
+ * coverage is healthy. Styled after the 'large corpus' detection warning.
+ */
+export function lowDescriptionCoverageWarning(
+  coverage: StudioDescriptionCoverage,
+): string | null {
+  const { total, described, provisional } = coverage;
+  if (total === 0) return null;
+  if (described / total > LOW_DESCRIPTION_COVERAGE_THRESHOLD) return null;
+  const pct = ((described / total) * 100).toFixed(described === 0 ? 0 : 1);
+  const provisionalNote =
+    provisional > 0
+      ? ` ${provisional} node(s) were filled provisionally from the extractor rationale (marked provisional in the studio) — good-enough, but not a real description.`
+      : "";
+  return (
+    `studio export: only ${described}/${total} node(s) (~${pct}%) have a real description. ` +
+    `A ~0%-description graph almost always means the description pass never ran.${provisionalNote} ` +
+    `Run \`graphify describe .\` (no API key needed — assistant mode) before exporting for non-null descriptions.`
+  );
+}
 
 /**
  * Guard against a destructive export. {@link buildStaticStudio} cleans `outDir`
@@ -309,16 +367,30 @@ export function buildStaticStudio(
   }
 
   // entities.json source: { id: sidecar } index built from stateDir BEFORE
-  // cleanup (buildEntitySidecar reads from stateDir).
+  // cleanup (buildEntitySidecar reads from stateDir). Track description coverage
+  // as we go so a ~0%-description export can warn (field report ia-aero).
   const entities: Record<string, unknown> = {};
+  const coverage: StudioDescriptionCoverage = { total: 0, described: 0, provisional: 0 };
   for (const node of nodes) {
     const id = (node as { id?: unknown }).id;
     if (typeof id !== "string" || !id) continue;
     // Pass the graph node so the sidecar carries its type/community (Bug A):
     // the SPA facets then populate from entities.json even when graph.json is
     // not hydrated (scene-only studio.html / file:// multi-file bundle).
-    entities[id] = buildEntitySidecar(stateDir, id, node as EntitySidecarNode);
+    const sidecar = buildEntitySidecar(stateDir, id, node as EntitySidecarNode);
+    entities[id] = sidecar;
+    coverage.total += 1;
+    if (isRealDescription(sidecar.description)) coverage.described += 1;
+    else if (sidecar.description?.source === "rationale") coverage.provisional += 1;
   }
+
+  // Low-description-coverage hint (field report ia-aero): a ~0%-description
+  // graph almost always means `describe` never ran. Emit a non-fatal warning
+  // pointing the user to `graphify describe` — provisional rationale fallbacks
+  // do NOT count as described, so the signal survives even when the studio is
+  // visually populated from rationales.
+  const coverageWarning = lowDescriptionCoverageWarning(coverage);
+  if (coverageWarning) warn(coverageWarning);
 
   // reconciliation candidates source (read before cleanup).
   let candidatesResponse: { items: unknown[]; total?: number } = { items: [], total: 0 };
@@ -480,6 +552,7 @@ export function buildStaticStudio(
     sceneNodeCount: scene.nodes.length,
     sceneEdgeCount: scene.edges.length,
     entityCount: Object.keys(entities).length,
+    descriptionCoverage: coverage,
     reconciliationCount: candidatesResponse.total ?? candidatesResponse.items.length,
     sceneHierarchiesPath: hierarchiesResult.path,
     classHierarchiesPath,

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -50,6 +50,12 @@
     }
     return null;
   });
+  // Provisional rationale fallback (field report ia-aero): the description text
+  // came from the extractor's `rationale`, not a real `describe` pass. Mark it so
+  // the panel never silently presents a fallback as a curated description.
+  const descriptionProvisional = $derived(
+    entity?.description?.source === "rationale" && entity?.description?.provisional === true,
+  );
 </script>
 
 <aside class="entity" aria-label="Entity detail">
@@ -84,7 +90,12 @@
 
     {#if description}
       <section class="entity-section">
-        <h3 class="entity-section-heading">Description</h3>
+        <h3 class="entity-section-heading">
+          Description
+          {#if descriptionProvisional}
+            <span class="entity-description-provisional" title="From the extractor rationale — run `graphify describe` for a proper description.">provisional</span>
+          {/if}
+        </h3>
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="entity-description">{@html renderInlineMarkdown(description)}</div>
       </section>
@@ -235,6 +246,18 @@
     line-height: 1.5;
     color: var(--st-semantic-text-primary, #0f172a);
     font-size: 0.9rem;
+  }
+  .entity-description-provisional {
+    margin-left: 0.4rem;
+    padding: 0.05rem 0.35rem;
+    border-radius: var(--st-radius-sm, 4px);
+    background: var(--st-semantic-surface-subtle, #f1f5f9);
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    color: var(--st-semantic-text-secondary, #64748b);
+    font-size: 0.62rem;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    cursor: help;
   }
   .entity-relations {
     list-style: none;

--- a/tests/studio-assets.test.ts
+++ b/tests/studio-assets.test.ts
@@ -171,6 +171,7 @@ describe("buildEntitySidecar", () => {
     expect(res.description).toEqual({
       status: "generated",
       description: "Entry point that wires the asset routes.",
+      source: "description",
     });
   });
 
@@ -180,7 +181,11 @@ describe("buildEntitySidecar", () => {
     // node's own description must win.
     writeGraph(dir, [{ id: "work_a", description: "Node-level one-liner." }]);
     const res = buildEntitySidecar(dir, "work_a");
-    expect(res.description).toEqual({ status: "generated", description: "Node-level one-liner." });
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "Node-level one-liner.",
+      source: "description",
+    });
   });
 
   it("falls back to the wiki sidecar when the node has no description", () => {
@@ -188,7 +193,11 @@ describe("buildEntitySidecar", () => {
     // graph.json present but work_a carries no description -> wiki fallback.
     writeGraph(dir, [{ id: "work_a" }]);
     const res = buildEntitySidecar(dir, "work_a");
-    expect(res.description).toEqual({ status: "generated", description: "A landmark **novel**." });
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "A landmark **novel**.",
+      source: "description",
+    });
   });
 
   it("ignores blank/non-string node descriptions and falls back", () => {
@@ -196,21 +205,34 @@ describe("buildEntitySidecar", () => {
     writeGraph(dir, [{ id: "place_b", description: "   " }]);
     const res = buildEntitySidecar(dir, "place_b");
     // Blank node description -> wiki sidecar (insufficient_evidence) takes over.
-    expect(res.description).toEqual({ status: "insufficient_evidence", description: null });
+    // No rationale on the node, so the provisional fallback does not fire.
+    expect(res.description).toEqual({
+      status: "insufficient_evidence",
+      description: null,
+      source: "description",
+    });
   });
 
   it("returns the generated wiki description for a node", () => {
     const dir = makeStateDir();
     const res = buildEntitySidecar(dir, "work_a");
     expect(res.id).toBe("work_a");
-    expect(res.description).toEqual({ status: "generated", description: "A landmark **novel**." });
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "A landmark **novel**.",
+      source: "description",
+    });
     expect(res.occurrences).toEqual({ total: 7, documents: { "doc.txt": 7 } });
   });
 
   it("normalises insufficient-evidence entries", () => {
     const dir = makeStateDir();
     const res = buildEntitySidecar(dir, "place_b");
-    expect(res.description).toEqual({ status: "insufficient_evidence", description: null });
+    expect(res.description).toEqual({
+      status: "insufficient_evidence",
+      description: null,
+      source: "description",
+    });
   });
 
   it("yields nulls for an unknown node id (panel degrades gracefully)", () => {
@@ -223,6 +245,69 @@ describe("buildEntitySidecar", () => {
   it("tolerates a missing state dir", () => {
     const res = buildEntitySidecar(join(tmpdir(), "does-not-exist-xyz"), "work_a");
     expect(res).toEqual({ id: "work_a", description: null, occurrences: null });
+  });
+});
+
+describe("buildEntitySidecar rationale fallback (field report ia-aero)", () => {
+  it("falls back to node.rationale, clearly marked provisional, when no description exists", () => {
+    const dir = makeStateDir();
+    // No description (node nor wiki) for rat_only, but it carries a rationale.
+    writeGraph(dir, [
+      { id: "rat_only", rationale: "Mentionné comme témoin principal de l'affaire." },
+    ]);
+    const res = buildEntitySidecar(dir, "rat_only");
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "Mentionné comme témoin principal de l'affaire.",
+      source: "rationale",
+      provisional: true,
+    });
+  });
+
+  it("prefers a REAL description over the rationale fallback", () => {
+    const dir = makeStateDir();
+    writeGraph(dir, [
+      { id: "both", description: "A real one-liner.", rationale: "A weaker rationale." },
+    ]);
+    const res = buildEntitySidecar(dir, "both");
+    // The node's own description wins; the rationale is NOT used.
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "A real one-liner.",
+      source: "description",
+    });
+  });
+
+  it("prefers a generated WIKI description over the rationale fallback", () => {
+    const dir = makeStateDir();
+    // work_a has a generated wiki description; the node carries only a rationale.
+    writeGraph(dir, [{ id: "work_a", rationale: "Should not win over the wiki description." }]);
+    const res = buildEntitySidecar(dir, "work_a");
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "A landmark **novel**.",
+      source: "description",
+    });
+  });
+
+  it("fills an insufficient_evidence wiki entry from the rationale (still provisional)", () => {
+    const dir = makeStateDir();
+    // place_b is insufficient_evidence in the wiki sidecar; the rationale fills it.
+    writeGraph(dir, [{ id: "place_b", rationale: "Lieu cité dans le rapport." }]);
+    const res = buildEntitySidecar(dir, "place_b");
+    expect(res.description).toEqual({
+      status: "generated",
+      description: "Lieu cité dans le rapport.",
+      source: "rationale",
+      provisional: true,
+    });
+  });
+
+  it("ignores a blank rationale (panel stays empty)", () => {
+    const dir = makeStateDir();
+    writeGraph(dir, [{ id: "blank_rat", rationale: "   " }]);
+    const res = buildEntitySidecar(dir, "blank_rat");
+    expect(res.description).toBeNull();
   });
 });
 

--- a/tests/studio-export-description-coverage.test.ts
+++ b/tests/studio-export-description-coverage.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Low-description-coverage hint (field report ia-aero).
+ *
+ * A French 1-PDF graph produced entities.json with 620/620 null descriptions
+ * SILENTLY. A ~0%-description graph almost always means the description pass
+ * never ran, so the static studio export now emits a non-fatal warning pointing
+ * the user to `graphify describe` — and the provisional rationale fallback does
+ * NOT count toward real coverage, so the signal survives even when the studio
+ * looks populated.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildStaticStudio,
+  lowDescriptionCoverageWarning,
+} from "../src/studio-export.js";
+import { __resetGraphDescriptionCache } from "../src/studio-assets.js";
+
+describe("lowDescriptionCoverageWarning (pure threshold)", () => {
+  it("warns at 0% coverage and points to graphify describe", () => {
+    const msg = lowDescriptionCoverageWarning({ total: 620, described: 0, provisional: 0 });
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/0\/620/);
+    expect(msg).toMatch(/graphify describe/);
+  });
+
+  it("mentions provisional rationale fills when present (both signals surfaced)", () => {
+    const msg = lowDescriptionCoverageWarning({ total: 620, described: 0, provisional: 596 });
+    expect(msg).not.toBeNull();
+    // The fallback filled it AND describe is still recommended.
+    expect(msg).toMatch(/596 node\(s\) were filled provisionally/);
+    expect(msg).toMatch(/graphify describe/);
+  });
+
+  it("is silent on healthy coverage", () => {
+    expect(lowDescriptionCoverageWarning({ total: 100, described: 80, provisional: 0 })).toBeNull();
+  });
+
+  it("is silent on an empty graph (no nodes -> no signal)", () => {
+    expect(lowDescriptionCoverageWarning({ total: 0, described: 0, provisional: 0 })).toBeNull();
+  });
+
+  it("fires just below the low threshold but not at a healthy ratio", () => {
+    // 1/100 = 1% < 2% threshold -> warn.
+    expect(lowDescriptionCoverageWarning({ total: 100, described: 1, provisional: 0 })).not.toBeNull();
+    // 3/100 = 3% > 2% threshold -> healthy enough, no warn.
+    expect(lowDescriptionCoverageWarning({ total: 100, described: 3, provisional: 0 })).toBeNull();
+  });
+});
+
+describe("buildStaticStudio description-coverage integration", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    __resetGraphDescriptionCache();
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  function makeFixture(nodes: Array<Record<string, unknown>>): { stateDir: string; spaDir: string } {
+    const stateDir = mkdtempSync(join(tmpdir(), "graphify-cov-state-"));
+    dirs.push(stateDir);
+    writeFileSync(join(stateDir, "graph.json"), JSON.stringify({ nodes, links: [] }));
+    const spaDir = mkdtempSync(join(tmpdir(), "graphify-cov-spa-"));
+    dirs.push(spaDir);
+    writeFileSync(join(spaDir, "index.html"), "<html></html>");
+    return { stateDir, spaDir };
+  }
+
+  it("warns + reports 0 real coverage when no node has a description (the ia-aero footgun)", () => {
+    // Every node carries only a rationale (the field-report shape): 0 real
+    // descriptions, all provisional.
+    const nodes = Array.from({ length: 10 }, (_, i) => ({
+      id: `n${i}`,
+      label: `N${i}`,
+      rationale: `Justification ${i}.`,
+    }));
+    const { stateDir, spaDir } = makeFixture(nodes);
+    const warnings: string[] = [];
+    const result = buildStaticStudio({
+      stateDir,
+      outDir: join(stateDir, "studio"),
+      spaDir,
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(result.descriptionCoverage).toEqual({ total: 10, described: 0, provisional: 10 });
+    const hint = warnings.find((m) => /graphify describe/.test(m));
+    expect(hint).toBeDefined();
+    expect(hint).toMatch(/10 node\(s\) were filled provisionally/);
+  });
+
+  it("does NOT warn when every node has a real description", () => {
+    const nodes = Array.from({ length: 10 }, (_, i) => ({
+      id: `n${i}`,
+      label: `N${i}`,
+      description: `A real description ${i}.`,
+    }));
+    const { stateDir, spaDir } = makeFixture(nodes);
+    const warnings: string[] = [];
+    const result = buildStaticStudio({
+      stateDir,
+      outDir: join(stateDir, "studio"),
+      spaDir,
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(result.descriptionCoverage).toEqual({ total: 10, described: 10, provisional: 0 });
+    expect(warnings.find((m) => /graphify describe/.test(m))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Field report (ia-aero)

A French 1-PDF graph produced `entities.json` with **620/620 `{description:null, occurrences:null}` SILENTLY**, even though **596/620 nodes had a `rationale`** filled (1–2 sentences, median ~116 chars). Root cause: the entity-sidecar builder read `node.description` then fell back to the wiki `descriptions*.json`, **never `rationale`**; `describe` was never run → all null, with no warning.

This rides the next release. Built on top of merged PR #200 (per-source describe-lang) — Step 5 changes **extend** the language-attention wording, they do not clobber it.

## 1. 0%-coverage WARNING
`buildStaticStudio` now tracks per-node description coverage while building the entities index and emits a non-fatal hint (styled after the existing 'large corpus' detection warning) when **real** coverage is at/under 2%, pointing to `graphify describe`. Provisional rationale fallbacks are **excluded** from the `described` count, so the warning still fires when the studio is only populated from rationales — and the message names how many were filled provisionally so **both signals surface at once**. `StudioDescriptionCoverage {total, described, provisional}` is returned and the CLI `studio export` prints it. Pure helper `lowDescriptionCoverageWarning()` is exported + unit-tested.

## 2. RATIONALE FALLBACK (additive, clearly-marked)
`buildEntitySidecar` falls back to `node.rationale` when no **real** description exists (node nor generated wiki entry). The fallback is **clearly marked**: `source: "rationale"`, `provisional: true`. `status` stays `"generated"` so the SPA renders the text, but the marking means it never masquerades as a curated description and never masks the "run describe" signal. New `loadGraphNodeRationales` (mtime-keyed graph.json index, parallel to descriptions). The studio EntityPanel shows a small **"provisional"** badge (tooltip → `graphify describe`) on rationale-sourced descriptions, surfacing both signals: the fallback filled the panel AND a proper describe pass is still recommended.

## 3. SKILL.md Step 5
Extended (on top of PR #200's wording) with an explicit REQUIRED callout for the labels-vs-describe asymmetry: the default `update` flow wires community-**labels** automatically but leaves node-**descriptions** opt-in → footgun. Spells out the order: `update` → fill BOTH descriptions and labels → ingest (or `describe`/`label` non-destructively) → THEN export the studio. References the new ~0%-coverage warning + provisional rationale backfill as a stop-gap, not a substitute.

## Tests
- `tests/studio-assets.test.ts`: rationale fallback fires + marking, precedence (real description/wiki wins), `insufficient_evidence` wiki entry filled from rationale, blank rationale ignored. Existing assertions updated for the new `source` field.
- `tests/studio-export-description-coverage.test.ts`: threshold edges, 0% + provisional message, healthy = silent, integration via `buildStaticStudio` onWarning.

Full root suite green (2052 passed, 17 skipped, 0 failed); `tsc --noEmit` clean; studio app `vite build` + 231 studio tests pass.