### PR TITLE
fix(build): bundle/vendor @sentropic/graph layout export so installed CLI resolves (smoke-test regression from #238)

### DIFF
--- a/src/scene-layout.ts
+++ b/src/scene-layout.ts
@@ -25,8 +25,12 @@
  * Anything other than `"typed-layer"` (including unset) ⇒ `"force"`.
  */
 
-import { computeTypedLayerPositions } from "@sentropic/graph";
-import type { TypedLayerLayoutOptions } from "@sentropic/graph";
+// Vendored locally (see typed-layer-layout.ts): the published
+// `@sentropic/graph@^0.1.0` graphify depends on at RUNTIME does NOT export
+// `computeTypedLayerPositions`, so importing it from the package crashes the
+// installed CLI at load (smoke-test regression from #238).
+import { computeTypedLayerPositions } from "./typed-layer-layout.js";
+import type { TypedLayerLayoutOptions } from "./typed-layer-layout.js";
 
 import { attachLayoutPositions } from "./graph-layout.js";
 

--- a/src/typed-layer-layout.ts
+++ b/src/typed-layer-layout.ts
@@ -1,0 +1,125 @@
+/**
+ * Vendored typed-layer (swimlane) layout core.
+ *
+ * This is a VERBATIM copy of the pure, deterministic `computeTypedLayerPositions`
+ * helper (+ its `TypedLayerLayoutOptions` type) from
+ * `packages/graph/src/layout-registry.ts`, which remains the CANONICAL home for
+ * the renderer package's own use.
+ *
+ * WHY VENDORED: graphify's RUNTIME dependency is the PUBLISHED
+ * `@sentropic/graph@^0.1.0`, which does NOT export `computeTypedLayerPositions`
+ * (that symbol was added to the local, still-unpublished package source). tsup
+ * keeps `@sentropic/graph` external, so an installed graphify would resolve the
+ * published tarball at runtime and crash at import with:
+ *   SyntaxError: ... does not provide an export named 'computeTypedLayerPositions'
+ * (regression from #238 — the installed-package smoke-test). Importing this
+ * symbol LOCALLY removes the runtime dependency on the unpublished export while
+ * keeping behaviour byte-identical. The renderer package's other (published)
+ * exports stay external, untouched.
+ *
+ * KEEP IN SYNC with `packages/graph/src/layout-registry.ts`. Once
+ * `@sentropic/graph` publishes `computeTypedLayerPositions` and graphify's
+ * dependency floor is bumped, this module can be deleted and `scene-layout.ts`
+ * can import from `@sentropic/graph` again.
+ *
+ * Pure, deterministic, O(n) — no renderer/WebGL/DOM dependency.
+ */
+
+/** Tuning for {@link computeTypedLayerPositions}. */
+export interface TypedLayerLayoutOptions {
+  /** Vertical distance between adjacent lane CENTRES (default 120). */
+  laneGap?: number;
+  /** Horizontal distance between adjacent nodes WITHIN a lane (default 40). */
+  nodeGap?: number;
+  /**
+   * Explicit lane ordering (top→bottom) by type name. Types present in the
+   * graph but absent here are appended in ascending (alpha) order; the untyped
+   * lane is always placed last. Default: all lanes alpha-sorted.
+   */
+  laneOrder?: readonly string[];
+}
+
+const DEFAULT_LANE_GAP = 120;
+const DEFAULT_NODE_GAP = 40;
+
+function normalizeType(raw: string | null | undefined): string | null {
+  return typeof raw === "string" && raw.trim() !== "" ? raw.trim() : null;
+}
+
+/**
+ * Variant A core — place nodes in horizontal bands ("swimlanes") by type.
+ *
+ *   • one lane per distinct `node_type`; lanes ordered deterministically
+ *     (`laneOrder` first, then ascending alpha; the untyped lane last);
+ *   • y = the lane CENTRE → every node of a type shares one y-band, and adjacent
+ *     bands are separated by `laneGap`;
+ *   • x = a stable even spread within the lane, centred on 0, in node order.
+ *
+ * Pure, deterministic, O(n) (+ O(L log L) to sort the L ≤ n lanes). Returns a
+ * fresh node-order-keyed `Float32Array` of length `2 * nodeTypes.length`.
+ *
+ * @param nodeTypes per-node type label, node-order keyed (parallel to node ids).
+ *                  A nullish / blank entry lands in the untyped lane.
+ */
+export function computeTypedLayerPositions(
+  nodeTypes: readonly (string | null | undefined)[],
+  options: TypedLayerLayoutOptions = {},
+): Float32Array {
+  const n = nodeTypes.length;
+  const out = new Float32Array(n * 2);
+  if (n === 0) return out;
+
+  const laneGap = options.laneGap ?? DEFAULT_LANE_GAP;
+  const nodeGap = options.nodeGap ?? DEFAULT_NODE_GAP;
+
+  // Bucket node indices by type, preserving node order within each lane.
+  const buckets = new Map<string, number[]>();
+  const untyped: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const type = normalizeType(nodeTypes[i]);
+    if (type === null) {
+      untyped.push(i);
+      continue;
+    }
+    let arr = buckets.get(type);
+    if (!arr) {
+      arr = [];
+      buckets.set(type, arr);
+    }
+    arr.push(i);
+  }
+
+  // Deterministic lane order: explicit laneOrder (present ones) → remaining
+  // defined types ascending → untyped lane last.
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const type of options.laneOrder ?? []) {
+    if (buckets.has(type) && !seen.has(type)) {
+      ordered.push(type);
+      seen.add(type);
+    }
+  }
+  for (const type of [...buckets.keys()].filter((t) => !seen.has(t)).sort()) {
+    ordered.push(type);
+  }
+
+  const lanes: number[][] = ordered.map((type) => buckets.get(type) as number[]);
+  if (untyped.length > 0) lanes.push(untyped);
+
+  const laneCount = lanes.length;
+  for (let lane = 0; lane < laneCount; lane++) {
+    // Centre the stack of lanes vertically around y = 0.
+    const y = (lane - (laneCount - 1) / 2) * laneGap;
+    const indices = lanes[lane] as number[];
+    const k = indices.length;
+    for (let j = 0; j < k; j++) {
+      // Centre the row of nodes horizontally around x = 0.
+      const x = (j - (k - 1) / 2) * nodeGap;
+      const idx = indices[j] as number;
+      out[idx * 2] = x;
+      out[idx * 2 + 1] = y;
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Regression (from #238)

`src/scene-layout.ts` does a **runtime** `import { computeTypedLayerPositions } from "@sentropic/graph"`. tsup keeps `@sentropic/graph` external, but graphify's runtime dependency is the **published** `@sentropic/graph@^0.1.0`, which does **not** export `computeTypedLayerPositions` (that symbol only exists in the local, still-unpublished `packages/graph` source). So the **installed** CLI crashes at import:

```
SyntaxError: The requested module '@sentropic/graph' does not provide an export named 'computeTypedLayerPositions'
```

This is the `smoke-test` job's **"Verify CLI from installed package"** failure on `main`. Because PR CI tests the PR *merged into* main, it also reds **every open PR**. The earlier `prebuild`/`sync-graph-dist` from #238 only repaired the in-repo **build** (it copies the local graph dist into `node_modules`); the published-package **runtime** path stayed broken.

## Fix — Option B (vendor), not bundle

Vendored the small, **pure**, deterministic `computeTypedLayerPositions` helper (+ its `TypedLayerLayoutOptions` type) into `src/typed-layer-layout.ts` — a verbatim copy of `packages/graph/src/layout-registry.ts` — and import it **locally** from `scene-layout.ts`.

**Why vendor over bundling (`noExternal`):** bundling the whole `@sentropic/graph` into the Node CLI would force-bundle `studio-render-buffers.ts`'s rendering primitives (`buildRenderGraphBuffers`/`buildStyleBuffers`) and the renderer's browser/WebGL code too — exactly the risk to avoid. Vendoring only the pure layout function keeps `studio-render-buffers` external (it resolves the **valid** published 0.1.0 exports, confirmed present), touches just two files, and has zero risk of pulling browser code. `packages/graph` stays the canonical home; behaviour is byte-identical.

## Verification (clean packed install — `npm pack` → install tarball into a clean dir)

**Before fix** — `npx graphify --help` crashed with the `computeTypedLayerPositions` SyntaxError (exit 1).

**After fix:**
- `npx graphify --help` → `Usage: graphify ...` (no SyntaxError); `npx graphify --version` → `0.17.2`; smoke "Verify CLI from installed package" **exit 0**
- "Verify library exports" (`require('@sentropic/graphify')`) → `All exports verified`
- Confirmed published `@sentropic/graph@0.1.0` in the clean install has `buildRenderGraphBuffers`/`buildStyleBuffers` (functions) but `computeTypedLayerPositions` = `undefined`
- `npm run build` exit 0 · `npm run lint` exit 0 · `npm run build:studio` exit 0
- `npx vitest run tests/scene-typed-layer.test.ts tests/studio-scene.test.ts` → 25 passed / 1 skipped (2 files)

No renderer draw-path/shader change. No publish.