### PR TITLE
feat(cited-source): Lot-0 projection/validator + multisource (md/txt) modality-aware validation

### DIFF
--- a/spec/SPEC_WP_CITED_SOURCE_VIZ.md
+++ b/spec/SPEC_WP_CITED_SOURCE_VIZ.md
@@ -14,6 +14,10 @@
 > viewer-seam expresses all five (incl. a **quote-less geometry-only image-bbox** citation), and a
 > v1 / v2 / v3 per-modality lot sequence is added (image-bbox = **v3, needs detection, excluded from
 > Lot 1**). See §"Per-modality lots" and the dossier §8 Source-modality matrix.
+> Increment (2026-06-28, multisource): the Lot-0 projection (`citationToCitedSourceRef`) and validator
+> (`validateCitedSourceRef`) landed; the validator is now **modality-aware** — `page` is required only
+> for page-addressable modalities (`pdf`/`pptx`/`image`), while `markdown`/`plain-text`/`csv`/`web`/`docx`
+> are complete without a page (locator + `section`|`paragraph_id` + `excerpt`|`citation`). See §0.2.1 + AC0.5.
 > Sign-off: Lot 0 + Lot 1 ship **unilaterally** (graphify-owned). The viewer (Lots 2–3 internals)
 > needs **architect sign-off** — its public API is a sibling SPEC; this doc freezes only its *seam*.
 
@@ -97,6 +101,31 @@ Notes:
 | registry CSV row (`csv`) | `"row {row_id}"` | `paragraph_id` carries the row id / `row_hash` |
 | web (`web`) | `"{url}#{anchor}"` | `source_url`, `paragraph_id?` |
 
+### 0.2.1 Modality-aware completeness — `validateCitedSourceRef` (multisource)
+
+`validateCitedSourceRef(ref: CitedSourceRef)` is the **minimum cited-source contract** check
+Radar/immo and the projection (`citationToCitedSourceRef`) rely on. It is **modality-aware**: a
+single `page`-for-every-ref rule is correct for page-addressable sources but wrong for md/txt/web/docx,
+which have no page. Every ref still needs a **locator** (`rawRef` | `sourceUrl` | `docSha`) and
+**evidence text** (`excerpt` | `citation`); the *positional anchor* depends on the modality:
+
+| Modality class | Modalities | Required positional anchor | `bbox`/`region` |
+|---|---|---|---|
+| **page-addressable** | `pdf`, `pptx`, `image` | a 1-based integer `page` | meaningful (overlay rect) |
+| **non-page** | `markdown`, `plain-text`, `csv`, `web`, `docx` | a `section` **or** `paragraph_id` anchor — **no `page`** | not used |
+
+- The modality is read from `ref.modality`; when absent it is **derived from the locator suffix**
+  (`.pdf`→pdf, `.pptx`/`.ppt`→pptx, image exts→image, `.md`→markdown, `.txt`→plain-text, `.csv`→csv,
+  `.docx`/`.doc`→docx), and when still undeterminable it **defaults to the lenient (non-page) path**.
+- `bbox` is always optional; **when present it is validated** against the normalized
+  `[x0,y0,x1,y1]` 0..1 page-fraction convention (top-left origin, `x1≥x0`, `y1≥y0`) regardless of
+  modality. `bbox`/`region` overlays are *meaningful* only for `pdf`/`image`/`pptx`.
+- For `markdown`, the OCR `## Page N` page (§0.2) is **display enrichment**, not a completeness
+  requirement: markdown refs are anchored by `section`/`paragraph_id` and are **complete without a page**.
+
+So a `pdf` ref is **invalid without a `page`**, whereas an `md`/`txt`/`web` ref is **valid without a
+`page`** as long as it carries a locator + (`section` | `paragraph_id`) + (`excerpt` | `citation`).
+
 ### 0.3 Acceptance criteria (Lot 0)
 
 - AC0.1 — `OntologyCitation` carries `quote?`, `confidence?`, `source_location?`, **`modality?`,
@@ -110,6 +139,12 @@ Notes:
   the public cited-source contract.
 - AC0.4 — Golden: re-projecting an existing sidecar (`reprojectCitationsLLMFree`) is byte-stable
   before/after the type change for graphs that have no `quote` field.
