### PR TITLE
chore(release): 0.17.2 — default Mistral OCR v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 This fork (`graphifyy@*`) is the TypeScript line. Pre-`0.7.x` entries below refer to the upstream Python Graphify line.
 
+## 0.17.2 (2026-06-24)
+
+- **Mistral OCR v4 default.** Bumps `mistral-ocr` to `^0.1.3` and pins Graphify's default PDF OCR model to `mistral-ocr-4-0` instead of the moving `mistral-ocr-latest` alias. `GRAPHIFY_PDF_OCR_MODEL` still overrides the model when needed.
+
 ## 0.17.1 (2026-06-23)
 
 - **SKILL — `graphify cite`.** The skill workflow (all 10 variants) now documents `graphify cite` in the Step-5 enrichment step (run before studio/wiki export for grounded `node.citations[]`; heuristic + no-key by default, `--mode heuristic|assistant|api`, anti-hallucination; symmetric to `describe`/`label`). Docs-only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sentropic/graphify",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sentropic/graphify",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.75",
@@ -24,7 +24,7 @@
         "graphology-metrics": "^2.1.0",
         "graphology-shortest-path": "^2.1.0",
         "graphology-types": "^0.24.7",
-        "mistral-ocr": "^0.1.0",
+        "mistral-ocr": "^0.1.3",
         "ollama-ai-provider": "^1.2.0",
         "web-tree-sitter": "^0.26.8",
         "yaml": "^2.8.3"
@@ -4997,9 +4997,9 @@
       }
     },
     "node_modules/mistral-ocr": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/mistral-ocr/-/mistral-ocr-0.1.1.tgz",
-      "integrity": "sha512-i4AhbKhQswJ92Kb+HLKBPcDOSBtBs1bnq9ImHWojpU2hU6aMZRDpCo6Sg4G8C2Rj0+eXyNFYEotw9qBo1XGBHg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mistral-ocr/-/mistral-ocr-0.1.3.tgz",
+      "integrity": "sha512-Ugo17A5Pb0HHUZ7LAA3fm1lpYDm5/G6F68zn2qe/5xt9iLeYVHOU8/SxeXKVTPyyWblBbFCn/4tmnODtd2FovQ==",
       "license": "MIT",
       "dependencies": {
         "@mistralai/mistralai": "^1.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/graphify",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "publishConfig": {
     "access": "public"
   },
@@ -95,7 +95,7 @@
     "graphology-metrics": "^2.1.0",
     "graphology-shortest-path": "^2.1.0",
     "graphology-types": "^0.24.7",
-    "mistral-ocr": "^0.1.0",
+    "mistral-ocr": "^0.1.3",
     "ollama-ai-provider": "^1.2.0",
     "web-tree-sitter": "^0.26.8",
     "yaml": "^2.8.3"

--- a/src/pdf-ocr.ts
+++ b/src/pdf-ocr.ts
@@ -4,7 +4,7 @@ import type { DetectionResult } from "./types.js";
 import { extractPdfTextLayer, pdfOcrSidecarStem, parsePdfOcrMode, preflightPdf, type PdfOcrMode, type PdfPreflightResult } from "./pdf-preflight.js";
 
 const MISTRAL_OCR_PACKAGE = "mistral-ocr";
-const DEFAULT_OCR_MODEL = "mistral-ocr-latest";
+const DEFAULT_OCR_MODEL = "mistral-ocr-4-0";
 const PDF_IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
 
 export interface PdfPreparationArtifact {

--- a/tests/pdf-preflight.test.ts
+++ b/tests/pdf-preflight.test.ts
@@ -170,7 +170,7 @@ describe("PDF preflight and OCR preparation", () => {
     expect(convertPdfMock).toHaveBeenCalledWith(pdfPath, expect.objectContaining({
       apiKey: "test-key",
       generateDocx: false,
-      model: "mistral-ocr-latest",
+      model: "mistral-ocr-4-0",
     }));
     expect(result.detection.files.paper).toEqual([]);
     expect(result.detection.files.document).toHaveLength(1);

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("release configuration", () => {
-  it("tracks the 0.17.1 release across package metadata and changelog", () => {
+  it("tracks the 0.17.2 release across package metadata and changelog", () => {
     const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as { name?: string; version?: string };
     const lock = JSON.parse(readFileSync(new URL("../package-lock.json", import.meta.url), "utf-8")) as {
       name?: string;
@@ -12,11 +12,11 @@ describe("release configuration", () => {
     const changelog = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf-8");
 
     expect(pkg.name).toBe("@sentropic/graphify");
-    expect(pkg.version).toBe("0.17.1");
+    expect(pkg.version).toBe("0.17.2");
     expect(lock.name).toBe("@sentropic/graphify");
-    expect(lock.version).toBe("0.17.1");
-    expect(lock.packages?.[""]?.version).toBe("0.17.1");
-    expect(changelog).toContain("## 0.17.1 (2026-06-23)");
+    expect(lock.version).toBe("0.17.2");
+    expect(lock.packages?.[""]?.version).toBe("0.17.2");
+    expect(changelog).toContain("## 0.17.2 (2026-06-24)");
   });
 
   it("runs the main TypeScript CI test matrix on Node 20, 22, and 24", () => {


### PR DESCRIPTION
## Summary
- bump graphify to 0.17.2
- upgrade mistral-ocr to ^0.1.3
- pin Graphify's default PDF OCR model to mistral-ocr-4-0 instead of the moving latest alias
- update release/changelog tests

## Tests
- npm run lint
- npx vitest run tests/pdf-preflight.test.ts tests/release-config.test.ts
- npm test (pre-rebase: 2110 passed, 16 skipped)