### PR TITLE
feat(agent-stats): T0 temporal stamps (t/t_end/t_src) on sessions + session-owned edges

### DIFF
--- a/src/agent-stats/project-graph.ts
+++ b/src/agent-stats/project-graph.ts
@@ -225,6 +225,47 @@ function nodeId(kind: string, key: string): string {
   return `${kind}_${key}`.replace(/[^A-Za-z0-9_]/g, "_").toLowerCase();
 }
 
+/** Provenance tag for the T0 session-derived temporal stamp (`t`/`t_end`). */
+const SESSION_TIME_SRC = "session.started_at";
+
+/**
+ * Shared-scene-contract temporal stamp (epoch-ms). `t`/`t_end` are allowlisted
+ * by src/studio-scene.ts and flow through to the studio scene; `t_src` is
+ * graph-only provenance (NOT in the scene allowlist) recording where `t` came
+ * from. Spread onto a node/edge object — empty `{}` adds NO keys, so a timeless
+ * element stays byte-identical.
+ */
+interface TemporalStamp {
+  /** Interval START, epoch-ms (scene contract `t`). */
+  t?: number;
+  /** Interval END, epoch-ms (scene contract `t_end`); omitted when open-ended. */
+  t_end?: number;
+  /** Provenance of the stamp (graph-only; not carried into the scene). */
+  t_src?: string;
+}
+
+/**
+ * T0 temporal stamp for a SESSION and every edge that session OWNS (the edges
+ * whose `source` is the session node). `t` = session start, `t_end` = session
+ * end WHEN KNOWN. An open (still-running) session gets a `t` but NO `t_end` —
+ * it is an open interval, deliberately NOT a point-in-time `t_end === t`.
+ * Returns `{}` when the session carries no start timestamp, so a timeless
+ * session (and its edges) stay byte-identical (no `t` key emitted).
+ *
+ * DEDUP / FIRST-TOUCH: edges are deduped by `source|target|relation` (see
+ * `addEdge`), so a stamp follows first-touch semantics. For these session-owned
+ * edges that is unambiguous — the `source` IS the owning session node, so the
+ * triple is unique per session and the only emission carries that session's `t`.
+ */
+function sessionTemporal(s: SessionInput): TemporalStamp {
+  const startMs = s.startedAtMs ?? isoToEpochMs(s.startedAt);
+  if (startMs === undefined) return {};
+  const endMs = s.endedAtMs ?? isoToEpochMs(s.endedAt);
+  const stamp: TemporalStamp = { t: startMs, t_src: SESSION_TIME_SRC };
+  if (endMs !== undefined) stamp.t_end = endMs;
+  return stamp;
+}
+
 /**
  * Build the project/conversation graph from reconciled session inputs.
  *
@@ -247,6 +288,9 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
     return n.id;
   };
   const addEdge = (e: GraphEdgeOut) => {
+    // Deduped by source|target|relation: the FIRST emission wins, any later
+    // duplicate is dropped — so a temporal stamp (t/t_end) on the edge follows
+    // FIRST-TOUCH semantics (see sessionTemporal).
     const k = `${e.source}|${e.target}|${e.relation}`;
     if (linkSeen.has(k)) return;
     linkSeen.add(k);
@@ -307,11 +351,20 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
   // 3. SESSION / AGENT / BRANCH / COMMIT nodes from each in-identity session.
   const agentSessions = new Map<string, number>();
   const sessionNodeBySessionId = new Map<string, string>();
+  // T0 temporal stamp per session, reused for the session-owned derived-from
+  // edge built in step 4 (which is sourced from the CHILD session node).
+  const temporalBySessionId = new Map<string, TemporalStamp>();
 
   for (const s of opts.sessions) {
     const aliasIdx = sessionAlias(identity, s);
     if (aliasIdx < 0) continue; // not part of this project's lineage
     const repoNodeId = repoNodeIds[aliasIdx]!;
+
+    // T0 temporal: the session's own [t, t_end) span, reused on every edge the
+    // session owns (worked-in / conducted-by / touched-branch / produced and the
+    // derived-from in step 4). Empty {} when the session has no start timestamp.
+    const temporal = sessionTemporal(s);
+    temporalBySessionId.set(s.sessionId, temporal);
 
     // session node
     const sessId = addNode({
@@ -330,6 +383,7 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
       files_touched: s.filesTouched,
       commit_count: s.commitShas.length,
       branch_count: s.branches.length,
+      ...temporal,
     });
     sessionNodeBySessionId.set(s.sessionId, sessId);
 
@@ -341,6 +395,7 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
       confidence: "EXTRACTED",
       source_file: "agent-stats://session",
       weight: 1,
+      ...temporal,
     });
 
     // agent node + conducted-by edge
@@ -362,6 +417,7 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
       confidence: "EXTRACTED",
       source_file: "agent-stats://session",
       weight: 1,
+      ...temporal,
     });
 
     // branches
@@ -383,6 +439,7 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
           confidence: "EXTRACTED",
           source_file: "agent-stats://session",
           weight: 1,
+          ...temporal,
         });
       }
     }
@@ -407,6 +464,7 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
           confidence: "EXTRACTED",
           source_file: "agent-stats://ground-truth",
           weight: 1,
+          ...temporal,
         });
       }
     }
@@ -425,6 +483,9 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
         confidence: "INFERRED",
         source_file: "agent-stats://parentage",
         weight: 1,
+        // Owned by the CHILD (source) session: the derivation exists because the
+        // child declared a parent, so it carries the child session's t/t_end.
+        ...(temporalBySessionId.get(s.sessionId) ?? {}),
       });
     }
   }

--- a/src/agent-stats/project-graph.ts
+++ b/src/agent-stats/project-graph.ts
@@ -63,6 +63,22 @@ export interface SessionInput {
   cwds: string[];
   startedAt?: string;
   endedAt?: string;
+  /**
+   * Session start/end as epoch-MILLISECONDS — the projection of the ISO
+   * `startedAt`/`endedAt`. T0 temporal slice: these feed the shared scene
+   * contract's `t`/`t_end` (epoch-ms; see src/studio-scene.ts) on the session
+   * node and on the edges that session OWNS. Carried HERE — the projection
+   * boundary — because finer timestamps are otherwise dropped crossing it.
+   *
+   * TODO(agent-stats temporal — deferred lots): only session-level start/end is
+   * projected for T0. The finer per-action timestamps are STILL dropped at this
+   * boundary — `GitAction.timestamp` and `EvidenceSnippet.timestamp`
+   * (src/agent-stats/types.ts) plus the git committer-date are NOT carried — so
+   * DERIVED Branch / Commit / Agent spans stay out of scope. Widen SessionInput
+   * with those per-action timestamps when the derived-span lots land.
+   */
+  startedAtMs?: number;
+  endedAtMs?: number;
   branches: string[];
   commitShas: string[];
   prUrls: string[];
