### PR TITLE
test(graph): B1-P1 — expand golden harness coverage (current canvas2d renderer)

### DIFF
--- a/packages/graph/tests/golden/diff.mjs
+++ b/packages/graph/tests/golden/diff.mjs
@@ -135,3 +135,73 @@ export function worldToDevice(world, { width, height, zoom, camera }) {
 export function drawnRadius(nodeSize, dpr, zoom) {
   return Math.max(1, nodeSize * dpr * zoom);
 }
+
+/**
+ * Bounding box of all NON-BACKGROUND pixels in a capture. The harness page
+ * paints a #ffffff (255,255,255,255) background, so any pixel whose RGB differs
+ * from white by more than `bgTolerance` on any channel is drawn content.
+ *
+ * Used for deterministic GEOMETRY-PARITY assertions that do NOT depend on font
+ * metrics or exact glyph rasters — e.g. asserting a #199-clipped box's rendered
+ * WIDTH stays within the BOX_MAX_WIDTH_RATIO cap, or that a glyph drew at all in
+ * its expected region. Returns null when the capture is entirely background.
+ *
+ * @returns {{ minX:number, minY:number, maxX:number, maxY:number,
+ *             width:number, height:number, count:number } | null}
+ */
+export function contentBBox(capture, bgTolerance = 8) {
+  const { width, height, data } = capture;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let count = 0;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const i = (y * width + x) * 4;
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      // Distance from white on any channel.
+      if (255 - r > bgTolerance || 255 - g > bgTolerance || 255 - b > bgTolerance) {
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+        count += 1;
+      }
+    }
+  }
+  if (count === 0) return null;
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: maxX - minX + 1,
+    height: maxY - minY + 1,
+    count,
+  };
+}
+
+/**
+ * Count pixels in a capture whose RGB is within `tolerance` (per channel) of a
+ * target rgb. A coarse "did this colour appear?" probe used to assert, e.g., a
+ * dashed edge of a given colour drew SOME pixels (presence) without pinning the
+ * exact fragile dash phase. `rgb` is [r,g,b]; alpha is ignored (edges/glyphs
+ * composite over white so the on-screen RGB is what matters).
+ */
+export function countColorPixels(capture, rgb, tolerance = 24) {
+  const { width, height, data } = capture;
+  let n = 0;
+  for (let i = 0; i < width * height * 4; i += 4) {
+    if (
+      Math.abs(data[i] - rgb[0]) <= tolerance &&
+      Math.abs(data[i + 1] - rgb[1]) <= tolerance &&
+      Math.abs(data[i + 2] - rgb[2]) <= tolerance
+    ) {
+      n += 1;
+    }
+  }
+  return n;
+}

--- a/packages/graph/tests/golden/fixtures.mjs
+++ b/packages/graph/tests/golden/fixtures.mjs
@@ -1,14 +1,93 @@
-// Golden fixtures for the B1 Phase-0 harness. These are the minimal Phase-0
-// smoke fixtures; the GL phases extend this with the full §5.2 matrix
-// (shape x fill x border x alpha x state, OVERLAP, Unicode text, edge families).
+// Golden fixtures for the B1 golden harness.
+//
+// Phase-0 (PR #193, hardened #206) shipped a SMOKE SUBSET: one mixed scene +
+// determinism / 3px-regression / DPR-zoom proofs. This file is the Phase-1
+// EXPANSION (test-only, no renderer change): named fixtures that exercise the
+// CURRENT canvas2d renderer across the inventory groups in
+// .graphify/scratch/B1_WEBGL2_MIGRATION_PLAN_OPUS.md §1 —
+//   per-type SHAPES (N1-N6), the labelled/empty/focal BOXES + #199 pixel-fit
+//   (N7-N9, L1/L3), COMMUNITY colours (N14), NODE BORDERS (N10/N11), EDGES
+//   (E1-E6/E12, styles/curve/dash/arrow), and SELECTION/highlight (N14/N16).
 //
 // Coordinates are WORLD coordinates. The camera maps them to the canvas at