+- AC0.5 — **Modality-aware validation (§0.2.1).** `validateCitedSourceRef` requires a `page` for
+  page-addressable modalities (`pdf`/`pptx`/`image`) and rejects them without one; a non-page ref
+  (`markdown`/`plain-text`/`csv`/`web`/`docx`) is complete with locator + (`section`|`paragraph_id`) +
+  (`excerpt`|`citation`) and **no `page`**. `bbox` is validated as normalized `[x0,y0,x1,y1]` 0..1
+  whenever present. Modality is taken from `ref.modality`, else derived from the locator suffix, else
+  the lenient (non-page) path. (Unit-covered in `tests/cited-source-refs.test.ts`.)
 
 ### 0.4 Sign-off — **graphify unilateral.** Data + schema graphify owns. No external sign-off.
 

--- a/src/cited-source-refs.ts
+++ b/src/cited-source-refs.ts
@@ -1,4 +1,4 @@
-import type { CitedSourceRef, OntologyCitation } from "./types.js";
+import type { CitationModality, CitedSourceRef, OntologyCitation } from "./types.js";
 
 export interface CitedSourceRefValidation {
   ok: boolean;
@@ -47,21 +47,93 @@ function hasEvidenceText(ref: CitedSourceRef): boolean {
   return Boolean(ref.excerpt || ref.citation);
 }
 
+/** Section / paragraph anchor used in place of a page for non-page modalities. */
+function hasAnchor(ref: CitedSourceRef): boolean {
+  return Boolean(ref.section || ref.paragraph_id);
+}
+
 function isNormalizedBbox(bbox: [number, number, number, number]): boolean {
   return bbox.every((v) => Number.isFinite(v) && v >= 0 && v <= 1) && bbox[2] >= bbox[0] && bbox[3] >= bbox[1];
 }
 
 /**
- * Validate the Radar/immo minimum cited-source contract.
+ * Page-addressable modalities: a `page` (or, for image, the page-as-frame) is the
+ * meaningful positional anchor, and `bbox`/`region` overlays apply only here.
+ */
+const PAGE_ADDRESSABLE_MODALITIES: ReadonlySet<CitationModality> = new Set<CitationModality>(["pdf", "pptx", "image"]);
+
+function isPageAddressable(modality: CitationModality | undefined): boolean {
+  // Absent modality → lenient (non-page) path per the multisource contract.
+  return modality != null && PAGE_ADDRESSABLE_MODALITIES.has(modality);
+}
+
+/**
+ * Derive a modality from the locator suffix when the ref does not carry an
+ * explicit `modality`. Unknown / extension-less locators yield `undefined`, which
+ * the validator treats as the lenient (non-page) path.
+ */
+function deriveModality(ref: CitedSourceRef): CitationModality | undefined {
+  const locator = (ref.rawRef ?? ref.sourceUrl ?? ref.docSha ?? "").toLowerCase();
+  const path = locator.split(/[?#]/, 1)[0] ?? "";
+  const dot = path.lastIndexOf(".");
+  if (dot < 0) return undefined;
+  switch (path.slice(dot + 1)) {
+    case "pdf":
+      return "pdf";
+    case "ppt":
+    case "pptx":
+      return "pptx";
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "webp":
+    case "gif":
+    case "tif":
+    case "tiff":
+    case "bmp":
+      return "image";
+    case "md":
+    case "markdown":
+      return "markdown";
+    case "txt":
+    case "text":
+      return "plain-text";
+    case "csv":
+      return "csv";
+    case "doc":
+    case "docx":
+      return "docx";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Validate the Radar/immo minimum cited-source contract — modality-aware.
  *
- * Complete proof requires a document locator, a 1-based page integer, and an
- * excerpt/citation. Bbox is optional; when present it must use Radar's normalized
- * page-fraction convention [x0,y0,x1,y1] with top-left origin.
+ * Every ref needs a document locator (`rawRef`/`sourceUrl`/`docSha`) and evidence
+ * text (`excerpt`/`citation`). The positional anchor is modality-dependent:
+ * - page-addressable modalities (pdf, pptx, image): a 1-based `page` integer;
+ * - non-page modalities (markdown, plain-text, csv, web, docx): a `section` or
+ *   `paragraph_id` anchor — `page` is neither required nor meaningful.
+ *
+ * The modality is read from `ref.modality`, otherwise derived from the locator
+ * suffix, otherwise treated as the lenient (non-page) path. `bbox` stays optional
+ * and, when present, must use Radar's normalized page-fraction convention
+ * [x0,y0,x1,y1] with top-left origin (overlays are meaningful for pdf/image/pptx).
  */
 export function validateCitedSourceRef(ref: CitedSourceRef): CitedSourceRefValidation {
   const errors: string[] = [];
+  const modality = ref.modality ?? deriveModality(ref);
+
   if (!hasLocator(ref)) errors.push("missing locator: expected rawRef, sourceUrl, or docSha");
-  if (!Number.isInteger(ref.page) || (ref.page ?? 0) < 1) errors.push("page must be a 1-based integer");
+
+  if (isPageAddressable(modality)) {
+    if (!Number.isInteger(ref.page) || (ref.page ?? 0) < 1) errors.push("page must be a 1-based integer");
+  } else if (!hasAnchor(ref)) {
+    errors.push("missing anchor: expected section or paragraph_id for non-page modalities");
+  }
+
   if (!hasEvidenceText(ref)) errors.push("missing evidence text: expected excerpt or citation");
   if (ref.bbox && !isNormalizedBbox(ref.bbox)) {
     errors.push("bbox must be normalized [x0,y0,x1,y1] page fractions with finite 0..1 values");

--- a/src/index.ts
+++ b/src/index.ts
@@ -433,6 +433,8 @@ export type {
   BuildPdfOcrPagesInput,
   NormalizedBbox,
 } from "./pdf-ocr-refs.js";
+export { citationToCitedSourceRef, citationsToCitedSourceRefs, validateCitedSourceRef } from "./cited-source-refs.js";
+export type { CitedSourceRefValidation } from "./cited-source-refs.js";
 export { prepareSemanticDetection } from "./semantic-prepare.js";
 export type { SemanticPreparationOptions, SemanticPreparationResult } from "./semantic-prepare.js";
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -517,9 +517,21 @@ export interface CitedSourceRef {
   /** Object-store/CAS key (for example raw/proces-verbaux-<city>/cas/<sha>.pdf). */
   rawRef?: string;
   sourceUrl?: string;
-  /** 1-based source page number. */
+  /**
+   * Source modality. Drives modality-aware completeness validation: `page` is the
+   * required anchor for page-addressable modalities (pdf, pptx, image), whereas
+   * markdown/plain-text/csv/web/docx are anchored by `section`/`paragraph_id`
+   * instead. When absent the validator derives it from the locator suffix and
+   * otherwise falls back to the lenient (non-page) path.
+   */
+  modality?: CitationModality;
+  /** 1-based source page number. Required anchor for page-addressable modalities. */
   page?: number;
-  /** Normalized top-left page fractions [x0,y0,x1,y1], when available. */
+  /** Section / heading anchor for non-page modalities (markdown, plain-text, web, docx). */
+  section?: string;
+  /** Paragraph / text-frame / CSV-row id anchor for non-page modalities. */
+  paragraph_id?: string;
+  /** Normalized top-left page fractions [x0,y0,x1,y1], when available (pdf/image/pptx). */
   bbox?: [number, number, number, number];
   /** Verbatim evidence text used for text-match fallback when bbox is absent. */
   excerpt?: string;

--- a/tests/cited-source-refs.test.ts
+++ b/tests/cited-source-refs.test.ts
@@ -93,4 +93,70 @@ describe("cited-source refs projection", () => {
     expect(citationKey(enriched)).toBe(citationKey(base));
     expect(unionCitations([[base], [enriched]])).toHaveLength(1);
   });
+
+  it("requires a page for page-addressable modalities (pdf)", () => {
+    const result = validateCitedSourceRef({ rawRef: "raw/doc.pdf", modality: "pdf", excerpt: "verbatim" });
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("page must be a 1-based integer");
+  });
+
+  it("accepts md/txt/web refs without a page (locator + section/paragraph_id + excerpt)", () => {
+    // markdown — anchored by section, no page
+    expect(
+      validateCitedSourceRef({
+        rawRef: "raw/notes.md",
+        docSha: "md-sha",
+        modality: "markdown",
+        section: "Background",
+        excerpt: "grounded passage",
+      }),
+    ).toEqual({ ok: true, errors: [] });
+
+    // plain-text — anchored by paragraph_id, citation as evidence
+    expect(
+      validateCitedSourceRef({
+        sourceUrl: "https://example.test/story.txt",
+        modality: "plain-text",
+        paragraph_id: "p-42",
+        citation: "chapter quote",
+      }).ok,
+    ).toBe(true);
+
+    // web — anchored by section, no page
+    expect(
+      validateCitedSourceRef({
+        sourceUrl: "https://example.test/article",
+        modality: "web",
+        section: "Methods",
+        excerpt: "web passage",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("requires a section/paragraph anchor for non-page modalities", () => {
+    const result = validateCitedSourceRef({ rawRef: "raw/notes.md", modality: "markdown", excerpt: "passage" });
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("missing anchor: expected section or paragraph_id for non-page modalities");
+  });
+
+  it("still validates bbox normalization when present, including non-page modalities", () => {
+    const result = validateCitedSourceRef({
+      rawRef: "raw/notes.md",
+      modality: "markdown",
+      section: "Background",
+      excerpt: "passage",
+      bbox: [0, 0, 1.5, 1],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("bbox must be normalized [x0,y0,x1,y1] page fractions with finite 0..1 values");
+  });
+
+  it("derives page-addressability from the locator suffix when modality is absent", () => {
+    // .pdf locator, no modality → page required
+    expect(validateCitedSourceRef({ rawRef: "raw/x.pdf", excerpt: "q" }).errors).toContain(
+      "page must be a 1-based integer",
+    );
+    // .md locator, no modality → lenient (no page), valid with a section anchor
+    expect(validateCitedSourceRef({ rawRef: "raw/x.md", section: "S", excerpt: "q" }).ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Lands the PDF cited-source **Lot-0** (projection `citationToCitedSourceRef` + validator `validateCitedSourceRef` + spec) and the **multisource** enrichment that makes the validator **modality-aware** so md/txt/web/docx refs are no longer wrongly rejected for lacking a `page`.

The 3 Lot-0 files (`spec/SPEC_WP_CITED_SOURCE_VIZ.md`, `src/cited-source-refs.ts`, `tests/cited-source-refs.test.ts`) were already merged to `main` (#228); this PR exports them from the package index and adds the modality-aware validation.

## What changed

- **Export** (`src/index.ts`): surface `citationToCitedSourceRef`, `citationsToCitedSourceRefs`, `validateCitedSourceRef`, `CitedSourceRefValidation` from the package root.
- **Modality-aware validator** (`src/cited-source-refs.ts`): `page` is required only for page-addressable modalities (`pdf`, `pptx`, `image`); `markdown`/`plain-text`/`csv`/`web`/`docx` are complete with a locator (`rawRef`|`sourceUrl`|`docSha`) + (`section`|`paragraph_id`) anchor + (`excerpt`|`citation`) and **no page**. Modality is read from `ref.modality`, else derived from the locator suffix, else defaults to the lenient (non-page) path. `bbox` is still validated as normalized `[x0,y0,x1,y1]` 0..1 when present.
- **Types** (`src/types.ts`): additive optional `modality`/`section`/`paragraph_id` on `CitedSourceRef` (backward-compatible).
- **Tests** (`tests/cited-source-refs.test.ts`): 5 → 10. pdf invalid without page; md/txt/web valid without page; non-page ref needs a section/paragraph anchor; bbox validated on non-page modalities; suffix-derived modality. The 5 existing projection/identity tests are unchanged and green.
- **Spec**: §0.2.1 (modality-aware completeness) + AC0.5 + header increment note.

## Verification (real)

- `npm run lint` (`tsc --noEmit`) → exit 0
- `npm test -- --run tests/cited-source-refs.test.ts` → 10 passed (10)

Does not touch renderer/scene/storage.
