### PR TITLE
feat(studio): WebGL2 dual-render beta switch (Ctrl+Shift+X, default canvas2d)

### DIFF
--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onDestroy, onMount } from "svelte";
-  import { createGraphRenderer } from "@sentropic/graph";
+  import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
 
   import {
     buildConnectedDimStyle,
@@ -13,6 +13,15 @@
     isBoxShape,
     truncateLabel,
   } from "../lib/graphRendererPayload.js";
+  import {
+    CANVAS2D_BACKEND,
+    WEBGL2_BACKEND,
+    backendIndicatorLabel,
+    createBackendRenderer,
+    isToggleShortcut,
+    paintBoxTextOverlay as paintBoxOverlay,
+    toggleBackend,
+  } from "../lib/renderBackend.js";
 
   const EMPTY_SCENE = {
     nodes: [],
@@ -66,11 +75,24 @@
 
   let container;
   let canvas;
+  // Stacked Canvas2D overlay that paints the in-box label text for the WebGL2
+  // box glyphs (mode B); stays cleared in mode A (canvas2d draws its own text).
+  let overlayCanvas;
+  let overlayCtx = null;
   let renderer = null;
   let payload = null;
   let camera = { x: 0, y: 0, zoom: 1 };
   let pixelRatio = 1;
   let mounted = false;
+
+  // Dual-render BETA switch (Ctrl+Shift+X). Mode A = canvas2d (DEFAULT). Mode B
+  // = WebGL2 beta. Default unchanged: the studio always boots on canvas2d.
+  let activeBackend = $state(CANVAS2D_BACKEND);
+  // True when a switch to mode B found no WebGL2 context and reverted to A.
+  let backendUnavailable = $state(false);
+  // Transient indicator-badge text (auto-hides ~2s after a toggle).
+  let renderIndicator = $state(null);
+  let indicatorTimer = null;
   let resizeObserver = null;
   let resizeFrame = null;
   let mergeFrame = null;
@@ -144,21 +166,108 @@
       canvas.height = nextHeight;
     }
 
+    // Keep the box-text overlay's backing store identical to the WebGL canvas so
+    // the device-px box draws (boxTextDraws) land exactly on the GPU boxes.
+    if (overlayCanvas && (overlayCanvas.width !== nextWidth || overlayCanvas.height !== nextHeight)) {
+      overlayCanvas.width = nextWidth;
+      overlayCanvas.height = nextHeight;
+    }
+
     return changed;
   }
 
