### PR TITLE
feat(studio): WebGL2 default (canvas2d fallback) + hover-intent dwell + backend-aware edge-skip

### DIFF
--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -85,15 +85,20 @@
   let pixelRatio = 1;
   let mounted = false;
 
-  // Dual-render BETA switch (Ctrl+Shift+X). Mode A = canvas2d (DEFAULT). Mode B
-  // = WebGL2 beta. Default unchanged: the studio always boots on canvas2d.
-  let activeBackend = $state(CANVAS2D_BACKEND);
-  // True when a switch to mode B found no WebGL2 context and reverted to A.
+  // Dual-render switch (Ctrl+Shift+X). Mode A = canvas2d, Mode B = WebGL2.
+  // P6 FLIP: the studio now BOOTS on WebGL2 (instancedShapes). `ensureRenderer`
+  // uses the EXISTING graceful fallback — when no WebGL2 context is available it
+  // reverts to canvas2d (mode A) and sets `backendUnavailable`. Ctrl+Shift+X
+  // still toggles both ways.
+  let activeBackend = $state(WEBGL2_BACKEND);
+  // True when WebGL2 was requested but no context was available, so we reverted
+  // to canvas2d — set at boot (fallback) or on a failed manual switch.
   let backendUnavailable = $state(false);
-  // Render-mode badge. HIDDEN by default (clean UI on boot); the FIRST
-  // Ctrl+Shift+X / badge-click reveals it, after which it stays visible and
-  // reflects the live backend on every subsequent switch. `justToggled` briefly
-  // pulses it right after a switch.
+  // Render-mode badge. On a successful WebGL2 boot it stays HIDDEN (clean UI);
+  // the FIRST Ctrl+Shift+X / badge-click reveals it. When the WebGL2 boot FALLS
+  // BACK to canvas2d (`backendUnavailable`) the badge is REVEALED immediately so
+  // the user sees the unavailable state. Once visible it reflects the live
+  // backend on every subsequent switch; `justToggled` briefly pulses it.
   let switchActivated = $state(false);
   let justToggled = $state(false);
   let indicatorTimer = null;
@@ -191,10 +196,11 @@
   //
   // The renderer is built from `activeBackend` (the dual-render switch):
   //   Mode A = createGraphRenderer(canvas, { backend: "canvas2d", pixelRatio }).
