### PR TITLE
feat(scene): optional temporal (t/t_end) + layout/snapshot scene contract + allowlist pass-through

### DIFF
--- a/src/studio-scene.ts
+++ b/src/studio-scene.ts
@@ -18,6 +18,33 @@
  * normalised by maxDegree, computeDegrees, nodeGroup, nodeLabel, nodeType,
  * communityStats for the live community count). Keep them in lockstep with the
  * studio source until ÉTAPE 2 (client wiring) collapses the duplication.
+ *
+ * SHARED SCENE CONTRACT — temporal + layout + snapshot (additive, opt-in).
+ * ------------------------------------------------------------------------
+ * Prerequisite contract that unblocks the display-layout, DB-windowing and
+ * time-oriented agent-stats streams. It is a PURE PASS-THROUGH: these fields
+ * are CARRIED (allowlist + scene-level copy) but NOT consumed here — no
+ * rendering, layout or query depends on them yet.
+ *
+ *   TEMPORAL (per node AND per edge, both optional):
+ *     • `t`     — interval START, epoch milliseconds.
+ *     • `t_end` — interval END,   epoch milliseconds.
+ *     Semantics: a half-open span [t, t_end); membership in a time window is
+ *     SPAN-OVERLAP (an element is "in window [w0, w1)" iff t < w1 && t_end > w0).
+ *     A point-in-time element sets `t_end === t`. The agreed source-of-truth
+ *     representation is bigint epoch-ms; the JSON scene carries the value
+ *     verbatim as a `number` (JSON has no bigint) — no coercion happens here.
+ *
+ *   SCENE-LEVEL META (optional, top of the scene object):
+ *     • `layout_id`   — identity of the precomputed layout these x/y/z came from.
+ *     • `layout_dims` — 2 | 3, the dimensionality of that layout.
+ *     • `snapshot_id` — identity of the graph snapshot this scene was built from
+ *                       (DB-windowing / cache key).
+ *
+ * BACK-COMPAT INVARIANT: every field above is OPTIONAL and only emitted WHEN
+ * PRESENT on the input node / edge / graph. A graph WITHOUT these fields
+ * produces a BYTE-IDENTICAL scene (no empty keys), so existing golden output
+ * and the SPA parity (graphAdapter.js buildScene) are unaffected.
  */
 
 // ---------------------------------------------------------------------------
@@ -35,6 +62,10 @@ export interface StudioSceneGraphNode {
   file_type?: unknown;
   community?: unknown;
   community_name?: unknown;
+  /** Shared scene contract — interval start, epoch-ms (see module header). */
+  t?: number;
+  /** Shared scene contract — interval end, epoch-ms (see module header). */
+  t_end?: number;
   [key: string]: unknown;
 }
 
@@ -43,6 +74,10 @@ export interface StudioSceneGraphEdge {
   target: string;
   relation?: unknown;
   confidence?: unknown;
+  /** Shared scene contract — interval start, epoch-ms (see module header). */
+  t?: number;
+  /** Shared scene contract — interval end, epoch-ms (see module header). */
+  t_end?: number;
   [key: string]: unknown;
 }
 
