### PR TITLE
fix(graph): WebGL2 beta premultiplied alpha (hover-dim + edge fringe) + heavier stroke

### DIFF
--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -182,7 +182,12 @@ void main() {
   float oa = border.a + fill.a * (1.0 - border.a);
   vec3 orgb = oa > 0.0 ? (border.rgb * border.a + fill.rgb * fill.a * (1.0 - border.a)) / oa : vec3(0.0);
   if (oa <= 0.0) discard;
-  outColor = vec4(orgb, oa);
+  // PREMULTIPLIED output (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)): orgb
+  // is the straight composited colour, so emit orgb·oa. Keeps alpha<1 boxes from
+  // compositing too transparent under premultipliedAlpha:true. (This GL box path
+  // is off by default — the studio + golden use the Canvas2D hybrid overlay — but
+  // it is kept premultiplied-consistent with the shape/edge passes.)
+  outColor = vec4(orgb * oa, oa);
 }
 `;
 
@@ -233,7 +238,10 @@ void main() {
   // by construction (the atlas WAS rasterized by Chrome's 2D engine).
   float cov = texture(u_atlas, v_uv).a;
   if (cov <= 0.0) discard;
-  outColor = vec4(v_color.rgb, cov * v_color.a);
+  // PREMULTIPLIED output (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)): the
+  // effective alpha is the glyph coverage times the node alpha; emit rgb·a.
+  float a = cov * v_color.a;
+  outColor = vec4(v_color.rgb * a, a);
 }
 `;
 
@@ -829,7 +837,8 @@ export function createWebGLBoxRenderer(
     // text atlas, interleaved by a per-node depth buffer for R7 occlusion.
     const maxDepth = Math.max(1, frame.nodeCount);
     gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    // PREMULTIPLIED-alpha "over": the box + text fragments emit premultiplied rgb.
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
     gl.enable(gl.DEPTH_TEST);
     gl.depthFunc(gl.LEQUAL);
     gl.depthMask(true);

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -210,7 +210,13 @@ void main() {
     if (coverage <= 0.0) discard;
   }
 
-  outColor = vec4(v_color.rgb, v_color.a * coverage);
+  // PREMULTIPLIED alpha output (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)).
+  // The effective alpha is the edge alpha times the analytic coverage; emit
+  // rgb·a so the framebuffer stays premultiplied (premultipliedAlpha:true). The
+  // old straight output + SRC_ALPHA factor under-accumulated the framebuffer
+  // alpha (squared coverage), washing alpha<1 edges out + dark-fringing AA rims.
+  float a = v_color.a * coverage;
+  outColor = vec4(v_color.rgb * a, a);
 }
 `;
 
@@ -256,7 +262,9 @@ precision highp float;
 in vec4 v_color;
 out vec4 outColor;
 void main() {
-  outColor = v_color;
+  // PREMULTIPLIED alpha (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)), so an
+  // alpha<1 arrowhead composites the same way as its (now premultiplied) edge.
+  outColor = vec4(v_color.rgb * v_color.a, v_color.a);
 }
 `;
 
@@ -561,7 +569,10 @@ export function createWebGLEdgeRenderer(context: GL2 | null): WebGLEdgeRenderer 
     const { capsules, arrows } = buildEdgeInstances(frame);
 
     gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    // PREMULTIPLIED-alpha "over": the capsule/arrow fragments emit rgb·a, so the
