### PR TITLE
feat(llm): honor direct provider base URL envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Transcription uses the published `faster-whisper-ts` runtime (no Python). Defaul
 
 ### Optional provider variables
 
-For CI/headless text corpora, semantic extraction can be delegated to a direct provider with `graphify extract --backend anthropic|openai|gemini|mistral|cohere|ollama` (via the Vercel AI SDK). `OLLAMA_BASE_URL` overrides the local Ollama URL. Google Workspace export (`.gdoc`, `.gsheet`, `.gslides`) is enabled with `GRAPHIFY_GOOGLE_WORKSPACE=1` and the relevant `GOOGLE_OAUTH_*` credentials. API keys are read only from environment variables and are never written to config, `.graphify/`, reports, or logs.
+For CI/headless text corpora, semantic extraction can be delegated to a direct provider with `graphify extract --backend anthropic|openai|gemini|mistral|cohere|ollama` (via the Vercel AI SDK). Provider base URLs can be overridden with `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_BASE_URL` / `GOOGLE_GENERATIVE_AI_BASE_URL`, `MISTRAL_BASE_URL`, `COHERE_BASE_URL`, and `OLLAMA_BASE_URL` (local Ollama URL). Google Workspace export (`.gdoc`, `.gsheet`, `.gslides`) is enabled with `GRAPHIFY_GOOGLE_WORKSPACE=1` and the relevant `GOOGLE_OAUTH_*` credentials. API keys are read only from environment variables and are never written to config, `.graphify/`, reports, or logs.
 
 ### Privacy
 

--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -20,6 +20,27 @@ This document tracks the delta between this TypeScript port and upstream Python 
 - Active CRG stable review reference: `tirth8205/code-review-graph` tag `v2.3.3` at `52cf3bc63ee77c8b204fb809791a5f212e83a2de`
 - Current released line: `@sentropic/graphify@0.10.0` (rename, 2026-05-26); the `0.8.16` and `0.8.18` drift intakes below are both closed for the TypeScript line. F-0819-P1/P2 (PRs #87/#88, upstream `#1075`/`#1077`/`#1007`/`#1010`) and F-0831-P1-security (PR #93) are merged on `main` and unreleased; the next traceability pass formalizes the `v0.8.18..v0.8.31` window (`upstream/v8` fetched locally through `v0.8.31` at `7a588fb`) and reconciles those early ports
 
+## Active `0.8.49` Drift Intake
+
+Observed on 2026-06-25 after merging `@sentropic/graphify@0.17.2`:
+
+- Safi Python Graphify: `upstream/v8` at `9b583a01c3f1f9d3e6cb8f6c6b23d76e4b98afc9` (`fix(hooks): match the real file extension in the Read|Glob hook (#1463)`).
+- New remote tags seen in this fetch include `v0.8.46`, `v0.8.47`, and `v0.8.49`; local `upstream/v8` now spans the previously-audited `v0.8.31` checkpoint through `v0.8.49`.
+- Local TS baseline: `origin/main` at `53a2024` (`@sentropic/graphify@0.17.2`).
+- Early port in this pass: upstream `68dba89` (`feat(llm): honor *_BASE_URL for kimi/gemini/deepseek backends (#1458)`) maps to the TS direct-provider set by honoring `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_BASE_URL` / `GOOGLE_GENERATIVE_AI_BASE_URL`, `MISTRAL_BASE_URL`, and `COHERE_BASE_URL` in addition to the pre-existing `OLLAMA_BASE_URL`. Upstream-only Kimi/DeepSeek providers remain `n/a` until the TS `DirectLlmProvider` union adds them.
+
+| Source window | Representative commits | Initial TS bucket | Notes / next action |
+| --- | --- | --- | --- |
+| LLM/provider endpoints | `68dba89` | `ported (early)` | Direct provider base-URL env support added in TS; README and `tests/llm-execution.test.ts` cover Gemini alias precedence. |
+| Export/wiki filename safety | `5d63aad`, `7278e24`, `30cc4c0`, `739230e` | `must-audit` | Compare against Studio/wiki filename slugging and canvas/card layout. Likely small robustness ports. |
+| Extractor/language surface | `7dc5d96`, `dbce453`, `8e6ba9d`, `d12eb28`, `895a60f`, `f117aac`, `dbce453`, `b3ab221` | `feature / must-audit` | WPF/XAML, CUDA, package manifests, Java records, PowerShell manifests, oversized-doc slicing, extractor split. Port incrementally only where TS extractor lacks parity and tests are cheap. |
+| Hooks/skills/install/work-memory | `9b583a0`, `1e3270a`, `6d9617a`, `89dd00f`, `c06db05`, `ad6cb75`, `e7ba16b`, `1f42a2d`, `382b669`, `30fe8ba` | `mixed` | Separate skill text/doc fixes from Python work-memory features. Do not adopt Python-only hook machinery without TS install contract review. |
+| Query/MCP/serve | `53edd27`, `f9ded63` | `must-audit` | Trigram prefilter and community-name MCP output may map to `src/serve.ts`/query surfaces. |
+| Update/build correctness | `533859d`, `897483f`, `fd463de`, `8437ef4`, `b2e01f37`, `9a7dbfb`, `d885833`, `2100b3d` | `must-audit` | Reconcile against TS build-merge/update tests; many prior rows may already be covered. |
+| Security/deps | `ec6b397`, `9e8fa2a`, `d8fa70e` | `partial / n-a` | Starlette is Python-only; web/export XSS and vulnerable npm deps require separate TS dependency/security audit. |
+| Reflection/work-memory | `1a14e94`, `d193b62`, `6d9617a`, `89dd00f` | `defer / product decision` | Python `graphify reflect` and LESSONS.md workflow are not in the current TS product contract. |
+| Release/changelog-only | `29fd98f`, `f87011b`, `6d3c959`, `bc362cb`, `e4ff54f` | `release-only` | Do not mirror Python package version bumps into the TS line. |
+
 ## Source Lock Notes
 
 - `git ls-remote` is the authority for Safi Python tags while local tag clobber risk exists.

--- a/src/llm-execution.ts
+++ b/src/llm-execution.ts
@@ -216,6 +216,31 @@ function ensureProviderCredential(provider: DirectLlmProvider): void {
   }
 }
 