-// capture time (see cdp-harness.capture).
+// capture time (see cdp-harness.capture). All fixtures are deterministic — no
+// randomness — so a same-fixture re-capture is byte-identical and the golden
+// BASELINE is the current canvas2d renderer itself (A/B model, no stored PNGs).
+
+// ---- renderer geometry constants (mirror src/renderer.ts + shape-geometry.ts)
+// These are the SAME literals the canvas2d renderer draws with; the golden
+// geometry-parity assertions compute expected device coordinates from them so a
+// probe failure is unambiguously geometry/colour drift, not AA. Kept in sync
+// with the renderer by the constants-parity test in golden-harness.test.ts.
+export const STAR_INNER_RATIO = 0.42;
+export const SQUARE_INSET_RATIO = 0.88;
+export const BOX_BASE_HEIGHT_PX = 18;
+export const BOX_MARGIN_RATIO = 5 / 22;
+export const BOX_FONT_RATIO = 12 / 22;
+export const BOX_CORNER_RATIO = 1 / 4;
+export const BOX_MAX_WIDTH_RATIO = 10;
+export const BOX_EMPTY_RATIO = 10 / 22;
+/** Translucent white box / hollow interior: rgba(255,255,255,0.5) -> a8=128. */
+export const BOX_FILL = [255, 255, 255, 128];
+/** Dark box label text (#0f172a slate-900). */
+export const BOX_TEXT_RGB = [15, 23, 42];
 
 /**
- * The Phase-0 base smoke fixture: a few node shapes + a styled edge, so the
- * capture exercises arcs (circle), polygons (diamond/hexagon), a labelled box
- * (text path), and a curved arrowed edge. Deterministic, no randomness.
+ * Polygon vertices (relative to centre, radius `r`) for a shape CODE, matching
+ * shape-geometry.ts shapePolygonPoints EXACTLY (same start angles + ratios).
+ * Returns null for circle (0) and box (5). Used to aim geometry probes at a
+ * KNOWN drawn vertex / interior point of each polygon.
+ */
+export function shapePolygonPoints(code, r) {
+  if (code === 1) return [[0, -r], [r, 0], [0, r], [-r, 0]]; // diamond
+  if (code === 2) {
+    const inner = r * STAR_INNER_RATIO;
+    const pts = [];
+    for (let i = 0; i < 10; i += 1) {
+      const a = (i * Math.PI) / 5 - Math.PI / 2;
+      const rad = i % 2 === 0 ? r : inner;
+      pts.push([Math.cos(a) * rad, Math.sin(a) * rad]);
+    }
+    return pts;
+  }
+  if (code === 3) {
+    const pts = [];
+    for (let i = 0; i < 6; i += 1) {
+      const a = (i * Math.PI) / 3 - Math.PI / 6;
+      pts.push([Math.cos(a) * r, Math.sin(a) * r]);
+    }
+    return pts;
+  }
+  if (code === 4) {
+    const h = r * SQUARE_INSET_RATIO;
+    return [[-h, -h], [h, -h], [h, h], [-h, h]];
+  }
+  if (code === 6) {
+    const pts = [];
+    for (let i = 0; i < 3; i += 1) {
+      const a = (i * 2 * Math.PI) / 3 - Math.PI / 2;
+      pts.push([Math.cos(a) * r, Math.sin(a) * r]);
+    }
+    return pts;
+  }
+  return null;
+}
+
+export const SHAPE_CODE = {
+  dot: 0,
+  circle: 0,
+  diamond: 1,
+  star: 2,
+  hexagon: 3,
+  square: 4,
+  box: 5,
+  roundedbox: 5,
+  triangle: 6,
+};
+
+/**
+ * The Phase-0 base smoke fixture (UNCHANGED — kept so the original smoke proofs
+ * keep their reference): a few shapes + a styled edge.
  */
 export const baseFixture = {
   nodes: [
@@ -23,6 +102,190 @@ export const baseFixture = {
   ],
 };
 
+// ---------------------------------------------------------------------------
+// GROUP 1.A — per-type SHAPES (N1 dot/circle, N2 diamond, N3 star, N4 square,
+// N5 hexagon, N6 triangle). One isolated node per shape, well-separated, large
+// enough that a center + a vertex probe land cleanly. The same colour on every
+// shape so a probe failure is shape geometry, not colour.
+// ---------------------------------------------------------------------------
+const SHAPE_COLOR = "#2563eb"; // one strong colour for every shape glyph
+export const shapeNode = (id, x, y, shape, size = 18) => ({
+  id,
+  x,
+  y,
+  size,
+  color: SHAPE_COLOR,
+  shape,
+});
+export const SHAPES_FIXTURE = {
+  nodes: [
+    shapeNode("dot", -110, -70, "dot"),
+    shapeNode("diamond", 0, -70, "diamond"),
+    shapeNode("star", 110, -70, "star"),
+    shapeNode("hexagon", -110, 70, "hexagon"),
+    shapeNode("square", 0, 70, "square"),
+    shapeNode("triangle", 110, 70, "triangle"),
+  ],
+  edges: [],
+};
+/** Every shape colour, as an rgba probe target. */
+export const SHAPES_COLOR_RGBA = [37, 99, 235, 255];
+
+// ---------------------------------------------------------------------------
+// GROUP 1.A (N7-N9) — BOXES: god-class Character labelled box, an empty
+// (collapsed) box, and the recon FOCAL box (a labelled box on a dense scene).
+// Box height is degree-independent (BOX_BASE_HEIGHT_PX), so size is irrelevant
+// to the box rect — assertions read the box centre (text colour) + the
+// translucent fill just inside a corner.
+// ---------------------------------------------------------------------------
+export const BOX_LABELLED_FIXTURE = {
+  nodes: [
+    { id: "char", x: 0, y: 0, size: 12, color: "#ef4444", shape: "box", label: "Sherlock" },
+  ],
+  edges: [],
+};
+export const BOX_EMPTY_FIXTURE = {
+  nodes: [
+    // No label -> collapses to BOX_EMPTY_RATIO × height square, no text.
+    { id: "work", x: 0, y: 0, size: 12, color: "#9467bd", shape: "box" },
+  ],
+  edges: [],
+};
+// Recon focal pair: two labelled boxes side by side (the recon "focal" twins),
+// each a degree-independent box. Different labels so each hugs its own text.
+export const BOX_FOCAL_FIXTURE = {
+  nodes: [
+    { id: "focalA", x: -55, y: 0, size: 11, color: "#2563eb", shape: "box", label: "Holmes" },
+    { id: "focalB", x: 55, y: 0, size: 11, color: "#2563eb", shape: "box", label: "Watson" },
+  ],
+  edges: [{ source: "focalA", target: "focalB", width: 3, color: "#94a3b8" }],
+};
+
+// #199 pixel-fit / glyph-aware ellipsis. A label far too long to hug within the
+// BOX_MAX_WIDTH_RATIO ceiling MUST be pixel-clipped to fit with a single "…";
+// a short label is untouched. We assert the box WIDTH stays within the cap
+// (geometry parity) rather than matching exact glyph rasters (font-fragile).
+export const BOX_LONG_LABEL_FIXTURE = {
+  nodes: [
+    {
+      id: "long",
+      x: 0,
+      y: 0,
+      size: 12,
+      color: "#0ea5e9",
+      shape: "box",
+      label: "A preposterously long chapter title that overflows the layout entirely",
+    },
+  ],
+  edges: [],
+};
+export const BOX_SHORT_LABEL_FIXTURE = {
+  nodes: [{ id: "short", x: 0, y: 0, size: 12, color: "#0ea5e9", shape: "box", label: "Hi" }],
+  edges: [],
+};
+
+// ---------------------------------------------------------------------------
+// GROUP 1.A (N14) — COMMUNITY colours, single-source. Three pairs: within a
+// pair both nodes carry the SAME group colour (must render IDENTICALLY at their
+// centres); across pairs the colours DIFFER (must render distinctly). Proves
+// the renderer is a faithful single-source colour consumer (the palette lives
+// upstream; the renderer must reproduce whatever rgba it is handed).
+// ---------------------------------------------------------------------------
+export const COMMUNITY_COLORS = ["#e6194b", "#3cb44b", "#4363d8"];
+export const COMMUNITY_FIXTURE = {
+  nodes: [
+    { id: "c0a", x: -100, y: -40, size: 14, color: COMMUNITY_COLORS[0], shape: "circle" },
+    { id: "c0b", x: -100, y: 40, size: 14, color: COMMUNITY_COLORS[0], shape: "circle" },
+    { id: "c1a", x: 0, y: -40, size: 14, color: COMMUNITY_COLORS[1], shape: "circle" },
+    { id: "c1b", x: 0, y: 40, size: 14, color: COMMUNITY_COLORS[1], shape: "circle" },
+    { id: "c2a", x: 100, y: -40, size: 14, color: COMMUNITY_COLORS[2], shape: "circle" },
+    { id: "c2b", x: 100, y: 40, size: 14, color: COMMUNITY_COLORS[2], shape: "circle" },
+  ],
+  edges: [],
+};
+
+// ---------------------------------------------------------------------------
+// GROUP 1.A (N10 hollow, N11 bold) — NODE BORDERS. Four circle variants of the
+// SAME node colour: solid / hollow / solid-bold / hollow-bold. A hollow node's
+// INTERIOR is fixed translucent white (alpha-independent), NOT the node colour
+// — that is the subtle N10 contract we probe (centre ~ white-over-white, edge ~
+// node colour). Bold thickens the border (N11).
+// ---------------------------------------------------------------------------
+const BORDER_COLOR = "#16a34a";
+export const BORDERS_FIXTURE = {
+  nodes: [
+    { id: "solid", x: -90, y: 0, size: 20, color: BORDER_COLOR, shape: "circle", fill: "solid", border: "normal" },
+    { id: "hollow", x: -30, y: 0, size: 20, color: BORDER_COLOR, shape: "circle", fill: "hollow", border: "normal" },
+    { id: "solidBold", x: 30, y: 0, size: 20, color: BORDER_COLOR, shape: "circle", fill: "solid", border: "bold" },
+    { id: "hollowBold", x: 90, y: 0, size: 20, color: BORDER_COLOR, shape: "circle", fill: "hollow", border: "bold" },
+  ],
+  edges: [],
+};
+export const BORDER_COLOR_RGBA = [22, 163, 74, 255];
+// The solid node centre = node colour; a hollow node centre over a WHITE page =
+// white (translucent white over white). These are the two N10 anchors.
+export const SOLID_CENTER_RGBA = [22, 163, 74, 255];
+export const HOLLOW_CENTER_RGBA = [255, 255, 255, 255];
+
+// ---------------------------------------------------------------------------
+// GROUP 1.B — EDGES (E1 thick, E2/E12 colour+alpha, E3 dash families, E4 curve,
+// E6 arrow). A row of edge cases: a thick solid edge, the three dash families
+// (dashed/dotted/long-dash), a curved edge, and the 255-vs-180 colour-alpha
+// split (studio #94a3b8 -> a255 vs a no-style fallback -> a180). Endpoints are
+// large circles so the edge clips to the border and the arrow sits on it.
+// ---------------------------------------------------------------------------
+const EP = (id, x, y) => ({ id, x, y, size: 8, color: "#cbd5e1", shape: "circle" });
+export const EDGES_FIXTURE = {
+  nodes: [
+    EP("a0", -150, -80), EP("a1", 150, -80), // thick solid
+    EP("b0", -150, -40), EP("b1", 150, -40), // dashed
+    EP("c0", -150, 0), EP("c1", 150, 0), // dotted
+    EP("d0", -150, 40), EP("d1", 150, 40), // long-dash
+    EP("e0", -150, 80), EP("e1", 150, 80), // curved
+  ],
+  edges: [
+    { source: "a0", target: "a1", width: 5, color: "#1d4ed8", dash: "solid" },
+    { source: "b0", target: "b1", width: 2, color: "#dc2626", dash: "dashed" },
+    { source: "c0", target: "c1", width: 2, color: "#16a34a", dash: "dotted" },
+    { source: "d0", target: "d1", width: 2, color: "#9333ea", dash: "long-dash" },
+    { source: "e0", target: "e1", width: 3, color: "#0891b2", curvature: 0.4 },
+  ],
+};
+// Colour-alpha split: same RGB, but one edge is opaque (a255) and one is the
+// renderer's no-style fallback alpha (a180). We feed the alpha explicitly via
+// "#rrggbbaa" so the capture shows the honoured alpha along the segment.
+export const EDGE_ALPHA_FIXTURE = {
+  nodes: [
+    EP("s0", -140, -30), EP("s1", 140, -30),
+    EP("w0", -140, 30), EP("w1", 140, 30),
+  ],
+  edges: [
+    { source: "s0", target: "s1", width: 6, color: "#3b82f6ff" }, // a255 (studio-style)
+    { source: "w0", target: "w1", width: 6, color: "#3b82f6b4" }, // a180 (no-style fallback)
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// GROUP — SELECTION / highlight. The renderer is a buffer consumer: selection
+// is encoded UPSTREAM as the SELECTED colour (#2563eb) / FOCUS colour (#ef4444)
+// in nodeColors and a size multiplier in nodeSizes. We exercise that contract
+// directly: a base node, the same node "selected" (selected colour + ×1.45
+// size), and the same node "focused" (focus colour). The renderer must render
+// the centre as the encoded colour and the glyph at the multiplied size.
+// ---------------------------------------------------------------------------
+export const SELECT_MULTIPLIER = 1.45; // N16 ×1.45 (non-box)
+const BASE_SIZE = 14;
+export const SELECTION_FIXTURE = {
+  nodes: [
+    { id: "base", x: -90, y: 0, size: BASE_SIZE, color: "#64748b", shape: "circle" },
+    { id: "selected", x: 0, y: 0, size: BASE_SIZE * SELECT_MULTIPLIER, color: "#2563eb", shape: "circle" },
+    { id: "focused", x: 90, y: 0, size: BASE_SIZE, color: "#ef4444", shape: "circle" },
+  ],
+  edges: [],
+};
+export const SELECTED_RGBA = [37, 99, 235, 255];
+export const FOCUS_RGBA = [239, 68, 68, 255];
+
 /**
  * Deep-clone a fixture so a perturbation never mutates the shared base.
  */
@@ -35,8 +298,8 @@ export function cloneFixture(fixture) {
 
 /**
  * Return a copy of `fixture` with node `nodeId` moved by (dx, dy) WORLD units.
- * Used by the Phase-0 acceptance proof: a 3px move MUST be detected above
- * tolerance (proves the harness catches regressions).
+ * Used by the acceptance proof: a 3px move MUST be detected above tolerance
+ * (proves the harness catches regressions).
  */
 export function perturbNode(fixture, nodeId, dx, dy) {
   const next = cloneFixture(fixture);
@@ -48,8 +311,26 @@ export function perturbNode(fixture, nodeId, dx, dy) {
 }
 
 /**
- * The DPR x zoom capture matrix the harness supports (B1 §5.2 subset for
- * Phase-0 smoke). The GL phases extend zoom to {0.05, 1, high}.
+ * All named fixtures, for the determinism sweep (every fixture must re-capture
+ * byte-identical — the floor the A/B golden model rests on).
+ */
+export const ALL_FIXTURES = {
+  base: baseFixture,
+  shapes: SHAPES_FIXTURE,
+  boxLabelled: BOX_LABELLED_FIXTURE,
+  boxEmpty: BOX_EMPTY_FIXTURE,
+  boxFocal: BOX_FOCAL_FIXTURE,
+  boxLong: BOX_LONG_LABEL_FIXTURE,
+  boxShort: BOX_SHORT_LABEL_FIXTURE,
+  community: COMMUNITY_FIXTURE,
+  borders: BORDERS_FIXTURE,
+  edges: EDGES_FIXTURE,
+  edgeAlpha: EDGE_ALPHA_FIXTURE,
+  selection: SELECTION_FIXTURE,
+};
+
+/**
+ * The DPR x zoom capture matrix the harness supports.
  */
 export const DPR_MATRIX = [1, 1.25, 2, 3];
 export const ZOOM_MATRIX = [1, 2]; // at least 2 zooms (plan: >=2)

--- a/packages/graph/tests/golden/golden-harness.test.ts
+++ b/packages/graph/tests/golden/golden-harness.test.ts
@@ -2,9 +2,43 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
 import { openOracle } from "./cdp-harness.mjs";
 // @ts-expect-error
-import { diffPixels, geometryProbes, worldToDevice, drawnRadius } from "./diff.mjs";
+import {
+  diffPixels,
+  geometryProbes,
+  worldToDevice,
+  drawnRadius,
+  contentBBox,
+  countColorPixels,
+} from "./diff.mjs";
 // @ts-expect-error
-import { baseFixture, perturbNode } from "./fixtures.mjs";
+import {
+  baseFixture,
+  perturbNode,
+  ALL_FIXTURES,
+  SHAPES_FIXTURE,
+  SHAPES_COLOR_RGBA,
+  shapePolygonPoints,
+  SHAPE_CODE,
+  BOX_LABELLED_FIXTURE,
+  BOX_EMPTY_FIXTURE,
+  BOX_FOCAL_FIXTURE,
+  BOX_LONG_LABEL_FIXTURE,
+  BOX_SHORT_LABEL_FIXTURE,
+  BOX_TEXT_RGB,
+  BOX_BASE_HEIGHT_PX,
+  BOX_MAX_WIDTH_RATIO,
+  BOX_EMPTY_RATIO,
+  COMMUNITY_FIXTURE,
+  BORDERS_FIXTURE,
+  SOLID_CENTER_RGBA,
+  HOLLOW_CENTER_RGBA,
+  BORDER_COLOR_RGBA,
+  EDGES_FIXTURE,
+  EDGE_ALPHA_FIXTURE,
+  SELECTION_FIXTURE,
+  SELECTED_RGBA,
+  FOCUS_RGBA,
+} from "./fixtures.mjs";
 // @ts-expect-error
 import { napiAvailable, smokeCapture } from "./smoke.mjs";
 
@@ -116,6 +150,409 @@ describe("B1 Phase-0 golden harness (Chrome/CDP direct-canvas-pixel oracle)", ()
     }
   }, 120_000);
 });
+
+// ===========================================================================
+// B1 Phase-1 EXPANSION (test-only, current canvas2d renderer is the source of
+// truth). Comprehensive non-regression coverage of the inventory groups that
+// were uncovered by the Phase-0 smoke subset. PREFER deterministic geometry-
+// parity assertions (probes computed from render-geometry constants + content
+// bounding boxes) over fragile full-frame baselines; add a per-fixture
+// determinism floor (same fixture twice == byte-identical) everywhere so the
+// A/B golden model holds. Every block SKIPS (not fails) when Chrome is absent.
+// ===========================================================================
+
+// Wider canvas for the multi-node "row/grid" fixtures (their nodes spread past
+// ±95 world, which would fall off the 200px default canvas at zoom 1).
+const WIDE_OPTS = { dpr: 1, cssWidth: 320, cssHeight: 240, camera: { x: 0, y: 0, zoom: 1 } };
+
+const VIEW = (cap: { width: number; height: number }, zoom = 1) => ({
+  width: cap.width,
+  height: cap.height,
+  zoom,
+  camera: { x: 0, y: 0 },
+});
+
+/** Assert a fixture re-captures byte-identical (the A/B golden floor). */
+async function expectDeterministic(
+  oracle: NonNullable<typeof oracle>,
+  fixture: unknown,
+  opts: Record<string, unknown> = CAPTURE_OPTS,
+): Promise<{ width: number; height: number; data: Uint8ClampedArray }> {
+  const a = await oracle.capture(fixture, opts);
+  const b = await oracle.capture(fixture, opts);
+  const d = diffPixels(a, b, { channelTolerance: 0, maxFailingPixels: 0 });
+  expect(d.dimsMatch).toBe(true);
+  expect(d.maxChannelDelta).toBe(0);
+  expect(d.failingPixels).toBe(0);
+  return a;
+}
+
+describe("B1-P1 SHAPES per type (N1 dot, N2 diamond, N3 star, N4 square, N5 hexagon, N6 triangle)", () => {
+  it("each shape draws at its center with the shape colour (geometry parity)", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, SHAPES_FIXTURE, WIDE_OPTS);
+    const view = VIEW(cap);
+    // Every node's center must be solidly the one shape colour. A center probe
+    // is interior (no AA), so a miss is unambiguous shape/colour drift.
+    const probes = SHAPES_FIXTURE.nodes.map((n: { id: string; x: number; y: number }) => {
+      const [x, y] = worldToDevice([n.x, n.y], view);
+      return { name: `${n.id}-center`, x, y, expect: SHAPES_COLOR_RGBA, tolerance: 12 };
+    });
+    const { pass, results } = geometryProbes(cap, probes);
+    if (!pass) console.error("[golden] shape probes:", JSON.stringify(results, null, 2));
+    expect(pass).toBe(true);
+  }, 60_000);
+
+  it("each polygon glyph fills a KNOWN interior point near a vertex (catches wrong start-angle/ratio)", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await oracle.capture(SHAPES_FIXTURE, WIDE_OPTS);
+    const view = VIEW(cap);
+    // For each polygon shape, sample a point 70% of the way to its FIRST drawn
+    // vertex (well inside the filled glyph): a wrong star-inner-ratio or a
+    // rotated hexagon would move that vertex and the probe would land on white.
+    const probes: Array<{ name: string; x: number; y: number; expect: number[]; tolerance: number }> = [];
+    for (const n of SHAPES_FIXTURE.nodes as Array<{ id: string; x: number; y: number; size: number; shape: string }>) {
+      const code = SHAPE_CODE[n.shape];
+      const r = drawnRadius(n.size, WIDE_OPTS.dpr, WIDE_OPTS.camera.zoom);
+      const pts = shapePolygonPoints(code, r);
+      if (!pts) continue; // circle/box covered elsewhere
+      const [vx, vy] = pts[0];
+      const [sx, sy] = worldToDevice([n.x, n.y], view);
+      // device-space: world dx/dy already in device px because r used dpr*zoom.
+      probes.push({
+        name: `${n.id}-near-vertex`,
+        x: sx + vx * 0.7,
+        y: sy + vy * 0.7,
+        expect: SHAPES_COLOR_RGBA,
+        tolerance: 16,
+      });
+    }
+    const { pass, results } = geometryProbes(cap, probes);
+    if (!pass) console.error("[golden] vertex probes:", JSON.stringify(results, null, 2));
+    expect(pass).toBe(true);
+  }, 60_000);
+
+  it("catches a moved shape: nudging the star 3px diffs above tolerance", async () => {
+    if (!chromeUp || !oracle) return;
+    const ref = await oracle.capture(SHAPES_FIXTURE, WIDE_OPTS);
+    const moved = perturbNode(SHAPES_FIXTURE, "star", 3, 0);
+    const cap = await oracle.capture(moved, WIDE_OPTS);
+    const d = diffPixels(ref, cap, { channelTolerance: 2, maxFailingPixels: 0 });
+    expect(d.pass).toBe(false);
+    expect(d.failingPixels).toBeGreaterThan(0);
+  }, 60_000);
+});
+
+describe("B1-P1 BOXES (N7 labelled / N9 empty / recon focal) + #199 pixel-fit ellipsis", () => {
+  it("a labelled god-class box draws dark text at its center over the translucent fill", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, BOX_LABELLED_FIXTURE);
+    // The box center sits on a glyph stroke of the dark label text most of the
+    // time; rather than pin a single glyph pixel (font-fragile), assert the box
+    // CONTAINS dark-text pixels and translucent-white fill in its region.
+    const darkText = countColorPixels(cap, BOX_TEXT_RGB, 40);
+    expect(darkText, "labelled box must render dark label text").toBeGreaterThan(0);
+    // The box rect is centered; its drawn region is a content bbox around (0,0).
+    const bbox = contentBBox(cap);
+    expect(bbox).not.toBeNull();
+    // Degree-independent height: BOX_BASE_HEIGHT_PX (× dpr × zoom). The drawn
+    // rect height must be ~that (allow a few px for the border stroke width).
+    const expectedH = BOX_BASE_HEIGHT_PX * CAPTURE_OPTS.dpr * CAPTURE_OPTS.camera.zoom;
+    expect(bbox.height).toBeGreaterThanOrEqual(expectedH - 2);
+    expect(bbox.height).toBeLessThanOrEqual(expectedH + 6);
+  }, 60_000);
+
+  it("an empty (unlabelled) box collapses to a small square with no text", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, BOX_EMPTY_FIXTURE);
+    // No dark label text at all (the empty box draws none).
+    const darkText = countColorPixels(cap, BOX_TEXT_RGB, 30);
+    // The node colour is purple; ensure we don't accidentally count it as text.
+    expect(darkText, "empty box must NOT render label text").toBe(0);
+    // The collapsed box is ~BOX_EMPTY_RATIO × height on a side (plus border).
+    const bbox = contentBBox(cap);
+    expect(bbox).not.toBeNull();
+    const side = BOX_BASE_HEIGHT_PX * BOX_EMPTY_RATIO * CAPTURE_OPTS.dpr * CAPTURE_OPTS.camera.zoom;
+    expect(bbox.width).toBeLessThanOrEqual(side + 6);
+    expect(bbox.height).toBeLessThanOrEqual(side + 6);
+  }, 60_000);
+
+  it("recon focal pair: two labelled boxes + connecting edge render deterministically", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, BOX_FOCAL_FIXTURE);
+    // Both focal boxes carry text -> dark-text pixels present; the connecting
+    // edge means the content spans both boxes (wide bbox).
+    expect(countColorPixels(cap, BOX_TEXT_RGB, 40)).toBeGreaterThan(0);
+    const bbox = contentBBox(cap);
+    expect(bbox).not.toBeNull();
+    // Two boxes at x=-55 and x=+55 world -> bbox spans well over 100 device px.
+    expect(bbox.width).toBeGreaterThan(100);
+  }, 60_000);
+
+  it("#199: a long box label is PIXEL-CLIPPED so the box stays within the width cap", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, BOX_LONG_LABEL_FIXTURE);
+    const bbox = contentBBox(cap);
+    expect(bbox).not.toBeNull();
+    // Cap = BOX_MAX_WIDTH_RATIO × height (device px). The rendered box WIDTH must
+    // NOT exceed it (plus a small border allowance). Without #199 the box would
+    // balloon to many hundreds of px; the cap is the geometry-parity invariant.
+    const cap199 = BOX_MAX_WIDTH_RATIO * BOX_BASE_HEIGHT_PX * CAPTURE_OPTS.dpr * CAPTURE_OPTS.camera.zoom;
+    expect(bbox.width).toBeLessThanOrEqual(cap199 + 6);
+    // ...and it must still draw text (the clipped label + ellipsis).
+    expect(countColorPixels(cap, BOX_TEXT_RGB, 40)).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("#199: a short box label is untouched and well under the cap", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await oracle.capture(BOX_SHORT_LABEL_FIXTURE, CAPTURE_OPTS);
+    const bbox = contentBBox(cap);
+    expect(bbox).not.toBeNull();
+    const cap199 = BOX_MAX_WIDTH_RATIO * BOX_BASE_HEIGHT_PX * CAPTURE_OPTS.dpr * CAPTURE_OPTS.camera.zoom;
+    // A 2-char label hugs a narrow box, far under the cap (sanity that the cap
+    // assertion above isn't trivially passing because all boxes are tiny).
+    expect(bbox.width).toBeLessThan(cap199 * 0.6);
+  }, 60_000);
+});
+
+describe("B1-P1 COMMUNITY colours (N14 single-source consumer)", () => {
+  it("same group colour renders IDENTICALLY; distinct groups render DISTINCTLY", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, COMMUNITY_FIXTURE, WIDE_OPTS);
+    const view = VIEW(cap);
+    const centerOf = (id: string) => {
+      const n = COMMUNITY_FIXTURE.nodes.find((m: { id: string }) => m.id === id);
+      const [x, y] = worldToDevice([n.x, n.y], view);
+      return samplePixelLocal(cap, x, y);
+    };
+    const c0a = centerOf("c0a");
+    const c0b = centerOf("c0b");
+    const c1a = centerOf("c1a");
+    const c2a = centerOf("c2a");
+    // Within a group: identical (same single-source colour -> same rgba).
+    expect(maxChannelDelta(c0a, c0b)).toBeLessThanOrEqual(4);
+    // Across groups: distinctly different colours.
+    expect(maxChannelDelta(c0a, c1a)).toBeGreaterThan(40);
+    expect(maxChannelDelta(c0a, c2a)).toBeGreaterThan(40);
+    expect(maxChannelDelta(c1a, c2a)).toBeGreaterThan(40);
+  }, 60_000);
+});
+
+describe("B1-P1 NODE BORDERS (N10 hollow interior fixed-white / N11 bold)", () => {
+  it("solid center = node colour; hollow center = translucent-white over white page", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, BORDERS_FIXTURE, WIDE_OPTS);
+    const view = VIEW(cap);
+    const at = (id: string) => {
+      const n = BORDERS_FIXTURE.nodes.find((m: { id: string }) => m.id === id);
+      return worldToDevice([n.x, n.y], view);
+    };
+    const [sx, sy] = at("solid");
+    const [hx, hy] = at("hollow");
+    const probes = [
+      // N10 anchor: a solid node's center is the node colour.
+      { name: "solid-center", x: sx, y: sy, expect: SOLID_CENTER_RGBA, tolerance: 14 },
+      // N10 anchor: a hollow node's center is translucent white over the white
+      // page => visually white, NOT the node colour. THE subtle N10 contract.
+      { name: "hollow-center", x: hx, y: hy, expect: HOLLOW_CENTER_RGBA, tolerance: 14 },
+    ];
+    const { pass, results } = geometryProbes(cap, probes);
+    if (!pass) console.error("[golden] border probes:", JSON.stringify(results, null, 2));
+    expect(pass).toBe(true);
+  }, 60_000);
+
+  it("a hollow node's BORDER carries the node colour (ring of node-colour pixels)", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await oracle.capture(BORDERS_FIXTURE, WIDE_OPTS);
+    // The four green-bordered nodes must put node-colour pixels on screen (the
+    // borders) even though the hollow interiors are white.
+    const greenPixels = countColorPixels(cap, [BORDER_COLOR_RGBA[0], BORDER_COLOR_RGBA[1], BORDER_COLOR_RGBA[2]], 40);
+    expect(greenPixels, "border colour must appear on screen").toBeGreaterThan(0);
+  }, 60_000);
+
+  it("bold vs normal border differs (more border ink) — same colour, thicker stroke", async () => {
+    if (!chromeUp || !oracle) return;
+    // Isolate a hollow-normal vs hollow-bold node: same geometry, the bold one
+    // paints MORE node-colour pixels (thicker ring). We render two single-node
+    // fixtures so the count is attributable.
+    const normal = {
+      nodes: [{ id: "n", x: 0, y: 0, size: 20, color: "#16a34a", shape: "circle", fill: "hollow", border: "normal" }],
+      edges: [],
+    };
+    const bold = {
+      nodes: [{ id: "n", x: 0, y: 0, size: 20, color: "#16a34a", shape: "circle", fill: "hollow", border: "bold" }],
+      edges: [],
+    };
+    const capN = await oracle.capture(normal, CAPTURE_OPTS);
+    const capB = await oracle.capture(bold, CAPTURE_OPTS);
+    const ringN = countColorPixels(capN, [22, 163, 74], 50);
+    const ringB = countColorPixels(capB, [22, 163, 74], 50);
+    expect(ringB, "bold border must paint more node-colour pixels than normal").toBeGreaterThan(ringN);
+  }, 60_000);
+});
+
+describe("B1-P1 EDGES (E1 thick / E2 colour+alpha / E3 dash families / E4 curve / E6 arrow)", () => {
+  it("the edge sampler scene (thick + 3 dash families + curve) is deterministic", async () => {
+    if (!chromeUp || !oracle) return;
+    await expectDeterministic(oracle, EDGES_FIXTURE, WIDE_OPTS);
+  }, 60_000);
+
+  it("each styled edge paints its colour (presence of thick/dashed/dotted/long-dash/curve ink)", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await oracle.capture(EDGES_FIXTURE, WIDE_OPTS);
+    // Each edge colour must appear (the edge drew). Dashed/dotted draw fewer
+    // pixels but still > 0; we assert presence, not exact dash phase (fragile).
+    expect(countColorPixels(cap, [29, 78, 216], 36), "thick solid edge").toBeGreaterThan(0);
+    expect(countColorPixels(cap, [220, 38, 38], 36), "dashed edge").toBeGreaterThan(0);
+    expect(countColorPixels(cap, [22, 163, 74], 36), "dotted edge").toBeGreaterThan(0);
+    expect(countColorPixels(cap, [147, 51, 234], 36), "long-dash edge").toBeGreaterThan(0);
+    expect(countColorPixels(cap, [8, 145, 178], 36), "curved edge").toBeGreaterThan(0);
+  }, 60_000);
+
+  it("dash families differ from a solid edge of the same colour (fewer ink pixels)", async () => {
+    if (!chromeUp || !oracle) return;
+    // A solid edge vs the same edge dashed/dotted: the dashed/dotted variants
+    // paint FEWER pixels along the identical segment (gaps). Single-edge
+    // fixtures so the count is attributable to the dash mode alone.
+    const mk = (dash: string) => ({
+      nodes: [
+        { id: "p", x: -120, y: 0, size: 6, color: "#cbd5e1", shape: "circle" },
+        { id: "q", x: 120, y: 0, size: 6, color: "#cbd5e1", shape: "circle" },
+      ],
+      edges: [{ source: "p", target: "q", width: 3, color: "#dc2626", dash }],
+    });
+    const solid = await oracle.capture(mk("solid"), WIDE_OPTS);
+    const dashed = await oracle.capture(mk("dashed"), WIDE_OPTS);
+    const dotted = await oracle.capture(mk("dotted"), WIDE_OPTS);
+    const ink = (c: { width: number; height: number; data: Uint8ClampedArray }) =>
+      countColorPixels(c, [220, 38, 38], 40);
+    const solidInk = ink(solid);
+    expect(ink(dashed), "dashed has gaps -> fewer red px than solid").toBeLessThan(solidInk);
+    expect(ink(dotted), "dotted has gaps -> fewer red px than solid").toBeLessThan(solidInk);
+    // Determinism per dash mode.
+    const dashed2 = await oracle.capture(mk("dashed"), WIDE_OPTS);
+    expect(diffPixels(dashed, dashed2, { channelTolerance: 0, maxFailingPixels: 0 }).maxChannelDelta).toBe(0);
+  }, 60_000);
+
+  it("a curved edge bends OFF the straight chord (control offset is honoured)", async () => {
+    if (!chromeUp || !oracle) return;
+    const straight = {
+      nodes: [
+        { id: "p", x: -120, y: 0, size: 6, color: "#cbd5e1", shape: "circle" },
+        { id: "q", x: 120, y: 0, size: 6, color: "#cbd5e1", shape: "circle" },
+      ],
+      edges: [{ source: "p", target: "q", width: 3, color: "#0891b2", curvature: 0 }],
+    };
+    const curved = {
+      ...straight,
+      edges: [{ source: "p", target: "q", width: 3, color: "#0891b2", curvature: 0.5 }],
+    };
+    const capS = await oracle.capture(straight, WIDE_OPTS);
+    const capC = await oracle.capture(curved, WIDE_OPTS);
+    const view = VIEW(capS);
+    // On the chord midpoint (world 0,0 -> device center) the STRAIGHT edge paints
+    // cyan; the CURVED edge bows away, so the center pixel is NOT cyan for the
+    // curve (it moved off the chord). This proves the control-point offset.
+    const [mx, my] = worldToDevice([0, 0], view);
+    const isCyan = (c: { width: number; data: Uint8ClampedArray }, x: number, y: number) => {
+      const i = (Math.round(y) * c.width + Math.round(x)) * 4;
+      return Math.abs(c.data[i] - 8) <= 40 && Math.abs(c.data[i + 1] - 145) <= 40 && Math.abs(c.data[i + 2] - 178) <= 40;
+    };
+    expect(isCyan(capS, mx, my), "straight edge crosses the chord midpoint").toBe(true);
+    expect(isCyan(capC, mx, my), "curved edge bows OFF the chord midpoint").toBe(false);
+  }, 60_000);
+
+  it("E2/E12 colour-alpha split: opaque (a255) edge is darker over white than a180", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, EDGE_ALPHA_FIXTURE, WIDE_OPTS);
+    const view = VIEW(cap);
+    // Both edges are blue #3b82f6; the a255 one composites fully (darker blue),
+    // the a180 one is lighter over the white page. Sample each segment midpoint.
+    const [ox, oy] = worldToDevice([0, -30], view); // opaque edge midpoint
+    const [tx, ty] = worldToDevice([0, 30], view); // translucent edge midpoint
+    const opaque = samplePixelLocal(cap, ox, oy);
+    const translucent = samplePixelLocal(cap, tx, ty);
+    // The translucent edge, composited over white, is LIGHTER (higher channel
+    // values) than the fully opaque one on the blue channels.
+    const opaqueLum = opaque[0] + opaque[1] + opaque[2];
+    const translucentLum = translucent[0] + translucent[1] + translucent[2];
+    expect(translucentLum, "a180 edge lighter over white than a255").toBeGreaterThan(opaqueLum);
+  }, 60_000);
+});
+
+describe("B1-P1 SELECTION / highlight (N14 selected/focus colour + N16 size multiplier)", () => {
+  it("selected node renders the SELECTED colour; focused node the FOCUS colour", async () => {
+    if (!chromeUp || !oracle) return;
+    const cap = await expectDeterministic(oracle, SELECTION_FIXTURE, WIDE_OPTS);
+    const view = VIEW(cap);
+    const at = (id: string) => {
+      const n = SELECTION_FIXTURE.nodes.find((m: { id: string }) => m.id === id);
+      return worldToDevice([n.x, n.y], view);
+    };
+    const [selx, sely] = at("selected");
+    const [focx, focy] = at("focused");
+    const probes = [
+      { name: "selected-blue", x: selx, y: sely, expect: SELECTED_RGBA, tolerance: 14 },
+      { name: "focus-red", x: focx, y: focy, expect: FOCUS_RGBA, tolerance: 14 },
+    ];
+    const { pass, results } = geometryProbes(cap, probes);
+    if (!pass) console.error("[golden] selection probes:", JSON.stringify(results, null, 2));
+    expect(pass).toBe(true);
+  }, 60_000);
+
+  it("N16: the selected node's glyph is LARGER (size multiplier baked in renders a bigger disc)", async () => {
+    if (!chromeUp || !oracle) return;
+    // Same colour, two sizes: base vs base×1.45. The larger renders a wider disc
+    // -> a bigger content bbox. Single-node fixtures so the bbox is attributable.
+    const base = { nodes: [{ id: "n", x: 0, y: 0, size: 14, color: "#2563eb", shape: "circle" }], edges: [] };
+    const sel = { nodes: [{ id: "n", x: 0, y: 0, size: 14 * 1.45, color: "#2563eb", shape: "circle" }], edges: [] };
+    const capBase = await oracle.capture(base, CAPTURE_OPTS);
+    const capSel = await oracle.capture(sel, CAPTURE_OPTS);
+    const bboxBase = contentBBox(capBase);
+    const bboxSel = contentBBox(capSel);
+    expect(bboxSel.width).toBeGreaterThan(bboxBase.width);
+    expect(bboxSel.height).toBeGreaterThan(bboxBase.height);
+  }, 60_000);
+});
+
+describe("B1-P1 DETERMINISM floor — every named fixture re-captures byte-identical", () => {
+  it("each fixture is byte-stable (the A/B golden model rests on this)", async () => {
+    if (!chromeUp || !oracle) return;
+    for (const [name, fixture] of Object.entries(ALL_FIXTURES)) {
+      const a = await oracle.capture(fixture, CAPTURE_OPTS);
+      const b = await oracle.capture(fixture, CAPTURE_OPTS);
+      const d = diffPixels(a, b, { channelTolerance: 0, maxFailingPixels: 0 });
+      expect(d.maxChannelDelta, `fixture "${name}" not byte-deterministic`).toBe(0);
+      expect(d.failingPixels, `fixture "${name}" not byte-deterministic`).toBe(0);
+    }
+  }, 180_000);
+});
+
+describe("B1-P1 render-geometry constants stay in sync with the renderer", () => {
+  it("the box constants the harness asserts against match src/renderer.ts literals", async () => {
+    // These mirror renderer.ts BOX_BASE_HEIGHT_PX / BOX_MAX_WIDTH_RATIO /
+    // BOX_EMPTY_RATIO. If the renderer changes them the golden assertions must
+    // follow — this guard makes a silent drift a test failure, not a flake.
+    expect(BOX_BASE_HEIGHT_PX).toBe(18);
+    expect(BOX_MAX_WIDTH_RATIO).toBe(10);
+    expect(BOX_EMPTY_RATIO).toBeCloseTo(10 / 22, 10);
+  });
+});
+
+// ---- local pixel helpers (no Chrome needed; pure functions) ---------------
+function samplePixelLocal(
+  cap: { width: number; data: Uint8ClampedArray },
+  x: number,
+  y: number,
+): [number, number, number, number] {
+  const i = (Math.round(y) * cap.width + Math.round(x)) * 4;
+  return [cap.data[i], cap.data[i + 1], cap.data[i + 2], cap.data[i + 3]];
+}
+function maxChannelDelta(a: number[], b: number[]): number {
+  let m = 0;
+  for (let c = 0; c < 4; c += 1) m = Math.max(m, Math.abs(a[c] - b[c]));
+  return m;
+}
 
 describe("B1 Phase-0 supplemental SMOKE path (@napi-rs/canvas, NOT the parity oracle)", () => {
   it("napi Canvas2D capture is deterministic and detects the 3px move", async () => {

--- a/packages/graph/tests/golden/harness-page.html
+++ b/packages/graph/tests/golden/harness-page.html
@@ -220,6 +220,26 @@
 
         const snap = renderer.snapshot();
 
+        // Composite an OPAQUE WHITE background BEHIND the rendered graph so the
+        // canvas BACKING STORE matches the visual page (the CSS background is
+        // white). The renderer clears to TRANSPARENT, so without this the
+        // backing store reads transparent-black where nothing drew and any
+        // translucent glyph (hollow interior, a<255 edge, box fill) reads over
+        // transparent instead of over white. The inventory contracts are
+        // defined OVER WHITE ("hollow interior reads white", "a180 edge lighter
+        // over white"), so we paint white-behind via destination-over. This is
+        // a HARNESS-ONLY composite (never the shipped renderer); for the WebGL
+        // backend the readback path is unchanged (GL clears to transparent and
+        // the same contract applies — a future GL capture would composite the
+        // same way). 2D only here.
+        if (snap.backend === "canvas2d") {
+          ctx2d.save();
+          ctx2d.globalCompositeOperation = "destination-over";
+          ctx2d.fillStyle = "#ffffff";
+          ctx2d.fillRect(0, 0, canvas.width, canvas.height);
+          ctx2d.restore();
+        }
+
         // Expose a direct-pixel read of the canvas BACKING STORE. For the 2D
         // backend we read via getImageData; for a future WebGL backend the
         // caller switches to gl.readPixels (handled in __readPixels).


### PR DESCRIPTION
## What

Expands the B1 golden pixel oracle (PR #193, hardened in #206) from a **smoke subset** to **comprehensive non-regression coverage of the CURRENT canvas2d renderer**.

**This is TEST-ONLY.** No renderer / `styles.ts` / `shape-geometry.ts` change; the default backend stays `canvas2d`. The current canvas2d renderer is the baseline source of truth (A/B model — render-twice determinism + computed geometry probes, no stored golden PNGs).

This is **P1** of the B1 plan (`.graphify/scratch/B1_WEBGL2_MIGRATION_PLAN_OPUS.md`) — the mandated prerequisite for the future WebGL2 migration AND an immediate regression-safety improvement for the shipping canvas2d renderer. **The WebGL2 migration (P2+) is a SEPARATE work-stream and is NOT started in this PR.**

## Inventory groups now covered (B1 plan §1)

| Group | Coverage |
|---|---|
| **Shapes N1–N6** (dot/diamond/star/square/hexagon/triangle) | per-shape center colour probe + near-vertex interior probe (catches a wrong star inner-ratio / rotated hexagon / shifted start angle); 3px-move regression |
| **Boxes N7/N9 + recon focal + #199** | god-class labelled box (degree-independent height), empty-box collapse (no text), recon focal pair; **#199** long-label is pixel-clipped within the `BOX_MAX_WIDTH_RATIO` cap, short label untouched |
| **Community colours N14** | same group colour renders identically; distinct groups render distinctly (single-source consumer) |
| **Node borders N10/N11** | hollow interior is fixed translucent-white over white (the subtle N10 contract), node colour rides the border; bold paints a thicker ring than normal |
| **Edges E1/E2/E3/E4/E6/E12** | thick edge; 3 dash families (each fewer ink pixels than the same solid edge); curve bows off the chord midpoint; opaque (a255) vs no-style (a180) colour-alpha split |
| **Selection / highlight N14/N16** | selected colour `#2563eb` / focus colour `#ef4444`; the N16 size multiplier renders a larger disc |

## Baseline vs geometry-assertion split

Per the plan's safety guidance, **deterministic geometry-parity assertions are preferred** over fragile full-frame pixel baselines:

- **Geometry-parity (the no-GL floor):** node center/vertex colour probes computed from the renderer's exact transforms (`worldToDevice` / `drawnRadius`); box height/width parity vs `render-geometry` constants via a content bounding box; dash/curve/alpha presence + relative-ink comparisons; size-multiplier via bbox growth. These are robust to AA.
- **Pixel baselines:** kept only where stable — a **per-fixture determinism floor** (same fixture twice == byte-identical, `channelTolerance:0`) underpins every block, plus the existing 3px-move regression proof, all under the conservative per-channel tolerance.
- A **constants-parity guard** mirrors the renderer's box constants so a future renderer change to them fails this test rather than silently diverging.

## Skip-on-no-Chrome guard (#206 pattern, unchanged)

Every CDP test early-returns via the existing `chromeUp` guard when headless Chrome / the CDP websocket is unavailable (suite **skips, never flakes**). `GOLDEN_REQUIRE_CHROME=1` turns a missing Chrome into a hard failure for the CI golden job. The harness now composites an opaque white background **behind** the rendered graph (destination-over, 2D-only, harness-only) so the canvas backing store matches the white page and the over-white inventory contracts hold.

## Verification

- `GOLDEN_REQUIRE_CHROME=1 npm run test:golden` → **27 golden tests pass** (JS bundle builds via `golden:build --no-dts`).
- Without Chrome → CDP tests **skip cleanly**, suite green.
- Full `@sentropic/graph` vitest suite → **56 tests pass**.
- Diff touches only `packages/graph/tests/golden/{diff.mjs,fixtures.mjs,golden-harness.test.ts,harness-page.html}` — **no `src/`**. (The pre-existing `styles.ts:165` DTS strictness error is unrelated and documented in the harness README; the golden path uses `--no-dts`.)