+    // source factor is ONE. Fixes alpha<1 edges compositing too transparent + the
+    // dark AA fringe the old SRC_ALPHA factor produced under premultipliedAlpha.
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
     if (capsules.length > 0) {
       gl.useProgram(capsule.program);

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -61,6 +61,19 @@ const DEFAULT_EDGE_COLOR = [121, 133, 153, 180] as const;
 /** Curve tessellation step count — matches the 16-sample hit-test (X8). */
 const CURVE_SEGMENTS = 16;
 
+/**
+ * UAT polish (fix/webgl-aa-and-stroke-weight): draw the WebGL2 beta edge a touch
+ * HEAVIER than the exact Canvas2D ink-mass. The merged width-parity fix (2266cfa)
+ * matched Canvas2D to ratio ~1.0, but real-browser UAT read the edges slightly
+ * THIN. We scale the DRAWN half-width — the coverage isoline the capsule fragment
+ * shader integrates — by this factor (NOT just the AA pad), so the stroke renders
+ * ~12% thicker. The per-instance `a_halfWidth` attribute stays the EXACT Canvas2D
+ * half-width (max(1,width·PR)/2), so the geometry-parity gate is unchanged; only
+ * the rasterized width grows. Canvas2D itself is untouched. ~12% lands the golden
+ * edge ink-mass ratio around ~1.1 (within the 0.85–1.3 tolerance).
+ */
+export const WEBGL_STROKE_WEIGHT_BOOST = 1.12;
+
 // ---------------------------------------------------------------------------
 // Capsule (thick segment) program. A unit quad [0..1]² is expanded along the
 // segment by the instance's endpoints + half-width. The fragment shader does
@@ -102,16 +115,25 @@ void main() {
   // 50%-coverage isoline at exactly a_halfWidth, so padding the quad widens the
   // rasterized region to fit the feather WITHOUT changing the drawn width --
   // matching Canvas2D. Mirrors webgl-boxes a_half + a_border quad pad.
+  //
+  // UAT polish: the DRAWN half-width is the instance half-width scaled by
+  // WEBGL_STROKE_WEIGHT_BOOST (the edge read slightly THIN at exact parity). This
+  // is the VISIBLE half-width the fragment coverage integrates (v_halfWidth) and
+  // the cap radius — NOT merely the AA pad — so the stroke renders a touch
+  // thicker. a_halfWidth (the instance attribute) stays the exact Canvas2D value,
+  // so geometry-parity is untouched. The quad pad uses drawHalf so the wider
+  // coverage + round caps never get clipped at thick widths.
+  float drawHalf = a_halfWidth * ${WEBGL_STROKE_WEIGHT_BOOST.toFixed(4)};
   float aaPad = 1.5;
-  float pad = a_halfWidth + aaPad;
+  float pad = drawHalf + aaPad;
   float along = a_corner.x * (len + 2.0 * pad) - pad;        // [-pad .. len+pad]
-  float across = a_corner.y * (a_halfWidth + aaPad);         // [-hw-aa .. hw+aa]
+  float across = a_corner.y * (drawHalf + aaPad);            // [-hw-aa .. hw+aa]
   vec2 screen = a_p0 + dir * along + nrm * across;
 
   // Local frame centred on the segment midpoint: x along, y across.
   v_local = vec2(along - len * 0.5, across);
   v_halfLen = len * 0.5;
-  v_halfWidth = a_halfWidth;
+  v_halfWidth = drawHalf;
   v_color = a_color;
   v_arc = a_arcStart + along; // arc-length accumulates along the polyline
   v_dashPeriod = a_dashPeriod;

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -360,10 +360,24 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
   return { fill, border, nonFiniteCount };
 }
 
+/**
+ * UAT polish (fix/webgl-aa-and-stroke-weight): draw the WebGL2 beta node-shape
+ * outline a touch HEAVIER than the exact Canvas2D ink-mass. The merged parity fix
+ * (2266cfa) centred the ring at the exact Canvas2D width, but real-browser UAT
+ * read the borders slightly THIN. We scale the centred-ring half-width by this
+ * factor (~12% thicker, symmetric about the drawn radius). Mirrors the edge boost
+ * (WEBGL_STROKE_WEIGHT_BOOST in webgl-edges.ts). Canvas2D (BORDER_WIDTH_* in
+ * render-geometry.ts) is untouched — only this WebGL ring widens, lifting the
+ * golden border-ink ratio further above its 0.6 floor.
+ */
+const WEBGL_OUTLINE_WEIGHT_BOOST = 1.12;
+
 /** Stroke HALF-width in device px: (bold?BOLD:NORMAL)·PR / 2 (Canvas2D centres
- *  a stroke of (bold?BOLD:NORMAL)·PR on the outline, so each side is HALF). */
+ *  a stroke of (bold?BOLD:NORMAL)·PR on the outline, so each side is HALF),
+ *  scaled by WEBGL_OUTLINE_WEIGHT_BOOST so the WebGL beta ring reads a touch
+ *  HEAVIER than Canvas2D (UAT polish) — Canvas2D's own stroke is unchanged. */
 function strokeHalfWidth(bold: boolean, pixelRatio: number): number {
-  return ((bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio) / 2;
+  return (((bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio) / 2) * WEBGL_OUTLINE_WEIGHT_BOOST;
 }
 
 function pushInstance(

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -87,7 +87,13 @@ precision mediump float;
 in vec4 v_color;
 out vec4 outColor;
 void main() {
-  outColor = v_color;
+  // PREMULTIPLIED alpha output (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)).
+  // The context is premultipliedAlpha:true (the default), so the framebuffer must
+  // hold premultiplied RGBA. With the old straight output + blendFunc(SRC_ALPHA,
+  // ONE_MINUS_SRC_ALPHA) the framebuffer ALPHA was under-accumulated (a·a instead
+  // of a), so dimmed (alpha<1) glyphs composited TOO TRANSPARENT and AA rims read
+  // as dark fringes. Emitting premultiplied rgb·a keeps rgb and alpha consistent.
+  outColor = vec4(v_color.rgb * v_color.a, v_color.a);
 }
 `;
 
@@ -436,7 +442,11 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
     if (shapeProgram.uniforms.maxDepth) gl.uniform1f(shapeProgram.uniforms.maxDepth, Math.max(1, frame.nodeCount));
 
     gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    // PREMULTIPLIED-alpha "over": the fragment emits rgb·a, so the source factor
+    // is ONE (not SRC_ALPHA). This composites alpha<1 glyphs correctly (the old
+    // SRC_ALPHA factor squared the source alpha into the framebuffer, dimming
+    // glyphs too far + dark-fringing AA rims under premultipliedAlpha:true).
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
     // Border ring pass first (under the fill), then the interior fill pass, so a
     // hollow ring / bold outline sits beneath the (translucent or solid) centre.

--- a/packages/graph/tests/golden/shapes-golden.test.ts
+++ b/packages/graph/tests/golden/shapes-golden.test.ts
@@ -244,6 +244,57 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
         borderRatio,
         `WebGL border ink ratio ${borderRatio.toFixed(3)} too low — outline under-weighted vs Canvas2D`,
       ).toBeGreaterThanOrEqual(0.6);
+
+      // -------------------------------------------------------------------
+      // HOVER-DIM PARITY (premultiplied-alpha regression). The FAMILIES + the
+      // outline fixture above are all alpha=255 (opaque), where a·a == a, so they
+      // NEVER exercised the alpha-COMPOSITING path — which is exactly why the
+      // straight-alpha + blendFunc(SRC_ALPHA, ONE_MINUS_SRC_ALPHA) bug slipped the
+      // gate. That blend squared the source alpha into the framebuffer, so under
+      // premultipliedAlpha:true a DIMMED (alpha<1) node — e.g. a non-connected node
+      // on hover — composited TOO TRANSPARENT (washed toward the white background)
+      // in WebGL vs Canvas2D. The premultiplied output (rgb·a) + blendFunc(ONE,
+      // ONE_MINUS_SRC_ALPHA) makes the composite correct. We render a solid node at
+      // alpha 0x80 (~0.5) on BOTH backends (composited over the harness white) and
+      // assert the CENTRE pixel matches — the regression guard for the hover-dim bug.
+      const dimFixture = {
+        // "#16a34a80": green at alpha 128/255 (~0.502) — a typical hover-dim node.
+        nodes: [{ id: "dim", x: 0, y: 0, size: 24, color: "#16a34a80", shape: "circle" }],
+        edges: [],
+      };
+      const dimRef = await oracle.capture(dimFixture, { ...opts, backend: "canvas2d" });
+      const dimGl = await oracle.capture(dimFixture, { ...opts, backend: "webgl", instancedShapes: true });
+      expect(dimGl.backend, "hover-dim: expected webgl backend").toBe("webgl");
+
+      const dview = { width: dimGl.width, height: dimGl.height, zoom, camera: { x: 0, y: 0 } };
+      const [dcx, dcy] = worldToDevice([0, 0], dview);
+      // Read the centre pixel on each backend (interior ⇒ fully covered, so AA is
+      // not a factor; only the alpha-compositing math differs). tolerance 1024 just
+      // forces geometryProbes to RETURN `got` without failing on the throwaway expect.
+      const refCenter = geometryProbes(dimRef, [
+        { name: "ref-dim-center", x: dcx, y: dcy, expect: [0, 0, 0, 0], tolerance: 1024 },
+      ]).results[0].got;
+      const glCenter = geometryProbes(dimGl, [
+        { name: "gl-dim-center", x: dcx, y: dcy, expect: [0, 0, 0, 0], tolerance: 1024 },
+      ]).results[0].got;
+      // eslint-disable-next-line no-console
+      console.log(
+        `[shapes-golden] HOVER-DIM parity: refCenter=${JSON.stringify(refCenter)} glCenter=${JSON.stringify(glCenter)}`,
+      );
+      // The WebGL dim composite must match Canvas2D per channel (was washed-white pre-fix).
+      for (let c = 0; c < 3; c += 1) {
+        expect(
+          Math.abs(glCenter[c] - refCenter[c]),
+          `hover-dim channel ${c}: gl ${glCenter[c]} vs ref ${refCenter[c]} (WebGL dim composited unlike Canvas2D)`,
+        ).toBeLessThanOrEqual(20);
+      }
+      // Sanity: the dim node stays GREEN-ish (G well above R) on BOTH backends — a
+      // washed-to-white result (the bug) would collapse G−R toward 0.
+      expect(refCenter[1] - refCenter[0], "canvas2d dim must read green-ish (sanity)").toBeGreaterThan(30);
+      expect(
+        glCenter[1] - glCenter[0],
+        `WebGL dim washed toward white (G−R=${glCenter[1] - glCenter[0]}) — premultiplied-alpha regression`,
+      ).toBeGreaterThan(30);
     } finally {
       await oracle.close();
     }

--- a/studio/src/lib/renderBackend.js
+++ b/studio/src/lib/renderBackend.js
@@ -25,7 +25,13 @@ export const WEBGL2_BACKEND = "webgl";
  */
 export function rendererOptionsFor(backend, pixelRatio) {
   if (backend === WEBGL2_BACKEND) {
-    return { backend: WEBGL2_BACKEND, instancedShapes: true, pixelRatio };
+    // Mode B (WebGL2 beta) requests a MULTISAMPLED context (antialias:true) so the
+    // GPU edges + node-shape borders get MSAA smoothing — without it the beta read
+    // more JAGGED than Canvas2D in real-browser UAT (the renderer's acquireContext
+    // honours options.antialias, which defaults to false). The Canvas2D branch and
+    // the golden harness are intentionally left untouched (the golden capture keeps
+    // its own deterministic context options).
+    return { backend: WEBGL2_BACKEND, instancedShapes: true, antialias: true, pixelRatio };
   }
   return { backend: CANVAS2D_BACKEND, pixelRatio };
 }


### PR DESCRIPTION
## What & why

Real-browser UAT of the WebGL2 dual-render beta (`@sentropic/graph`, studio mode B,
Ctrl+Shift+X) was "almost perfect". This PR lands the UAT polish on the **WebGL2 beta
path only** — the default backend stays `canvas2d` and Canvas2D rendering is untouched.

Two issues were folded in (the second is a root-cause that subsumes the original
"aliasing" symptom):

### 1. Premultiplied alpha (hover-dim transparency + edge/border dark fringe)
The WebGL2 context is `premultipliedAlpha:true` (the default — `acquireContext` only
sets `antialias`/`preserveDrawingBuffer`), but the instanced shaders emitted **straight**
alpha with `blendFunc(SRC_ALPHA, ONE_MINUS_SRC_ALPHA)`. That blend multiplies the source
alpha **into the framebuffer alpha** (`a·a`, not `a`), so the framebuffer alpha is
under-accumulated for `alpha<1` elements. RGB is correctly premultiplied but alpha is
wrong → under `premultipliedAlpha` compositing (and the golden harness's own
`rgb+(255−a)` over-white composite) too much background bleeds through:
- hover-**dimmed** (non-connected) nodes/edges rendered **too transparent** vs Canvas2D;
- AA rims read as **dark fringes** (perceived as aliasing).

The golden never caught it because every shape fixture is `alpha=255` (where `a·a == a`).

**Fix:** premultiplied alpha end-to-end on the instanced WebGL2 path —
`outColor = vec4(rgb·a, a)` + `blendFunc(ONE, ONE_MINUS_SRC_ALPHA)` in `webgl-shapes.ts`,
`webgl-edges.ts` (capsule + arrow), and `webgl-boxes.ts` (border-over-fill + text;
off-by-default GL box path — studio+golden use the Canvas2D hybrid overlay — converted
for consistency). Identical to the old output for **opaque** pixels (golden stays green);
correct for `alpha<1`/AA pixels. Context stays `premultipliedAlpha` default true; the
legacy point-sprite path is unchanged.

### 2. Slightly heavier edge + outline stroke (UAT: "un poil plus épais")
The merged width-parity fix (2266cfa) matched Canvas2D ink-mass exactly (~1.0), but users
read edges + node-shape outlines slightly thin. A ~12% boost (`WEBGL_STROKE_WEIGHT_BOOST`
/ `WEBGL_OUTLINE_WEIGHT_BOOST`) scales the **drawn** stroke weight only on WebGL; Canvas2D
unchanged. For edges this scales the visible half-width the coverage integrates
(`v_halfWidth`) + cap radius + quad pad — **not** just the AA pad — and leaves the
per-instance `a_halfWidth` attribute at the exact Canvas2D value so the geometry-parity
gate is untouched.

### MSAA (`antialias:true`) — kept
The studio mode-B `rendererOptionsFor` now requests `antialias:true`. **Kept** (not
dropped) because the node shapes are flat-colour triangle fans with **no in-shader
coverage AA** — only MSAA smooths their polygon silhouettes (the golden harness itself
requests it for the same reason). It is complementary to the premultiplied fix, not
redundant: premult fixes alpha compositing, MSAA fixes geometric edge AA.

## Verification (all run, real results)
- `npm run lint` (tsc) → **exit 0**
- `npm run test:graph` → **158 passed** (11 files)
- `GOLDEN_ENABLE_WEBGL=1 GOLDEN_REQUIRE_WEBGL=1 CHROME_BIN=/snap/bin/chromium npm run test:golden:webgl`
  (chromium 149 + ANGLE/SwiftShader) → **111 passed** (4 files). Observed ratios:
  - **edge ink-mass** glMass=51800 refMass=46200 → **ratio 1.121** (within 0.85–1.3)
  - **shape border-ink** gl=1556 ref=1374 → **ratio 1.132** (≥ 0.6 floor)
  - **hover-dim parity** refCenter=`[138,209,164]` glCenter=`[138,209,164]` → **exact match**
- `npm run build:studio` → **exit 0**

**No golden tolerance was changed** — the +12% boost + premult land the edge ratio at
1.121 (< 1.3) and the border ratio at 1.132, both inside the existing bounds.

## Scope note (transparency)
The original ask was MSAA + heavier stroke. The premultiplied-alpha root-cause + the
hover-dim regression test were added per a coordinator hand-off; I independently verified
the mechanism against the golden harness before implementing. All changes are confined to
the WebGL2 beta path (default `canvas2d` unchanged) and are reversible at review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
