### PR TITLE
feat(studio): server group-by counts route + prefer-server grouping (client fallback)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3174,6 +3174,44 @@ export async function main(): Promise<void> {
         process.exit(1);
       }
       const { startOntologyStudioServer } = await import("./ontology-studio.js");
+      // Storage LOT 2: when an aggregate-capable GraphStore mirror is configured
+      // (env GRAPHIFY_STORE, or a storage.mirrors[] backend in the project
+      // config), wire it so the SPA group rail reads precomputed O(#groups)
+      // counts via GET /api/ontology/groups. Resolution is best-effort and
+      // NON-FATAL: with no backend configured — or on any connect/capability
+      // miss — the studio keeps serving flat JSON only (the route 404s and the
+      // SPA falls back to client-side group-by). Never blocks the default studio.
+      let groupCountsStore:
+        | import("./ontology-studio.js").StudioGroupCountsStore
+        | undefined;
+      const storeBackendId =
+        process.env.GRAPHIFY_STORE ?? projectConfig.storage?.mirrors?.[0]?.backend;
+      if (storeBackendId) {
+        try {
+          const { resolveStoreConfig } = await import("./storage/config.js");
+          const { resolveGraphStore } = await import("./storage/registry.js");
+          const storeConfig = resolveStoreConfig(storeBackendId, { projectConfig });
+          const resolved = await resolveGraphStore(storeBackendId, storeConfig);
+          if (resolved.capabilities.aggregate && typeof resolved.groupCounts === "function") {
+            groupCountsStore = resolved;
+            console.log(
+              `Group-by counts served from the '${storeBackendId}' store aggregate ` +
+                `(axes: ${resolved.capabilities.aggregate.axes.join(", ")}).`,
+            );
+          } else {
+            console.warn(
+              `Store '${storeBackendId}' declares no group-by aggregate capability; ` +
+                `the studio will compute group counts client-side.`,
+            );
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.warn(
+            `Could not wire a group-by counts store (${message}); ` +
+              `the studio will compute group counts client-side.`,
+          );
+        }
+      }
       try {
         const started = await startOntologyStudioServer({
           profileStatePath,
@@ -3181,6 +3219,7 @@ export async function main(): Promise<void> {
           ...(opts.port ? { port: Number.parseInt(opts.port, 10) } : {}),
           ...(opts.write ? { write: true } : {}),
           ...(opts.token ? { token: String(opts.token) } : {}),
+          ...(groupCountsStore ? { store: groupCountsStore } : {}),
         });
         if (started.writeEnabled) {
           console.log(`Ontology studio (write-enabled) listening at ${started.url}`);

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -24,9 +24,19 @@ import {
 } from "./ontology-reconciliation-api.js";
 import type { OntologyReconciliationCandidateFilter } from "./ontology-reconciliation.js";
 import type { OntologyReconciliationDecisionLogOptions } from "./ontology-patch.js";
+import type { GraphStore } from "./storage/types.js";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost", "ip6-loopback"]);
 const POST_BODY_MAX_BYTES = 256 * 1024;
+
+/**
+ * The slice of a {@link GraphStore} the `/api/ontology/groups` route reads: the
+ * capability descriptor (to gate on the optional `aggregate`) plus the
+ * `groupCounts(axis)` reader. A full GraphStore satisfies it; tests inject a
+ * minimal fake. Optional everywhere downstream, so the DEFAULT flat-JSON studio
+ * (no store configured) is byte-for-byte unchanged.
+ */
+export type StudioGroupCountsStore = Pick<GraphStore, "capabilities" | "groupCounts">;
 
 export interface OntologyStudioWriteOptions {
   token: string;
@@ -37,6 +47,14 @@ export interface OntologyStudioHandlerOptions {
   write?: OntologyStudioWriteOptions;
   /** Bind host; when loopback, same-origin writes are trusted without a token. */
   host?: string;
+  /**
+   * Optional GraphStore mirror (storage LOT 1/2). Present ONLY when a backend
+   * declaring the `aggregate` capability is configured; the
+   * `GET /api/ontology/groups` route then serves O(#groups) precomputed counts
+   * from it. Absent for the default flat-JSON studio, where the route 404s and
+   * the SPA falls back to its in-memory group-by — so the default is unchanged.
+   */
+  store?: StudioGroupCountsStore;
 }
 
 export interface StartOntologyStudioServerOptions {
@@ -45,6 +63,12 @@ export interface StartOntologyStudioServerOptions {
   port?: number;
   write?: boolean;
   token?: string;
+  /**
+   * Optional aggregate-capable GraphStore for the `/api/ontology/groups` route
+   * (storage LOT 2). Omitted by the default studio, which keeps serving flat
+   * JSON only; the route then 404s and the SPA falls back to client group-by.
+   */
+  store?: StudioGroupCountsStore;
 }
 
 export interface StartedOntologyStudioServer {
@@ -317,6 +341,49 @@ function patchRouteForMethod(pathname: string): "validate" | "dry-run" | "apply"
   return null;
 }
 
+/**
+ * GET /api/ontology/groups?axis=node_type — storage LOT 2.
+ *
+ * Capability-gated, READ-ONLY group-by counts served from a configured
+ * GraphStore mirror's precomputed aggregate (O(#groups), never an O(#nodes) scan
+ * of the snapshot). The studio PREFERS these counts for the group rail and falls
+ * back to its in-memory computation whenever the route is unavailable, so the
+ * default flat-JSON studio (no store) is unaffected.
+ *
+ * Any gating miss returns 404 so the SPA cleanly falls back to client group-by:
+ *   - no store configured (the default studio);
+ *   - the store omits the `aggregate` capability / `groupCounts` reader;
+ *   - the requested axis is not one the capability advertises (e.g. an ontology
+ *     class axis the store does not precompute) — the client keeps owning it.
+ *
+ * Async because `groupCounts()` is async; it is dispatched from the (async)
+ * request handler ahead of the synchronous route table.
+ */
+export async function handleOntologyGroupsRequest(
+  options: OntologyStudioHandlerOptions,
+  requestUrl: string,
+): Promise<OntologyStudioRouteResult> {
+  const url = new URL(requestUrl, "http://127.0.0.1");
+  const axis = optionalString(url.searchParams.get("axis")) ?? "node_type";
+  const store = options.store;
+  const aggregate = store?.capabilities?.aggregate;
+  if (!store || !aggregate || typeof store.groupCounts !== "function") {
+    return jsonResult(404, {
+      error: "group counts unavailable: no aggregate-capable store configured",
+    });
+  }
+  if (!aggregate.axes.includes(axis)) {
+    return jsonResult(404, { error: `group counts unavailable for axis '${axis}'` });
+  }
+  try {
+    const counts = await store.groupCounts(axis);
+    return jsonResult(200, counts);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return jsonResult(500, { error: message });
+  }
+}
+
 export function createOntologyStudioRequestHandler(options: OntologyStudioHandlerOptions) {
   return async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
     const method = request.method ?? "GET";
@@ -386,6 +453,14 @@ export function createOntologyStudioRequestHandler(options: OntologyStudioHandle
           sendAsset(response, asset);
           return;
         }
+      }
+      // Storage LOT 2: the async, store-backed group-by counts route. Handled
+      // here (not in the synchronous route table) because `groupCounts()` is
+      // async. With no store configured it returns 404 and the SPA falls back to
+      // its in-memory group-by, so the default studio path is unchanged.
+      if (url.pathname === "/api/ontology/groups") {
+        sendResult(response, await handleOntologyGroupsRequest(options, requestUrl));
+        return;
       }
     }
 
@@ -471,6 +546,9 @@ export async function startOntologyStudioServer(
   };
   if (writeEnabled) {
     handlerOptions.write = { token: options.token ?? generateOntologyStudioToken() };
+  }
+  if (options.store) {
+    handlerOptions.store = options.store;
   }
   const server = createServer(createOntologyStudioRequestHandler(handlerOptions));
   await new Promise<void>((resolve, reject) => {

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -21,6 +21,7 @@
     fetchClassHierarchies,
     fetchEntity,
     fetchGraph,
+    fetchGroupCounts,
     fetchModelsManifest,
     fetchScene,
     setStaticBaseProvider,
@@ -94,6 +95,12 @@
   // absent, in which case the toggle injects nothing. $state.raw — only ever
   // reassigned in bulk, never mutated in place.
   let classHierarchies = $state.raw(null);
+  // Storage LOT 2 (prefer-server group counts): the precomputed `node_type`
+  // group-by counts from a configured GraphStore mirror, fetched once per model
+  // via `GET /api/ontology/groups`. null when no store is configured (the
+  // default flat-JSON studio) — the Types rail then recomputes counts in-memory
+  // exactly as before. $state.raw: reassigned in bulk, never mutated in place.
+  let serverTypeCounts = $state.raw(null);
   // EVOL 2.b/2.d: the class-injection granularity is "all" — EVERY class (not
   // just leaves) is injected so that intermediate super-classes exist as collapse
   // HANDLES. `computeGroupedGraph` (lib/groupBy.js) owns the inject granularity;
@@ -429,6 +436,10 @@
     // the class taxonomy, so fetch class-hierarchies eagerly (not just on the
     // class-display toggle). Cached; a no-op when the artifact is absent.
     await ensureClassHierarchies();
+    // Storage LOT 2: prefer the store's precomputed `node_type` counts for the
+    // Types rail when a mirror is configured. Resolves null off the default
+    // flat-JSON studio, in which case the rail keeps computing counts in-memory.
+    serverTypeCounts = await fetchGroupCounts("node_type");
   }
 
   /** Flip the active model and re-render the SAME studio in place. */
@@ -454,6 +465,9 @@
     // re-fetches under the new model's base.
     classHierarchies = null;
     classHierarchiesFetched = false;
+    // The store group-counts are per-model too; drop them so the rail recomputes
+    // in-memory until loadActiveModel re-fetches for the new model.
+    serverTypeCounts = null;
     viewerState = clearSelection(viewerState);
     try {
       await loadActiveModel();
@@ -562,6 +576,7 @@
           <LeftRail
             graph={facetGraph}
             {classHierarchies}
+            {serverTypeCounts}
             query={viewerState.query}
             selection={viewerState.selection}
             showWeakLinks={viewerState.options.showWeakLinks}

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -25,6 +25,11 @@
   let {
     graph,
     classHierarchies = null,
+    // Storage LOT 2 (prefer-server): the store's precomputed `node_type`
+    // group-by counts (the `GET /api/ontology/groups` payload), or null. When
+    // present the Types rail uses these O(#groups) counts instead of an O(#nodes)
+    // in-memory pass; null (the default flat-JSON studio) keeps the client count.
+    serverTypeCounts = null,
     query = "",
     selection = { types: [], communities: [], entities: [] },
     showWeakLinks = true,
@@ -67,7 +72,9 @@
     onClearCommunityGrouping,
   } = $props();
 
-  const typeList = $derived(groupCounts(graph, nodeType));
+  // Storage LOT 2: prefer the store's precomputed counts when present; otherwise
+  // `groupCounts` falls back to the in-memory pass (default studio unchanged).
+  const typeList = $derived(groupCounts(graph, nodeType, serverTypeCounts));
   // Communities excluding degree-0 singletons (folded into `isolatedCount`).
   const communityInfo = $derived(communityStats(graph));
 

--- a/studio/src/lib/api.js
+++ b/studio/src/lib/api.js
@@ -259,6 +259,36 @@ export async function fetchClassHierarchies() {
   }
 }
 
+/**
+ * Storage LOT 2: fetch the precomputed group-by counts for an axis from a
+ * configured GraphStore mirror via `GET /api/ontology/groups?axis=<axis>`. The
+ * payload is a `graphify` group-counts document `{ axis, groups: [{ key, label,
+ * count, parent_key? }] }`. The studio PREFERS these over recomputing the rail
+ * counts across the full in-memory graph; whenever the route is unavailable —
+ * the default flat-JSON studio (no store), an offline bundle, a 404, or any
+ * network error — this resolves `null` so the caller falls back to its
+ * client-side group-by. Never throws (mirrors fetchClassHierarchies).
+ *
+ * Unlike the artifact fetchers there is NO bundle-relative static fallback: the
+ * counts are a live store projection, not a build-time artifact, so an offline
+ * export simply has none and the client computes them.
+ *
+ * @param {string} axis  e.g. "node_type".
+ * @returns {Promise<{ axis: string, groups: { key: string, label?: string,
+ *   count: number, parent_key?: string }[] } | null>}
+ */
+export async function fetchGroupCounts(axis) {
+  // Offline export ships no store aggregate; fall back to client group-by.
+  if (bundlePresent()) return null;
+  const param = encodeURIComponent(axis ?? "node_type");
+  try {
+    return await getJson(`/api/ontology/groups?axis=${param}`);
+  } catch {
+    // 404 (no aggregate-capable store / off-axis) or network error → client path.
+    return null;
+  }
+}
+
 export async function fetchReconciliationCandidates() {
   // Offline: serve the inlined queue if present (only with `--full-offline`),
   // else an empty queue (no doomed file:// fetch).

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -729,10 +729,52 @@ export function nodeSourcePath(node) {
 }
 
 /**
+ * Storage LOT 2: normalize a server group-counts payload into the rail's
+ * `{ key, count }[]` shape, or null when there is nothing usable. Accepts either
+ * the route document (`{ axis, groups: [...] }`) or a bare `groups` array, so the
+ * caller can pass whatever `fetchGroupCounts` returned. Returns null for a
+ * missing/empty set so the caller falls back to the client computation.
+ * @param {{ groups?: { key: string, count: number }[] } | { key: string, count: number }[] | null | undefined} serverCounts
+ * @returns {{ key: string, count: number }[] | null}
+ */
+function normalizeServerGroups(serverCounts) {
+  if (!serverCounts) return null;
+  const groups = Array.isArray(serverCounts) ? serverCounts : serverCounts.groups;
+  if (!Array.isArray(groups) || groups.length === 0) return null;
+  const out = [];
+  for (const g of groups) {
+    if (!g || g.key == null) continue;
+    const count = typeof g.count === "number" ? g.count : Number(g.count);
+    if (!Number.isFinite(count)) continue;
+    out.push({ key: String(g.key), count });
+  }
+  return out.length > 0 ? out : null;
+}
+
+/**
  * Group nodes by their grouping key for the left-rail Types/Communities lists.
+ *
+ * Storage LOT 2 (prefer-server): when `serverCounts` is supplied — the
+ * precomputed group-by aggregate from a configured GraphStore mirror (via
+ * `fetchGroupCounts(axis)`) — the list is built STRAIGHT from it in O(#groups),
+ * with NO O(#nodes) pass over the in-memory graph (the "instant grouping" win).
+ * When it is absent/empty (the default flat-JSON studio, an offline bundle, or a
+ * 404), the original client-side computation runs UNCHANGED. Either way the
+ * output shape, key stringification and sort order are identical, so the rail UI
+ * is the same — only the COUNT SOURCE changes when a store is present.
+ *
+ * @param {object} graph  the in-memory graph (client fallback source).
+ * @param {(node: object) => string|null|undefined} keyFn  the grouping key.
+ * @param {object|Array|null} [serverCounts]  the store's group-counts payload.
  * @returns {{ key: string, count: number }[]} sorted by descending count.
  */
-export function groupCounts(graph, keyFn) {
+export function groupCounts(graph, keyFn, serverCounts = null) {
+  const serverGroups = normalizeServerGroups(serverCounts);
+  if (serverGroups) {
+    return serverGroups
+      .map(({ key, count }) => ({ key: String(key), count }))
+      .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+  }
   const counts = new Map();
   for (const node of graphNodes(graph)) {
     const key = keyFn(node);

--- a/studio/src/tests/api.test.js
+++ b/studio/src/tests/api.test.js
@@ -6,6 +6,7 @@ import {
   fetchClassHierarchies,
   fetchEntity,
   fetchGraph,
+  fetchGroupCounts,
   fetchModelsManifest,
   fetchReconciliationCandidates,
   fetchScene,
@@ -133,6 +134,59 @@ describe("fetchClassHierarchies (EVOL 2.a)", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(fetchClassHierarchies()).resolves.toBeNull();
+  });
+});
+
+describe("fetchGroupCounts (storage LOT 2)", () => {
+  const counts = {
+    axis: "node_type",
+    groups: [
+      { key: "Character", label: "Character", count: 12 },
+      { key: "Place", label: "Place", count: 5 },
+    ],
+  };
+
+  it("returns the store counts from the same-origin route for the given axis", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url === "/api/ontology/groups?axis=node_type") return jsonResponse(counts);
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchGroupCounts("node_type")).resolves.toEqual(counts);
+  });
+
+  it("defaults to the node_type axis when none is passed", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url === "/api/ontology/groups?axis=node_type") return jsonResponse(counts);
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchGroupCounts()).resolves.toEqual(counts);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/ontology/groups?axis=node_type",
+      expect.anything(),
+    );
+  });
+
+  it("returns null when the route 404s (default flat-JSON studio, no store)", async () => {
+    // No bundle-relative static fallback: the counts are a live store projection.
+    const fetchMock = vi.fn(async () => jsonResponse({ error: "no store" }, false));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchGroupCounts("node_type")).resolves.toBeNull();
+  });
+
+  it("returns null in an offline bundle WITHOUT issuing any fetch", async () => {
+    window.__GRAPHIFY_BUNDLE__ = { "scene.json": { nodes: [], edges: [] } };
+    const fetchMock = vi.fn(() => {
+      throw new Error("fetch must not be called in an offline bundle");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchGroupCounts("node_type")).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -234,6 +234,51 @@ describe("graphAdapter helpers", () => {
   });
 });
 
+describe("groupCounts prefer-server (storage LOT 2)", () => {
+  it("uses the store's precomputed counts when supplied, NOT the in-memory graph", () => {
+    // A keyFn that EXPLODES if called proves no O(#nodes) pass happens when the
+    // server provided counts (the "instant grouping" win).
+    const keyFn = () => {
+      throw new Error("client keyFn must not run when server counts are present");
+    };
+    const serverCounts = {
+      axis: "node_type",
+      groups: [
+        { key: "Character", label: "Character", count: 12 },
+        { key: "Place", label: "Place", count: 5 },
+      ],
+    };
+    const result = groupCounts(FIXTURE, keyFn, serverCounts);
+    // Built straight from the server payload, re-sorted by count desc, key asc.
+    expect(result).toEqual([
+      { key: "Character", count: 12 },
+      { key: "Place", count: 5 },
+    ]);
+  });
+
+  it("accepts a bare groups array and re-sorts it by count desc, key asc", () => {
+    const result = groupCounts(FIXTURE, nodeType, [
+      { key: "Place", count: 5 },
+      { key: "Character", count: 12 },
+    ]);
+    expect(result.map((g) => g.key)).toEqual(["Character", "Place"]);
+  });
+
+  it("falls back to the client computation when serverCounts is null/empty", () => {
+    // Default flat-JSON studio: no store → null → identical to the legacy call.
+    const client = groupCounts(FIXTURE, nodeType);
+    expect(groupCounts(FIXTURE, nodeType, null)).toEqual(client);
+    expect(groupCounts(FIXTURE, nodeType, { axis: "node_type", groups: [] })).toEqual(client);
+    expect(groupCounts(FIXTURE, nodeType, [])).toEqual(client);
+  });
+
+  it("falls back when the server payload has no usable rows (missing key / NaN count)", () => {
+    const client = groupCounts(FIXTURE, nodeType);
+    const garbage = { axis: "node_type", groups: [{ label: "no key" }, { key: "x", count: "nope" }] };
+    expect(groupCounts(FIXTURE, nodeType, garbage)).toEqual(client);
+  });
+});
+
 describe("citationsByFile (SVELTE-2)", () => {
   it("groups citations by source file with passages", async () => {
     const { citationsByFile } = await import("../lib/graphAdapter.js");

--- a/tests/ontology-studio-groups-route.test.ts
+++ b/tests/ontology-studio-groups-route.test.ts
@@ -1,0 +1,147 @@
+/**
+ * GET /api/ontology/groups — storage LOT 2 server route.
+ *
+ * The route serves the studio's group-rail counts from a configured,
+ * aggregate-capable GraphStore (O(#groups)). When no such store is wired the
+ * route 404s so the SPA falls back to its in-memory group-by — i.e. the default
+ * flat-JSON studio is unchanged. These tests inject a MINIMAL fake store (the
+ * `StudioGroupCountsStore` slice) directly; no live DB and no postgres driver
+ * are required, mirroring the storage fake-driver harness.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  handleOntologyGroupsRequest,
+  type OntologyStudioHandlerOptions,
+  type StudioGroupCountsStore,
+} from "../src/ontology-studio.js";
+import type { GraphGroupCounts } from "../src/storage/types.js";
+
+/** A minimal aggregate-capable store: declares `axes` + serves canned counts. */
+function fakeStore(
+  axes: string[],
+  countsByAxis: Record<string, GraphGroupCounts>,
+  opts: { onCall?: (axis: string) => void } = {},
+): StudioGroupCountsStore {
+  return {
+    capabilities: {
+      push: true,
+      query: true,
+      clear: true,
+      snapshotMeta: true,
+      aggregate: { version: 1, axes },
+    },
+    async groupCounts(axis: string): Promise<GraphGroupCounts> {
+      opts.onCall?.(axis);
+      return countsByAxis[axis] ?? { axis, groups: [] };
+    },
+  };
+}
+
+/** A store WITHOUT the aggregate capability (and no groupCounts), e.g. neo4j. */
+const noAggregateStore: StudioGroupCountsStore = {
+  capabilities: { push: true, query: true, clear: true, snapshotMeta: true },
+};
+
+const NODE_TYPE_COUNTS: GraphGroupCounts = {
+  axis: "node_type",
+  groups: [
+    { key: "Character", label: "Character", count: 12 },
+    { key: "Place", label: "Place", count: 5 },
+  ],
+};
+
+function options(store?: StudioGroupCountsStore): OntologyStudioHandlerOptions {
+  // profileStatePath is unused by this route (no patch context load); a dummy
+  // value keeps the shape valid.
+  return store ? { profileStatePath: "/unused", store } : { profileStatePath: "/unused" };
+}
+
+describe("GET /api/ontology/groups (store configured)", () => {
+  it("returns the store's precomputed counts for an advertised axis", async () => {
+    const calls: string[] = [];
+    const store = fakeStore(["node_type", "community"], { node_type: NODE_TYPE_COUNTS }, {
+      onCall: (axis) => calls.push(axis),
+    });
+
+    const result = await handleOntologyGroupsRequest(
+      options(store),
+      "/api/ontology/groups?axis=node_type",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.contentType).toBe("application/json; charset=utf-8");
+    expect(JSON.parse(result.body)).toEqual(NODE_TYPE_COUNTS);
+    // The read hit the store exactly once, for the requested axis (O(#groups)).
+    expect(calls).toEqual(["node_type"]);
+  });
+
+  it("defaults to the node_type axis when ?axis is omitted", async () => {
+    const calls: string[] = [];
+    const store = fakeStore(["node_type", "community"], { node_type: NODE_TYPE_COUNTS }, {
+      onCall: (axis) => calls.push(axis),
+    });
+
+    const result = await handleOntologyGroupsRequest(options(store), "/api/ontology/groups");
+
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual(NODE_TYPE_COUNTS);
+    expect(calls).toEqual(["node_type"]);
+  });
+
+  it("404s for an axis the capability does not advertise (client keeps owning it)", async () => {
+    const calls: string[] = [];
+    const store = fakeStore(["node_type", "community"], {}, { onCall: (axis) => calls.push(axis) });
+
+    const result = await handleOntologyGroupsRequest(
+      options(store),
+      "/api/ontology/groups?axis=class_id",
+    );
+
+    expect(result.status).toBe(404);
+    // Gated BEFORE any store read — the store is never queried for an off-axis.
+    expect(calls).toEqual([]);
+  });
+
+  it("500s when the store read throws (the SPA can still fall back)", async () => {
+    const store: StudioGroupCountsStore = {
+      capabilities: {
+        push: true,
+        query: true,
+        clear: true,
+        snapshotMeta: true,
+        aggregate: { version: 1, axes: ["node_type"] },
+      },
+      async groupCounts(): Promise<GraphGroupCounts> {
+        throw new Error("connection refused");
+      },
+    };
+
+    const result = await handleOntologyGroupsRequest(
+      options(store),
+      "/api/ontology/groups?axis=node_type",
+    );
+
+    expect(result.status).toBe(500);
+    expect(JSON.parse(result.body).error).toContain("connection refused");
+  });
+});
+
+describe("GET /api/ontology/groups (no aggregate-capable store)", () => {
+  it("404s when NO store is configured (default flat-JSON studio)", async () => {
+    const result = await handleOntologyGroupsRequest(
+      options(),
+      "/api/ontology/groups?axis=node_type",
+    );
+    expect(result.status).toBe(404);
+    expect(JSON.parse(result.body).error).toMatch(/no aggregate-capable store/);
+  });
+
+  it("404s when a store is configured but omits the aggregate capability", async () => {
+    const result = await handleOntologyGroupsRequest(
+      options(noAggregateStore),
+      "/api/ontology/groups?axis=node_type",
+    );
+    expect(result.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## DB-backend LOT 2 — instant grouping via the Postgres group-by aggregate

Wires the storage LOT 1 `GraphStore.groupCounts(axis)` aggregate (#235) into the
studio so the group rail can read **precomputed** counts (O(#groups)) instead of
recomputing over the full in-memory graph. **Additive** — the default flat-JSON
studio (no store configured) is byte-for-byte unchanged.

### What changed
1. **Server route** — `GET /api/ontology/groups?axis=node_type`
   (`src/ontology-studio.ts`). Async, read-only, capability-gated: serves
   `store.groupCounts(axis)` only when an injected `store` declares the
   `aggregate` capability **and** advertises the axis; otherwise **404** so the
   SPA falls back. Injected via a narrow optional option
   `StudioGroupCountsStore = Pick<GraphStore, "capabilities" | "groupCounts">`.
2. **CLI wiring** (`src/cli.ts`) — `graphify ontology studio` resolves an
   aggregate-capable mirror when one is configured (env `GRAPHIFY_STORE` or a
   `storage.mirrors[]` backend) and passes it through. Best-effort + non-fatal:
   no backend / missing driver / failed connect / no aggregate ⇒ studio serves
   flat JSON only. Never blocks the default studio.
3. **Studio api accessor** — `fetchGroupCounts(axis)` (`studio/src/lib/api.js`)
   mirrors `fetchClassHierarchies`; resolves `null` on absent route / offline
   bundle / 404, never throws.
4. **Prefer-server grouping** — `graphAdapter.groupCounts(graph, keyFn,
   serverCounts?)` builds the Types-rail list straight from the store payload
   when present (O(#groups), no O(#nodes) pass), else the original client
   computation **unchanged**. `App.svelte` fetches the `node_type` counts once
   per model and threads them to `LeftRail`; the prop defaults to `null`.

Scope note: only the **node_type** axis is wired to the server (clean 1:1 keys).
The store's `community` axis uses numeric-id keys with `Community N` labels,
which diverge from the studio's display keys (community_name), so the community
rail intentionally stays client-side. The route/api/groupBy are axis-agnostic.

### Default no-store path stays unchanged
Route 404s with no store → `fetchGroupCounts` → `null` → `LeftRail`
`serverTypeCounts` default `null` → `groupCounts` runs the legacy in-memory pass.
A fallback test asserts byte-equality with the pre-change computation.

### Verification (local, real)
- `npm run lint` (tsc --noEmit) — exit 0
- `npm run build` + `npm run build:studio` — exit 0
- `npx vitest run` route test + `tests/storage-postgres*.test.ts` — green
- studio suite (`api.test.js`, `graphAdapter.test.js`, full 22 files) — green

Does NOT touch the renderer/scene/layout.