### PR TITLE
fix(graph): WebGL2 edge + shape-outline width parity with Canvas2D (WP1 beta)

### DIFF
--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -93,10 +93,19 @@ void main() {
   vec2 dir = len > 1e-6 ? d / len : vec2(1.0, 0.0);
   vec2 nrm = vec2(-dir.y, dir.x);
 
-  // Pad each end by the half-width so the round cap fits inside the quad.
-  float pad = a_halfWidth;
+  // Pad each end by the half-width (so the round cap fits) PLUS a ~1.5px AA
+  // margin. WITHOUT the AA margin the quad ended at exactly a_halfWidth across,
+  // which clipped the fragment SDF's OUTER coverage feather (smoothstep up to
+  // a_halfWidth + fwidth): the outer ~1px of the stroke was never rasterized, so
+  // a WebGL edge rendered ~1px THINNER than the Canvas2D line of the SAME
+  // max(1,width·PR) width (the B1 beta fidelity bug). The SDF still puts the
+  // 50%-coverage isoline at exactly a_halfWidth, so padding the quad widens the
+  // rasterized region to fit the feather WITHOUT changing the drawn width --
+  // matching Canvas2D. Mirrors webgl-boxes a_half + a_border quad pad.
+  float aaPad = 1.5;
+  float pad = a_halfWidth + aaPad;
   float along = a_corner.x * (len + 2.0 * pad) - pad;        // [-pad .. len+pad]
-  float across = a_corner.y * a_halfWidth;                   // [-hw .. hw]
+  float across = a_corner.y * (a_halfWidth + aaPad);         // [-hw-aa .. hw+aa]
   vec2 screen = a_p0 + dir * along + nrm * across;
 
   // Local frame centred on the segment midpoint: x along, y across.
@@ -133,12 +142,19 @@ void main() {
   vec2 closest = vec2(ax, 0.0);
   float dist = distance(v_local, closest);
 
-  // ~1px SDF coverage AA at the capsule boundary so the stroke rim approximates
-  // Canvas2D's analytic-coverage AA (the MSAA-on-the-quad-triangles the golden
-  // capture requests does NOT smooth this in-quad boundary, so we feather it
-  // here). The hard core (dist << halfWidth) stays fully opaque.
-  float aa = fwidth(dist);
-  float cov = 1.0 - smoothstep(v_halfWidth - aa, v_halfWidth + aa, dist);
+  // ANALYTIC linear coverage at the capsule boundary so the stroke rim
+  // approximates Canvas2D's analytic-coverage AA (the MSAA-on-the-quad-triangles
+  // the golden capture requests does NOT smooth this in-quad boundary, so we
+  // feather it here). A LINEAR ramp of width aa centred on halfWidth -- NOT a
+  // smoothstep -- because smoothstep's inner skirt extends BELOW halfWidth - aa
+  // and, for a THIN stroke (halfWidth comparable to the ~1px aa), that skirt is
+  // truncated at the centerline so the cross-section integral falls below the
+  // true width: the stroke renders TOO THIN (the B1 beta fidelity bug). The
+  // linear ramp clamp((halfWidth - dist)/aa + 0.5, 0, 1) keeps the centerline
+  // fully opaque whenever halfWidth >= aa/2 and integrates to EXACTLY 2·halfWidth
+  // (= the Canvas2D max(1,width·PR) width), so thin and thick strokes both match.
+  float aa = max(fwidth(dist), 1e-4);
+  float cov = clamp((v_halfWidth - dist) / aa + 0.5, 0.0, 1.0);
   if (cov <= 0.0) discard;
 
   // Arc-length dashing with ROUND PIPS (E3 + E14). Canvas2D sets lineCap="round"
@@ -163,8 +179,9 @@ void main() {
     // Capsule SDF of the pip: combine the across-distance (v_local.y) with the
     // along-overrun so the cap is round in BOTH axes, ≤ v_halfWidth keeps it.
     float pipDist = length(vec2(dAlong, v_local.y));
-    float aaPip = fwidth(pipDist);
-    float pipCov = 1.0 - smoothstep(v_halfWidth - aaPip, v_halfWidth + aaPip, pipDist);
+    float aaPip = max(fwidth(pipDist), 1e-4);
+    // Analytic linear coverage (same width-conserving rule as the core stroke).
+    float pipCov = clamp((v_halfWidth - pipDist) / aaPip + 0.5, 0.0, 1.0);
     // The straight-segment coverage already handled the across axis for the
     // on-core; gate by the pip capsule so caps/gaps read round.
     coverage = min(coverage, pipCov);

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -321,36 +321,49 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     const fillList = fill.get(family)!;
     const borderList = border.get(family)!;
 
+    // Stroke HALF-width in device px. Canvas2D strokes a line of width
+    // (bold?BOLD:NORMAL)·PR CENTRED on the glyph outline, so the visible border
+    // ring must span [radius - strokeHalf, radius + strokeHalf]. The two-disc
+    // ring is therefore built CENTRED on the radius (outer disc at radius +
+    // strokeHalf, carved by an inner disc at radius - strokeHalf) — NOT the old
+    // inside-only `radius - width` ring, which under-weighted the outline and
+    // (for solid+bold) was fully hidden by the full-radius fill disc.
+    const strokeHalf = strokeHalfWidth(bold, frame.pixelRatio);
+
     if (hollow) {
-      // Interior: FIXED translucent white, alpha-INDEPENDENT (N10). Only the
-      // border carries the dim/merge alpha.
-      pushInstance(fillList, cx, cy, radius, BOX_FILL[0], BOX_FILL[1], BOX_FILL[2], BOX_FILL[3] / 255, depth);
-      // Border: node colour at node alpha, drawn as a slightly-inset second
-      // pass scaled down by the stroke width so the ring reads (approximation
-      // of the Canvas2D stroke; tightened in a later phase).
-      const inset = strokeInset(radius, bold, frame.pixelRatio);
-      pushInstance(borderList, cx, cy, radius, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
-      pushInstance(fillList, cx, cy, Math.max(0, radius - inset), BOX_FILL[0], BOX_FILL[1], BOX_FILL[2], BOX_FILL[3] / 255, depth);
+      // Hollow glyph: a node-colour border RING centred on the drawn radius over
+      // a FIXED translucent-white interior (alpha-INDEPENDENT, N10). The ring is
+      // a node-colour disc out to radius + strokeHalf (drawn UNDER) carved by the
+      // translucent-white interior disc at radius - strokeHalf (drawn ON TOP), so
+      // the visible ring spans [radius - strokeHalf, radius + strokeHalf] — the
+      // SAME width AND position Canvas2D strokes. Only the border carries the
+      // node alpha; the interior keeps the fixed white.
+      pushInstance(borderList, cx, cy, radius + strokeHalf, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
+      pushInstance(fillList, cx, cy, Math.max(0, radius - strokeHalf), BOX_FILL[0], BOX_FILL[1], BOX_FILL[2], BOX_FILL[3] / 255, depth);
+    } else if (bold) {
+      // Solid + bold: a darkened-colour border RING (factor 0.62) centred on the
+      // radius, exactly like the Canvas2D solid+bold stroke. The outer darkened
+      // disc (radius + strokeHalf, drawn UNDER) is carved by the node-colour
+      // interior disc at radius - strokeHalf (drawn ON TOP), leaving a centred
+      // [radius - strokeHalf, radius + strokeHalf] ring. (The old code drew the
+      // darkened disc at `radius` UNDER a full-radius node-colour fill, which hid
+      // the border entirely — the worst case of the under-weight bug.)
+      const d = darken(nodeColor);
+      pushInstance(borderList, cx, cy, radius + strokeHalf, d[0], d[1], d[2], alpha, depth);
+      pushInstance(fillList, cx, cy, Math.max(0, radius - strokeHalf), nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
     } else {
-      // Solid fill at node colour + alpha.
+      // Solid fill at node colour + alpha (no border).
       pushInstance(fillList, cx, cy, radius, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
-      if (bold) {
-        // Solid+bold: darkened-colour border ring (factor 0.62) under the fill.
-        const d = darken(nodeColor);
-        const inset = strokeInset(radius, true, frame.pixelRatio);
-        pushInstance(borderList, cx, cy, radius, d[0], d[1], d[2], alpha, depth);
-        pushInstance(fillList, cx, cy, Math.max(0, radius - inset), nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
-      }
     }
   }
 
   return { fill, border, nonFiniteCount };
 }
 
-/** Stroke half-width inset for the ring approximation (device px). */
-function strokeInset(radius: number, bold: boolean, pixelRatio: number): number {
-  const width = (bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio;
-  return Math.min(radius, width);
+/** Stroke HALF-width in device px: (bold?BOLD:NORMAL)·PR / 2 (Canvas2D centres
+ *  a stroke of (bold?BOLD:NORMAL)·PR on the outline, so each side is HALF). */
+function strokeHalfWidth(bold: boolean, pixelRatio: number): number {
+  return ((bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio) / 2;
 }
 
 function pushInstance(

--- a/packages/graph/tests/golden/diff.mjs
+++ b/packages/graph/tests/golden/diff.mjs
@@ -191,6 +191,38 @@ export function contentBBox(capture, bgTolerance = 8) {
  * exact fragile dash phase. `rgb` is [r,g,b]; alpha is ignored (edges/glyphs
  * composite over white so the on-screen RGB is what matters).
  */
+/**
+ * AA-INVARIANT "ink mass" of a stroke over a WHITE background, summed across a
+ * rectangle: Σ (255 − channelValue) for one high-contrast channel. Because a
+ * stroke composites OVER WHITE as `channel = C·a + 255·(1−a)`, each pixel's
+ * `255 − channel = (255 − C)·a`, so the SUM equals `(255 − C) · Σa = (255 − C) ·
+ * coveredArea`. Crucially Σa (the total geometric coverage) is CONSERVED no
+ * matter how the rasterizer distributes its anti-aliasing — a soft SDF edge and
+ * a crisp analytic edge of the SAME width yield the SAME ink mass. That makes
+ * this the right WIDTH metric for a cross-rasterizer (WebGL-vs-Canvas2D) diff: a
+ * pure colour-pixel COUNT conflates AA softness with width (a soft thin stroke
+ * has few full-colour pixels yet the correct width), but the ink mass does not.
+ *
+ * `rect` is {x0,x1,y0,y1} in device px (half-open); pick a band that contains
+ * ONLY the stroke (no node glyphs). `channel` is 0=R/1=G/2=B — choose the
+ * channel where the stroke colour is FARTHEST from 255 (max contrast).
+ */
+export function inkMass(capture, rect, channel = 1) {
+  const { width, height, data } = capture;
+  const x0 = Math.max(0, Math.floor(rect.x0));
+  const x1 = Math.min(width, Math.ceil(rect.x1));
+  const y0 = Math.max(0, Math.floor(rect.y0));
+  const y1 = Math.min(height, Math.ceil(rect.y1));
+  let sum = 0;
+  for (let y = y0; y < y1; y += 1) {
+    for (let x = x0; x < x1; x += 1) {
+      const i = (y * width + x) * 4 + channel;
+      sum += 255 - data[i];
+    }
+  }
+  return sum;
+}
+
 export function countColorPixels(capture, rgb, tolerance = 24) {
   const { width, height, data } = capture;
   let n = 0;

--- a/packages/graph/tests/golden/edges-golden.test.ts
+++ b/packages/graph/tests/golden/edges-golden.test.ts
@@ -40,7 +40,7 @@ import {
 // @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
 import { openOracle } from "./cdp-harness.mjs";
 // @ts-expect-error
-import { countColorPixels, contentBBox } from "./diff.mjs";
+import { countColorPixels, contentBBox, inkMass } from "./diff.mjs";
 // @ts-expect-error
 import { EDGE_GL_FIXTURES } from "./fixtures.mjs";
 
@@ -341,6 +341,47 @@ describe("B1 Phase 2 — edge pixel parity (WebGL vs Canvas2D, Chrome/CDP)", () 
       for (const r of results) {
         expect(r.pass, `${r.name}: ${r.note}`).toBe(true);
       }
+
+      // -------------------------------------------------------------------
+      // E1 WIDTH PARITY (B1 beta fidelity bug — was masked by the loose
+      // 0.5..2.0 ink-ratio above). The instanced capsule expanded its quad to
+      // EXACTLY ±halfWidth, which CLIPPED the fragment SDF's outer coverage
+      // feather, so a WebGL edge rendered ~1px THINNER than the Canvas2D line of
+      // the same max(1,width·PR) width. A THIN edge (≈2 device px here) makes
+      // that lost ~1px a LARGE fraction of the stroke, so the under-weight shows
+      // up as proportionally FEWER edge-colour pixels. We require the WebGL
+      // edge-ink to stay within a TIGHT ratio of Canvas2D — this FAILS on the
+      // pre-fix capsule and PASSES once the quad is padded to fit the feather.
+      const thinRgb: [number, number, number] = [190, 24, 93]; // pink-700
+      const thinFixture = {
+        nodes: [
+          { id: "tn0", x: -120, y: 0, size: 8, color: "#cbd5e1", shape: "circle" },
+          { id: "tn1", x: 120, y: 0, size: 8, color: "#cbd5e1", shape: "circle" },
+        ],
+        edges: [{ source: "tn0", target: "tn1", width: 1, color: "#be185d", dash: "solid" }],
+      };
+      const thinRef = await oracle.capture(thinFixture, { ...opts, backend: "canvas2d" });
+      const thinGl = await oracle.capture(thinFixture, { ...opts, backend: "webgl", instancedShapes: true });
+      expect(thinGl.backend, "thin edge: expected webgl backend").toBe("webgl");
+      // Measure the AA-INVARIANT ink mass in a CENTRAL band that holds ONLY the
+      // edge (no endpoint nodes): the green channel is the high-contrast one for
+      // pink (#be185d, G=24). Ink mass ∝ stroke width, independent of how each
+      // rasterizer spreads its AA — so it isolates WIDTH from softness.
+      const cx = thinGl.width / 2;
+      const band = { x0: cx - 50, x1: cx + 50, y0: 0, y1: thinGl.height };
+      const thinRefMass = inkMass(thinRef, band, 1);
+      const thinGlMass = inkMass(thinGl, band, 1);
+      const thinRatio = thinRefMass > 0 ? thinGlMass / thinRefMass : 0;
+      // eslint-disable-next-line no-console
+      console.log(
+        `[edges-golden] E1 thin-edge WIDTH parity (ink mass): glMass=${thinGlMass} refMass=${thinRefMass} ratio=${thinRatio.toFixed(3)}`,
+      );
+      expect(thinRefMass, "canvas2d thin edge must paint ink").toBeGreaterThan(0);
+      expect(
+        thinRatio,
+        `thin-edge width-parity ratio ${thinRatio.toFixed(3)} below floor — WebGL edge is too thin vs Canvas2D`,
+      ).toBeGreaterThanOrEqual(0.85);
+      expect(thinRatio, `thin-edge ratio ${thinRatio.toFixed(3)} above ceiling — WebGL edge is too thick`).toBeLessThanOrEqual(1.3);
     } finally {
       await oracle.close();
     }

--- a/packages/graph/tests/golden/shapes-golden.test.ts
+++ b/packages/graph/tests/golden/shapes-golden.test.ts
@@ -29,7 +29,7 @@ import { shapeCode } from "../../src/shape-geometry";
 // @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
 import { openOracle } from "./cdp-harness.mjs";
 // @ts-expect-error
-import { diffPixels, geometryProbes, worldToDevice } from "./diff.mjs";
+import { diffPixels, geometryProbes, worldToDevice, countColorPixels } from "./diff.mjs";
 // @ts-expect-error
 import { SHAPE_FAMILIES, shapeFixture, SHAPE_ZOOM_MATRIX, DPR_MATRIX } from "./fixtures.mjs";
 
@@ -190,6 +190,60 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
       for (const r of results) {
         expect(r.pass, `${r.name}: failing=${r.failingPixels} maxDelta=${r.maxDelta}`).toBe(true);
       }
+
+      // -------------------------------------------------------------------
+      // OUTLINE WIDTH PARITY (B1 beta fidelity bug). The FAMILIES above are all
+      // SOLID fills, so they NEVER exercise the node BORDER — the path the beta
+      // rendered TOO THIN, which is why this oracle passed despite the visible
+      // bug. Canvas2D strokes the border CENTRED on the drawn radius (a band of
+      // (bold?3:1.5)·PR spanning [radius-half, radius+half]); the pre-fix WebGL
+      // ring was INSIDE-ONLY (a disc out to `radius`, carved from the inside),
+      // and for solid+bold the border was hidden entirely by the full-radius
+      // fill. We probe a pixel on the OUTER half of the Canvas2D stroke ring
+      // (radius + 1 device px): node-colour on Canvas2D AND the fixed WebGL ring,
+      // BACKGROUND on the pre-fix inside-only ring. So this FAILS on the too-thin
+      // outline and PASSES once the ring is centred at the correct width.
+      const borderRgb: [number, number, number] = [22, 163, 74]; // #16a34a
+      const hbFixture = {
+        nodes: [{ id: "hb", x: 0, y: 0, size: 20, color: "#16a34a", shape: "circle", fill: "hollow", border: "bold" }],
+        edges: [],
+      };
+      const hbRef = await oracle.capture(hbFixture, { ...opts, backend: "canvas2d" });
+      const hbGl = await oracle.capture(hbFixture, { ...opts, backend: "webgl", instancedShapes: true });
+      expect(hbGl.backend, "hollow-bold: expected webgl backend").toBe("webgl");
+
+      const view = { width: hbGl.width, height: hbGl.height, zoom, camera: { x: 0, y: 0 } };
+      const [cx, cy] = worldToDevice([0, 0], view);
+      const radius = drawnRadius(20, dpr, zoom); // 40 device px @ dpr 2
+      // Outer-half-of-ring probe: only painted when the border is centred at the
+      // correct (Canvas2D) width — NOT by the pre-fix inside-only ring.
+      const probeX = cx + radius + 1;
+      const refProbe = geometryProbes(hbRef, [
+        { name: "ref-border-outer", x: probeX, y: cy, expect: [...borderRgb, 255], tolerance: 40 },
+      ]);
+      const glProbe = geometryProbes(hbGl, [
+        { name: "gl-border-outer", x: probeX, y: cy, expect: [...borderRgb, 255], tolerance: 40 },
+      ]);
+      // Secondary: the WebGL border must paint a comparable amount of node-colour
+      // ink to Canvas2D (the pre-fix washed/inside-only ring paints much less).
+      const refBorderInk = countColorPixels(hbRef, borderRgb, 50);
+      const glBorderInk = countColorPixels(hbGl, borderRgb, 50);
+      const borderRatio = refBorderInk > 0 ? glBorderInk / refBorderInk : 0;
+      // eslint-disable-next-line no-console
+      console.log(
+        `[shapes-golden] OUTLINE width parity: refProbe=${JSON.stringify(refProbe.results[0].got)} ` +
+          `glProbe=${JSON.stringify(glProbe.results[0].got)} ` +
+          `refBorderInk=${refBorderInk} glBorderInk=${glBorderInk} ratio=${borderRatio.toFixed(3)}`,
+      );
+      expect(refProbe.pass, "canvas2d border ring must cover radius+1 (sanity)").toBe(true);
+      expect(
+        glProbe.pass,
+        `WebGL hollow-bold border too thin/inside-only at radius+1 (got ${JSON.stringify(glProbe.results[0].got)})`,
+      ).toBe(true);
+      expect(
+        borderRatio,
+        `WebGL border ink ratio ${borderRatio.toFixed(3)} too low — outline under-weighted vs Canvas2D`,
+      ).toBeGreaterThanOrEqual(0.6);
     } finally {
       await oracle.close();
     }


### PR DESCRIPTION
## What

Fixes two **WebGL2-vs-Canvas2D rendering fidelity** bugs in the `@sentropic/graph` renderer, confirmed in real-browser UAT of the mystery-studio WebGL2 beta. Canvas2D is the parity target and is **not** changed; this only affects the flag-gated WebGL2 beta (default backend stays `canvas2d`).

- **01KW5PWR7MDB09HK79KXF0TVBM** — edges render too thin in WebGL2.
- **01KW5PWRBFQ8BF5NJSD8K6F0KD** — node shape outlines/borders render too thin in WebGL2.

## Root causes & fixes

**Edges (`webgl-edges.ts`).** `edgeStrokeWidth = max(1, width·PR)` already matched Canvas2D nominally, but the capsule under-rendered it: the quad expanded to exactly `±halfWidth` (clipping the AA feather) and the boundary used `smoothstep`, whose inner skirt is truncated at the centerline for thin strokes so the cross-section integral fell below the true width. Fix: pad the quad by a 1.5px AA margin **and** switch to analytic linear coverage `clamp((halfWidth-dist)/aa + 0.5, 0, 1)`, which integrates to exactly `2·halfWidth`.

**Shapes (`webgl-shapes.ts`).** Canvas2D strokes the outline of width `(bold?3:1.5)·PR` **centred** on the radius (`[radius-half, radius+half]`). The WebGL ring was built inside-only (`radius-width`), and for solid+bold the darkened border disc at `radius` was fully hidden by the full-radius fill (border invisible). Fix: build the two-disc ring **centred** — border disc to `radius + strokeHalf`, interior carve at `radius - strokeHalf`.

**Boxes (`webgl-boxes.ts`).** Checked — no change needed: the GL box SDF already centres a half-width band and pads the quad, and the shipping hybrid path draws boxes via the Canvas2D overlay (correct by construction).

## Why the golden oracle missed it (and the new gate)

The golden-webgl diff was too loose to catch a 1–2px width delta: the edge check used a 0.5–2.0 ink-**ratio** with 60/255 colour tolerance and never probed an edge interior, and the shape diff swept only **solid** fills, so the border path was never pixel-probed. Tightened:

- `diff.mjs` `inkMass()` — an **AA-invariant** width metric (Σ(255−channel) = (255−C)·coveredArea, conserved across rasterizers).
- A thin (≈2 device px) edge must keep WebGL ink mass within 0.85–1.3 of Canvas2D.
- A hollow-**bold** circle: probe the outer half of the Canvas2D stroke ring (radius+1 px) + a border-ink ratio ≥ 0.6.

## Verification (real SwiftShader WebGL2 pixel oracle)

`cd packages/graph && GOLDEN_ENABLE_WEBGL=1 GOLDEN_REQUIRE_WEBGL=1 CHROME_BIN=/snap/bin/chromium npm run test:golden:webgl` → **4 files / 111 tests pass**.

Measured parity (pre-fix → post-fix, confirmed by stashing the src fixes and re-running the same tightened gate):
| metric | unfixed | fixed |
| --- | --- | --- |
| thin-edge ink-mass ratio | 0.701 (FAIL) | **1.000** |
| hollow-bold border outer-ring probe @ radius+1 | `[255,255,255,255]` (white, FAIL) | **`[22,163,74,255]`** (node green) |
| hollow-bold border ink ratio | 0.000 (FAIL) | **1.004** |

Also green: `npm run lint` (tsc) and `npm run test:graph` (158 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)