### PR TITLE
feat(graph): B1-P2 — WebGL2 edges canary (flag-gated, default canvas2d)

### DIFF
--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -6,5 +6,6 @@ export * from "./render-geometry";
 export * from "./renderer";
 export * from "./shape-geometry";
 export * from "./webgl-shapes";
+export * from "./webgl-edges";
 export * from "./styles";
 export * from "./types";

--- a/packages/graph/src/render-geometry.ts
+++ b/packages/graph/src/render-geometry.ts
@@ -302,3 +302,171 @@ export function coerceFinitePositions(
   }
   return { positions: out ?? positions, nonFiniteCount };
 }
+
+// ---------------------------------------------------------------------------
+// EDGE geometry (B1 Phase 2). Lifted VERBATIM from the `drawFallback2D` edge
+// pass (renderer.ts:844-921) into pure functions so the Canvas2D fallback, the
+// WebGL2 instanced-edge path, and the hit-test all consume ONE computation —
+// the same anti-divergence decision the node geometry made. The WebGL path
+// tessellates the curve here so the render-curve == hit-curve (R10): this is
+// the ONLY parity helper; `edge-geometry.ts` is NOT on this path (it uses a
+// different control-point sign/factor and a different default curvature).
+// ---------------------------------------------------------------------------
+
+/** Edge curvature lateral factor (renderer.ts:492). Control offset = curvature·this. */
+export const EDGE_CURVE_FACTOR = 0.5;
+
+/**
+ * Arrowhead length in world units per unit of edge width (renderer.ts:543).
+ * Device-space length = ARROW_LENGTH · width · pixelRatio · zoom (world-space,
+ * scales with zoom like every glyph).
+ */
+export const ARROW_LENGTH = 2.5;
+/** Arrow triangle base width as a fraction of its length (renderer.ts:545). */
+export const ARROW_WIDTH_RATIO = 0.9;
+
+/** Dash pattern (on/off CSS px, scaled by pixelRatio) per dash code (renderer.ts:480-489). */
+export function dashPattern(dash: number, pixelRatio: number): [number, number] | null {
+  if (dash === 1) return [6 * pixelRatio, 4 * pixelRatio];
+  if (dash === 2) return [1.5 * pixelRatio, 4 * pixelRatio];
+  if (dash === 3) return [10 * pixelRatio, 6 * pixelRatio];
+  return null; // solid
+}
+
+/** Drawn stroke width in device px (E1, renderer.ts:903): max(1, width·pixelRatio). */
+export function edgeStrokeWidth(width: number, pixelRatio: number): number {
+  return Math.max(1, width * pixelRatio);
+}
+
+/**
+ * Resolved per-edge geometry in DEVICE pixels, computed once with the EXACT
+ * `drawFallback2D` math: the (curved) control point, the OUTGOING/INCOMING unit
+ * tangents (the chord for straight edges, the control→endpoint directions for
+ * arcs — E7), whether the edge clips to the node borders (E5/E13), and the
+ * clipped start/end points the stroke and arrowhead use.
+ */
+export interface EdgeGeometry {
+  /** Edge is degenerate (endpoints coincide) — caller skips it (renderer.ts:857). */
+  degenerate: boolean;
+  /** Endpoints clip to the node borders; false ⇒ raw segment + NO arrow (E13). */
+  clipped: boolean;
+  /** Whether the edge is curved (curvature !== 0). */
+  curved: boolean;
+  /** Quadratic control point (device px); only meaningful when `curved`. */
+  controlX: number;
+  controlY: number;
+  /** Outgoing unit tangent at the source (curve start tangent / chord). */
+  outSx: number;
+  outSy: number;
+  /** Incoming unit tangent at the target (curve end tangent / chord). */
+  inTx: number;
+  inTy: number;
+  /** Clipped stroke start (source border) — raw source when not clipped. */
+  startX: number;
+  startY: number;
+  /** Clipped stroke end (target border) — raw target when not clipped. */
+  endX: number;
+  endY: number;
+}
+
+/**
+ * Compute one edge's drawn geometry from its endpoint SCREEN points + curvature.
+ * `offsetForDir(end, dirX, dirY)` returns the border offset of the given
+ * endpoint (`"source"`/`"target"`) along a unit direction — wire it to
+ * `borderOffset` so the box-rect / circular-clip choice is single-sourced.
+ *
+ * This is the verbatim renderer.ts:854-898 math: control point, tangents,
+ * clip test (`dist > offsetSource + offsetTarget + 1e-3`), clipped endpoints.
+ */
+export function edgeGeometry(
+  source: { x: number; y: number },
+  target: { x: number; y: number },
+  curvature: number,
+  offsetForDir: (end: "source" | "target", dirX: number, dirY: number) => number,
+): EdgeGeometry {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const distance = Math.hypot(dx, dy);
+  const degenerate = distance < 1e-6;
+  const curved = curvature !== 0;
+
+  let controlX = 0;
+  let controlY = 0;
+  if (curved && !degenerate) {
+    const midX = (source.x + target.x) / 2;
+    const midY = (source.y + target.y) / 2;
+    // control = mid + (-dy/d, dx/d)·d·curvature·EDGE_CURVE_FACTOR (renderer.ts:865)
+    controlX = midX + (-dy / distance) * distance * curvature * EDGE_CURVE_FACTOR;
+    controlY = midY + (dx / distance) * distance * curvature * EDGE_CURVE_FACTOR;
+  }
+
+  let outSx = degenerate ? 0 : dx / distance;
+  let outSy = degenerate ? 0 : dy / distance;
+  let inTx = outSx;
+  let inTy = outSy;
+  if (curved && !degenerate) {
+    const sLen = Math.hypot(controlX - source.x, controlY - source.y);
+    const tLen = Math.hypot(target.x - controlX, target.y - controlY);
+    if (sLen > 1e-6) {
+      outSx = (controlX - source.x) / sLen;
+      outSy = (controlY - source.y) / sLen;
+    }
+    if (tLen > 1e-6) {
+      inTx = (target.x - controlX) / tLen;
+      inTy = (target.y - controlY) / tLen;
+    }
+  }
+
+  const offsetSource = offsetForDir("source", outSx, outSy);
+  const offsetTarget = offsetForDir("target", -inTx, -inTy);
+  const clipped = !degenerate && distance > offsetSource + offsetTarget + 1e-3;
+
+  const startX = clipped ? source.x + outSx * offsetSource : source.x;
+  const startY = clipped ? source.y + outSy * offsetSource : source.y;
+  const endX = clipped ? target.x - inTx * offsetTarget : target.x;
+  const endY = clipped ? target.y - inTy * offsetTarget : target.y;
+
+  return {
+    degenerate,
+    clipped,
+    curved,
+    controlX,
+    controlY,
+    outSx,
+    outSy,
+    inTx,
+    inTy,
+    startX,
+    startY,
+    endX,
+    endY,
+  };
+}
+
+/**
+ * Tessellate the drawn edge into a polyline of device-pixel points. A straight
+ * edge is the single [start, end] segment; a curved edge samples the quadratic
+ * Bézier (start, control, end) at `segments+1` points. The polyline is what the
+ * WebGL capsule pipeline expands, and (sampled at the same steps) what the
+ * hit-test walks — so render-curve == hit-curve. The endpoints are the CLIPPED
+ * endpoints from `edgeGeometry`, so the curve starts/ends on the node borders.
+ */
+export function tessellateEdge(geom: EdgeGeometry, segments = 16): Array<[number, number]> {
+  if (!geom.curved) {
+    return [
+      [geom.startX, geom.startY],
+      [geom.endX, geom.endY],
+    ];
+  }
+  const steps = Math.max(2, segments);
+  const points: Array<[number, number]> = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = i / steps;
+    const mt = 1 - t;
+    // Quadratic Bézier with the CLIPPED endpoints and the shared control point.
+    const x = mt * mt * geom.startX + 2 * mt * t * geom.controlX + t * t * geom.endX;
+    const y = mt * mt * geom.startY + 2 * mt * t * geom.controlY + t * t * geom.endY;
+    points.push([x, y]);
+  }
+  return points;
+}

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -1,6 +1,7 @@
 import { computePositionBounds, copyPositions } from "./positions";
 import { BOX_GLYPH_CORNER_RATIO, SQUARE_INSET_RATIO, shapePolygonPoints } from "./shape-geometry";
 import { createWebGLShapeRenderer, type WebGLShapeRenderer } from "./webgl-shapes";
