### PR TITLE
feat(storage): Postgres group-by counts (replace-snapshot aggregate, O(#groups))

### DIFF
--- a/spec/SPEC_STORAGE_BACKENDS.md
+++ b/spec/SPEC_STORAGE_BACKENDS.md
@@ -143,6 +143,26 @@ Port rules:
 - `dryRun` must produce the same counts and warnings as a real push, without writes.
 - Adapters own backend mechanics (sessions, batching, retries, type mapping). Core owns graph loading, namespace derivation, snapshot bookkeeping and reporting.
 
+### Group-by aggregate (storage LOT 1)
+
+An OPTIONAL, versioned capability lets a backend serve instant group-by counts without re-scanning every node:
+
+```ts
+export interface GraphStoreAggregateCapability {
+  version: 1;
+  axes: readonly string[]; // e.g. ["node_type", "community"]
+}
+// GraphStoreCapabilities gains: aggregate?: GraphStoreAggregateCapability
+// GraphStore gains:            groupCounts?(axis: string): Promise<GraphGroupCounts>
+```
+
+Rules:
+
+- **Capability-gated.** `groupCounts` is present only when `capabilities.aggregate` is set; neo4j/spanner/file omit both. The method is never assumed — call sites check the capability first, exactly like `query`/`clear`. The contract implies no cross-backend transaction semantics.
+- **REPLACE-snapshot scoped (the staleness guard).** The precomputed table is rebuilt ONLY inside a `mode: "replace"` push, from the full snapshot just loaded. A `merge` is an upsert that may leave deleted nodes behind, so rebuilding after a merge could surface stale/half-merged groups; merge therefore leaves the aggregate untouched and `groupCounts` keeps reporting the last committed full snapshot. The rows are stamped with the producing push's `snapshot_id` (== `graph_meta.pushed_at`) for cross-checks.
+- **O(#groups), not O(#nodes).** A read returns one row per distinct axis value, not the underlying node rows.
+- **Postgres v1 axes.** `node_type` and `community` (lifted to typed columns / derivable on push). `class_id`, `registry`, `status` and `ts` are DEFERRED to LOT 2 until those fields are lifted out of the props jsonb into queryable columns. The studio read path (route + `studio/src/lib/groupBy.js` refactor) is also LOT 2.
+
 ## Store Registry And Driver Loading
 
 Stores register through a factory so that driver loading stays lazy and testable:

--- a/src/storage/postgres.ts
+++ b/src/storage/postgres.ts
@@ -25,6 +25,7 @@ import { mkdirSync, readFileSync } from "node:fs";
 import type Graph from "graphology";
 import { toJson } from "../export.js";
 import type {
+  GraphGroupCounts,
   GraphPushOptions,
   GraphPushResult,
   GraphStore,
@@ -40,6 +41,16 @@ import type {
 const NODE_TABLE = "graph_nodes";
 const EDGE_TABLE = "graph_edges";
 const META_TABLE = "graph_meta";
+/** Precomputed group-by aggregate (storage LOT 1); rebuilt on replace pushes. */
+const COUNT_TABLE = "graph_group_counts";
+
+/**
+ * Axes the precomputed aggregate serves in LOT 1. `node_type` + `community` are
+ * lifted to typed columns / derivable on push, so the GROUP BY is cheap.
+ * `class_id`, `registry`, `status` and `ts` are DEFERRED to LOT 2 until those
+ * fields are lifted out of the props jsonb into queryable columns.
+ */
+const AGGREGATE_AXES = ["node_type", "community"] as const;
 
 /** Schema columns lifted into typed node columns; the rest go into props jsonb. */
 const NODE_SCHEMA_COLS = ["id", "label", "type", "node_type", "community"];
@@ -137,6 +148,18 @@ function buildPropsBag(
   return props;
 }
 
+/**
+ * Resolve a node's `node_type` the same way the `type` column is filled, so the
+ * graph_nodes rows and the graph_group_counts aggregate never disagree:
+ * node_type > type > file_type, else null (untyped — excluded from the axis).
+ */
+function resolveNodeType(a: Record<string, unknown>): string | null {
+  if (typeof a.node_type === "string") return a.node_type;
+  if (typeof a.type === "string") return a.type;
+  if (typeof a.file_type === "string") return a.file_type;
+  return null;
+}
+
 /** Chunk an array into subarrays of at most `size` elements. */
 function chunk<T>(arr: T[], size: number): T[][] {
   const out: T[][] = [];
@@ -158,6 +181,8 @@ function chunk<T>(arr: T[], size: number): T[][] {
  *   - graph_edges(city_slug, source_id, target_id, relation)
  *       PRIMARY KEY (city_slug, source_id, target_id, relation), props jsonb
  *   - graph_meta(city_slug) PRIMARY KEY — one snapshot row per city_slug
+ *   - graph_group_counts(city_slug, axis, key) PRIMARY KEY — precomputed
+ *       group-by aggregate (LOT 1); rebuilt only inside a replace-mode push
  *
  * Indexes:
  *   - (city_slug, type) composite, for type-scoped scans
@@ -219,6 +244,28 @@ export function postgresDdlStatements(schema?: string): string[] {
       "  pushed_at text,",
       "  tool_version text,",
       "  PRIMARY KEY (city_slug)",
+      ")",
+    ].join("\n"),
+  );
+
+  // graph_group_counts — precomputed group-by aggregate (storage LOT 1).
+  // Rebuilt ONLY inside a replace-mode push (delete-all-then-load per city), so
+  // it holds exactly one snapshot's worth of rows per city_slug and a read by
+  // (city_slug, axis) is O(#groups). `snapshot_id` stamps the producing push
+  // (== graph_meta.pushed_at) for staleness cross-checks. The (city_slug, axis,
+  // key) primary key both enforces one row per group and serves the read as a
+  // covering prefix index — no extra index needed.
+  statements.push(
+    [
+      `CREATE TABLE IF NOT EXISTS ${q(COUNT_TABLE)} (`,
+      "  city_slug text NOT NULL,",
+      "  snapshot_id text NOT NULL,",
+      "  axis text NOT NULL,",
+      "  key text NOT NULL,",
+      "  label text,",
+      "  count integer NOT NULL,",
+      "  parent_key text,",
+      "  PRIMARY KEY (city_slug, axis, key)",
       ")",
     ].join("\n"),
   );
@@ -288,6 +335,12 @@ export interface PostgresGraphStore extends GraphStore {
    * not one SELECT per edge (the N+1 fix). Returns the matched neighbor rows.
    */
   queryNeighbors(nodeId: string, citySlug?: string): Promise<Array<Record<string, unknown>>>;
+  /**
+   * O(#groups) group-by counts read from the precomputed `graph_group_counts`
+   * table (storage LOT 1). Scoped to the latest REPLACE snapshot. Supported
+   * axes: see `AGGREGATE_AXES`. Unknown axes return an empty group list.
+   */
+  groupCounts(axis: string): Promise<GraphGroupCounts>;
 }
 
 // ---------------------------------------------------------------------------
@@ -420,17 +473,59 @@ export async function createPostgresGraphStore(
         citySlug,
         nodeId,
         typeof a.label === "string" ? a.label : nodeId,
-        typeof a.node_type === "string"
-          ? a.node_type
-          : typeof a.type === "string"
-            ? a.type
-            : typeof a.file_type === "string"
-              ? a.file_type
-              : null,
+        resolveNodeType(a),
         community ?? (typeof a.community === "number" ? a.community : null),
         JSON.stringify(buildPropsBag(a, NODE_SCHEMA_COLS)),
       ]);
     });
+    return rows;
+  }
+
+  /** Columns written for graph_group_counts, in order. */
+  const COUNT_COLUMNS = [
+    "city_slug",
+    "snapshot_id",
+    "axis",
+    "key",
+    "label",
+    "count",
+    "parent_key",
+  ];
+
+  /**
+   * Aggregate the full snapshot into group-count rows IN JS (one pass over the
+   * graph), mirroring the `node_type`/`community` derivation used for the node
+   * rows. Computed from the same in-memory snapshot that is being loaded, so the
+   * rows are exactly consistent with the post-replace graph_nodes — never with a
+   * stale row that a merge left behind. `node_type` and `community` are flat
+   * axes (no parent_key) in LOT 1.
+   */
+  function buildGroupCountRows(
+    G: Graph,
+    communityMap: Map<string, number>,
+    snapshotId: string,
+  ): unknown[][] {
+    const byType = new Map<string, number>();
+    const byCommunity = new Map<number, number>();
+    G.forEachNode((nodeId, attrs) => {
+      const a = attrs as Record<string, unknown>;
+      const nodeType = resolveNodeType(a);
+      if (nodeType !== null) byType.set(nodeType, (byType.get(nodeType) ?? 0) + 1);
+      const community =
+        communityMap.get(nodeId) ??
+        (typeof a.community === "number" ? a.community : null);
+      if (community !== null) {
+        byCommunity.set(community, (byCommunity.get(community) ?? 0) + 1);
+      }
+    });
+    const rows: unknown[][] = [];
+    for (const [key, count] of byType) {
+      rows.push([citySlug, snapshotId, "node_type", key, key, count, null]);
+    }
+    for (const [cid, count] of byCommunity) {
+      const key = String(cid);
+      rows.push([citySlug, snapshotId, "community", key, `Community ${key}`, count, null]);
+    }
     return rows;
   }
 
@@ -513,8 +608,8 @@ export async function createPostgresGraphStore(
     runner: { query(text: string, params?: unknown[]): Promise<PgQueryResult> },
     topologySignature: string,
     toolVersion: string,
+    pushedAt: string,
   ): Promise<void> {
-    const pushedAt = new Date().toISOString();
     await runner.query(
       `INSERT INTO ${q(META_TABLE)} (city_slug, topology_signature, pushed_at, tool_version) ` +
         `VALUES ($1, $2, $3, $4) ` +
@@ -569,6 +664,8 @@ export async function createPostgresGraphStore(
       query: true,
       clear: true,
       snapshotMeta: true,
+      // Precomputed group-by aggregate (storage LOT 1), replace-snapshot scoped.
+      aggregate: { version: 1, axes: [...AGGREGATE_AXES] },
     },
 
     async verifyConnection(): Promise<void> {
@@ -600,6 +697,7 @@ export async function createPostgresGraphStore(
       const communityMap = buildNodeCommunityMap(communities);
       const nodeRows = buildNodeRows(G, communityMap);
       const edgeRows = buildEdgeRows(G);
+      const pushedAt = new Date().toISOString();
 
       // All writes for one push run in a single transaction so a backend error
       // leaves the previous snapshot intact (SPEC: "the push aborts").
@@ -626,7 +724,23 @@ export async function createPostgresGraphStore(
           edgeRows,
           batchSize,
         );
-        await writeMeta(client, computeTopologySignature(G), resolveToolVersion());
+        // Aggregate is REPLACE-snapshot scoped (storage LOT 1): rebuild
+        // graph_group_counts ONLY in replace mode, from the full snapshot just
+        // loaded. A merge push is an upsert that may leave deleted nodes behind,
+        // so it deliberately leaves the counts table untouched — the staleness
+        // guard. Delete-all-then-upsert keeps exactly one snapshot per city.
+        if (mode === "replace") {
+          await deleteCityRows(client, q(COUNT_TABLE), citySlug);
+          await upsertBatched(
+            client,
+            q(COUNT_TABLE),
+            COUNT_COLUMNS,
+            ["city_slug", "axis", "key"],
+            buildGroupCountRows(G, communityMap, pushedAt),
+            batchSize,
+          );
+        }
+        await writeMeta(client, computeTopologySignature(G), resolveToolVersion(), pushedAt);
         await client.query("COMMIT");
       } catch (err) {
         try {
@@ -685,6 +799,30 @@ export async function createPostgresGraphStore(
       return result.rows ?? [];
     },
 
+    async groupCounts(axis: string): Promise<GraphGroupCounts> {
+      // O(#groups): read the precomputed aggregate, never the 47k node rows.
+      // The (city_slug, axis, key) primary key serves this as a prefix scan.
+      await ensureSchema();
+      const result = await pool.query(
+        `SELECT key, label, count, parent_key FROM ${q(COUNT_TABLE)} ` +
+          `WHERE city_slug = $1 AND axis = $2 ORDER BY count DESC, key ASC`,
+        [citySlug, axis],
+      );
+      const groups = (result.rows ?? []).map((row) => {
+        const group: GraphGroupCounts["groups"][number] = {
+          key: String(row.key),
+          label:
+            typeof row.label === "string" && row.label.length > 0
+              ? row.label
+              : String(row.key),
+          count: typeof row.count === "number" ? row.count : Number(row.count ?? 0),
+        };
+        if (row.parent_key != null) group.parent_key = String(row.parent_key);
+        return group;
+      });
+      return { axis, groups };
+    },
+
     async clear(options?: string | PostgresClearOptions): Promise<void> {
       const opts = typeof options === "string" ? { namespace: options } : options ?? {};
       if (!opts.force) {
@@ -699,6 +837,7 @@ export async function createPostgresGraphStore(
         await deleteCityRows(client, q(NODE_TABLE), targetSlug);
         await deleteCityRows(client, q(EDGE_TABLE), targetSlug);
         await deleteCityRows(client, q(META_TABLE), targetSlug);
+        await deleteCityRows(client, q(COUNT_TABLE), targetSlug);
         await client.query("COMMIT");
       } catch (err) {
         try {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -11,6 +11,47 @@ export interface GraphStoreCapabilities {
   query: boolean;
   clear: boolean;
   snapshotMeta: boolean;
+  /**
+   * Optional, VERSIONED group-by aggregate (storage LOT 1). Absent on backends
+   * that do not precompute it (neo4j/spanner simply omit it). When present, the
+   * adapter exposes `groupCounts(axis)` reading a backend-maintained counts
+   * table in O(#groups) — not O(#nodes).
+   *
+   * The aggregate is tied to REPLACE / full-snapshot semantics: it is rebuilt
+   * ONLY inside a `mode: "replace"` push, never on a `merge` push. A merge is an
+   * upsert that may leave stale rows behind, so rebuilding the aggregate after a
+   * merge could surface deleted / half-merged groups; gating the rebuild on
+   * replace keeps the counts coherent with a committed full snapshot. This
+   * capability does NOT imply any cross-backend transaction semantics — each
+   * adapter owns when and how it maintains its table.
+   */
+  aggregate?: GraphStoreAggregateCapability;
+}
+
+/** Versioned descriptor for the optional group-by aggregate capability (LOT 1). */
+export interface GraphStoreAggregateCapability {
+  /** Schema/behaviour version of the aggregate contract; consumers gate on it. */
+  version: 1;
+  /** Axes the backend can serve from its precomputed table (e.g. `node_type`). */
+  axes: readonly string[];
+}
+
+/** One group bucket: a distinct value of an axis and its node count. */
+export interface GraphGroupCount {
+  /** The axis value (e.g. a node_type string, or a community id as text). */
+  key: string;
+  /** Human-readable label for the bucket; defaults to `key` when none. */
+  label: string;
+  /** Number of nodes in the bucket for the current snapshot. */
+  count: number;
+  /** Parent bucket key for hierarchical axes; omitted for flat axes. */
+  parent_key?: string;
+}
+
+/** Result of `groupCounts(axis)`: the axis plus its precomputed buckets. */
+export interface GraphGroupCounts {
+  axis: string;
+  groups: GraphGroupCount[];
 }
 
 export interface GraphPushOptions {
@@ -57,6 +98,15 @@ export interface GraphStore {
     statement: string,
     params?: unknown[] | Record<string, unknown>,
   ): Promise<unknown>;
+  /**
+   * Capability-gated O(#groups) group-by counts (storage LOT 1). Present ONLY
+   * when `capabilities.aggregate` is set; backends that omit the capability omit
+   * this method (a no-op/absent on the contract). Reads a backend-maintained
+   * counts table (not the node rows), so it is O(#groups), not O(#nodes). The
+   * result is scoped to the latest REPLACE snapshot — see
+   * `GraphStoreCapabilities.aggregate`.
+   */
+  groupCounts?(axis: string): Promise<GraphGroupCounts>;
   close(): Promise<void>;
 }
 

--- a/tests/storage-postgres-group-counts.test.ts
+++ b/tests/storage-postgres-group-counts.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Postgres group-by counts aggregate tests (storage LOT 1).
+ *
+ * Mirrors the tests/storage-postgres.test.ts harness: an in-memory fake `pg`
+ * module injected via StoreTestDeps — no real Postgres connection is required.
+ * This fake additionally maintains a tiny in-memory `graph_group_counts` table
+ * (reconstructed from INSERT params, cleared on DELETE, filtered on SELECT) so
+ * the replace push → groupCounts read round-trip is exercised end-to-end.
+ *
+ * Coverage:
+ *   - after a REPLACE push, groupCounts('node_type') returns correct per-type
+ *     counts (and 'community' as the second LOT 1 axis);
+ *   - after a MERGE push that changes the node population, the counts do NOT
+ *     include the stale row — the merge leaves graph_group_counts untouched
+ *     (the staleness guard), so the aggregate stays scoped to the last REPLACE
+ *     snapshot;
+ *   - the capability is absent and groupCounts is a no-op/undefined on a backend
+ *     that does not implement it (FileGraphStore).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import type { GraphStore, StoreTestDeps } from "../src/storage/types.js";
+import type { PostgresGraphStore } from "../src/storage/postgres.js";
+
+// ---------------------------------------------------------------------------
+// Fake driver with a real graph_group_counts round-trip
+// ---------------------------------------------------------------------------
+
+interface RecordedSql {
+  via: "pool" | "client";
+  text: string;
+  params?: unknown[];
+}
+
+/** A reconstructed graph_group_counts row (column order = COUNT_COLUMNS). */
+interface CountRow {
+  city_slug: string;
+  snapshot_id: string;
+  axis: string;
+  key: string;
+  label: string | null;
+  count: number;
+  parent_key: string | null;
+}
+
+interface InMemoryPgState {
+  queries: RecordedSql[];
+  connects: number;
+  /** The emulated graph_group_counts table contents. */
+  countRows: CountRow[];
+}
+
+function freshState(): InMemoryPgState {
+  return { queries: [], connects: 0, countRows: [] };
+}
+
+const COUNT_COLS = 7; // city_slug, snapshot_id, axis, key, label, count, parent_key
+
+function chunkParams(params: unknown[] | undefined): CountRow[] {
+  const rows: CountRow[] = [];
+  if (!params) return rows;
+  for (let i = 0; i + COUNT_COLS <= params.length; i += COUNT_COLS) {
+    rows.push({
+      city_slug: String(params[i]),
+      snapshot_id: String(params[i + 1]),
+      axis: String(params[i + 2]),
+      key: String(params[i + 3]),
+      label: params[i + 4] == null ? null : String(params[i + 4]),
+      count: Number(params[i + 5]),
+      parent_key: params[i + 6] == null ? null : String(params[i + 6]),
+    });
+  }
+  return rows;
+}
+
+function answer(state: InMemoryPgState, text: string, params?: unknown[]) {
+  const upper = text.toUpperCase();
+
+  // graph_group_counts DELETE (replace rebuild / clear): drop the city's rows.
+  if (text.includes("DELETE FROM graph_group_counts")) {
+    const slug = String(params?.[0]);
+    state.countRows = state.countRows.filter((r) => r.city_slug !== slug);
+    return { rows: [], rowCount: 0 };
+  }
+  // graph_group_counts INSERT (upsert): reconstruct rows from params, upsert by
+  // the (city_slug, axis, key) primary key.
+  if (text.includes("INSERT INTO graph_group_counts")) {
+    for (const row of chunkParams(params)) {
+      const idx = state.countRows.findIndex(
+        (r) => r.city_slug === row.city_slug && r.axis === row.axis && r.key === row.key,
+      );
+      if (idx >= 0) state.countRows[idx] = row;
+      else state.countRows.push(row);
+    }
+    return { rows: [], rowCount: 0 };
+  }
+  // graph_group_counts SELECT (groupCounts read): filter by city_slug + axis,
+  // ORDER BY count DESC, key ASC (mirrors the adapter's query).
+  if (text.includes("graph_group_counts") && upper.includes("SELECT")) {
+    const slug = String(params?.[0]);
+    const axis = String(params?.[1]);
+    const rows = state.countRows
+      .filter((r) => r.city_slug === slug && r.axis === axis)
+      .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
+      .map((r) => ({ key: r.key, label: r.label, count: r.count, parent_key: r.parent_key }));
+    return { rows, rowCount: rows.length };
+  }
+  // graph_meta SELECT: no preseeded rows here (local cache covers reads).
+  return { rows: [], rowCount: 0 };
+}
+
+function makeFakePgModule(state: InMemoryPgState) {
+  class FakePool {
+    constructor(_config?: Record<string, unknown>) {}
+    query(text: string, params?: unknown[]) {
+      state.queries.push({ via: "pool", text, params });
+      return Promise.resolve(answer(state, text, params));
+    }
+    connect() {
+      state.connects += 1;
+      const client = {
+        query(text: string, params?: unknown[]) {
+          state.queries.push({ via: "client", text, params });
+          return Promise.resolve(answer(state, text, params));
+        },
+        release() {
+          /* no-op */
+        },
+      };
+      return Promise.resolve(client);
+    }
+    end() {
+      return Promise.resolve();
+    }
+  }
+  return { Pool: FakePool };
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox for the S3-replayable latest.json writes
+// ---------------------------------------------------------------------------
+
+const tempDirs: string[] = [];
+function freshArtifactBase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-pgcounts-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function makePostgresStore(
+  state: InMemoryPgState,
+  citySlug: string,
+): Promise<PostgresGraphStore> {
+  const { createPostgresGraphStore } = await import("../src/storage/postgres.js");
+  const deps: StoreTestDeps = { driverModule: makeFakePgModule(state) };
+  return createPostgresGraphStore(
+    {
+      connectionString: "postgres://user:pass@localhost:5432/testdb",
+      citySlug,
+      target: freshArtifactBase(),
+    },
+    deps,
+  );
+}
+
+/** code×2 + doc×1, 2 communities (0 → alpha,beta ; 1 → gamma). */
+function typedGraph(): { G: Graph; communities: Map<number, string[]> } {
+  const G = new Graph();
+  G.addNode("alpha", { label: "Alpha", node_type: "code" });
+  G.addNode("beta", { label: "Beta", node_type: "code" });
+  G.addNode("gamma", { label: "Gamma", node_type: "doc" });
+  G.addEdge("alpha", "beta", { relation: "imports" });
+  return { G, communities: new Map([[0, ["alpha", "beta"]], [1, ["gamma"]]]) };
+}
+
+function countOf(groups: { key: string; count: number }[], key: string): number | undefined {
+  return groups.find((g) => g.key === key)?.count;
+}
+
+// ---------------------------------------------------------------------------
+// Capability surface
+// ---------------------------------------------------------------------------
+
+describe("Postgres group counts: capability", () => {
+  it("declares a versioned aggregate capability over node_type + community", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "caps_agg");
+    expect(store.capabilities.aggregate).toBeDefined();
+    expect(store.capabilities.aggregate!.version).toBe(1);
+    expect(store.capabilities.aggregate!.axes).toContain("node_type");
+    expect(store.capabilities.aggregate!.axes).toContain("community");
+    await store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REPLACE push → groupCounts
+// ---------------------------------------------------------------------------
+
+describe("Postgres group counts: replace push aggregate", () => {
+  it("groupCounts('node_type') returns correct per-type counts after a REPLACE push", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "gc_replace");
+    const { G, communities } = typedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const result = await store.groupCounts!("node_type");
+    await store.close();
+
+    expect(result.axis).toBe("node_type");
+    expect(countOf(result.groups, "code")).toBe(2);
+    expect(countOf(result.groups, "doc")).toBe(1);
+    // Ordered by count desc: code (2) before doc (1).
+    expect(result.groups.map((g) => g.key)).toEqual(["code", "doc"]);
+    // Flat axis: no parent_key.
+    expect(result.groups.every((g) => g.parent_key === undefined)).toBe(true);
+  });
+
+  it("rebuilds the counts INSIDE the replace push transaction (on the txn client)", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "gc_in_txn");
+    const { G, communities } = typedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    await store.close();
+
+    const countWrites = state.queries.filter(
+      (q) => q.text.includes("INSERT INTO graph_group_counts"),
+    );
+    expect(countWrites).toHaveLength(1);
+    // The aggregate write happens on the checked-out transaction client, not the
+    // pool — so it commits/rolls back with the snapshot.
+    expect(countWrites[0]!.via).toBe("client");
+    const clientSql = state.queries.filter((q) => q.via === "client").map((q) => q.text);
+    expect(clientSql).toContain("BEGIN");
+    expect(clientSql).toContain("COMMIT");
+  });
+
+  it("groupCounts('community') returns correct per-community counts", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "gc_comm");
+    const { G, communities } = typedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const result = await store.groupCounts!("community");
+    await store.close();
+
+    expect(countOf(result.groups, "0")).toBe(2);
+    expect(countOf(result.groups, "1")).toBe(1);
+    expect(result.groups.find((g) => g.key === "0")!.label).toBe("Community 0");
+  });
+
+  it("returns an empty group list for an unknown / deferred axis (class_id)", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "gc_unknown");
+    const { G, communities } = typedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const result = await store.groupCounts!("class_id");
+    await store.close();
+
+    expect(result).toEqual({ axis: "class_id", groups: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Staleness guard: a MERGE push never rebuilds the aggregate
+// ---------------------------------------------------------------------------
+
+describe("Postgres group counts: merge staleness guard", () => {
+  it("a MERGE push leaves graph_group_counts untouched, so the counts exclude the stale row", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "gc_merge_guard");
+
+    // Baseline REPLACE snapshot: 2 code nodes only → { code: 2 }.
+    const base = new Graph();
+    base.addNode("alpha", { label: "Alpha", node_type: "code" });
+    base.addNode("beta", { label: "Beta", node_type: "code" });
+    await store.pushGraph(base, new Map([[0, ["alpha", "beta"]]]), { mode: "replace" });
+
+    const afterReplace = await store.groupCounts!("node_type");
+    expect(countOf(afterReplace.groups, "code")).toBe(2);
+    expect(countOf(afterReplace.groups, "doc")).toBeUndefined();
+
+    // Drop the writes recorded so far so the next assertion is about the merge.
+    const writesBeforeMerge = state.queries.length;
+
+    // MERGE push that mutates the node population: it upserts a NEW doc node
+    // (gamma). A merge is upsert-only — it physically lands gamma in graph_nodes
+    // but, by design, does NOT rebuild the aggregate. A naive rebuild-on-merge
+    // would surface a stale "doc: 1" bucket; the guard keeps it out.
+    const merged = new Graph();
+    merged.addNode("gamma", { label: "Gamma", node_type: "doc" });
+    await store.pushGraph(merged, new Map(), { mode: "merge" });
+
+    const mergeQueries = state.queries.slice(writesBeforeMerge);
+    // The guard: the merge issued NO write against graph_group_counts.
+    expect(
+      mergeQueries.filter((q) => q.text.includes("INSERT INTO graph_group_counts")),
+    ).toHaveLength(0);
+    expect(
+      mergeQueries.filter((q) => q.text.includes("DELETE FROM graph_group_counts")),
+    ).toHaveLength(0);
+
+    // The outcome: the aggregate still reflects the last REPLACE snapshot and
+    // does NOT include the stale doc row introduced by the merge.
+    const afterMerge = await store.groupCounts!("node_type");
+    await store.close();
+    expect(countOf(afterMerge.groups, "code")).toBe(2);
+    expect(countOf(afterMerge.groups, "doc")).toBeUndefined();
+    expect(afterMerge.groups).toEqual(afterReplace.groups);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability absent / no-op on a backend that doesn't implement it
+// ---------------------------------------------------------------------------
+
+describe("Postgres group counts: capability gating on other backends", () => {
+  it("FileGraphStore neither declares aggregate nor exposes groupCounts", async () => {
+    const { createFileGraphStore } = await import("../src/storage/file.js");
+    const base = freshArtifactBase();
+    const store: GraphStore = createFileGraphStore({ target: join(base, "graph.json") });
+
+    expect(store.capabilities.aggregate).toBeUndefined();
+    expect(store.groupCounts).toBeUndefined();
+    await store.close();
+  });
+});


### PR DESCRIPTION
## Storage LOT 1 — Postgres group-by counts (replace-snapshot aggregate, O(#groups))

Narrowed per the Opus+Codex double-review. Instant group-by counts from Postgres, read from a precomputed table instead of recomputing client-side over the full ~47k-node graph.

### What this delivers (Postgres-only, narrow)
1. **Port widening** (`src/storage/types.ts`) — an OPTIONAL, **versioned** aggregate capability `GraphStoreCapabilities.aggregate?: { version: 1; axes }`, the typed result shapes `GraphGroupCount` / `GraphGroupCounts`, and `GraphStore.groupCounts?(axis): Promise<GraphGroupCounts>`. Optional + capability-gated so neo4j/spanner/file omit it; it implies no cross-backend transaction semantics.
2. **Postgres impl** (`src/storage/postgres.ts`) — a new `graph_group_counts(city_slug, snapshot_id, axis, key, label, count, parent_key)` table, **rebuilt only inside a `mode: "replace"` push transaction** (delete-all-then-upsert, computed in JS from the full snapshot just loaded). `groupCounts(axis)` reads it in O(#groups). Axes first: `node_type` + `community`. `capabilities.aggregate = { version: 1, axes: [node_type, community] }`.
3. **Tests** (`tests/storage-postgres-group-counts.test.ts`) — driver-injected (no live DB), with a fake `pg` that round-trips the counts table.

### Merge-staleness handling (the Codex finding)
`pushGraph` defaults to MERGE, and Postgres deletes rows only in `replace` mode — so a counts table naively rebuilt after a MERGE could carry **stale** rows the upsert left behind. Guard: the aggregate is **rebuilt only on `replace`**. A merge push leaves `graph_group_counts` untouched, so `groupCounts` always reports the last committed full snapshot, never a half-merged state. Rows are stamped with `snapshot_id == graph_meta.pushed_at` for cross-checks. A test asserts a MERGE push issues **no** INSERT/DELETE against `graph_group_counts` and that the counts exclude the stale row.

### Deferred to LOT 2 (stated explicitly)
- **Studio read path** — the route + `studio/src/lib/groupBy.js` refactor are NOT wired here. The only read accessor added is `groupCounts()` on the store itself.
- **Axes** `class_id`, `registry`, `status`, `ts` — deferred until those fields are lifted out of the props jsonb into queryable columns.
- No renderer/scene changes.

### Verify (real, run on this branch)
- `npm run lint` (tsc --noEmit) → exit 0.
- `npx vitest run tests/storage-postgres.test.ts tests/storage-postgres-group-counts.test.ts` → 2 files, **39 passed, 1 skipped** (the gated live suite). The full `tests/storage` dir: 181 passed, 4 skipped.

Do NOT merge.
