### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 This fork (`graphifyy@*`) is the TypeScript line. Pre-`0.7.x` entries below refer to the upstream Python Graphify line.
 
+## 0.17.0 (2026-06-23)
+
+- **`graphify cite` — citation grounding (new producer command).** Scans a corpus and populates `node.citations[]` `{quote, source_file, source_location}` per entity — symmetric to `describe`/`label` (alias `ground-citations`). **Heuristic-first, no API key by default** (`--mode heuristic|assistant|api`); LLM-assisted modes are opt-in and gated by the same structural anti-hallucination invariant — every emitted `quote` is a verified verbatim substring of the source. Modality-aware (OCR-markdown sections + page resolution, plain-text), unions with existing citations (never clobbers the exhaustive `citations.json` tail), reuses the 0.14.0 citation tiering. Opt-in (not auto-run). Verified on a real corpus: 792/876 nodes grounded, 2854/2854 quotes verbatim, zero hallucinations, zero API calls.
+- **`OntologyCitation` contract.** Promoted `quote?`, `confidence?`, `source_location?` to first-class optional fields — additive, backward-compatible (already de-facto present on the sibling evidence record and consumed by the studio); reverses the old SPEC_CITATIONS "no quote" non-goal. Storage/tiering unchanged.
+- **Renderer regression coverage.** Expanded the graph renderer's golden pixel oracle from a smoke subset to comprehensive non-regression coverage (per-type shapes, labelled/recon boxes + the pixel-fit label ellipsis, community colours, node borders, edges, selection) — test-only, no renderer change.
+
 ## 0.16.0 (2026-06-23)
 
 - **Studio group-by (B2).** Per-item group-by checkboxes on every groupable row (ontology Domain / Sub-domain / Type and communities) with tri-state bulk buttons ("Group all to: Domain / Sub-domain / Type" + scoped "Ungroup all") and nesting absorption — DS-native, no horizontal overflow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sentropic/graphify",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sentropic/graphify",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.75",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/graphify",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("release configuration", () => {
-  it("tracks the 0.16.0 release across package metadata and changelog", () => {
+  it("tracks the 0.17.0 release across package metadata and changelog", () => {
     const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as { name?: string; version?: string };
     const lock = JSON.parse(readFileSync(new URL("../package-lock.json", import.meta.url), "utf-8")) as {
       name?: string;
@@ -12,11 +12,11 @@ describe("release configuration", () => {
     const changelog = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf-8");
 
     expect(pkg.name).toBe("@sentropic/graphify");
-    expect(pkg.version).toBe("0.16.0");
+    expect(pkg.version).toBe("0.17.0");
     expect(lock.name).toBe("@sentropic/graphify");
-    expect(lock.version).toBe("0.16.0");
-    expect(lock.packages?.[""]?.version).toBe("0.16.0");
-    expect(changelog).toContain("## 0.16.0 (2026-06-23)");
+    expect(lock.version).toBe("0.17.0");
+    expect(lock.packages?.[""]?.version).toBe("0.17.0");
+    expect(changelog).toContain("## 0.17.0 (2026-06-23)");
   });
 
   it("runs the main TypeScript CI test matrix on Node 20, 22, and 24", () => {


### PR DESCRIPTION
Release **0.17.0** — ships `graphify cite` (the citation-grounding producer).

## Contents (since 0.16.0)
- #207 `graphify cite` — heuristic-first (no-key) citation grounding + `OntologyCitation` contract additions (`quote?`/`confidence?`/`source_location?`)
- #208 expanded golden renderer regression coverage (test-only)

## Why now
Unblocks **radar's client-priority need** (the 33 z∩m∩p signals — 4 citations re-extractable via `graphify cite`, **not** gated on LLM enrollment since cite is heuristic/no-key) and **aclp-am** (`page:"unknown"` resolution) and **ia-aero**.

## Release mechanics
After merge, tag `v0.17.0` → `release-guard` (ancestor-of-main + version-match) → `publish`. The flaky `direct-llm-uat` (openai quota) does not run on the tag push.

**HELD: do not merge/tag until the principal says "go".**