### PR TITLE
feat(pdf-ocr): capture Mistral OCR v4 per-page text + normalized bbox (cited-source bridge)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,16 @@ export { parsePdfOcrMode, preflightPdf, pdfOcrSidecarStem } from "./pdf-prefligh
 export type { PdfOcrMode, PdfPreflightOptions, PdfPreflightResult } from "./pdf-preflight.js";
 export { augmentDetectionWithPdfPreflight } from "./pdf-ocr.js";
 export type { PdfPreparationArtifact, PdfPreparationOptions } from "./pdf-ocr.js";
+export { buildPdfOcrPagesSidecar, pdfOcrPagesToCitedSourceRefs, PDF_OCR_PAGES_SCHEMA } from "./pdf-ocr-refs.js";
+export type {
+  PdfOcrPagesSidecar,
+  PdfOcrPageRef,
+  PdfOcrImageRef,
+  PdfOcrBlockRef,
+  PdfOcrRefOptions,
+  BuildPdfOcrPagesInput,
+  NormalizedBbox,
+} from "./pdf-ocr-refs.js";
 export { prepareSemanticDetection } from "./semantic-prepare.js";
 export type { SemanticPreparationOptions, SemanticPreparationResult } from "./semantic-prepare.js";
 export {

--- a/src/pdf-ocr-refs.ts
+++ b/src/pdf-ocr-refs.ts
@@ -1,0 +1,264 @@
+import type { CitedSourceRef } from "./types.js";
+
+/**
+ * Schema identifier for the structured per-page OCR sidecar (`<stem>.ocr.json`)
+ * emitted alongside the markdown when Mistral OCR v4 returns a structured
+ * response. The sidecar is additive: the markdown sidecar is unchanged.
+ */
+export const PDF_OCR_PAGES_SCHEMA = "graphify_pdf_ocr_pages_v1";
+
+/** Normalized 0..1 page fractions, top-left origin: [x0, y0, x1, y1]. */
+export type NormalizedBbox = [number, number, number, number];
+
+export interface PdfOcrImageRef {
+  /** Image id as reported by the OCR response (matches the markdown image ref). */
+  id: string;
+  /** Normalized [x0,y0,x1,y1] page fractions. Omitted when the API gave no coords. */
+  bbox?: NormalizedBbox;
+}
+
+export interface PdfOcrBlockRef {
+  /** Verbatim block text, when the response carried block-level text. */
+  text?: string;
+  /** Normalized [x0,y0,x1,y1] page fractions. Omitted when the API gave no coords. */
+  bbox?: NormalizedBbox;
+}
+
+export interface PdfOcrPageRef {
+  /** 1-based page number (OCR `index` + 1). */
+  page: number;
+  /** Page screenshot width in pixels, when the API reported dimensions. */
+  width?: number;
+  /** Page screenshot height in pixels, when the API reported dimensions. */
+  height?: number;
+  /** Dots-per-inch of the page screenshot, when the API reported dimensions. */
+  dpi?: number;
+  /** Extracted images with normalized bboxes (when coords were provided). */
+  images?: PdfOcrImageRef[];
+  /**
+   * Block-level text regions with normalized bboxes. The standard Mistral OCR
+   * v4 response only carries image geometry, so this is populated only when the
+   * response includes block/segment geometry (e.g. via bbox annotations).
+   */
+  blocks?: PdfOcrBlockRef[];
+}
+
+export interface PdfOcrPagesSidecar {
+  schema: typeof PDF_OCR_PAGES_SCHEMA;
+  source_file: string;
+  sha256: string;
+  model: string;
+  pages: PdfOcrPageRef[];
+}
+
+export interface BuildPdfOcrPagesInput {
+  /** Raw Mistral OCR response (`convertPdf(...).ocrResponse`). Defensively parsed. */
+  ocrResponse: unknown;
+  source_file: string;
+  sha256: string;
+  model: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function pickNumber(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const found = asFiniteNumber(record[key]);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function clampUnit(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function roundFraction(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+interface PixelBox {
+  x0?: number;
+  y0?: number;
+  x1?: number;
+  y1?: number;
+}
+
+/**
+ * Read pixel-space corner coordinates from an OCR image/block record. Accepts
+ * both the SDK camelCase form (`topLeftX`) and the raw API snake_case form
+ * (`top_left_x`), plus an explicit `bbox: [x0,y0,x1,y1]` pixel array.
+ */
+function readPixelBox(record: Record<string, unknown>): PixelBox {
+  const bboxArray = record["bbox"] ?? record["bounding_box"];
+  if (Array.isArray(bboxArray) && bboxArray.length >= 4) {
+    return {
+      x0: asFiniteNumber(bboxArray[0]),
+      y0: asFiniteNumber(bboxArray[1]),
+      x1: asFiniteNumber(bboxArray[2]),
+      y1: asFiniteNumber(bboxArray[3]),
+    };
+  }
+  return {
+    x0: pickNumber(record, "topLeftX", "top_left_x"),
+    y0: pickNumber(record, "topLeftY", "top_left_y"),
+    x1: pickNumber(record, "bottomRightX", "bottom_right_x"),
+    y1: pickNumber(record, "bottomRightY", "bottom_right_y"),
+  };
+}
+
+/**
+ * Normalize pixel-space corners to 0..1 page fractions (top-left origin):
+ *   x ÷ pageWidthPx, y ÷ pageHeightPx, clamped to [0,1].
+ * Returns undefined when any corner or the page dimensions are missing.
+ */
+function normalizeBbox(box: PixelBox, width?: number, height?: number): NormalizedBbox | undefined {
+  const { x0, y0, x1, y1 } = box;
+  if (
+    x0 === undefined || y0 === undefined || x1 === undefined || y1 === undefined ||
+    width === undefined || height === undefined || width <= 0 || height <= 0
+  ) {
+    return undefined;
+  }
+  return [
+    roundFraction(clampUnit(x0 / width)),
+    roundFraction(clampUnit(y0 / height)),
+    roundFraction(clampUnit(x1 / width)),
+    roundFraction(clampUnit(y1 / height)),
+  ];
+}
+
+/**
+ * Build the structured per-page OCR sidecar from a Mistral OCR v4 response.
+ * Pure: no IO. Returns null when the response carries no pages (so the caller
+ * skips writing the sidecar — e.g. mocks/non-OCR providers that don't expose
+ * the structured response).
+ */
+export function buildPdfOcrPagesSidecar(input: BuildPdfOcrPagesInput): PdfOcrPagesSidecar | null {
+  const root = asRecord(input.ocrResponse);
+  if (!root) return null;
+  const rawPages = asArray(root["pages"]);
+  if (rawPages.length === 0) return null;
+
+  const pages: PdfOcrPageRef[] = [];
+  rawPages.forEach((rawPage, position) => {
+    const pageRecord = asRecord(rawPage);
+    if (!pageRecord) return;
+
+    const index = asFiniteNumber(pageRecord["index"]);
+    const page = (index !== undefined ? index : position) + 1;
+
+    const dimensions = asRecord(pageRecord["dimensions"]);
+    const width = dimensions ? pickNumber(dimensions, "width") : undefined;
+    const height = dimensions ? pickNumber(dimensions, "height") : undefined;
+    const dpi = dimensions ? pickNumber(dimensions, "dpi") : undefined;
+
+    const pageRef: PdfOcrPageRef = { page };
+    if (width !== undefined) pageRef.width = width;
+    if (height !== undefined) pageRef.height = height;
+    if (dpi !== undefined) pageRef.dpi = dpi;
+
+    const images: PdfOcrImageRef[] = [];
+    for (const rawImage of asArray(pageRecord["images"])) {
+      const imageRecord = asRecord(rawImage);
+      if (!imageRecord) continue;
+      const id = asNonEmptyString(imageRecord["id"]);
+      if (id === undefined) continue;
+      const bbox = normalizeBbox(readPixelBox(imageRecord), width, height);
+      const imageRef: PdfOcrImageRef = { id };
+      if (bbox) imageRef.bbox = bbox;
+      images.push(imageRef);
+    }
+    if (images.length > 0) pageRef.images = images;
+
+    const blocks: PdfOcrBlockRef[] = [];
+    for (const rawBlock of [...asArray(pageRecord["blocks"]), ...asArray(pageRecord["segments"])]) {
+      const blockRecord = asRecord(rawBlock);
+      if (!blockRecord) continue;
+      const text = asNonEmptyString(blockRecord["text"] ?? blockRecord["markdown"] ?? blockRecord["content"]);
+      const bbox = normalizeBbox(readPixelBox(blockRecord), width, height);
+      if (text === undefined && !bbox) continue;
+      const blockRef: PdfOcrBlockRef = {};
+      if (text !== undefined) blockRef.text = text;
+      if (bbox) blockRef.bbox = bbox;
+      blocks.push(blockRef);
+    }
+    if (blocks.length > 0) pageRef.blocks = blocks;
+
+    pages.push(pageRef);
+  });
+
+  if (pages.length === 0) return null;
+
+  return {
+    schema: PDF_OCR_PAGES_SCHEMA,
+    source_file: input.source_file,
+    sha256: input.sha256,
+    model: input.model,
+    pages,
+  };
+}
+
+export interface PdfOcrRefOptions {
+  /**
+   * Base fields stamped onto every produced ref (docSha / rawRef / sourceUrl /
+   * citation / publishedAt …), matching the radar CitedSourceRef convention.
+   */
+  base?: Partial<CitedSourceRef>;
+  /** Emit refs for images with a bbox (geometry only, no excerpt). Default true. */
+  includeImages?: boolean;
+  /** Emit refs for blocks with text and/or a bbox. Default true. */
+  includeBlocks?: boolean;
+}
+
+/**
+ * Map a structured OCR pages sidecar to CitedSourceRef[] (radar convention:
+ * 1-based page + normalized [x0,y0,x1,y1] bbox + optional verbatim excerpt).
+ * Block refs carry the block text as `excerpt`; image refs carry geometry only.
+ * Entries with neither geometry nor text are skipped.
+ */
+export function pdfOcrPagesToCitedSourceRefs(
+  sidecar: PdfOcrPagesSidecar,
+  options: PdfOcrRefOptions = {},
+): CitedSourceRef[] {
+  const includeImages = options.includeImages ?? true;
+  const includeBlocks = options.includeBlocks ?? true;
+  const base = options.base ?? {};
+  const refs: CitedSourceRef[] = [];
+
+  for (const page of sidecar.pages) {
+    if (includeBlocks && page.blocks) {
+      for (const block of page.blocks) {
+        if (block.text === undefined && !block.bbox) continue;
+        const ref: CitedSourceRef = { ...base, page: page.page };
+        if (block.bbox) ref.bbox = block.bbox;
+        if (block.text !== undefined) ref.excerpt = block.text;
+        refs.push(ref);
+      }
+    }
+    if (includeImages && page.images) {
+      for (const image of page.images) {
+        if (!image.bbox) continue;
+        refs.push({ ...base, page: page.page, bbox: image.bbox });
+      }
+    }
+  }
+
+  return refs;
+}

--- a/src/pdf-ocr.ts
+++ b/src/pdf-ocr.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { join, resolve } from "node:path";
 import type { DetectionResult } from "./types.js";
 import { extractPdfTextLayer, pdfOcrSidecarStem, parsePdfOcrMode, preflightPdf, type PdfOcrMode, type PdfPreflightResult } from "./pdf-preflight.js";
+import { buildPdfOcrPagesSidecar } from "./pdf-ocr-refs.js";
 
 const MISTRAL_OCR_PACKAGE = "mistral-ocr";
 const DEFAULT_OCR_MODEL = "mistral-ocr-4-0";
@@ -48,7 +49,11 @@ function countWords(text: string): number {
   return text.split(/\s+/).filter(Boolean).length;
 }
 
-function metadataPath(markdownPath: string): string {
+function prepMetadataPath(markdownPath: string): string {
+  return markdownPath.replace(/\.md$/i, ".prep.json");
+}
+
+function ocrPagesSidecarPath(markdownPath: string): string {
   return markdownPath.replace(/\.md$/i, ".ocr.json");
 }
 
@@ -130,7 +135,7 @@ async function preparePdf(
   const stem = pdfOcrSidecarStem(filePath, preflight.sha256);
   const markdownPath = join(outputDir, stem + ".md");
   const imageOutputDir = join(outputDir, stem + "_images");
-  const ocrMetadataPath = metadataPath(markdownPath);
+  const prepPath = prepMetadataPath(markdownPath);
 
   if (existsSync(markdownPath)) {
     const provider = preflight.shouldOcr ? "mistral-ocr" : preflight.textLayerProvider === "pdftotext" ? "pdftotext" : "unpdf";
@@ -144,7 +149,7 @@ async function preparePdf(
       reason: "sidecar_exists",
       preflight,
     };
-    writeMetadata(ocrMetadataPath, artifact);
+    writeMetadata(prepPath, artifact);
     return artifact;
   }
 
@@ -164,7 +169,7 @@ async function preparePdf(
           reason: preflight.reason,
           preflight,
         };
-        writeMetadata(ocrMetadataPath, artifact);
+        writeMetadata(prepPath, artifact);
         return artifact;
       }
     }
@@ -197,14 +202,28 @@ async function preparePdf(
 
   try {
     const mistralOcr = await loadMistralOcrModule();
-    await mistralOcr.convertPdf(resolve(filePath), {
+    const ocrModel = options.model ?? process.env.GRAPHIFY_PDF_OCR_MODEL ?? DEFAULT_OCR_MODEL;
+    const conversion = await mistralOcr.convertPdf(resolve(filePath), {
       apiKey,
-      model: options.model ?? process.env.GRAPHIFY_PDF_OCR_MODEL ?? DEFAULT_OCR_MODEL,
+      model: ocrModel,
       markdownPath,
       imageOutputDir,
       generateDocx: false,
       logger: false,
     });
+    // Additive capture: when Mistral OCR v4 returns the structured response,
+    // persist per-page text geometry to <stem>.ocr.json. The markdown sidecar
+    // above is untouched (byte-identical), and this is skipped entirely when the
+    // response is absent (e.g. non-OCR providers / mocked conversions).
+    const ocrPagesSidecar = buildPdfOcrPagesSidecar({
+      ocrResponse: conversion.ocrResponse,
+      source_file: resolve(filePath),
+      sha256: preflight.sha256,
+      model: ocrModel,
+    });
+    if (ocrPagesSidecar) {
+      writeFileSync(ocrPagesSidecarPath(markdownPath), JSON.stringify(ocrPagesSidecar, null, 2), "utf-8");
+    }
     const originalMarkdown = existsSync(markdownPath) ? readFileSync(markdownPath, "utf-8") : "";
     if (originalMarkdown && !originalMarkdown.startsWith("---\n")) {
       writeFileSync(
@@ -230,7 +249,7 @@ async function preparePdf(
       reason: preflight.reason,
       preflight,
     };
-    writeMetadata(ocrMetadataPath, artifact);
+    writeMetadata(prepPath, artifact);
     return artifact;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);

--- a/tests/pdf-ocr-refs.test.ts
+++ b/tests/pdf-ocr-refs.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  PDF_OCR_PAGES_SCHEMA,
+  buildPdfOcrPagesSidecar,
+  pdfOcrPagesToCitedSourceRefs,
+  type PdfOcrPagesSidecar,
+} from "../src/pdf-ocr-refs.js";
+
+// Mock OCR response shaped like the @mistralai/mistralai SDK deserialization
+// (camelCase, 0-based `index`, nullable corner coords, `dimensions|null`).
+const MOCK_OCR_RESPONSE = {
+  model: "mistral-ocr-4-0",
+  usageInfo: { pagesProcessed: 2 },
+  pages: [
+    {
+      index: 0,
+      markdown: "# Page one",
+      dimensions: { dpi: 200, width: 1000, height: 1400 },
+      images: [
+        { id: "img-0", topLeftX: 100, topLeftY: 140, bottomRightX: 500, bottomRightY: 700, imageBase64: null },
+        // No coords -> bbox omitted but image id retained.
+        { id: "img-1", topLeftX: null, topLeftY: null, bottomRightX: null, bottomRightY: null },
+      ],
+      blocks: [
+        { text: "Hello world", topLeftX: 0, topLeftY: 0, bottomRightX: 1000, bottomRightY: 70 },
+      ],
+    },
+    {
+      index: 1,
+      markdown: "# Page two",
+      // No dimensions -> cannot normalize -> no width/height and no image bbox.
+      dimensions: null,
+      images: [{ id: "img-2", topLeftX: 10, topLeftY: 10, bottomRightX: 20, bottomRightY: 20 }],
+    },
+  ],
+};
+
+describe("buildPdfOcrPagesSidecar", () => {
+  function build(): PdfOcrPagesSidecar {
+    const sidecar = buildPdfOcrPagesSidecar({
+      ocrResponse: MOCK_OCR_RESPONSE,
+      source_file: "/abs/scan.pdf",
+      sha256: "deadbeef",
+      model: "mistral-ocr-4-0",
+    });
+    expect(sidecar).not.toBeNull();
+    return sidecar!;
+  }
+
+  it("emits the graphify_pdf_ocr_pages_v1 envelope with passthrough metadata", () => {
+    const sidecar = build();
+    expect(sidecar.schema).toBe(PDF_OCR_PAGES_SCHEMA);
+    expect(sidecar.schema).toBe("graphify_pdf_ocr_pages_v1");
+    expect(sidecar.source_file).toBe("/abs/scan.pdf");
+    expect(sidecar.sha256).toBe("deadbeef");
+    expect(sidecar.model).toBe("mistral-ocr-4-0");
+    expect(sidecar.pages).toHaveLength(2);
+  });
+
+  it("makes pages 1-based and carries dimensions when present", () => {
+    const [page1, page2] = build().pages;
+    expect(page1!.page).toBe(1); // index 0 -> page 1
+    expect(page1!.width).toBe(1000);
+    expect(page1!.height).toBe(1400);
+    expect(page1!.dpi).toBe(200);
+    expect(page2!.page).toBe(2); // index 1 -> page 2
+    // dimensions === null -> width/height/dpi omitted entirely.
+    expect(page2!).not.toHaveProperty("width");
+    expect(page2!).not.toHaveProperty("height");
+    expect(page2!).not.toHaveProperty("dpi");
+  });
+
+  it("normalizes image bboxes to 0..1 page fractions (pixel ÷ dimensions, top-left)", () => {
+    const page1 = build().pages[0]!;
+    expect(page1.images).toHaveLength(2);
+    // [100/1000, 140/1400, 500/1000, 700/1400] = [0.1, 0.1, 0.5, 0.5]
+    expect(page1.images![0]).toEqual({ id: "img-0", bbox: [0.1, 0.1, 0.5, 0.5] });
+  });
+
+  it("omits bbox when the API did not provide corner coords", () => {
+    const page1 = build().pages[0]!;
+    expect(page1.images![1]).toEqual({ id: "img-1" });
+    expect(page1.images![1]).not.toHaveProperty("bbox");
+  });
+
+  it("omits bbox when page dimensions are missing", () => {
+    const page2 = build().pages[1]!;
+    expect(page2.images![0]).toEqual({ id: "img-2" });
+    expect(page2.images![0]).not.toHaveProperty("bbox");
+  });
+
+  it("maps block-level text + normalized bbox when present", () => {
+    const page1 = build().pages[0]!;
+    expect(page1.blocks).toHaveLength(1);
+    // [0/1000, 0/1400, 1000/1000, 70/1400] = [0, 0, 1, 0.05]
+    expect(page1.blocks![0]).toEqual({ text: "Hello world", bbox: [0, 0, 1, 0.05] });
+  });
+
+  it("does not emit a blocks array for pages without block geometry", () => {
+    const page2 = build().pages[1]!;
+    expect(page2).not.toHaveProperty("blocks");
+  });
+
+  it("accepts the raw snake_case corner form too", () => {
+    const sidecar = buildPdfOcrPagesSidecar({
+      ocrResponse: {
+        pages: [
+          {
+            index: 0,
+            dimensions: { width: 200, height: 100, dpi: 72 },
+            images: [{ id: "snake", top_left_x: 50, top_left_y: 25, bottom_right_x: 150, bottom_right_y: 75 }],
+          },
+        ],
+      },
+      source_file: "/abs/snake.pdf",
+      sha256: "feed",
+      model: "mistral-ocr-4-0",
+    });
+    expect(sidecar!.pages[0]!.images![0]).toEqual({ id: "snake", bbox: [0.25, 0.25, 0.75, 0.75] });
+  });
+
+  it("returns null when the response carries no pages", () => {
+    expect(buildPdfOcrPagesSidecar({ ocrResponse: null, source_file: "x", sha256: "y", model: "m" })).toBeNull();
+    expect(buildPdfOcrPagesSidecar({ ocrResponse: {}, source_file: "x", sha256: "y", model: "m" })).toBeNull();
+    expect(buildPdfOcrPagesSidecar({ ocrResponse: { pages: [] }, source_file: "x", sha256: "y", model: "m" })).toBeNull();
+  });
+});
+
+describe("pdfOcrPagesToCitedSourceRefs", () => {
+  function sidecar(): PdfOcrPagesSidecar {
+    return buildPdfOcrPagesSidecar({
+      ocrResponse: MOCK_OCR_RESPONSE,
+      source_file: "/abs/scan.pdf",
+      sha256: "deadbeef",
+      model: "mistral-ocr-4-0",
+    })!;
+  }
+
+  it("maps blocks (text+bbox) and located images to CitedSourceRef, skipping geometry-less entries", () => {
+    const refs = pdfOcrPagesToCitedSourceRefs(sidecar());
+    // page1 block (text+bbox) + page1 img-0 (bbox). img-1 (no bbox) and img-2 (no bbox) skipped.
+    expect(refs).toEqual([
+      { page: 1, bbox: [0, 0, 1, 0.05], excerpt: "Hello world" },
+      { page: 1, bbox: [0.1, 0.1, 0.5, 0.5] },
+    ]);
+  });
+
+  it("stamps radar base fields (docSha/rawRef/sourceUrl) onto every ref", () => {
+    const refs = pdfOcrPagesToCitedSourceRefs(sidecar(), {
+      base: { docSha: "abc123", rawRef: "raw/scan/cas/abc.pdf" },
+    });
+    for (const ref of refs) {
+      expect(ref.docSha).toBe("abc123");
+      expect(ref.rawRef).toBe("raw/scan/cas/abc.pdf");
+    }
+    expect(refs[0]!.page).toBe(1);
+  });
+
+  it("honors includeImages / includeBlocks toggles", () => {
+    const onlyBlocks = pdfOcrPagesToCitedSourceRefs(sidecar(), { includeImages: false });
+    expect(onlyBlocks).toEqual([{ page: 1, bbox: [0, 0, 1, 0.05], excerpt: "Hello world" }]);
+    const onlyImages = pdfOcrPagesToCitedSourceRefs(sidecar(), { includeBlocks: false });
+    expect(onlyImages).toEqual([{ page: 1, bbox: [0.1, 0.1, 0.5, 0.5] }]);
+  });
+});

--- a/tests/pdf-ocr-sidecar.test.ts
+++ b/tests/pdf-ocr-sidecar.test.ts
@@ -1,0 +1,134 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { convertPdfMock } = vi.hoisted(() => ({ convertPdfMock: vi.fn() }));
+
+vi.mock("mistral-ocr", () => ({ convertPdf: convertPdfMock }));
+
+import { augmentDetectionWithPdfPreflight } from "../src/pdf-ocr.js";
+import type { DetectionResult } from "../src/types.js";
+
+const MARKDOWN_BODY = "# OCR markdown\n\nDetected text";
+
+const MOCK_OCR_RESPONSE = {
+  model: "mistral-ocr-4-0",
+  pages: [
+    {
+      index: 0,
+      markdown: "# Page one",
+      dimensions: { dpi: 200, width: 1000, height: 1400 },
+      images: [
+        { id: "img-0", topLeftX: 100, topLeftY: 140, bottomRightX: 500, bottomRightY: 700 },
+        { id: "img-1", topLeftX: null, topLeftY: null, bottomRightX: null, bottomRightY: null },
+      ],
+    },
+  ],
+};
+
+const tempDirs: string[] = [];
+
+function detection(pdfPath: string, root: string): DetectionResult {
+  return {
+    files: { code: [], document: [], paper: [pdfPath], image: [], video: [] },
+    skipped_sensitive: [],
+    root,
+    total_files: 1,
+    total_words: 0,
+    needs_graph: false,
+    warning: null,
+    graphifyignore_patterns: 0,
+  } as DetectionResult;
+}
+
+describe("Mistral OCR v4 structured sidecar capture", () => {
+  let tmpDir: string;
+  let pdfPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "graphify-ocr-sidecar-"));
+    tempDirs.push(tmpDir);
+    pdfPath = join(tmpDir, "scan.pdf");
+    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n/Image /XObject\n"));
+    process.env.MISTRAL_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    convertPdfMock.mockReset();
+    delete process.env.MISTRAL_API_KEY;
+    delete process.env.GRAPHIFY_PDF_OCR;
+    delete process.env.GRAPHIFY_PDF_OCR_MODEL;
+    while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  });
+
+  it("writes <stem>.ocr.json with normalized geometry when the response is structured", async () => {
+    convertPdfMock.mockImplementation(async (_input: string, options: { markdownPath: string }) => {
+      writeFileSync(options.markdownPath, MARKDOWN_BODY, "utf-8");
+      return { markdown: MARKDOWN_BODY, markdownPath: options.markdownPath, images: [], ocrResponse: MOCK_OCR_RESPONSE };
+    });
+
+    const outputDir = join(tmpDir, "out");
+    const result = await augmentDetectionWithPdfPreflight(detection(pdfPath, tmpDir), { outputDir, mode: "always" });
+
+    const markdownPath = result.detection.files.document[0]!;
+    const ocrPath = markdownPath.replace(/\.md$/, ".ocr.json");
+    expect(existsSync(ocrPath)).toBe(true);
+
+    const sidecar = JSON.parse(readFileSync(ocrPath, "utf-8"));
+    expect(sidecar.schema).toBe("graphify_pdf_ocr_pages_v1");
+    expect(sidecar.model).toBe("mistral-ocr-4-0");
+    expect(sidecar.source_file).toBe(pdfPath);
+    expect(sidecar.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(sidecar.pages).toHaveLength(1);
+    expect(sidecar.pages[0]).toMatchObject({ page: 1, width: 1000, height: 1400, dpi: 200 });
+    expect(sidecar.pages[0].images[0]).toEqual({ id: "img-0", bbox: [0.1, 0.1, 0.5, 0.5] });
+    expect(sidecar.pages[0].images[1]).toEqual({ id: "img-1" });
+  });
+
+  it("moves prep bookkeeping to <stem>.prep.json (distinct from the structured .ocr.json)", async () => {
+    convertPdfMock.mockImplementation(async (_input: string, options: { markdownPath: string }) => {
+      writeFileSync(options.markdownPath, MARKDOWN_BODY, "utf-8");
+      return { markdown: MARKDOWN_BODY, markdownPath: options.markdownPath, images: [], ocrResponse: MOCK_OCR_RESPONSE };
+    });
+
+    const outputDir = join(tmpDir, "out");
+    const result = await augmentDetectionWithPdfPreflight(detection(pdfPath, tmpDir), { outputDir, mode: "always" });
+    const markdownPath = result.detection.files.document[0]!;
+    const prepPath = markdownPath.replace(/\.md$/, ".prep.json");
+
+    expect(existsSync(prepPath)).toBe(true);
+    const prep = JSON.parse(readFileSync(prepPath, "utf-8"));
+    expect(prep).toHaveProperty("provider", "mistral-ocr");
+    expect(prep).not.toHaveProperty("pages"); // prep bookkeeping, not the OCR sidecar
+  });
+
+  it("leaves the markdown sidecar byte-identical whether or not the structured response is present", async () => {
+    // Run A: convertPdf returns a structured ocrResponse.
+    convertPdfMock.mockImplementation(async (_input: string, options: { markdownPath: string }) => {
+      writeFileSync(options.markdownPath, MARKDOWN_BODY, "utf-8");
+      return { markdown: MARKDOWN_BODY, markdownPath: options.markdownPath, images: [], ocrResponse: MOCK_OCR_RESPONSE };
+    });
+    const outA = join(tmpDir, "outA");
+    const resA = await augmentDetectionWithPdfPreflight(detection(pdfPath, tmpDir), { outputDir: outA, mode: "always" });
+    const mdA = resA.detection.files.document[0]!;
+    const markdownBytesA = readFileSync(mdA);
+
+    // Run B: same source, convertPdf returns NO ocrResponse (legacy/non-structured).
+    convertPdfMock.mockReset();
+    convertPdfMock.mockImplementation(async (_input: string, options: { markdownPath: string }) => {
+      writeFileSync(options.markdownPath, MARKDOWN_BODY, "utf-8");
+      return { markdown: MARKDOWN_BODY, markdownPath: options.markdownPath, images: [] };
+    });
+    const outB = join(tmpDir, "outB");
+    const resB = await augmentDetectionWithPdfPreflight(detection(pdfPath, tmpDir), { outputDir: outB, mode: "always" });
+    const mdB = resB.detection.files.document[0]!;
+    const markdownBytesB = readFileSync(mdB);
+
+    // Markdown is identical; the .ocr.json is the only additive difference.
+    expect(markdownBytesB.equals(markdownBytesA)).toBe(true);
+    expect(existsSync(mdA.replace(/\.md$/, ".ocr.json"))).toBe(true);
+    expect(existsSync(mdB.replace(/\.md$/, ".ocr.json"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

graphify already defaults to Mistral OCR v4 (`mistral-ocr-4-0`) and forwards the
model through `mistralOcr.convertPdf(...)`, but it only consumed the **markdown
sidecar** and discarded the structured OCR response (per-page text geometry +
image bounding boxes). This PR captures that response — **additively**.

## Response-access path

`mistral-ocr@0.1.3`'s `convertPdf` **returns** the raw response:
`node_modules/mistral-ocr/build/convert.js:234-242` →
`{ fileName, markdown, markdownPath, docxBuffer, docxPath, images, ocrResponse }`.
So no direct `@mistralai/mistralai` call is needed — graphify now reads
`conversion.ocrResponse` from the existing call (`src/pdf-ocr.ts`).

SDK shape (`@mistralai/mistralai` deserializes to camelCase): `pages[].index`
(0-based), `pages[].images[].{topLeftX,topLeftY,bottomRightX,bottomRightY}`
(nullable px), `pages[].dimensions: {dpi,height,width} | null`. The parser also
accepts raw snake_case (`top_left_x`…) defensively.

## Deliverables

1. **Capture** — on a successful OCR conversion, write `<stem>.ocr.json` next to
   the markdown, schema `graphify_pdf_ocr_pages_v1`. Written only when the
   response is present (non-OCR providers / mocks are unaffected).
2. **Bridge** — `src/pdf-ocr-refs.ts`, a pure module: `buildPdfOcrPagesSidecar()`
   (response → sidecar, normalized bboxes) and `pdfOcrPagesToCitedSourceRefs()`
   (sidecar → `CitedSourceRef[]`, radar convention).
3. **Tests** — fully mocked OCR response, **no live `MISTRAL_API_KEY`**.

### `<stem>.ocr.json` schema (example)

```json
{
  "schema": "graphify_pdf_ocr_pages_v1",
  "source_file": "/abs/scan.pdf",
  "sha256": "…64 hex…",
  "model": "mistral-ocr-4-0",
  "pages": [
    {
      "page": 1,
      "width": 1000, "height": 1400, "dpi": 200,
      "images": [{ "id": "img-0", "bbox": [0.1, 0.1, 0.5, 0.5] }, { "id": "img-1" }],
      "blocks": [{ "text": "Hello world", "bbox": [0, 0, 1, 0.05] }]
    }
  ]
}
```

### bbox normalization

Pixel corners ÷ page dimensions, top-left origin, clamped to `[0,1]`:
`x0 = topLeftX/width`, `y0 = topLeftY/height`, `x1 = bottomRightX/width`,
`y1 = bottomRightY/height`. bbox is **omitted** when any corner or `dimensions`
is absent (e.g. `100/1000, 140/1400, 500/1000, 700/1400 → [0.1, 0.1, 0.5, 0.5]`).

### CitedSourceRef mapping

`page` (1-based) + `bbox` (`[x0,y0,x1,y1]`) + optional `excerpt`. Block refs
carry the block text as `excerpt`; image refs carry geometry only; entries with
neither geometry nor text are skipped. An optional `base` stamps
`docSha`/`rawRef`/`sourceUrl` onto every ref (radar convention).

## Additive / regression

- Default model **unchanged** (`mistral-ocr-4-0`).
- The markdown sidecar is **byte-identical** whether or not `ocrResponse` is
  present (regression test compares bytes across both paths).
- Name-collision fix: the **write-only** preparation bookkeeping (never read
  anywhere in the repo) moves from `<stem>.ocr.json` → `<stem>.prep.json`,
  freeing `.ocr.json` for the structured OCR data.

## Verify (run, real)

- `npm run lint` (tsc --noEmit) → exit 0
- `npm test -- tests/pdf-ocr-refs.test.ts tests/pdf-ocr-sidecar.test.ts tests/pdf-preflight.test.ts` → 25 passed
- Broader sweep (pdf + image + dataprep, 7 files) → 46 passed
- **No live OCR call** — the response is mocked.
