### PR TITLE
test(studio): skip T1 offline-render on environmental Chrome launch failure

### DIFF
--- a/tests/studio-export-offline-render.test.ts
+++ b/tests/studio-export-offline-render.test.ts
@@ -7,7 +7,11 @@
  * network log shows no `Network.loadingFailed`.
  *
  * Best-effort gate: SKIPS (does not fail) when the prebuilt single-file template,
- * a Chrome binary, or the `ws` module is unavailable in the environment.
+ * a Chrome binary, or the `ws` module is unavailable in the environment — and also
+ * when Chrome is present but fails to launch / expose its CDP websocket for an
+ * ENVIRONMENTAL reason (e.g. the GitHub runner's flaky `Failed to connect to the
+ * bus` / dbus error that intermittently kills the devtools endpoint). The render
+ * assertions stay hard failures whenever Chrome actually comes up.
  */
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -102,12 +106,13 @@ describe("T1 — offline studio.html renders over file:// with zero failed reque
 
   run(
     "graph paints from the inlined bundle, no blocked/failed network requests",
-    async () => {
+    async (ctx) => {
       const WebSocketCtor = (await tryLoadWs()) as
         | (new (url: string, opts?: unknown) => WsLike)
         | null;
       if (!WebSocketCtor) {
         // ws unavailable: skip rather than fail (best-effort environment gate).
+        ctx.skip("ws module unavailable");
         return;
       }
 
@@ -133,6 +138,10 @@ describe("T1 — offline studio.html renders over file:// with zero failed reque
           "--headless=new",
           "--disable-gpu",
           "--no-sandbox",
+          // Stability flags for constrained CI runners: avoid the tiny default
+          // /dev/shm and the dbus session bus that flakes on GitHub runners.
+          "--disable-dev-shm-usage",
+          "--disable-dbus",
           "--remote-debugging-port=0",
           `--user-data-dir=${userDir}`,
           "about:blank",
@@ -141,18 +150,40 @@ describe("T1 — offline studio.html renders over file:// with zero failed reque
       );
       procs.push(chrome);
 
-      const wsUrl = await new Promise<string>((res, rej) => {
-        let stderr = "";
-        const t = setTimeout(() => rej(new Error(`no devtools ws; stderr:\n${stderr}`)), 20000);
-        chrome.stderr!.on("data", (d) => {
-          stderr += String(d);
-          const m = stderr.match(/ws:\/\/[^\s]+\/devtools\/browser\/[a-f0-9-]+/);
-          if (m) {
+      // A failed/aborted launch (missing binary, dbus failure, runner refusing to
+      // expose the CDP websocket) is ENVIRONMENTAL — skip rather than fail T1. Any
+      // error from the spawn itself or from waiting on the devtools ws lands here.
+      let wsUrl: string;
+      try {
+        wsUrl = await new Promise<string>((res, rej) => {
+          let stderr = "";
+          const t = setTimeout(() => rej(new Error(`no devtools ws; stderr:\n${stderr}`)), 20000);
+          chrome.on("error", (err) => {
             clearTimeout(t);
-            res(m[0]);
-          }
+            rej(err instanceof Error ? err : new Error(String(err)));
+          });
+          chrome.on("exit", (code, signal) => {
+            clearTimeout(t);
+            rej(new Error(`chrome exited early (code=${code}, signal=${signal})\n${stderr}`));
+          });
+          chrome.stderr!.on("data", (d) => {
+            stderr += String(d);
+            const m = stderr.match(/ws:\/\/[^\s]+\/devtools\/browser\/[a-f0-9-]+/);
+            if (m) {
+              clearTimeout(t);
+              res(m[0]);
+            }
+          });
         });
-      });
+      } catch (err) {
+        try {
+          chrome.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+        ctx.skip(`chrome failed to launch / expose CDP websocket: ${(err as Error).message}`);
+        return;
+      }
 
       const browser = makeCdp(WebSocketCtor, wsUrl);
       await browser.ready;


### PR DESCRIPTION
## Problem

`tests/studio-export-offline-render.test.ts` (T1 — "offline studio.html renders over file:// with zero failed requests"), re-enabled by #197, launches headless Chrome over `file://` via CDP. On constrained CI runners Chrome **intermittently fails to start / expose its devtools websocket**: the 0.16.0 release run FAILED on node 24 with

```
Error: no devtools ws; stderr: ... Failed to connect to the bus: Could not parse server address (dbus)
```

while passing on node 20/22; a re-run then passed. This is an environmental launch flake, not a render regression — but it currently fails the whole job every release/PR.

## Fix

Treat an **environmental Chrome-launch failure as a SKIP, not a FAILURE**, while keeping T1 a real assertion whenever Chrome is available.

- Wrap the Chrome `spawn` + devtools-ws acquisition in a `try/catch`. On any launch failure — spawn `error`, early `exit`, or the 20s ws timeout (the "no devtools ws" / dbus path) — call `ctx.skip(...)` with a clear message instead of throwing.
- Reject the ws-wait promise on `chrome.on("error")` and `chrome.on("exit")` so a dead launch skips fast instead of waiting out the full timeout.
- The `ws`-module-unavailable branch now calls `ctx.skip()` explicitly too (was a silent `return`).
- Add Chrome stability flags: `--disable-dev-shm-usage --disable-dbus` (alongside the existing `--no-sandbox --disable-gpu`).

`ctx.skip(): never` (vitest 4) means TS control-flow correctly treats `wsUrl` as definitely-assigned on the success path. Pattern matches the existing `context.skip()` precedent in `tests/mistral-ocr.integration.test.ts`.

## Skip vs assert

- **Chrome launches** → success path runs unchanged: still requires the canvas to paint from the inlined `__GRAPHIFY_BUNDLE__`, the SPA to mount (`#app` children > 0), the canvas to be sized, and **zero** `Network.loadingFailed` events. Real render regressions still fail.
- **Chrome fails to launch / no devtools ws** → dynamic skip with the failure message; the test file passes.

## Verification (local)

- `tsc --noEmit` → exit 0.
- `vitest run tests/studio-export-offline-render.test.ts` with real Chrome → **1 passed** (all render assertions enforced).
- Same test with a fake `google-chrome` on PATH that emits the dbus error and exits 1 (reproducing the CI failure mode) → **1 skipped**, file passes, exit 0.

Scope is limited to this single test; the CDP harness (`makeCdp`, the launch logic) is self-contained in this file and no other test launches Chrome via CDP.