### PR TITLE
fix(studio-export): ship class-hierarchies.json in static studio bundles (group-by taxonomy)

### DIFF
--- a/scripts/build-studio-demo.mjs
+++ b/scripts/build-studio-demo.mjs
@@ -278,6 +278,7 @@ mkdirSync(outDir, { recursive: true });
 for (const f of [
   "scene.json",
   "scene-hierarchies.json",
+  "class-hierarchies.json",
   "graph.json",
   "reconciliation-candidates.json",
   "entities.json",
@@ -328,10 +329,15 @@ let classHierarchiesResult = { written: false, path: null, artifact: null };
 if (args.profile) {
   try {
     const ontologyProfile = loadOntologyProfile(args.profile);
+    // Emit into the bundle OUT dir (next to scene.json), mirroring
+    // emitSceneHierarchies(sceneDir: outDir) + buildStaticStudio — the SPA
+    // fetches class-hierarchies.json from the bundle root to drive the group-by
+    // / ontology-tree facets. (Previously written to <state>/ontology, so static
+    // exports shipped WITHOUT it and lost the group-by taxonomy.)
     classHierarchiesResult = emitClassHierarchies({
       classHierarchies: ontologyProfile.class_hierarchies,
       graphNodes: nodes,
-      ontologyOutputDir: join(stateDir, "ontology"),
+      ontologyOutputDir: outDir,
       profileHash: ontologyProfile.profile_hash,
     });
   } catch (err) {


### PR DESCRIPTION
Static studio exports (mystery pack publish, every static deploy) shipped WITHOUT class-hierarchies.json, so the group-by / ontology-tree facets were silently disabled (the SPA fetches it from the bundle root: App.svelte canGroupOntology, LeftRail typeTree).

Root cause: scripts/build-studio-demo.mjs emitted it to <state>/ontology (ontologyOutputDir) instead of the bundle outDir. The library buildStaticStudio already emits to outDir correctly; this brings the script to parity.

Fix: emitClassHierarchies(ontologyOutputDir: outDir) + add class-hierarchies.json to the wipe list. Gate unchanged (no profile/block => no file, byte-identical — verified). 

Verified: lint exit 0; ontology-class-hierarchies(+emitter)/studio-export-offline/workspace-manifest suites 46/46 green; negative gate confirmed via a real build-studio-demo run (no class-hierarchies.json without --profile). Positive case proven by composition (emitter writes to the given dir; we pass outDir) + parity with buildStaticStudio.