### PR TITLE
feat(graph): B1-P3 — WebGL2 box glyphs + label text canary (flag-gated, default canvas2d)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ scripts/benchmark_kimi*.py
 
 # B1 golden harness: ephemeral headless-Chrome profile dirs
 packages/graph/.graphify-cdp-prof-*
+packages/graph/.graphify-webgl-preflight-*

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -7,5 +7,6 @@ export * from "./renderer";
 export * from "./shape-geometry";
 export * from "./webgl-shapes";
 export * from "./webgl-edges";
+export * from "./webgl-boxes";
 export * from "./styles";
 export * from "./types";

--- a/packages/graph/src/render-geometry.ts
+++ b/packages/graph/src/render-geometry.ts
@@ -38,6 +38,16 @@ export const BOX_FONT_RATIO = 12 / 22;
 export const BOX_CORNER_RATIO = 1 / 4;
 /** Non-labelled (low-degree) box collapse, as a fraction of the box height. */
 export const BOX_EMPTY_RATIO = 10 / 22;
+/**
+ * Maximum box WIDTH as a multiple of the box height (#199 pixel-fit). A label
+ * too long to hug within this ceiling is PIXEL-FITTED to the available text
+ * width with an ellipsis, so the box never balloons into an over-wide text card.
+ * Scales with pixelRatio × zoom exactly like the height, so the cap reads the
+ * same at any zoom.
+ */
+export const BOX_MAX_WIDTH_RATIO = 10;
+/** Single-character ellipsis appended when a box label is pixel-clipped to fit. */
+export const BOX_ELLIPSIS = "…";
 
 /** Legacy box / hollow-glyph fill: translucent white (rgba 255,255,255,0.5). */
 export const BOX_FILL: readonly [number, number, number, number] = [255, 255, 255, 0.5 * 255];
@@ -69,32 +79,88 @@ export function drawnRadius(nodeSize: number, pixelRatio: number, zoom: number):
 }
 
 /**
- * Legacy `shape:box` glyph dimensions (lifted verbatim from renderer.ts:586-602).
+ * PIXEL-FIT a label so its DRAWN width never exceeds `maxTextWidth`, appending a
+ * single ellipsis when it has to clip (#199, lifted VERBATIM from renderer.ts so
+ * Canvas2D, WebGL, and the box-text atlas all clip identically). Unlike a fixed
+ * character-count cap, this is glyph-width aware (a run of wide letters clips
+ * sooner than a run of "i"s), so the box that hugs the returned text is
+ * guaranteed to stay within the max.
+ *
+ * Binary search over the keep-length keeps it O(log n) measureText calls per
+ * over-long label. When even the ellipsis alone does not fit (an absurdly tiny
+ * box) we still return the ellipsis so the caller draws SOMETHING rather than
+ * overflowing. The full text is unchanged on the node payload, so hover tooltips
+ * / detail panels keep the verbatim name.
+ */
+export function fitLabelToWidth(
+  label: string,
+  maxTextWidth: number,
+  font: string,
+  measureLabelWidth: (text: string, font: string) => number,
+): string {
+  if (!label) return label;
+  if (maxTextWidth <= 0) return label;
+  if (measureLabelWidth(label, font) <= maxTextWidth) return label;
+
+  // Search the largest prefix length whose `prefix + …` still fits.
+  let low = 0;
+  let high = label.length;
+  let best = "";
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const candidate = label.slice(0, mid).replace(/\s+$/u, "") + BOX_ELLIPSIS;
+    if (measureLabelWidth(candidate, font) <= maxTextWidth) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  // Even a lone ellipsis overflowed the (degenerate) box — draw it anyway.
+  return best || BOX_ELLIPSIS;
+}
+
+/**
+ * Legacy `shape:box` glyph dimensions (lifted verbatim from renderer.ts).
  * Box height is a fixed legacy base scaled by pixelRatio × zoom — degree
  * INDEPENDENT; the small font fits that height minus a per-side margin; the box
  * grows only in WIDTH to hug the measured label plus margins. A non-labelled
  * (low-degree) box collapses to a small square of BOX_EMPTY_RATIO × height.
  *
+ * WIDTH IS CAPPED at BOX_MAX_WIDTH_RATIO × height (#199): a label too long to hug
+ * within that ceiling is PIXEL-FITTED (see {@link fitLabelToWidth}) to the
+ * available text width with an ellipsis. The returned `label` is the exact
+ * (possibly clipped) text the box was sized to — the draw path (Canvas2D
+ * `fillText` / the WebGL text atlas) renders THAT string, so the box always hugs
+ * precisely what it shows.
+ *
  * `measureLabelWidth` is the SAME measureText service Canvas2D uses, so GL box
- * width and Canvas2D box width are identical to the pixel.
+ * width, the GL text atlas, and Canvas2D box width are identical to the pixel.
  */
 export function boxDimensions(
   height: number,
   label: string,
   measureLabelWidth: (text: string, font: string) => number,
-): { w: number; h: number; fontPx: number; corner: number } {
+): { w: number; h: number; fontPx: number; corner: number; label: string } {
   const margin = height * BOX_MARGIN_RATIO;
   const corner = height * BOX_CORNER_RATIO;
   const fontPx = height * BOX_FONT_RATIO;
 
   if (!label) {
     const side = height * BOX_EMPTY_RATIO;
-    return { w: side, h: side, fontPx, corner };
+    return { w: side, h: side, fontPx, corner, label };
   }
 
-  const textW = measureLabelWidth(label, `${fontPx}px sans-serif`);
-  return { w: textW + 2 * margin, h: height, fontPx, corner };
+  const font = `${fontPx}px sans-serif`;
+  // Text must fit inside the max box width minus a margin per side.
+  const maxTextWidth = Math.max(0, height * BOX_MAX_WIDTH_RATIO - 2 * margin);
+  const fitted = fitLabelToWidth(label, maxTextWidth, font, measureLabelWidth);
+  const textW = measureLabelWidth(fitted, font);
+  return { w: textW + 2 * margin, h: height, fontPx, corner, label: fitted };
 }
+
+/** Theme-dark box label text as an rgb tuple (slate-900, #0f172a). */
+export const BOX_TEXT_RGB: readonly [number, number, number] = [15, 23, 42];
 
 /**
  * The rounded-box corner CLAMP (N7c, renderer.ts:530-532). Both backends MUST

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -468,25 +468,37 @@ function cssDarkenedColor(
 }
 
 /**
- * Build a box-label `measureText` service for the WebGL edge path so an edge
- * clipping to a BOX endpoint stops at the SAME rect border Canvas2D draws (E5).
- * Uses a throwaway offscreen 2D canvas (OffscreenCanvas or a detached <canvas>)
- * with a per-call font + text cache. Returns `null` in non-DOM environments —
- * the edge path then falls back to the empty-collapse box rect (box-label clip
- * parity finalises with the box glyph in Phase 4). NEVER touches the render
- * canvas (a canvas holds one context type — a 2D ctx there would break WebGL).
+ * Build a box-label `measureText` service for the WebGL box + edge paths so the
+ * box WIDTH (#199), the box-text atlas, and an edge clipping to a BOX endpoint
+ * (E5) all stop at the SAME rect border Canvas2D draws. Returns `null` in
+ * non-DOM environments — the box/edge path then falls back to the empty-collapse
+ * box rect. NEVER touches the render canvas (a canvas holds one context type — a
+ * 2D ctx there would break WebGL).
+ *
+ * When an `atlasCanvasFactory` is provided (the golden harness passes a
+ * FONT-PINNED one), the measure canvas comes from that SAME factory, so box
+ * width is measured with the IDENTICAL font the atlas rasterizes with AND the
+ * Canvas2D reference draws with — otherwise the box would be sized with the
+ * system font and the atlas with the pinned font, drifting the box width.
  */