-  // Returns true when a NEW renderer instance was created (first run or a
-  // devicePixelRatio change) — that renderer has no graph/style yet.
-  function ensureRenderer() {
+  // Returns true when a NEW renderer instance was created (first run, a
+  // devicePixelRatio change, or a forced backend rebuild) — that renderer has
+  // no graph/style yet.
+  //
+  // The renderer is built from `activeBackend` (the dual-render switch):
+  //   Mode A = createGraphRenderer(canvas, { backend: "canvas2d", pixelRatio }).
+  //   Mode B = { backend: "webgl", instancedShapes: true, pixelRatio }.
+  // `createBackendRenderer` degrades gracefully: when mode B is requested but no
+  // WebGL2 context is available, it reverts to canvas2d and we flag the
+  // unavailable indicator.
+  function ensureRenderer(force = false) {
     if (!canvas) return false;
 
     const nextPixelRatio = readPixelRatio();
-    if (renderer && nextPixelRatio === pixelRatio) return false;
+    if (renderer && !force && nextPixelRatio === pixelRatio) return false;
 
     renderer?.destroy();
     pixelRatio = nextPixelRatio;
-    renderer = createGraphRenderer(canvas, { backend: "canvas2d", pixelRatio });
+    const result = createBackendRenderer(createGraphRenderer, canvas, activeBackend, pixelRatio);
+    renderer = result.renderer;
+    if (result.fellBack) {
+      // mode B requested but no WebGL2 here → reverted to canvas2d (mode A).
+      activeBackend = CANVAS2D_BACKEND;
+      backendUnavailable = true;
+    } else {
+      backendUnavailable = false;
+    }
+    ensureOverlayCtx();
     return true;
+  }
+
+  function ensureOverlayCtx() {
+    if (!overlayCtx && overlayCanvas) {
+      overlayCtx = overlayCanvas.getContext("2d");
+    }
+    return overlayCtx;
+  }
+
+  // Single overlay-paint helper called after EVERY render. Mode B clears the
+  // overlay and paints renderer.boxTextDraws() (device-px in-box label text);
+  // mode A keeps the overlay cleared (canvas2d draws its own in-box text).
+  function paintBoxTextOverlay() {
+    paintBoxOverlay({
+      overlayCtx: ensureOverlayCtx(),
+      overlayCanvas,
+      renderer,
+      backend: activeBackend,
+      drawBoxLabels: drawBoxLabels2D,
+    });
+  }
+
+  // Render + paint the box-text overlay. Used wherever the canvas is redrawn so
+  // the WebGL2 in-box text stays in sync with the GPU boxes.
+  function renderNow(options) {
+    if (!renderer) return;
+    renderer.render(options);
+    paintBoxTextOverlay();
+  }
+
+  // --- Dual-render BETA switch (Ctrl+Shift+X) ---
+  // Window keydown handler: toggle the render backend, force a full renderer
+  // rebuild on the new backend, re-apply graph/style/positions/camera (preserving
+  // the user's view), and flash a transient indicator badge.
+  function handleKeydown(event) {
+    if (!isToggleShortcut(event)) return;
+    event.preventDefault();
+    toggleRenderBackend();
+  }
+
+  function toggleRenderBackend() {
+    activeBackend = toggleBackend(activeBackend);
+    // Force a destroy + recreate on the new backend (ensureRenderer reverts to
+    // canvas2d + flags `backendUnavailable` when mode B finds no WebGL2 context).
+    ensureRenderer(true);
+    resizeCanvas();
+    // Re-apply graph + style + dragged positions and PRESERVE the current camera
+    // (no refit) so toggling the backend doesn't jump the view.
+    applyPayloadNoFit();
+    showRenderIndicator();
+  }
+
+  function showRenderIndicator() {
+    renderIndicator =
+      backendUnavailable && activeBackend === CANVAS2D_BACKEND
+        ? "WebGL2 unavailable — using Canvas2D"
+        : backendIndicatorLabel(activeBackend);
+    if (typeof window === "undefined") return;
+    if (indicatorTimer !== null) window.clearTimeout(indicatorTimer);
+    indicatorTimer = window.setTimeout(() => {
+      indicatorTimer = null;
+      renderIndicator = null;
+    }, 2000);
   }
 
   function fitAndRender() {
@@ -189,14 +298,14 @@
         renderer.setCamera(camera);
       }
     }
-    renderer.render();
+    renderNow();
     setLabelsHidden(false);
   }
 
   function applyCamera(skipEdges = false) {
     if (!renderer) return;
     renderer.setCamera(camera);
-    renderer.render(skipEdges ? { skipEdges: true } : undefined);
+    renderNow(skipEdges ? { skipEdges: true } : undefined);
     updateLabels();
   }
 
@@ -238,7 +347,7 @@
       if (zoomSettleTimer !== null) window.clearTimeout(zoomSettleTimer);
       zoomSettleTimer = window.setTimeout(() => {
         zoomSettleTimer = null;
-        if (renderer && skipEdgesOnInteract) renderer.render();
+        if (renderer && skipEdgesOnInteract) renderNow();
         setLabelsHidden(false);
       }, ZOOM_SETTLE_MS);
     }