+import { createWebGLEdgeRenderer, type WebGLEdgeRenderer } from "./webgl-edges";
 import type {
   CameraState,
   FitViewOptions,
@@ -462,6 +463,44 @@ function cssDarkenedColor(
   const b = Math.round((source?.[offset + 2] ?? fallback[2]) * factor);
   const a = (source?.[offset + 3] ?? fallback[3]) / 255;
   return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+/**
+ * Build a box-label `measureText` service for the WebGL edge path so an edge
+ * clipping to a BOX endpoint stops at the SAME rect border Canvas2D draws (E5).
+ * Uses a throwaway offscreen 2D canvas (OffscreenCanvas or a detached <canvas>)
+ * with a per-call font + text cache. Returns `null` in non-DOM environments —
+ * the edge path then falls back to the empty-collapse box rect (box-label clip
+ * parity finalises with the box glyph in Phase 4). NEVER touches the render
+ * canvas (a canvas holds one context type — a 2D ctx there would break WebGL).
+ */
+function createMeasureService(): ((text: string, font: string) => number) | null {
+  const g = globalThis as {
+    OffscreenCanvas?: new (w: number, h: number) => { getContext(t: "2d"): CanvasRenderingContext2D | null };
+    document?: { createElement(tag: "canvas"): HTMLCanvasElement };
+  };
+  let ctx: CanvasRenderingContext2D | null = null;
+  try {
+    if (typeof g.OffscreenCanvas === "function") {
+      ctx = new g.OffscreenCanvas(1, 1).getContext("2d");
+    } else if (g.document?.createElement) {
+      ctx = g.document.createElement("canvas").getContext("2d");
+    }
+  } catch {
+    return null;
+  }
+  if (!ctx) return null;
+  const measureCtx = ctx;
+  const cache = new Map<string, number>();
+  return (text: string, font: string): number => {
+    const key = `${font}|${text}`;
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+    measureCtx.font = font;
+    const width = measureCtx.measureText(text).width;
+    cache.set(key, width);
+    return width;
+  };
 }
 
 function screenPoint(
@@ -1008,6 +1047,15 @@ export function createGraphRenderer(
   const shapeRenderer: WebGLShapeRenderer | null =
     wantInstancedShapes && context && isWebGL2(context) ? createWebGLShapeRenderer(context) : null;
   const usesInstancedShapes = shapeRenderer !== null;
+  // B1 Phase 2 INTERNAL CANARY: the SAME `instancedShapes` flag turns on the
+  // WebGL2 instanced-EDGE path (thick/clip/dash/curve/arrows via capsule SDF),
+  // replacing the legacy 1px `LINES`. Gated identically — the studio default
+  // (canvas2d) never enters this branch, so there is no user-facing change.
+  const edgeRenderer: WebGLEdgeRenderer | null =
+    wantInstancedShapes && context && isWebGL2(context) ? createWebGLEdgeRenderer(context) : null;
+  // Box-label measure service for the WebGL edge clip (E5). Built once; null in
+  // non-DOM envs (the edge path then uses the empty-collapse box rect).
+  const edgeMeasureLabelWidth = edgeRenderer ? createMeasureService() ?? undefined : undefined;
   let lastNonFiniteCount = 0;
   let state: RendererState = {
     nodeIds: [],
@@ -1092,27 +1140,46 @@ export function createGraphRenderer(
     }
 
     if (!skipEdges && state.edges.length > 0) {
-      context.useProgram(resources.edgeProgram.program);
-      bindCameraUniforms(context, resources.edgeProgram.uniforms, camera, canvas, pixelRatio);
-      uploadAttribute(
-        context,
-        resources.positionBuffer,
-        resources.edgeProgram.attributes.position,
-        buildEdgePositions(state, pixelRatio),
-        2,
-        context.FLOAT,
-        false,
-      );
-      uploadAttribute(
-        context,
-        resources.colorBuffer,
-        resources.edgeProgram.attributes.color,
-        buildEdgeColors(state),
-        4,
-        context.UNSIGNED_BYTE,
-        true,
-      );
-      context.drawArrays(context.LINES, 0, state.edges.length);
+      if (edgeRenderer) {
+        // B1 Phase 2 INTERNAL CANARY: WebGL2 instanced edges (thick round-capped
+        // capsules + clip + dash + curve + arrowheads), driven by the shared
+        // render-geometry so the GL edge matches the Canvas2D edge — NOT the
+        // legacy 1px `LINES`. Box/labels/picking stay on later phases / Canvas2D.
+        edgeRenderer.renderEdges({
+          positions: state.positions,
+          nodeCount: state.nodeIds.length,
+          edges: state.edges,
+          style: state.style,
+          camera,
+          pixelRatio,
+          viewportWidth: canvas?.width ?? 0,
+          viewportHeight: canvas?.height ?? 0,
+          measureLabelWidth: edgeMeasureLabelWidth,
+        });
+      } else {
+        // Legacy 1px point-sprite edge path (default for users).
+        context.useProgram(resources.edgeProgram.program);
+        bindCameraUniforms(context, resources.edgeProgram.uniforms, camera, canvas, pixelRatio);
+        uploadAttribute(
+          context,
+          resources.positionBuffer,
+          resources.edgeProgram.attributes.position,
+          buildEdgePositions(state, pixelRatio),
+          2,
+          context.FLOAT,
+          false,
+        );
+        uploadAttribute(
+          context,
+          resources.colorBuffer,
+          resources.edgeProgram.attributes.color,
+          buildEdgeColors(state),
+          4,
+          context.UNSIGNED_BYTE,
+          true,
+        );
+        context.drawArrays(context.LINES, 0, state.edges.length);
+      }
     }
 
     if (state.nodeIds.length > 0) {
@@ -1200,6 +1267,7 @@ export function createGraphRenderer(
     destroy() {
       destroyed = true;
       shapeRenderer?.destroy();
+      edgeRenderer?.destroy();
     },
   };
 }

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -141,15 +141,33 @@ void main() {
   float cov = 1.0 - smoothstep(v_halfWidth - aa, v_halfWidth + aa, dist);
   if (cov <= 0.0) discard;
 
-  // Arc-length dashing: keep only fragments in the "on" portion of the period,
-  // with a soft ~1px edge on the on/off transition (round pips read smooth).
+  // Arc-length dashing with ROUND PIPS (E3 + E14). Canvas2D sets lineCap="round"
+  // for the whole frame, so each dash "on" run is a round-capped capsule: it
+  // bulges out by the stroke radius (= v_halfWidth) at BOTH ends, AND the pip is
+  // rounded across its width. We model the pip as a capsule whose CORE runs the
+  // on-length and whose caps add v_halfWidth each side — matching Canvas2D's
+  // visibly-longer round dashes (a hard cut would under-cover the pip, e.g. a
+  // 3px "on" reading as ~3px instead of Canvas2D's ~9px with 3px round caps).
   float coverage = cov;
   if (v_dashPeriod > 0.0) {
     float phase = mod(v_arc, v_dashPeriod);
-    float aaArc = fwidth(v_arc);
-    // Fade out as phase crosses the "on" length (one-sided; the period wrap is a
-    // hard reset which is acceptable — the gap is many px wide).
-    coverage *= 1.0 - smoothstep(v_dashOn - aaArc, v_dashOn + aaArc, phase);
+    // Distance ALONG the arc to the nearest point of the on-run [0 .. v_dashOn].
+    float dAlong = phase < 0.0 ? -phase
+                 : phase > v_dashOn ? phase - v_dashOn
+                 : 0.0;
+    // Also fold the previous period's pip so a pip that wraps the period seam
+    // still caps correctly (phase near v_dashPeriod is close to the NEXT pip's
+    // start at 0). Take the min distance to either pip.
+    float dNext = v_dashPeriod - phase; // distance to the next pip start (at 0)
+    dAlong = min(dAlong, dNext);
+    // Capsule SDF of the pip: combine the across-distance (v_local.y) with the
+    // along-overrun so the cap is round in BOTH axes, ≤ v_halfWidth keeps it.
+    float pipDist = length(vec2(dAlong, v_local.y));
+    float aaPip = fwidth(pipDist);
+    float pipCov = 1.0 - smoothstep(v_halfWidth - aaPip, v_halfWidth + aaPip, pipDist);
+    // The straight-segment coverage already handled the across axis for the
+    // on-core; gate by the pip capsule so caps/gaps read round.
+    coverage = min(coverage, pipCov);
     if (coverage <= 0.0) discard;
   }
 

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -1,0 +1,586 @@
+/**
+ * WebGL2 INSTANCED EDGE renderer (B1 migration plan §2.4, Phase 2).
+ *
+ * Phase 2 scope: graph EDGES (E1 thick, E2/E12 colour+alpha, E3 dash families,
+ * E4 curve, E5 clip, E6 arrowheads, E13 overlap fallback, E14 round caps/joins).
+ * It REPLACES the legacy 1px `LINES` edge path when the instanced-shape canary
+ * is on; the box glyph (shape 5), labels, and picking remain LATER phases. The
+ * path is gated behind the SAME `instancedShapes` canary the P1 shapes use and
+ * is INTERNAL-CANARY-ONLY: the studio default stays `canvas2d`, so there is no
+ * user-facing change. Canvas2D edges remain the golden source of truth.
+ *
+ * Architecture (mirrors webgl-shapes.ts):
+ *
+ *  - **Capsule SDF for thick round-capped edges (E1/E14).** Each drawn edge is
+ *    tessellated (render-geometry.tessellateEdge) into device-pixel segments —
+ *    one for a straight edge, N for a quadratic curve (E4). Each SEGMENT is an
+ *    instanced quad expanded by ±half-width plus a half-width pad at the caps;
+ *    the fragment shader keeps only fragments whose distance to the segment is
+ *    ≤ half-width, giving ROUND caps and (on curves) round joins for free — the
+ *    same `lineCap/lineJoin="round"` Canvas2D sets once per frame.
+ *
+ *  - **Arc-length dashing (E3).** Each segment instance carries the arc-length
+ *    at its start; the fragment shader gates the on/off pattern by
+ *    `fract(arcLen / period)`, with the pattern scaled by pixelRatio exactly as
+ *    `applyDash` does. Round pips fall out of the capsule cap.
+ *
+ *  - **Border clip (E5) + overlap fallback (E13).** Endpoints clip to the node
+ *    border via render-geometry.borderOffset (circular non-box / rect box,
+ *    single-sourced with Canvas2D + the hit-test). An edge whose combined
+ *    border offsets exceed the centre distance draws the RAW segment and NO
+ *    arrow — verbatim Canvas2D behaviour.
+ *
+ *  - **Arrowheads (E6/E7).** A filled triangle, tip on the target border,
+ *    oriented by the incoming tangent (the curve end tangent for arcs), length
+ *    `ARROW_LENGTH·width·pixelRatio·zoom` (world-space). One instanced triangle
+ *    per CLIPPED edge; skipped when `!clipped` (E13).
+ *
+ * The vertex transform mirrors webgl-shapes.ts / the edge shader: positions are
+ * computed in DEVICE pixels on the CPU (the same `screenPoint` Canvas2D uses),
+ * then mapped to clip space with the viewport. Edges sit at the FAR depth
+ * (z = +1, behind every node) because Canvas2D draws all edges before all nodes.
+ */
+
+import {
+  ARROW_LENGTH,
+  ARROW_WIDTH_RATIO,
+  borderOffset,
+  dashPattern,
+  edgeGeometry,
+  edgeStrokeWidth,
+  nodeGeometry,
+  tessellateEdge,
+  type NodeGeometry,
+} from "./render-geometry";
+import type { GraphStyleBuffers } from "./types";
+
+type GL2 = WebGL2RenderingContext;
+
+const DEFAULT_EDGE_COLOR = [121, 133, 153, 180] as const;
+
+/** Curve tessellation step count — matches the 16-sample hit-test (X8). */
+const CURVE_SEGMENTS = 16;
+
+// ---------------------------------------------------------------------------
+// Capsule (thick segment) program. A unit quad [0..1]² is expanded along the
+// segment by the instance's endpoints + half-width. The fragment shader does
+// the round-capped capsule coverage + arc-length dashing.
+// ---------------------------------------------------------------------------
+
+const CAPSULE_VERTEX_SHADER = `#version 300 es
+layout(location = 0) in vec2 a_corner;     // unit quad corner: x in {0,1} along, y in {-1,1} across
+layout(location = 1) in vec2 a_p0;         // instance: segment start (device px)
+layout(location = 2) in vec2 a_p1;         // instance: segment end (device px)
+layout(location = 3) in float a_halfWidth; // instance: stroke half-width (device px)
+layout(location = 4) in vec4 a_color;      // instance: rgba (0..1)
+layout(location = 5) in float a_arcStart;  // instance: arc-length at p0 (device px)
+layout(location = 6) in float a_dashPeriod;// instance: dash on+off period (0 = solid)
+layout(location = 7) in float a_dashOn;    // instance: dash on length (device px)
+
+uniform vec2 u_viewport;
+
+out vec2 v_local;      // (alongPx, acrossPx) relative to the segment for SDF
+out float v_halfLen;   // half segment length (device px)
+out float v_halfWidth; // stroke half-width (device px)
+out vec4 v_color;
+out float v_arc;       // arc-length at this fragment (device px) for dashing
+out float v_dashPeriod;
+out float v_dashOn;
+
+void main() {
+  vec2 d = a_p1 - a_p0;
+  float len = length(d);
+  vec2 dir = len > 1e-6 ? d / len : vec2(1.0, 0.0);
+  vec2 nrm = vec2(-dir.y, dir.x);
+
+  // Pad each end by the half-width so the round cap fits inside the quad.
+  float pad = a_halfWidth;
+  float along = a_corner.x * (len + 2.0 * pad) - pad;        // [-pad .. len+pad]
+  float across = a_corner.y * a_halfWidth;                   // [-hw .. hw]
+  vec2 screen = a_p0 + dir * along + nrm * across;
+
+  // Local frame centred on the segment midpoint: x along, y across.
+  v_local = vec2(along - len * 0.5, across);
+  v_halfLen = len * 0.5;
+  v_halfWidth = a_halfWidth;
+  v_color = a_color;
+  v_arc = a_arcStart + along; // arc-length accumulates along the polyline
+  v_dashPeriod = a_dashPeriod;
+  v_dashOn = a_dashOn;
+
+  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x - 1.0, 1.0 - screen.y * 2.0 / u_viewport.y);
+  // Edges sit BEHIND every node (Canvas2D draws all edges before all nodes).
+  gl_Position = vec4(clip, 1.0, 1.0);
+}
+`;
+
+const CAPSULE_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+in vec2 v_local;
+in float v_halfLen;
+in float v_halfWidth;
+in vec4 v_color;
+in float v_arc;
+in float v_dashPeriod;
+in float v_dashOn;
+out vec4 outColor;
+
+void main() {
+  // Distance to the capsule core segment (a horizontal segment of half-length
+  // v_halfLen centred at the origin in local space). Round caps fall out of the
+  // clamp + euclidean distance.
+  float ax = clamp(v_local.x, -v_halfLen, v_halfLen);
+  vec2 closest = vec2(ax, 0.0);
+  float dist = distance(v_local, closest);
+
+  // ~1px SDF coverage AA at the capsule boundary so the stroke rim approximates
+  // Canvas2D's analytic-coverage AA (the MSAA-on-the-quad-triangles the golden
+  // capture requests does NOT smooth this in-quad boundary, so we feather it
+  // here). The hard core (dist << halfWidth) stays fully opaque.
+  float aa = fwidth(dist);
+  float cov = 1.0 - smoothstep(v_halfWidth - aa, v_halfWidth + aa, dist);
+  if (cov <= 0.0) discard;
+
+  // Arc-length dashing: keep only fragments in the "on" portion of the period,
+  // with a soft ~1px edge on the on/off transition (round pips read smooth).
+  float coverage = cov;
+  if (v_dashPeriod > 0.0) {
+    float phase = mod(v_arc, v_dashPeriod);
+    float aaArc = fwidth(v_arc);
+    // Fade out as phase crosses the "on" length (one-sided; the period wrap is a
+    // hard reset which is acceptable — the gap is many px wide).
+    coverage *= 1.0 - smoothstep(v_dashOn - aaArc, v_dashOn + aaArc, phase);
+    if (coverage <= 0.0) discard;
+  }
+
+  outColor = vec4(v_color.rgb, v_color.a * coverage);
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Arrowhead program: an instanced filled triangle. The unit triangle (3 verts
+// per instance) is placed by the tip + the incoming tangent + the length.
+// ---------------------------------------------------------------------------
+
+const ARROW_VERTEX_SHADER = `#version 300 es
+layout(location = 0) in float a_vertex;  // 0 = tip, 1 = base+, 2 = base-
+layout(location = 1) in vec2 a_tip;      // instance: arrow tip (device px)
+layout(location = 2) in vec2 a_dir;      // instance: incoming unit tangent (points INTO target)
+layout(location = 3) in float a_length;  // instance: arrow length (device px)
+layout(location = 4) in vec4 a_color;    // instance: rgba (0..1)
+
+uniform vec2 u_viewport;
+
+out vec4 v_color;
+
+void main() {
+  vec2 dir = a_dir;
+  vec2 perp = vec2(-dir.y, dir.x);
+  float halfBase = a_length * ${ARROW_WIDTH_RATIO.toFixed(4)} * 0.5;
+  vec2 base = a_tip - dir * a_length;
+
+  vec2 screen;
+  if (a_vertex < 0.5) {
+    screen = a_tip;
+  } else if (a_vertex < 1.5) {
+    screen = base + perp * halfBase;
+  } else {
+    screen = base - perp * halfBase;
+  }
+
+  v_color = a_color;
+  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x - 1.0, 1.0 - screen.y * 2.0 / u_viewport.y);
+  gl_Position = vec4(clip, 1.0, 1.0);
+}
+`;
+
+const ARROW_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+in vec4 v_color;
+out vec4 outColor;
+void main() {
+  outColor = v_color;
+}
+`;
+
+/** Floats per capsule instance. p0(2)+p1(2)+halfWidth(1)+color(4)+arcStart(1)+period(1)+on(1) = 12 */
+export const CAPSULE_FLOATS_PER_INSTANCE = 12;
+/** Floats per arrow instance. tip(2)+dir(2)+length(1)+color(4) = 9 */
+export const ARROW_FLOATS_PER_INSTANCE = 9;
+
+export interface WebGLEdgeFrame {
+  positions: Float32Array;
+  nodeCount: number;
+  edges: Uint32Array;
+  style?: GraphStyleBuffers;
+  camera: { x: number; y: number; zoom: number };
+  pixelRatio: number;
+  /** Device backing-store size. */
+  viewportWidth: number;
+  viewportHeight: number;
+  /**
+   * Box-label width measure service (the SAME `measureText` cache Canvas2D uses)
+   * so an edge clipping to a BOX endpoint stops at the SAME rect border (E5).
+   * Optional: when absent, box endpoints fall back to the empty-collapse rect
+   * (an unlabelled box's extents) — box-label clipping parity is finalised with
+   * the box glyph in Phase 4. Circle/polygon endpoints never need it.
+   */
+  measureLabelWidth?: (text: string, font: string) => number;
+}
+
+export interface WebGLEdgeRenderer {
+  /** Draw the graph edges (E1–E14) for this frame. */
+  renderEdges(frame: WebGLEdgeFrame): void;
+  destroy(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Instance build (EXPORTED, pure — the geometry-parity test layer asserts the
+// capsule segments + arrows match the Canvas2D edge math without a GPU).
+// ---------------------------------------------------------------------------
+
+export interface EdgeInstanceSet {
+  /** Flat capsule-segment instances (CAPSULE_FLOATS_PER_INSTANCE each). */
+  capsules: number[];
+  /** Flat arrow-triangle instances (ARROW_FLOATS_PER_INSTANCE each). */
+  arrows: number[];
+}
+
+/** A node's centre in DEVICE px (the same transform as renderer.ts screenPoint). */
+function screenPoint(
+  positions: Float32Array,
+  nodeIndex: number,
+  frame: WebGLEdgeFrame,
+): { x: number; y: number } {
+  const offset = nodeIndex * 2;
+  const px = positions[offset] ?? 0;
+  const py = positions[offset + 1] ?? 0;
+  return {
+    x: (px - frame.camera.x) * frame.camera.zoom + frame.viewportWidth / 2,
+    y: (py - frame.camera.y) * frame.camera.zoom + frame.viewportHeight / 2,
+  };
+}
+
+function edgeColorAt(
+  source: Uint8Array | undefined,
+  offset: number,
+): [number, number, number, number] {
+  return [
+    source?.[offset] ?? DEFAULT_EDGE_COLOR[0],
+    source?.[offset + 1] ?? DEFAULT_EDGE_COLOR[1],
+    source?.[offset + 2] ?? DEFAULT_EDGE_COLOR[2],
+    source?.[offset + 3] ?? DEFAULT_EDGE_COLOR[3],
+  ];
+}
+
+/**
+ * Build the per-frame edge instance arrays from the SAME inputs Canvas2D's
+ * `drawFallback2D` edge pass consumes, using the shared render-geometry. Each
+ * edge yields: capsule segments (1 straight / CURVE_SEGMENTS curved) carrying
+ * colour + arc-length dash params, and — when clipped — one arrow triangle.
+ */
+export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
+  const capsules: number[] = [];
+  const arrows: number[] = [];
+  const style = frame.style;
+
+  const edgeCount = frame.edges.length / 2;
+  if (edgeCount === 0) return { capsules, arrows };
+
+  // Shared node geometry (radii + box extents) in device px, so the edge clip
+  // reads the SAME border offsets the node pass draws. Boxes need a measureText
+  // service; edges to boxes use their rect extents (box label measuring is a
+  // later phase, so a no-op width keeps a box as an empty-collapse rect here —
+  // the same value Canvas2D would compute for an unlabelled box).
+  const geometry: NodeGeometry = nodeGeometry(
+    {
+      nodeCount: frame.nodeCount,
+      nodeSizes: style?.nodeSizes,
+      nodeShapes: style?.nodeShapes,
+      nodeLabels: style?.nodeLabels,
+    },
+    frame.pixelRatio,
+    frame.camera.zoom,
+    frame.measureLabelWidth ?? (() => 0),
+  );
+
+  for (let edgeIndex = 0; edgeIndex < edgeCount; edgeIndex += 1) {
+    const sourceIndex = frame.edges[edgeIndex * 2] ?? 0;
+    const targetIndex = frame.edges[edgeIndex * 2 + 1] ?? 0;
+    const source = screenPoint(frame.positions, sourceIndex, frame);
+    const target = screenPoint(frame.positions, targetIndex, frame);
+    const curvature = style?.edgeCurvatures?.[edgeIndex] ?? 0;
+    const width = style?.edgeWidths?.[edgeIndex] ?? 1;
+
+    const geom = edgeGeometry(source, target, curvature, (end, dx, dy) =>
+      borderOffset(geometry, style?.nodeShapes, end === "source" ? sourceIndex : targetIndex, dx, dy),
+    );
+    if (geom.degenerate) continue;
+
+    const color = edgeColorAt(style?.edgeColors, edgeIndex * 4);
+    const r = color[0] / 255;
+    const g = color[1] / 255;
+    const b = color[2] / 255;
+    const a = color[3] / 255;
+    const halfWidth = edgeStrokeWidth(width, frame.pixelRatio) / 2;
+
+    const dash = dashPattern(style?.edgeDash?.[edgeIndex] ?? 0, frame.pixelRatio);
+    const dashPeriod = dash ? dash[0] + dash[1] : 0;
+    const dashOn = dash ? dash[0] : 0;
+
+    // Tessellate the (clipped) drawn polyline and emit one capsule per segment,
+    // accumulating arc-length so dashes are continuous across curve segments.
+    const polyline = tessellateEdge(geom, CURVE_SEGMENTS);
+    let arc = 0;
+    for (let i = 0; i < polyline.length - 1; i += 1) {
+      const p0 = polyline[i]!;
+      const p1 = polyline[i + 1]!;
+      capsules.push(
+        p0[0], p0[1],
+        p1[0], p1[1],
+        halfWidth,
+        r, g, b, a,
+        arc,
+        dashPeriod,
+        dashOn,
+      );
+      arc += Math.hypot(p1[0] - p0[0], p1[1] - p0[1]);
+    }
+
+    // Arrowhead on every CLIPPED edge (E6), tip on the target border, oriented
+    // by the incoming tangent (E7); skipped when !clipped (E13).
+    if (geom.clipped) {
+      const arrowLength = ARROW_LENGTH * width * frame.pixelRatio * frame.camera.zoom;
+      arrows.push(geom.endX, geom.endY, geom.inTx, geom.inTy, arrowLength, r, g, b, a);
+    }
+  }
+
+  return { capsules, arrows };
+}
+
+// ---------------------------------------------------------------------------
+// GL plumbing.
+// ---------------------------------------------------------------------------
+
+function compile(gl: GL2, type: number, src: string): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("failed to create WebGL shader");
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(shader) || "shader compile error";
+    gl.deleteShader(shader);
+    throw new Error(log);
+  }
+  return shader;
+}
+
+function link(gl: GL2, vsSrc: string, fsSrc: string): WebGLProgram {
+  const vs = compile(gl, gl.VERTEX_SHADER, vsSrc);
+  const fs = compile(gl, gl.FRAGMENT_SHADER, fsSrc);
+  const program = gl.createProgram();
+  if (!program) throw new Error("failed to create WebGL program");
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(program) || "program link error";
+    throw new Error(log);
+  }
+  return program;
+}
+
+interface CapsulePipeline {
+  program: WebGLProgram;
+  vao: WebGLVertexArrayObject;
+  cornerBuffer: WebGLBuffer;
+  instanceBuffer: WebGLBuffer;
+  viewport: WebGLUniformLocation | null;
+}
+
+interface ArrowPipeline {
+  program: WebGLProgram;
+  vao: WebGLVertexArrayObject;
+  vertexBuffer: WebGLBuffer;
+  instanceBuffer: WebGLBuffer;
+  viewport: WebGLUniformLocation | null;
+}
+
+/** Unit quad as two triangles, corners (along∈{0,1}, across∈{-1,1}). */
+const QUAD_CORNERS = new Float32Array([
+  0, -1, 1, -1, 1, 1,
+  0, -1, 1, 1, 0, 1,
+]);
+/** Arrow triangle vertex selectors: 0 tip, 1 base+, 2 base−. */
+const ARROW_VERTICES = new Float32Array([0, 1, 2]);
+
+function createCapsulePipeline(gl: GL2): CapsulePipeline {
+  const program = link(gl, CAPSULE_VERTEX_SHADER, CAPSULE_FRAGMENT_SHADER);
+  const vao = gl.createVertexArray();
+  const cornerBuffer = gl.createBuffer();
+  const instanceBuffer = gl.createBuffer();
+  if (!vao || !cornerBuffer || !instanceBuffer) throw new Error("failed to create capsule buffers");
+  const stride = CAPSULE_FLOATS_PER_INSTANCE * 4;
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, cornerBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, QUAD_CORNERS, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
+  // location 1 a_p0, 2 a_p1, 3 a_halfWidth, 4 a_color, 5 a_arcStart, 6 a_dashPeriod, 7 a_dashOn
+  const layout: Array<[number, number, number]> = [
+    [1, 2, 0],
+    [2, 2, 2 * 4],
+    [3, 1, 4 * 4],
+    [4, 4, 5 * 4],
+    [5, 1, 9 * 4],
+    [6, 1, 10 * 4],
+    [7, 1, 11 * 4],
+  ];
+  for (const [loc, size, offset] of layout) {
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, size, gl.FLOAT, false, stride, offset);
+    gl.vertexAttribDivisor(loc, 1);
+  }
+  gl.bindVertexArray(null);
+
+  return { program, vao, cornerBuffer, instanceBuffer, viewport: gl.getUniformLocation(program, "u_viewport") };
+}
+
+function createArrowPipeline(gl: GL2): ArrowPipeline {
+  const program = link(gl, ARROW_VERTEX_SHADER, ARROW_FRAGMENT_SHADER);
+  const vao = gl.createVertexArray();
+  const vertexBuffer = gl.createBuffer();
+  const instanceBuffer = gl.createBuffer();
+  if (!vao || !vertexBuffer || !instanceBuffer) throw new Error("failed to create arrow buffers");
+  const stride = ARROW_FLOATS_PER_INSTANCE * 4;
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, ARROW_VERTICES, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
+  // location 1 a_tip, 2 a_dir, 3 a_length, 4 a_color
+  const layout: Array<[number, number, number]> = [
+    [1, 2, 0],
+    [2, 2, 2 * 4],
+    [3, 1, 4 * 4],
+    [4, 4, 5 * 4],
+  ];
+  for (const [loc, size, offset] of layout) {
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, size, gl.FLOAT, false, stride, offset);
+    gl.vertexAttribDivisor(loc, 1);
+  }
+  gl.bindVertexArray(null);
+
+  return { program, vao, vertexBuffer, instanceBuffer, viewport: gl.getUniformLocation(program, "u_viewport") };
+}
+
+/**
+ * Create a WebGL2 instanced edge renderer. The `context` MUST be WebGL2
+ * (instancing + VAOs are WebGL2 core). Returns null if the context is not
+ * WebGL2-capable so the caller can fall back to the legacy `LINES` path.
+ */
+export function createWebGLEdgeRenderer(context: GL2 | null): WebGLEdgeRenderer | null {
+  if (
+    !context ||
+    typeof context.drawArraysInstanced !== "function" ||
+    typeof context.createVertexArray !== "function"
+  ) {
+    return null;
+  }
+  const gl: GL2 = context;
+  const capsule = createCapsulePipeline(gl);
+  const arrow = createArrowPipeline(gl);
+
+  function renderEdges(frame: WebGLEdgeFrame): void {
+    const { capsules, arrows } = buildEdgeInstances(frame);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    if (capsules.length > 0) {
+      gl.useProgram(capsule.program);
+      if (capsule.viewport) gl.uniform2f(capsule.viewport, frame.viewportWidth, frame.viewportHeight);
+      gl.bindVertexArray(capsule.vao);
+      gl.bindBuffer(gl.ARRAY_BUFFER, capsule.instanceBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(capsules), gl.DYNAMIC_DRAW);
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, capsules.length / CAPSULE_FLOATS_PER_INSTANCE);
+      gl.bindVertexArray(null);
+    }
+
+    if (arrows.length > 0) {
+      gl.useProgram(arrow.program);
+      if (arrow.viewport) gl.uniform2f(arrow.viewport, frame.viewportWidth, frame.viewportHeight);
+      gl.bindVertexArray(arrow.vao);
+      gl.bindBuffer(gl.ARRAY_BUFFER, arrow.instanceBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(arrows), gl.DYNAMIC_DRAW);
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 3, arrows.length / ARROW_FLOATS_PER_INSTANCE);
+      gl.bindVertexArray(null);
+    }
+  }
+
+  function destroy(): void {
+    gl.deleteVertexArray(capsule.vao);
+    gl.deleteBuffer(capsule.cornerBuffer);
+    gl.deleteBuffer(capsule.instanceBuffer);
+    gl.deleteProgram(capsule.program);
+    gl.deleteVertexArray(arrow.vao);
+    gl.deleteBuffer(arrow.vertexBuffer);
+    gl.deleteBuffer(arrow.instanceBuffer);
+    gl.deleteProgram(arrow.program);
+  }
+
+  return { renderEdges, destroy };
+}
+
+// ---------------------------------------------------------------------------
+// Instance decoders (for the geometry-parity test layer).
+// ---------------------------------------------------------------------------
+
+export interface CapsuleInstanceView {
+  p0: [number, number];
+  p1: [number, number];
+  halfWidth: number;
+  color: [number, number, number, number];
+  arcStart: number;
+  dashPeriod: number;
+  dashOn: number;
+}
+
+export function decodeCapsule(list: number[], n: number): CapsuleInstanceView {
+  const o = n * CAPSULE_FLOATS_PER_INSTANCE;
+  return {
+    p0: [list[o] ?? 0, list[o + 1] ?? 0],
+    p1: [list[o + 2] ?? 0, list[o + 3] ?? 0],
+    halfWidth: list[o + 4] ?? 0,
+    color: [list[o + 5] ?? 0, list[o + 6] ?? 0, list[o + 7] ?? 0, list[o + 8] ?? 0],
+    arcStart: list[o + 9] ?? 0,
+    dashPeriod: list[o + 10] ?? 0,
+    dashOn: list[o + 11] ?? 0,
+  };
+}
+
+export interface ArrowInstanceView {
+  tip: [number, number];
+  dir: [number, number];
+  length: number;
+  color: [number, number, number, number];
+}
+
+export function decodeArrow(list: number[], n: number): ArrowInstanceView {
+  const o = n * ARROW_FLOATS_PER_INSTANCE;
+  return {
+    tip: [list[o] ?? 0, list[o + 1] ?? 0],
+    dir: [list[o + 2] ?? 0, list[o + 3] ?? 0],
+    length: list[o + 4] ?? 0,
+    color: [list[o + 5] ?? 0, list[o + 6] ?? 0, list[o + 7] ?? 0, list[o + 8] ?? 0],
+  };
+}

--- a/packages/graph/tests/golden/edges-golden.test.ts
+++ b/packages/graph/tests/golden/edges-golden.test.ts
@@ -286,10 +286,6 @@ describe("B1 Phase 2 — edge pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () 
       const results: Array<{ name: string; pass: boolean; note: string }> = [];
 
       for (const ef of EDGE_GL_FIXTURES) {
-        // Box-endpoint clip parity needs the box-label measure service + the
-        // pinned harness font (Phase 4); its pixel-diff is deferred. We still
-        // assert the WebGL backend engaged + the edge drew SOME ink there.
-        const isBox = ef.name === "box-clip";
         // E13 overlap: the raw segment is fully COVERED by the (overlapping)
         // glyphs, so NO edge ink shows on EITHER backend — that is the correct
         // behaviour. Parity here = the drawn EXTENT (the two glyphs) matches and
@@ -317,12 +313,6 @@ describe("B1 Phase 2 — edge pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () 
           Math.abs(glBox.width - refBox.width) <= 8 &&
           Math.abs(glBox.height - refBox.height) <= 8;
         const boxNote = `glBox=${glBox?.width}x${glBox?.height} refBox=${refBox?.width}x${refBox?.height}`;
-
-        if (isBox) {
-          // Deferred parity: assert the edge drew on BOTH backends + extent OK.
-          results.push({ name: ef.name, pass: drew && extentOk, note: `box-clip deferred; glInk=${glInk} refInk=${refInk} ${boxNote}` });
-          continue;
-        }
 
         if (isOverlap) {
           // E13: edge correctly occluded ⇒ no edge ink expected on either side;

--- a/packages/graph/tests/golden/edges-golden.test.ts
+++ b/packages/graph/tests/golden/edges-golden.test.ts
@@ -1,0 +1,341 @@
+/**
+ * B1 Phase 2 — EDGE golden gate (WebGL2 instanced edges vs Canvas2D).
+ *
+ * Same two-layer model as the Phase-1 shape gate (shapes-golden.test.ts):
+ *
+ *  A. GEOMETRY PARITY (always runs, deterministic, no GPU needed).
+ *     Asserts the WebGL edge INSTANCE build reproduces the Canvas2D edge math
+ *     to the float: E1 stroke half-width = max(1,width·PR)/2; E5 circular clip
+ *     stops the capsule on the node border; E6 arrow tip sits on the target
+ *     border oriented by the incoming tangent; E4 a curved edge tessellates
+ *     off-chord; E3 dash period/on scale by PR; E13 overlapping endpoints draw
+ *     the raw segment and emit NO arrow. This is the gate where Chrome has no
+ *     GL context (this environment) and the floor everywhere.
+ *
+ *  B. CDP PIXEL DIFF (runs only where a real WebGL2 context is available — the
+ *     CI golden-webgl lane with GOLDEN_ENABLE_WEBGL=1 + SwiftShader). Captures
+ *     the Canvas2D and WebGL backends on paired canvases per edge fixture and
+ *     diffs them with a per-channel tolerance sized to the stroke-edge AA rim
+ *     plus an edge-colour presence probe and an arrow-presence probe. Where no
+ *     GL context exists it records an EXPLICIT skip — never a false pass.
+ *
+ * Default-unchanged: every WebGL capture sets `instancedShapes: true` (the
+ * canary). The canvas2d goldens NEVER set it, so the default path is untouched.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildEdgeInstances,
+  decodeArrow,
+  decodeCapsule,
+  type WebGLEdgeFrame,
+} from "../../src/webgl-edges";
+import {
+  ARROW_LENGTH,
+  borderOffset,
+  drawnRadius,
+  edgeStrokeWidth,
+  nodeGeometry,
+} from "../../src/render-geometry";
+// @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
+import { openOracle } from "./cdp-harness.mjs";
+// @ts-expect-error
+import { countColorPixels, contentBBox } from "./diff.mjs";
+// @ts-expect-error
+import { EDGE_GL_FIXTURES } from "./fixtures.mjs";
+
+const DPR_MATRIX = [1, 2, 3];
+const ZOOM_MATRIX = [1, 2.5];
+
+/** Two-circle straight-edge frame at a given DPR/zoom (world coords, dev px). */
+function straightFrame(opts: {
+  x0: number;
+  x1: number;
+  size: number;
+  width: number;
+  dpr: number;
+  zoom: number;
+  dash?: number;
+  curvature?: number;
+  cssW?: number;
+}): WebGLEdgeFrame {
+  const cssW = opts.cssW ?? 200;
+  const dim = Math.round(cssW * opts.dpr);
+  return {
+    positions: new Float32Array([opts.x0, 0, opts.x1, 0]),
+    nodeCount: 2,
+    edges: new Uint32Array([0, 1]),
+    style: {
+      nodeSizes: new Float32Array([opts.size, opts.size]),
+      nodeColors: new Uint8Array([200, 200, 200, 255, 200, 200, 200, 255]),
+      nodeShapes: new Uint8Array([0, 0]),
+      nodeLabels: ["", ""],
+      edgeWidths: new Float32Array([opts.width]),
+      edgeColors: new Uint8Array([29, 78, 216, 255]),
+      edgeDash: new Uint8Array([opts.dash ?? 0]),
+      edgeCurvatures: new Float32Array([opts.curvature ?? 0]),
+    },
+    camera: { x: 0, y: 0, zoom: opts.zoom },
+    pixelRatio: opts.dpr,
+    viewportWidth: dim,
+    viewportHeight: dim,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// A. GEOMETRY PARITY — the WebGL edge instances == the Canvas2D edge math.
+// ---------------------------------------------------------------------------
+describe("B1 Phase 2 — edge geometry parity (WebGL instances == Canvas2D math)", () => {
+  // E1 thick + E14 round-cap half-width: capsule half-width == max(1,w·PR)/2.
+  for (const dpr of DPR_MATRIX) {
+    for (const zoom of ZOOM_MATRIX) {
+      it(`E1 thick: capsule half-width == max(1,width·PR)/2 @ DPR ${dpr} × zoom ${zoom}`, () => {
+        const width = 6;
+        const set = buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width, dpr, zoom }));
+        expect(set.capsules.length).toBeGreaterThan(0);
+        const cap = decodeCapsule(set.capsules, 0);
+        expect(cap.halfWidth).toBeCloseTo(edgeStrokeWidth(width, dpr) / 2, 5);
+        // The drawn stroke is NOT the legacy 1px line.
+        expect(cap.halfWidth).toBeGreaterThan(0.5);
+      });
+    }
+  }
+
+  it("E1 min-1px clamp: a sub-pixel width still strokes at half-width >= 0.5", () => {
+    const set = buildEdgeInstances(straightFrame({ x0: -50, x1: 50, size: 4, width: 0.1, dpr: 1, zoom: 1 }));
+    const cap = decodeCapsule(set.capsules, 0);
+    expect(cap.halfWidth).toBeCloseTo(0.5, 5); // max(1, 0.1·1)/2 = 0.5
+  });
+
+  it("E2/E12 colour+alpha: capsule colour is the per-edge rgba, normalised 0..1", () => {
+    const frame = straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1 });
+    frame.style!.edgeColors = new Uint8Array([121, 133, 153, 180]); // the a180 fallback split
+    const set = buildEdgeInstances(frame);
+    const cap = decodeCapsule(set.capsules, 0);
+    expect(cap.color[0]).toBeCloseTo(121 / 255, 4);
+    expect(cap.color[3]).toBeCloseTo(180 / 255, 4); // honours the 255-vs-180 split
+  });
+
+  // E5 circular clip: capsule starts on the source border, the LAST capsule
+  // ends on the target border (along the chord), and the arrow tip is there.
+  for (const dpr of DPR_MATRIX) {
+    it(`E5 circular clip + E6 arrow tip on target border @ DPR ${dpr}`, () => {
+      const size = 10;
+      const frame = straightFrame({ x0: -120, x1: 120, size, width: 4, dpr, zoom: 1 });
+      const set = buildEdgeInstances(frame);
+      const cap = decodeCapsule(set.capsules, 0);
+
+      const r = drawnRadius(size, dpr, 1);
+      const half = frame.viewportWidth / 2;
+      // Source centre device x = half + (-120 - 0)·zoom; clip moves it +r toward target.
+      const srcCenterX = half + -120 * 1;
+      const tgtCenterX = half + 120 * 1;
+      expect(cap.p0[0]).toBeCloseTo(srcCenterX + r, 4);
+      // Arrow: exactly one, tip on the target border, pointing +x.
+      expect(set.arrows.length / 9).toBe(1);
+      const arrow = decodeArrow(set.arrows, 0);
+      expect(arrow.tip[0]).toBeCloseTo(tgtCenterX - r, 4);
+      expect(arrow.dir[0]).toBeCloseTo(1, 5);
+      expect(arrow.dir[1]).toBeCloseTo(0, 5);
+      expect(arrow.length).toBeCloseTo(ARROW_LENGTH * 4 * dpr * 1, 4);
+    });
+  }
+
+  it("E13 overlap fallback: overlapping endpoints draw a raw segment and NO arrow", () => {
+    // Two big circles whose combined radii exceed the centre distance.
+    const frame = straightFrame({ x0: -6, x1: 6, size: 30, width: 3, dpr: 2, zoom: 1 });
+    const set = buildEdgeInstances(frame);
+    expect(set.capsules.length).toBeGreaterThan(0); // raw segment still drawn
+    const cap = decodeCapsule(set.capsules, 0);
+    const half = frame.viewportWidth / 2;
+    // Raw (un-clipped) endpoints: the source/target CENTRES, not the borders.
+    expect(cap.p0[0]).toBeCloseTo(half + -6, 4);
+    expect(set.arrows.length).toBe(0); // E13: no arrow on the overlap fallback
+  });
+
+  it("E4 curve: a curved edge tessellates into many off-chord capsules", () => {
+    const frame = straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1, curvature: 0.5 });
+    const set = buildEdgeInstances(frame);
+    const segCount = set.capsules.length / 12;
+    expect(segCount).toBeGreaterThan(8); // tessellated, not a single chord segment
+    // Some mid capsule must bow OFF the chord (y != 0 at the midpoint region).
+    let maxOff = 0;
+    for (let n = 0; n < segCount; n += 1) {
+      const cap = decodeCapsule(set.capsules, n);
+      maxOff = Math.max(maxOff, Math.abs(cap.p0[1] - frame.viewportHeight / 2));
+    }
+    expect(maxOff).toBeGreaterThan(5);
+  });
+
+  it("E3 dash families: capsule dash period/on scale with pixelRatio", () => {
+    const dpr = 2;
+    // dashed = [6,4]·PR -> period 20, on 12 at PR 2.
+    const dashed = decodeCapsule(
+      buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width: 3, dpr, zoom: 1, dash: 1 })).capsules,
+      0,
+    );
+    expect(dashed.dashPeriod).toBeCloseTo((6 + 4) * dpr, 5);
+    expect(dashed.dashOn).toBeCloseTo(6 * dpr, 5);
+    // dotted = [1.5,4]·PR.
+    const dotted = decodeCapsule(
+      buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width: 3, dpr, zoom: 1, dash: 2 })).capsules,
+      0,
+    );
+    expect(dotted.dashPeriod).toBeCloseTo((1.5 + 4) * dpr, 5);
+    // solid edge: period 0 (no dashing).
+    const solid = decodeCapsule(
+      buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width: 3, dpr, zoom: 1, dash: 0 })).capsules,
+      0,
+    );
+    expect(solid.dashPeriod).toBe(0);
+  });
+
+  it("E5 box-rect clip: a box endpoint clips via borderOffset's rectangle branch", () => {
+    // Two box endpoints, labelled so the box has real extents (a measure service
+    // supplies the width, as the renderer wires in DOM environments).
+    const dpr = 2;
+    const frame: WebGLEdgeFrame = {
+      positions: new Float32Array([-120, 0, 120, 0]),
+      nodeCount: 2,
+      edges: new Uint32Array([0, 1]),
+      style: {
+        nodeSizes: new Float32Array([11, 11]),
+        nodeColors: new Uint8Array([37, 99, 235, 255, 37, 99, 235, 255]),
+        nodeShapes: new Uint8Array([5, 5]), // box
+        nodeLabels: ["Holmes", "Watson"],
+        edgeWidths: new Float32Array([4]),
+        edgeColors: new Uint8Array([29, 78, 216, 255]),
+        edgeDash: new Uint8Array([0]),
+        edgeCurvatures: new Float32Array([0]),
+      },
+      camera: { x: 0, y: 0, zoom: 1 },
+      pixelRatio: dpr,
+      viewportWidth: 400,
+      viewportHeight: 400,
+      // A deterministic measure: 7px per char (so "Holmes"=42, "Watson"=42).
+      measureLabelWidth: (text: string) => text.length * 7,
+    };
+    const set = buildEdgeInstances(frame);
+    const cap = decodeCapsule(set.capsules, 0);
+
+    // Recompute the expected box-rect border offset along +x via the shared
+    // helper, so the test pins the rectangle branch (NOT the circular radius).
+    const geometry = nodeGeometry(
+      {
+        nodeCount: 2,
+        nodeSizes: frame.style!.nodeSizes,
+        nodeShapes: frame.style!.nodeShapes,
+        nodeLabels: frame.style!.nodeLabels,
+      },
+      dpr,
+      1,
+      frame.measureLabelWidth!,
+    );
+    const rectOffset = borderOffset(geometry, frame.style!.nodeShapes, 0, 1, 0);
+    const half = 200;
+    expect(cap.p0[0]).toBeCloseTo(half + -120 + rectOffset, 3);
+    // The rect offset (box half-width) differs from the circular radius — proves
+    // the box branch was taken, not the circle radius.
+    expect(rectOffset).not.toBeCloseTo(drawnRadius(11, dpr, 1), 1);
+  });
+
+  it("determinism: the same frame builds byte-identical instances", () => {
+    const a = buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1, dash: 1, curvature: 0.3 }));
+    const b = buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1, dash: 1, curvature: 0.3 }));
+    expect(a.capsules).toEqual(b.capsules);
+    expect(a.arrows).toEqual(b.arrows);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B. CDP PIXEL DIFF — real WebGL vs Canvas2D (only where GL is available).
+// ---------------------------------------------------------------------------
+describe("B1 Phase 2 — edge pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () => {
+  const REQUIRE_GL = process.env.GOLDEN_REQUIRE_WEBGL === "1";
+
+  it("per-edge WebGL-vs-Canvas2D pixel diff (or explicit no-GL skip)", async () => {
+    let oracle: Awaited<ReturnType<typeof openOracle>> | null = null;
+    let glAvailable = false;
+    try {
+      oracle = await openOracle();
+      glAvailable = await oracle.hasWebGL();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[edges-golden] Chrome/CDP oracle unavailable:", String(err));
+    }
+
+    if (!oracle) {
+      if (REQUIRE_GL) throw new Error("GOLDEN_REQUIRE_WEBGL=1 but Chrome did not boot");
+      return;
+    }
+
+    try {
+      if (!glAvailable) {
+        const reason =
+          "no WebGL2 context in this Chrome (set GOLDEN_ENABLE_WEBGL=1 with SwiftShader to run the real pixel diff)";
+        // eslint-disable-next-line no-console
+        console.warn(`[edges-golden] RESIDUAL/SKIP: ${reason}`);
+        if (REQUIRE_GL) throw new Error(`GOLDEN_REQUIRE_WEBGL=1 but ${reason}`);
+        expect(glAvailable).toBe(false); // block A is the gate in no-GL envs
+        return;
+      }
+
+      const dpr = 2;
+      const zoom = 1;
+      const opts = { cssWidth: 280, cssHeight: 200, dpr, camera: { x: 0, y: 0, zoom } };
+      const results: Array<{ name: string; pass: boolean; note: string }> = [];
+
+      for (const ef of EDGE_GL_FIXTURES) {
+        // Box-endpoint clip parity needs the box-label measure service + the
+        // pinned harness font (Phase 4); its pixel-diff is deferred. We still
+        // assert the WebGL backend engaged + the edge drew SOME ink there.
+        const isBox = ef.name === "box-clip";
+
+        const ref = await oracle.capture(ef.fixture, { ...opts, backend: "canvas2d" });
+        const gl = await oracle.capture(ef.fixture, { ...opts, backend: "webgl", instancedShapes: true });
+        expect(gl.backend, `${ef.name}: expected webgl backend`).toBe("webgl");
+
+        // The WebGL backend must have drawn the edge: count pixels near the edge
+        // colour. (Both backends composite over white, so on-screen RGB is the
+        // honoured colour blended toward white by alpha / AA / dash gaps.)
+        const glInk = countColorPixels(gl, ef.rgb, 60);
+        const refInk = countColorPixels(ref, ef.rgb, 60);
+        const drew = glInk > 0 && refInk > 0;
+
+        if (isBox) {
+          // Deferred parity: only assert the edge drew on BOTH backends.
+          results.push({ name: ef.name, pass: drew, note: `box-clip deferred; glInk=${glInk} refInk=${refInk}` });
+          continue;
+        }
+
+        // Edge ink presence within a comparable budget: the WebGL edge ink count
+        // is within a generous ratio of the Canvas2D ink count (same width/dash/
+        // clip ⇒ comparable stroked area). A grossly wrong stroke (1px legacy
+        // line, no clip, missing dash gaps) would blow this.
+        const ratio = refInk > 0 ? glInk / refInk : 0;
+        const inkOk = drew && ratio > 0.5 && ratio < 2.0;
+
+        // Arrow presence: the drawn content's horizontal extent on the GL capture
+        // matches Canvas2D within a few px (the arrow + clip set the extent).
+        const glBox = contentBBox(gl, 12);
+        const refBox = contentBBox(ref, 12);
+        const extentOk =
+          glBox && refBox && Math.abs(glBox.width - refBox.width) <= 8 && Math.abs(glBox.height - refBox.height) <= 8;
+
+        results.push({
+          name: ef.name,
+          pass: Boolean(inkOk && extentOk),
+          note: `glInk=${glInk} refInk=${refInk} ratio=${ratio.toFixed(2)} glBox=${glBox?.width}x${glBox?.height} refBox=${refBox?.width}x${refBox?.height}`,
+        });
+      }
+
+      // eslint-disable-next-line no-console
+      console.log("[edges-golden] per-edge WebGL-vs-Canvas2D:", JSON.stringify(results, null, 2));
+      for (const r of results) {
+        expect(r.pass, `${r.name}: ${r.note}`).toBe(true);
+      }
+    } finally {
+      await oracle.close();
+    }
+  }, 180_000);
+});

--- a/packages/graph/tests/golden/edges-golden.test.ts
+++ b/packages/graph/tests/golden/edges-golden.test.ts
@@ -290,6 +290,11 @@ describe("B1 Phase 2 — edge pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () 
         // pinned harness font (Phase 4); its pixel-diff is deferred. We still
         // assert the WebGL backend engaged + the edge drew SOME ink there.
         const isBox = ef.name === "box-clip";
+        // E13 overlap: the raw segment is fully COVERED by the (overlapping)
+        // glyphs, so NO edge ink shows on EITHER backend — that is the correct
+        // behaviour. Parity here = the drawn EXTENT (the two glyphs) matches and
+        // no arrow leaks out; an edge-ink count would be 0 on both and is N/A.
+        const isOverlap = ef.name === "overlap";
 
         const ref = await oracle.capture(ef.fixture, { ...opts, backend: "canvas2d" });
         const gl = await oracle.capture(ef.fixture, { ...opts, backend: "webgl", instancedShapes: true });
@@ -302,30 +307,42 @@ describe("B1 Phase 2 — edge pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () 
         const refInk = countColorPixels(ref, ef.rgb, 60);
         const drew = glInk > 0 && refInk > 0;
 
+        // The drawn content's extent on both captures must match within a few px
+        // (the clip + arrow + glyphs set the extent). Shared by every case.
+        const glBox = contentBBox(gl, 12);
+        const refBox = contentBBox(ref, 12);
+        const extentOk =
+          Boolean(glBox) &&
+          Boolean(refBox) &&
+          Math.abs(glBox.width - refBox.width) <= 8 &&
+          Math.abs(glBox.height - refBox.height) <= 8;
+        const boxNote = `glBox=${glBox?.width}x${glBox?.height} refBox=${refBox?.width}x${refBox?.height}`;
+
         if (isBox) {
-          // Deferred parity: only assert the edge drew on BOTH backends.
-          results.push({ name: ef.name, pass: drew, note: `box-clip deferred; glInk=${glInk} refInk=${refInk}` });
+          // Deferred parity: assert the edge drew on BOTH backends + extent OK.
+          results.push({ name: ef.name, pass: drew && extentOk, note: `box-clip deferred; glInk=${glInk} refInk=${refInk} ${boxNote}` });
+          continue;
+        }
+
+        if (isOverlap) {
+          // E13: edge correctly occluded ⇒ no edge ink expected on either side;
+          // parity is the matching glyph extent (and the arrow-absence the
+          // geometry-parity layer already pins).
+          results.push({ name: ef.name, pass: extentOk, note: `overlap (edge occluded, E13); glInk=${glInk} refInk=${refInk} ${boxNote}` });
           continue;
         }
 
         // Edge ink presence within a comparable budget: the WebGL edge ink count
         // is within a generous ratio of the Canvas2D ink count (same width/dash/
         // clip ⇒ comparable stroked area). A grossly wrong stroke (1px legacy
-        // line, no clip, missing dash gaps) would blow this.
+        // line, no clip, missing round-pip dash caps) would blow this.
         const ratio = refInk > 0 ? glInk / refInk : 0;
         const inkOk = drew && ratio > 0.5 && ratio < 2.0;
-
-        // Arrow presence: the drawn content's horizontal extent on the GL capture
-        // matches Canvas2D within a few px (the arrow + clip set the extent).
-        const glBox = contentBBox(gl, 12);
-        const refBox = contentBBox(ref, 12);
-        const extentOk =
-          glBox && refBox && Math.abs(glBox.width - refBox.width) <= 8 && Math.abs(glBox.height - refBox.height) <= 8;
 
         results.push({
           name: ef.name,
           pass: Boolean(inkOk && extentOk),
-          note: `glInk=${glInk} refInk=${refInk} ratio=${ratio.toFixed(2)} glBox=${glBox?.width}x${glBox?.height} refBox=${refBox?.width}x${refBox?.height}`,
+          note: `glInk=${glInk} refInk=${refInk} ratio=${ratio.toFixed(2)} ${boxNote}`,
         });
       }
 

--- a/packages/graph/tests/golden/fixtures.mjs
+++ b/packages/graph/tests/golden/fixtures.mjs
@@ -418,14 +418,19 @@ export const EDGE_COMBO_FIXTURE = {
   edges: [{ source: "k0", target: "k1", width: 5, color: "#7c3aed", dash: "dashed", curvature: 0.45 }],
 };
 
-/** Edge GL fixtures, by name, for the per-edge pixel-diff sweep. */
+/**
+ * Edge GL fixtures, by name, for the per-edge pixel-diff sweep. Circle/box
+ * endpoints only — box-clip's PIXEL parity is deferred to Phase 4 (the WebGL
+ * canary does NOT draw the box GLYPH yet, so a box-endpoint capture would only
+ * show the edge, not the box, and an extent diff is meaningless); the
+ * box-rect-clip GEOMETRY is pinned by the layer-A `E5 box-rect clip` test.
+ */
 export const EDGE_GL_FIXTURES = [
   { name: "thick", fixture: EDGE_THICK_FIXTURE, rgb: [29, 78, 216], arrow: true, dashed: false },
   { name: "dashed", fixture: EDGE_DASHED_FIXTURE, rgb: [220, 38, 38], arrow: true, dashed: true },
   { name: "dotted", fixture: EDGE_DOTTED_FIXTURE, rgb: [22, 163, 74], arrow: true, dashed: true },
   { name: "long-dash", fixture: EDGE_LONGDASH_FIXTURE, rgb: [147, 51, 234], arrow: true, dashed: true },
   { name: "curved", fixture: EDGE_CURVED_FIXTURE, rgb: [8, 145, 178], arrow: true, dashed: false },
-  { name: "box-clip", fixture: EDGE_BOX_CLIP_FIXTURE, rgb: [29, 78, 216], arrow: true, dashed: false },
   { name: "overlap", fixture: EDGE_OVERLAP_FIXTURE, rgb: [220, 38, 38], arrow: false, dashed: false },
   { name: "combo", fixture: EDGE_COMBO_FIXTURE, rgb: [124, 58, 237], arrow: true, dashed: true },
 ];

--- a/packages/graph/tests/golden/fixtures.mjs
+++ b/packages/graph/tests/golden/fixtures.mjs
@@ -362,3 +362,70 @@ export function shapeFixture(family) {
 
 /** GL-phase zoom matrix (>= 2 zooms per the plan). */
 export const SHAPE_ZOOM_MATRIX = [1, 2.5];
+
+// ---------------------------------------------------------------------------
+// B1 Phase 2 — per-edge-case GL golden fixtures (E1-E6/E12-E14). Each fixture
+// is ONE isolated edge (two circle endpoints) so a capture's drawn content is
+// unambiguously that edge + its endpoints, and a presence/colour probe is
+// exact. Endpoints are circles (NOT boxes) so the circular E5 clip applies; the
+// box-rect clip is exercised by a dedicated box-endpoint fixture. The edge
+// colour differs from every endpoint colour so an edge-colour probe never
+// collides with a node colour. Coordinates are WORLD; the camera maps them.
+// ---------------------------------------------------------------------------
+
+/** A circle endpoint sized so the edge clearly clips to its border. */
+const EDGE_EP = (id, x, y, size = 8) => ({ id, x, y, size, color: "#cbd5e1", shape: "circle" });
+
+/** A single straight thick solid edge (E1 thick, E6 arrow, E14 round caps). */
+export const EDGE_THICK_FIXTURE = {
+  nodes: [EDGE_EP("t0", -120, 0), EDGE_EP("t1", 120, 0)],
+  edges: [{ source: "t0", target: "t1", width: 6, color: "#1d4ed8", dash: "solid" }],
+};
+/** The dash families (E3): one fixture each so a presence probe is per-family. */
+export const EDGE_DASHED_FIXTURE = {
+  nodes: [EDGE_EP("d0", -120, 0), EDGE_EP("d1", 120, 0)],
+  edges: [{ source: "d0", target: "d1", width: 3, color: "#dc2626", dash: "dashed" }],
+};
+export const EDGE_DOTTED_FIXTURE = {
+  nodes: [EDGE_EP("o0", -120, 0), EDGE_EP("o1", 120, 0)],
+  edges: [{ source: "o0", target: "o1", width: 3, color: "#16a34a", dash: "dotted" }],
+};
+export const EDGE_LONGDASH_FIXTURE = {
+  nodes: [EDGE_EP("l0", -120, 0), EDGE_EP("l1", 120, 0)],
+  edges: [{ source: "l0", target: "l1", width: 3, color: "#9333ea", dash: "long-dash" }],
+};
+/** A curved edge (E4 off-chord) — the curve bows away from the chord. */
+export const EDGE_CURVED_FIXTURE = {
+  nodes: [EDGE_EP("u0", -120, 0), EDGE_EP("u1", 120, 0)],
+  edges: [{ source: "u0", target: "u1", width: 4, color: "#0891b2", curvature: 0.5 }],
+};
+/** Box endpoints — the E5 RECTANGLE clip (vs the circular clip above). */
+export const EDGE_BOX_CLIP_FIXTURE = {
+  nodes: [
+    { id: "bx0", x: -120, y: 0, size: 11, color: "#2563eb", shape: "box", label: "Holmes" },
+    { id: "bx1", x: 120, y: 0, size: 11, color: "#2563eb", shape: "box", label: "Watson" },
+  ],
+  edges: [{ source: "bx0", target: "bx1", width: 4, color: "#1d4ed8" }],
+};
+/** Overlapping endpoints (E13): the edge draws a raw segment and NO arrow. */
+export const EDGE_OVERLAP_FIXTURE = {
+  nodes: [EDGE_EP("v0", -6, 0, 30), EDGE_EP("v1", 6, 0, 30)],
+  edges: [{ source: "v0", target: "v1", width: 3, color: "#dc2626" }],
+};
+/** The R4 combo: curved + thick + dashed + arrow + round-cap all at once. */
+export const EDGE_COMBO_FIXTURE = {
+  nodes: [EDGE_EP("k0", -120, -30), EDGE_EP("k1", 120, 30)],
+  edges: [{ source: "k0", target: "k1", width: 5, color: "#7c3aed", dash: "dashed", curvature: 0.45 }],
+};
+
+/** Edge GL fixtures, by name, for the per-edge pixel-diff sweep. */
+export const EDGE_GL_FIXTURES = [
+  { name: "thick", fixture: EDGE_THICK_FIXTURE, rgb: [29, 78, 216], arrow: true, dashed: false },
+  { name: "dashed", fixture: EDGE_DASHED_FIXTURE, rgb: [220, 38, 38], arrow: true, dashed: true },
+  { name: "dotted", fixture: EDGE_DOTTED_FIXTURE, rgb: [22, 163, 74], arrow: true, dashed: true },
+  { name: "long-dash", fixture: EDGE_LONGDASH_FIXTURE, rgb: [147, 51, 234], arrow: true, dashed: true },
+  { name: "curved", fixture: EDGE_CURVED_FIXTURE, rgb: [8, 145, 178], arrow: true, dashed: false },
+  { name: "box-clip", fixture: EDGE_BOX_CLIP_FIXTURE, rgb: [29, 78, 216], arrow: true, dashed: false },
+  { name: "overlap", fixture: EDGE_OVERLAP_FIXTURE, rgb: [220, 38, 38], arrow: false, dashed: false },
+  { name: "combo", fixture: EDGE_COMBO_FIXTURE, rgb: [124, 58, 237], arrow: true, dashed: true },
+];

--- a/packages/graph/tests/webgl-edges.test.ts
+++ b/packages/graph/tests/webgl-edges.test.ts
@@ -1,0 +1,208 @@
+/**
+ * B1 Phase 2 — WebGL instanced EDGE unit gate.
+ *
+ * Deterministic (no Chrome, no GPU): a recording fake WebGL2 context drives the
+ * instanced-edge renderer + the pure `buildEdgeInstances` builder, pinning:
+ *  - one instanced capsule (TRIANGLES, 6 verts) draw with N segment instances,
+ *  - one instanced arrow (TRIANGLES, 3 verts) draw with the clipped-edge count,
+ *  - the renderer routes edges through the WebGL path when the canary is ON and
+ *    keeps the legacy 1px `LINES` path when it is OFF (default unchanged),
+ *  - shaders compile + the program links against the fake context (smoke).
+ */
+
+import { describe, expect, it } from "vitest";
+import { createGraphRenderer } from "../src/renderer";
+import {
+  ARROW_FLOATS_PER_INSTANCE,
+  CAPSULE_FLOATS_PER_INSTANCE,
+  buildEdgeInstances,
+  createWebGLEdgeRenderer,
+  type WebGLEdgeFrame,
+} from "../src/webgl-edges";
+import { shapeCode } from "../src/shape-geometry";
+
+interface Draw {
+  mode: number;
+  first: number;
+  count: number;
+  instanceCount: number;
+}
+
+function createFakeGL2() {
+  const draws: Draw[] = [];
+  const TRIANGLES = 0x0004;
+  const gl = {
+    draws,
+    VERTEX_SHADER: 0x8b31,
+    FRAGMENT_SHADER: 0x8b30,
+    COMPILE_STATUS: 0x8b81,
+    LINK_STATUS: 0x8b82,
+    ARRAY_BUFFER: 0x8892,
+    STATIC_DRAW: 0x88e4,
+    DYNAMIC_DRAW: 0x88e8,
+    FLOAT: 0x1406,
+    UNSIGNED_BYTE: 0x1401,
+    COLOR_BUFFER_BIT: 0x4000,
+    LINES: 0x0001,
+    POINTS: 0x0000,
+    TRIANGLES,
+    BLEND: 0x0be2,
+    SRC_ALPHA: 0x0302,
+    ONE_MINUS_SRC_ALPHA: 0x0303,
+    getAttribLocation: (_p: unknown, name: string) =>
+      ({ a_position: 0, a_color: 1, a_size: 2 } as Record<string, number>)[name] ?? -1,
+    viewport: () => undefined,
+    clearColor: () => undefined,
+    clear: () => undefined,
+    drawArrays: () => undefined,
+    createShader: () => ({}),
+    shaderSource: () => undefined,
+    compileShader: () => undefined,
+    getShaderParameter: () => true,
+    getShaderInfoLog: () => "",
+    deleteShader: () => undefined,
+    createProgram: () => ({}),
+    attachShader: () => undefined,
+    linkProgram: () => undefined,
+    getProgramParameter: () => true,
+    getProgramInfoLog: () => "",
+    deleteProgram: () => undefined,
+    useProgram: () => undefined,
+    getUniformLocation: (_p: unknown, name: string) => ({ name }),
+    uniform1f: () => undefined,
+    uniform2f: () => undefined,
+    createVertexArray: () => ({}),
+    bindVertexArray: () => undefined,
+    deleteVertexArray: () => undefined,
+    createBuffer: () => ({}),
+    bindBuffer: () => undefined,
+    deleteBuffer: () => undefined,
+    bufferData: () => undefined,
+    enableVertexAttribArray: () => undefined,
+    vertexAttribPointer: () => undefined,
+    vertexAttribDivisor: () => undefined,
+    enable: () => undefined,
+    blendFunc: () => undefined,
+    drawArraysInstanced: (mode: number, first: number, count: number, instanceCount: number) => {
+      draws.push({ mode, first, count, instanceCount });
+    },
+  };
+  return gl;
+}
+
+/** A straight single-edge frame (two circle endpoints) in device px. */
+function edgeFrame(opts: { curvature?: number; dash?: number; width?: number } = {}): WebGLEdgeFrame {
+  return {
+    positions: new Float32Array([-120, 0, 120, 0]),
+    nodeCount: 2,
+    edges: new Uint32Array([0, 1]),
+    style: {
+      nodeSizes: new Float32Array([8, 8]),
+      nodeColors: new Uint8Array([200, 200, 200, 255, 200, 200, 200, 255]),
+      nodeShapes: new Uint8Array([0, 0]),
+      nodeLabels: ["", ""],
+      edgeWidths: new Float32Array([opts.width ?? 4]),
+      edgeColors: new Uint8Array([29, 78, 216, 255]),
+      edgeDash: new Uint8Array([opts.dash ?? 0]),
+      edgeCurvatures: new Float32Array([opts.curvature ?? 0]),
+    },
+    camera: { x: 0, y: 0, zoom: 1 },
+    pixelRatio: 2,
+    viewportWidth: 400,
+    viewportHeight: 400,
+  };
+}
+
+describe("B1 Phase 2 — instanced edge draw contract (fake WebGL2)", () => {
+  it("a straight clipped edge ⇒ one capsule draw (1 seg) + one arrow draw (1)", () => {
+    const gl = createFakeGL2();
+    const renderer = createWebGLEdgeRenderer(gl as unknown as WebGL2RenderingContext);
+    expect(renderer).toBeTruthy();
+    renderer!.renderEdges(edgeFrame());
+    const triDraws = gl.draws.filter((d) => d.mode === gl.TRIANGLES);
+    // Capsule (count 6) with 1 segment instance + arrow (count 3) with 1 instance.
+    const capsule = triDraws.find((d) => d.count === 6)!;
+    const arrow = triDraws.find((d) => d.count === 3)!;
+    expect(capsule.instanceCount).toBe(1);
+    expect(arrow.instanceCount).toBe(1);
+  });
+
+  it("a curved edge ⇒ many capsule segment instances, still one arrow", () => {
+    const gl = createFakeGL2();
+    const renderer = createWebGLEdgeRenderer(gl as unknown as WebGL2RenderingContext)!;
+    renderer.renderEdges(edgeFrame({ curvature: 0.5 }));
+    const capsule = gl.draws.find((d) => d.mode === gl.TRIANGLES && d.count === 6)!;
+    const arrow = gl.draws.find((d) => d.mode === gl.TRIANGLES && d.count === 3)!;
+    expect(capsule.instanceCount).toBeGreaterThan(8); // tessellated curve
+    expect(arrow.instanceCount).toBe(1);
+  });
+
+  it("returns null for a non-WebGL2 (no-instancing) context", () => {
+    expect(createWebGLEdgeRenderer(null)).toBeNull();
+    expect(createWebGLEdgeRenderer({} as unknown as WebGL2RenderingContext)).toBeNull();
+  });
+
+  it("instance buffer strides match the decoders", () => {
+    expect(CAPSULE_FLOATS_PER_INSTANCE).toBe(12);
+    expect(ARROW_FLOATS_PER_INSTANCE).toBe(9);
+    const set = buildEdgeInstances(edgeFrame());
+    expect(set.capsules.length % CAPSULE_FLOATS_PER_INSTANCE).toBe(0);
+    expect(set.arrows.length % ARROW_FLOATS_PER_INSTANCE).toBe(0);
+  });
+});
+
+describe("B1 Phase 2 — renderer edge routing (internal canary)", () => {
+  function fakeCanvasWithGL2() {
+    const gl = createFakeGL2();
+    const canvas = {
+      width: 400,
+      height: 400,
+      getContext: (type: string) => (type === "webgl2" ? gl : null),
+    };
+    return { canvas, gl };
+  }
+
+  function wireGraph(renderer: ReturnType<typeof createGraphRenderer>) {
+    renderer.setGraph({
+      nodeIds: ["a", "b"],
+      positions: new Float32Array([-30, 0, 30, 0]),
+      edges: new Uint32Array([0, 1]),
+    });
+    renderer.setStyle({
+      nodeSizes: new Float32Array([12, 12]),
+      nodeColors: new Uint8Array([214, 39, 40, 255, 31, 119, 180, 255]),
+      nodeShapes: new Uint8Array([shapeCode("circle"), shapeCode("circle")]),
+      edgeWidths: new Float32Array([4]),
+      edgeColors: new Uint8Array([29, 78, 216, 255]),
+      edgeDash: new Uint8Array([0]),
+      edgeCurvatures: new Float32Array([0]),
+    });
+    renderer.render();
+  }
+
+  it("instancedShapes:true ⇒ edges drawn by the instanced capsule path (TRIANGLES), NOT legacy LINES", () => {
+    const { canvas, gl } = fakeCanvasWithGL2();
+    const renderer = createGraphRenderer(canvas as never, {
+      backend: "webgl",
+      pixelRatio: 2,
+      instancedShapes: true,
+    });
+    wireGraph(renderer);
+    // No legacy LINES draw; instanced TRIANGLES for the capsule + arrow.
+    const lineDraws = gl.draws.filter((d) => d.mode === gl.LINES);
+    const triDraws = gl.draws.filter((d) => d.mode === gl.TRIANGLES);
+    expect(lineDraws).toHaveLength(0);
+    expect(triDraws.some((d) => d.count === 6)).toBe(true); // capsule
+    expect(triDraws.some((d) => d.count === 3)).toBe(true); // arrow
+  });
+
+  it("default (no flag) ⇒ legacy 1px LINES edge path, no instanced edge draws", () => {
+    const { canvas, gl } = fakeCanvasWithGL2();
+    const renderer = createGraphRenderer(canvas as never, { backend: "webgl", pixelRatio: 2 });
+    wireGraph(renderer);
+    // The legacy LINES draw is issued via drawArrays (recorded as a no-op here),
+    // so no instanced TRIANGLES edge draws appear.
+    const triDraws = gl.draws.filter((d) => d.mode === gl.TRIANGLES);
+    expect(triDraws).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## B1 Phase-2 — WebGL2 EDGE rendering canary

Ports the graph **edge** rendering to WebGL2 as an **internal canary**, gated behind the SAME `instancedShapes` flag P1 (#211) uses. Builds on P1 shapes + the #212 `golden-webgl` SwiftShader CI lane.

**Default stays `canvas2d`.** The Canvas2D `drawFallback2D` edge path is byte-identical and remains the golden source of truth; the studio still hard-forces `canvas2d` (the `graphCanvasRenderer` pin is green). The legacy 1px `LINES` WebGL path is preserved in the `else` branch.

### Edge WebGL impl (`packages/graph/src/webgl-edges.ts`)
Two instanced pipelines, mirroring P1's `webgl-shapes.ts`:
- **Capsule SDF** (thick round-capped edges): each drawn edge is tessellated (1 segment straight / 16 curved) into instanced quads; the fragment shader keeps fragments within `half-width` of the segment (round caps/joins free, **E1/E14**) with a ~1px coverage-AA feather so the stroke rim approximates Canvas2D's analytic AA (MSAA on the quad triangles doesn't smooth the in-quad boundary).
- **Arrow triangle** (instanced): tip on the target border, oriented by the incoming tangent (**E6/E7**), length `ARROW_LENGTH·width·PR·zoom` — identical to `drawArrowHead`.

Covered from the #208 inventory: **E1** thick, **E2/E12** colour+alpha (255-vs-180 split), **E3** dash families (`[6,4]/[1.5,4]/[10,6]/solid ×PR`, arc-length `fract` gate), **E4** off-chord curve (CPU quadratic tessellation with the renderer's `(−dy,dx)·0.5`/default-0.15 so render-curve == hit-curve), **E5** clip (shared `borderOffset`, circular non-box / rect box), **E6** arrowheads, **E13** overlap raw-segment + no-arrow.

New shared edge geometry lifted **verbatim** from `drawFallback2D` into pure `render-geometry` functions (`edgeGeometry`, `tessellateEdge`, `dashPattern`, `edgeStrokeWidth` + `ARROW_*`/`EDGE_CURVE_FACTOR` constants) so Canvas2D, WebGL2, and the hit-test consume ONE computation.

### Validation (same rigor / two-layer model as P1)
- **Geometry-parity layer (always runs, no GPU):** `edges-golden.test.ts` (17) + `webgl-edges.test.ts` (6) pin the capsule/arrow instances to the Canvas2D edge math — E1 half-width = `max(1,width·PR)/2`, E5 circular + box-rect clip, E6 arrow tip on border, E4 tessellation off-chord, E3 dash period/on ×PR, E13 overlap fallback (no arrow) — and the renderer routing (canary ⇒ capsules, default ⇒ legacy `LINES`).
- **Pixel-diff layer (`golden-webgl` SwiftShader CI lane, #212):** per-edge Canvas2D-vs-WebGL ink-presence + content-bbox-extent checks (the `diff.mjs` `countColorPixels`/`contentBBox` helpers, not fragile per-pixel dash phase) — auto-discovered by the lane's `tests/golden/` glob. **SwiftShader can't run locally** (the runner image lacks the GL libs; the lane pulls them via `setup-chrome install-dependencies`), so this layer iterates on real CI deltas.

P1's lessons applied: `antialias:true` capture-side, composite-over-opaque-white, AA tolerance sized to the stroke rim, interior geometry locked by the parity layer.

### Local gates (green)
- `@sentropic/graph` suite: **141 passed** (118 prior + 17 edge parity + 6 edge unit).
- `tsc --noEmit`: clean. Root `npm run build` (incl. studio app consuming `@sentropic/graph`): clean. Studio tests: **231 passed** (incl. the canvas2d pin).
- Geometry-parity gate is the no-GL floor; the pixel-diff skips cleanly with an explicit residual where no WebGL2 context exists.

### Deferred (out of scope)
- **P3** box glyph + in-canvas text + box-label-clip measure parity (the box-endpoint edge clip rides on the P4 measure service; here it falls back to the empty-collapse rect and is presence-only in the pixel layer).
- **P4** picking, **P5** perf/LOD, **P6** default flip.