-  //   Mode B = { backend: "webgl", instancedShapes: true, pixelRatio }.
-  // `createBackendRenderer` degrades gracefully: when mode B is requested but no
-  // WebGL2 context is available, it reverts to canvas2d and we flag the
-  // unavailable indicator.
+  //   Mode B = { backend: "webgl", instancedShapes: true, pixelRatio }  ← the
+  //            BOOT DEFAULT after the P6 flip.
+  // `createBackendRenderer` degrades gracefully: when mode B (the default) is
+  // requested but no WebGL2 context is available, it reverts to canvas2d and we
+  // flag `backendUnavailable` (which reveals the badge in its unavailable state).
   function ensureRenderer(force = false) {
     if (!canvas) return false;
 
@@ -1082,10 +1088,12 @@
     aria-hidden="true"
   ></canvas>
 
-  <!-- Render-backend badge. HIDDEN until the first Ctrl+Shift+X (clean default
-       UI); once revealed it stays visible, reflects the live mode, and doubles
-       as a click target to switch (same as the shortcut). -->
-  {#if switchActivated}
+  <!-- Render-backend badge. On a successful WebGL2 boot it stays HIDDEN until the
+       first Ctrl+Shift+X (clean default UI); a boot fallback to canvas2d
+       (`backendUnavailable`) REVEALS it immediately so the unavailable state is
+       visible. Once revealed it reflects the live mode and doubles as a click
+       target to switch (same as the shortcut). -->
+  {#if switchActivated || backendUnavailable}
     <button
       type="button"
       class="render-indicator"

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -22,6 +22,10 @@
     paintBoxTextOverlay as paintBoxOverlay,
     toggleBackend,
   } from "../lib/renderBackend.js";
+  import {
+    createHoverIntent,
+    shouldDelayConnectedDim,
+  } from "../lib/hoverIntent.js";
 
   const EMPTY_SCENE = {
     nodes: [],
@@ -114,6 +118,10 @@
   let hoveredEdge = $state(null);
   let hoveredNode = $state(null);
   let hoveredNodeId = $state(null);
+  // Hover-intent dwell timer controller (Task B): defers the rest-of-graph
+  // connected-dim until the pointer DWELLS, but ONLY before the first
+  // selection/focus, so a pre-selection sweep across the graph no longer strobes.
+  const hoverIntent = createHoverIntent(() => applyConnectedDim());
 
   // Scene identity tracking so we only auto-fit on a genuine new graph (not selection/focus).
   let lastScene = null;
@@ -378,6 +386,9 @@
 
   // --- Pointer down: node drag (over a node) or pan (over the background) ---
   function handlePointerDown(event) {
+    // A pan/drag is starting — cancel any pending hover-intent dwell so it can't
+    // fire (and dim) mid-interaction.
+    hoverIntent.cancel();
     const id = pickNode(event);
 
     if (id) {
@@ -852,21 +863,41 @@
       hoveredNode = null;
     }
 
-    if (mounted && payload) {
-      const style = buildConnectedDimStyle(payload, {
-        selectedIds: selectedIds ?? [],
-        focusId,
-        hoveredNodeId,
-      });
-      if (renderer && style) {
-        payload = { ...payload, style };
-        renderer.setStyle(style);
-        renderNow();
-      }
-    }
+    // Rest-of-graph connected-dim. Gated by hover-intent: immediate when a
+    // selection/focus already exists (unchanged behavior) OR when the hover is
+    // clearing (restore base now); otherwise DEFERRED behind a ~200ms dwell so a
+    // pre-first-selection sweep across the graph no longer strobes dim/undim.
+    requestConnectedDim(Boolean(nodeId));
 
-    // Always-on label for the hovered node (plus the god-node set).
+    // The hovered node's OWN feedback (tooltip + label) stays immediate — only
+    // the rest-of-graph dim is delayed.
     updateLabels();
+  }
+
+  // Apply the connected-dim style for the CURRENT hover/selection/focus through
+  // the style buffers (no full payload rebuild). Pulled out of setHoveredNode so
+  // the hover-intent dwell timer can invoke it once the pointer settles.
+  function applyConnectedDim() {
+    if (!(mounted && payload)) return;
+    const style = buildConnectedDimStyle(payload, {
+      selectedIds: selectedIds ?? [],
+      focusId,
+      hoveredNodeId,
+    });
+    if (renderer && style) {
+      payload = { ...payload, style };
+      renderer.setStyle(style);
+      renderNow();
+    }
+  }
+
+  // Gate the rest-of-graph dim through the hover-intent dwell. Immediate when a
+  // selection/focus already exists OR when the hover is clearing (no target →
+  // restore base now); otherwise deferred until the pointer dwells.
+  function requestConnectedDim(hasHoverTarget) {
+    const immediate =
+      !shouldDelayConnectedDim({ selectedIds, focusId }) || !hasHoverTarget;
+    hoverIntent.request({ immediate });
   }
 
   function handlePointerLeave() {
@@ -996,6 +1027,9 @@
     // zoom and pan instead of resetting the view.
     selectedIds;
     focusId;
+    // A selection/focus appearing supersedes any pending pre-selection hover
+    // dwell — updateSelection() rebuilds the (selection-dimmed) style itself.
+    hoverIntent.cancel();
     updateSelection();
   });
 
@@ -1036,6 +1070,7 @@
       window.removeEventListener("keydown", handleKeydown);
       if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
       if (indicatorTimer !== null) window.clearTimeout(indicatorTimer);
+      hoverIntent.cancel();
       cancelMergeFrame();
       renderer?.destroy();
       renderer = null;

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -42,8 +42,24 @@
   const NODE_TIGHT_SLOP = 4;
   const HOVER_EDGE_COLOR = [37, 99, 235, 255];
   const MERGE_ANIMATION_DURATION_MS = 520;
-  // Hide edges during pan/zoom when nodes+edges exceed this, for interaction fluidity on large graphs.
-  const EDGE_SKIP_THRESHOLD = 1000;
+  // CANVAS2D ONLY: hide edges during active pan/zoom/drag when nodes+edges exceed
+  // this, for interaction fluidity (a legacy SVG-era guard). WebGL2 NEVER skips
+  // (GPU-instanced edges are cheap) — see `skipEdgesOnInteract`.
+  //
+  // Threshold raised 1000 → 6000 from a Skia/Canvas2D bench (Skia is the SAME
+  // rasterizer Chrome's 2D canvas uses), median per-frame full render() at
+  // 1440×900 DPR1 (.graphify/scratch/edge-skip-bench.mjs):
+  //   ·   1000 obj (old threshold): ~2.9 ms  (~343 fps) — skipping was absurdly
+  //       over-conservative for graphs this cheap.
+  //   ·   mystery 5676 obj (1983n/3693e): ~17 ms (~58 fps), ~13 ms of it edges.
+  //   ·   5k edges  / 7500 obj:  ~22.5 ms (~44 fps)
+  //   ·  10k edges  / 15000 obj: ~45 ms   (~22 fps)
+  //   ·  20k edges  / 28000 obj: ~87 ms   (~11 fps)
+  // 6000 sits just ABOVE mystery scale so typical graphs (incl. mystery) keep
+  // edges live during interaction (~58 fps, smooth), and just BELOW the 5k-edge
+  // step so denser graphs — and especially 10k+ edges (the non-regression guard)
+  // — still skip edges during pan/zoom to stay fluid. (See PR description.)
+  const EDGE_SKIP_THRESHOLD = 6000;
   // Delay before restoring edges after the last wheel/zoom event settles.
   const ZOOM_SETTLE_MS = 150;
   // Boxed labels: show a label for nodes whose degree >= this fraction of the max
@@ -132,8 +148,15 @@
   // + edge endpoints): a recompute that yields the SAME content does NOT refit,
   // which also preserves a dragged node's position across an incidental rebuild.
   let lastSceneKey = null;
-  // True when the current update path is a real scene/graph-data change (mount/new graph/resize).
-  let skipEdgesOnInteract = false;
+  // BACKEND-AWARE edge-skip during active pan/zoom/drag. WebGL2 NEVER skips
+  // (GPU-instanced edges are cheap), so this is false whenever the active backend
+  // is WebGL2 — edges always render during interaction. On Canvas2D it skips only
+  // past EDGE_SKIP_THRESHOLD objects. `$derived` so a Ctrl+Shift+X backend flip
+  // (or a boot fallback to canvas2d) re-evaluates it immediately.
+  const skipEdgesOnInteract = $derived(
+    activeBackend !== WEBGL2_BACKEND &&
+      (scene?.nodes?.length ?? 0) + (scene?.edges?.length ?? 0) > edgeSkipThreshold,
+  );
   // Zoom-settle debounce timer: full-edge render after the last wheel event settles.
   let zoomSettleTimer = null;
 
@@ -470,10 +493,8 @@
     clearHoveredEdge({ notify: false, render: false });
     computeNodeDegrees();
     reapplyDraggedPositions();
-
-    // Skip edges during pan/zoom only when the object count is large enough.
-    const objectCount = (scene?.nodes?.length ?? 0) + (scene?.edges?.length ?? 0);
-    skipEdgesOnInteract = objectCount > edgeSkipThreshold;
+    // NB: `skipEdgesOnInteract` is a backend-aware `$derived` (declared above) —
+    // no imperative recompute here, so a backend flip updates it reactively.
   }
 
   // Re-write any user-dragged node positions onto the freshly-built payload so a

--- a/studio/src/lib/hoverIntent.js
+++ b/studio/src/lib/hoverIntent.js
@@ -1,0 +1,82 @@
+// Hover-intent DWELL gate for the connected-dim styling.
+//
+// PROBLEM (strobe): before the first selection/focus, hovering any node
+// IMMEDIATELY dimmed the rest of the graph (buildConnectedDimStyle), and leaving
+// un-dimmed it — so sweeping the pointer across the graph strobed the whole graph
+// dim/undim.
+//
+// FIX: while NO selection AND NO focus exists, require the pointer to DWELL on an
+// object ~200ms before applying the rest-of-graph dim. If the pointer leaves the
+// object (or moves to empty space) before the dwell elapses, the dim is never
+// applied. Once a selection/focus exists, the dim stays IMMEDIATE — the
+// established behavior is unchanged; only the pre-first-selection path is gated.
+//
+// The hovered object's OWN feedback (tooltip + label + edge emphasis) is left
+// immediate by the caller; only the REST-OF-GRAPH dim flows through this gate.
+
+export const HOVER_INTENT_DWELL_MS = 200;
+
+/**
+ * True when the connected-dim should be DEFERRED behind the dwell delay: only
+ * before the first selection/focus. With a selection OR a focus present the dim
+ * is applied immediately (the established behavior).
+ *
+ * @param {{ selectedIds?: unknown, focusId?: unknown }} state
+ */
+export function shouldDelayConnectedDim({ selectedIds, focusId } = {}) {
+  const hasSelection = Array.isArray(selectedIds)
+    ? selectedIds.length > 0
+    : Boolean(selectedIds);
+  const hasFocus = focusId !== null && focusId !== undefined;
+  return !hasSelection && !hasFocus;
+}
+
+/**
+ * Small dwell-timer controller. `apply` performs the actual rest-of-graph dim
+ * (reads the live hover/selection/focus when invoked). Timers are injectable so
+ * the gate is unit-testable with fake timers and SSR-safe.
+ *
+ * @param {() => void} apply
+ * @param {{ delayMs?: number, setTimer?: (fn: () => void, ms: number) => unknown, clearTimer?: (id: unknown) => void }} [opts]
+ */
+export function createHoverIntent(apply, {
+  delayMs = HOVER_INTENT_DWELL_MS,
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (id) => clearTimeout(id),
+} = {}) {
+  let timer = null;
+
+  function cancel() {
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  }
+
+  /**
+   * Request the dim for the CURRENT hover. `immediate` (a selection/focus is
+   * present, or the hover is clearing and must restore the base style now)
+   * applies it synchronously; otherwise the dim is deferred until the pointer
+   * dwells `delayMs`. Any prior pending dwell is cancelled first, so a hover
+   * target change restarts the dwell rather than firing early.
+   *
+   * @param {{ immediate?: boolean }} [options]
+   */
+  function request({ immediate = false } = {}) {
+    cancel();
+    if (immediate) {
+      apply();
+      return;
+    }
+    timer = setTimer(() => {
+      timer = null;
+      apply();
+    }, delayMs);
+  }
+
+  return {
+    request,
+    cancel,
+    isPending: () => timer !== null,
+  };
+}

--- a/studio/src/tests/dualRenderBackend.test.js
+++ b/studio/src/tests/dualRenderBackend.test.js
@@ -43,6 +43,9 @@ describe("dual-render backend lib", () => {
     expect(rendererOptionsFor(WEBGL2_BACKEND, 2)).toEqual({
       backend: "webgl",
       instancedShapes: true,
+      // Mode B requests a MULTISAMPLED context (#229) so GPU edges/borders get
+      // MSAA smoothing — the lib returns antialias:true for WebGL2.
+      antialias: true,
       pixelRatio: 2,
     });
   });
@@ -142,7 +145,8 @@ describe("dual-render backend lib", () => {
   });
 
   it("simulating Ctrl+Shift+X toggles the backend, recreates the renderer, and paints the overlay via boxTextDraws()", () => {
-    // Start in mode A (the default).
+    // Start this toggle simulation from mode A (canvas2d); the toggle mechanics are
+    // backend-agnostic. (The studio BOOT default is WebGL2 — covered separately.)
     let activeBackend = CANVAS2D_BACKEND;
     const draws = [{ nodeIndex: 0, centerX: 1, centerY: 2, height: 8, label: "Hub", borderWidth: 2, borderColor: "rgba(1,2,3,1)", alpha: 1 }];
     // The factory hands out a webgl renderer when webgl is requested (WebGL2
@@ -184,10 +188,20 @@ describe("dual-render backend lib", () => {
 // Source-text guards: the component must wire the lib in (default canvas2d, the
 // keyboard toggle, the stacked overlay, the indicator badge).
 describe("GraphCanvas dual-render wiring", () => {
-  it("imports the render-backend lib and defaults to canvas2d", () => {
+  it("imports the render-backend lib and BOOTS on WebGL2 with a canvas2d fallback (P6 flip)", () => {
     const source = graphCanvasSource();
     expect(source).toContain('from "../lib/renderBackend.js"');
-    expect(source).toMatch(/activeBackend\s*=\s*\$state\(\s*CANVAS2D_BACKEND\s*\)/);
+    // P6 flip: the studio now boots on WebGL2 (was CANVAS2D_BACKEND), relying on
+    // the EXISTING graceful fallback when no WebGL2 context exists.
+    expect(source).toMatch(/activeBackend\s*=\s*\$state\(\s*WEBGL2_BACKEND\s*\)/);
+    expect(source).not.toMatch(/activeBackend\s*=\s*\$state\(\s*CANVAS2D_BACKEND\s*\)/);
+    // Graceful fallback still wired: createBackendRenderer's fellBack path reverts
+    // activeBackend to canvas2d and flags backendUnavailable.
+    expect(source).toContain("createBackendRenderer");
+    expect(source).toMatch(/result\.fellBack/);
+    expect(source).toMatch(/backendUnavailable\s*=\s*true/);
+    // The badge is revealed on the boot fallback so the unavailable state shows.
+    expect(source).toMatch(/switchActivated\s*\|\|\s*backendUnavailable/);
   });
 
   it("adds a window keydown listener for the Ctrl+Shift+X toggle and removes it on destroy", () => {

--- a/studio/src/tests/edgeSkipBackend.test.js
+++ b/studio/src/tests/edgeSkipBackend.test.js
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const graphCanvasSource = () =>
+  readFileSync(resolve("src/components/GraphCanvas.svelte"), "utf8");
+
+// Task C: edge-skip-during-pan/zoom is now BACKEND-AWARE.
+//  - WebGL2: never skip (GPU-instanced edges are cheap).
+//  - Canvas2D: skip only past EDGE_SKIP_THRESHOLD, raised after a Skia bench.
+describe("GraphCanvas backend-aware edge-skip", () => {
+  it("disables edge-skipping entirely on WebGL2 (always renders edges)", () => {
+    const source = graphCanvasSource();
+    // skipEdgesOnInteract is a $derived gated on the active backend NOT being WebGL2.
+    expect(source).toMatch(/skipEdgesOnInteract\s*=\s*\$derived\(/);
+    const block = source.slice(
+      source.indexOf("skipEdgesOnInteract = $derived("),
+      source.indexOf("skipEdgesOnInteract = $derived(") + 220,
+    );
+    expect(block).toContain("activeBackend !== WEBGL2_BACKEND");
+    expect(block).toContain("edgeSkipThreshold");
+  });
+
+  it("raises the Canvas2D threshold above mystery scale but below 10k-edge graphs", () => {
+    const source = graphCanvasSource();
+    const match = source.match(/const EDGE_SKIP_THRESHOLD\s*=\s*(\d+)/);
+    expect(match).not.toBeNull();
+    const threshold = Number(match[1]);
+    // Above mystery scale (1983 nodes + 3693 edges = 5676 objects) so mystery keeps
+    // edges live during interaction...
+    expect(threshold).toBeGreaterThan(5676);
+    // ...but a clear ceiling well below a 10k-edge graph (~15000 objects) so very
+    // large graphs still skip edges during pan/zoom (non-regression).
+    expect(threshold).toBeLessThan(15000);
+  });
+
+  it("no longer recomputes skipEdgesOnInteract imperatively in rebuildPayload", () => {
+    const source = graphCanvasSource();
+    // The old imperative assignment (skipEdgesOnInteract = objectCount > ...) is gone;
+    // the only assignment is the $derived declaration.
+    const assigns = source.match(/skipEdgesOnInteract\s*=/g) ?? [];
+    expect(assigns.length).toBe(1);
+  });
+});

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -24,10 +24,16 @@ describe("GraphCanvas renderer", () => {
     expect(source.indexOf("renderer.setPositions")).toBeLessThan(source.indexOf("onMergeComplete?.()"));
   });
 
-  it("forces the rich Canvas2D backend and restores pointer hover hit testing", () => {
+  it("boots on the WebGL2 backend (canvas2d fallback) and keeps pointer hover hit testing", () => {
     const source = graphCanvasSource();
 
-    expect(source).toContain('backend: "canvas2d"');
+    // P6 flip: WebGL2 is the boot default; canvas2d stays the graceful fallback
+    // (createBackendRenderer's fellBack path → backendUnavailable).
+    expect(source).toMatch(/activeBackend\s*=\s*\$state\(\s*WEBGL2_BACKEND\s*\)/);
+    expect(source).toContain("createBackendRenderer");
+    expect(source).toContain("backendUnavailable");
+    expect(source).toContain("CANVAS2D_BACKEND");
+    // hover hit-testing is unchanged.
     expect(source).toContain("findNearestEdge");
     expect(source).toContain("onpointermove");
   });

--- a/studio/src/tests/hoverIntent.test.js
+++ b/studio/src/tests/hoverIntent.test.js
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  HOVER_INTENT_DWELL_MS,
+  createHoverIntent,
+  shouldDelayConnectedDim,
+} from "../lib/hoverIntent.js";
+
+const graphCanvasSource = () =>
+  readFileSync(resolve("src/components/GraphCanvas.svelte"), "utf8");
+
+describe("hover-intent dwell gate", () => {
+  it("defers the dim ONLY before the first selection/focus", () => {
+    // No selection AND no focus → defer (dwell).
+    expect(shouldDelayConnectedDim({ selectedIds: [], focusId: null })).toBe(true);
+    expect(shouldDelayConnectedDim({ selectedIds: [], focusId: undefined })).toBe(true);
+    expect(shouldDelayConnectedDim({})).toBe(true);
+    // A selection OR a focus → immediate (established behavior).
+    expect(shouldDelayConnectedDim({ selectedIds: ["a"], focusId: null })).toBe(false);
+    expect(shouldDelayConnectedDim({ selectedIds: [], focusId: "f" })).toBe(false);
+    expect(shouldDelayConnectedDim({ selectedIds: ["a", "b"], focusId: "f" })).toBe(false);
+  });
+
+  describe("createHoverIntent timer", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("no-selection hover: NO dim before 200ms, dim AFTER", () => {
+      const apply = vi.fn();
+      const hi = createHoverIntent(apply);
+
+      hi.request({ immediate: false });
+      vi.advanceTimersByTime(HOVER_INTENT_DWELL_MS - 1);
+      expect(apply).not.toHaveBeenCalled(); // still within the dwell
+      expect(hi.isPending()).toBe(true);
+
+      vi.advanceTimersByTime(1);
+      expect(apply).toHaveBeenCalledTimes(1); // dwell elapsed → dim
+      expect(hi.isPending()).toBe(false);
+    });
+
+    it("pointer leaves (cancel) before the dwell → NEVER dims", () => {
+      const apply = vi.fn();
+      const hi = createHoverIntent(apply);
+
+      hi.request({ immediate: false });
+      vi.advanceTimersByTime(100); // leave mid-dwell
+      hi.cancel();
+      vi.advanceTimersByTime(1000);
+      expect(apply).not.toHaveBeenCalled();
+    });
+
+    it("selection/focus present → IMMEDIATE dim (no dwell)", () => {
+      const apply = vi.fn();
+      const hi = createHoverIntent(apply);
+
+      hi.request({ immediate: true });
+      expect(apply).toHaveBeenCalledTimes(1); // synchronous, before any timer
+      expect(hi.isPending()).toBe(false);
+    });
+
+    it("hover target change restarts the dwell (no early dim)", () => {
+      const apply = vi.fn();
+      const hi = createHoverIntent(apply);
+
+      hi.request({ immediate: false }); // hover node A
+      vi.advanceTimersByTime(150);
+      hi.request({ immediate: false }); // moved to node B before A's dwell elapsed
+      vi.advanceTimersByTime(150); // 150ms into B's dwell (A's timer was cancelled)
+      expect(apply).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(50); // B's full 200ms now elapsed
+      expect(apply).toHaveBeenCalledTimes(1);
+    });
+
+    it("an immediate request cancels a pending dwell (selection appears mid-dwell)", () => {
+      const apply = vi.fn();
+      const hi = createHoverIntent(apply);
+
+      hi.request({ immediate: false });
+      vi.advanceTimersByTime(120);
+      hi.request({ immediate: true }); // selection appeared → dim now
+      expect(apply).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(1000);
+      expect(apply).toHaveBeenCalledTimes(1); // the stale dwell did NOT also fire
+    });
+  });
+});
+
+// Source-text guard: the component must wire the dwell gate into the hover path
+// (only the rest-of-graph dim is deferred; tooltip/label stay immediate).
+describe("GraphCanvas hover-intent wiring", () => {
+  it("gates the connected-dim through the hover-intent dwell", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain('from "../lib/hoverIntent.js"');
+    expect(source).toContain("createHoverIntent");
+    expect(source).toContain("shouldDelayConnectedDim");
+    // setHoveredNode no longer applies the dim inline; it requests it via the gate.
+    expect(source).toContain("requestConnectedDim");
+    expect(source).toContain("applyConnectedDim");
+    // the dwell is cancelled on pan/drag start, on selection change, and on destroy.
+    expect(source).toContain("hoverIntent.cancel()");
+  });
+});


### PR DESCRIPTION
Three cohesive studio render-behavior changes (one atomic commit each).

## A — WebGL2 is the default backend (canvas2d fallback) — the "P6 flip"
- The studio now BOOTS on the WebGL2 (`instancedShapes`) backend instead of canvas2d, reusing the EXISTING graceful fallback in `createBackendRenderer`: when no WebGL2 context exists it reverts to canvas2d (`fellBack`) and sets `backendUnavailable`.
- Exact default change: `let activeBackend = $state(CANVAS2D_BACKEND)` → `$state(WEBGL2_BACKEND)`.
- Badge: on a successful WebGL2 boot the badge stays HIDDEN (clean UI); the first `Ctrl+Shift+X` / click reveals it. On a boot FALLBACK to canvas2d the badge is REVEALED immediately — the guard became `{#if switchActivated || backendUnavailable}` — showing "WebGL2 unavailable — Canvas2D". `Ctrl+Shift+X` still toggles both ways.
- Tests updated (coverage kept, not deleted): `dualRenderBackend.test.js` and `graphCanvasRenderer.test.js` source-text guards now assert the WebGL2 default + the canvas2d fallback wiring (`fellBack` / `backendUnavailable` / badge reveal). Also fixes a **pre-existing** stale unit assertion (`rendererOptionsFor(WEBGL2)` returns `antialias:true` since #229) that fails on `origin/main`. In jsdom (no WebGL2) the studio exercises the fallback path → canvas2d; the guards are source-text based so they're robust to that.

## B — hover-intent dwell before the first selection (de-strobe)
- While NO selection AND NO focus exists, the rest-of-graph connected-dim is deferred behind a ~200 ms hover-intent DWELL: the pointer must settle on an object before the dim applies; leaving (or moving to empty space) before the dwell cancels it (never dims). Once a selection/focus exists the dim stays IMMEDIATE (unchanged). The hovered object's own feedback (tooltip / label / edge emphasis) stays immediate — only the rest-of-graph dim is gated.
- Mechanism: small injectable-timer controller `studio/src/lib/hoverIntent.js` (`createHoverIntent` + `shouldDelayConnectedDim`, `HOVER_INTENT_DWELL_MS = 200`). `setHoveredNode` requests the dim through the gate; `applyConnectedDim` was pulled out so the timer can invoke it. The dwell is cancelled on pan/drag start, when a selection/focus appears, and on destroy.
- Test: `hoverIntent.test.js` — dwell-gating with fake timers (no dim before 200 ms; dim after; cancel-before-dwell never dims; selection present → immediate; target change restarts the dwell) + a component-wiring guard.

## C — backend-aware edge-skip during pan/zoom
- WebGL2: edge-skipping DISABLED entirely (GPU-instanced edges are cheap) — edges always render during interaction. `skipEdgesOnInteract` became a `$derived` gated on `activeBackend !== WEBGL2_BACKEND`, so a `Ctrl+Shift+X` flip (or boot fallback) re-evaluates immediately.
- Canvas2D: still skips, threshold raised **1000 → 6000**. Canvas2D correctness unchanged.

### Benchmark (Skia/Canvas2D — the same rasterizer Chrome's 2D canvas uses — via `@napi-rs/canvas` + the real renderer; median per-frame full `render()` at 1440×900 DPR1):
| case | objects | full render | ~fps |
|---|---|---|---|
| 1000 obj (old threshold) | 1000 | ~2.9 ms | ~343 |
| **mystery** (1983n / 3693e) | 5676 | ~17 ms (~13 ms edges) | ~58 |
| 5k edges | 7500 | ~22.5 ms | ~44 |
| 10k edges | 15000 | ~45 ms | ~22 |
| 20k edges | 28000 | ~87 ms | ~11 |

**Chosen threshold = 6000**: just ABOVE mystery scale (so the canonical graph keeps edges live during interaction, ~58 fps, smooth) and just BELOW the 5k-edge step — a clear skip ceiling so 10k+ edge graphs still skip during pan/zoom (non-regression). The old 1000 made even trivially-cheap (~2.9 ms / 343 fps) graphs skip. (Random vs clustered/force-layout-like edges measured within noise at DPR1; the bench lives at `.graphify/scratch/edge-skip-bench.mjs`, not committed.)
- Test: `edgeSkipBackend.test.js` — WebGL no-skip, threshold above mystery / below 10k, no imperative recompute.

## Verification (all run, all green)
- `npm run lint` (tsc --noEmit): exit 0
- `cd studio && npx vitest run`: **22 files / 257 tests passed**
- `npm run build:studio`: exit 0
- `cd packages/graph && GOLDEN_ENABLE_WEBGL=1 GOLDEN_REQUIRE_WEBGL=1 CHROME_BIN=/snap/bin/chromium npm run test:golden:webgl`: **4 files / 111 tests passed** (real WebGL2 via SwiftShader, pixel-diff ran). The golden harness uses its own renderer/harness page, so the studio default flip does not affect it — confirmed (packages/graph is untouched by these commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)