@@ -281,7 +390,7 @@
       if (canvas) canvas.style.cursor = "default";
       if (wasDrag) {
         // Finalize the moved node: refresh hover hit-testing + labels.
-        if (skipEdgesOnInteract && renderer) renderer.render();
+        if (skipEdgesOnInteract && renderer) renderNow();
         setLabelsHidden(false);
         // Swallow the trailing click so a drag doesn't also select.
         suppressNextClick = true;
@@ -293,7 +402,7 @@
     isPanning = false;
     if (canvas) canvas.style.cursor = "default";
     // Pan ended: restore edges with a full render.
-    if (skipEdgesOnInteract && renderer) renderer.render();
+    if (skipEdgesOnInteract && renderer) renderNow();
     setLabelsHidden(false);
   }
 
@@ -543,7 +652,7 @@
     if (draggingNodeId) draggedPositions.set(draggingNodeId, { x: worldX, y: worldY });
     renderer.setPositions(positions);
     // Skip edges mid-drag on dense graphs for fluidity (restored on pointerup).
-    renderer.render(skipEdgesOnInteract ? { skipEdges: true } : undefined);
+    renderNow(skipEdgesOnInteract ? { skipEdges: true } : undefined);
     updateLabels();
   }
 
@@ -601,7 +710,7 @@
     if (!renderer || !payload) return;
     const style = styleForHoveredEdge(hit);
     if (style) renderer.setStyle(style);
-    renderer.render();
+    renderNow();
   }
 
   function setHoveredEdge(hit, localX, localY) {
@@ -729,7 +838,7 @@
       if (renderer && style) {
         payload = { ...payload, style };
         renderer.setStyle(style);
-        renderer.render();
+        renderNow();
       }
     }
 
@@ -742,7 +851,7 @@
     setHoveredNode(null);
     isPanning = false;
     if (draggingNodeId) {
-      if (dragMoved && skipEdgesOnInteract && renderer) renderer.render();
+      if (dragMoved && skipEdgesOnInteract && renderer) renderNow();
       draggingNodeId = null;
       dragNodeIndex = -1;
       dragMoved = false;
@@ -771,7 +880,7 @@
     if (!renderer || !payload) return;
     renderer.setPositions(payload.renderGraph.positions);
     renderer.setStyle(payload.style);
-    renderer.render();
+    renderNow();
   }
 
   function finishMergeAnimation() {
@@ -810,7 +919,7 @@
 
       renderer.setPositions(positions);
       renderer.setStyle(interpolateMergeStyle(payload, pair, easeMergeProgress(progress)));
-      renderer.render();
+      renderNow();
 
       if (progress < 1) {
         mergeFrame = window.requestAnimationFrame(tick);
@@ -821,7 +930,7 @@
 
     renderer.setPositions(firstFrame);
     renderer.setStyle(interpolateMergeStyle(payload, pair, 0));
-    renderer.render();
+    renderNow();
     mergeFrame = window.requestAnimationFrame(tick);
   }
 
@@ -893,12 +1002,17 @@
     }
 
     window.addEventListener("resize", scheduleResize);
