### PR TITLE
feat(ontology): WP4 ACLP-AM hierarchy lifecycle — overlay status + UAT evidence

### DIFF
--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/hierarchies.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/hierarchies.json
@@ -1,0 +1,92 @@
+[
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM01",
+    "child_id": "AM0101",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM01",
+    "child_id": "AM0104",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM03",
+    "child_id": "AM0301",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM06",
+    "child_id": "AM0601",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM0104",
+    "child_id": "AM0104.01",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM0104.01",
+    "child_id": "AM0104.01.10",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM0104.01.10",
+    "child_id": "AM0104.01.10.02",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "AM08",
+    "child_id": "AM0801",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  },
+  {
+    "hierarchy_id": "am_process_tree",
+    "parent_id": "MISSING_PARENT",
+    "child_id": "ORPHAN01",
+    "level": 0,
+    "type": "parent_process_of",
+    "source": "profile",
+    "status": "reference",
+    "confidence": 1
+  }
+]

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/hierarchy-index.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/hierarchy-index.json
@@ -1,0 +1,52 @@
+{
+  "schema": "graphify_ontology_hierarchies_v1",
+  "root_ids": [
+    "AM01",
+    "AM03",
+    "AM06",
+    "AM08",
+    "MISSING_PARENT"
+  ],
+  "depth": 4,
+  "ancestor_paths": {
+    "AM01": [],
+    "AM0101": [
+      "AM01"
+    ],
+    "AM0104": [
+      "AM01"
+    ],
+    "AM0104.01": [
+      "AM01",
+      "AM0104"
+    ],
+    "AM0104.01.10": [
+      "AM01",
+      "AM0104",
+      "AM0104.01"
+    ],
+    "AM0104.01.10.02": [
+      "AM01",
+      "AM0104",
+      "AM0104.01",
+      "AM0104.01.10"
+    ],
+    "AM03": [],
+    "AM0301": [
+      "AM03"
+    ],
+    "AM06": [],
+    "AM0601": [
+      "AM06"
+    ],
+    "AM08": [],
+    "AM0801": [
+      "AM08"
+    ],
+    "MISSING_PARENT": [],
+    "ORPHAN01": [
+      "MISSING_PARENT"
+    ]
+  },
+  "cycles": []
+}

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/reconciliation-candidates.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/reconciliation-candidates.json
@@ -1,0 +1,30 @@
+{
+  "schema": "graphify_ontology_reconciliation_candidates_response_v1",
+  "generated_at": "2026-06-26T00:00:00.000Z",
+  "graph_hash": "uat-graph",
+  "profile_hash": "uat-profile",
+  "stale": false,
+  "total": 1,
+  "limit": 1,
+  "offset": 0,
+  "items": [
+    {
+      "id": "uat-candidate",
+      "kind": "entity_match",
+      "status": "candidate",
+      "score": 0.9,
+      "candidate_id": "registry_processes_AM0104_01",
+      "canonical_id": "registry_processes_AM0104",
+      "shared_terms": [
+        "process"
+      ],
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0104.01"
+      ],
+      "reasons": [
+        "representative ACLP-AM hierarchy UAT fixture"
+      ],
+      "proposed_patch_operation": "accept_match"
+    }
+  ]
+}

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/reconciliation-lifecycle-output.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/reconciliation-lifecycle-output.json
@@ -1,0 +1,260 @@
+{
+  "_note": "Lifecycle states on hierarchy edges, routed by the REAL buildSceneHierarchySidecar. Stable IDs = raw ACLP registry ids (verbatim, D2). Reference/validated -> authoritative tree lane; candidate/proposed/inferred/guessed/rejected/superseded -> overlay lane.",
+  "schema": "graphify_scene_hierarchies_v1",
+  "graph_hash": "uat-lifecycle",
+  "input_arcs": [
+    {
+      "parent_id": "AM01",
+      "child_id": "AM0104",
+      "status": "reference",
+      "confidence": 1,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM0104",
+      "child_id": "AM0104.01",
+      "status": "validated",
+      "confidence": 1,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM0104.01",
+      "child_id": "AM0104.01.10",
+      "status": "candidate",
+      "confidence": 0.9,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM0104.01.10",
+      "child_id": "AM0104.01.10.02",
+      "status": "proposed",
+      "confidence": 0.75,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM03",
+      "child_id": "AM0301",
+      "status": "inferred",
+      "confidence": 0.6,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM06",
+      "child_id": "AM0601",
+      "status": "guessed",
+      "confidence": 0.4,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM08",
+      "child_id": "AM0801",
+      "status": "rejected",
+      "confidence": 0.2,
+      "source": "profile"
+    },
+    {
+      "parent_id": "AM01",
+      "child_id": "AM0101",
+      "status": "superseded",
+      "confidence": 0.5,
+      "source": "profile"
+    }
+  ],
+  "lifecycle_states_present": [
+    "candidate",
+    "guessed",
+    "inferred",
+    "proposed",
+    "reference",
+    "rejected",
+    "superseded",
+    "validated"
+  ],
+  "tree_lane_edges": [
+    {
+      "stable_id": "AM01",
+      "parent_id": null,
+      "level": 0,
+      "status": "reference",
+      "lane": "tree"
+    },
+    {
+      "stable_id": "AM0104",
+      "parent_id": "AM01",
+      "level": 1,
+      "status": "reference",
+      "lane": "tree"
+    },
+    {
+      "stable_id": "AM0104.01",
+      "parent_id": "AM0104",
+      "level": 2,
+      "status": "validated",
+      "lane": "tree"
+    }
+  ],
+  "overlay_lane_edges": [
+    {
+      "stable_parent_id": "AM01",
+      "stable_child_id": "AM0101",
+      "status": "superseded",
+      "confidence": 0.5,
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0101"
+      ],
+      "lane": "overlay"
+    },
+    {
+      "stable_parent_id": "AM0104.01",
+      "stable_child_id": "AM0104.01.10",
+      "status": "candidate",
+      "confidence": 0.9,
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0104.01.10"
+      ],
+      "lane": "overlay"
+    },
+    {
+      "stable_parent_id": "AM0104.01.10",
+      "stable_child_id": "AM0104.01.10.02",
+      "status": "proposed",
+      "confidence": 0.75,
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0104.01.10.02"
+      ],
+      "lane": "overlay"
+    },
+    {
+      "stable_parent_id": "AM03",
+      "stable_child_id": "AM0301",
+      "status": "inferred",
+      "confidence": 0.6,
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0301"
+      ],
+      "lane": "overlay"
+    },
+    {
+      "stable_parent_id": "AM06",
+      "stable_child_id": "AM0601",
+      "status": "guessed",
+      "confidence": 0.4,
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0601"
+      ],
+      "lane": "overlay"
+    },
+    {
+      "stable_parent_id": "AM08",
+      "stable_child_id": "AM0801",
+      "status": "rejected",
+      "confidence": 0.2,
+      "evidence_refs": [
+        "aclp-am/forest.csv#AM0801"
+      ],
+      "lane": "overlay"
+    }
+  ],
+  "sidecar": {
+    "schema": "graphify_scene_hierarchies_v1",
+    "generated_at": "2026-06-27T14:45:57.028Z",
+    "graph_hash": "uat-lifecycle",
+    "hierarchies": {
+      "am_process_lifecycle": {
+        "relation_type": "parent_process_of",
+        "kind": "tree",
+        "root_ids": [
+          "AM01"
+        ],
+        "max_depth": 2,
+        "nodes_by_id": {
+          "AM01": {
+            "parent_id": null,
+            "child_ids": [
+              "AM0104"
+            ],
+            "level": 0,
+            "status": "reference",
+            "registry_record_id": "AM01"
+          },
+          "AM0104": {
+            "parent_id": "AM01",
+            "child_ids": [
+              "AM0104.01"
+            ],
+            "level": 1,
+            "status": "reference",
+            "registry_record_id": "AM0104"
+          },
+          "AM0104.01": {
+            "parent_id": "AM0104",
+            "child_ids": [],
+            "level": 2,
+            "status": "validated",
+            "registry_record_id": "AM0104.01"
+          }
+        },
+        "overlay_arcs": [
+          {
+            "parent_id": "AM01",
+            "child_id": "AM0101",
+            "status": "superseded",
+            "confidence": 0.5,
+            "evidence_refs": [
+              "aclp-am/forest.csv#AM0101"
+            ]
+          },
+          {
+            "parent_id": "AM0104.01",
+            "child_id": "AM0104.01.10",
+            "status": "candidate",
+            "confidence": 0.9,
+            "evidence_refs": [
+              "aclp-am/forest.csv#AM0104.01.10"
+            ]
+          },
+          {
+            "parent_id": "AM0104.01.10",
+            "child_id": "AM0104.01.10.02",
+            "status": "proposed",
+            "confidence": 0.75,
+            "evidence_refs": [
+              "aclp-am/forest.csv#AM0104.01.10.02"
+            ]
+          },
+          {
+            "parent_id": "AM03",
+            "child_id": "AM0301",
+            "status": "inferred",
+            "confidence": 0.6,
+            "evidence_refs": [
+              "aclp-am/forest.csv#AM0301"
+            ]
+          },
+          {
+            "parent_id": "AM06",
+            "child_id": "AM0601",
+            "status": "guessed",
+            "confidence": 0.4,
+            "evidence_refs": [
+              "aclp-am/forest.csv#AM0601"
+            ]
+          },
+          {
+            "parent_id": "AM08",
+            "child_id": "AM0801",
+            "status": "rejected",
+            "confidence": 0.2,
+            "evidence_refs": [
+              "aclp-am/forest.csv#AM0801"
+            ]
+          }
+        ],
+        "orphan_ids": [],
+        "cycles": [],
+        "conflicts": [],
+        "dangling_arc_count": 0
+      }
+    }
+  }
+}

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/review-double-review.md
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/review-double-review.md
@@ -1,0 +1,113 @@
+# WP4 ACLP-AM — UAT evidence / double-review record
+
+- HEAD: `8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec`
+- Branch: `feat/aclp-am-wp4-uat-evidence`
+- Run date (UTC): 2026-06-27
+- Runner: `vitest run` (vitest v4.1.6, node v22.22.1)
+
+This is a factual record of what was actually executed and observed. Nothing here
+is asserted that was not run. The transient emit harness used to persist the
+artifacts (`tests/zz-wp4-emit-artifacts.test.ts`) drove the SAME source modules
+the suite asserts against and was deleted after the run; no source file was modified.
+
+## 1. Tests executed (full output: `test-run.txt`)
+
+Command:
+```
+npx vitest run --reporter=verbose \
+  tests/aclp-am-wp4-uat.test.ts tests/ontology-aclp-am.test.ts \
+  tests/ontology-hierarchies.test.ts tests/scene-hierarchies.test.ts \
+  tests/scene-hierarchies-emitter.test.ts tests/workspace-manifest.test.ts
+```
+
+Observed result: **Test Files 6 passed (6) — Tests 76 passed (76)**, exit 0.
+
+| Test file | tests passed |
+| --- | --- |
+| tests/aclp-am-wp4-uat.test.ts | 2 |
+| tests/ontology-aclp-am.test.ts | 17 |
+| tests/ontology-hierarchies.test.ts | 22 |
+| tests/scene-hierarchies.test.ts | 13 |
+| tests/scene-hierarchies-emitter.test.ts | 7 |
+| tests/workspace-manifest.test.ts | 15 |
+| **total** | **76** |
+
+The two `aclp-am-wp4-uat` cases are the representative end-to-end UAT: (a) "emits
+ontology + workspace hierarchy artifacts and renders workspace/reconciliation/
+evidence routes", (b) "keeps Radar-compatible cited-source refs on Signal and
+DesignationEvent nodes". Both passed.
+
+## 2. Artifacts emitted (real code path)
+
+All artifacts were produced by the production modules — `compileHierarchies` /
+`buildHierarchyIndex` (`src/ontology-hierarchies.ts`), `buildStaticStudio`
+(`src/studio-export.ts`) which internally calls `emitSceneHierarchies`
+(`src/scene-hierarchies-emitter.ts` → pure builder `src/scene-hierarchies.ts`) and
+`emitWorkspaceManifest` (`src/workspace-manifest-emitter.ts`), fed from the
+checked-in fixture `tests/fixtures/aclp-am/` (profile `graphify/ontology-profile.yaml`,
+registry `references/forest.csv`). No artifact was hand-edited.
+
+- `hierarchies.json`, `hierarchy-index.json` — compiled ontology hierarchy + index.
+- `scene-hierarchies.json` — `graphify_scene_hierarchies_v1` studio sidecar.
+- `workspace-manifest.json` — `graphify_workspace_manifest_v1` bundle descriptor.
+- `reconciliation-candidates.json` — candidate set as the studio reads it.
+- `scene-and-sidecars.json` — consolidated bundle (scene + sidecars).
+- `reconciliation-lifecycle-output.json` — lifecycle states on hierarchy edges.
+
+## 3. Verifications actually performed against the emitted bytes
+
+- **Ontology output fidelity.** The emitted `hierarchies.json` (9 arcs) and
+  `hierarchy-index.json` are **byte-identical** to the checked-in expected fixtures
+  `tests/fixtures/aclp-am/expected/forest-hierarchies.json` and
+  `expected/forest-hierarchy-index.json` (compared via `JSON.stringify` equality →
+  `true`). Index: roots `["AM01","AM03","AM06","AM08","MISSING_PARENT"]`, depth 4,
+  cycles `[]`.
+
+- **Hierarchy exported into studio scene + sidecars.** `buildStaticStudio` wrote
+  `scene-hierarchies.json` next to `scene.json`; `result.sceneHierarchiesPath`
+  pointed at it and `result.reconciliationCount === 1` (asserted green in the UAT).
+  The sidecar's deep branch is intact:
+  `nodes_by_id["AM0104.01.10.02"] = { parent_id: "AM0104.01.10", level: 4,
+  registry_record_id: "AM0104.01.10.02", status: "reference" }`.
+
+- **Manifest discoverability.** `workspace-manifest.json` lists `present_count: 5`
+  with `scene-hierarchies` present, `schema: graphify_scene_hierarchies_v1`,
+  `role: hierarchy`, plus `scene`, `graph`, `entities`,
+  `reconciliation-candidates` (each with sha256 + size_bytes).
+
+- **Stable-ID preservation across reconciliation (D2).** Scene nodes use slugged
+  native ids but carry the **raw** registry id verbatim as `registry_record_id`:
+  `registry_processes_AM0104_01 → AM0104.01`. The sidecar keys are those raw ids
+  **verbatim** — `AM01, AM0104, AM0104.01, AM0104.01.10, AM0104.01.10.02` (dots
+  preserved, no `.`/`-`→`_` transform). The reconciliation candidate
+  (`candidate_id: registry_processes_AM0104_01`, `canonical_id:
+  registry_processes_AM0104`, `status: candidate`) joins back to the same raw ids,
+  i.e. the ids survive both sides of the join unchanged.
+
+- **Reference vs proposed / lifecycle layers distinct.** `reconciliation-lifecycle-output.json`
+  was produced by feeding `buildSceneHierarchySidecar` (the real lane-splitting
+  builder) a set of arcs over the real ACLP stable ids carrying every lifecycle
+  status. The builder routed them deterministically:
+  - tree (authoritative) lane — `reference` (`AM01→AM0104`) and `validated`
+    (`AM0104→AM0104.01`);
+  - overlay lane — `candidate`, `proposed`, `inferred`, `guessed`, `rejected`,
+    `superseded` (6 edges). `lifecycle_states_present` =
+    `["candidate","guessed","inferred","proposed","reference","rejected","superseded","validated"]`.
+  The reference arcs are the profile-compiled fixture arcs verbatim; the
+  non-reference arcs are clones of real fixture (parent,child) pairs with status
+  overridden, used only to exercise the lanes the v1 profile pipeline does not
+  itself emit (it only emits `status:"reference"`). The lane routing / levels /
+  conflicts are computed by the builder, not hand-written.
+
+## 4. Honest limitations
+
+- The non-`reference` lifecycle arcs in `reconciliation-lifecycle-output.json` are
+  synthetic annotations layered on real stable ids: v1's profile pipeline emits
+  only `reference` arcs, so candidate/validated/etc. cannot arise from the fixture
+  registry alone. What is demonstrated end-to-end is that the production builder
+  classifies each declared status into the correct lane while preserving ids — not
+  that the v1 pipeline generates non-reference statuses on its own.
+- The studio route rendering (workspace/reconciliation/evidence tabs) is asserted
+  inside the passing UAT test via `handleOntologyStudioRequest` returning HTTP 200
+  with the three `data-tab` markers; it is not separately re-captured as an HTML
+  artifact here.

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/reviewer-note.md
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/reviewer-note.md
@@ -1,0 +1,72 @@
+# WP4 ACLP-AM — reviewer note (for claude:aclp-am)
+
+You can accept or reject WP4 from this folder alone, without owning the graphify
+implementation. Everything below was actually run on HEAD
+`8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec` (branch `feat/aclp-am-wp4-uat-evidence`);
+the full test log is `test-run.txt`.
+
+**Bottom line:** 76/76 tests passed across 6 files (incl. the 2-case representative
+ACLP-AM UAT). The hierarchy artifacts are byte-identical to the checked-in expected
+fixtures, are exported into the studio scene + sidecars, are discoverable via the
+workspace manifest, preserve raw stable IDs verbatim across reconciliation, and the
+reference vs proposed/candidate/validated/rejected/superseded lifecycle layers are
+kept distinct by the production builder.
+
+## Artifacts in this folder
+
+All paths are under
+`artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/`.
+
+| File | What it is |
+| --- | --- |
+| `test-run.txt` | Full verbose `vitest run` output — 6 files, 76 tests, all passed. |
+| `hierarchies.json` | Compiled ACLP hierarchy arcs (reference layer). Byte-identical to the `forest-hierarchies.json` expected fixture. |
+| `hierarchy-index.json` | Roots/levels/cycles index. Byte-identical to the `forest-hierarchy-index.json` expected fixture. |
+| `scene-hierarchies.json` | `graphify_scene_hierarchies_v1` studio sidecar (the hierarchy as the workspace consumes it). |
+| `workspace-manifest.json` | `graphify_workspace_manifest_v1` bundle descriptor — lists the sidecar as a discoverable, present artifact. |
+| `reconciliation-candidates.json` | Candidate set as the studio reads it (1 entity_match candidate, status `candidate`). |
+| `scene-and-sidecars.json` | Consolidated bundle: studio scene + all sidecars, showing the native-id ↔ raw-id join. |
+| `reconciliation-lifecycle-output.json` | Lifecycle states on hierarchy edges with stable IDs, routed by the real sidecar builder. |
+| `review-double-review.md` | Factual record of exactly what was run/observed (read this for the detail). |
+
+## Acceptance-criterion mapping
+
+- **01KTKVFZ1CJV4899JW5XN4MGPK** — reference vs proposed ontology, hierarchy edges,
+  lifecycle statuses, double review before merge.
+  → `hierarchies.json` (reference arcs, `status:"reference"`, `source:"profile"`) +
+  `reconciliation-lifecycle-output.json` (`lifecycle_states_present` covers
+  reference/validated vs candidate/proposed/inferred/guessed/rejected/superseded,
+  split into authoritative tree vs overlay lanes) + this `review-double-review.md`
+  as the pre-merge review record.
+
+- **01KTPW5080V863FAA5F71D9HQD** — hierarchy exported in studio scene + sidecars,
+  survives reconciliation, stable IDs.
+  → `scene-and-sidecars.json` + `scene-hierarchies.json` + `workspace-manifest.json`.
+  The deep branch `AM0104.01.10.02` (level 4) is intact; raw ids are preserved
+  verbatim (`AM0104.01`, dots kept) and joined from scene nodes via
+  `registry_record_id`; the manifest marks the sidecar `present: true`,
+  `role: hierarchy`.
+
+- **01KTPW54QN10KFA0DJ2TSMZRSE** — inferred/proposed/candidate/validated/reference
+  layers distinct + exposed to patch/reconciliation APIs.
+  → `reconciliation-lifecycle-output.json` shows all eight statuses routed by the
+  production `buildSceneHierarchySidecar`: reference/validated → tree lane;
+  inferred/proposed/candidate/guessed/rejected/superseded → overlay lane (with
+  confidence + evidence_refs). `reconciliation-candidates.json` shows the candidate
+  surfaced to the reconciliation API with `proposed_patch_operation: accept_match`.
+
+- **01KTPW5CEJ3EVP4HYHB8AT4JJB** — ACLP-AM representative fixture/contract reviewable
+  without implementation ownership.
+  → This whole folder. The fixture (`tests/fixtures/aclp-am/`) is a self-contained
+  ACLP asset-management process forest; every artifact here is regenerated from it
+  by the real pipeline and is plain inspectable JSON. You need no graphify internals
+  to read it.
+
+## Caveat to weigh before sign-off
+
+The non-`reference` lifecycle edges in `reconciliation-lifecycle-output.json` are
+synthetic annotations on real stable ids: graphify v1's profile pipeline emits only
+`reference` arcs, so this artifact proves the **builder correctly classifies and
+id-preserves** each lifecycle status — not that v1 auto-generates non-reference
+statuses. If your acceptance for 01KTPW54QN10KFA0DJ2TSMZRSE requires the latter,
+flag it; otherwise the contract (layers distinct + exposed) is demonstrated.

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/scene-and-sidecars.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/scene-and-sidecars.json
@@ -1,0 +1,248 @@
+{
+  "_note": "Consolidated Workspace Consumption Bundle: studio scene + autonomous sidecars, all emitted by buildStaticStudio (real code path).",
+  "scene": {
+    "nodes": [
+      {
+        "id": "registry_processes_AM01",
+        "label": "Organiser",
+        "weight": 7.5625,
+        "shape": "square",
+        "group": "Process",
+        "type": "Process",
+        "status": "validated",
+        "registry_record_id": "AM01",
+        "x": 710.8903345781563,
+        "y": 680.6364624439357,
+        "fx": 710.8903345781563,
+        "fy": 680.6364624439357
+      },
+      {
+        "id": "registry_processes_AM0104",
+        "label": "Tracer",
+        "weight": 23.04,
+        "shape": "square",
+        "group": "Process",
+        "type": "Process",
+        "status": "validated",
+        "registry_record_id": "AM0104",
+        "x": 411.01169697724515,
+        "y": 614.9315439302221,
+        "fx": 411.01169697724515,
+        "fy": 614.9315439302221
+      },
+      {
+        "id": "registry_processes_AM0104_01",
+        "label": "Qualifier",
+        "weight": 7.5625,
+        "shape": "square",
+        "group": "Process",
+        "type": "Process",
+        "status": "candidate",
+        "registry_record_id": "AM0104.01",
+        "x": 112.46526224102801,
+        "y": 537.7185943922799,
+        "fx": 112.46526224102801,
+        "fy": 537.7185943922799
+      },
+      {
+        "id": "registry_processes_AM0104_01_10",
+        "label": "Contrôler",
+        "weight": 1,
+        "shape": "square",
+        "group": "Process",
+        "type": "Process",
+        "status": "candidate",
+        "registry_record_id": "AM0104.01.10",
+        "x": 394.7339165503416,
+        "y": -19.49014572738563,
+        "fx": 394.7339165503416,
+        "fy": -19.49014572738563
+      },
+      {
+        "id": "registry_processes_AM0104_01_10_02",
+        "label": "Valider",
+        "weight": 1,
+        "shape": "square",
+        "group": "Process",
+        "type": "Process",
+        "status": "candidate",
+        "registry_record_id": "AM0104.01.10.02",
+        "x": 878.9770320916073,
+        "y": 163.64101237713496,
+        "fx": 878.9770320916073,
+        "fy": 163.64101237713496
+      }
+    ],
+    "edges": [
+      {
+        "source": "registry_processes_AM01",
+        "target": "registry_processes_AM0104",
+        "relation": "parent_process_of",
+        "dash": "solid"
+      },
+      {
+        "source": "registry_processes_AM0104",
+        "target": "registry_processes_AM0104_01",
+        "relation": "parent_process_of",
+        "dash": "solid"
+      }
+    ],
+    "communityColors": {},
+    "stats": {
+      "nodeCount": 5,
+      "edgeCount": 2,
+      "weakEdgeCount": 0,
+      "communityCount": 0
+    }
+  },
+  "scene_hierarchies": {
+    "schema": "graphify_scene_hierarchies_v1",
+    "generated_at": "2026-06-27T14:45:57.027Z",
+    "graph_hash": null,
+    "hierarchies": {
+      "am_process_tree": {
+        "relation_type": "parent_process_of",
+        "kind": "tree",
+        "root_ids": [
+          "AM01"
+        ],
+        "max_depth": 4,
+        "nodes_by_id": {
+          "AM01": {
+            "parent_id": null,
+            "child_ids": [
+              "AM0104"
+            ],
+            "level": 0,
+            "status": "reference",
+            "registry_record_id": "AM01"
+          },
+          "AM0104": {
+            "parent_id": "AM01",
+            "child_ids": [
+              "AM0104.01"
+            ],
+            "level": 1,
+            "status": "reference",
+            "registry_record_id": "AM0104"
+          },
+          "AM0104.01": {
+            "parent_id": "AM0104",
+            "child_ids": [
+              "AM0104.01.10"
+            ],
+            "level": 2,
+            "status": "reference",
+            "registry_record_id": "AM0104.01"
+          },
+          "AM0104.01.10": {
+            "parent_id": "AM0104.01",
+            "child_ids": [
+              "AM0104.01.10.02"
+            ],
+            "level": 3,
+            "status": "reference",
+            "registry_record_id": "AM0104.01.10"
+          },
+          "AM0104.01.10.02": {
+            "parent_id": "AM0104.01.10",
+            "child_ids": [],
+            "level": 4,
+            "status": "reference",
+            "registry_record_id": "AM0104.01.10.02"
+          }
+        },
+        "overlay_arcs": [],
+        "orphan_ids": [],
+        "cycles": [],
+        "conflicts": [],
+        "dangling_arc_count": 5
+      }
+    }
+  },
+  "workspace_manifest": {
+    "schema": "graphify_workspace_manifest_v1",
+    "schema_version": 1,
+    "contract": "workspace-bundle-contract-v1",
+    "generated_at": "2026-06-27T14:45:57.028Z",
+    "graph_hash": null,
+    "present_count": 5,
+    "artifacts": [
+      {
+        "name": "entities",
+        "path": "entities.json",
+        "schema": null,
+        "present": true,
+        "sha256": "07653c2b9e9503deb3787f19b4e6ba94ce69f082bd4a502a2d17480e7dc78771",
+        "size_bytes": 623,
+        "role": "entities"
+      },
+      {
+        "name": "graph",
+        "path": "graph.json",
+        "schema": null,
+        "present": true,
+        "sha256": "2b04b78da0b5d41407f721e97274798de3b8f934b931d56662d002fa569c47e2",
+        "size_bytes": 904,
+        "role": "graph"
+      },
+      {
+        "name": "reconciliation-candidates",
+        "path": "reconciliation-candidates.json",
+        "schema": "graphify_ontology_reconciliation_candidates_v1",
+        "present": true,
+        "sha256": "7b4fefa0ed2d3e72c16d73eb5857e4f19fd5ac8f4fe621d9b70b1d7ae2da1f81",
+        "size_bytes": 563,
+        "role": "reconciliation"
+      },
+      {
+        "name": "scene",
+        "path": "scene.json",
+        "schema": null,
+        "present": true,
+        "sha256": "1cb0d28cdbe92e472c5acaa673220f33fb3e6ac7f4a592000326bdcd195e006f",
+        "size_bytes": 1707,
+        "role": "scene"
+      },
+      {
+        "name": "scene-hierarchies",
+        "path": "scene-hierarchies.json",
+        "schema": "graphify_scene_hierarchies_v1",
+        "present": true,
+        "sha256": "3f1ef31f5ef7be719cfc96861bcbe619e5af2c3ae7040b8d9d7b034ad3ae43cf",
+        "size_bytes": 1573,
+        "role": "hierarchy"
+      }
+    ]
+  },
+  "reconciliation_candidates": {
+    "schema": "graphify_ontology_reconciliation_candidates_response_v1",
+    "generated_at": "2026-06-26T00:00:00.000Z",
+    "graph_hash": "uat-graph",
+    "profile_hash": "uat-profile",
+    "stale": false,
+    "total": 1,
+    "limit": 1,
+    "offset": 0,
+    "items": [
+      {
+        "id": "uat-candidate",
+        "kind": "entity_match",
+        "status": "candidate",
+        "score": 0.9,
+        "candidate_id": "registry_processes_AM0104_01",
+        "canonical_id": "registry_processes_AM0104",
+        "shared_terms": [
+          "process"
+        ],
+        "evidence_refs": [
+          "aclp-am/forest.csv#AM0104.01"
+        ],
+        "reasons": [
+          "representative ACLP-AM hierarchy UAT fixture"
+        ],
+        "proposed_patch_operation": "accept_match"
+      }
+    ]
+  }
+}

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/scene-hierarchies.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/scene-hierarchies.json
@@ -1,0 +1,65 @@
+{
+  "schema": "graphify_scene_hierarchies_v1",
+  "generated_at": "2026-06-27T14:45:57.027Z",
+  "graph_hash": null,
+  "hierarchies": {
+    "am_process_tree": {
+      "relation_type": "parent_process_of",
+      "kind": "tree",
+      "root_ids": [
+        "AM01"
+      ],
+      "max_depth": 4,
+      "nodes_by_id": {
+        "AM01": {
+          "parent_id": null,
+          "child_ids": [
+            "AM0104"
+          ],
+          "level": 0,
+          "status": "reference",
+          "registry_record_id": "AM01"
+        },
+        "AM0104": {
+          "parent_id": "AM01",
+          "child_ids": [
+            "AM0104.01"
+          ],
+          "level": 1,
+          "status": "reference",
+          "registry_record_id": "AM0104"
+        },
+        "AM0104.01": {
+          "parent_id": "AM0104",
+          "child_ids": [
+            "AM0104.01.10"
+          ],
+          "level": 2,
+          "status": "reference",
+          "registry_record_id": "AM0104.01"
+        },
+        "AM0104.01.10": {
+          "parent_id": "AM0104.01",
+          "child_ids": [
+            "AM0104.01.10.02"
+          ],
+          "level": 3,
+          "status": "reference",
+          "registry_record_id": "AM0104.01.10"
+        },
+        "AM0104.01.10.02": {
+          "parent_id": "AM0104.01.10",
+          "child_ids": [],
+          "level": 4,
+          "status": "reference",
+          "registry_record_id": "AM0104.01.10.02"
+        }
+      },
+      "overlay_arcs": [],
+      "orphan_ids": [],
+      "cycles": [],
+      "conflicts": [],
+      "dangling_arc_count": 5
+    }
+  }
+}

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/test-run.txt
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/test-run.txt
@@ -1,0 +1,91 @@
+# WP4 ACLP-AM UAT test run
+# HEAD=8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec
+# date=2026-06-27T14:43:04Z
+# command: npx vitest run --reporter=verbose <6 files>
+
+npm warn Unknown builtin config "globalignorefile". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
+
+ RUN  v4.1.6 /home/antoinefa/src/graphify
+
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > returns the envelope with hierarchies:{} for empty arcs 2ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > stamps graph_hash when provided 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > builds a simple lane-1 tree: roots, levels, child_ids, max_depth, kind 1ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > lane-splits by status: reference/validated → tree, the rest → overlay_arcs 1ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > enforces mono-parent deterministically: first wins by stable sort, losers → conflicts + overlay 1ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > collapses exact duplicate arcs without a conflict 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > promotes orphans to roots (parent absent from sceneNodeIds) and lists orphan_ids 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > promotes a leaf orphan (no children) to a level-0 root entry 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > counts dangling arcs: unknown child, or absent parent when the child already has one 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > reports cycles with buildHierarchyIndex parity and excludes cycle nodes from the tree 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > splits multiple hierarchies sharing ids into independent trees 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > keeps raw ids verbatim lossless as join keys (D2: no `.`/`-`→`_`) 0ms
+ ✓ tests/scene-hierarchies.test.ts > buildSceneHierarchySidecar — graphify_scene_hierarchies_v1 > round-trips through JSON cleanly (the artifact is pure data) 0ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > writes scene-hierarchies.json next to scene.json when hierarchies.json exists 5ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > writes NO file (not null) when hierarchies.json is absent 1ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > reuses the cache when hierarchies.json is unchanged (same mtime) 1ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > invalidates the cache when hierarchies.json mtime changes 1ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > rewrites a cached sidecar when the target file vanished 1ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > defaults the node universe to the arc endpoints when sceneNodeIds is omitted (scene optional, F1) 1ms
+ ✓ tests/scene-hierarchies-emitter.test.ts > emitSceneHierarchies — standalone scene-hierarchies.json (D1) > applies sceneNodeIds when provided: missing parents become orphan promotions 1ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > returns empty array when no hierarchies declared 1ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > returns empty array when registry is empty 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > skips rows with blank parent (root nodes) 1ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > generates correct arcs for a 3-level hierarchy 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > tags every profile arc with status:reference and confidence:1.0 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > skips self-loops (parent_id === id) 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > produces arcs from multiple hierarchies 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileHierarchies > round-trips through JSON cleanly 0ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > returns empty index for empty arcs 1ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > builds correct index for a 3-level linear chain 1ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > detects a cycle and excludes cycled nodes from paths and roots 1ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > handles a mixed graph with one cycle and one clean tree 0ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > computes correct depth for a wide tree 0ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > round-trips through JSON cleanly 0ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > handles disconnected forest: multiple independent roots 0ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > tolerates orphan nodes: missing parent becomes extra root, child not dropped 0ms
+ ✓ tests/ontology-hierarchies.test.ts > buildHierarchyIndex > computes correct depth and ancestor_paths for a 5-level pointed-code chain 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileOntologyOutputs — hierarchy integration > does NOT write hierarchy files when profile has no hierarchies 2ms
+ ✓ tests/ontology-hierarchies.test.ts > compileOntologyOutputs — hierarchy integration > writes hierarchies.json and hierarchy-index.json when hierarchies declared 1ms
+ ✓ tests/ontology-hierarchies.test.ts > compileOntologyOutputs — hierarchy integration > adds hierarchy files to manifest when they exist 1ms
+ ✓ tests/ontology-hierarchies.test.ts > compileOntologyOutputs — hierarchy integration > returns hierarchyArcCount in result when hierarchies present 0ms
+ ✓ tests/ontology-hierarchies.test.ts > compileOntologyOutputs — hierarchy integration > does not write hierarchy files when compilation is disabled 0ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > stamps the schema id, numeric schema_version, and signed contract 2ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > records present:true with sha256 + size for supplied bytes 2ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > records present:false (NOT dropped) for null/undefined bytes 0ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > sorts artifacts by logical name (stable, deterministic ordering) 0ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > is byte-identical for identical inputs modulo generated_at 0ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > throws on a duplicate logical name (no silent shadowing) 0ms
+ ✓ tests/workspace-manifest.test.ts > buildWorkspaceManifest — pure builder (graphify_workspace_manifest_v1) > stamps the supplied graph hash 0ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > writes workspace-manifest.json into the bundle dir 2ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > hashes the REAL bytes on disk (sha256 + size correctness) 1ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > records present:false for absent artifacts (not silently dropped) 1ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > carries the contract schema ids for the core sidecars 0ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > does NOT list the manifest itself 0ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > is byte-identical across two runs over a byte-identical bundle (modulo generated_at) 0ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > ignores a directory shadowing an artifact name (present:false) 0ms
+ ✓ tests/workspace-manifest.test.ts > emitWorkspaceManifest — owns the I/O, hashes real bytes > emits a portable manifest (relative paths only — passes portable-check) 1ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > compiles the AM process tree to the expected arcs 13ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > compiles the AM process tree to the expected index 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > detects AM as the single root 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > spans at least 3 levels (depth 2) 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > computes ancestor paths for grandchildren 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > has no cycles 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > emits 6 arcs (one per non-root process) 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM fixture — hierarchy compile > tags every arc as a reference fact with confidence 1.0 (increment B) 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — multi-root forest (DR-1) > compiles to the expected arcs (forest-hierarchies.json) 3ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — multi-root forest (DR-1) > compiles to the expected index (forest-hierarchy-index.json) 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — multi-root forest (DR-1) > root_ids has 5 entries (4 ACLP roots + 1 orphan parent), not 1 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — multi-root forest (DR-1) > treats orphan node (MISSING_PARENT→ORPHAN01) as extra root, not dropped 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — multi-root forest (DR-1) > has no cycles 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — pointed-code L4 depth (DR-2) > depth is 4 (5 levels L0..L4) 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — pointed-code L4 depth (DR-2) > computes full ancestor chain for L4 pointed-code node 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — pointed-code L4 depth (DR-2) > level contract: node level == ancestor_paths[node].length for all depths 2ms
+ ✓ tests/ontology-aclp-am.test.ts > ACLP-AM forest fixture — pointed-code L4 depth (DR-2) > arc parent_ids resolve correctly on dotted-code segments 2ms
+ ✓ tests/aclp-am-wp4-uat.test.ts > WP4 ACLP-AM UAT — hierarchy bundle and studio routes > emits ontology + workspace hierarchy artifacts and renders workspace/reconciliation/evidence routes 40ms
+ ✓ tests/aclp-am-wp4-uat.test.ts > WP4 ACLP-AM UAT — hierarchy bundle and studio routes > keeps Radar-compatible cited-source refs on Signal and DesignationEvent nodes 2ms
+
+ Test Files  6 passed (6)
+      Tests  76 passed (76)
+   Start at  10:43:04
+   Duration  450ms (transform 504ms, setup 0ms, import 776ms, tests 140ms, environment 0ms)
+