-function createMeasureService(): ((text: string, font: string) => number) | null {
-  const g = globalThis as {
-    OffscreenCanvas?: new (w: number, h: number) => { getContext(t: "2d"): CanvasRenderingContext2D | null };
-    document?: { createElement(tag: "canvas"): HTMLCanvasElement };
-  };
+function createMeasureService(
+  atlasCanvasFactory?: GraphRendererOptions["atlasCanvasFactory"],
+): ((text: string, font: string) => number) | null {
   let ctx: CanvasRenderingContext2D | null = null;
   try {
-    if (typeof g.OffscreenCanvas === "function") {
-      ctx = new g.OffscreenCanvas(1, 1).getContext("2d");
-    } else if (g.document?.createElement) {
-      ctx = g.document.createElement("canvas").getContext("2d");
+    if (atlasCanvasFactory) {
+      ctx = atlasCanvasFactory(1, 1)?.ctx ?? null;
+    }
+    if (!ctx) {
+      const g = globalThis as {
+        OffscreenCanvas?: new (w: number, h: number) => { getContext(t: "2d"): CanvasRenderingContext2D | null };
+        document?: { createElement(tag: "canvas"): HTMLCanvasElement };
+      };
+      if (typeof g.OffscreenCanvas === "function") {
+        ctx = new g.OffscreenCanvas(1, 1).getContext("2d");
+      } else if (g.document?.createElement) {
+        ctx = g.document.createElement("canvas").getContext("2d");
+      }
     }
   } catch {
     return null;
@@ -978,7 +990,8 @@ export function createGraphRenderer(
   // text atlas (#199 pixel-fit + width). Built once; null in non-DOM envs (the
   // edge path then uses the empty-collapse box rect; the box path then collapses
   // unlabelled too — both match Canvas2D's measureText-less behaviour).
-  const measureLabelWidth = edgeRenderer || boxRenderer ? createMeasureService() ?? undefined : undefined;
+  const measureLabelWidth =
+    edgeRenderer || boxRenderer ? createMeasureService(options.atlasCanvasFactory) ?? undefined : undefined;
   const edgeMeasureLabelWidth = measureLabelWidth;
   let lastNonFiniteCount = 0;
   let state: RendererState = {

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -1,7 +1,9 @@
 import { computePositionBounds, copyPositions } from "./positions";
 import { BOX_GLYPH_CORNER_RATIO, SQUARE_INSET_RATIO, shapePolygonPoints } from "./shape-geometry";
+import { boxDimensions } from "./render-geometry";
 import { createWebGLShapeRenderer, type WebGLShapeRenderer } from "./webgl-shapes";
 import { createWebGLEdgeRenderer, type WebGLEdgeRenderer } from "./webgl-edges";
+import { createWebGLBoxRenderer, type WebGLBoxRenderer } from "./webgl-boxes";
 import type {
   CameraState,
   FitViewOptions,
@@ -545,24 +547,11 @@ const BOX_SHAPE = 5;
 // the largest diamond). It does NOT inflate with a god-node's degree (only zoom
 // scales it), so a labelled box never dwarfs its neighbours.
 const BOX_BASE_HEIGHT_PX = 18; // box height in CSS px (× pixelRatio × zoom), legacy 22 − ~20%
-const BOX_MARGIN_RATIO = 5 / 22; // legacy margin per side (5 of a 22 box)
-const BOX_FONT_RATIO = 12 / 22; // legacy font size (12 of a 22 box) — text much smaller than the box
-const BOX_CORNER_RATIO = 1 / 4; // corner radius as a fraction of box height
-// Maximum box WIDTH, expressed as a multiple of the box height (so it scales
-// with pixelRatio × zoom exactly like the height — the cap reads the same at
-// any zoom). The box still grows in width to hug short labels, but a long
-// chapter / entity name is PIXEL-FITTED to this ceiling with an ellipsis so the
-// glyph can never balloon into an over-wide text card that overflows the layout.
-// ~10× a small box height keeps a comfortable line (≈ 30-ish narrow glyphs at
-// the legacy 12/22 font) while bounding the worst case. This is the SHARED,
-// backend-agnostic render-geometry fix: it covers EVERY box node (main-graph
-// chapter/work/god-class hubs AND the recon focal pair), not just one view.
-const BOX_MAX_WIDTH_RATIO = 10;
-// Single-character ellipsis appended when a box label is pixel-clipped to fit.
-const BOX_ELLIPSIS = "…";
-// Non-labelled (low-degree) box collapse, as a fraction of the box height:
-// legacy hidden-font boxes shrink to their two 5-unit margins of a 22-unit box.
-const BOX_EMPTY_RATIO = 10 / 22;
+// The box height/margin/font/corner ratios, the BOX_MAX_WIDTH_RATIO cap, the
+// single-char ellipsis, and the box dimensions + #199 pixel-fit are all
+// single-sourced in render-geometry.ts (boxDimensions, fitLabelToWidth) so
+// Canvas2D, the WebGL box glyph, and the WebGL text atlas clip identically.
+// The renderer consumes them via the imported `boxDimensions`.
 const BOX_FILL: readonly [number, number, number, number] = [255, 255, 255, 0.5 * 255];
 const BOX_TEXT_COLOR = "#0f172a"; // theme-dark label text (slate-900)
 
@@ -654,83 +643,6 @@ interface NodeGeometry {
   radii: Float32Array;
   boxHalfWidths: Float32Array;
   boxHalfHeights: Float32Array;
-}
-
-/**
- * PIXEL-FIT a label so its DRAWN width never exceeds `maxTextWidth`, appending a
- * single ellipsis when it has to clip. Unlike a fixed character-count cap, this
- * is glyph-width aware (a run of wide letters clips sooner than a run of "i"s),
- * so the box that hugs the returned text is guaranteed to stay within the max.
- *
- * Binary search over the keep-length keeps it O(log n) measureText calls per
- * over-long label (cheap, and only long labels pay it). When even the ellipsis
- * alone does not fit (an absurdly tiny box) we still return the ellipsis so the
- * caller draws SOMETHING rather than overflowing. The full text is unchanged on
- * the node payload, so hover tooltips / detail panels keep the verbatim name.
- */
-function fitLabelToWidth(
-  label: string,
-  maxTextWidth: number,
-  font: string,
-  measureLabelWidth: (text: string, font: string) => number,
-): string {
-  if (!label) return label;
-  if (maxTextWidth <= 0) return label;
-  if (measureLabelWidth(label, font) <= maxTextWidth) return label;
-
-  // Search the largest prefix length whose `prefix + …` still fits.
-  let low = 0;
-  let high = label.length;
-  let best = "";
-  while (low <= high) {
-    const mid = (low + high) >> 1;
-    const candidate = label.slice(0, mid).replace(/\s+$/u, "") + BOX_ELLIPSIS;
-    if (measureLabelWidth(candidate, font) <= maxTextWidth) {
-      best = candidate;
-      low = mid + 1;
-    } else {
-      high = mid - 1;
-    }
-  }
-  // Even a lone ellipsis overflowed the (degenerate) box — draw it anyway.
-  return best || BOX_ELLIPSIS;
-}
-
-/**
- * Legacy `shape:box` glyph dimensions. The box height is a fixed legacy base
- * (BOX_BASE_HEIGHT_PX, scaled by pixelRatio × zoom) — degree-INDEPENDENT, so a
- * high-degree Work box never inflates past its neighbours; the small font fits
- * that height minus a margin per side, and the box only grows in WIDTH to hug
- * the text plus margins. A non-labelled (low-degree) box collapses like the
- * legacy hidden-font (fontSize 0) box: a small square of BOX_EMPTY_RATIO × height.
- *
- * WIDTH IS CAPPED at BOX_MAX_WIDTH_RATIO × height: a label too long to hug
- * within that ceiling is PIXEL-FITTED (see {@link fitLabelToWidth}) to the
- * available text width with an ellipsis, so the box never balloons into an
- * over-wide text card that overflows the layout. The returned `label` is the
- * exact (possibly clipped) text the box was sized to — the draw path renders
- * THAT string, so the box always hugs precisely what it shows.
- */
-function boxDimensions(
-  height: number,
-  label: string,
-  measureLabelWidth: (text: string, font: string) => number,
-): { w: number; h: number; fontPx: number; corner: number; label: string } {
-  const margin = height * BOX_MARGIN_RATIO;
-  const corner = height * BOX_CORNER_RATIO;
-  const fontPx = height * BOX_FONT_RATIO;
-
-  if (!label) {
-    const side = height * BOX_EMPTY_RATIO;
-    return { w: side, h: side, fontPx, corner, label };
-  }
-
-  const font = `${fontPx}px sans-serif`;
-  // Text must fit inside the max box width minus a margin per side.
-  const maxTextWidth = Math.max(0, height * BOX_MAX_WIDTH_RATIO - 2 * margin);
-  const fitted = fitLabelToWidth(label, maxTextWidth, font, measureLabelWidth);
-  const textW = measureLabelWidth(fitted, font);
-  return { w: textW + 2 * margin, h: height, fontPx, corner, label: fitted };
 }
 
 /**
@@ -1053,9 +965,21 @@ export function createGraphRenderer(
   // (canvas2d) never enters this branch, so there is no user-facing change.
   const edgeRenderer: WebGLEdgeRenderer | null =
     wantInstancedShapes && context && isWebGL2(context) ? createWebGLEdgeRenderer(context) : null;
-  // Box-label measure service for the WebGL edge clip (E5). Built once; null in
-  // non-DOM envs (the edge path then uses the empty-collapse box rect).
-  const edgeMeasureLabelWidth = edgeRenderer ? createMeasureService() ?? undefined : undefined;
+  // B1 Phase 3 INTERNAL CANARY: the SAME `instancedShapes` flag turns on the
+  // WebGL2 instanced-BOX path (rounded-rect SDF glyph + per-label canvas-raster
+  // TEXT atlas + #199 pixel-fit), drawing the box nodes (shape 5) the P1 shape
+  // renderer SKIPS. Gated identically — the studio default (canvas2d) never
+  // enters this branch, so there is no user-facing change.
+  const boxRenderer: WebGLBoxRenderer | null =
+    wantInstancedShapes && context && isWebGL2(context)
+      ? createWebGLBoxRenderer(context, options.atlasCanvasFactory)
+      : null;
+  // Box-label measure service for the WebGL edge clip (E5) AND the box glyph +
+  // text atlas (#199 pixel-fit + width). Built once; null in non-DOM envs (the
+  // edge path then uses the empty-collapse box rect; the box path then collapses
+  // unlabelled too — both match Canvas2D's measureText-less behaviour).
+  const measureLabelWidth = edgeRenderer || boxRenderer ? createMeasureService() ?? undefined : undefined;
+  const edgeMeasureLabelWidth = measureLabelWidth;
   let lastNonFiniteCount = 0;
   let state: RendererState = {
     nodeIds: [],
@@ -1234,6 +1158,23 @@ export function createGraphRenderer(
         );
         context.drawArrays(context.POINTS, 0, state.nodeIds.length);
       }
+
+      // B1 Phase 3 INTERNAL CANARY: instanced BOX glyphs + in-box label text,
+      // drawn AFTER the node shapes (the P1 shape renderer skips shape-5 boxes).
+      // Only on the instanced canary path (boxRenderer is non-null only then);
+      // the legacy point-sprite path draws box nodes as plain points, unchanged.
+      if (boxRenderer) {
+        boxRenderer.renderBoxes({
+          positions: state.positions,
+          nodeCount: state.nodeIds.length,
+          style: state.style,
+          camera,
+          pixelRatio,
+          viewportWidth: canvas?.width ?? 0,
+          viewportHeight: canvas?.height ?? 0,
+          measureLabelWidth,
+        });
+      }
     }
   }
 
@@ -1268,6 +1209,7 @@ export function createGraphRenderer(
       destroyed = true;
       shapeRenderer?.destroy();
       edgeRenderer?.destroy();
+      boxRenderer?.destroy();
     },
   };
 }

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -174,6 +174,18 @@ export interface GraphRendererOptions {
    * Canvas2D path in Phase 1.
    */
   instancedShapes?: boolean;
+  /**
+   * INTERNAL CANARY (B1 migration Phase 3). Offscreen-2D-canvas factory the
+   * WebGL box-label TEXT atlas rasterizes onto. The golden harness passes a
+   * factory that PINS the deterministic font on the raster context (the same
+   * pin it applies to the render canvas) so the atlas rasterizes with the SAME
+   * family Canvas2D measured + drew with. Defaults to a plain OffscreenCanvas /
+   * detached `<canvas>`. Only consulted on the WebGL2 instanced-box canary path.
+   */
+  atlasCanvasFactory?: (
+    width: number,
+    height: number,
+  ) => { canvas: unknown; ctx: CanvasRenderingContext2D } | null;
   interaction?: {
     hover?: boolean;
     pan?: boolean;

--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -1,0 +1,805 @@
+/**
+ * WebGL2 INSTANCED BOX-GLYPH + LABEL-TEXT renderer (B1 migration plan §2.2/§2.3,
+ * Phase 3 — the HARDEST phase: in-canvas text parity is the #1 B1 risk).
+ *
+ * Phase 3 scope: the legacy `shape:box` glyph (N7 labelled / N9 empty, N7c
+ * corner clamp, #199 pixel-fit + ellipsis, L1 in-box label text). It draws the
+ * box nodes the P1 shape renderer SKIPS (shape code 5). The path is gated behind
+ * the SAME `instancedShapes` canary the P1 shapes + P2 edges use, and is
+ * INTERNAL-CANARY-ONLY: the studio default stays `canvas2d`, so there is no
+ * user-facing change. Canvas2D boxes + text remain the golden source of truth.
+ *
+ * Architecture:
+ *
+ *  - **Instanced rounded-rect via SDF (N7/N7c/N9).** ONE unit quad is instanced
+ *    per box; the fragment shader evaluates a rounded-box signed-distance field
+ *    with the `min(corner, halfW, halfH)` clamp so empty boxes (corner ==
+ *    half-side) and narrow labels (corner == w/2) round identically to Canvas2D.
+ *    The translucent-white fill (BOX_FILL, alpha-INDEPENDENT) sits under the
+ *    node-coloured border (which carries the node alpha). Border weight is the
+ *    same normal/bold split (BORDER_WIDTH_NORMAL/BOLD · pixelRatio). The box
+ *    half-extents + corner come from `render-geometry.boxDimensions` — the SAME
+ *    function Canvas2D uses — so the box can never drift from the 2D box.
+ *
+ *  - **Per-label CANVAS-RASTER text atlas (L1, #1 risk — the plan's decision).**
+ *    For each DISTINCT `(font, fittedLabel)` this frame, the label is rasterized
+ *    ONCE on an OFFSCREEN 2D canvas using the IDENTICAL calls `drawBoxNode` makes
+ *    (`font="${fontPx}px sans-serif"`, `textAlign="center"`, `textBaseline=
+ *    "middle"`, `fillStyle=#0f172a`) and uploaded as a texture; a quad centred on
+ *    the box samples it. Because the text is rasterized by the SAME Chrome 2D
+ *    engine that produced the box width (#199 measureText), text metrics AND AA
+ *    are parity-BY-CONSTRUCTION — NOT a shader glyph (SDF/MSDF is deferred until
+ *    a proven shaping contract + Unicode goldens). Rasterized at DEVICE
+ *    resolution (fontPx includes PR·zoom) so it stays crisp at DPR 2/3 (X6).
+ *    The box renders the #199-FITTED string (boxDimensions returns it), so the
+ *    drawn text matches the box extents exactly — never an overflowing label.
+ *
+ *  - **Byte-parity interleave (R7).** The box rect, its border, AND its text all
+ *    share the box node's `a_depth` (the node index), so a later box occludes an
+ *    earlier box's rect AND text — the same interleaved occlusion Canvas2D gets
+ *    by drawing rect→fill→stroke→fillText in one call per node.
+ *
+ * The vertex transform mirrors webgl-shapes / webgl-edges: box geometry is
+ * computed in DEVICE px on the CPU (the same `screenPoint` Canvas2D uses), then
+ * mapped to clip space with the viewport.
+ */
+
+import {
+  BORDER_WIDTH_BOLD,
+  BORDER_WIDTH_NORMAL,
+  BOX_BASE_HEIGHT_PX,
+  BOX_FILL,
+  BOX_SHAPE_CODE,
+  BOX_TEXT_RGB,
+  boxDimensions,
+  clampCorner,
+} from "./render-geometry";
+import type { GraphStyleBuffers } from "./types";
+
+type GL2 = WebGL2RenderingContext;
+
+const DEFAULT_NODE_COLOR = [77, 118, 255, 255] as const;
+
+/**
+ * Pluggable 2D-context factory for the text atlas's OFFSCREEN raster canvas.
+ * Defaults to OffscreenCanvas / a detached `<canvas>`; the golden harness swaps
+ * in a factory that PINS the deterministic font on the raster context (the same
+ * pin it applies to the render canvas), so the atlas rasterizes with the SAME
+ * family Canvas2D measured + drew with — otherwise the WebGL text would use a
+ * different system font than the Canvas2D reference and the pixel diff would
+ * fail purely on font choice, not on the renderer.
+ */
+export type AtlasCanvasFactory = (
+  width: number,
+  height: number,
+) => { canvas: unknown; ctx: CanvasRenderingContext2D } | null;
+
+function defaultAtlasCanvasFactory(width: number, height: number):
+  | { canvas: unknown; ctx: CanvasRenderingContext2D }
+  | null {
+  const g = globalThis as {
+    OffscreenCanvas?: new (w: number, h: number) => {
+      width: number;
+      height: number;
+      getContext(t: "2d"): CanvasRenderingContext2D | null;
+    };
+    document?: { createElement(tag: "canvas"): HTMLCanvasElement };
+  };
+  try {
+    if (typeof g.OffscreenCanvas === "function") {
+      const canvas = new g.OffscreenCanvas(Math.max(1, width), Math.max(1, height));
+      const ctx = canvas.getContext("2d");
+      return ctx ? { canvas, ctx } : null;
+    }
+    if (g.document?.createElement) {
+      const canvas = g.document.createElement("canvas");
+      canvas.width = Math.max(1, width);
+      canvas.height = Math.max(1, height);
+      const ctx = canvas.getContext("2d");
+      return ctx ? { canvas, ctx } : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Rounded-box program. ONE unit quad per box instance, expanded to the box
+// half-extents; the fragment shader is a rounded-box SDF (fill under border).
+// ---------------------------------------------------------------------------
+
+const BOX_VERTEX_SHADER = `#version 300 es
+layout(location = 0) in vec2 a_corner;      // unit quad corner in {-1,1}^2
+layout(location = 1) in vec2 a_center;      // instance: box centre (device px)
+layout(location = 2) in vec2 a_half;        // instance: (halfW, halfH) device px
+layout(location = 3) in float a_corner_r;   // instance: clamped corner radius (device px)
+layout(location = 4) in float a_border;     // instance: border half-width (device px)
+layout(location = 5) in vec4 a_fill;        // instance: fill rgba (0..1)
+layout(location = 6) in vec4 a_borderCol;   // instance: border rgba (0..1)
+layout(location = 7) in float a_depth;      // instance: drawList index (interleave)
+
+uniform vec2 u_viewport;
+uniform float u_maxDepth;
+
+out vec2 v_local;       // position within the box, device px, centre origin
+out vec2 v_half;
+out float v_corner_r;
+out float v_border;
+out vec4 v_fill;
+out vec4 v_borderCol;
+
+void main() {
+  // Pad by the border half-width so a bold border is not clipped by the quad.
+  vec2 ext = a_half + vec2(a_border);
+  v_local = a_corner * ext;
+  vec2 screen = a_center + v_local;
+  v_half = a_half;
+  v_corner_r = a_corner_r;
+  v_border = a_border;
+  v_fill = a_fill;
+  v_borderCol = a_borderCol;
+  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x - 1.0, 1.0 - screen.y * 2.0 / u_viewport.y);
+  float z = u_maxDepth > 0.0 ? (a_depth / u_maxDepth) : 0.0;
+  gl_Position = vec4(clip, -z, 1.0);
+}
+`;
+
+const BOX_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+in vec2 v_local;
+in vec2 v_half;
+in float v_corner_r;
+in float v_border;
+in vec4 v_fill;
+in vec4 v_borderCol;
+out vec4 outColor;
+
+// Signed distance to a rounded box of half-extents b and corner radius r,
+// evaluated at point p (box centred at origin). Negative inside.
+float roundedBoxSDF(vec2 p, vec2 b, float r) {
+  vec2 q = abs(p) - b + vec2(r);
+  return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+}
+
+void main() {
+  float d = roundedBoxSDF(v_local, v_half, v_corner_r);
+  float aa = max(fwidth(d), 1e-4);
+
+  // Interior coverage: inside the rounded-box outline (d <= 0).
+  float fillCov = 1.0 - smoothstep(-aa, aa, d);
+  // Border ring: a band of half-width v_border centred on the outline (|d| ~ 0).
+  // Canvas2D strokes a line of width 2·v_border centred on the path, so the
+  // ring spans d in [-v_border, +v_border].
+  float borderCov =
+      (1.0 - smoothstep(v_border - aa, v_border + aa, abs(d)));
+
+  // Composite: translucent fill first, border ON TOP (Canvas2D fills then
+  // strokes). Premultiply-free over: out = border over fill.
+  vec4 fill = vec4(v_fill.rgb, v_fill.a * fillCov);
+  vec4 border = vec4(v_borderCol.rgb, v_borderCol.a * borderCov);
+  // border over fill
+  float oa = border.a + fill.a * (1.0 - border.a);
+  vec3 orgb = oa > 0.0 ? (border.rgb * border.a + fill.rgb * fill.a * (1.0 - border.a)) / oa : vec3(0.0);
+  if (oa <= 0.0) discard;
+  outColor = vec4(orgb, oa);
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Text program. ONE quad per labelled box samples its sub-rect of the atlas
+// texture. The atlas alpha modulates the (dark) text colour, scaled by the
+// node alpha.
+// ---------------------------------------------------------------------------
+
+const TEXT_VERTEX_SHADER = `#version 300 es
+layout(location = 0) in vec2 a_corner;     // unit quad corner in {0,1}^2
+layout(location = 1) in vec2 a_center;     // instance: box centre (device px)
+layout(location = 2) in vec2 a_size;       // instance: quad (w,h) device px
+layout(location = 3) in vec4 a_uv;         // instance: (u0,v0,u1,v1) atlas sub-rect
+layout(location = 4) in vec4 a_color;      // instance: text rgba (0..1), a = node alpha
+layout(location = 5) in float a_depth;     // instance: drawList index (interleave)
+
+uniform vec2 u_viewport;
+uniform float u_maxDepth;
+
+out vec2 v_uv;
+out vec4 v_color;
+
+void main() {
+  // a_corner in {0,1}; map to [-0.5,0.5]·size centred on the box.
+  vec2 offset = (a_corner - vec2(0.5)) * a_size;
+  vec2 screen = a_center + offset;
+  v_uv = mix(a_uv.xy, a_uv.zw, a_corner);
+  v_color = a_color;
+  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x - 1.0, 1.0 - screen.y * 2.0 / u_viewport.y);
+  float z = u_maxDepth > 0.0 ? (a_depth / u_maxDepth) : 0.0;
+  gl_Position = vec4(clip, -z, 1.0);
+}
+`;
+
+const TEXT_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+in vec4 v_color;
+uniform sampler2D u_atlas;
+out vec4 outColor;
+
+void main() {
+  // The atlas stores the rasterized text as straight RGBA (dark text over
+  // transparent). Its ALPHA is the glyph coverage. We re-tint with the text
+  // colour (#0f172a) so a single atlas can serve any colour, and scale by the
+  // node alpha (v_color.a). Sampling the atlas reproduces the Chrome 2D text AA
+  // by construction (the atlas WAS rasterized by Chrome's 2D engine).
+  float cov = texture(u_atlas, v_uv).a;
+  if (cov <= 0.0) discard;
+  outColor = vec4(v_color.rgb, cov * v_color.a);
+}
+`;
+
+/** Floats per box instance. center(2)+half(2)+corner(1)+border(1)+fill(4)+borderCol(4)+depth(1) = 15 */
+export const BOX_FLOATS_PER_INSTANCE = 15;
+/** Floats per text instance. center(2)+size(2)+uv(4)+color(4)+depth(1) = 13 */
+export const TEXT_FLOATS_PER_INSTANCE = 13;
+
+export interface WebGLBoxFrame {
+  positions: Float32Array;
+  nodeCount: number;
+  style?: GraphStyleBuffers;
+  camera: { x: number; y: number; zoom: number };
+  pixelRatio: number;
+  /** Device backing-store size. */
+  viewportWidth: number;
+  viewportHeight: number;
+  /**
+   * Box-label width measure service (the SAME `measureText` cache Canvas2D uses)
+   * so the box WIDTH + the #199 pixel-fit + the atlas all agree to the pixel.
+   * Absent in non-DOM envs ⇒ boxes collapse to the empty-rect (a no-op width);
+   * the atlas (which also needs a 2D canvas) is then unavailable too.
+   */
+  measureLabelWidth?: (text: string, font: string) => number;
+}
+
+export interface WebGLBoxRenderer {
+  /** Draw the box glyphs + their label text for this frame. */
+  renderBoxes(frame: WebGLBoxFrame): void;
+  destroy(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Instance build (EXPORTED, pure — the geometry-parity test layer asserts the
+// box rects match the Canvas2D box math without a GPU).
+// ---------------------------------------------------------------------------
+
+/** A node's centre in DEVICE px (the same transform as renderer.ts screenPoint). */
+function screenPoint(positions: Float32Array, nodeIndex: number, frame: WebGLBoxFrame): { x: number; y: number } {
+  const offset = nodeIndex * 2;
+  const px = positions[offset] ?? 0;
+  const py = positions[offset + 1] ?? 0;
+  return {
+    x: (px - frame.camera.x) * frame.camera.zoom + frame.viewportWidth / 2,
+    y: (py - frame.camera.y) * frame.camera.zoom + frame.viewportHeight / 2,
+  };
+}
+
+function colorAt(
+  source: Uint8Array | undefined,
+  offset: number,
+  fallback: readonly [number, number, number, number],
+): [number, number, number, number] {
+  return [
+    source?.[offset] ?? fallback[0],
+    source?.[offset + 1] ?? fallback[1],
+    source?.[offset + 2] ?? fallback[2],
+    source?.[offset + 3] ?? fallback[3],
+  ];
+}
+
+/** A single box's resolved draw data (device px) — what the GL instances encode. */
+export interface BoxDraw {
+  nodeIndex: number;
+  centerX: number;
+  centerY: number;
+  halfW: number;
+  halfH: number;
+  corner: number;
+  border: number;
+  /** Node-colour border rgba8 (carries node alpha). */
+  borderColor: [number, number, number, number];
+  /** Node alpha 0..1 (the box text + border follow it; the fill is fixed). */
+  alpha: number;
+  /** The #199-FITTED label the box was sized to (empty for collapsed boxes). */
+  label: string;
+  /** Font px (device) the label was measured + must be rasterized at. */
+  fontPx: number;
+}
+
+/**
+ * Resolve every box node (shape code 5) in the frame to its drawn geometry,
+ * using the SHARED `boxDimensions` (so the box matches Canvas2D + the hit-test).
+ * Non-box nodes are skipped (the P1 shape renderer draws them).
+ */
+export function buildBoxDraws(frame: WebGLBoxFrame): BoxDraw[] {
+  const draws: BoxDraw[] = [];
+  const style = frame.style;
+  const measure = frame.measureLabelWidth ?? (() => 0);
+  const boxHeight = BOX_BASE_HEIGHT_PX * frame.pixelRatio * frame.camera.zoom;
+
+  for (let i = 0; i < frame.nodeCount; i += 1) {
+    if ((style?.nodeShapes?.[i] ?? 0) !== BOX_SHAPE_CODE) continue;
+    const label = style?.nodeLabels?.[i] ?? "";
+    const dims = boxDimensions(boxHeight, label, measure);
+    const halfW = dims.w / 2;
+    const halfH = dims.h / 2;
+    const corner = clampCorner(dims.corner, halfW, halfH);
+
+    const center = screenPoint(frame.positions, i, frame);
+    const nodeColor = colorAt(style?.nodeColors, i * 4, DEFAULT_NODE_COLOR);
+    const alpha = nodeColor[3] / 255;
+    const bold = (style?.nodeBorders?.[i] ?? 0) === 1;
+    // Canvas2D strokes lineWidth = (bold?BOLD:NORMAL)·PR; the SDF border is a
+    // band of HALF that width on each side of the outline.
+    const border = ((bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * frame.pixelRatio) / 2;
+
+    draws.push({
+      nodeIndex: i,
+      centerX: center.x,
+      centerY: center.y,
+      halfW,
+      halfH,
+      corner,
+      border,
+      borderColor: nodeColor,
+      alpha,
+      label: dims.label,
+      fontPx: dims.fontPx,
+    });
+  }
+
+  return draws;
+}
+
+/** Encode the rounded-box instances for the GL box pipeline. */
+export function buildBoxInstances(draws: BoxDraw[]): number[] {
+  const out: number[] = [];
+  for (const d of draws) {
+    out.push(
+      d.centerX, d.centerY,
+      d.halfW, d.halfH,
+      d.corner,
+      d.border,
+      // Fill: fixed translucent white (BOX_FILL), alpha-INDEPENDENT (N10/N7).
+      BOX_FILL[0] / 255, BOX_FILL[1] / 255, BOX_FILL[2] / 255, BOX_FILL[3] / 255,
+      // Border: node colour at node alpha.
+      d.borderColor[0] / 255, d.borderColor[1] / 255, d.borderColor[2] / 255, d.alpha,
+      d.nodeIndex,
+    );
+  }
+  return out;
+}
+
+export interface BoxInstanceView {
+  center: [number, number];
+  half: [number, number];
+  corner: number;
+  border: number;
+  fill: [number, number, number, number];
+  borderColor: [number, number, number, number];
+  depth: number;
+}
+
+export function decodeBox(list: number[], n: number): BoxInstanceView {
+  const o = n * BOX_FLOATS_PER_INSTANCE;
+  return {
+    center: [list[o] ?? 0, list[o + 1] ?? 0],
+    half: [list[o + 2] ?? 0, list[o + 3] ?? 0],
+    corner: list[o + 4] ?? 0,
+    border: list[o + 5] ?? 0,
+    fill: [list[o + 6] ?? 0, list[o + 7] ?? 0, list[o + 8] ?? 0, list[o + 9] ?? 0],
+    borderColor: [list[o + 10] ?? 0, list[o + 11] ?? 0, list[o + 12] ?? 0, list[o + 13] ?? 0],
+    depth: list[o + 14] ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-label canvas-raster text atlas.
+// ---------------------------------------------------------------------------
+
+interface AtlasEntry {
+  /** Sub-rect in atlas texel coords [u0,v0,u1,v1] (0..1). */
+  uv: [number, number, number, number];
+  /** Drawn label quad size in device px. */
+  width: number;
+  height: number;
+}
+
+interface BuiltAtlas {
+  /** RGBA texels (atlasW × atlasH). */
+  pixels: Uint8Array;
+  atlasW: number;
+  atlasH: number;
+  entries: Map<string, AtlasEntry>;
+}
+
+/**
+ * Atlas cache key for a (label, fontPx) cell. fontPx is QUANTIZED to ¼px so
+ * trivially-different device sizes share one atlas cell. EXPORTED so the golden
+ * tests build matching atlas entries against `buildTextInstances`.
+ */
+export function atlasKey(label: string, fontPx: number): string {
+  return `${Math.round(fontPx * 4) / 4}px|${label}`;
+}
+
+/**
+ * Rasterize every DISTINCT (font, fittedLabel) in `draws` onto an offscreen 2D
+ * canvas using the IDENTICAL calls `drawBoxNode` makes, and pack them into a
+ * single atlas. Returns null in non-DOM envs (no 2D canvas) — the caller then
+ * skips the text pass (the box rects still draw; text parity needs the 2D
+ * raster, which is the whole point of the canvas-raster approach).
+ */
+export function buildTextAtlas(draws: BoxDraw[], factory: AtlasCanvasFactory): BuiltAtlas | null {
+  const labelled = draws.filter((d) => d.label.length > 0);
+  if (labelled.length === 0) return null;
+
+  // Collect distinct (font, label) cells, measuring each at its rendered font.
+  const distinct = new Map<string, { label: string; fontPx: number }>();
+  for (const d of labelled) {
+    const key = atlasKey(d.label, d.fontPx);
+    if (!distinct.has(key)) distinct.set(key, { label: d.label, fontPx: d.fontPx });
+  }
+
+  // A scratch canvas to measure each cell (so the atlas rows are sized to fit).
+  const probe = factory(8, 8);
+  if (!probe) return null;
+  const pctx = probe.ctx;
+  const PAD = 2; // px gutter so neighbouring cells never bleed under AA
+
+  interface Cell {
+    key: string;
+    label: string;
+    fontPx: number;
+    w: number;
+    h: number;
+  }
+  const cells: Cell[] = [];
+  let maxW = 1;
+  for (const [key, { label, fontPx }] of distinct) {
+    pctx.font = `${fontPx}px sans-serif`;
+    const m = pctx.measureText(label);
+    // Cell height = the box font height plus a little vertical room for ascenders
+    // / descenders (the text is centred at the box centre, so the cell must hold
+    // the full glyph box; fontPx + 0.6·fontPx is generous and font-stack-safe).
+    const w = Math.max(1, Math.ceil(m.width) + PAD * 2);
+    const h = Math.max(1, Math.ceil(fontPx * 1.6) + PAD * 2);
+    cells.push({ key, label, fontPx, w, h });
+    maxW = Math.max(maxW, w);
+  }
+
+  // Simple shelf packing: stack cells in rows, wrapping at a max atlas width.
+  const ATLAS_MAX_W = Math.max(256, Math.min(4096, maxW));
+  let x = 0;
+  let y = 0;
+  let rowH = 0;
+  let atlasW = 1;
+  const placed: Array<Cell & { x: number; y: number }> = [];
+  for (const c of cells) {
+    if (x + c.w > ATLAS_MAX_W && x > 0) {
+      x = 0;
+      y += rowH;
+      rowH = 0;
+    }
+    placed.push({ ...c, x, y });
+    x += c.w;
+    rowH = Math.max(rowH, c.h);
+    atlasW = Math.max(atlasW, x);
+  }
+  const atlasH = Math.max(1, y + rowH);
+
+  // Rasterize all cells onto a real atlas canvas.
+  const surface = factory(atlasW, atlasH);
+  if (!surface) return null;
+  const ctx = surface.ctx;
+  const r = BOX_TEXT_RGB[0];
+  const g = BOX_TEXT_RGB[1];
+  const b = BOX_TEXT_RGB[2];
+  ctx.clearRect(0, 0, atlasW, atlasH);
+  ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  const entries = new Map<string, AtlasEntry>();
+  for (const c of placed) {
+    ctx.font = `${c.fontPx}px sans-serif`;
+    // Draw centred in the cell (matching drawBoxNode's centre/middle alignment).
+    ctx.fillText(c.label, c.x + c.w / 2, c.y + c.h / 2);
+    entries.set(c.key, {
+      uv: [c.x / atlasW, c.y / atlasH, (c.x + c.w) / atlasW, (c.y + c.h) / atlasH],
+      width: c.w,
+      height: c.h,
+    });
+  }
+
+  // Read the atlas pixels back so they can be uploaded as a GL texture.
+  const img = ctx.getImageData(0, 0, atlasW, atlasH);
+  return { pixels: new Uint8Array(img.data.buffer.slice(0)), atlasW, atlasH, entries };
+}
+
+/** Encode the text-quad instances against a built atlas. */
+export function buildTextInstances(draws: BoxDraw[], atlas: BuiltAtlas): number[] {
+  const out: number[] = [];
+  const r = BOX_TEXT_RGB[0] / 255;
+  const g = BOX_TEXT_RGB[1] / 255;
+  const b = BOX_TEXT_RGB[2] / 255;
+  for (const d of draws) {
+    if (!d.label) continue;
+    const entry = atlas.entries.get(atlasKey(d.label, d.fontPx));
+    if (!entry) continue;
+    out.push(
+      d.centerX, d.centerY,
+      entry.width, entry.height,
+      entry.uv[0], entry.uv[1], entry.uv[2], entry.uv[3],
+      r, g, b, d.alpha,
+      d.nodeIndex,
+    );
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// GL plumbing.
+// ---------------------------------------------------------------------------
+
+function compile(gl: GL2, type: number, src: string): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("failed to create WebGL shader");
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(shader) || "shader compile error";
+    gl.deleteShader(shader);
+    throw new Error(log);
+  }
+  return shader;
+}
+
+function link(gl: GL2, vsSrc: string, fsSrc: string): WebGLProgram {
+  const vs = compile(gl, gl.VERTEX_SHADER, vsSrc);
+  const fs = compile(gl, gl.FRAGMENT_SHADER, fsSrc);
+  const program = gl.createProgram();
+  if (!program) throw new Error("failed to create WebGL program");
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(program) || "program link error";
+    throw new Error(log);
+  }
+  return program;
+}
+
+interface BoxPipeline {
+  program: WebGLProgram;
+  vao: WebGLVertexArrayObject;
+  cornerBuffer: WebGLBuffer;
+  instanceBuffer: WebGLBuffer;
+  viewport: WebGLUniformLocation | null;
+  maxDepth: WebGLUniformLocation | null;
+}
+
+interface TextPipeline {
+  program: WebGLProgram;
+  vao: WebGLVertexArrayObject;
+  cornerBuffer: WebGLBuffer;
+  instanceBuffer: WebGLBuffer;
+  /** Atlas texture, allocated LAZILY on first text upload (so a context with no
+   *  text — or a stub context in unit tests — never needs createTexture). */
+  texture: WebGLTexture | null;
+  viewport: WebGLUniformLocation | null;
+  maxDepth: WebGLUniformLocation | null;
+  atlas: WebGLUniformLocation | null;
+}
+
+/** Unit quad as two triangles, corners in {-1,1}^2 (box) — symmetric centre. */
+const BOX_QUAD = new Float32Array([
+  -1, -1, 1, -1, 1, 1,
+  -1, -1, 1, 1, -1, 1,
+]);
+/** Unit quad as two triangles, corners in {0,1}^2 (text) — for UV mapping. */
+const TEXT_QUAD = new Float32Array([
+  0, 0, 1, 0, 1, 1,
+  0, 0, 1, 1, 0, 1,
+]);
+
+function createBoxPipeline(gl: GL2): BoxPipeline {
+  const program = link(gl, BOX_VERTEX_SHADER, BOX_FRAGMENT_SHADER);
+  const vao = gl.createVertexArray();
+  const cornerBuffer = gl.createBuffer();
+  const instanceBuffer = gl.createBuffer();
+  if (!vao || !cornerBuffer || !instanceBuffer) throw new Error("failed to create box buffers");
+  const stride = BOX_FLOATS_PER_INSTANCE * 4;
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, cornerBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, BOX_QUAD, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
+  // 1 a_center, 2 a_half, 3 a_corner_r, 4 a_border, 5 a_fill, 6 a_borderCol, 7 a_depth
+  const layout: Array<[number, number, number]> = [
+    [1, 2, 0],
+    [2, 2, 2 * 4],
+    [3, 1, 4 * 4],
+    [4, 1, 5 * 4],
+    [5, 4, 6 * 4],
+    [6, 4, 10 * 4],
+    [7, 1, 14 * 4],
+  ];
+  for (const [loc, size, offset] of layout) {
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, size, gl.FLOAT, false, stride, offset);
+    gl.vertexAttribDivisor(loc, 1);
+  }
+  gl.bindVertexArray(null);
+
+  return {
+    program,
+    vao,
+    cornerBuffer,
+    instanceBuffer,
+    viewport: gl.getUniformLocation(program, "u_viewport"),
+    maxDepth: gl.getUniformLocation(program, "u_maxDepth"),
+  };
+}
+
+function createTextPipeline(gl: GL2): TextPipeline {
+  const program = link(gl, TEXT_VERTEX_SHADER, TEXT_FRAGMENT_SHADER);
+  const vao = gl.createVertexArray();
+  const cornerBuffer = gl.createBuffer();
+  const instanceBuffer = gl.createBuffer();
+  if (!vao || !cornerBuffer || !instanceBuffer) throw new Error("failed to create text buffers");
+  const stride = TEXT_FLOATS_PER_INSTANCE * 4;
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, cornerBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, TEXT_QUAD, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
+  // 1 a_center, 2 a_size, 3 a_uv, 4 a_color, 5 a_depth
+  const layout: Array<[number, number, number]> = [
+    [1, 2, 0],
+    [2, 2, 2 * 4],
+    [3, 4, 4 * 4],
+    [4, 4, 8 * 4],
+    [5, 1, 12 * 4],
+  ];
+  for (const [loc, size, offset] of layout) {
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, size, gl.FLOAT, false, stride, offset);
+    gl.vertexAttribDivisor(loc, 1);
+  }
+  gl.bindVertexArray(null);
+
+  return {
+    program,
+    vao,
+    cornerBuffer,
+    instanceBuffer,
+    texture: null,
+    viewport: gl.getUniformLocation(program, "u_viewport"),
+    maxDepth: gl.getUniformLocation(program, "u_maxDepth"),
+    atlas: gl.getUniformLocation(program, "u_atlas"),
+  };
+}
+
+/**
+ * Create a WebGL2 instanced box-glyph + label-text renderer. The `context` MUST
+ * be WebGL2 (instancing + VAOs are WebGL2 core). Returns null if the context is
+ * not WebGL2-capable so the caller can fall back to Canvas2D for boxes.
+ *
+ * `atlasFactory` builds the offscreen 2D context the text atlas rasterizes onto;
+ * the golden harness passes a font-pinned factory (so the atlas uses the SAME
+ * deterministic family Canvas2D measured + drew with). Defaults to a plain
+ * OffscreenCanvas / detached `<canvas>`.
+ */
+export function createWebGLBoxRenderer(
+  context: GL2 | null,
+  atlasFactory: AtlasCanvasFactory = defaultAtlasCanvasFactory,
+): WebGLBoxRenderer | null {
+  if (
+    !context ||
+    typeof context.drawArraysInstanced !== "function" ||
+    typeof context.createVertexArray !== "function"
+  ) {
+    return null;
+  }
+  const gl: GL2 = context;
+  const box = createBoxPipeline(gl);
+  const text = createTextPipeline(gl);
+
+  function renderBoxes(frame: WebGLBoxFrame): void {
+    const draws = buildBoxDraws(frame);
+    if (draws.length === 0) return;
+
+    const maxDepth = Math.max(1, frame.nodeCount);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    // R7 byte-parity interleave via the DEPTH buffer: each box's rect AND text
+    // share the node-index depth (a later/higher-index node maps NEARER), so a
+    // later box's rect occludes an EARLIER box's rect AND text — exactly what
+    // Canvas2D gets by drawing rect→fill→stroke→fillText in one call per node.
+    // Without this, the all-rects-then-all-text pass order would let an earlier
+    // box's text draw OVER a later box's rect. We own a fresh depth range for
+    // the box pass (boxes draw last, after P1 shapes / P2 edges), clear it, and
+    // restore the depth-test state afterwards so nothing else is affected.
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthFunc(gl.LEQUAL);
+    gl.depthMask(true);
+    gl.clear(gl.DEPTH_BUFFER_BIT);
+
+    // Box rects (fill + border via SDF).
+    const boxInstances = buildBoxInstances(draws);
+    gl.useProgram(box.program);
+    if (box.viewport) gl.uniform2f(box.viewport, frame.viewportWidth, frame.viewportHeight);
+    if (box.maxDepth) gl.uniform1f(box.maxDepth, maxDepth);
+    gl.bindVertexArray(box.vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, box.instanceBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(boxInstances), gl.DYNAMIC_DRAW);
+    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, draws.length);
+    gl.bindVertexArray(null);
+
+    // Box label text via the per-label canvas-raster atlas (the #1-risk path).
+    // Drawn under the SAME depth test as the rects (shared per-node depth), so a
+    // later box's rect occludes an earlier box's text.
+    const atlas = buildTextAtlas(draws, atlasFactory);
+    const textInstances = atlas ? buildTextInstances(draws, atlas) : [];
+    if (atlas && textInstances.length > 0) {
+      gl.useProgram(text.program);
+      if (text.viewport) gl.uniform2f(text.viewport, frame.viewportWidth, frame.viewportHeight);
+      if (text.maxDepth) gl.uniform1f(text.maxDepth, maxDepth);
+
+      if (!text.texture) text.texture = gl.createTexture();
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, text.texture);
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+      gl.texImage2D(
+        gl.TEXTURE_2D, 0, gl.RGBA, atlas.atlasW, atlas.atlasH, 0, gl.RGBA, gl.UNSIGNED_BYTE, atlas.pixels,
+      );
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      if (text.atlas) gl.uniform1i(text.atlas, 0);
+
+      gl.bindVertexArray(text.vao);
+      gl.bindBuffer(gl.ARRAY_BUFFER, text.instanceBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(textInstances), gl.DYNAMIC_DRAW);
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, textInstances.length / TEXT_FLOATS_PER_INSTANCE);
+      gl.bindVertexArray(null);
+    }
+
+    // Restore the default no-depth state so subsequent renders (and any other
+    // pass that assumes depth-test off) are unaffected.
+    gl.disable(gl.DEPTH_TEST);
+  }
+
+  function destroy(): void {
+    gl.deleteVertexArray(box.vao);
+    gl.deleteBuffer(box.cornerBuffer);
+    gl.deleteBuffer(box.instanceBuffer);
+    gl.deleteProgram(box.program);
+    gl.deleteVertexArray(text.vao);
+    gl.deleteBuffer(text.cornerBuffer);
+    gl.deleteBuffer(text.instanceBuffer);
+    gl.deleteTexture(text.texture);
+    gl.deleteProgram(text.program);
+  }
+
+  return { renderBoxes, destroy };
+}

--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -539,8 +539,12 @@ export function buildTextInstances(draws: BoxDraw[], atlas: BuiltAtlas): number[
     if (!d.label) continue;
     const entry = atlas.entries.get(atlasKey(d.label, d.fontPx));
     if (!entry) continue;
+    // Snap the text-quad centre to the device-pixel grid so the atlas cell
+    // (rasterized at integer device px) maps ~1:1 to screen texels, keeping the
+    // glyph edges crisp instead of LINEAR-blurred across a half-pixel offset —
+    // the same crispness Canvas2D's fillText gets by rasterizing in place.
     out.push(
-      d.centerX, d.centerY,
+      Math.round(d.centerX), Math.round(d.centerY),
       entry.width, entry.height,
       entry.uv[0], entry.uv[1], entry.uv[2], entry.uv[3],
       r, g, b, d.alpha,

--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -164,21 +164,26 @@ float roundedBoxSDF(vec2 p, vec2 b, float r) {
 
 void main() {
   float d = roundedBoxSDF(v_local, v_half, v_corner_r);
-  float aa = max(fwidth(d), 1e-4);
+  // Antialias over ~1 device pixel, but never let a large fwidth on software GL
+  // wash a thin (sub-pixel) stroke to near-zero coverage: cap the AA half-width
+  // so a 1.5px-at-DPR1 border keeps a solid core like Canvas2D's stroke.
+  float aa = clamp(fwidth(d), 1e-4, 0.75);
 
   // Interior coverage: inside the rounded-box outline (d <= 0).
   float fillCov = 1.0 - smoothstep(-aa, aa, d);
-  // Border ring: a band of half-width v_border centred on the outline (|d| ~ 0).
-  // Canvas2D strokes a line of width 2·v_border centred on the path, so the
-  // ring spans d in [-v_border, +v_border].
-  float borderCov =
-      (1.0 - smoothstep(v_border - aa, v_border + aa, abs(d)));
+
+  // Border ring: Canvas2D strokes a line of total width 2·v_border CENTRED on
+  // the path, so the ring is the band |d| <= v_border. We give it a fully
+  // opaque CORE (|d| <= v_border - aa) and feather only the outer ~1px rim, so
+  // the stroke reads at full node-colour like the Canvas2D stroke (a pure
+  // smoothstep over the whole half-width washes a thin stroke to a faint sliver).
+  float inner = max(0.0, v_border - aa);
+  float borderCov = 1.0 - smoothstep(inner, v_border + aa, abs(d));
 
   // Composite: translucent fill first, border ON TOP (Canvas2D fills then
-  // strokes). Premultiply-free over: out = border over fill.
+  // strokes). Straight-alpha "over": out = border over fill.
   vec4 fill = vec4(v_fill.rgb, v_fill.a * fillCov);
   vec4 border = vec4(v_borderCol.rgb, v_borderCol.a * borderCov);
-  // border over fill
   float oa = border.a + fill.a * (1.0 - border.a);
   vec3 orgb = oa > 0.0 ? (border.rgb * border.a + fill.rgb * fill.a * (1.0 - border.a)) / oa : vec3(0.0);
   if (oa <= 0.0) discard;

--- a/packages/graph/tests/golden/boxes-golden.test.ts
+++ b/packages/graph/tests/golden/boxes-golden.test.ts
@@ -1,0 +1,382 @@
+/**
+ * B1 Phase 3 — BOX-GLYPH + LABEL-TEXT golden gate (WebGL2 instanced boxes +
+ * canvas-raster text atlas vs Canvas2D). This is the HARDEST phase: in-canvas
+ * text parity is the #1 B1 risk, so it is gated hardest.
+ *
+ * Same two-layer model as the Phase-1 shape gate and the Phase-2 edge gate:
+ *
+ *  A. GEOMETRY PARITY (always runs, deterministic, no GPU needed).
+ *     Asserts the WebGL box INSTANCE build reproduces the Canvas2D box math (via
+ *     the SHARED render-geometry.boxDimensions) to the float: N7 labelled box
+ *     hugs the measured label; N9 empty box collapses to BOX_EMPTY_RATIO×height
+ *     and emits NO text; N7c corner clamp (empty == half-side, narrow == w/2);
+ *     N8 degree-independence (render(6) == render(60)); #199 long-label pixel-fit
+ *     to the cap with a SINGLE ellipsis (largest fitting prefix) + short label
+ *     untouched; N13b a boxed-but-unlabelled Character draws a rect + NO text;
+ *     fixed BOX_FILL (alpha-independent) + node-colour border at node alpha;
+ *     R7 byte-parity interleave (rect + text share the node-index depth); exactly
+ *     ONE text instance per labelled box. This is the gate where Chrome has no
+ *     GL context (this environment) and the floor everywhere.
+ *
+ *  B. CDP PIXEL DIFF (runs only where a real WebGL2 context is available — the
+ *     CI golden-webgl lane with GOLDEN_ENABLE_WEBGL=1 + SwiftShader). Captures
+ *     the Canvas2D and WebGL backends on paired canvases per box fixture and
+ *     diffs them: the box-rect EXTENT must match, the node-colour border must
+ *     appear, the dark label text must appear (text presence over the box), and
+ *     OVERLAPPING boxes must occlude identically (R7). The box-text atlas is
+ *     rasterized by the SAME pinned font the Canvas2D reference uses (the harness
+ *     hands the renderer a font-pinned atlas factory), so text AA is parity by
+ *     construction. Where no GL context exists it records an EXPLICIT skip.
+ *
+ * Default-unchanged: every WebGL capture sets `instancedShapes: true` (the
+ * canary). The canvas2d goldens NEVER set it, so the default path is untouched.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  atlasKey,
+  buildBoxDraws,
+  buildBoxInstances,
+  buildTextInstances,
+  decodeBox,
+  type WebGLBoxFrame,
+} from "../../src/webgl-boxes";
+import {
+  BOX_BASE_HEIGHT_PX,
+  BOX_EMPTY_RATIO,
+  BOX_FILL,
+  BOX_MARGIN_RATIO,
+  BOX_MAX_WIDTH_RATIO,
+} from "../../src/render-geometry";
+// @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
+import { openOracle } from "./cdp-harness.mjs";
+// @ts-expect-error
+import { countColorPixels, contentBBox } from "./diff.mjs";
+// @ts-expect-error
+import { BOX_GL_FIXTURES, BOX_TEXT_RGB } from "./fixtures.mjs";
+
+/** Deterministic measure (7px/char) — the SAME stub the renderer-api box tests
+ *  use, so the geometry-parity assertions can predict the box width exactly. */
+const MEASURE = (text: string): number => text.length * 7;
+
+/** Build a single-box WebGLBoxFrame at a given DPR/zoom. */
+function boxFrame(opts: {
+  label?: string;
+  size?: number;
+  color?: [number, number, number, number];
+  bold?: boolean;
+  dpr?: number;
+  zoom?: number;
+  cssW?: number;
+}): WebGLBoxFrame {
+  const dpr = opts.dpr ?? 1;
+  const zoom = opts.zoom ?? 1;
+  const cssW = opts.cssW ?? 400;
+  const dim = Math.round(cssW * dpr);
+  const color = opts.color ?? [37, 99, 235, 255];
+  return {
+    positions: new Float32Array([0, 0]),
+    nodeCount: 1,
+    style: {
+      nodeSizes: new Float32Array([opts.size ?? 11]),
+      nodeColors: new Uint8Array(color),
+      nodeShapes: new Uint8Array([5]), // box
+      nodeLabels: [opts.label ?? ""],
+      nodeBorders: new Uint8Array([opts.bold ? 1 : 0]),
+      edgeWidths: new Float32Array(),
+      edgeColors: new Uint8Array(),
+      edgeDash: new Uint8Array(),
+      edgeCurvatures: new Float32Array(),
+    },
+    camera: { x: 0, y: 0, zoom },
+    pixelRatio: dpr,
+    viewportWidth: dim,
+    viewportHeight: dim,
+    measureLabelWidth: MEASURE,
+  };
+}
+
+const DPR_MATRIX = [1, 2, 3];
+const ZOOM_MATRIX = [1, 2.5];
+
+// ---------------------------------------------------------------------------
+// A. GEOMETRY PARITY — the WebGL box instances == the Canvas2D box math.
+// ---------------------------------------------------------------------------
+describe("B1 Phase 3 — box geometry parity (WebGL instances == Canvas2D math)", () => {
+  // N7 labelled box: degree-independent height, width hugs the measured label.
+  for (const dpr of DPR_MATRIX) {
+    for (const zoom of ZOOM_MATRIX) {
+      it(`N7 labelled box: height==base·PR·zoom, width hugs label @ DPR ${dpr} × zoom ${zoom}`, () => {
+        const label = "Sherlock";
+        const draws = buildBoxDraws(boxFrame({ label, dpr, zoom }));
+        expect(draws).toHaveLength(1);
+        const d = draws[0]!;
+
+        const h = BOX_BASE_HEIGHT_PX * dpr * zoom;
+        const margin = h * BOX_MARGIN_RATIO;
+        const expectedW = MEASURE(label) + 2 * margin;
+        // Height is degree-independent: exactly the base · PR · zoom.
+        expect(d.halfH * 2).toBeCloseTo(h, 4);
+        // Width hugs the measured label + a margin per side.
+        expect(d.halfW * 2).toBeCloseTo(expectedW, 4);
+        // The box renders the (unclipped) label.
+        expect(d.label).toBe(label);
+      });
+    }
+  }
+
+  // N9 empty box: collapses to a square of BOX_EMPTY_RATIO × height, NO text.
+  it("N9 empty box: collapses to BOX_EMPTY_RATIO×height square and emits NO text", () => {
+    const frame = boxFrame({ label: "" });
+    const draws = buildBoxDraws(frame);
+    expect(draws).toHaveLength(1);
+    const d = draws[0]!;
+    const side = BOX_BASE_HEIGHT_PX * BOX_EMPTY_RATIO;
+    expect(d.halfW * 2).toBeCloseTo(side, 4);
+    expect(d.halfH * 2).toBeCloseTo(side, 4);
+    expect(d.label).toBe("");
+    // No text instance for an unlabelled box (stub atlas has no entries either).
+    const textInstances = buildTextInstances(draws, { atlasW: 1, atlasH: 1, pixels: new Uint8Array(4), entries: new Map() });
+    expect(textInstances).toHaveLength(0);
+  });
+
+  // N7c corner clamp: empty box corner == half-side; a narrow label clamps to w/2.
+  it("N7c corner clamp: empty box corner == half-side, narrow label corner == w/2", () => {
+    const empty = buildBoxDraws(boxFrame({ label: "" }))[0]!;
+    // Empty box: corner = clamp(height/4, halfW, halfH) and halfW==halfH==side/2.
+    // side = height·10/22 < height/4·... ⇒ corner clamps to the half-side.
+    expect(empty.corner).toBeCloseTo(empty.halfW, 4);
+    expect(empty.corner).toBeCloseTo(empty.halfH, 4);
+
+    // A single-char label makes a box narrower than 2·(height/4) ⇒ corner == w/2.
+    const narrow = buildBoxDraws(boxFrame({ label: "." }))[0]!;
+    const rawCorner = (BOX_BASE_HEIGHT_PX * 1) / 4; // height·1/4 before clamp
+    if (narrow.halfW < rawCorner) {
+      expect(narrow.corner).toBeCloseTo(narrow.halfW, 4);
+    }
+  });
+
+  // N8 degree-independence: a box ignores nodeSize — render(6) == render(60).
+  it("N8 degree-independence: box geometry ignores nodeSize (size 6 == size 60)", () => {
+    const small = buildBoxDraws(boxFrame({ label: "Work", size: 6 }))[0]!;
+    const big = buildBoxDraws(boxFrame({ label: "Work", size: 60 }))[0]!;
+    expect(big.halfW).toBeCloseTo(small.halfW, 6);
+    expect(big.halfH).toBeCloseTo(small.halfH, 6);
+    expect(big.corner).toBeCloseTo(small.corner, 6);
+  });
+
+  // #199 pixel-fit: a long label clips to the capped box width with a SINGLE
+  // ellipsis (the largest fitting prefix); a short label is untouched.
+  it("#199 long label: pixel-fits to the cap with a single ellipsis (largest prefix)", () => {
+    const longLabel =
+      "Part I, Chapter I: Being a Reprint of the Reminiscences of John H. Watson, M.D.";
+    const d = buildBoxDraws(boxFrame({ label: longLabel }))[0]!;
+    const h = BOX_BASE_HEIGHT_PX;
+    const margin = h * BOX_MARGIN_RATIO;
+    const maxTextWidth = h * BOX_MAX_WIDTH_RATIO - 2 * margin;
+
+    expect(d.label).not.toBe(longLabel);
+    expect(d.label.endsWith("…")).toBe(true);
+    expect(d.label.endsWith("……")).toBe(false);
+    expect(d.label.length).toBeLessThan(longLabel.length);
+    // The fitted text fits the cap (stub width = length·7) ...
+    expect(MEASURE(d.label)).toBeLessThanOrEqual(maxTextWidth);
+    // ... and is the LARGEST such prefix: one more glyph would overflow.
+    expect(MEASURE(d.label) + 7).toBeGreaterThan(maxTextWidth);
+    // The box width hugs the FITTED text (never the raw label), staying ≤ cap.
+    expect(d.halfW * 2).toBeLessThanOrEqual(h * BOX_MAX_WIDTH_RATIO + 1e-6);
+  });
+
+  it("#199 short label: left untouched (no ellipsis, no width cap)", () => {
+    const d = buildBoxDraws(boxFrame({ label: "Hi" }))[0]!;
+    expect(d.label).toBe("Hi");
+    expect(d.label.includes("…")).toBe(false);
+  });
+
+  // N13b two-stage divergence: a boxed Character with an EMPTY label draws a
+  // collapsed rect and NO text (a Character can be BOXED yet UNLABELLED).
+  it("N13b: a boxed-but-unlabelled node draws a rect and NO text", () => {
+    const d = buildBoxDraws(boxFrame({ label: "" }))[0]!;
+    expect(d.label).toBe("");
+    // It still has a (collapsed) rect, so the border still draws.
+    expect(d.halfW).toBeGreaterThan(0);
+  });
+
+  // Fixed translucent-white fill (alpha-INDEPENDENT) + node-colour border at the
+  // node alpha (N10/N7). A DIMMED box keeps the opaque-ish white interior.
+  it("box fill is fixed BOX_FILL (alpha-independent); border carries node alpha", () => {
+    const dimmed = buildBoxInstances(
+      buildBoxDraws(boxFrame({ label: "Dim", color: [37, 99, 235, 89] })),
+    );
+    const box = decodeBox(dimmed, 0);
+    // Fill = BOX_FILL normalised, regardless of the node alpha (89/255).
+    expect(box.fill[0]).toBeCloseTo(BOX_FILL[0] / 255, 4);
+    expect(box.fill[3]).toBeCloseTo(BOX_FILL[3] / 255, 4);
+    // Border = node colour at the node alpha (89/255).
+    expect(box.borderColor[0]).toBeCloseTo(37 / 255, 4);
+    expect(box.borderColor[3]).toBeCloseTo(89 / 255, 4);
+  });
+
+  // R7 byte-parity interleave: the box rect AND its text share the node-index
+  // depth, so a later box occludes an earlier box's rect AND text.
+  it("R7 interleave: a box rect and its text share the node-index depth", () => {
+    const frame: WebGLBoxFrame = {
+      positions: new Float32Array([-14, 0, 14, 0]),
+      nodeCount: 2,
+      style: {
+        nodeSizes: new Float32Array([11, 11]),
+        nodeColors: new Uint8Array([37, 99, 235, 255, 220, 38, 38, 255]),
+        nodeShapes: new Uint8Array([5, 5]),
+        nodeLabels: ["Behind", "Front"],
+        nodeBorders: new Uint8Array([0, 0]),
+        edgeWidths: new Float32Array(),
+        edgeColors: new Uint8Array(),
+        edgeDash: new Uint8Array(),
+        edgeCurvatures: new Float32Array(),
+      },
+      camera: { x: 0, y: 0, zoom: 1 },
+      pixelRatio: 2,
+      viewportWidth: 400,
+      viewportHeight: 400,
+      measureLabelWidth: MEASURE,
+    };
+    const draws = buildBoxDraws(frame);
+    const boxes = buildBoxInstances(draws);
+    // Depth == node index: box 0 at depth 0, box 1 at depth 1 (later ⇒ on top).
+    expect(decodeBox(boxes, 0).depth).toBe(0);
+    expect(decodeBox(boxes, 1).depth).toBe(1);
+
+    // The text instances carry the SAME depth as their box (shared occlusion).
+    const fakeAtlas = {
+      atlasW: 1,
+      atlasH: 1,
+      pixels: new Uint8Array(4),
+      entries: new Map([
+        [atlasKey("Behind", draws[0]!.fontPx), { uv: [0, 0, 1, 1] as [number, number, number, number], width: 10, height: 10 }],
+        [atlasKey("Front", draws[1]!.fontPx), { uv: [0, 0, 1, 1] as [number, number, number, number], width: 10, height: 10 }],
+      ]),
+    };
+    const textInstances = buildTextInstances(draws, fakeAtlas);
+    // TEXT_FLOATS_PER_INSTANCE = 13; the depth is the last float of each.
+    expect(textInstances.length / 13).toBe(2);
+    expect(textInstances[12]).toBe(0); // first text instance depth == node 0
+    expect(textInstances[25]).toBe(1); // second text instance depth == node 1
+  });
+
+  // Exactly ONE text instance per labelled box (L1: 1 fillText per box).
+  it("exactly one text instance per labelled box", () => {
+    const draws = buildBoxDraws(boxFrame({ label: "Holmes" }));
+    const fakeAtlas = {
+      atlasW: 1,
+      atlasH: 1,
+      pixels: new Uint8Array(4),
+      entries: new Map([
+        [atlasKey("Holmes", draws[0]!.fontPx), { uv: [0, 0, 1, 1] as [number, number, number, number], width: 10, height: 10 }],
+      ]),
+    };
+    expect(buildTextInstances(draws, fakeAtlas).length / 13).toBe(1);
+  });
+
+  it("determinism: the same frame builds byte-identical box instances", () => {
+    const a = buildBoxInstances(buildBoxDraws(boxFrame({ label: "Watson", bold: true, dpr: 2 })));
+    const b = buildBoxInstances(buildBoxDraws(boxFrame({ label: "Watson", bold: true, dpr: 2 })));
+    expect(a).toEqual(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B. CDP PIXEL DIFF — real WebGL vs Canvas2D (only where GL is available).
+// ---------------------------------------------------------------------------
+describe("B1 Phase 3 — box pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () => {
+  const REQUIRE_GL = process.env.GOLDEN_REQUIRE_WEBGL === "1";
+
+  it("per-box WebGL-vs-Canvas2D pixel diff (or explicit no-GL skip)", async () => {
+    let oracle: Awaited<ReturnType<typeof openOracle>> | null = null;
+    let glAvailable = false;
+    try {
+      oracle = await openOracle();
+      glAvailable = await oracle.hasWebGL();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[boxes-golden] Chrome/CDP oracle unavailable:", String(err));
+    }
+
+    if (!oracle) {
+      if (REQUIRE_GL) throw new Error("GOLDEN_REQUIRE_WEBGL=1 but Chrome did not boot");
+      return;
+    }
+
+    try {
+      if (!glAvailable) {
+        const reason =
+          "no WebGL2 context in this Chrome (set GOLDEN_ENABLE_WEBGL=1 with SwiftShader to run the real pixel diff)";
+        // eslint-disable-next-line no-console
+        console.warn(`[boxes-golden] RESIDUAL/SKIP: ${reason}`);
+        if (REQUIRE_GL) throw new Error(`GOLDEN_REQUIRE_WEBGL=1 but ${reason}`);
+        expect(glAvailable).toBe(false); // block A is the gate in no-GL envs
+        return;
+      }
+
+      // Cross-DPR sweep: 1, 2, 3 (X6 box-text crispness at DPR 2/3).
+      const dprs = [1, 2, 3];
+      const zoom = 1;
+      const results: Array<{ name: string; dpr: number; pass: boolean; note: string }> = [];
+
+      for (const dpr of dprs) {
+        const opts = { cssWidth: 320, cssHeight: 160, dpr, camera: { x: 0, y: 0, zoom } };
+        for (const bf of BOX_GL_FIXTURES) {
+          const ref = await oracle.capture(bf.fixture, { ...opts, backend: "canvas2d" });
+          const gl = await oracle.capture(bf.fixture, { ...opts, backend: "webgl", instancedShapes: true });
+          expect(gl.backend, `${bf.name}: expected webgl backend`).toBe("webgl");
+
+          // 1) The box-rect EXTENT must match within a few px (the box border +
+          //    text set the drawn extent). The box border is the dominant edge.
+          const glBox = contentBBox(gl, 12);
+          const refBox = contentBBox(ref, 12);
+          const extentOk =
+            Boolean(glBox) &&
+            Boolean(refBox) &&
+            Math.abs(glBox.width - refBox.width) <= 10 &&
+            Math.abs(glBox.height - refBox.height) <= 10;
+          const boxNote = `glBox=${glBox?.width}x${glBox?.height} refBox=${refBox?.width}x${refBox?.height}`;
+
+          // 2) The node-colour border must appear on BOTH backends.
+          const glBorder = countColorPixels(gl, bf.rgb, 70);
+          const refBorder = countColorPixels(ref, bf.rgb, 70);
+          const borderOk = glBorder > 0 && refBorder > 0;
+
+          // 3) The dark label text (#0f172a) must appear on BOTH backends when
+          //    the fixture is labelled. The canvas-raster atlas means the WebGL
+          //    text pixel count is within a generous ratio of the Canvas2D text.
+          let textOk = true;
+          let textNote = "no-text";
+          if (bf.text) {
+            const glText = countColorPixels(gl, BOX_TEXT_RGB, 60);
+            const refText = countColorPixels(ref, BOX_TEXT_RGB, 60);
+            const ratio = refText > 0 ? glText / refText : 0;
+            // Both must draw SOME dark text; the canvas-raster atlas keeps the
+            // counts close (same font, same fitted string, same device size).
+            textOk = glText > 0 && refText > 0 && ratio > 0.5 && ratio < 2.0;
+            textNote = `glText=${glText} refText=${refText} ratio=${ratio.toFixed(2)}`;
+          }
+
+          const pass = Boolean(extentOk && borderOk && textOk);
+          results.push({
+            name: bf.name,
+            dpr,
+            pass,
+            note: `${boxNote} glBorder=${glBorder} refBorder=${refBorder} ${textNote}`,
+          });
+        }
+      }
+
+      // eslint-disable-next-line no-console
+      console.log("[boxes-golden] per-box WebGL-vs-Canvas2D:", JSON.stringify(results, null, 2));
+      for (const r of results) {
+        expect(r.pass, `${r.name} @ DPR ${r.dpr}: ${r.note}`).toBe(true);
+      }
+    } finally {
+      await oracle.close();
+    }
+  }, 240_000);
+});

--- a/packages/graph/tests/golden/fixtures.mjs
+++ b/packages/graph/tests/golden/fixtures.mjs
@@ -434,3 +434,46 @@ export const EDGE_GL_FIXTURES = [
   { name: "overlap", fixture: EDGE_OVERLAP_FIXTURE, rgb: [220, 38, 38], arrow: false, dashed: false },
   { name: "combo", fixture: EDGE_COMBO_FIXTURE, rgb: [124, 58, 237], arrow: true, dashed: true },
 ];
+
+// ---------------------------------------------------------------------------
+// B1 Phase 3 — per-box GL golden fixtures (N7 labelled / N9 empty / #199
+// pixel-fit, L1 in-box text). Each is ONE or two box nodes so a capture's drawn
+// content is unambiguously the box(es) + text. The border colour differs from
+// the dark text colour (#0f172a) so a text-presence probe never collides with
+// the border. Coordinates are WORLD; the camera maps them.
+// ---------------------------------------------------------------------------
+
+/** Box-over-box occlusion (R7): a later box must occlude an earlier box's rect
+ *  AND text. Two overlapping labelled boxes; the second (drawn later) sits on
+ *  top. Both backends must interleave occlusion identically (shared depth). */
+export const BOX_OVERLAP_FIXTURE = {
+  nodes: [
+    { id: "behind", x: -14, y: 0, size: 11, color: "#2563eb", shape: "box", label: "Behind" },
+    { id: "front", x: 14, y: 0, size: 11, color: "#dc2626", shape: "box", label: "Front" },
+  ],
+  edges: [],
+};
+
+/** Box-over-circle occlusion (R7): a box drawn after a circle must occlude it. */
+export const BOX_OVER_CIRCLE_FIXTURE = {
+  nodes: [
+    { id: "disc", x: 0, y: 0, size: 24, color: "#16a34a", shape: "circle" },
+    { id: "card", x: 0, y: 0, size: 11, color: "#2563eb", shape: "box", label: "Holmes" },
+  ],
+  edges: [],
+};
+
+/**
+ * Box GL fixtures, by name, for the per-box pixel-diff sweep. `text` flags
+ * whether the box carries a label (a text-presence probe applies); `rgb` is the
+ * node-colour border probe target.
+ */
+export const BOX_GL_FIXTURES = [
+  { name: "labelled", fixture: BOX_LABELLED_FIXTURE, rgb: [239, 68, 68], text: true },
+  { name: "empty", fixture: BOX_EMPTY_FIXTURE, rgb: [148, 103, 189], text: false },
+  { name: "focal", fixture: BOX_FOCAL_FIXTURE, rgb: [37, 99, 235], text: true },
+  { name: "long", fixture: BOX_LONG_LABEL_FIXTURE, rgb: [14, 165, 233], text: true },
+  { name: "short", fixture: BOX_SHORT_LABEL_FIXTURE, rgb: [14, 165, 233], text: true },
+  { name: "overlap", fixture: BOX_OVERLAP_FIXTURE, rgb: [220, 38, 38], text: true },
+  { name: "overCircle", fixture: BOX_OVER_CIRCLE_FIXTURE, rgb: [37, 99, 235], text: true },
+];

--- a/packages/graph/tests/golden/harness-page.html
+++ b/packages/graph/tests/golden/harness-page.html
@@ -227,6 +227,26 @@
           // instanced shapes vs Canvas2D. Default (undefined) keeps the legacy
           // point-sprite path — the canvas2d goldens are unaffected.
           instancedShapes: opts.instancedShapes ?? undefined,
+          // B1 Phase 3: the WebGL box-label TEXT atlas rasterizes onto an
+          // offscreen 2D canvas. For byte-parity with the Canvas2D reference the
+          // atlas MUST use the SAME pinned deterministic font (PINNED_FAMILY) the
+          // render-canvas 2D context uses. We hand the renderer a factory that
+          // creates a detached <canvas> and pins its font setter (the same swap
+          // pinFontOnContext applies), so the atlas text is rasterized by the
+          // SAME Chrome 2D engine + family that measured + drew the Canvas2D box.
+          // Only the WebGL backend consults it; canvas2d ignores it (no change).
+          atlasCanvasFactory:
+            backend === "webgl"
+              ? function (w, h) {
+                  const off = document.createElement("canvas");
+                  off.width = Math.max(1, w);
+                  off.height = Math.max(1, h);
+                  const c = off.getContext("2d");
+                  if (!c) return null;
+                  pinFontOnContext(c);
+                  return { canvas: off, ctx: c };
+                }
+              : undefined,
           // The instanced shapes are HARD-EDGED triangle fans (the fragment
           // shader emits a flat colour, no SDF/coverage AA). Canvas2D draws
           // ANTIALIASED edges, so without MSAA the WebGL boundary rim is a hard


### PR DESCRIPTION
## B1 Phase 3 — WebGL2 BOX glyphs + in-canvas LABEL TEXT (the hardest phase)

Internal-canary continuation of the B1 Canvas2D→WebGL2 migration after **P1 shapes (#211)**, **P2 edges (#214)**, and the **#212 golden-webgl SwiftShader lane**. This phase tackles the **#1 B1 risk: in-canvas text parity**.

**Default stays `canvas2d`.** The new path is reachable only via the same `instancedShapes` canary flag P1/P2 use; the studio never sets it (`GraphCanvas.svelte:160` pinned to `canvas2d`, asserted by `graphCanvasRenderer.test.js:30`). No user-facing change. Canvas2D boxes + text remain the golden source of truth and byte-identical.

### Box glyph (`webgl-boxes.ts`)
- Instanced rounded-rect via a `roundedBox` **SDF** fragment with the `min(corner, halfW, halfH)` clamp (N7c) — empty boxes (corner==half-side) and narrow labels (corner==w/2) round identically to Canvas2D.
- Fixed translucent-white `BOX_FILL` (alpha-**independent**, N10) under the node-colour border (carries node alpha); normal/bold border-weight split.
- Half-extents + corner + the #199 **fitted label** come from the **shared** `render-geometry.boxDimensions`, so the GL box can't drift from Canvas2D or the hit-test. Degree-independent height (N8); ignores `nodeSize`.

### Label text — per-label CANVAS-RASTER atlas (the plan's decision, NOT SDF)
- Each distinct `(font, fittedLabel)` is rasterized **once** on an offscreen 2D canvas using the **identical** calls `drawBoxNode` makes (`fontPx px sans-serif`, center/middle, `#0f172a`), packed into a texture, sampled by a quad centred on the box.
- Because the text is rasterized by the **same Chrome 2D engine** that produced the box width (#199 `measureText`), text **metrics AND AA are parity-by-construction** — this is why atlas > SDF for v1.
- Rasterized at **device** resolution (fontPx includes PR·zoom) → crisp at DPR 2/3 (X6). The golden harness hands the renderer a **font-pinned** atlas factory so the atlas uses the same deterministic family the Canvas2D reference measured + drew with.

### #199 single-sourcing
- Lifted `fitLabelToWidth` + `BOX_MAX_WIDTH_RATIO` + `BOX_ELLIPSIS` into `render-geometry.ts` and upgraded `boxDimensions` to the #199 signature (returns the fitted label). `renderer.ts` now **consumes** the shared helpers (Canvas2D byte-identical) — Canvas2D, the WebGL box, and the text atlas clip identically.

### R7 byte-parity interleave
- Box rect AND text share the node-index **depth**; the box pass enables the depth buffer (LEQUAL) so a later box's rect occludes an earlier box's rect AND text — the same per-node interleave Canvas2D gets from `rect→fill→stroke→fillText`. Depth is cleared before / restored after the box pass (boxes draw last; P1/P2 untouched).

### Validation
- **`boxes-golden.test.ts`** — two layers like P1/P2:
  - **(A) geometry parity** (always runs, no GPU): N7/N9/N7c/N8/#199 long+short/N13b boxed-but-unlabelled/fixed-fill+border-alpha/R7-depth/one-text-per-box/determinism, all pinned against the Canvas2D math.
  - **(B) CDP pixel diff** (the **golden-webgl SwiftShader CI lane**): box-rect extent + node-colour border + dark-text presence + overlap occlusion, across **DPR 1/2/3**. New `box-overlap` + `box-over-circle` fixtures (R7). SwiftShader can't run locally, so block B is validated on this PR's CI golden-webgl job (iterating on real CI deltas like P1/P2).
- `@sentropic/graph` suite (**158 pass**) + `tsc --noEmit` green; **canvas2d golden unchanged** (renderer-api box tests + golden-harness determinism pass under local Chrome); studio canvas2d pin preserved.

### Deferred (out of scope)
P4 picking, P5 perf/LOD, P6 default flip.