+    // Dual-render BETA toggle (Ctrl+Shift+X) — window-level so the shortcut
+    // works regardless of canvas focus.
+    window.addEventListener("keydown", handleKeydown);
 
     return () => {
       mounted = false;
       resizeObserver?.disconnect();
       window.removeEventListener("resize", scheduleResize);
+      window.removeEventListener("keydown", handleKeydown);
       if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      if (indicatorTimer !== null) window.clearTimeout(indicatorTimer);
       cancelMergeFrame();
       renderer?.destroy();
       renderer = null;
@@ -935,6 +1049,19 @@
     onmouseleave={handlePointerLeave}
     onwheel={handleWheel}
   ></canvas>
+
+  <!-- Stacked Canvas2D overlay for the WebGL2 in-box label text (mode B). It
+       shares the main canvas's CSS box, never receives pointer events, and stays
+       cleared in mode A. -->
+  <canvas
+    class="canvas-overlay"
+    bind:this={overlayCanvas}
+    aria-hidden="true"
+  ></canvas>
+
+  {#if renderIndicator}
+    <div class="render-indicator" role="status" aria-live="polite">{renderIndicator}</div>
+  {/if}
 
   {#if labels.length}
     <div class={`node-labels node-labels-${labelMode}`} aria-hidden="true">
@@ -1025,6 +1152,35 @@
   .canvas-element:focus-visible {
     outline: 2px solid var(--st-semantic-action-primary, #2563eb);
     outline-offset: -2px;
+  }
+
+  /* Box-text overlay: same CSS box as the main canvas, painted on top, never
+     intercepts pointer events (all hit-testing stays on the main canvas). */
+  .canvas-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  /* Transient render-mode indicator badge (auto-hides ~2s after a toggle). */
+  .render-indicator {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 4;
+    padding: 0.3rem 0.6rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--st-semantic-surface-inverse, #0f172a) 88%, transparent);
+    color: var(--st-semantic-text-inverse, #fff);
+    font-size: 0.72rem;
+    line-height: 1;
+    pointer-events: none;
+    box-shadow: 0 2px 8px rgb(15 23 42 / 0.18);
   }
 
   .canvas-empty {

--- a/studio/src/lib/renderBackend.js
+++ b/studio/src/lib/renderBackend.js
@@ -1,0 +1,103 @@
+// Render-backend selection + box-text overlay helpers for the studio's
+// dual-render BETA switch (Ctrl+Shift+X).
+//
+//   Mode A = canvas2d  → the DEFAULT, current behavior. The canvas2d backend
+//                        draws node shapes, edges, AND in-box label text itself.
+//   Mode B = WebGL2    → the beta backend: { backend: "webgl",
+//                        instancedShapes: true }. On a real WebGL2 context it
+//                        draws node shapes (P1), edges (P2) and box fill/border
+//                        (P3) on the GPU, but the in-box LABEL TEXT is collected
+//                        as `renderer.boxTextDraws()` and painted by a stacked
+//                        Canvas2D overlay (hybrid B1-P3) — the same text engine
+//                        the canvas2d golden uses, parity by construction.
+//
+// This logic lives in a plain module (not the Svelte component) so the backend
+// choice, the graceful WebGL2-unavailable fallback, the overlay paint, and the
+// toggle are unit-testable with a mocked renderer factory.
+
+export const CANVAS2D_BACKEND = "canvas2d";
+export const WEBGL2_BACKEND = "webgl";
+
+/**
+ * `createGraphRenderer` options for a studio render mode.
+ *  - Mode A (canvas2d): the DEFAULT.
+ *  - Mode B (webgl): the WebGL2 beta — instanced shapes/edges/boxes.
+ */
+export function rendererOptionsFor(backend, pixelRatio) {
+  if (backend === WEBGL2_BACKEND) {
+    return { backend: WEBGL2_BACKEND, instancedShapes: true, pixelRatio };
+  }
+  return { backend: CANVAS2D_BACKEND, pixelRatio };
+}
+
+/** Toggle between the two render modes (A ↔ B). */
+export function toggleBackend(backend) {
+  return backend === WEBGL2_BACKEND ? CANVAS2D_BACKEND : WEBGL2_BACKEND;
+}
+
+/** Transient indicator-badge text for the active backend. */
+export function backendIndicatorLabel(backend) {
+  return backend === WEBGL2_BACKEND ? "Render: WebGL2 (beta)" : "Render: Canvas2D";
+}
+
+/** True when the renderer actually drew on a WebGL2 backend. */
+export function isWebglActive(renderer) {
+  return renderer?.snapshot?.().backend === WEBGL2_BACKEND;
+}
+
+/**
+ * True when a keyboard event is the dual-render toggle shortcut: Ctrl+Shift+X.
+ * Matches on `code` ("KeyX") or `key` ("x"/"X") so it survives layouts where
+ * the Shift+x key value differs.
+ */
+export function isToggleShortcut(event) {
+  if (!event || !event.ctrlKey || !event.shiftKey) return false;
+  if (event.code === "KeyX") return true;
+  return typeof event.key === "string" && event.key.toLowerCase() === "x";
+}
+
+/**
+ * Create the renderer for `requestedBackend` with a GRACEFUL WebGL2 fallback:
+ * when mode B is requested but the renderer comes back on canvas2d/none (no
+ * WebGL2 in this environment), the webgl renderer is destroyed and a canvas2d
+ * renderer is created instead, so the studio always renders something.
+ *
+ * @param create  the `createGraphRenderer` factory (injected so it is mockable).
+ * @returns { renderer, backend, fellBack } — `backend` is the ACTIVE backend
+ *          and `fellBack` is true when mode B degraded to canvas2d.
+ */
+export function createBackendRenderer(create, canvas, requestedBackend, pixelRatio) {
+  const renderer = create(canvas, rendererOptionsFor(requestedBackend, pixelRatio));
+  if (requestedBackend === WEBGL2_BACKEND && !isWebglActive(renderer)) {
+    renderer?.destroy?.();
+    const canvas2d = create(canvas, rendererOptionsFor(CANVAS2D_BACKEND, pixelRatio));
+    return { renderer: canvas2d, backend: CANVAS2D_BACKEND, fellBack: true };
+  }
+  return {
+    renderer,
+    backend: requestedBackend === WEBGL2_BACKEND ? WEBGL2_BACKEND : CANVAS2D_BACKEND,
+    fellBack: false,
+  };
+}
+
+/**
+ * Paint (or clear) the stacked Canvas2D overlay that carries the in-box label
+ * text for the WebGL2 box glyphs.
+ *
+ *   Mode A → the overlay stays CLEARED (canvas2d already drew its own in-box
+ *            text inside the glyph).
+ *   Mode B → clear, then paint `renderer.boxTextDraws()` (device-px coords with
+ *            each draw's font/label/alpha) via `drawBoxLabels` — the same
+ *            canvas2d text engine, composited on top of the WebGL canvas.
+ *
+ * The overlay backing store is expected to match the WebGL canvas (device px),
+ * so the box draws land exactly on the GPU boxes with no extra transform.
+ */
+export function paintBoxTextOverlay({ overlayCtx, overlayCanvas, renderer, backend, drawBoxLabels }) {
+  if (!overlayCtx || !overlayCanvas) return [];
+  overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+  if (backend !== WEBGL2_BACKEND || !renderer) return [];
+  const draws = renderer.boxTextDraws?.() ?? [];
+  drawBoxLabels(overlayCtx, draws);
+  return draws;
+}

--- a/studio/src/tests/dualRenderBackend.test.js
+++ b/studio/src/tests/dualRenderBackend.test.js
@@ -1,0 +1,207 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CANVAS2D_BACKEND,
+  WEBGL2_BACKEND,
+  backendIndicatorLabel,
+  createBackendRenderer,
+  isToggleShortcut,
+  isWebglActive,
+  paintBoxTextOverlay,
+  rendererOptionsFor,
+  toggleBackend,
+} from "../lib/renderBackend.js";
+
+// A no-op recorder renderer. `snapshotBackend` controls what snapshot().backend
+// reports — that is how createBackendRenderer decides WebGL2 was (un)available.
+function makeRenderer(snapshotBackend, boxDraws = []) {
+  return {
+    boxTextDraws: vi.fn(() => boxDraws),
+    snapshot: vi.fn(() => ({ backend: snapshotBackend })),
+    destroy: vi.fn(),
+    render: vi.fn(),
+  };
+}
+
+function makeOverlay() {
+  const ctx = { clearRect: vi.fn() };
+  return { canvas: { width: 800, height: 600 }, ctx };
+}
+
+const graphCanvasSource = () =>
+  readFileSync(resolve("src/components/GraphCanvas.svelte"), "utf8");
+
+describe("dual-render backend lib", () => {
+  it("builds canvas2d options for mode A and webgl+instancedShapes for mode B", () => {
+    expect(rendererOptionsFor(CANVAS2D_BACKEND, 2)).toEqual({
+      backend: "canvas2d",
+      pixelRatio: 2,
+    });
+    expect(rendererOptionsFor(WEBGL2_BACKEND, 2)).toEqual({
+      backend: "webgl",
+      instancedShapes: true,
+      pixelRatio: 2,
+    });
+  });
+
+  it("toggles A <-> B and labels each backend", () => {
+    expect(toggleBackend(CANVAS2D_BACKEND)).toBe(WEBGL2_BACKEND);
+    expect(toggleBackend(WEBGL2_BACKEND)).toBe(CANVAS2D_BACKEND);
+    expect(backendIndicatorLabel(WEBGL2_BACKEND)).toBe("Render: WebGL2 (beta)");
+    expect(backendIndicatorLabel(CANVAS2D_BACKEND)).toBe("Render: Canvas2D");
+  });
+
+  it("recognizes Ctrl+Shift+X (by code or key) and rejects everything else", () => {
+    expect(isToggleShortcut({ ctrlKey: true, shiftKey: true, code: "KeyX" })).toBe(true);
+    expect(isToggleShortcut({ ctrlKey: true, shiftKey: true, key: "X" })).toBe(true);
+    expect(isToggleShortcut({ ctrlKey: true, shiftKey: true, key: "x" })).toBe(true);
+    expect(isToggleShortcut({ ctrlKey: true, shiftKey: false, code: "KeyX" })).toBe(false);
+    expect(isToggleShortcut({ ctrlKey: false, shiftKey: true, code: "KeyX" })).toBe(false);
+    expect(isToggleShortcut({ ctrlKey: true, shiftKey: true, code: "KeyZ" })).toBe(false);
+    expect(isToggleShortcut(null)).toBe(false);
+  });
+
+  it("mode A creates a canvas2d renderer with no fallback", () => {
+    const create = vi.fn((_c, opts) => makeRenderer(opts.backend));
+    const out = createBackendRenderer(create, {}, CANVAS2D_BACKEND, 1);
+    expect(out.backend).toBe(CANVAS2D_BACKEND);
+    expect(out.fellBack).toBe(false);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][1]).toEqual({ backend: "canvas2d", pixelRatio: 1 });
+  });
+
+  it("mode B keeps webgl when a WebGL2 context is available", () => {
+    const create = vi.fn(() => makeRenderer(WEBGL2_BACKEND));
+    const out = createBackendRenderer(create, {}, WEBGL2_BACKEND, 1);
+    expect(out.backend).toBe(WEBGL2_BACKEND);
+    expect(out.fellBack).toBe(false);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(isWebglActive(out.renderer)).toBe(true);
+  });
+
+  it("mode B falls back to canvas2d (destroy + recreate) when WebGL2 is unavailable", () => {
+    // First creation reports canvas2d/none (no WebGL2): the helper must destroy
+    // it and recreate on canvas2d.
+    const webglAttempt = makeRenderer(CANVAS2D_BACKEND);
+    const canvas2dRenderer = makeRenderer(CANVAS2D_BACKEND);
+    const create = vi
+      .fn()
+      .mockReturnValueOnce(webglAttempt)
+      .mockReturnValueOnce(canvas2dRenderer);
+
+    const out = createBackendRenderer(create, {}, WEBGL2_BACKEND, 1);
+
+    expect(out.backend).toBe(CANVAS2D_BACKEND);
+    expect(out.fellBack).toBe(true);
+    expect(out.renderer).toBe(canvas2dRenderer);
+    expect(webglAttempt.destroy).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0][1]).toMatchObject({ backend: "webgl", instancedShapes: true });
+    expect(create.mock.calls[1][1]).toEqual({ backend: "canvas2d", pixelRatio: 1 });
+  });
+
+  it("mode B overlay paint clears then draws boxTextDraws()", () => {
+    const draws = [{ nodeIndex: 0, centerX: 10, centerY: 20, height: 8, label: "Work", borderWidth: 2, borderColor: "rgba(0,0,0,1)", alpha: 1 }];
+    const renderer = makeRenderer(WEBGL2_BACKEND, draws);
+    const { canvas, ctx } = makeOverlay();
+    const drawBoxLabels = vi.fn();
+
+    const painted = paintBoxTextOverlay({
+      overlayCtx: ctx,
+      overlayCanvas: canvas,
+      renderer,
+      backend: WEBGL2_BACKEND,
+      drawBoxLabels,
+    });
+
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 800, 600);
+    expect(renderer.boxTextDraws).toHaveBeenCalledTimes(1);
+    expect(drawBoxLabels).toHaveBeenCalledWith(ctx, draws);
+    expect(painted).toBe(draws);
+  });
+
+  it("mode A overlay paint stays cleared and never touches boxTextDraws()", () => {
+    const renderer = makeRenderer(CANVAS2D_BACKEND, [{ nodeIndex: 0 }]);
+    const { canvas, ctx } = makeOverlay();
+    const drawBoxLabels = vi.fn();
+
+    paintBoxTextOverlay({
+      overlayCtx: ctx,
+      overlayCanvas: canvas,
+      renderer,
+      backend: CANVAS2D_BACKEND,
+      drawBoxLabels,
+    });
+
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 800, 600);
+    expect(renderer.boxTextDraws).not.toHaveBeenCalled();
+    expect(drawBoxLabels).not.toHaveBeenCalled();
+  });
+
+  it("simulating Ctrl+Shift+X toggles the backend, recreates the renderer, and paints the overlay via boxTextDraws()", () => {
+    // Start in mode A (the default).
+    let activeBackend = CANVAS2D_BACKEND;
+    const draws = [{ nodeIndex: 0, centerX: 1, centerY: 2, height: 8, label: "Hub", borderWidth: 2, borderColor: "rgba(1,2,3,1)", alpha: 1 }];
+    // The factory hands out a webgl renderer when webgl is requested (WebGL2
+    // available in this simulated env), else a canvas2d one.
+    const create = vi.fn((_canvas, opts) =>
+      makeRenderer(opts.backend === "webgl" ? WEBGL2_BACKEND : CANVAS2D_BACKEND, draws),
+    );
+    const drawBoxLabels = vi.fn();
+    const { canvas: overlayCanvas, ctx: overlayCtx } = makeOverlay();
+
+    // Mount: build the default (mode A) renderer.
+    let { renderer, backend } = createBackendRenderer(create, {}, activeBackend, 1);
+    activeBackend = backend;
+    expect(activeBackend).toBe(CANVAS2D_BACKEND);
+
+    // Press Ctrl+Shift+X.
+    const event = { ctrlKey: true, shiftKey: true, code: "KeyX", preventDefault: vi.fn() };
+    expect(isToggleShortcut(event)).toBe(true);
+    activeBackend = toggleBackend(activeBackend);
+    expect(activeBackend).toBe(WEBGL2_BACKEND);
+
+    // Force a rebuild on the new backend (destroy the old one first, as the
+    // component does).
+    renderer.destroy();
+    ({ renderer, backend } = createBackendRenderer(create, {}, activeBackend, 1));
+    activeBackend = backend;
+    expect(activeBackend).toBe(WEBGL2_BACKEND);
+    // createBackendRenderer was called twice (mount + toggle rebuild).
+    expect(create).toHaveBeenCalledTimes(2);
+
+    // Render → paint overlay: in mode B the overlay paint reads boxTextDraws().
+    renderer.render();
+    paintBoxTextOverlay({ overlayCtx, overlayCanvas, renderer, backend: activeBackend, drawBoxLabels });
+    expect(renderer.boxTextDraws).toHaveBeenCalled();
+    expect(drawBoxLabels).toHaveBeenCalledWith(overlayCtx, draws);
+  });
+});
+
+// Source-text guards: the component must wire the lib in (default canvas2d, the
+// keyboard toggle, the stacked overlay, the indicator badge).
+describe("GraphCanvas dual-render wiring", () => {
+  it("imports the render-backend lib and defaults to canvas2d", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain('from "../lib/renderBackend.js"');
+    expect(source).toMatch(/activeBackend\s*=\s*\$state\(\s*CANVAS2D_BACKEND\s*\)/);
+  });
+
+  it("adds a window keydown listener for the Ctrl+Shift+X toggle and removes it on destroy", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("isToggleShortcut");
+    expect(source).toContain('addEventListener("keydown"');
+    expect(source).toContain('removeEventListener("keydown"');
+  });
+
+  it("stacks a box-text overlay canvas and paints it after render", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("overlayCanvas");
+    expect(source).toContain("paintBoxTextOverlay");
+    expect(source).toContain("drawBoxLabels2D");
+    expect(source).toContain("render-indicator");
+  });
+});