--- a/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/workspace-manifest.json
+++ b/artifacts/uat/wp4-aclp-am/8e1a25c5cc157fdf4cf83831e1be5e17855fd8ec/workspace-manifest.json
@@ -1,0 +1,55 @@
+{
+  "schema": "graphify_workspace_manifest_v1",
+  "schema_version": 1,
+  "contract": "workspace-bundle-contract-v1",
+  "generated_at": "2026-06-27T14:45:57.028Z",
+  "graph_hash": null,
+  "present_count": 5,
+  "artifacts": [
+    {
+      "name": "entities",
+      "path": "entities.json",
+      "schema": null,
+      "present": true,
+      "sha256": "07653c2b9e9503deb3787f19b4e6ba94ce69f082bd4a502a2d17480e7dc78771",
+      "size_bytes": 623,
+      "role": "entities"
+    },
+    {
+      "name": "graph",
+      "path": "graph.json",
+      "schema": null,
+      "present": true,
+      "sha256": "2b04b78da0b5d41407f721e97274798de3b8f934b931d56662d002fa569c47e2",
+      "size_bytes": 904,
+      "role": "graph"
+    },
+    {
+      "name": "reconciliation-candidates",
+      "path": "reconciliation-candidates.json",
+      "schema": "graphify_ontology_reconciliation_candidates_v1",
+      "present": true,
+      "sha256": "7b4fefa0ed2d3e72c16d73eb5857e4f19fd5ac8f4fe621d9b70b1d7ae2da1f81",
+      "size_bytes": 563,
+      "role": "reconciliation"
+    },
+    {
+      "name": "scene",
+      "path": "scene.json",
+      "schema": null,
+      "present": true,
+      "sha256": "1cb0d28cdbe92e472c5acaa673220f33fb3e6ac7f4a592000326bdcd195e006f",
+      "size_bytes": 1707,
+      "role": "scene"
+    },
+    {
+      "name": "scene-hierarchies",
+      "path": "scene-hierarchies.json",
+      "schema": "graphify_scene_hierarchies_v1",
+      "present": true,
+      "sha256": "3f1ef31f5ef7be719cfc96861bcbe619e5af2c3ae7040b8d9d7b034ad3ae43cf",
+      "size_bytes": 1573,
+      "role": "hierarchy"
+    }
+  ]
+}