+export function directProviderBaseUrlEnv(provider: DirectLlmProvider): string[] {
+  switch (provider) {
+    case "anthropic":
+      return ["ANTHROPIC_BASE_URL"];
+    case "openai":
+      return ["OPENAI_BASE_URL"];
+    case "gemini":
+      return ["GEMINI_BASE_URL", "GOOGLE_GENERATIVE_AI_BASE_URL"];
+    case "mistral":
+      return ["MISTRAL_BASE_URL"];
+    case "cohere":
+      return ["COHERE_BASE_URL"];
+    case "ollama":
+      return ["OLLAMA_BASE_URL"];
+  }
+}
+
+function resolveProviderBaseUrl(provider: DirectLlmProvider): string | undefined {
+  for (const envName of directProviderBaseUrlEnv(provider)) {
+    const value = process.env[envName]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
 const MAX_DIRECT_LLM_JSON_BYTES = 10 * 1024 * 1024;
 
 export function parseJsonFromLlmText(text: string | null | undefined): unknown {
@@ -251,24 +276,29 @@ async function resolveDirectModel(provider: DirectLlmProvider, model: string): P
   ensureProviderCredential(provider);
   switch (provider) {
     case "anthropic": {
-      const { anthropic } = await import("@ai-sdk/anthropic");
-      return anthropic(model);
+      const { anthropic, createAnthropic } = await import("@ai-sdk/anthropic");
+      const baseURL = resolveProviderBaseUrl(provider);
+      return baseURL ? createAnthropic({ baseURL })(model) : anthropic(model);
     }
     case "openai": {
-      const { openai } = await import("@ai-sdk/openai");
-      return openai(model);
+      const { openai, createOpenAI } = await import("@ai-sdk/openai");
+      const baseURL = resolveProviderBaseUrl(provider);
+      return baseURL ? createOpenAI({ baseURL })(model) : openai(model);
     }
     case "gemini": {
-      const { google } = await import("@ai-sdk/google");
-      return google(model);
+      const { google, createGoogleGenerativeAI } = await import("@ai-sdk/google");
+      const baseURL = resolveProviderBaseUrl(provider);
+      return baseURL ? createGoogleGenerativeAI({ baseURL })(model) : google(model);
     }
     case "mistral": {
-      const { mistral } = await import("@ai-sdk/mistral");
-      return mistral(model);
+      const { mistral, createMistral } = await import("@ai-sdk/mistral");
+      const baseURL = resolveProviderBaseUrl(provider);
+      return baseURL ? createMistral({ baseURL })(model) : mistral(model);
     }
     case "cohere": {
-      const { cohere } = await import("@ai-sdk/cohere");
-      return cohere(model);
+      const { cohere, createCohere } = await import("@ai-sdk/cohere");
+      const baseURL = resolveProviderBaseUrl(provider);
+      return baseURL ? createCohere({ baseURL })(model) : cohere(model);
     }
     case "ollama": {
       const { createOllama } = await import("ollama-ai-provider");

--- a/tests/llm-execution.test.ts
+++ b/tests/llm-execution.test.ts
@@ -9,6 +9,7 @@ import {
   createAssistantTextJsonClient,
   createAssistantVisionJsonClient,
   defaultDirectLlmModel,
+  directProviderBaseUrlEnv,
   directProviderCredentialEnv,
   parseJsonFromLlmText,
   preflightLlmExecution,
@@ -17,17 +18,22 @@ import {
 
 const generateTextMock = vi.fn();
 const openaiMock = vi.fn((model: string) => ({ provider: "openai", model }));
+const createOpenAIMock = vi.fn((settings: unknown) => vi.fn((model: string) => ({ provider: "openai", model, settings })));
 const anthropicMock = vi.fn((model: string) => ({ provider: "anthropic", model }));
+const createAnthropicMock = vi.fn((settings: unknown) => vi.fn((model: string) => ({ provider: "anthropic", model, settings })));
 const googleMock = vi.fn((model: string) => ({ provider: "google", model }));
+const createGoogleGenerativeAIMock = vi.fn((settings: unknown) => vi.fn((model: string) => ({ provider: "google", model, settings })));
 const mistralMock = vi.fn((model: string) => ({ provider: "mistral", model }));
+const createMistralMock = vi.fn((settings: unknown) => vi.fn((model: string) => ({ provider: "mistral", model, settings })));
 const cohereMock = vi.fn((model: string) => ({ provider: "cohere", model }));
+const createCohereMock = vi.fn((settings: unknown) => vi.fn((model: string) => ({ provider: "cohere", model, settings })));
 
 vi.mock("ai", () => ({ generateText: generateTextMock }));
-vi.mock("@ai-sdk/openai", () => ({ openai: openaiMock }));
-vi.mock("@ai-sdk/anthropic", () => ({ anthropic: anthropicMock }));
-vi.mock("@ai-sdk/google", () => ({ google: googleMock }));
-vi.mock("@ai-sdk/mistral", () => ({ mistral: mistralMock }));
-vi.mock("@ai-sdk/cohere", () => ({ cohere: cohereMock }));
+vi.mock("@ai-sdk/openai", () => ({ openai: openaiMock, createOpenAI: createOpenAIMock }));
+vi.mock("@ai-sdk/anthropic", () => ({ anthropic: anthropicMock, createAnthropic: createAnthropicMock }));
+vi.mock("@ai-sdk/google", () => ({ google: googleMock, createGoogleGenerativeAI: createGoogleGenerativeAIMock }));
+vi.mock("@ai-sdk/mistral", () => ({ mistral: mistralMock, createMistral: createMistralMock }));
+vi.mock("@ai-sdk/cohere", () => ({ cohere: cohereMock, createCohere: createCohereMock }));
 
 const cleanupDirs: string[] = [];
 
@@ -51,6 +57,13 @@ beforeEach(() => {
   delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
   delete process.env.MISTRAL_API_KEY;
   delete process.env.COHERE_API_KEY;
+  delete process.env.OPENAI_BASE_URL;
+  delete process.env.ANTHROPIC_BASE_URL;
+  delete process.env.GEMINI_BASE_URL;
+  delete process.env.GOOGLE_GENERATIVE_AI_BASE_URL;
+  delete process.env.MISTRAL_BASE_URL;
+  delete process.env.COHERE_BASE_URL;
+  delete process.env.OLLAMA_BASE_URL;
 });
 
 describe("LLM execution ports", () => {
@@ -239,6 +252,32 @@ describe("LLM execution ports", () => {
       hyperedges: [],
     });
     expect(JSON.stringify(result.audit)).not.toContain("test-key");
+  });
+
+  it("honors provider-specific base URL environment variables for direct mode", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "{\"nodes\":[],\"edges\":[],\"hyperedges\":[]}",
+      finishReason: "stop",
+      usage: {},
+    });
+    process.env.GEMINI_API_KEY = "test-key";
+    process.env.GEMINI_BASE_URL = "https://gemini-proxy.example.test/v1beta";
+    const client = createDirectTextJsonClient({ provider: "gemini", model: "gemini-test" });
+
+    await client.generateJson({ schema: "graphify_extraction_v1", prompt: "Return JSON only." });
+
+    expect(directProviderBaseUrlEnv("gemini")).toEqual(["GEMINI_BASE_URL", "GOOGLE_GENERATIVE_AI_BASE_URL"]);
+    expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith({
+      baseURL: "https://gemini-proxy.example.test/v1beta",
+    });
+    expect(googleMock).not.toHaveBeenCalled();
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      model: {
+        provider: "google",
+        model: "gemini-test",
+        settings: { baseURL: "https://gemini-proxy.example.test/v1beta" },
+      },
+    }));
   });
 
   it("rejects invalid direct JSON responses", async () => {

--- a/tests/llm-mesh-max-output-tokens-env.test.ts
+++ b/tests/llm-mesh-max-output-tokens-env.test.ts
@@ -72,6 +72,7 @@ describe("Track F F-0816-P2 (row 14) — GRAPHIFY_MAX_OUTPUT_TOKENS env", () => 
     // provider too so the test does not require provider credentials.
     vi.doMock("@ai-sdk/openai", () => ({
       openai: () => ({ provider: "openai" }),
+      createOpenAI: () => () => ({ provider: "openai" }),
     }));
 
     process.env.GRAPHIFY_MAX_OUTPUT_TOKENS = "12345";


### PR DESCRIPTION
## Summary
- port the TS-relevant part of upstream safishamsi/graphify#1458 (): direct providers now honor provider-specific  env vars
- document the supported envs in README
- add the 2026-06-25  drift intake through  to 
- keep Kimi/DeepSeek marked n/a until the TS  union grows those providers

## Tests
- npm run lint
- npx vitest run tests/llm-execution.test.ts tests/llm-mesh-max-output-tokens-env.test.ts
- npm test (2111 passed, 16 skipped)