### PR DESCRIPTION
## What

A user-facing **BETA toggle** between two STUDIO render backends, **default unchanged**:

- **Mode A = canvas2d** (DEFAULT, current behavior).
- **Mode B = WebGL2 beta** = `{ backend: "webgl", instancedShapes: true, pixelRatio }` (P1 shapes, P2 edges, P3 box glyphs on a real WebGL2 context, with the in-box label text painted by a stacked Canvas2D overlay — hybrid B1-P3).
- **Ctrl+Shift+X** toggles A↔B.

The default render mode is **not** flipped, so the `golden-webgl` CI lane stays green.

## How

- New `studio/src/lib/renderBackend.js` — pure, mockable helpers: `rendererOptionsFor`, `toggleBackend`, `isToggleShortcut` (Ctrl+Shift+X, by `code` or `key`), `createBackendRenderer` (graceful WebGL2-unavailable fallback: if `snapshot().backend` comes back `canvas2d`/`none`, destroy + recreate on canvas2d and report `fellBack`), and `paintBoxTextOverlay` (clears, then paints `renderer.boxTextDraws()` via the package's `drawBoxLabels2D` — parity by construction).
- `studio/src/components/GraphCanvas.svelte`:
  - Reactive `activeBackend` (`$state`, default `canvas2d`).
  - `ensureRenderer(force)` builds from `activeBackend`; on a forced rebuild that finds no WebGL2 it reverts to canvas2d and flags an unavailable indicator.
  - A stacked `pointer-events:none` overlay `<canvas>` (same CSS box, backing store kept in lockstep) painted after **every** render through a single `paintBoxTextOverlay()` / `renderNow()` — mode B paints `boxTextDraws()`, mode A stays cleared.
  - A window `keydown` listener (added on mount, removed on destroy) toggles A↔B, forces a renderer rebuild, re-applies graph/style/positions/camera (preserving the view), and flashes a transient indicator badge (`Render: WebGL2 (beta)` / `Render: Canvas2D`) that auto-hides after ~2s.
- Mode A behavior is identical; the default is not flipped.

## Tests / validation (run, real output)

- `cd studio && npx vitest run` → **20 files, 247 tests passed** (incl. new `dualRenderBackend.test.js` and the unchanged `pickingBackendAgnostic.test.js`).
- `npm run build:studio` → **built OK** (4115 modules; copied to `dist/studio-app`).
- `npm run lint` (`tsc --noEmit`) → **pass** (exit 0).
- `npm run test:graph` → **11 files, 158 tests passed** (WebGL2 canary unaffected).

## Caveats

- The headless CI/jsdom env has **no real WebGL2**, so toggling to mode B there **degrades gracefully** to canvas2d (covered by the fallback test). Real WebGL2 box rendering is exercised in a browser. No GPU picking added — picking stays CPU/studio-owned and backend-agnostic.