--- a/src/scene-hierarchies.ts
+++ b/src/scene-hierarchies.ts
@@ -18,8 +18,8 @@
  *     `conflicts[]` and demoted into `overlay_arcs`. `status` is carried by
  *     the CHILD entry. The sidecar is AUTHORITATIVE for traversal; the
  *     node-level parent_id/child_ids from G1 are display-only.
- *   - LANE 2 (overlay): the remaining statuses (proposed / inferred /
- *     candidate). Empty in v1 (the profile pipeline only produces
+ *   - LANE 2 (overlay): the remaining statuses (guessed / proposed / inferred /
+ *     candidate / rejected / superseded). Empty in v1 (the profile pipeline only produces
  *     status:"reference" arcs) apart from mono-parent demotions.
  *   - Orphan tolerance (B6): a child whose parent is absent from
  *     `sceneNodeIds` is promoted to root and listed in `orphan_ids`.
@@ -62,7 +62,7 @@ export interface SceneHierarchyNodeEntry {
 export interface SceneHierarchyOverlayArc {
   parent_id: string;
   child_id: string;
-  status: "proposed" | "inferred" | "candidate";
+  status: "guessed" | "proposed" | "inferred" | "candidate" | "rejected" | "superseded";
   confidence?: number;
   evidence_refs?: string[];
   derivation_method?: string;
@@ -158,8 +158,16 @@ function treeStatus(value: string): "reference" | "validated" {
   return value === "validated" ? "validated" : "reference";
 }
 
-function overlayStatus(value: string): "proposed" | "inferred" | "candidate" {
-  return value === "inferred" || value === "candidate" ? value : "proposed";
+type SceneHierarchyOverlayStatus = SceneHierarchyOverlayArc["status"];
+
+function overlayStatus(value: string): SceneHierarchyOverlayStatus {
+  return value === "guessed" ||
+    value === "inferred" ||
+    value === "candidate" ||
+    value === "rejected" ||
+    value === "superseded"
+    ? value
+    : "proposed";
 }
 
 function compareStrings(a: string, b: string): number {
@@ -168,7 +176,7 @@ function compareStrings(a: string, b: string): number {
 
 function overlayArcFrom(
   arc: OntologyHierarchyArc,
-  status: "proposed" | "inferred" | "candidate",
+  status: SceneHierarchyOverlayStatus,
   derivationMethod?: string,
 ): SceneHierarchyOverlayArc {
   const out: SceneHierarchyOverlayArc = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -488,6 +488,7 @@ export interface ProjectConfigValidationIssue {
 export type OntologyStatus =
   | "inferred"
   | "proposed"
+  | "guessed"
   | "candidate"
   | "validated"
   | "reference"
@@ -508,14 +509,48 @@ export type OntologyStatus =
  */
 export type CitationConfidence = "EXTRACTED" | "INFERRED";
 
+export type CitationModality = "markdown" | "pdf" | "docx" | "pptx" | "image" | "plain-text" | "csv" | "web";
+
+export interface CitedSourceRef {
+  /** Content-addressed document hash, without a sha256: prefix when exchanged with Radar. */
+  docSha?: string;
+  /** Object-store/CAS key (for example raw/proces-verbaux-<city>/cas/<sha>.pdf). */
+  rawRef?: string;
+  sourceUrl?: string;
+  /** 1-based source page number. */
+  page?: number;
+  /** Normalized top-left page fractions [x0,y0,x1,y1], when available. */
+  bbox?: [number, number, number, number];
+  /** Verbatim evidence text used for text-match fallback when bbox is absent. */
+  excerpt?: string;
+  citation?: string;
+  publishedAt?: string;
+  meetingDate?: string;
+  quoteSpan?: [number, number];
+}
+
 export interface OntologyCitation {
   source_file: string;
   source_url?: string;
+  /** Radar/raw-store compatible object reference for source viewers. */
+  rawRef?: string;
+  /** Content-addressed document hash, without a sha256: prefix when exchanged with Radar. */
+  docSha?: string;
+  /** Public/source URL alias used by Radar DTOs; mirrors source_url when both are present. */
+  sourceUrl?: string;
   page?: number | string;
   section?: string;
   paragraph_id?: string;
   figure_id?: string;
   bbox?: [number, number, number, number];
+  /** Canonical normalized overlay rectangle. For Radar PDF this is [x0,y0,x1,y1] page fractions. */
+  region?: [number, number, number, number];
+  /** Explicit source modality for viewer routing; otherwise consumers derive it from the source. */
+  modality?: CitationModality;
+  /** Optional excerpt alias for Radar/text-match consumers; quote remains the graphify canonical text. */
+  excerpt?: string;
+  /** Optional source-text span for consumers that can map quote offsets back to layout. */
+  quoteSpan?: [number, number];
   /**
    * Human-readable, modality-encoded locator string (WP #24). The display form
    * the studio shows next to a quote: `"p.12 · Section"` for OCR-markdown,

--- a/tests/aclp-am-wp4-uat.test.ts
+++ b/tests/aclp-am-wp4-uat.test.ts
@@ -1,0 +1,317 @@
+/**
+ * WP4 ACLP-AM representative UAT.
+ *
+ * This is intentionally a small end-to-end fixture rather than another unit
+ * snapshot: it proves the ACLP hierarchy artifacts produced by the ontology
+ * pipeline (`hierarchies.json`, `hierarchy-index.json`) are consumable by the
+ * studio/export workspace bundle as the standalone `scene-hierarchies.json`
+ * sidecar, discoverable via `workspace-manifest.json`, while the same state can
+ * render the Workspace / Reconciliation / Evidence studio routes.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildStaticStudio } from "../src/studio-export.js";
+import { compileHierarchies, buildHierarchyIndex } from "../src/ontology-hierarchies.js";
+import { handleOntologyStudioRequest } from "../src/ontology-studio.js";
+import { loadOntologyProfile } from "../src/ontology-profile.js";
+import { loadProfileRegistry } from "../src/profile-registry.js";
+import type { CitedSourceRef, NormalizedOntologyRegistrySpec, OntologyHierarchyArc, OntologyHierarchyIndex } from "../src/types.js";
+
+import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
+
+const tempDirs: string[] = [];
+const fixtureRoot = join(process.cwd(), "tests", "fixtures", "aclp-am");
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-aclp-wp4-uat-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeSpaDir(): string {
+  const spaDir = makeTempDir();
+  writeFileSync(
+    join(spaDir, "index.html"),
+    '<!doctype html><html><body><div id="app"></div><script type="module" src="./assets/index.js"></script></body></html>',
+    "utf-8",
+  );
+  mkdirSync(join(spaDir, "assets"), { recursive: true });
+  writeFileSync(join(spaDir, "assets", "index.js"), "/* app */\n", "utf-8");
+  writeFileSync(
+    join(spaDir, "studio-template.html"),
+    '<!doctype html><html><body><div id="app"></div><script type="module">boot()</script></body></html>',
+    "utf-8",
+  );
+  return spaDir;
+}
+
+function compileAclpForestFixture(): { arcs: OntologyHierarchyArc[]; index: OntologyHierarchyIndex } {
+  const profilePath = join(fixtureRoot, "graphify", "ontology-profile.yaml");
+  const profile = loadOntologyProfile(profilePath);
+  const spec: NormalizedOntologyRegistrySpec = {
+    ...profile.registries.processes,
+    bound_source_path: join(fixtureRoot, "references", "forest.csv"),
+  };
+  const records = loadProfileRegistry("processes", spec);
+  const arcs = compileHierarchies({
+    hierarchies: profile.hierarchies,
+    registries: { processes: records },
+  });
+  return { arcs, index: buildHierarchyIndex(arcs) };
+}
+
+function expectCitedSourceRef(ref: CitedSourceRef, opts: { bboxRequired: boolean }): void {
+  expect(ref.rawRef || ref.sourceUrl || ref.docSha).toBeTruthy();
+  expect(ref.rawRef).toMatch(/^raw\/proces-verbaux-fixture-ville\/cas\/[0-9a-f]{64}\.pdf$/);
+  expect(ref.rawRef).not.toContain("/tmp/");
+  expect(ref.sourceUrl).toBe("https://example.invalid/fixture-ville/pv-2026-04-02.pdf");
+  expect(ref.docSha).toMatch(/^[0-9a-f]{64}$/);
+  expect(ref.page).toEqual(expect.any(Number));
+  expect(Number.isInteger(ref.page)).toBe(true);
+  expect(ref.page).toBeGreaterThanOrEqual(1);
+  expect(ref.excerpt).toEqual(expect.any(String));
+  expect(ref.excerpt?.length).toBeGreaterThan(0);
+  expect(ref.meetingDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  expect(ref.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+  if (!opts.bboxRequired) {
+    expect(ref).not.toHaveProperty("bbox");
+    return;
+  }
+
+  expect(ref.bbox).toEqual(expect.arrayContaining([expect.any(Number)]));
+  expect(ref.bbox).toHaveLength(4);
+  const [x0, y0, x1, y1] = ref.bbox!;
+  expect(x0).toBeGreaterThanOrEqual(0);
+  expect(y0).toBeGreaterThanOrEqual(0);
+  expect(x1).toBeLessThanOrEqual(1);
+  expect(y1).toBeLessThanOrEqual(1);
+  expect(x0).toBeLessThan(x1);
+  expect(y0).toBeLessThan(y1);
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("WP4 ACLP-AM UAT — hierarchy bundle and studio routes", () => {
+  it("emits ontology + workspace hierarchy artifacts and renders workspace/reconciliation/evidence routes", () => {
+    const root = makeTempDir();
+    const fixture = writeOntologyWriteFixture(root);
+    const ontologyDir = join(fixture.stateDir, "ontology");
+    mkdirSync(ontologyDir, { recursive: true });
+
+    const { arcs, index } = compileAclpForestFixture();
+    writeFileSync(join(ontologyDir, "hierarchies.json"), JSON.stringify(arcs, null, 2), "utf-8");
+    writeFileSync(join(ontologyDir, "hierarchy-index.json"), JSON.stringify(index, null, 2), "utf-8");
+
+    // Minimal representative ACLP graph: ids are graphify-native, while
+    // registry_record_id carries the raw ACLP join key consumed by the hierarchy
+    // sidecar. Includes enough nodes for a deep branch and a reconciliation pair.
+    writeFileSync(
+      join(fixture.stateDir, "graph.json"),
+      JSON.stringify({
+        nodes: [
+          { id: "registry_processes_AM01", label: "Organiser", node_type: "Process", registry_record_id: "AM01", status: "validated" },
+          { id: "registry_processes_AM0104", label: "Tracer", node_type: "Process", registry_record_id: "AM0104", status: "validated" },
+          { id: "registry_processes_AM0104_01", label: "Qualifier", node_type: "Process", registry_record_id: "AM0104.01", status: "candidate" },
+          { id: "registry_processes_AM0104_01_10", label: "Contrôler", node_type: "Process", registry_record_id: "AM0104.01.10", status: "candidate" },
+          { id: "registry_processes_AM0104_01_10_02", label: "Valider", node_type: "Process", registry_record_id: "AM0104.01.10.02", status: "candidate" },
+        ],
+        links: [
+          { source: "registry_processes_AM01", target: "registry_processes_AM0104", relation: "parent_process_of" },
+          { source: "registry_processes_AM0104", target: "registry_processes_AM0104_01", relation: "parent_process_of" },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const reconciliationDir = join(ontologyDir, "reconciliation");
+    mkdirSync(reconciliationDir, { recursive: true });
+    writeFileSync(
+      join(reconciliationDir, "candidates.json"),
+      JSON.stringify({
+        schema: "graphify_ontology_reconciliation_candidates_v1",
+        graph_hash: "uat-graph",
+        profile_hash: "uat-profile",
+        generated_at: "2026-06-26T00:00:00.000Z",
+        candidate_count: 1,
+        candidates: [{
+          id: "uat-candidate",
+          kind: "entity_match",
+          status: "candidate",
+          score: 0.9,
+          candidate_id: "registry_processes_AM0104_01",
+          canonical_id: "registry_processes_AM0104",
+          shared_terms: ["process"],
+          evidence_refs: ["aclp-am/forest.csv#AM0104.01"],
+          reasons: ["representative ACLP-AM hierarchy UAT fixture"],
+          proposed_patch_operation: "accept_match",
+        }],
+      }),
+      "utf-8",
+    );
+
+    expect(existsSync(join(ontologyDir, "hierarchies.json"))).toBe(true);
+    expect(existsSync(join(ontologyDir, "hierarchy-index.json"))).toBe(true);
+
+    const outDir = join(root, "studio-export");
+    const result = buildStaticStudio({ stateDir: fixture.stateDir, outDir, spaDir: makeSpaDir(), onWarning: () => {} });
+    expect(result.sceneHierarchiesPath).toBe(join(outDir, "scene-hierarchies.json"));
+    expect(result.reconciliationCount).toBe(1);
+
+    const sceneHierarchies = JSON.parse(readFileSync(join(outDir, "scene-hierarchies.json"), "utf-8"));
+    const tree = sceneHierarchies.hierarchies.am_process_tree;
+    expect(sceneHierarchies.schema).toBe("graphify_scene_hierarchies_v1");
+    expect(tree.nodes_by_id["AM0104.01.10.02"]).toMatchObject({
+      parent_id: "AM0104.01.10",
+      level: 4,
+      registry_record_id: "AM0104.01.10.02",
+      status: "reference",
+    });
+
+    const manifest = JSON.parse(readFileSync(join(outDir, "workspace-manifest.json"), "utf-8"));
+    const byName = new Map(manifest.artifacts.map((artifact: { name: string }) => [artifact.name, artifact]));
+    expect(byName.get("scene-hierarchies")).toMatchObject({
+      path: "scene-hierarchies.json",
+      schema: "graphify_scene_hierarchies_v1",
+      present: true,
+    });
+    expect(byName.get("reconciliation-candidates")).toMatchObject({ present: true });
+    expect(byName.get("scene")).toMatchObject({ present: true });
+
+    for (const url of ["/", "/?view=reconciliation&candidate=uat-candidate", "/?view=evidence"]) {
+      const response = handleOntologyStudioRequest({ profileStatePath: fixture.profileStatePath }, "GET", url);
+      expect(response.status, url).toBe(200);
+      expect(response.body, url).toContain('data-tab="workspace"');
+      expect(response.body, url).toContain('data-tab="reconciliation"');
+      expect(response.body, url).toContain('data-tab="evidence"');
+    }
+  });
+
+  it("keeps Radar-compatible cited-source refs on Signal and DesignationEvent nodes", () => {
+    const sha1 = "1111111111111111111111111111111111111111111111111111111111111111";
+    const sha2 = "2222222222222222222222222222222222222222222222222222222222222222";
+    const sourceUrl = "https://example.invalid/fixture-ville/pv-2026-04-02.pdf";
+    const graph = {
+      municipality: "fixture-ville",
+      generated_at: "2026-06-26T14:00:00Z",
+      ontology_version: "2.3",
+      pv_count: 1,
+      nodes: [
+        {
+          id: "source-fixture-ville-pv-2026-04-02",
+          type: "Source",
+          label: "PV Conseil municipal 2026-04-02 — Fixture Ville",
+          properties: {
+            docSha: sha1,
+            date: "2026-04-02",
+            municipality: "fixture-ville",
+            sourceKind: "proces-verbal",
+            format: "pdf",
+            sourceUrl,
+            rawRef: `raw/proces-verbaux-fixture-ville/cas/${sha1}.pdf`,
+            publishedAt: "2026-04-05",
+          },
+        },
+        {
+          id: "signal-fixture-ville-rezonage-zone-h-123",
+          type: "Signal",
+          label: "Signal : rezonage zone H-123 pour densification",
+          properties: {
+            municipality: "fixture-ville",
+            category: "rezonage",
+            kind: "densification",
+            date: "2026-04-02",
+            meetingDate: "2026-04-02",
+            publishedAt: "2026-04-05",
+            etape: "avis_motion",
+            etape_date: "2026-04-02",
+            description: "Avis de motion visant une modification au règlement de zonage pour permettre une densification dans la zone H-123.",
+            zone_ref: "H-123",
+            reglement_number: "2026-045",
+            docSha: sha1,
+            sourceUrl,
+            rawRef: `raw/proces-verbaux-fixture-ville/cas/${sha1}.pdf`,
+            refs: [{
+              docSha: sha1,
+              rawRef: `raw/proces-verbaux-fixture-ville/cas/${sha1}.pdf`,
+              sourceUrl,
+              page: 7,
+              bbox: [0.12, 0.34, 0.88, 0.41] satisfies [number, number, number, number],
+              excerpt: "Avis de motion est donné afin de modifier le règlement de zonage pour la zone H-123 afin de permettre une densification résidentielle.",
+              citation: "PV du conseil municipal, 2026-04-02, p. 7",
+              publishedAt: "2026-04-05",
+              meetingDate: "2026-04-02",
+            } satisfies CitedSourceRef],
+          },
+        },
+        {
+          id: "event-fixture-ville-second-projet-2026-04-02",
+          type: "DesignationEvent",
+          label: "Second projet de règlement 2026-045 — zone H-123",
+          properties: {
+            municipality: "fixture-ville",
+            kind: "rezonage",
+            decision: "adopté",
+            date: "2026-04-02",
+            meetingDate: "2026-04-02",
+            publishedAt: "2026-04-05",
+            etape: "second_projet",
+            etape_date: "2026-04-02",
+            description: "Adoption du second projet de règlement 2026-045 concernant la zone H-123.",
+            zone_ref: "H-123",
+            reglement_number: "2026-045",
+            docSha: sha2,
+            sourceUrl,
+            rawRef: `raw/proces-verbaux-fixture-ville/cas/${sha2}.pdf`,
+            refs: [{
+              docSha: sha2,
+              rawRef: `raw/proces-verbaux-fixture-ville/cas/${sha2}.pdf`,
+              sourceUrl,
+              page: 8,
+              excerpt: "Le conseil adopte le second projet de règlement numéro 2026-045 modifiant le zonage applicable à la zone H-123.",
+              citation: "PV du conseil municipal, 2026-04-02, p. 8",
+              publishedAt: "2026-04-05",
+              meetingDate: "2026-04-02",
+            } satisfies CitedSourceRef],
+          },
+        },
+      ],
+      edges: [
+        { source: "signal-fixture-ville-rezonage-zone-h-123", target: "source-fixture-ville-pv-2026-04-02", type: "has_source", refs: [{ docSha: sha1, page: 7 }] },
+        { source: "event-fixture-ville-second-projet-2026-04-02", target: "source-fixture-ville-pv-2026-04-02", type: "has_source", refs: [{ docSha: sha2, page: 8 }] },
+      ],
+    };
+
+    const nodesByType = new Map(graph.nodes.map((node) => [node.type, node]));
+    const signal = nodesByType.get("Signal")!;
+    const event = nodesByType.get("DesignationEvent")!;
+
+    expect(Array.isArray(signal.properties.refs)).toBe(true);
+    expect(Array.isArray(event.properties.refs)).toBe(true);
+    expect(signal.properties.refs).toHaveLength(1);
+    expect(event.properties.refs).toHaveLength(1);
+    expectCitedSourceRef(signal.properties.refs[0]!, { bboxRequired: true });
+    expectCitedSourceRef(event.properties.refs[0]!, { bboxRequired: false });
+
+    // Radar reads graph_nodes.props directly: refs must live at properties.refs,
+    // not under a second nested properties object, and tests must stay offline.
+    expect(signal.properties).not.toHaveProperty("properties.refs");
+    expect(event.properties).not.toHaveProperty("properties.refs");
+    expect(sourceUrl).toMatch(/^https:\/\/example\.invalid\//);
+  });
+});

--- a/tests/scene-hierarchies.test.ts
+++ b/tests/scene-hierarchies.test.ts
@@ -102,10 +102,13 @@ describe("buildSceneHierarchySidecar — graphify_scene_hierarchies_v1", () => {
       arc("h", "a", "c", "proposed", { confidence: 0.7, evidence_refs: ["doc#1"] }),
       arc("h", "b", "c", "inferred", { confidence: 0.4 }),
       arc("h", "a", "b", "candidate"),
+      arc("h", "c", "d", "guessed"),
+      arc("h", "d", "e", "rejected"),
+      arc("h", "e", "f", "superseded"),
     ];
     const h = buildSceneHierarchySidecar({
       arcs,
-      sceneNodeIds: ids("r", "a", "b", "c"),
+      sceneNodeIds: ids("r", "a", "b", "c", "d", "e", "f"),
     }).hierarchies["h"]!;
 
     // Tree only contains the lane-1 arcs.
@@ -119,6 +122,9 @@ describe("buildSceneHierarchySidecar — graphify_scene_hierarchies_v1", () => {
       { parent_id: "a", child_id: "b", status: "candidate", confidence: 1.0 },
       { parent_id: "a", child_id: "c", status: "proposed", confidence: 0.7, evidence_refs: ["doc#1"] },
       { parent_id: "b", child_id: "c", status: "inferred", confidence: 0.4 },
+      { parent_id: "c", child_id: "d", status: "guessed", confidence: 1.0 },
+      { parent_id: "d", child_id: "e", status: "rejected", confidence: 1.0 },
+      { parent_id: "e", child_id: "f", status: "superseded", confidence: 1.0 },
     ]);
     expect(h.conflicts).toEqual([]);
     expect(h.dangling_arc_count).toBe(0);


### PR DESCRIPTION
WP4 ACLP-AM ontology hierarchy lifecycle increment.

What:
- Expand scene-hierarchy overlay lane to full lifecycle status set (guessed/proposed/inferred/candidate/rejected/superseded).
- Add guessed to OntologyStatus; tighten overlayStatus() to the sidecar status union.
- WP4 UAT test: studio scene + sidecars (scene-hierarchies.json, workspace-manifest.json) + workspace/reconciliation/evidence routes + Radar-compatible CitedSourceRef on nodes.
- UAT evidence committed under artifacts/uat/wp4-aclp-am/ (6/6 files, 76/76 tests).

Scope: WP4 only. PDF cited-source projection module, agent-stats, and the .track WP0-WP8 migration are intentionally NOT in this PR (separate lanes). CitedSourceRef type is shared (additive, no consumer here).

Track: WP4 item 01KTKVB57HBGPP7HA9Q25F5FMV — acceptance run will be stamped at the merge HEAD.