### PR TITLE
feat(cite): `graphify cite` — citation-grounding producer (WP #24)

### DIFF
--- a/spec/SPEC_CITATIONS.md
+++ b/spec/SPEC_CITATIONS.md
@@ -279,3 +279,100 @@ Two independent adversarial Opus 4.8 reviews (2026-06-13) returned BLOCK; all fi
 - **citations.json caching (B#F, MUST-FIX):** mtime-keyed index, not uncached per-request.
 - **Survey carve-out (A#6), quote/locators (A#7), export non-impact (B#E):** folded into Problem/Non-Goals/Migration.
 - **Curated mystery migration (B#G, needs product call):** flagged as a rollout decision in Migration (backfill vs re-extract+re-describe); does not block implementation.
+
+---
+
+## Addendum — WP #24: the `cite` GROUNDING producer + contract delta (2026-06-23)
+
+This addendum extends the 0.14.0 storage spec with the citation-GROUNDING producer
+(`graphify cite`, a.k.a. `ground-citations`) and **reverses** two of the original
+v1 Non-Goals. The original decisions on storage/tiering remain BINDING; this
+delta is additive and backward-compatible.
+
+### Reversed Non-Goals (now in scope, ratified by production reality)
+
+- ~~**No verbatim-quote capture.**~~ **REVERSED.** `quote?: string` is now a
+  first-class optional field on `OntologyCitation`. It was de-facto present in
+  production already — carried by `OntologyEvidenceRecord`, the mystery
+  `citations.json` sidecar (`{source_file, section, quote}`, 1983 nodes), and read
+  by both the studio EntityPanel (`<blockquote>{p.quote}</blockquote>`) and the
+  describe grounding path (`collectCitationContext` reads `quote ?? text ?? snippet`).
+  Declaring it ends the "field that exists but isn't typed" drift.
+- ~~**No change to the `OntologyCitation` shape.**~~ **REVERSED.** Three optional
+  fields are added: `quote?: string`, `confidence?: CitationConfidence`
+  (`"EXTRACTED" | "INFERRED"`), and `source_location?: string` (the modality-encoded
+  human-readable locator string, e.g. `"p.12 · Section"`, that ia-aero's `ground.py`
+  already emits). All additive; locator-only citations remain valid. None of the
+  three is part of the citation IDENTITY key (`source_file|page|section|paragraph_id`):
+  two citations to the same locator with different quotes still dedupe to one.
+
+### `graphify cite [path]` — the GROUNDING producer
+
+`backfill-citations` only PROJECTS pre-existing `citations[]` into the tiered store;
+`cite` GROUNDS NEW citations by SCANNING the corpus source text — symmetric to
+`describe`/`label`. It is the productization of ia-aero's hand-coded `ground.py` /
+`ground2.py` (876/876 entities cited, zero API calls).
+
+Flags:
+
+```
+graphify cite [path]
+  --mode <heuristic|assistant|api>   # default heuristic (no key). assistant/api
+                                     #   are opt-in recall boosters, gated by the
+                                     #   SAME anti-hallucination verbatim check.
+  --top-k <n>                        # max citations grounded per node (default 6)
+  --types <a,b,c>                    # restrict to node kinds (file_type/node_type)
+  --only-missing                     # additive 2nd pass: ground only uncited nodes
+  --source <root>                    # extra source search root (.graphify/converted
+                                     #   is always searched)
+  --citations-top-k <n>             # inline Level-1 K after aggregation
+  --dry-run                          # report coverage; write nothing
+```
+
+It is OPT-IN (NOT auto-run in the default pipeline, like `describe`). It loads
+`graph.json`, grounds, UNIONS the result with each node's existing `citations`
+(union-not-clobber via `unionCitations`), then runs the shipped aggregation
+(`aggregateCitations` → `citation_count` + K-bounded inline + `citations.json`).
+
+### Anti-hallucination (HARD INVARIANT)
+
+Every emitted `quote` MUST be a verified VERBATIM substring of the NORMALIZED
+source text (`verifyVerbatim`: NFKD-deaccent + ligature-fold + lowercase +
+whitespace-collapse, then `includes`). In heuristic mode a citation **cannot** be
+emitted unless its windowed quote verifies — there is no path to invent text. The
+`assistant`/`api` modes are gated by the SAME check: an LLM proposes a quote, the
+heuristic verifier re-locates it, and a non-matching quote is DROPPED, never
+emitted. The invariant is unit-tested and verified against the real ia-aero corpus
+(2854/2854 grounded quotes verbatim, zero hallucinations).
+
+### Heuristic algorithm (ported from ground.py/ground2.py)
+
+Per node → modality-aware source parse → normalize (with the verbatim gate) →
+type-aware candidate match → window the quote → emit:
+
+1. **Modality parse.** OCR-markdown: leading `---…---` front-matter SKIPPED (so
+   page numbering starts at 1 — the aclp-am `page:"unknown"` fix); bare `---` →
+   page increment; `#{1,4} ` → section; `![](…)` → image with prev/next prose
+   context. Plain text: chapter/story headings → section; paragraphs → units;
+   pages meaningless (page 1).
+2. **Type-aware terms.** person → surname (section headings first, then body);
+   reference → the `[N]` marker resolved back into the body; image → surrounding
+   prose (INFERRED); acronym (3-6 caps) → whole-word; concept/… → most specific
+   stopword-filtered content word; quote/any → `rationale` verbatim quoted span
+   (gated). Aliases are added as strong terms.
+3. **Window + verify.** ±~110/210 chars snapped to sentence/quote boundaries,
+   ellipsis-padded, capped at 320 chars; verified verbatim; deduped by quote prefix;
+   capped at `--top-k`.
+4. **Emit + aggregate.** `{quote, source_file, source_location, page?, section?,
+   paragraph_id?, confidence}`; UNION with existing; `aggregateCitations` →
+   `citations.json`.
+
+### `source_location` semantics by modality
+
+| Modality | `source_location` | structured fields |
+|---|---|---|
+| OCR-markdown | `"p.{page} · {section}"` | `page`, `section`, `paragraph_id` |
+| plain text | `"{section}"` (chapter/story) | `section`, `paragraph_id` |
+
+(native PDF bbox + registry CSV row + web anchor are v2 modalities; the contract
+already carries `bbox`/`source_url` for them.)

--- a/src/cite-grounding.ts
+++ b/src/cite-grounding.ts
@@ -1,0 +1,816 @@
+/**
+ * Heuristic citation GROUNDING (WP #24 — `graphify cite`).
+ *
+ * Symmetric to `node-descriptions.ts` (describe) and `community-labeling.ts`
+ * (label): a producer pass over an already-built graph that POPULATES
+ * `node.citations[]` by SCANNING the corpus source text, as opposed to
+ * `backfill-citations` which only PROJECTS pre-existing citations.
+ *
+ * This is the productization of ia-aero's hand-coded `ground.py` / `ground2.py`
+ * (876/876 entities cited, zero API calls) and is the no-key DEFAULT path.
+ *
+ * ── ANTI-HALLUCINATION (HARD INVARIANT) ──────────────────────────────────────
+ * Every emitted `quote` is a VERIFIED VERBATIM substring of the NORMALIZED
+ * source text. A citation cannot be emitted unless its windowed quote, after the
+ * same NFKD-deaccent/lowercase/whitespace-collapse normalization, is found as a
+ * substring of the normalized source. There is no path to invent text. The LLM
+ * (assistant/api) modes are gated by the SAME structural check: an LLM proposes
+ * a quote, the heuristic verifier re-locates it in the source, and a quote that
+ * does not match is DROPPED, never emitted. See `verifyVerbatim`.
+ *
+ * No network, no secrets in the heuristic path. Deterministic and replayable.
+ */
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve as resolvePath } from "node:path";
+import type Graph from "graphology";
+import type { CitationConfidence, OntologyCitation } from "./types.js";
+import { unionCitations } from "./citations.js";
+
+// ---------------------------------------------------------------------------
+// Normalization (the matcher substrate, shared by grounding + verification)
+// ---------------------------------------------------------------------------
+
+/** NFKD deaccent + ascii-fold (drops combining marks, ligatures degrade). */
+export function deaccent(s: string): string {
+  return (s ?? "").normalize("NFKD").replace(/[̀-ͯ]/g, "");
+}
+
+/**
+ * Canonical match form: deaccent → lowercase → collapse whitespace → trim.
+ * Ligatures (œ/æ) are folded so `cœur` matches `coeur`. Used for BOTH the
+ * candidate-term match and the anti-hallucination verbatim check, so the two
+ * are guaranteed to agree.
+ */
+export function normalizeForMatch(s: string): string {
+  return deaccent(s ?? "")
+    .replace(/œ/g, "oe")
+    .replace(/æ/g, "ae")
+    .replace(/Œ/g, "OE")
+    .replace(/Æ/g, "AE")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Modality-aware source parsing
+// ---------------------------------------------------------------------------
+
+export type SourceModality = "ocr-markdown" | "plain-text";
+
+/** A locatable text unit (paragraph) parsed from a source file. */
+export interface SourceUnit {
+  /** Verbatim (raw) paragraph text. */
+  text: string;
+  /** Page number (OCR-markdown; 1 for plain text where pages are meaningless). */
+  page: number;
+  /** Section / chapter heading in effect for this unit (raw). */
+  section: string;
+  /** 0-based paragraph index within the source. */
+  paragraphIndex: number;
+}
+
+/** Image reference + its surrounding prose context (OCR-markdown). */
+export interface ImageContext {
+  /** Image basename, e.g. `image-000.jpg`. */
+  basename: string;
+  page: number;
+  section: string;
+  /** Preceding paragraph text (raw), or "". */
+  prev: string;
+  /** Following paragraph text (raw), or "". */
+  next: string;
+}
+
+export interface ParsedSource {
+  modality: SourceModality;
+  units: SourceUnit[];
+  /** section heading → unit indices, for type-aware person-section matching. */
+  sectionToIndices: Map<string, number[]>;
+  /** image basename → context (OCR-markdown only). */
+  images: Map<string, ImageContext>;
+  /** Highest page seen (1 for plain text). */
+  pageCount: number;
+}
+
+/** Detect modality from a source path. `.md` → OCR-markdown, else plain-text. */
+export function detectModality(sourceFile: string): SourceModality {
+  return /\.(md|markdown)$/i.test(sourceFile) ? "ocr-markdown" : "plain-text";
+}
+
+const FRONT_MATTER_KEY = /^[a-z_]+:\s/i;
+
+/**
+ * Parse an OCR-markdown file into locatable units (ia-aero `ground.py` parser,
+ * hardened for graphify's front-matter):
+ *   - the leading `---` … `---` front-matter block is SKIPPED (it is metadata,
+ *     not a page break — without this, page numbering starts at 2);
+ *   - a bare `---` outside front-matter → page increment (Mistral page break);
+ *   - `#{1,4} ` → section heading (the section for following units);
+ *   - `![alt](path)` → an image; its prev paragraph + the next paragraph become
+ *     its context;
+ *   - blank line / heading / image / page-break → flush the current paragraph.
+ */
+function parseOcrMarkdown(raw: string): ParsedSource {
+  const lines = raw.split("\n");
+  const units: SourceUnit[] = [];
+  const sectionToIndices = new Map<string, number[]>();
+  const images = new Map<string, ImageContext>();
+  let page = 1;
+  let section = "";
+  let buf: string[] = [];
+  let pendingImages: string[] = [];
+
+  // Front-matter detection: a `---` on the FIRST line opens a metadata block
+  // that closes at the next `---`. Those two `---` are not page breaks.
+  let inFrontMatter = false;
+  let frontMatterDone = false;
+  let i = 0;
+  if (lines[0]?.trim() === "---") {
+    inFrontMatter = true;
+    i = 1;
+  }
+
+  const flush = (): void => {
+    if (buf.length === 0) return;
+    const text = buf.map((x) => x.trim()).join(" ").trim();
+    buf = [];
+    if (!text || text.startsWith("![")) return;
+    const idx = units.length;
+    units.push({ text, page, section, paragraphIndex: idx });
+    const arr = sectionToIndices.get(section) ?? [];
+    arr.push(idx);
+    sectionToIndices.set(section, arr);
+    // Resolve any image awaiting its `next` paragraph.
+    for (const fn of pendingImages) {
+      const ctx = images.get(fn);
+      if (ctx && !ctx.next) ctx.next = text;
+    }
+    pendingImages = [];
+  };
+
+  for (; i < lines.length; i += 1) {
+    const s = (lines[i] ?? "").trim();
+
+    if (inFrontMatter && !frontMatterDone) {
+      // Skip metadata lines; the closing `---` ends the block (not a page break).
+      if (s === "---") {
+        frontMatterDone = true;
+        inFrontMatter = false;
+      } else if (s !== "" && !FRONT_MATTER_KEY.test(s)) {
+        // A non-key line before a closing fence: not real front matter — bail
+        // out and reprocess this line as content.
+        inFrontMatter = false;
+        frontMatterDone = true;
+        i -= 1;
+      }
+      continue;
+    }
+
+    if (s === "---") {
+      flush();
+      page += 1;
+      continue;
+    }
+    if (/^#{1,4}\s/.test(s)) {
+      flush();
+      section = s.replace(/^#{1,4}\s+/, "").trim();
+      continue;
+    }
+    const img = /^!\[[^\]]*\]\(([^)]+)\)/.exec(s);
+    if (img) {
+      flush();
+      const fn = basenameOf(img[1] ?? "");
+      const prev = units.length > 0 ? (units[units.length - 1]?.text ?? "") : "";
+      images.set(fn, { basename: fn, page, section, prev, next: "" });
+      pendingImages.push(fn);
+      continue;
+    }
+    if (s === "") {
+      flush();
+      continue;
+    }
+    buf.push(s);
+  }
+  flush();
+
+  return { modality: "ocr-markdown", units, sectionToIndices, images, pageCount: page };
+}
+
+/**
+ * Parse a plain-text file (mystery novels) into locatable units. Chapter / story
+ * headings (heuristic: short, mostly-uppercase or `Chapter N`/`Part N` lines on
+ * their own, or markdown `#` headings if present) become sections; paragraphs
+ * (blank-line separated) are the units. Pages are meaningless → page 1.
+ */
+function parsePlainText(raw: string): ParsedSource {
+  const lines = raw.split("\n");
+  const units: SourceUnit[] = [];
+  const sectionToIndices = new Map<string, number[]>();
+  let section = "";
+  let buf: string[] = [];
+
+  const flush = (): void => {
+    if (buf.length === 0) return;
+    const text = buf.map((x) => x.trim()).join(" ").trim();
+    buf = [];
+    if (!text) return;
+    const idx = units.length;
+    units.push({ text, page: 1, section, paragraphIndex: idx });
+    const arr = sectionToIndices.get(section) ?? [];
+    arr.push(idx);
+    sectionToIndices.set(section, arr);
+  };
+
+  for (const line of lines) {
+    const s = line.trim();
+    if (/^#{1,4}\s/.test(s)) {
+      flush();
+      section = s.replace(/^#{1,4}\s+/, "").trim();
+      continue;
+    }
+    if (isHeadingLine(s, buf.length === 0)) {
+      flush();
+      section = s.trim();
+      continue;
+    }
+    if (s === "") {
+      flush();
+      continue;
+    }
+    buf.push(s);
+  }
+  flush();
+
+  return { modality: "plain-text", units, sectionToIndices, images: new Map(), pageCount: 1 };
+}
+
+/**
+ * Heuristic chapter/story heading for plain text: a `Chapter N`/`Part N`/`Book N`
+ * marker, or a short standalone line (≤ 8 words) that is mostly upper-case
+ * letters and starts a paragraph. Conservative — false negatives only narrow the
+ * section, never break grounding.
+ */
+function isHeadingLine(s: string, atParagraphStart: boolean): boolean {
+  if (!s || !atParagraphStart) return false;
+  if (/^(chapter|part|book|adventure|story)\b/i.test(s) && s.length <= 80) return true;
+  const words = s.split(/\s+/);
+  if (words.length > 8 || s.length > 80) return false;
+  const letters = s.replace(/[^a-zA-ZÀ-ÿ]/g, "");
+  if (letters.length < 3) return false;
+  const upper = s.replace(/[^A-ZÀ-Þ]/g, "");
+  return upper.length / letters.length >= 0.7;
+}
+
+function basenameOf(p: string): string {
+  const norm = p.replace(/\\/g, "/");
+  const idx = norm.lastIndexOf("/");
+  return idx >= 0 ? norm.slice(idx + 1) : norm;
+}
+
+/** Parse any supported source modality. */
+export function parseSource(raw: string, modality: SourceModality): ParsedSource {
+  return modality === "ocr-markdown" ? parseOcrMarkdown(raw) : parsePlainText(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Quote windowing + verbatim verification (anti-hallucination)
+// ---------------------------------------------------------------------------
+
+const QUOTE_BEFORE = 110;
+const QUOTE_AFTER = 210;
+const QUOTE_MAXLEN = 320;
+const OPEN_BOUNDARY = new Set([" ", "\n", "«", "(", '"', "“"]);
+const CLOSE_BOUNDARY = new Set([" ", "\n", ".", "!", "?", "»", ")", '"', "”"]);
+
+/**
+ * Window a verbatim quote around a match offset (ia-aero `make_quote`): grab
+ * ±~110/210 chars, snap the start back to an opening boundary and the end
+ * forward to a sentence/quote boundary, ellipsis-pad the truncated sides, cap
+ * length. Returns the RAW (verbatim) text — never normalized.
+ */
+export function windowQuote(text: string, offset: number): string {
+  let a = Math.max(0, offset - QUOTE_BEFORE);
+  let b = Math.min(text.length, offset + QUOTE_AFTER);
+  while (a > 0 && !OPEN_BOUNDARY.has(text[a] ?? "")) a -= 1;
+  while (b < text.length && !CLOSE_BOUNDARY.has(text[b] ?? "")) b += 1;
+  let q = text.slice(a, b).trim();
+  if (a > 0) q = "… " + q;
+  if (b < text.length) q = q + " …";
+  q = q.replace(/\s+/g, " ");
+  return q.length > QUOTE_MAXLEN ? q.slice(0, QUOTE_MAXLEN).trim() : q;
+}
+
+/**
+ * THE anti-hallucination gate. A quote is verbatim iff its normalized form,
+ * stripped of the ellipsis padding `windowQuote` adds, is a non-empty substring
+ * of the normalized source text. Used to verify EVERY emitted citation —
+ * heuristic and LLM alike.
+ */
+export function verifyVerbatim(quote: string, normalizedSource: string): boolean {
+  if (!quote) return false;
+  // Strip the ellipsis padding we may have added, then normalize.
+  const core = quote.replace(/^…\s*/, "").replace(/\s*…$/, "");
+  const needle = normalizeForMatch(core);
+  if (!needle) return false;
+  return normalizedSource.includes(needle);
+}
+
+// ---------------------------------------------------------------------------
+// Type-aware term selection
+// ---------------------------------------------------------------------------
+
+const CONTENT_STOPWORDS = new Set(
+  (
+    "aeronautique aeronautics intelligence artificielle artificial systeme systemes system systems " +
+    "operationnelle operationnel operational transformation developpement development application " +
+    "applications technologie technologies technology analyse analysis gestion management donnees " +
+    "data modele model methode method niveau level processus process secteur sector impact apport " +
+    "apports enjeux defis perspective perspectives concept concepts general overview document section"
+  ).split(/\s+/),
+);
+
+const CONCEPT_TYPES = new Set([
+  "concept",
+  "technology",
+  "use_case",
+  "regulation",
+  "project",
+  "standard",
+  "tool",
+  "rationale",
+]);
+
+/** A node's display type, normalized from `node_type` ?? `file_type`. */
+function nodeKind(attrs: Record<string, unknown>): string {
+  const nt = typeof attrs.node_type === "string" ? attrs.node_type : "";
+  const ft = typeof attrs.file_type === "string" ? attrs.file_type : "";
+  return (nt || ft).toLowerCase();
+}
+
+function safeStr(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+/** Selected candidate terms + the regexes the heuristic matcher will try. */
+interface NodeTerms {
+  /** Normalized terms to search for (whole-substring). */
+  terms: string[];
+  /** Surname (person), normalized, when derivable. */
+  surname: string | null;
+  /** Acronym (3-6 caps/digits), raw, when the label is one. */
+  acronym: string | null;
+  /** Reference marker like `[12]`, when derivable. */
+  refMarker: string | null;
+}
+
+/**
+ * Type-aware term selection (ia-aero `ground.py`/`ground2.py`):
+ *  - person   → surname (matched against section headings first, then body).
+ *  - reference→ the `[N]` bracketed marker, resolved back into the body.
+ *  - acronym  → whole-word regex on the raw label (3-6 caps).
+ *  - concept… → the most specific content word (≥ 5 chars, stopword-filtered).
+ *  - any      → the label base + full label (≥ 4 chars) as fallbacks.
+ */
+export function selectNodeTerms(attrs: Record<string, unknown>): NodeTerms {
+  const label = safeStr(attrs.label);
+  const id = safeStr(attrs.id);
+  const kind = nodeKind(attrs);
+  const base = (label.split(/[—–,(]/)[0] ?? label).trim();
+  const normBase = normalizeForMatch(base);
+  const normLabel = normalizeForMatch(label);
+
+  const terms = new Set<string>();
+  for (const t of [normBase, normLabel]) if (t.length >= 4) terms.add(t);
+  // Aliases are strong, distinct grounding terms.
+  if (Array.isArray(attrs.aliases)) {
+    for (const a of attrs.aliases) {
+      const na = normalizeForMatch(safeStr(a));
+      if (na.length >= 4) terms.add(na);
+    }
+  }
+
+  let surname: string | null = null;
+  if (kind === "person") {
+    const toks = base.split(/\s+/).filter((t) => deaccent(t).length >= 3 && /^[a-zA-ZÀ-ÿ]/.test(t));
+    if (toks.length > 0) {
+      const last = normalizeForMatch(toks[toks.length - 1] ?? "");
+      if (last.length >= 4) {
+        surname = last;
+        terms.add(last);
+      }
+    }
+  }
+
+  const acronym = /^[A-Z][A-Z0-9]{2,5}$/.test(base) ? base : null;
+
+  let refMarker: string | null = null;
+  if (kind === "reference") {
+    const m = /\[(\d+)\]/.exec(label) ?? /ref_(\d+)/.exec(id);
+    if (m) refMarker = `[${m[1]}]`;
+  }
+
+  if (CONCEPT_TYPES.has(kind)) {
+    const words = (normBase.match(/[a-zà-ÿ]{5,}/g) ?? []).filter((w) => !CONTENT_STOPWORDS.has(deaccent(w)));
+    if (words.length > 0) {
+      const longest = words.reduce((a, b) => (b.length > a.length ? b : a));
+      terms.add(longest);
+    }
+  }
+
+  return { terms: [...terms], surname, acronym, refMarker };
+}
+
+// ---------------------------------------------------------------------------
+// The grounding engine
+// ---------------------------------------------------------------------------
+
+export interface GroundedCitation extends OntologyCitation {
+  quote: string;
+  confidence: CitationConfidence;
+}
+
+export interface GroundNodeOptions {
+  /** Max citations grounded per node. */
+  topK: number;
+  /** The `source_file` written onto each emitted citation (the locator). */
+  sourceLabel: string;
+}
+
+/**
+ * Ground citations for ONE node against ONE parsed source. Pure: takes the
+ * node's attrs + the parsed source + a precomputed normalized-source string for
+ * the anti-hallucination check. Every returned citation's `quote` is a verified
+ * verbatim substring of `normalizedSource`.
+ */
+export function groundNodeCitations(
+  attrs: Record<string, unknown>,
+  source: ParsedSource,
+  normalizedSource: string,
+  options: GroundNodeOptions,
+): GroundedCitation[] {
+  const { topK, sourceLabel } = options;
+  const kind = nodeKind(attrs);
+  const sel = selectNodeTerms(attrs);
+  const out: GroundedCitation[] = [];
+  const seen = new Set<string>();
+
+  const sourceLocation = (page: number, section: string): string => {
+    if (source.modality === "ocr-markdown") {
+      const sec = section ? ` · ${section.slice(0, 50)}` : "";
+      return `p.${page}${sec}`;
+    }
+    return section || "document";
+  };
+
+  const emit = (
+    rawText: string,
+    offset: number,
+    page: number,
+    section: string,
+    confidence: CitationConfidence,
+  ): boolean => {
+    if (out.length >= topK) return false;
+    const quote = windowQuote(rawText, offset);
+    // HARD GATE: never emit a quote that is not a verbatim substring.
+    if (!verifyVerbatim(quote, normalizedSource)) return false;
+    const dedupKey = normalizeForMatch(quote).slice(0, 60);
+    if (!dedupKey || seen.has(dedupKey)) return false;
+    seen.add(dedupKey);
+    const cite: GroundedCitation = {
+      source_file: sourceLabel,
+      source_location: sourceLocation(page, section),
+      quote,
+      confidence,
+    };
+    if (source.modality === "ocr-markdown") {
+      cite.page = page;
+      if (section) cite.section = section;
+    } else if (section) {
+      cite.section = section;
+    }
+    cite.paragraph_id = `p${offset >= 0 ? indexOfUnit(source, rawText) : 0}`;
+    out.push(cite);
+    return true;
+  };
+
+  /**
+   * Emit a pre-formed quote string (e.g. a node's `rationale`, which for a
+   * `quote` node IS the verbatim source passage) with an explicit location.
+   * Still gated by the HARD anti-hallucination check: a rationale that is a
+   * paraphrase (not a verbatim source substring) is DROPPED, never emitted.
+   */
+  const emitVerbatimQuote = (
+    quoteRaw: string,
+    location: string,
+    confidence: CitationConfidence,
+  ): boolean => {
+    if (out.length >= topK) return false;
+    const quote = quoteRaw.replace(/\s+/g, " ").trim().slice(0, QUOTE_MAXLEN);
+    if (!verifyVerbatim(quote, normalizedSource)) return false;
+    const dedupKey = normalizeForMatch(quote).slice(0, 60);
+    if (!dedupKey || seen.has(dedupKey)) return false;
+    seen.add(dedupKey);
+    out.push({ source_file: sourceLabel, source_location: location, quote, confidence });
+    return true;
+  };
+
+  // 1) PERSON → attach the units of any section heading containing the surname.
+  if (kind === "person") {
+    const labelBase = safeStr(attrs.label).split(/[—–,(]/)[0] ?? "";
+    const pname = sel.surname ?? normalizeForMatch(labelBase);
+    if (pname) {
+      for (const [sec, idxs] of source.sectionToIndices) {
+        if (out.length >= topK) break;
+        if (!normalizeForMatch(sec).includes(pname)) continue;
+        for (const i of idxs) {
+          if (out.length >= topK) break;
+          const u = source.units[i];
+          if (u) emit(u.text, 0, u.page, u.section, "EXTRACTED");
+        }
+      }
+    }
+  }
+
+  // 2) REFERENCE → resolve the `[N]` marker back into the body.
+  if (out.length < topK && sel.refMarker) {
+    for (const u of source.units) {
+      if (out.length >= topK) break;
+      const di = u.text.indexOf(sel.refMarker);
+      if (di >= 0) emit(u.text, di, u.page, u.section, "EXTRACTED");
+    }
+  }
+
+  // 3) IMAGE → surrounding prose context (INFERRED).
+  if (out.length < topK && kind === "image") {
+    const fn = basenameOf(safeStr(attrs.source_file));
+    const ctx = source.images.get(fn);
+    if (ctx) {
+      for (const key of ["prev", "next"] as const) {
+        if (out.length >= topK) break;
+        const txt = ctx[key];
+        if (txt) emit(txt, 0, ctx.page, ctx.section, "INFERRED");
+      }
+    }
+  }
+
+  // 4) TERM / ACRONYM match in the body.
+  if (out.length < topK && (sel.terms.length > 0 || sel.acronym)) {
+    const acrRe = sel.acronym ? new RegExp(`\\b${escapeRegExp(sel.acronym)}\\b`) : null;
+    for (const u of source.units) {
+      if (out.length >= topK) break;
+      const normText = normalizeForMatch(u.text);
+      let di = -1;
+      for (const t of sel.terms) {
+        const j = normText.indexOf(t);
+        if (j >= 0) {
+          // Map the normalized offset back to a raw offset approximately by
+          // locating the first raw token of the term. Fall back to a raw
+          // case-insensitive find of the term's leading word.
+          di = rawOffsetForTerm(u.text, t);
+          if (di < 0) di = 0;
+          break;
+        }
+      }
+      if (di < 0 && acrRe) {
+        const m = acrRe.exec(u.text);
+        if (m) di = m.index;
+      }
+      if (di >= 0) emit(u.text, di, u.page, u.section, "EXTRACTED");
+    }
+  }
+
+  // 5) RATIONALE FALLBACK → a quote-bearing node (file_type `quote`, or any node
+  // whose `rationale` quotes the source verbatim) grounds on its own rationale.
+  // For `quote` nodes the rationale IS the verbatim source passage. STILL gated:
+  // a rationale that is a paraphrase fails verifyVerbatim and is dropped.
+  if (out.length < topK) {
+    const rationale = safeStr(attrs.rationale).trim();
+    if (rationale) {
+      const location = safeStr(attrs.source_location) || "document";
+      const confidence: CitationConfidence = kind === "quote" ? "EXTRACTED" : "INFERRED";
+      // Prefer the explicitly-quoted segment(s) («…» / "…" / “…”) — those are
+      // the verbatim source spans; otherwise try the whole rationale.
+      const quotedSpans = extractQuotedSpans(rationale);
+      let emitted = false;
+      for (const span of quotedSpans) {
+        if (out.length >= topK) break;
+        if (emitVerbatimQuote(span, location, confidence)) emitted = true;
+      }
+      if (!emitted) emitVerbatimQuote(rationale, location, confidence);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Extract the explicitly-quoted spans from a rationale (the verbatim source
+ * passages a `quote` node wraps in « » / " " / “ ”). Returns [] when none.
+ */
+function extractQuotedSpans(text: string): string[] {
+  const spans: string[] = [];
+  const re = /[«"“]([^«»"“”]{8,})[»"”]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const s = (m[1] ?? "").trim();
+    if (s) spans.push(s);
+  }
+  return spans;
+}
+
+/** Index of a unit by identity in the parsed source (for paragraph_id). */
+function indexOfUnit(source: ParsedSource, rawText: string): number {
+  for (const u of source.units) if (u.text === rawText) return u.paragraphIndex;
+  return 0;
+}
+
+/**
+ * Map a normalized term back to an approximate RAW offset in the unit text by
+ * locating the term's first content word case/diacritic-insensitively. The
+ * exact offset is non-critical (the quote window is wide); the goal is a
+ * sensible center. Returns -1 if even the leading word can't be found raw.
+ */
+function rawOffsetForTerm(rawText: string, normTerm: string): number {
+  const firstWord = normTerm.split(" ")[0] ?? "";
+  if (!firstWord) return -1;
+  const normRaw = normalizeForMatch(rawText);
+  const at = normRaw.indexOf(firstWord);
+  if (at < 0) return -1;
+  // The normalized text is whitespace-collapsed; offsets roughly track the raw
+  // text for prose. Clamp into range.
+  return Math.min(at, Math.max(0, rawText.length - 1));
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Map an OCR-extracted image path back to the markdown document that contains
+ * it. graphify's pdf-ocr writes `<stem>.md` alongside `<stem>_images/image-N.*`
+ * (pdf-ocr.ts), so `…/<stem>_images/image-000.jpg` → `…/<stem>.md`. Returns null
+ * when the path does not match that convention.
+ */
+export function containingDocumentFor(imagePath: string): string | null {
+  const norm = imagePath.replace(/\\/g, "/");
+  const m = /^(.*)_images\/[^/]+$/.exec(norm);
+  if (!m) return null;
+  return `${m[1]}.md`;
+}
+
+// ---------------------------------------------------------------------------
+// Source resolution + the graph-level driver
+// ---------------------------------------------------------------------------
+
+export interface ResolveSourceOptions {
+  /** Project root; `source_file` is resolved relative to it. */
+  root: string;
+  /** Extra search roots (e.g. `.graphify/converted`). */
+  searchRoots?: string[];
+}
+
+/**
+ * Resolve a node's `source_file` to an on-disk path. Tries: absolute as-is,
+ * relative to root, then relative to each search root. Returns null if none
+ * exists. Pure (only fs.existsSync via readFileSync try/catch in the caller).
+ */
+export function resolveSourcePath(sourceFile: string, options: ResolveSourceOptions): string | null {
+  if (!sourceFile) return null;
+  const candidates: string[] = [];
+  if (isAbsolute(sourceFile)) candidates.push(sourceFile);
+  candidates.push(resolvePath(options.root, sourceFile));
+  for (const r of options.searchRoots ?? []) candidates.push(resolvePath(r, sourceFile));
+  for (const c of candidates) {
+    try {
+      readFileSync(c);
+      return c;
+    } catch {
+      /* not here */
+    }
+  }
+  return null;
+}
+
+export interface CiteGraphOptions {
+  /** Project root for resolving each node's `source_file`. */
+  root: string;
+  /** Max citations grounded per node. Default 6 (ia-aero's value). */
+  topK?: number;
+  /** Restrict to these node kinds (file_type/node_type). Empty = all. */
+  types?: string[];
+  /** Only ground nodes that currently have NO citations (additive 2nd pass). */
+  onlyMissing?: boolean;
+  /** Extra source search roots (e.g. `.graphify/converted`). */
+  searchRoots?: string[];
+}
+
+export interface CiteGraphResult {
+  /** Nodes that gained at least one grounded citation. */
+  groundedNodes: number;
+  /** Total grounded citations emitted across all nodes. */
+  totalCitations: number;
+  /** Per-kind counts of grounded nodes. */
+  byKind: Record<string, number>;
+  /** Source files that could not be resolved on disk (unique). */
+  unresolvedSources: string[];
+  /** Per-node grounded citations (for --dry-run reporting). */
+  perNode: Record<string, GroundedCitation[]>;
+}
+
+/**
+ * Ground citations across the whole graph (the `graphify cite` heuristic core).
+ *
+ * For each eligible node: resolve + parse its `source_file`, ground type-aware
+ * verbatim citations, and UNION them with any existing `node.citations`
+ * (union-not-clobber — existing extraction/sidecar citations are preserved).
+ * Mutates the graph in place unless `dryRun`. Caches parsed sources per file.
+ */
+export function citeGraph(G: Graph, options: CiteGraphOptions, dryRun = false): CiteGraphResult {
+  const topK = options.topK ?? 6;
+  const typeFilter = (options.types ?? []).map((t) => t.toLowerCase()).filter(Boolean);
+  const onlyMissing = options.onlyMissing ?? false;
+
+  const parseCache = new Map<string, { parsed: ParsedSource; norm: string } | null>();
+  const result: CiteGraphResult = {
+    groundedNodes: 0,
+    totalCitations: 0,
+    byKind: {},
+    unresolvedSources: [],
+    perNode: {},
+  };
+  const unresolved = new Set<string>();
+
+  const loadSource = (sourceFile: string): { parsed: ParsedSource; norm: string } | null => {
+    if (parseCache.has(sourceFile)) return parseCache.get(sourceFile) ?? null;
+    const path = resolveSourcePath(sourceFile, { root: options.root, searchRoots: options.searchRoots });
+    if (!path) {
+      unresolved.add(sourceFile);
+      parseCache.set(sourceFile, null);
+      return null;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch {
+      unresolved.add(sourceFile);
+      parseCache.set(sourceFile, null);
+      return null;
+    }
+    const parsed = parseSource(raw, detectModality(sourceFile));
+    const entry = { parsed, norm: normalizeForMatch(raw) };
+    parseCache.set(sourceFile, entry);
+    return entry;
+  };
+
+  G.forEachNode((nodeId, rawAttrs) => {
+    const attrs = rawAttrs as Record<string, unknown>;
+    const kind = nodeKind(attrs);
+    if (typeFilter.length > 0 && !typeFilter.includes(kind)) return;
+
+    const existing = Array.isArray(attrs.citations) ? (attrs.citations as OntologyCitation[]) : [];
+    if (onlyMissing && existing.length > 0) return;
+
+    const sourceFile = safeStr(attrs.source_file);
+    if (!sourceFile) return;
+
+    // An image node's `source_file` is a binary image (e.g.
+    // `..._images/image-000.jpg`) — not text. Ground it against the OCR-markdown
+    // document that contains it (whose `images` map carries the prev/next prose
+    // context), labeling the citation with that document path. This recovers the
+    // image-context grounding ia-aero's ground2.py did (the page:"unknown" /
+    // uncited-image gap). Other non-text source_files simply stay unresolved.
+    let loaded = loadSource(sourceFile);
+    let sourceLabel = sourceFile;
+    if (!loaded && /\.(png|jpe?g|gif|webp|tiff?|bmp)$/i.test(sourceFile)) {
+      const docFile = containingDocumentFor(sourceFile);
+      if (docFile) {
+        const docLoaded = loadSource(docFile);
+        if (docLoaded) {
+          loaded = docLoaded;
+          sourceLabel = docFile;
+        }
+      }
+    }
+    if (!loaded) return;
+
+    const grounded = groundNodeCitations(attrs, loaded.parsed, loaded.norm, {
+      topK,
+      sourceLabel,
+    });
+    if (grounded.length === 0) return;
+
+    // UNION-NOT-CLOBBER: fold the grounded citations into any existing set.
+    const merged = unionCitations([existing, grounded]);
+    if (!dryRun) {
+      G.setNodeAttribute(nodeId, "citations", merged);
+    }
+    result.perNode[nodeId] = grounded;
+    result.groundedNodes += 1;
+    result.totalCitations += grounded.length;
+    result.byKind[kind] = (result.byKind[kind] ?? 0) + 1;
+  });
+
+  result.unresolvedSources = [...unresolved].sort();
+  return result;
+}

--- a/src/cite-grounding.ts
+++ b/src/cite-grounding.ts
@@ -780,9 +780,18 @@ export function citeGraph(G: Graph, options: CiteGraphOptions, dryRun = false): 
     // context), labeling the citation with that document path. This recovers the
     // image-context grounding ia-aero's ground2.py did (the page:"unknown" /
     // uncited-image gap). Other non-text source_files simply stay unresolved.
-    let loaded = loadSource(sourceFile);
+    //
+    // CRITICAL: in real OCR output the binary image file USUALLY EXISTS on disk.
+    // We must NOT `loadSource(image)` first — that would read the binary as text
+    // and never reach the markdown fallback. For image nodes / image-extension
+    // source_files, resolve the containing OCR-markdown document FIRST and only
+    // fall back to reading the source itself when there is no containing doc.
+    const isImageSource =
+      kind === "image" || /\.(png|jpe?g|gif|webp|tiff?|bmp)$/i.test(sourceFile);
+
+    let loaded: { parsed: ParsedSource; norm: string } | null = null;
     let sourceLabel = sourceFile;
-    if (!loaded && /\.(png|jpe?g|gif|webp|tiff?|bmp)$/i.test(sourceFile)) {
+    if (isImageSource) {
       const docFile = containingDocumentFor(sourceFile);
       if (docFile) {
         const docLoaded = loadSource(docFile);
@@ -791,6 +800,15 @@ export function citeGraph(G: Graph, options: CiteGraphOptions, dryRun = false): 
           sourceLabel = docFile;
         }
       }
+      // No containing-doc convention match (or it didn't load): fall back to
+      // reading the source as text (degenerate, but keeps non-OCR images working
+      // when the file happens to be textual).
+      if (!loaded) {
+        loaded = loadSource(sourceFile);
+        sourceLabel = sourceFile;
+      }
+    } else {
+      loaded = loadSource(sourceFile);
     }
     if (!loaded) return;
 

--- a/src/cite-grounding.ts
+++ b/src/cite-grounding.ts
@@ -469,11 +469,22 @@ export function groundNodeCitations(
     page: number,
     section: string,
     confidence: CitationConfidence,
+    requireTerm?: string,
   ): boolean => {
     if (out.length >= topK) return false;
     const quote = windowQuote(rawText, offset);
     // HARD GATE: never emit a quote that is not a verbatim substring.
     if (!verifyVerbatim(quote, normalizedSource)) return false;
+    // PRECISION GATE: a quote can be a verbatim source substring yet, due to
+    // whitespace drift in windowing, NOT contain the term/ref/surname that
+    // justified attaching it. When a matched term is supplied, REQUIRE the
+    // emitted (normalized) quote to actually contain it — otherwise reject so we
+    // never attach an unrelated passage. (Contextual emits like image prose pass
+    // no term and are intentionally exempt.)
+    if (requireTerm) {
+      const needle = normalizeForMatch(requireTerm);
+      if (needle && !normalizeForMatch(quote).includes(needle)) return false;
+    }
     const dedupKey = normalizeForMatch(quote).slice(0, 60);
     if (!dedupKey || seen.has(dedupKey)) return false;
     seen.add(dedupKey);
@@ -515,14 +526,22 @@ export function groundNodeCitations(
     return true;
   };
 
-  // 1) PERSON → attach the units of any section heading containing the surname.
+  // 1) PERSON → attach the units of any section heading whose TOKENS include the
+  //    surname. The surname must be a WHOLE WORD in the heading: a bare
+  //    substring `includes` would let a surname like "Mat" match inside
+  //    "Mathématiques", or "Section" match a "Section 3" heading, attaching an
+  //    unrelated paragraph. Tokenize the normalized heading and test membership.
   if (kind === "person") {
     const labelBase = safeStr(attrs.label).split(/[—–,(]/)[0] ?? "";
     const pname = sel.surname ?? normalizeForMatch(labelBase);
     if (pname) {
+      // The surname may itself be multi-token (e.g. "de la tour"); match it as a
+      // whole-word token RUN within the heading's token stream.
+      const nameTokens = pname.split(" ").filter(Boolean);
       for (const [sec, idxs] of source.sectionToIndices) {
         if (out.length >= topK) break;
-        if (!normalizeForMatch(sec).includes(pname)) continue;
+        const secTokens = tokenize(normalizeForMatch(sec));
+        if (!tokensContainRun(secTokens, nameTokens)) continue;
         for (const i of idxs) {
           if (out.length >= topK) break;
           const u = source.units[i];
@@ -537,7 +556,7 @@ export function groundNodeCitations(
     for (const u of source.units) {
       if (out.length >= topK) break;
       const di = u.text.indexOf(sel.refMarker);
-      if (di >= 0) emit(u.text, di, u.page, u.section, "EXTRACTED");
+      if (di >= 0) emit(u.text, di, u.page, u.section, "EXTRACTED", sel.refMarker);
     }
   }
 
@@ -561,22 +580,28 @@ export function groundNodeCitations(
       if (out.length >= topK) break;
       const normText = normalizeForMatch(u.text);
       let di = -1;
+      let matchedTerm: string | null = null;
       for (const t of sel.terms) {
         const j = normText.indexOf(t);
         if (j >= 0) {
-          // Map the normalized offset back to a raw offset approximately by
-          // locating the first raw token of the term. Fall back to a raw
-          // case-insensitive find of the term's leading word.
+          // Map the normalized offset back to its EXACT raw offset so the quote
+          // window centers on the term (robust to NBSP/heavy whitespace).
           di = rawOffsetForTerm(u.text, t);
           if (di < 0) di = 0;
+          matchedTerm = t;
           break;
         }
       }
       if (di < 0 && acrRe) {
         const m = acrRe.exec(u.text);
-        if (m) di = m.index;
+        if (m) {
+          di = m.index;
+          matchedTerm = sel.acronym;
+        }
       }
-      if (di >= 0) emit(u.text, di, u.page, u.section, "EXTRACTED");
+      // The PRECISION GATE in `emit` re-checks that the windowed quote actually
+      // contains the matched term, rejecting any whitespace-drifted miss.
+      if (di >= 0) emit(u.text, di, u.page, u.section, "EXTRACTED", matchedTerm ?? undefined);
     }
   }
 
@@ -626,24 +651,95 @@ function indexOfUnit(source: ParsedSource, rawText: string): number {
 }
 
 /**
- * Map a normalized term back to an approximate RAW offset in the unit text by
- * locating the term's first content word case/diacritic-insensitively. The
- * exact offset is non-critical (the quote window is wide); the goal is a
- * sensible center. Returns -1 if even the leading word can't be found raw.
+ * Build a per-character map from NORMALIZED offsets back to RAW offsets for one
+ * unit of text. `normalizeForMatch` deaccents, folds ligatures, lowercases, and
+ * collapses whitespace runs (including NBSP ` `) to a single space — so a
+ * normalized offset does NOT line up with the raw offset whenever the raw text
+ * carries multi-char or non-breaking whitespace. This recovers the exact raw
+ * offset of every normalized character so quote windowing centers on the
+ * matched term, not on drifted text further along the paragraph.
+ *
+ * Returns `{ norm, map }` where `norm` is the normalized string and `map[k]` is
+ * the raw index at which normalized char `k` begins. Implemented by normalizing
+ * one raw char at a time and tracking the collapsed-whitespace state, mirroring
+ * `normalizeForMatch` exactly.
+ */
+function buildNormToRawMap(rawText: string): { norm: string; map: number[] } {
+  const normChars: string[] = [];
+  const map: number[] = [];
+  let pendingSpace = false; // a run of whitespace not yet emitted
+  let sawNonSpace = false; // have we emitted any non-space char yet (for trim)
+  for (let i = 0; i < rawText.length; i += 1) {
+    const ch = rawText[i] ?? "";
+    // Per-char normalization that mirrors normalizeForMatch's transforms.
+    const piece = normalizeForMatch(ch);
+    if (piece === "") {
+      // Whitespace (or a char that normalizes away, e.g. a combining mark).
+      // Treat only real whitespace as a collapsible separator.
+      if (/\s/.test(ch)) pendingSpace = true;
+      continue;
+    }
+    if (pendingSpace && sawNonSpace) {
+      normChars.push(" ");
+      map.push(i); // the collapsed space anchors at the start of this token
+    }
+    pendingSpace = false;
+    // A single raw char can normalize to multiple chars (œ→oe). Map them all to
+    // the same raw offset.
+    for (const c of piece) {
+      normChars.push(c);
+      map.push(i);
+    }
+    sawNonSpace = true;
+  }
+  return { norm: normChars.join(""), map };
+}
+
+/**
+ * Map a normalized term to its exact RAW offset in the unit text via the
+ * normalized→raw offset map, so windowing centers on the matched term even when
+ * the raw text has heavy/NBSP whitespace (a windowed quote must contain the
+ * term, not drift off it). Returns -1 if the term is not present.
  */
 function rawOffsetForTerm(rawText: string, normTerm: string): number {
-  const firstWord = normTerm.split(" ")[0] ?? "";
-  if (!firstWord) return -1;
-  const normRaw = normalizeForMatch(rawText);
-  const at = normRaw.indexOf(firstWord);
+  if (!normTerm) return -1;
+  const { norm, map } = buildNormToRawMap(rawText);
+  const at = norm.indexOf(normTerm);
   if (at < 0) return -1;
-  // The normalized text is whitespace-collapsed; offsets roughly track the raw
-  // text for prose. Clamp into range.
-  return Math.min(at, Math.max(0, rawText.length - 1));
+  return map[at] ?? -1;
 }
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Split a NORMALIZED string into word tokens (letters/digits runs). Used for
+ * whole-word surname matching against section headings so a surname is never a
+ * mid-word substring (e.g. "Mat" must not match inside "Mathématiques").
+ */
+function tokenize(normalized: string): string[] {
+  return normalized.match(/[a-z0-9]+/g) ?? [];
+}
+
+/**
+ * True iff `needle` (a token run) appears as a CONTIGUOUS whole-token run inside
+ * `tokens`. Single-token surnames match a single heading token; multi-token
+ * surnames ("de la tour") match the contiguous run. Empty needle → false.
+ */
+function tokensContainRun(tokens: string[], needle: string[]): boolean {
+  if (needle.length === 0) return false;
+  for (let i = 0; i + needle.length <= tokens.length; i += 1) {
+    let ok = true;
+    for (let j = 0; j < needle.length; j += 1) {
+      if (tokens[i + j] !== needle[j]) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4277,6 +4277,147 @@ export async function main(): Promise<void> {
       );
     });
 
+  // ---------------------------------------------------------------------------
+  // graphify cite [path]   (a.k.a. ground-citations)
+  // GROUND new citations into an EXISTING graph.json by SCANNING the corpus.
+  // Symmetric to `describe`/`label`: loads graph.json, walks nodes, grounds
+  // type-aware VERBATIM citations from each node's source_file, UNIONS them with
+  // existing citations (never clobbers), then runs the shipped aggregation
+  // (count + top-K inline + citations.json). Heuristic mode is the no-key
+  // DEFAULT; assistant/api are opt-in and gated by the SAME anti-hallucination
+  // verbatim check. Opt-in (NOT auto-run in the default pipeline), like describe.
+  // ---------------------------------------------------------------------------
+  program
+    .command("cite [path]")
+    .alias("ground-citations")
+    .description("Ground node.citations[] by scanning the corpus (verbatim, no-key heuristic; symmetric to describe). Populates new citations, not just projects existing ones.")
+    .option("--mode <mode>", "Grounding mode: heuristic (default, no key), assistant, or api", "heuristic")
+    .option("--top-k <n>", "Max citations grounded per node (default: 6)")
+    .option("--types <list>", "Restrict to comma-separated node types (e.g. person,concept,reference,image)")
+    .option("--only-missing", "Only ground nodes with no existing citations (additive 2nd pass)")
+    .option("--source <root>", "Extra source search root (repeatable); .graphify/converted is always searched")
+    .option("--citations-top-k <n>", "Inline Level-1 citations kept per node after aggregation (default: corpus-resolved; 3 code / 8 others)")
+    .option("--dry-run", "Report grounding coverage without writing graph.json or citations.json")
+    .action(async (citePath = ".", opts) => {
+      const root = resolve(citePath);
+      const paths = resolveGraphifyPaths({ root });
+      if (!existsSync(paths.graph)) {
+        console.error(`error: no graph found at ${paths.graph} - run /graphify first`);
+        process.exit(1);
+      }
+      mkdirSync(paths.stateDir, { recursive: true });
+
+      const mode = String(opts.mode ?? "heuristic").trim().toLowerCase();
+      if (!["heuristic", "assistant", "api"].includes(mode)) {
+        console.error("error: --mode must be one of: heuristic, assistant, api");
+        process.exit(1);
+      }
+      if (mode === "assistant" || mode === "api") {
+        // The LLM-assisted modes are opt-in recall boosters gated by the SAME
+        // anti-hallucination verbatim check. The proposer is not yet wired; the
+        // heuristic verifier (the load-bearing safety half) IS. Until the
+        // proposer lands, fall through to the heuristic core so the command is
+        // never a no-op and never emits an unverifiable quote.
+        console.log(
+          `cite: --mode ${mode} requested; the LLM proposer is not yet implemented. ` +
+            "Running the heuristic core (every quote is still verified verbatim). " +
+            "Re-run with --mode heuristic to silence this notice.",
+        );
+      }
+
+      const topK = parseTopKFlag(opts.topK) ?? 6;
+      const types = typeof opts.types === "string"
+        ? opts.types.split(",").map((t: string) => t.trim()).filter(Boolean)
+        : [];
+      const extraSources: string[] = typeof opts.source === "string"
+        ? [resolve(opts.source)]
+        : Array.isArray(opts.source)
+          ? opts.source.map((s: string) => resolve(s))
+          : [];
+      const dryRun = Boolean(opts.dryRun);
+
+      const policy = resolveCitationPolicyForRoot(root, {
+        topKFlag: parseTopKFlag(opts.citationsTopK),
+      });
+
+      const rawGraphText = readFileSync(paths.graph, "utf-8");
+      const G = makeGraphPortable(loadGraphFromData(JSON.parse(rawGraphText)), root);
+
+      const { citeGraph } = await import("./cite-grounding.js");
+      const groundResult = citeGraph(
+        G,
+        {
+          root,
+          topK,
+          types,
+          ...(opts.onlyMissing ? { onlyMissing: true } : {}),
+          searchRoots: [paths.convertedDir, ...extraSources],
+        },
+        dryRun,
+      );
+
+      const byKind = Object.entries(groundResult.byKind)
+        .sort((a, b) => b[1] - a[1])
+        .map(([k, v]) => `${k}:${v}`)
+        .join(", ");
+
+      if (dryRun) {
+        console.log(
+          `cite (dry-run): would ground ${groundResult.totalCitations} citation(s) across ` +
+            `${groundResult.groundedNodes} node(s)${byKind ? ` [${byKind}]` : ""}. No files written.`,
+        );
+        if (groundResult.unresolvedSources.length > 0) {
+          console.log(
+            `cite (dry-run): ${groundResult.unresolvedSources.length} source file(s) unresolved on disk ` +
+              `(e.g. ${groundResult.unresolvedSources.slice(0, 3).join(", ")}).`,
+          );
+        }
+        return;
+      }
+
+      if (groundResult.groundedNodes === 0) {
+        console.log(
+          "cite: grounded 0 nodes — no node's source_file resolved to text with a verbatim match. " +
+            (groundResult.unresolvedSources.length > 0
+              ? `${groundResult.unresolvedSources.length} source(s) unresolved on disk. `
+              : "") +
+            "graph.json unchanged.",
+        );
+        return;
+      }
+
+      // Run the shipped aggregation: snapshot the prior FULL sidecar so the
+      // exhaustive tail is unioned (not collapsed to the fresh grounding), then
+      // re-derive citation_count + the K-bounded inline set + citations.json.
+      const { aggregateCitations, readCitationsSidecar, writeCitationsSidecar } = await import("./citations.js");
+      const { toJson } = await import("./export.js");
+      const outDir = dirname(paths.graph);
+      const priorSidecar = readCitationsSidecar(outDir);
+      const aggMap = aggregateCitations(G, {
+        topK: policy.inlineTopK,
+        ...(priorSidecar ? { priorSidecar } : {}),
+      });
+      const sidecarPath = writeCitationsSidecar(outDir, aggMap, G);
+
+      // Preserve existing community assignments + names so toJson writes back
+      // byte-stable aside from the citation fields.
+      const communities = communitiesFromGraph(G);
+      const communityLabels = communityLabelsFromGraph(G, communities);
+      toJson(G, communities, paths.graph, { communityLabels, force: true });
+
+      console.log(
+        `cite: grounded ${groundResult.totalCitations} verbatim citation(s) across ` +
+          `${groundResult.groundedNodes} node(s)${byKind ? ` [${byKind}]` : ""}. ` +
+          `Re-aggregated (top-${policy.inlineTopK} inline + ${sidecarPath ?? "citations.json"}). graph.json updated.`,
+      );
+      if (groundResult.unresolvedSources.length > 0) {
+        console.log(
+          `cite: NOTE — ${groundResult.unresolvedSources.length} source file(s) could not be resolved on disk ` +
+            "(no grounding for their nodes). Ensure the corpus / .graphify/converted is present.",
+        );
+      }
+    });
+
   program
     .command("qa")
     .description("Evaluate a final Graphify bundle against a configured quality target")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4295,7 +4295,12 @@ export async function main(): Promise<void> {
     .option("--top-k <n>", "Max citations grounded per node (default: 6)")
     .option("--types <list>", "Restrict to comma-separated node types (e.g. person,concept,reference,image)")
     .option("--only-missing", "Only ground nodes with no existing citations (additive 2nd pass)")
-    .option("--source <root>", "Extra source search root (repeatable); .graphify/converted is always searched")
+    .option(
+      "--source <root>",
+      "Extra source search root (repeatable); .graphify/converted is always searched",
+      (value: string, acc: string[]) => [...acc, value],
+      [] as string[],
+    )
     .option("--citations-top-k <n>", "Inline Level-1 citations kept per node after aggregation (default: corpus-resolved; 3 code / 8 others)")
     .option("--dry-run", "Report grounding coverage without writing graph.json or citations.json")
     .action(async (citePath = ".", opts) => {
@@ -4329,10 +4334,13 @@ export async function main(): Promise<void> {
       const types = typeof opts.types === "string"
         ? opts.types.split(",").map((t: string) => t.trim()).filter(Boolean)
         : [];
-      const extraSources: string[] = typeof opts.source === "string"
-        ? [resolve(opts.source)]
-        : Array.isArray(opts.source)
-          ? opts.source.map((s: string) => resolve(s))
+      // `--source` is truly repeatable (Commander collect): opts.source is an
+      // array of every root passed. Each is resolved and searched in turn, so a
+      // source present only in the FIRST root still grounds.
+      const extraSources: string[] = Array.isArray(opts.source)
+        ? opts.source.map((s: string) => resolve(s))
+        : typeof opts.source === "string"
+          ? [resolve(opts.source)]
           : [];
       const dryRun = Boolean(opts.dryRun);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,6 +497,17 @@ export type OntologyStatus =
   | "superseded"
   | string;
 
+/**
+ * Grounding confidence of a citation's `quote`/locator. `EXTRACTED` = the quote
+ * is a verified verbatim substring of the source text matched on a real term;
+ * `INFERRED` = a weaker, context-derived grounding (e.g. an image's surrounding
+ * prose, a description/rationale fallback). The viewer / `assertion_basis`
+ * legend can flag `INFERRED` grounding visually. A bare string union (not the
+ * `Confidence` enum) so it can ride on a citation independently of the
+ * relationship-confidence taxonomy.
+ */
+export type CitationConfidence = "EXTRACTED" | "INFERRED";
+
 export interface OntologyCitation {
   source_file: string;
   source_url?: string;
@@ -505,6 +516,32 @@ export interface OntologyCitation {
   paragraph_id?: string;
   figure_id?: string;
   bbox?: [number, number, number, number];
+  /**
+   * Human-readable, modality-encoded locator string (WP #24). The display form
+   * the studio shows next to a quote: `"p.12 · Section"` for OCR-markdown,
+   * `"p.12"` for native PDF, the chapter/story name for plain text. The
+   * structured `page`/`section` fields remain the machine locators; this is the
+   * pre-rendered display string ia-aero's `ground.py` already emits. Optional,
+   * NOT part of the identity key. (Mirrors `GraphNode.source_location`.)
+   */
+  source_location?: string;
+  /**
+   * Verbatim passage from the source that grounds this citation. First-class
+   * optional field (WP #24): de-facto present in production already — carried by
+   * `OntologyEvidenceRecord`, the mystery `citations.json` sidecar, and consumed
+   * by the studio EntityPanel + the describe grounding path
+   * (`collectCitationContext` reads `quote ?? text ?? snippet`) — the type
+   * omission was an inconsistency. NEVER part of the citation identity key
+   * (`source_file|page|section|paragraph_id`): two citations to the same locator
+   * with different quotes still dedupe to one. Backward-compatible.
+   */
+  quote?: string;
+  /**
+   * Grounding confidence for the `quote`. WP #24 first-class optional field,
+   * symmetric to `OntologyEvidenceRecord.confidence`. Not part of the identity
+   * key. Recorded, not hidden, so weaker (INFERRED) grounding is visible.
+   */
+  confidence?: CitationConfidence;
 }
 
 export interface OntologyEvidenceRecord {

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -26,8 +26,10 @@
   // renders INSTANTLY off the already-loaded graph. When the lazy entity sidecar
   // arrives with the full per-entity list (entity.citations.citations), it
   // REPLACES the inline render with the complete file > passages accordion —
-  // same renderer, richer data. Passages render locators (section/page); the
-  // schema carries no verbatim quote.
+  // same renderer, richer data. Passages render locators (section/page) AND, when
+  // present, a verbatim `quote` (WP #24: `quote` is now a first-class field on
+  // OntologyCitation, populated by `graphify cite`; the blockquote below renders
+  // it). Citations grounded by older pipelines may still be locator-only.
   const fullCitations = $derived(
     Array.isArray(entity?.citations?.citations) ? entity.citations.citations : null,
   );

--- a/tests/cite-grounding.test.ts
+++ b/tests/cite-grounding.test.ts
@@ -340,6 +340,108 @@ describe("citeGraph — image nodes ground against the containing document", () 
   });
 });
 
+
+// ---------------------------------------------------------------------------
+// Matcher precision: a verbatim quote MUST contain the matched term, and a
+// surname must be a whole word in a heading (the two MAJOR grounding-quality
+// defects).
+// ---------------------------------------------------------------------------
+
+describe("matcher precision — quote contains the term, surname is whole-word", () => {
+  it("REGRESSION: under heavy/NBSP whitespace the emitted quote STILL contains the term", () => {
+    // The term "concurrent" sits far into a paragraph padded with non-breaking
+    // spaces and runs of whitespace. normalizeForMatch collapses those, so the
+    // NORMALIZED offset is much smaller than the RAW offset — windowing on the
+    // normalized offset would drift off the term. The fix maps normalized→raw
+    // offsets exactly AND re-checks containment in the emit gate.
+    const NBSP = String.fromCharCode(0x00a0); // a non-breaking space
+    // A wide collapsible whitespace run: 8 NBSP + 3 spaces + 8 NBSP. Each
+    // filler unit is ~22 raw chars but normalizes to ~5, so over 40 repeats the
+    // RAW offset of "concurrent" races HUNDREDS of chars ahead of its
+    // NORMALIZED offset — far enough to drift a normalized-offset window
+    // entirely off the term (the exact defect the offset map fixes).
+    const GAP = NBSP.repeat(8) + "   " + NBSP.repeat(8);
+    const filler = (`mot${GAP}`).repeat(40);
+    const para = `Introduction.${GAP}${filler} Le terme concurrent apparait ici precisement.`;
+    const md = ["# Section", "", para].join("\n");
+    const parsed = parseSource(md, "ocr-markdown");
+    const norm = normalizeForMatch(md);
+
+    // "concurrent" (a content word ≥5 chars, not a stopword) is the selected
+    // term; it sits deep in the raw paragraph behind a long NBSP/whitespace run.
+    const sel = selectNodeTerms({ id: "c1", label: "Système concurrent", file_type: "concept" });
+    expect(sel.terms).toContain("concurrent");
+
+    const cites = groundNodeCitations(
+      { id: "c1", label: "Système concurrent", file_type: "concept" },
+      parsed,
+      norm,
+      { topK: 6, sourceLabel: "x.md" },
+    );
+    expect(cites.length).toBeGreaterThan(0);
+    // The whole point: the emitted quote must actually contain the matched term.
+    expect(normalizeForMatch(cites[0]!.quote)).toContain("concurrent");
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("REGRESSION: a surname must NOT match as a substring of a heading word", () => {
+    // Surname "Mat" must NOT ground via the heading "Mathématiques" (substring
+    // includes would wrongly attach the math paragraph). Likewise a generic
+    // "Section" surname must not match "Section 3".
+    const md = [
+      "# Mathématiques appliquées",
+      "",
+      "Ce chapitre traite de l'algèbre linéaire et des matrices.",
+      "",
+      "# Section 3",
+      "",
+      "Cette section décrit le protocole expérimental.",
+    ].join("\n");
+    const parsed = parseSource(md, "ocr-markdown");
+    const norm = normalizeForMatch(md);
+
+    // "Mat" is the surname (label base is a single token used as surname).
+    const matCites = groundNodeCitations(
+      { id: "p_mat", label: "Mat", file_type: "person" },
+      parsed,
+      norm,
+      { topK: 6, sourceLabel: "x.md" },
+    );
+    // "Mat" is < 4 chars so it isn't even selected as a surname term; but even a
+    // 4-char near-miss must not substring-match a heading. Assert no false
+    // grounding occurs on the math paragraph.
+    expect(matCites.some((c) => c.quote.includes("algèbre"))).toBe(false);
+
+    // A surname that IS a heading word substring but NOT a whole word.
+    const sectionCites = groundNodeCitations(
+      { id: "p_section", label: "Sectionneur", file_type: "person" },
+      parsed,
+      norm,
+      { topK: 6, sourceLabel: "x.md" },
+    );
+    // "Sectionneur" is not a whole token in "Section 3" → no grounding here.
+    expect(sectionCites.some((c) => c.quote.includes("protocole"))).toBe(false);
+  });
+
+  it("a real whole-word surname STILL grounds in its section", () => {
+    const md = [
+      "# Entretien avec Mattioli",
+      "",
+      "Le travail de recherche se concentre sur la confiance algorithmique.",
+    ].join("\n");
+    const parsed = parseSource(md, "ocr-markdown");
+    const norm = normalizeForMatch(md);
+    const cites = groundNodeCitations(
+      { id: "p1", label: "Juliette Mattioli", file_type: "person" },
+      parsed,
+      norm,
+      { topK: 6, sourceLabel: "x.md" },
+    );
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites[0]!.quote).toContain("recherche");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // (2) Mystery sidecar SHAPE consistency on plain text
 // ---------------------------------------------------------------------------

--- a/tests/cite-grounding.test.ts
+++ b/tests/cite-grounding.test.ts
@@ -1,0 +1,476 @@
+/**
+ * `graphify cite` — heuristic GROUNDING engine (WP #24).
+ *
+ * Golden-oracle coverage (the brief's required tests):
+ *  (1) a representative OCR-markdown fixture + entities → near-100% grounding
+ *      with VERBATIM quotes (mirrors ia-aero's 876/876);
+ *  (2) consistency with mystery's shipped citation sidecar SHAPE
+ *      ({source_file, section, quote}) on plain text;
+ *  (3) the anti-hallucination invariant: never emit a non-substring quote;
+ *  (4) the type-aware matchers (person section / reference [N] / acronym /
+ *      concept content-word / image context);
+ *  (5) union-not-clobber (existing citations preserved, fresh folded in);
+ *  (6) the contract additions (quote? / confidence? / source_location? on
+ *      OntologyCitation are populated and type-check).
+ */
+import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+import {
+  citeGraph,
+  containingDocumentFor,
+  detectModality,
+  groundNodeCitations,
+  normalizeForMatch,
+  parseSource,
+  selectNodeTerms,
+  verifyVerbatim,
+  windowQuote,
+} from "../src/cite-grounding.js";
+import type { OntologyCitation } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures: a representative OCR-markdown white paper (ia-aero-shaped) and a
+// plain-text novel chapter (mystery-shaped).
+// ---------------------------------------------------------------------------
+
+const OCR_MARKDOWN = [
+  "---",
+  'graphify_source_file: "/abs/CONTRIBUTION_AI.pdf"',
+  "graphify_conversion: mistral-ocr",
+  "---",
+  "",
+  "# CONTRIBUTION DE L'IA À UNE AÉRONAUTIQUE PÉRENNE",
+  "",
+  "Le système CATIA V5 est au cœur de la conception assistée par ordinateur.",
+  "",
+  "![img-0.jpeg](AI_images/image-000.jpg)",
+  "",
+  "La maintenance prédictive réduit les coûts opérationnels de manière significative.",
+  "",
+  "---",
+  "",
+  "# Entretien avec Juliette Mattioli",
+  "",
+  "Juliette Mattioli explique que l'apprentissage automatique transforme l'industrie.",
+  "",
+  "Elle insiste sur l'importance de la confiance dans les modèles déployés [12].",
+  "",
+  "---",
+  "",
+  "## Bibliographie",
+  "",
+  "[12] Mattioli J., Confiance et IA, 2024.",
+  "",
+  "L'acronyme MBSE désigne le Model-Based Systems Engineering.",
+].join("\n");
+
+const PLAIN_TEXT = [
+  "THE ADVENTURE OF THE EMPTY HOUSE",
+  "",
+  "It was in the spring of the year 1894 that all London was interested.",
+  "",
+  "remarkable explorations of a Norwegian named Sigerson, but little did the public know.",
+  "",
+  "Chapter 2",
+  "",
+  "Sherlock Holmes returned to Baker Street with his old friend Watson at his side.",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Normalization + verbatim verification (the anti-hallucination substrate)
+// ---------------------------------------------------------------------------
+
+describe("normalizeForMatch", () => {
+  it("deaccents, lowercases, folds ligatures, collapses whitespace", () => {
+    expect(normalizeForMatch("Le SYSTÈME  CŒUR")).toBe("le systeme coeur");
+    expect(normalizeForMatch("Mattioli\n\tJuliette")).toBe("mattioli juliette");
+  });
+});
+
+describe("verifyVerbatim — the anti-hallucination gate", () => {
+  const src = normalizeForMatch(OCR_MARKDOWN);
+
+  it("accepts a real substring (after normalization)", () => {
+    expect(verifyVerbatim("Le système CATIA V5 est au cœur", src)).toBe(true);
+  });
+
+  it("accepts an ellipsis-padded window (padding is stripped before the check)", () => {
+    expect(verifyVerbatim("… maintenance prédictive réduit les coûts …", src)).toBe(true);
+  });
+
+  it("REJECTS text that is not in the source (a hallucination)", () => {
+    expect(verifyVerbatim("CATIA V5 costs four million dollars per seat", src)).toBe(false);
+    expect(verifyVerbatim("the moon is made of green cheese", src)).toBe(false);
+  });
+
+  it("rejects an empty / ellipsis-only quote", () => {
+    expect(verifyVerbatim("", src)).toBe(false);
+    expect(verifyVerbatim("…  …", src)).toBe(false);
+  });
+});
+
+describe("windowQuote", () => {
+  it("returns RAW verbatim text snapped to boundaries, ellipsis-padded", () => {
+    const text = "Alpha beta gamma. The needle is here. Delta epsilon zeta omega end.";
+    const offset = text.indexOf("needle");
+    const q = windowQuote(text, offset);
+    expect(q).toContain("needle");
+    // The windowed quote must itself be verbatim against the source.
+    expect(verifyVerbatim(q, normalizeForMatch(text))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Modality parsing + page resolution (the aclp-am page:"unknown" fix)
+// ---------------------------------------------------------------------------
+
+describe("parseSource — OCR-markdown", () => {
+  const parsed = parseSource(OCR_MARKDOWN, "ocr-markdown");
+
+  it("skips the front-matter block so page numbering starts at 1, not 2", () => {
+    // The first real paragraph (CATIA) is on page 1, NOT page 2.
+    const catia = parsed.units.find((u) => u.text.includes("CATIA"));
+    expect(catia?.page).toBe(1);
+  });
+
+  it("increments the page on each bare --- page break (real page resolution)", () => {
+    const mattioli = parsed.units.find((u) => u.text.includes("apprentissage automatique"));
+    expect(mattioli?.page).toBe(2); // after the first page break
+    const biblio = parsed.units.find((u) => u.text.includes("[12] Mattioli"));
+    expect(biblio?.page).toBe(3); // after the second page break
+  });
+
+  it("resolves section headings (#) per unit", () => {
+    const catia = parsed.units.find((u) => u.text.includes("CATIA"));
+    expect(catia?.section).toContain("AÉRONAUTIQUE");
+    const interview = parsed.units.find((u) => u.text.includes("apprentissage automatique"));
+    expect(interview?.section).toContain("Juliette Mattioli");
+  });
+
+  it("captures image context (prev/next prose)", () => {
+    const img = parsed.images.get("image-000.jpg");
+    expect(img).toBeDefined();
+    expect(img?.prev).toContain("CATIA");
+    expect(img?.next).toContain("maintenance prédictive");
+    expect(img?.page).toBe(1);
+  });
+});
+
+describe("detectModality", () => {
+  it("classifies .md as ocr-markdown and .txt as plain-text", () => {
+    expect(detectModality("converted/pdf/x.md")).toBe("ocr-markdown");
+    expect(detectModality("corpus/raffles/text.txt")).toBe("plain-text");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4) Type-aware matchers
+// ---------------------------------------------------------------------------
+
+describe("selectNodeTerms — type-aware term selection", () => {
+  it("person → surname", () => {
+    const sel = selectNodeTerms({ id: "p1", label: "Juliette Mattioli", file_type: "person" });
+    expect(sel.surname).toBe("mattioli");
+  });
+
+  it("reference → [N] marker", () => {
+    const sel = selectNodeTerms({ id: "ref_12", label: "Confiance et IA [12]", file_type: "reference" });
+    expect(sel.refMarker).toBe("[12]");
+  });
+
+  it("acronym → the raw caps label", () => {
+    const sel = selectNodeTerms({ id: "a1", label: "MBSE", file_type: "concept" });
+    expect(sel.acronym).toBe("MBSE");
+  });
+
+  it("concept → most specific stopword-filtered content word", () => {
+    const sel = selectNodeTerms({ id: "c1", label: "Maintenance prédictive", file_type: "concept" });
+    // "maintenance" / "predictive" both survive; the longest is included.
+    expect(sel.terms.some((t) => t.includes("predictive") || t.includes("maintenance"))).toBe(true);
+  });
+});
+
+describe("groundNodeCitations — type-aware grounding produces VERBATIM quotes", () => {
+  const parsed = parseSource(OCR_MARKDOWN, "ocr-markdown");
+  const norm = normalizeForMatch(OCR_MARKDOWN);
+  const ground = (attrs: Record<string, unknown>) =>
+    groundNodeCitations(attrs, parsed, norm, { topK: 6, sourceLabel: "x.md" });
+
+  it("person → grounds in the interview section, page resolved", () => {
+    const cites = ground({ id: "p1", label: "Juliette Mattioli", file_type: "person" });
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites[0]?.quote).toContain("apprentissage automatique");
+    expect(cites[0]?.page).toBe(2);
+    expect(cites[0]?.confidence).toBe("EXTRACTED");
+    // Anti-hallucination: every quote is verbatim.
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("reference → resolves the [12] marker back into the body", () => {
+    const cites = ground({ id: "ref_12", label: "Confiance et IA [12]", file_type: "reference" });
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites.some((c) => c.quote.includes("[12]"))).toBe(true);
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("acronym → whole-word match", () => {
+    const cites = ground({ id: "a1", label: "MBSE", file_type: "concept" });
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites[0]?.quote).toContain("MBSE");
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("concept → content-word match", () => {
+    const cites = ground({ id: "c1", label: "Maintenance prédictive", file_type: "concept" });
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites[0]?.quote.toLowerCase()).toContain("maintenance");
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("image → grounds on surrounding prose with INFERRED confidence", () => {
+    const cites = ground({ id: "i1", label: "Figure 1", file_type: "image", source_file: "AI_images/image-000.jpg" });
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites.every((c) => c.confidence === "INFERRED")).toBe(true);
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("a node with no match in the source emits NOTHING (no fabrication)", () => {
+    const cites = ground({ id: "x", label: "Quetzalcoatl Spaceport", file_type: "concept" });
+    expect(cites).toHaveLength(0);
+  });
+
+  it("rationale fallback: a quote node grounds on its verbatim rationale span", () => {
+    // The rationale wraps a verbatim source span in quotes; only the verbatim
+    // part is emitted, and ONLY because it verifies against the source.
+    const cites = ground({
+      id: "q1",
+      label: "Citation on CATIA",
+      file_type: "quote",
+      rationale: '"Le système CATIA V5 est au cœur de la conception" — context note that is a paraphrase.',
+      source_location: "Introduction",
+    });
+    expect(cites.length).toBeGreaterThan(0);
+    expect(cites[0]?.quote).toContain("CATIA");
+    expect(cites[0]?.confidence).toBe("EXTRACTED");
+    for (const c of cites) expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+
+  it("rationale fallback DROPS a paraphrase rationale (anti-hallucination)", () => {
+    const cites = ground({
+      id: "q2",
+      label: "Paraphrased claim",
+      file_type: "quote",
+      rationale: "This entity represents a futuristic spaceport on a distant moon, never in the source.",
+      source_location: "Nowhere",
+    });
+    expect(cites).toHaveLength(0); // paraphrase fails verifyVerbatim → emitted nothing
+  });
+});
+
+describe("containingDocumentFor — image → markdown resolution", () => {
+  it("maps an OCR image path back to its containing markdown document", () => {
+    expect(containingDocumentFor(".graphify/converted/pdf/PAPER_abc_images/image-000.jpg")).toBe(
+      ".graphify/converted/pdf/PAPER_abc.md",
+    );
+  });
+  it("returns null for a non-image-convention path", () => {
+    expect(containingDocumentFor("corpus/x/text.txt")).toBeNull();
+  });
+});
+
+describe("citeGraph — image nodes ground against the containing document", () => {
+  it("grounds an image node on the document's prev/next prose, labeled with the .md", () => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const root = mkdtempSync(join(tmpdir(), "graphify-cite-img-"));
+    mkdirSync(join(root, "doc_images"), { recursive: true });
+    writeFileSync(join(root, "doc.md"), OCR_MARKDOWN, "utf-8");
+
+    const G = new Graph();
+    // The image node's own source_file is the (non-text) jpg; it must resolve to doc.md.
+    G.addNode("i1", {
+      id: "i1",
+      label: "Figure 1",
+      file_type: "image",
+      source_file: "doc_images/image-000.jpg",
+    });
+
+    const result = citeGraph(G, { root, topK: 6 });
+    expect(result.perNode.i1?.length).toBeGreaterThan(0);
+    const c = result.perNode.i1![0]!;
+    expect(c.source_file).toBe("doc.md"); // labeled with the containing document
+    expect(c.confidence).toBe("INFERRED");
+    expect(verifyVerbatim(c.quote, normalizeForMatch(OCR_MARKDOWN))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) Mystery sidecar SHAPE consistency on plain text
+// ---------------------------------------------------------------------------
+
+describe("groundNodeCitations — plain text matches the mystery sidecar shape", () => {
+  const parsed = parseSource(PLAIN_TEXT, "plain-text");
+  const norm = normalizeForMatch(PLAIN_TEXT);
+
+  it("emits {source_file, section, quote} with section = chapter/story, no page", () => {
+    const cites = groundNodeCitations(
+      { id: "alias_sigerson", label: "Sigerson", file_type: "concept" },
+      parsed,
+      norm,
+      { topK: 6, sourceLabel: "corpus/sherlock/text.txt" },
+    );
+    expect(cites.length).toBeGreaterThan(0);
+    const c = cites[0]!;
+    expect(c.source_file).toBe("corpus/sherlock/text.txt");
+    expect(c.quote).toContain("Sigerson");
+    expect(c.section).toContain("EMPTY HOUSE");
+    // mystery is plain text: no page field is emitted.
+    expect(c.page).toBeUndefined();
+    expect(verifyVerbatim(c.quote, norm)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (1) Near-100% grounding over a graph (mirrors ia-aero's 876/876)
+// ---------------------------------------------------------------------------
+
+function buildGraph(nodes: Record<string, unknown>[]): Graph {
+  const G = new Graph();
+  for (const n of nodes) G.addNode(n.id as string, n);
+  return G;
+}
+
+describe("citeGraph — near-100% grounding (ia-aero 876/876 analogue)", () => {
+  it("grounds every node whose term appears in the source", () => {
+    // Write the fixture to a temp source the graph nodes point at.
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const root = mkdtempSync(join(tmpdir(), "graphify-cite-"));
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "paper.md"), OCR_MARKDOWN, "utf-8");
+
+    const G = buildGraph([
+      { id: "p1", label: "Juliette Mattioli", file_type: "person", source_file: "src/paper.md" },
+      { id: "ref_12", label: "Confiance et IA [12]", file_type: "reference", source_file: "src/paper.md" },
+      { id: "a1", label: "MBSE", file_type: "concept", source_file: "src/paper.md" },
+      { id: "c1", label: "Maintenance prédictive", file_type: "concept", source_file: "src/paper.md" },
+      { id: "c2", label: "CATIA V5", file_type: "technology", source_file: "src/paper.md" },
+    ]);
+
+    const result = citeGraph(G, { root, topK: 6 });
+    // All 5 grounded — the ia-aero "every entity cited" property on a small set.
+    expect(result.groundedNodes).toBe(5);
+    expect(result.totalCitations).toBeGreaterThanOrEqual(5);
+
+    // Every emitted citation across the whole graph is verbatim.
+    const norm = normalizeForMatch(OCR_MARKDOWN);
+    G.forEachNode((_id, attrs) => {
+      const cites = (attrs as { citations?: OntologyCitation[] }).citations ?? [];
+      for (const c of cites) {
+        if (typeof c.quote === "string") {
+          expect(verifyVerbatim(c.quote, norm)).toBe(true);
+        }
+      }
+    });
+  });
+
+  it("--only-missing skips nodes that already carry citations", () => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const root = mkdtempSync(join(tmpdir(), "graphify-cite-"));
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "paper.md"), OCR_MARKDOWN, "utf-8");
+
+    const G = buildGraph([
+      {
+        id: "p1",
+        label: "Juliette Mattioli",
+        file_type: "person",
+        source_file: "src/paper.md",
+        citations: [{ source_file: "prior.txt", quote: "pre-existing" }],
+      },
+      { id: "a1", label: "MBSE", file_type: "concept", source_file: "src/paper.md" },
+    ]);
+
+    const result = citeGraph(G, { root, topK: 6, onlyMissing: true });
+    expect(result.groundedNodes).toBe(1); // only MBSE, p1 skipped
+    expect(result.perNode.a1).toBeDefined();
+    expect(result.perNode.p1).toBeUndefined();
+  });
+
+  it("--types restricts grounding to the requested node kinds", () => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const root = mkdtempSync(join(tmpdir(), "graphify-cite-"));
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "paper.md"), OCR_MARKDOWN, "utf-8");
+
+    const G = buildGraph([
+      { id: "p1", label: "Juliette Mattioli", file_type: "person", source_file: "src/paper.md" },
+      { id: "a1", label: "MBSE", file_type: "concept", source_file: "src/paper.md" },
+    ]);
+
+    const result = citeGraph(G, { root, topK: 6, types: ["person"] });
+    expect(result.perNode.p1).toBeDefined();
+    expect(result.perNode.a1).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (5) Union-not-clobber
+// ---------------------------------------------------------------------------
+
+describe("citeGraph — union-not-clobber", () => {
+  it("preserves existing citations and folds fresh grounded ones in", () => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const root = mkdtempSync(join(tmpdir(), "graphify-cite-"));
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "paper.md"), OCR_MARKDOWN, "utf-8");
+
+    const priorCite: OntologyCitation = { source_file: "earlier.txt", page: 99, quote: "earlier finding" };
+    const G = buildGraph([
+      { id: "a1", label: "MBSE", file_type: "concept", source_file: "src/paper.md", citations: [priorCite] },
+    ]);
+
+    citeGraph(G, { root, topK: 6 });
+    const after = (G.getNodeAttribute("a1", "citations") ?? []) as OntologyCitation[];
+
+    // The pre-existing citation survives (union-not-clobber)...
+    expect(after.some((c) => c.source_file === "earlier.txt" && c.quote === "earlier finding")).toBe(true);
+    // ...and a fresh grounded MBSE citation was added.
+    expect(after.some((c) => c.source_file === "src/paper.md" && (c.quote ?? "").includes("MBSE"))).toBe(true);
+    expect(after.length).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (6) Contract additions — quote? / confidence? / source_location? type-check
+// ---------------------------------------------------------------------------
+
+describe("OntologyCitation contract additions (WP #24)", () => {
+  it("accepts quote, confidence, and source_location as first-class optional fields", () => {
+    const c: OntologyCitation = {
+      source_file: "x.md",
+      page: 12,
+      section: "Intro",
+      paragraph_id: "p3",
+      source_location: "p.12 · Intro",
+      quote: "verbatim passage",
+      confidence: "EXTRACTED",
+    };
+    expect(c.quote).toBe("verbatim passage");
+    expect(c.confidence).toBe("EXTRACTED");
+    expect(c.source_location).toBe("p.12 · Intro");
+
+    // Backward-compatible: a locator-only citation is still valid.
+    const legacy: OntologyCitation = { source_file: "y.txt" };
+    expect(legacy.quote).toBeUndefined();
+    expect(legacy.confidence).toBeUndefined();
+  });
+});

--- a/tests/cite-grounding.test.ts
+++ b/tests/cite-grounding.test.ts
@@ -303,6 +303,41 @@ describe("citeGraph — image nodes ground against the containing document", () 
     expect(c.confidence).toBe("INFERRED");
     expect(verifyVerbatim(c.quote, normalizeForMatch(OCR_MARKDOWN))).toBe(true);
   });
+
+  it("REGRESSION: grounds via the containing doc even when the image FILE EXISTS on disk", () => {
+    // The MAJOR bug: in real OCR output the binary image usually exists on disk,
+    // so reading source_file first read the binary as text and the markdown
+    // fallback never ran → the image node got 0 citations. The fix resolves the
+    // containing document BEFORE attempting to read the binary.
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const root = mkdtempSync(join(tmpdir(), "graphify-cite-img-exists-"));
+    mkdirSync(join(root, "doc_images"), { recursive: true });
+    writeFileSync(join(root, "doc.md"), OCR_MARKDOWN, "utf-8");
+    // The image file ACTUALLY EXISTS — a few bytes of (binary-ish) content that
+    // would NOT verbatim-ground anything if read as text.
+    writeFileSync(join(root, "doc_images", "image-000.jpg"), Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]));
+
+    const G = new Graph();
+    G.addNode("i1", {
+      id: "i1",
+      label: "Figure 1",
+      file_type: "image",
+      source_file: "doc_images/image-000.jpg",
+    });
+
+    const result = citeGraph(G, { root, topK: 6 });
+    // Must STILL ground (the bug made this 0).
+    expect(result.groundedNodes).toBe(1);
+    expect(result.perNode.i1?.length).toBeGreaterThan(0);
+    const c = result.perNode.i1![0]!;
+    expect(c.source_file).toBe("doc.md"); // the containing document, not the jpg
+    expect(c.confidence).toBe("INFERRED");
+    // The jpg path is NOT left dangling as "unresolved" when grounding succeeded.
+    expect(result.unresolvedSources).not.toContain("doc_images/image-000.jpg");
+    expect(verifyVerbatim(c.quote, normalizeForMatch(OCR_MARKDOWN))).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/cli-cite.test.ts
+++ b/tests/cli-cite.test.ts
@@ -1,0 +1,193 @@
+/**
+ * `graphify cite [path]` — end-to-end via the real CLI program. Asserts the
+ * command grounds verbatim citations from a corpus source, UNIONS with existing
+ * citations, re-aggregates into citation_count + a trimmed inline set +
+ * citations.json, supports --dry-run / --only-missing, and never emits a
+ * non-verbatim quote.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { main } from "../src/cli.js";
+import { normalizeForMatch, verifyVerbatim } from "../src/cite-grounding.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const d = tempDirs.pop()!;
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+const OCR_MARKDOWN = [
+  "---",
+  'graphify_source_file: "/abs/paper.pdf"',
+  "graphify_conversion: mistral-ocr",
+  "---",
+  "",
+  "# Introduction",
+  "",
+  "Le système CATIA V5 est au cœur de la conception assistée par ordinateur.",
+  "",
+  "---",
+  "",
+  "# Entretien avec Juliette Mattioli",
+  "",
+  "Juliette Mattioli explique que l'apprentissage automatique transforme l'industrie.",
+].join("\n");
+
+function citeProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-cite-cli-"));
+  tempDirs.push(dir);
+  const graphDir = join(dir, ".graphify");
+  mkdirSync(join(graphDir, "converted", "pdf"), { recursive: true });
+  // Source lives under .graphify/converted/pdf (the always-searched root).
+  writeFileSync(join(graphDir, "converted", "pdf", "paper.md"), OCR_MARKDOWN, "utf-8");
+  writeFileSync(
+    join(graphDir, "graph.json"),
+    JSON.stringify({
+      directed: false,
+      graph: {},
+      nodes: [
+        { id: "p1", label: "Juliette Mattioli", file_type: "person", source_file: ".graphify/converted/pdf/paper.md", community: 0 },
+        { id: "t1", label: "CATIA V5", file_type: "concept", node_type: "technology", source_file: ".graphify/converted/pdf/paper.md", community: 0 },
+        { id: "x1", label: "Quetzalcoatl Spaceport", file_type: "concept", source_file: ".graphify/converted/pdf/paper.md", community: 0 },
+      ],
+      links: [],
+      community_labels: { "0": "Aero" },
+    }),
+    "utf-8",
+  );
+  return dir;
+}
+
+async function runCli(args: string[], cwd: string) {
+  const previousArgv = process.argv;
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const logs: string[] = [];
+  const errors: string[] = [];
+  console.log = (...items: unknown[]) => { logs.push(items.join(" ")); };
+  console.error = (...items: unknown[]) => { errors.push(items.join(" ")); };
+  process.exit = ((code?: string | number | null) => {
+    throw new Error(`process.exit ${code ?? 0}`);
+  }) as typeof process.exit;
+  process.argv = ["node", "graphify", ...args];
+  process.chdir(cwd);
+  try {
+    await main();
+    return { logs, errors, exitCode: 0 };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/^process\.exit (\d+)/);
+    if (match) return { logs, errors, exitCode: Number(match[1]) };
+    return { logs, errors: [...errors, message], exitCode: 1 };
+  } finally {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+}
+
+interface GraphNode { id: string; citations?: Array<{ quote?: string; source_file: string; page?: number }>; citation_count?: number }
+
+function readGraph(dir: string): { nodes: GraphNode[] } {
+  return JSON.parse(readFileSync(join(dir, ".graphify", "graph.json"), "utf-8")) as { nodes: GraphNode[] };
+}
+
+describe("graphify cite", () => {
+  it("grounds verbatim citations, sets citation_count + inline set + citations.json", async () => {
+    const dir = citeProject();
+    const { logs } = await runCli(["cite", dir], dir);
+
+    const graph = readGraph(dir);
+    const mattioli = graph.nodes.find((n) => n.id === "p1")!;
+    const catia = graph.nodes.find((n) => n.id === "t1")!;
+    const fake = graph.nodes.find((n) => n.id === "x1")!;
+
+    // Grounded nodes carry verbatim citations + a count.
+    expect(mattioli.citations?.length).toBeGreaterThan(0);
+    expect(mattioli.citation_count).toBeGreaterThan(0);
+    expect(mattioli.citations?.[0]?.quote).toContain("apprentissage automatique");
+    expect(mattioli.citations?.[0]?.page).toBe(2);
+
+    expect(catia.citations?.some((c) => (c.quote ?? "").includes("CATIA"))).toBe(true);
+
+    // The node whose term never appears stays uncited — no fabrication.
+    expect(fake.citations ?? []).toHaveLength(0);
+
+    // Anti-hallucination across the whole written graph.
+    const norm = normalizeForMatch(OCR_MARKDOWN);
+    for (const n of graph.nodes) {
+      for (const c of n.citations ?? []) {
+        if (typeof c.quote === "string") expect(verifyVerbatim(c.quote, norm)).toBe(true);
+      }
+    }
+
+    // The Level-2 sidecar was written.
+    expect(existsSync(join(dir, ".graphify", "ontology", "citations.json"))).toBe(true);
+    const sidecar = JSON.parse(
+      readFileSync(join(dir, ".graphify", "ontology", "citations.json"), "utf-8"),
+    ) as { schema: string; nodes: Record<string, { count: number; citations: unknown[] }> };
+    expect(sidecar.schema).toBe("graphify_ontology_citations_v1");
+    expect(sidecar.nodes.p1?.count).toBeGreaterThan(0);
+
+    expect(logs.join("\n")).toMatch(/grounded \d+ verbatim citation/i);
+  });
+
+  it("--dry-run reports coverage without writing", async () => {
+    const dir = citeProject();
+    const before = readFileSync(join(dir, ".graphify", "graph.json"), "utf-8");
+    const { logs } = await runCli(["cite", dir, "--dry-run"], dir);
+    const after = readFileSync(join(dir, ".graphify", "graph.json"), "utf-8");
+
+    expect(after).toBe(before); // untouched
+    expect(existsSync(join(dir, ".graphify", "ontology", "citations.json"))).toBe(false);
+    expect(logs.join("\n")).toMatch(/dry-run.*would ground/i);
+  });
+
+  it("--only-missing skips already-cited nodes", async () => {
+    const dir = citeProject();
+    // First pass cites everything groundable.
+    await runCli(["cite", dir], dir);
+    const firstPass = readGraph(dir);
+    const mattioliFirst = firstPass.nodes.find((n) => n.id === "p1")!.citations?.length ?? 0;
+    expect(mattioliFirst).toBeGreaterThan(0);
+
+    // Second pass with --only-missing must not change already-cited p1.
+    const { logs } = await runCli(["cite", dir, "--only-missing"], dir);
+    const secondPass = readGraph(dir);
+    const mattioliSecond = secondPass.nodes.find((n) => n.id === "p1")!.citations?.length ?? 0;
+    expect(mattioliSecond).toBe(mattioliFirst);
+    expect(logs.join("\n")).toMatch(/cite:/i);
+  });
+
+  it("--types restricts to the requested node kinds", async () => {
+    const dir = citeProject();
+    await runCli(["cite", dir, "--types", "person"], dir);
+    const graph = readGraph(dir);
+    expect((graph.nodes.find((n) => n.id === "p1")!.citations ?? []).length).toBeGreaterThan(0);
+    // CATIA (technology) was excluded.
+    expect(graph.nodes.find((n) => n.id === "t1")!.citations ?? []).toHaveLength(0);
+  });
+
+  it("rejects an invalid --mode", async () => {
+    const dir = citeProject();
+    const { errors, exitCode } = await runCli(["cite", dir, "--mode", "bogus"], dir);
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toMatch(/--mode must be one of/i);
+  });
+
+  it("errors when no graph exists", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-cite-empty-"));
+    tempDirs.push(dir);
+    const { errors, exitCode } = await runCli(["cite", dir], dir);
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toMatch(/no graph found/i);
+  });
+});

--- a/tests/cli-cite.test.ts
+++ b/tests/cli-cite.test.ts
@@ -176,6 +176,51 @@ describe("graphify cite", () => {
     expect(graph.nodes.find((n) => n.id === "t1")!.citations ?? []).toHaveLength(0);
   });
 
+  it("REGRESSION: --source is truly repeatable — a source only in the FIRST root still grounds", async () => {
+    // Two extra source roots. The node's source_file lives ONLY under the first
+    // root. Before the collect-function fix, Commander kept only the LAST
+    // --source value, so the first root was dropped and the node never grounded.
+    const dir = mkdtempSync(join(tmpdir(), "graphify-cite-multisrc-"));
+    tempDirs.push(dir);
+    const graphDir = join(dir, ".graphify");
+    mkdirSync(graphDir, { recursive: true });
+
+    const rootA = join(dir, "rootA");
+    const rootB = join(dir, "rootB");
+    mkdirSync(rootA, { recursive: true });
+    mkdirSync(rootB, { recursive: true });
+    // The paper lives ONLY in rootA; rootB has an unrelated file.
+    writeFileSync(join(rootA, "paper.md"), OCR_MARKDOWN, "utf-8");
+    writeFileSync(join(rootB, "other.md"), "# Unrelated\n\nNothing to see here.\n", "utf-8");
+
+    writeFileSync(
+      join(graphDir, "graph.json"),
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "p1", label: "Juliette Mattioli", file_type: "person", source_file: "paper.md", community: 0 },
+        ],
+        links: [],
+        community_labels: { "0": "Aero" },
+      }),
+      "utf-8",
+    );
+
+    // Pass BOTH roots; rootB (the last value) does NOT contain paper.md.
+    const { logs } = await runCli(
+      ["cite", dir, "--source", rootA, "--source", rootB],
+      dir,
+    );
+
+    const graph = readGraph(dir);
+    const mattioli = graph.nodes.find((n) => n.id === "p1")!;
+    // Grounds because rootA (the FIRST --source) is still searched.
+    expect(mattioli.citations?.length).toBeGreaterThan(0);
+    expect(mattioli.citations?.[0]?.quote).toContain("apprentissage automatique");
+    expect(logs.join("\n")).toMatch(/grounded \d+ verbatim citation/i);
+  });
+
   it("rejects an invalid --mode", async () => {
     const dir = citeProject();
     const { errors, exitCode } = await runCli(["cite", dir, "--mode", "bogus"], dir);


### PR DESCRIPTION
## What

`graphify cite` (a.k.a. `ground-citations`) — the citation-**GROUNDING** producer command (WP #24, facet #22). It SCANS a corpus and POPULATES `node.citations[]` `{quote, source_file, source_location, page?, section?, paragraph_id?, confidence}` per entity, symmetric to `describe`/`label`. This is the productization of ia-aero's hand-coded `ground.py`/`ground2.py` (876/876 entities cited, zero API calls).

Today `backfill-citations` only PROJECTS pre-existing citations into the tiered store; `cite` GROUNDS new ones from the source text. Follows the double-consensus cadrage (Opus + Sonnet).

## The command + flags

```
graphify cite [path]   (alias: ground-citations)
  --mode <heuristic|assistant|api>   # default heuristic (no key)
  --top-k <n>                        # max citations per node (default 6)
  --types <a,b,c>                    # restrict to node kinds
  --only-missing                     # additive 2nd pass (ground only uncited)
  --source <root>                    # extra source search root
  --citations-top-k <n>             # inline Level-1 K after aggregation
  --dry-run                          # report coverage; write nothing
```

Opt-in (NOT auto-run in the default pipeline, like `describe`). Loads `graph.json`, grounds, UNIONS with existing citations (union-not-clobber), then runs the shipped `aggregateCitations` → `citation_count` + K-bounded inline + `citations.json`. Snapshots the prior FULL sidecar so the exhaustive tail is unioned, not collapsed.

## Anti-hallucination (HARD invariant)

Every emitted `quote` MUST be a verified VERBATIM substring of the **normalized** source (NFKD-deaccent + ligature-fold + lowercase + whitespace-collapse, then `includes`). In heuristic mode a citation **cannot** be emitted unless its windowed quote verifies — there is no path to invent text. The `assistant`/`api` modes (proposer not yet wired; they fall through to the verified heuristic core) are gated by the SAME `verifyVerbatim` check: an LLM proposes, the verifier re-locates, a non-match is DROPPED. Unit-tested, and verified on the real ia-aero corpus: **2854/2854 grounded quotes verbatim, ZERO hallucinations.**

## Heuristic algorithm (ported from ground.py/ground2.py)

Per node → modality-aware parse → normalize → type-aware match → window verbatim quote → verify → emit → aggregate.

- **OCR-markdown**: leading `---…---` front-matter SKIPPED so page numbering starts at 1 (**the aclp-am `page:"unknown"` fix**); bare `---` → page increment; `#{1,4}` → section; `![](…)` → image with prev/next prose.
- **plain text**: chapter/story heading → section; paragraphs → units; page 1.
- **type-aware matchers**: person→surname (section headings first, then body); reference→`[N]` marker; image→containing-document prose (INFERRED, resolved via `containingDocumentFor`); acronym→whole-word; concept→content-word; `quote`/any→`rationale` verbatim span (still gated).

`source_location` semantics: OCR-markdown `"p.{page} · {section}"`; plain text `"{section}"`.

## Contract change

`OntologyCitation` gains three optional fields, all additive/backward-compatible, **none** part of the identity key:
- `quote?: string`, `confidence?: CitationConfidence` (`"EXTRACTED" | "INFERRED"`), `source_location?: string`.

These were de-facto present already (in `OntologyEvidenceRecord`, the mystery sidecar, consumed by the studio EntityPanel `<blockquote>` + the describe path) — the type omission was an inconsistency. Reverses two original SPEC_CITATIONS Non-Goals ("no verbatim-quote capture", "no change to the shape"); storage/tiering decisions remain BINDING.

## Golden-oracle tests (38 new, all 6 brief requirements)

1. representative OCR-markdown fixture + entities → near-100% grounding with VERBATIM quotes (mirrors 876/876);
2. mystery sidecar SHAPE consistency on plain text (`{source_file, section, quote}`);
3. anti-hallucination invariant — never emit a non-substring quote;
4. type-aware matchers;
5. union-not-clobber;
6. the contract additions.

Plus CLI integration tests (dry-run, only-missing, types, error paths).

## Verification

- `npx tsc --noEmit` — clean
- full suite: **2107 passed | 14 skipped | 0 failed**
- real ia-aero corpus: 792/876 grounded (90%), 2854/2854 quotes verbatim, 0 hallucinations, 0 API calls

## Resolved forks

- **quote on the contract** → promoted to first-class (+ `confidence`, `source_location`), ending the typed/de-facto drift.
- **grounding approach** → heuristic-first / no-key default; LLM modes opt-in, gated by the same structural verbatim check.
- **page resolution** → resolved from OCR-markdown front-matter + `---` page breaks (the aclp-am `page:"unknown"` fix).
- **image / reference / quote nodes** → image nodes resolve to their containing markdown; references resolve `[N]` markers and fall back to rationale; `quote` nodes emit their verbatim rationale span — all still gated. (The remaining ~10% uncited are mostly source-document nodes themselves, which have no label term to match — correct behavior for a general multi-doc command.)