@@ -114,6 +130,17 @@ export interface BuildProjectGraphOptions {
   provenance?: unknown;
 }
 
+/**
+ * Parse an ISO-8601 timestamp to epoch-MILLISECONDS, or `undefined` when the
+ * input is absent or unparseable. The single conversion point for the T0
+ * temporal projection (ISO `startedAt`/`endedAt` → scene-contract `t`/`t_end`).
+ */
+export function isoToEpochMs(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
 /** Project the rich SessionFact onto the minimal SessionInput. */
 export function sessionFactToInput(fact: SessionFact, agentId: string): SessionInput {
   const branches = new Set<string>();
@@ -127,6 +154,8 @@ export function sessionFactToInput(fact: SessionFact, agentId: string): SessionI
     cwds: fact.cwds,
     startedAt: fact.startedAt,
     endedAt: fact.endedAt,
+    startedAtMs: isoToEpochMs(fact.startedAt),
+    endedAtMs: isoToEpochMs(fact.endedAt),
     branches: Array.from(branches).sort(),
     commitShas: Array.from(new Set(fact.groundTruth.commitShas.map((s) => s.slice(0, 7)))).sort(),
     prUrls: Array.from(new Set(fact.groundTruth.prUrls)),

--- a/tests/agent-stats-project-graph.test.ts
+++ b/tests/agent-stats-project-graph.test.ts
@@ -17,6 +17,7 @@ import {
   type SessionInput,
 } from "../src/agent-stats/project-graph.js";
 import type { SessionFact } from "../src/agent-stats/types.js";
+import { buildStudioScene } from "../src/studio-scene.js";
 
 const sentropicIdentity: ProjectIdentity = {
   canonicalId: "sentropic",
@@ -37,6 +38,8 @@ function mkSession(over: Partial<SessionInput>): SessionInput {
     cwds: over.cwds ?? ["~/src/sentropic"],
     startedAt: over.startedAt,
     endedAt: over.endedAt,
+    startedAtMs: over.startedAtMs,
+    endedAtMs: over.endedAtMs,
     branches: over.branches ?? [],
     commitShas: over.commitShas ?? [],
     prUrls: over.prUrls ?? [],
@@ -167,6 +170,163 @@ describe("buildProjectGraph — session detail", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// T0 temporal stamps: `t` / `t_end` (epoch-ms) + `t_src` (provenance) on
+// Session nodes and on every edge a session OWNS (worked-in / conducted-by /
+// touched-branch / produced / derived-from). Epoch-ms matches the shared scene
+// contract (src/studio-scene.ts). `t_src` is graph-only provenance.
+// ---------------------------------------------------------------------------
+const START_ISO = "2026-01-01T00:00:00.000Z";
+const END_ISO = "2026-01-01T01:00:00.000Z";
+const START_MS = Date.parse(START_ISO);
+const END_MS = Date.parse(END_ISO);
+
+describe("buildProjectGraph — T0 temporal stamps", () => {
+  it("stamps t/t_end/t_src on the Session node from started/ended", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [mkSession({ cwds: ["~/src/graphify"], startedAt: START_ISO, endedAt: END_ISO })],
+    });
+    const sess = g.nodes.find((n) => n.node_type === "Session")!;
+    expect(sess.t).toBe(START_MS);
+    expect(sess.t_end).toBe(END_MS);
+    expect(sess.t_src).toBe("session.started_at");
+  });
+
+  it("stamps the session's t/t_end/t_src on every edge it OWNS", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({
+          cwds: ["~/src/graphify"],
+          startedAt: START_ISO,
+          endedAt: END_ISO,
+          branches: ["feat/x"],
+          commitShas: ["abc1234"],
+          agentId: "claude:graphify:111",
+        }),
+      ],
+    });
+    const owned = g.links.filter((e) =>
+      ["worked-in", "conducted-by", "touched-branch", "produced"].includes(e.relation),
+    );
+    expect(owned.map((e) => e.relation).sort()).toEqual([
+      "conducted-by",
+      "produced",
+      "touched-branch",
+      "worked-in",
+    ]);
+    for (const e of owned) {
+      expect(e.t).toBe(START_MS);
+      expect(e.t_end).toBe(END_MS);
+      expect(e.t_src).toBe("session.started_at");
+    }
+  });
+
+  it("stamps derived-from with the CHILD (source) session's t/t_end", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({
+          factId: "codex:parent",
+          sessionId: "parent",
+          host: "codex",
+          cwds: ["~/src/graphify"],
+          startedAt: "2026-01-01T00:00:00.000Z",
+          endedAt: "2026-01-01T00:30:00.000Z",
+        }),
+        mkSession({
+          factId: "codex:child",
+          sessionId: "child",
+          host: "codex",
+          cwds: ["~/src/graphify"],
+          parentThreadId: "parent",
+          startedAt: START_ISO,
+          endedAt: END_ISO,
+        }),
+      ],
+    });
+    const derived = g.links.find((e) => e.relation === "derived-from")!;
+    expect(derived.t).toBe(START_MS); // child's start, not the parent's
+    expect(derived.t_end).toBe(END_MS);
+    expect(derived.t_src).toBe("session.started_at");
+  });
+
+  it("omits t_end for an OPEN session (started, not ended) — open interval, not a point", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [mkSession({ cwds: ["~/src/graphify"], startedAt: START_ISO })],
+    });
+    const sess = g.nodes.find((n) => n.node_type === "Session")!;
+    expect(sess.t).toBe(START_MS);
+    expect("t_end" in sess).toBe(false);
+    expect(sess.t_src).toBe("session.started_at");
+    const worked = g.links.find((e) => e.relation === "worked-in")!;
+    expect(worked.t).toBe(START_MS);
+    expect("t_end" in worked).toBe(false);
+  });
+
+  it("prefers the explicit epoch-ms (projection-boundary value) over the ISO string", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({ cwds: ["~/src/graphify"], startedAt: "ignored-iso", startedAtMs: 123456789, endedAtMs: 987654321 }),
+      ],
+    });
+    const sess = g.nodes.find((n) => n.node_type === "Session")!;
+    expect(sess.t).toBe(123456789);
+    expect(sess.t_end).toBe(987654321);
+  });
+
+  it("emits NO temporal keys for a timeless session (byte-identical back-compat)", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [mkSession({ cwds: ["~/src/graphify"], branches: ["main"], commitShas: ["abc1234"] })],
+    });
+    const sess = g.nodes.find((n) => n.node_type === "Session")!;
+    expect("t" in sess).toBe(false);
+    expect("t_end" in sess).toBe(false);
+    expect("t_src" in sess).toBe(false);
+    for (const e of g.links) {
+      expect("t" in e).toBe(false);
+      expect("t_end" in e).toBe(false);
+      expect("t_src" in e).toBe(false);
+    }
+  });
+});
+
+describe("agent-stats → studio scene carries t/t_end", () => {
+  it("a session node's t/t_end survive buildStudioScene (#234 scene allowlist)", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({
+          factId: "claude:a",
+          sessionId: "a",
+          cwds: ["~/src/graphify"],
+          startedAt: START_ISO,
+          endedAt: END_ISO,
+          branches: ["feat/x"],
+        }),
+      ],
+    });
+    // buildProjectGraph emits `links`; buildStudioScene reads links as edges.
+    const scene = buildStudioScene(g);
+    const sceneSession = scene.nodes.find((n) => n.type === "Session")!;
+    expect(sceneSession).toBeTruthy();
+    expect(sceneSession.t).toBe(START_MS);
+    expect(sceneSession.t_end).toBe(END_MS);
+    // A session-owned edge also carries the span into the scene.
+    const ownedEdge = scene.edges.find(
+      (e) => e.relation === "worked-in" || e.relation === "touched-branch",
+    )!;
+    expect(ownedEdge.t).toBe(START_MS);
+    expect(ownedEdge.t_end).toBe(END_MS);
+    // t_src is graph-only provenance — NOT in the scene allowlist.
+    expect("t_src" in sceneSession).toBe(false);
+  });
+});
+
 describe("graph.json shape", () => {
   it("produces a valid node-link graph the studio can read", () => {
     const g = buildProjectGraph({ identity: sentropicIdentity, sessions: [mkSession({ cwds: ["~/src/graphify"] })], provenance: { tool: "test" } });
@@ -221,5 +381,27 @@ describe("sessionFactToInput", () => {
     expect(inp.commitShas).toEqual(["abc1234"]); // 7-char, deduped
     expect(inp.filesTouched).toBe(2);
     expect(inp.parentThreadId).toBe("p");
+    // T0 projection boundary: ISO started/ended also carried as epoch-ms.
+    expect(inp.startedAtMs).toBe(Date.parse("2026-01-01T00:00:00Z"));
+    expect(inp.endedAtMs).toBe(Date.parse("2026-01-01T01:00:00Z"));
+  });
+
+  it("leaves the epoch-ms undefined when the fact has no started/ended", () => {
+    const fact: SessionFact = {
+      factId: "claude:n",
+      host: "claude",
+      sessionId: "n",
+      cwds: ["~/src/graphify"],
+      models: [],
+      tokens: { input: 0, output: 0, cached: 0, total: 0 },
+      gitActions: [],
+      groundTruth: { commitShas: [], branches: [], shaBranch: {}, prUrls: [] },
+      branchesObserved: [],
+      filesTouched: [],
+      evidence: [],
+    };
+    const inp = sessionFactToInput(fact, "claude:graphify:zz");
+    expect(inp.startedAtMs).toBeUndefined();
+    expect(inp.endedAtMs).toBeUndefined();
   });
 });


### PR DESCRIPTION
## T0 — temporal stamps on the agent-stats project graph (narrowed per Opus+Codex reviews)

Produces the shared scene-contract temporal values (`t`/`t_end`, epoch-ms) in the
agent-stats project graph (`graphify.agent-stats.project-graph/v1`). Before this,
the only time reaching the graph was `Session.started_at/ended_at` as display
strings; finer timestamps were dropped at the projection boundary.

### What lands (T0 — smallest correct slice)
1. **Stamp on Session nodes**: `t` = `started_at` (epoch-ms), `t_end` = `ended_at`
   (epoch-ms, omitted for an OPEN/still-running session — an open interval, NOT a
   point-in-time `t_end === t`), `t_src` = `"session.started_at"` (graph-only
   provenance; intentionally NOT in the scene allowlist).
2. **Stamp on session-OWNED edges**: the session's span is carried on every edge
   sourced from the session node — `worked-in`, `conducted-by`, `touched-branch`,
   `produced`, and `derived-from` (which takes the **child** (source) session's
   span). Edges dedup by `source|target|relation`, so the stamp follows
   **first-touch**; for session-owned edges this is unambiguous because the
   `source` IS the session node (triple unique per session).
3. **Projection boundary widened minimally**: `SessionInput` now carries
   `startedAtMs`/`endedAtMs` (epoch-ms), populated by a single `isoToEpochMs`
   converter in `sessionFactToInput`.
4. **Scene carry proven**: since #234 added `t`/`t_end` to the scene allowlist, a
   session node's `t`/`t_end` survive into `buildStudioScene` output — asserted by
   a new test.

### Back-compat
A timeless session (no start) emits **no** `t`/`t_end`/`t_src` keys — byte-identical
to before. Touches no renderer and no storage.

### Deferred (clear TODO on `SessionInput`)
Finer per-action timestamps remain dropped at the boundary: `GitAction.timestamp`,
`EvidenceSnippet.timestamp`, and the git committer-date are NOT carried, so DERIVED
Branch/Commit/Agent **spans** are out of scope for T0 (later lots).

### Verify (ran locally)
- `npm run lint` (`tsc --noEmit`) — exit 0
- `npx vitest run tests/agent-stats-project-graph.test.ts tests/studio-scene.test.ts tests/studio-scene-temporal-contract.test.ts` — 3 files, 45 passed / 1 pre-existing skip

> NOTE: CI's `mistral-ocr.integration` test 401s on an expired `MISTRAL_API_KEY`
> (external, unrelated to this change) and fails the shared test job for all PRs.
> The targeted local tests above are the source of truth for this change.