@@ -50,6 +85,12 @@ export interface StudioSceneGraphLike {
   nodes?: StudioSceneGraphNode[];
   edges?: StudioSceneGraphEdge[];
   links?: StudioSceneGraphEdge[];
+  /** Shared scene contract — precomputed layout identity (see module header). */
+  layout_id?: string;
+  /** Shared scene contract — layout dimensionality (2 or 3). */
+  layout_dims?: 2 | 3;
+  /** Shared scene contract — graph snapshot identity (DB-windowing key). */
+  snapshot_id?: string;
 }
 
 export interface BuildStudioSceneOptions {
@@ -90,6 +131,13 @@ export interface StudioSceneNode {
   fx?: number;
   fy?: number;
   fixed?: boolean;
+  /**
+   * Shared scene contract — interval start, epoch-ms. Carried through verbatim
+   * from the input node WHEN PRESENT (omitted otherwise). Not consumed here.
+   */
+  t?: number;
+  /** Shared scene contract — interval end, epoch-ms. See {@link t}. */
+  t_end?: number;
   [key: string]: unknown;
 }
 
@@ -100,6 +148,13 @@ export interface StudioSceneEdge {
   relation_type?: string;
   dash?: string;
   weak?: true;
+  /**
+   * Shared scene contract — interval start, epoch-ms. Carried through verbatim
+   * from the input edge WHEN PRESENT (omitted otherwise). Not consumed here.
+   */
+  t?: number;
+  /** Shared scene contract — interval end, epoch-ms. See {@link t}. */
+  t_end?: number;
   [key: string]: unknown;
 }
 
@@ -121,6 +176,21 @@ export interface StudioScene {
    */
   communityColors: Record<string, string>;
   stats: StudioSceneStats;
+  /**
+   * Shared scene contract (additive, opt-in) — identity of the precomputed
+   * layout these node x/y(/z) coordinates came from. Carried through from the
+   * input graph WHEN PRESENT; omitted otherwise (back-compat byte-identity).
+   * Not consumed here.
+   */
+  layout_id?: string;
+  /** Shared scene contract — layout dimensionality (2 or 3). See {@link layout_id}. */
+  layout_dims?: 2 | 3;
+  /**
+   * Shared scene contract — identity of the graph snapshot this scene was built
+   * from (DB-windowing / cache key). Carried through WHEN PRESENT; omitted
+   * otherwise. Not consumed here.
+   */
+  snapshot_id?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +274,12 @@ const NODE_PROFILE_FIELDS = [
   "hierarchy_ids",
   "badges",
   "documents",
+  // Shared scene contract (additive, opt-in): temporal interval [t, t_end),
+  // epoch-ms. copyOwnFields only copies an own, defined value, so a node
+  // WITHOUT these fields yields NO key (byte-identical scene). Pass-through
+  // only — not consumed here. See the module-header SHARED SCENE CONTRACT.
+  "t",
+  "t_end",
 ] as const;
 
 const EDGE_PROFILE_FIELDS = [
@@ -215,6 +291,11 @@ const EDGE_PROFILE_FIELDS = [
   "evidence_refs",
   "hierarchy_id",
   "structural",
+  // Shared scene contract (additive, opt-in): temporal interval [t, t_end),
+  // epoch-ms. Omitted when absent on the input edge (byte-identical scene).
+  // Pass-through only. See the module-header SHARED SCENE CONTRACT.
+  "t",
+  "t_end",
 ] as const;
 
 function nodeLabel(node: StudioSceneGraphNode | undefined): string {
@@ -655,7 +736,7 @@ export function buildStudioScene(
   });
 
   const cstats = communityStats(safeGraph);
-  return {
+  const scene: StudioScene = {
     nodes,
     edges: sceneEdges,
     // BUG B: emitted single source of truth community → colour map (see
@@ -669,4 +750,17 @@ export function buildStudioScene(
       communityCount: cstats.liveCount,
     },
   };
+
+  // Shared scene contract (additive, opt-in) — layout + snapshot meta. Carried
+  // through from the INPUT graph WHEN PRESENT, omitted otherwise so a graph
+  // without these fields serialises BYTE-IDENTICALLY to before (no empty keys).
+  // Pass-through only — nothing here consumes them. See module-header contract.
+  const snapshotId = displayValue(graph?.snapshot_id);
+  if (snapshotId) scene.snapshot_id = snapshotId;
+  const layoutId = displayValue(graph?.layout_id);
+  if (layoutId) scene.layout_id = layoutId;
+  const layoutDims = graph?.layout_dims;
+  if (layoutDims === 2 || layoutDims === 3) scene.layout_dims = layoutDims;
+
+  return scene;
 }

--- a/tests/studio-scene-temporal-contract.test.ts
+++ b/tests/studio-scene-temporal-contract.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildStudioScene,
+  type StudioSceneGraphLike,
+  type StudioScene,
+} from "../src/studio-scene.js";
+
+// ---------------------------------------------------------------------------
+// Shared scene contract — optional temporal (t / t_end, epoch-ms) on nodes and
+// edges + scene-level layout/snapshot meta. These are PURE PASS-THROUGH: the
+// builder must carry them WHEN PRESENT on the input and stay BYTE-IDENTICAL
+// (no new keys) WHEN ABSENT. Nothing here may consume them (no render/layout/
+// query change). See src/studio-scene.ts module-header SHARED SCENE CONTRACT.
+// ---------------------------------------------------------------------------
+
+/**
+ * Base graph WITHOUT any contract field — the byte-identity baseline. Mirrors
+ * the shape of the existing studio-scene fixtures (Sherlock corpus).
+ */
+const BASE_GRAPH: StudioSceneGraphLike = {
+  nodes: [
+    { id: "n1", label: "Sherlock", type: "Character", community: 1, community_name: "Detectives" },
+    { id: "n2", label: "Watson", type: "Character", community: 1, community_name: "Detectives" },
+    { id: "n3", label: "Moriarty", type: "Character", community: 2, community_name: "Villains" },
+    { id: "n4", title: "The Final Problem", type: "Work", community: 3 },
+  ],
+  links: [
+    { source: "n1", target: "n2", relation: "assists" },
+    { source: "n1", target: "n3", relation: "opposes" },
+    { source: "n1", target: "n4", relation: "appears_in" },
+  ],
+};
+
+// Epoch-ms instants (1887/1891/1893/1894-ish) — large, realistic numbers so a
+// verbatim pass-through is observable (no truncation / coercion).
+const T_1887 = Date.UTC(1887, 2, 1);
+const T_1891 = Date.UTC(1891, 4, 4);
+const T_1893 = Date.UTC(1893, 11, 1);
+const T_1894 = Date.UTC(1894, 3, 5);
+
+/** Deep clone so a fixture mutation never leaks across cases. */
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/** BASE_GRAPH enriched with temporal spans on every node + edge and scene meta. */
+function temporalGraph(): StudioSceneGraphLike {
+  const g = clone(BASE_GRAPH);
+  const nodes = g.nodes ?? [];
+  nodes[0]!.t = T_1887;
+  nodes[0]!.t_end = T_1894; // span
+  nodes[1]!.t = T_1887;
+  nodes[1]!.t_end = T_1894;
+  nodes[2]!.t = T_1891;
+  nodes[2]!.t_end = T_1891; // point-in-time: t_end === t
+  nodes[3]!.t = T_1893;
+  nodes[3]!.t_end = T_1893;
+  const links = g.links ?? [];
+  links[0]!.t = T_1887;
+  links[0]!.t_end = T_1894;
+  links[1]!.t = T_1891;
+  links[1]!.t_end = T_1894;
+  links[2]!.t = T_1893;
+  links[2]!.t_end = T_1893;
+  g.layout_id = "fa2-2025-06-28";
+  g.layout_dims = 3;
+  g.snapshot_id = "snap_0xdeadbeef";
+  return g;
+}
+
+describe("buildStudioScene — shared temporal/layout/snapshot contract", () => {
+  it("carries node t/t_end verbatim WHEN PRESENT", () => {
+    const scene = buildStudioScene(temporalGraph());
+    const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+    expect(byId.get("n1")).toMatchObject({ t: T_1887, t_end: T_1894 });
+    expect(byId.get("n3")).toMatchObject({ t: T_1891, t_end: T_1891 }); // point-in-time
+    // Values are the same epoch-ms numbers, not coerced/truncated.
+    expect(byId.get("n1")!.t).toBe(T_1887);
+    expect(byId.get("n1")!.t_end).toBe(T_1894);
+  });
+
+  it("carries edge t/t_end verbatim WHEN PRESENT", () => {
+    const scene = buildStudioScene(temporalGraph());
+    expect(scene.edges[0]).toMatchObject({ t: T_1887, t_end: T_1894 });
+    expect(scene.edges[2]).toMatchObject({ t: T_1893, t_end: T_1893 });
+  });
+
+  it("carries scene-level layout_id / layout_dims / snapshot_id WHEN PRESENT", () => {
+    const scene = buildStudioScene(temporalGraph());
+    expect(scene.layout_id).toBe("fa2-2025-06-28");
+    expect(scene.layout_dims).toBe(3);
+    expect(scene.snapshot_id).toBe("snap_0xdeadbeef");
+  });
+
+  it("is BYTE-IDENTICAL (no new keys) WHEN ABSENT", () => {
+    const plain = buildStudioScene(clone(BASE_GRAPH));
+    // No node/edge carries a temporal key.
+    for (const node of plain.nodes) {
+      expect("t" in node).toBe(false);
+      expect("t_end" in node).toBe(false);
+    }
+    for (const edge of plain.edges) {
+      expect("t" in edge).toBe(false);
+      expect("t_end" in edge).toBe(false);
+    }
+    // No scene-level meta key is emitted.
+    expect("layout_id" in plain).toBe(false);
+    expect("layout_dims" in plain).toBe(false);
+    expect("snapshot_id" in plain).toBe(false);
+  });
+
+  it("PROOF: stripping the contract fields reproduces the absent-field scene exactly", () => {
+    const withTemporal = buildStudioScene(temporalGraph());
+    const without = buildStudioScene(clone(BASE_GRAPH));
+
+    const strip = <T extends Record<string, unknown>>(o: T, keys: string[]): Record<string, unknown> => {
+      const copy: Record<string, unknown> = { ...o };
+      for (const k of keys) delete copy[k];
+      return copy;
+    };
+
+    const strippedScene = {
+      ...strip(withTemporal as unknown as Record<string, unknown>, [
+        "layout_id",
+        "layout_dims",
+        "snapshot_id",
+      ]),
+      nodes: withTemporal.nodes.map((n) => strip(n as Record<string, unknown>, ["t", "t_end"])),
+      edges: withTemporal.edges.map((e) => strip(e as Record<string, unknown>, ["t", "t_end"])),
+    };
+
+    // Byte-for-byte (key order + presence) equality with the absent-field scene.
+    expect(JSON.stringify(strippedScene)).toBe(JSON.stringify(without));
+  });
+
+  it("ignores an invalid layout_dims (only 2 | 3 pass through)", () => {
+    const g = clone(BASE_GRAPH);
+    (g as { layout_dims?: unknown }).layout_dims = 4; // not 2|3 -> omitted
+    const scene = buildStudioScene(g);
+    expect("layout_dims" in scene).toBe(false);
+  });
+
+  it("does NOT consume temporal fields (stats unchanged by t/t_end)", () => {
+    // The contract is pass-through only: adding temporal data must not change
+    // any derived value (stats, communityColors).
+    const withTemporal: StudioScene = buildStudioScene(temporalGraph());
+    const without: StudioScene = buildStudioScene(clone(BASE_GRAPH));
+    expect(withTemporal.stats).toEqual(without.stats);
+    expect(withTemporal.communityColors).toEqual(without.communityColors);
+  });
+});


### PR DESCRIPTION
## Prerequisite shared scene contract (additive, backward-compatible, golden-safe)

Both Opus and Codex flagged this as the blocker: `buildStudioScene` copies only ALLOWLISTED node/edge fields into the scene, so `t`/`t_end`/layout-id/snapshot-id could **not** pass through. Every downstream stream (time-oriented agent-stats, display layout registry, DB windowing) assumes a pass-through that was false. This PR makes that contract + pass-through **exist** — nothing consumes the fields yet.

### What changed (only `src/studio-scene.ts` + one new test)
- **Scene node + edge types**: optional `t?: number` + `t_end?: number` (epoch-ms; half-open `[t, t_end)` **span-overlap** semantics — source-of-truth is bigint epoch-ms, JSON carries the value verbatim as a number).
- **Scene-level optional meta**: `layout_id?: string`, `layout_dims?: 2 | 3`, `snapshot_id?: string`, carried from the input graph when present.
- **Allowlists + copy sites**: `t`/`t_end` added to `NODE_PROFILE_FIELDS` and `EDGE_PROFILE_FIELDS`. `copyOwnFields` only copies own, defined values, so a graph WITHOUT these fields yields a **byte-identical** scene (no empty keys).
- **Pure pass-through**: no render / layout / query consumes the fields. Contract documented in the module header (`SHARED SCENE CONTRACT`) + JSDoc.

### Back-compat / golden safety
- No `packages/` or `studio/` (renderer/adapter) code touched — golden lane unaffected.
- Absent fields ⇒ byte-identical scene. The heavy **real-graph parity** test (6002 nodes / 50275 edges) vs the SPA `buildScene` stays green because the real corpus carries none of the new fields.

### Verification (all run, green)
- `npm run lint` (tsc --noEmit) → exit 0
- `npx vitest run tests/studio-scene.test.ts tests/studio-scene-temporal-contract.test.ts tests/aclp-am-wp4-uat.test.ts` → 25 passed, 1 skipped, exit 0
- `npm run build:studio` → exit 0

### New test (`tests/studio-scene-temporal-contract.test.ts`)
Asserts node/edge `t`/`t_end` + scene-level meta carry through verbatim when present; are omitted (no new keys) when absent; that stripping the contract fields reproduces the absent-field scene byte-for-byte; that an invalid `layout_dims` is dropped; and that temporal data does not perturb `stats`/`communityColors`.

Do **not** merge — prerequisite contract for review.