### PR TITLE
feat(view): time-oriented layout (Variant E) + time-scrub playback (2D, opt-in)

### DIFF
--- a/packages/graph/src/layout-registry.ts
+++ b/packages/graph/src/layout-registry.ts
@@ -8,13 +8,17 @@
  * only chooses WHICH positions are produced; it never touches the renderer,
  * camera, or shaders (raw-WebGL2 instanced draw path is unchanged).
  *
- * Two layouts ship registered:
- *   • `"force"`       — the DEFAULT. Passthrough of the already-baked positions
- *                       (the deterministic Barnes-Hut FA2 force layout runs OFF
- *                       this path — `src/graph-layout.ts` — and is pinned into
- *                       `graph.positions`; this engine returns them verbatim).
- *   • `"typed-layer"` — Variant A swimlane: deterministic O(n) banding by node
- *                       type. OPT-IN; never the default.
+ * Three layouts ship registered:
+ *   • `"force"`         — the DEFAULT. Passthrough of the already-baked positions
+ *                         (the deterministic Barnes-Hut FA2 force layout runs OFF
+ *                         this path — `src/graph-layout.ts` — and is pinned into
+ *                         `graph.positions`; this engine returns them verbatim).
+ *   • `"typed-layer"`   — Variant A swimlane: deterministic O(n) banding by node
+ *                         type. OPT-IN; never the default.
+ *   • `"time-oriented"` — Variant E: deterministic O(n) placement of nodes by
+ *                         their interval-start `t` on the X (time) axis (oldest
+ *                         left → newest right), banded into type lanes on Y.
+ *                         OPT-IN; never the default.
  *
  * The registry honors the existing {@link LayoutEngine} / {@link LayoutOptions}
  * contract: {@link createLayoutEngine} wraps any registered layout as the
@@ -37,6 +41,9 @@ export const DEFAULT_LAYOUT_ID = "force";
 
 /** Registered id of Variant A — the typed-layer / swimlane layout. */
 export const TYPED_LAYER_LAYOUT_ID = "typed-layer";
+
+/** Registered id of Variant E — the time-oriented (temporal X-axis) layout. */
+export const TIME_ORIENTED_LAYOUT_ID = "time-oriented";
 
 // ---------------------------------------------------------------------------
 // Registry
@@ -231,9 +238,164 @@ export const typedLayerLayout: LayoutFn = (graph, options) => {
 };
 
 // ---------------------------------------------------------------------------
+// Variant E — time-oriented layout (deterministic, O(n)). X = normalized time.
+// ---------------------------------------------------------------------------
+
+/** Tuning for {@link computeTimeOrientedPositions}. */
+export interface TimeOrientedLayoutOptions {
+  /**
+   * Total WIDTH of the time axis. Timed nodes spread across `[-width/2, +width/2]`
+   * (centred on x = 0, like Variant A), oldest `t` at the left edge, newest at the
+   * right. Default 1000.
+   */
+  width?: number;
+  /** Vertical distance between adjacent type-lane CENTRES (default 120). */
+  laneGap?: number;
+  /**
+   * Explicit lane ordering (top→bottom) by type name — identical semantics to
+   * Variant A. Types present but absent here are appended ascending (alpha); the
+   * untyped lane is always last. Default: all lanes alpha-sorted.
+   */
+  laneOrder?: readonly string[];
+  /**
+   * Horizontal gap LEFT of the timeline where UNTIMED nodes are parked. An
+   * untimed node (nullish / non-finite `t`) gets a deterministic x =
+   * `-width/2 - untimedGap`, sitting on a "park rail" just left of the oldest
+   * timed node, while keeping its type lane on Y. Default 80.
+   */
+  untimedGap?: number;
+}
+
+const DEFAULT_TIME_WIDTH = 1000;
+const DEFAULT_UNTIMED_GAP = 80;
+
+function finiteTime(value: number | null | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Variant E core — place nodes on a horizontal TIME axis.
+ *
+ *   • x = the node's interval-start `t`, NORMALIZED across the timed range
+ *     `[tMin, tMax]` into `[-width/2, +width/2]` (oldest left → newest right).
+ *     When every timed node shares one instant (tMax === tMin) they sit at x = 0.
+ *     UNTIMED nodes (nullish / non-finite `t`) are parked deterministically at
+ *     x = `-width/2 - untimedGap`, just left of the timeline.
+ *   • y = a type LANE centre (one band per distinct type), ordered exactly like
+ *     Variant A (`laneOrder` first, then ascending alpha; untyped lane last), so
+ *     the time-oriented view is a temporal swimlane. With no `nodeTypes` every
+ *     node shares one lane (y = 0).
+ *
+ * Pure, deterministic, O(n) (+ O(L log L) to sort the L ≤ n lanes). Returns a
+ * fresh node-order-keyed `Float32Array` of length `2 * nodeTimes.length`.
+ *
+ * @param nodeTimes per-node interval start (epoch-ms), node-order keyed. A
+ *                  nullish / non-finite entry is "untimed".
+ * @param nodeTypes optional per-node type, node-order keyed (parallel). Absent ⇒
+ *                  one lane (y = 0).
+ */
+export function computeTimeOrientedPositions(
+  nodeTimes: readonly (number | null | undefined)[],
+  nodeTypes?: readonly (string | null | undefined)[],
+  options: TimeOrientedLayoutOptions = {},
+): Float32Array {
+  const n = nodeTimes.length;
+  const out = new Float32Array(n * 2);
+  if (n === 0) return out;
+
+  const width = options.width ?? DEFAULT_TIME_WIDTH;
+  const laneGap = options.laneGap ?? DEFAULT_LANE_GAP;
+  const untimedGap = options.untimedGap ?? DEFAULT_UNTIMED_GAP;
+  const halfWidth = width / 2;
+
+  // --- X: normalize timed nodes; park untimed ones on a deterministic rail. ---
+  let tMin = Number.POSITIVE_INFINITY;
+  let tMax = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < n; i++) {
+    const t = nodeTimes[i];
+    if (!finiteTime(t)) continue;
+    if (t < tMin) tMin = t;
+    if (t > tMax) tMax = t;
+  }
+  const span = tMax - tMin;
+  const untimedX = -halfWidth - untimedGap;
+  for (let i = 0; i < n; i++) {
+    const t = nodeTimes[i];
+    if (!finiteTime(t)) {
+      out[i * 2] = untimedX;
+      continue;
+    }
+    // span === 0 ⇒ every timed node shares one instant ⇒ centre them at x = 0.
+    const frac = span > 0 ? (t - tMin) / span : 0.5;
+    out[i * 2] = (frac - 0.5) * width;
+  }
+
+  // --- Y: type lanes, ordered exactly like Variant A. ---
+  const buckets = new Map<string, number[]>();
+  const untyped: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const type = normalizeType(nodeTypes?.[i]);
+    if (type === null) {
+      untyped.push(i);
+      continue;
+    }
+    let arr = buckets.get(type);
+    if (!arr) {
+      arr = [];
+      buckets.set(type, arr);
+    }
+    arr.push(i);
+  }
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const type of options.laneOrder ?? []) {
+    if (buckets.has(type) && !seen.has(type)) {
+      ordered.push(type);
+      seen.add(type);
+    }
+  }
+  for (const type of [...buckets.keys()].filter((t) => !seen.has(t)).sort()) {
+    ordered.push(type);
+  }
+  const lanes: number[][] = ordered.map((type) => buckets.get(type) as number[]);
+  if (untyped.length > 0) lanes.push(untyped);
+
+  const laneCount = lanes.length;
+  for (let lane = 0; lane < laneCount; lane++) {
+    // Centre the stack of lanes vertically around y = 0 (single lane ⇒ y = 0).
+    const y = (lane - (laneCount - 1) / 2) * laneGap;
+    for (const idx of lanes[lane] as number[]) {
+      out[idx * 2 + 1] = y;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Variant E as a {@link LayoutFn}. Reads per-node start times from
+ * {@link LayoutOptions.nodeTimes} and optional types from
+ * {@link LayoutOptions.nodeTypes} (both node-order keyed). Absent times ⇒ every
+ * node untimed (all parked on the left rail); absent types ⇒ one lane. Length
+ * always matches `graph.nodeIds.length`.
+ */
+export const timeOrientedLayout: LayoutFn = (graph, options) => {
+  const n = graph.nodeIds.length;
+  const times = options?.nodeTimes;
+  const nodeTimes: (number | null)[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = times?.[i];
+    nodeTimes[i] = finiteTime(t) ? t : null;
+  }
+  return computeTimeOrientedPositions(nodeTimes, options?.nodeTypes);
+};
+
+// ---------------------------------------------------------------------------
 // Register built-ins at module load. The DEFAULT (`"force"`) MUST stay the
-// passthrough — typed-layer is strictly opt-in and never replaces it.
+// passthrough — typed-layer / time-oriented are strictly opt-in and never
+// replace it.
 // ---------------------------------------------------------------------------
 
 registerLayout(DEFAULT_LAYOUT_ID, forceLayout);
 registerLayout(TYPED_LAYER_LAYOUT_ID, typedLayerLayout);
+registerLayout(TIME_ORIENTED_LAYOUT_ID, timeOrientedLayout);

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -149,6 +149,14 @@ export interface LayoutOptions {
    * engines. Optional & additive — absent ⇒ a single (untyped) lane.
    */
   nodeTypes?: readonly (string | null | undefined)[];
+  /**
+   * Per-node interval START, epoch-ms, node-order keyed (parallel to
+   * {@link RenderGraphBuffers.nodeIds}) — the shared scene-contract `t` (#234).
+   * Consumed by the time-oriented (Variant E) layout to place nodes on the X
+   * (time) axis; ignored by the force / typed-layer / static engines. Optional &
+   * additive — a nullish / non-finite entry is treated as "untimed".
+   */
+  nodeTimes?: readonly (number | null | undefined)[];
 }
 
 export interface LayoutEngine {

--- a/packages/graph/tests/layout-time-oriented.test.ts
+++ b/packages/graph/tests/layout-time-oriented.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRenderGraphBuffers,
+  computeTimeOrientedPositions,
+  getLayout,
+  hasLayout,
+  listLayouts,
+  TIME_ORIENTED_LAYOUT_ID,
+  type LayoutFn,
+} from "../src/index";
+
+/** Read back the (x, y) of node index `i` from a node-order-keyed positions array. */
+function xy(positions: Float32Array, i: number): { x: number; y: number } {
+  return { x: positions[i * 2]!, y: positions[i * 2 + 1]! };
+}
+
+// Epoch-ms instants, intentionally out of chronological node order so X ordering
+// can't be an accident of input order.
+const T0 = Date.UTC(1887, 2, 1);
+const T1 = Date.UTC(1891, 4, 4);
+const T2 = Date.UTC(1893, 11, 1);
+const T3 = Date.UTC(1894, 3, 5);
+
+describe("Variant E — time-oriented layout", () => {
+  it("returns a valid node-order-keyed Float32Array of length 2*N", () => {
+    const positions = computeTimeOrientedPositions([T0, T1, T2]);
+    expect(positions).toBeInstanceOf(Float32Array);
+    expect(positions.length).toBe(3 * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("orders nodes by `t` on the X axis (older = smaller x, newer = larger x)", () => {
+    // Node order is [T2, T0, T3, T1] — deliberately NOT chronological.
+    const times = [T2, T0, T3, T1];
+    const positions = computeTimeOrientedPositions(times);
+    const x = times.map((_, i) => xy(positions, i).x);
+    // Larger t ⇒ larger x: x of (T0) < x of (T1) < x of (T2) < x of (T3).
+    const xByT = new Map(times.map((t, i) => [t, x[i]!]));
+    expect(xByT.get(T0)!).toBeLessThan(xByT.get(T1)!);
+    expect(xByT.get(T1)!).toBeLessThan(xByT.get(T2)!);
+    expect(xByT.get(T2)!).toBeLessThan(xByT.get(T3)!);
+  });
+
+  it("normalizes the timed range into [-width/2, +width/2] (oldest left, newest right)", () => {
+    const width = 1000;
+    const positions = computeTimeOrientedPositions([T0, T3, T1], undefined, { width });
+    // T0 is the oldest ⇒ left edge; T3 the newest ⇒ right edge.
+    expect(xy(positions, 0).x).toBeCloseTo(-width / 2, 3); // T0
+    expect(xy(positions, 1).x).toBeCloseTo(width / 2, 3); // T3
+    // T1 sits strictly between the edges.
+    expect(xy(positions, 2).x).toBeGreaterThan(-width / 2);
+    expect(xy(positions, 2).x).toBeLessThan(width / 2);
+  });
+
+  it("places a single shared instant (span 0) at x = 0", () => {
+    const positions = computeTimeOrientedPositions([T1, T1, T1]);
+    for (let i = 0; i < 3; i++) expect(xy(positions, i).x).toBe(0);
+  });
+
+  it("parks UNTIMED nodes deterministically left of the timeline, keeping them finite", () => {
+    const width = 1000;
+    const untimedGap = 80;
+    // index 1 + 3 are untimed (null / undefined / NaN).
+    const positions = computeTimeOrientedPositions(
+      [T0, null, T3, undefined, Number.NaN],
+      undefined,
+      { width, untimedGap },
+    );
+    const parkX = -width / 2 - untimedGap;
+    expect(xy(positions, 1).x).toBe(parkX);
+    expect(xy(positions, 3).x).toBe(parkX);
+    expect(xy(positions, 4).x).toBe(parkX);
+    // The parked rail is strictly left of the oldest timed node (T0 at -width/2).
+    expect(parkX).toBeLessThan(xy(positions, 0).x);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("bands nodes into type LANES on Y (like Variant A) when nodeTypes is given", () => {
+    const times = [T0, T1, T2, T3];
+    const types = ["Character", "Location", "Character", "Evidence"];
+    const positions = computeTimeOrientedPositions(times, types);
+    // Same type ⇒ same y band; different type ⇒ different band.
+    expect(xy(positions, 0).y).toBe(xy(positions, 2).y); // both Character
+    expect(xy(positions, 0).y).not.toBe(xy(positions, 1).y); // Character vs Location
+    expect(xy(positions, 3).y).not.toBe(xy(positions, 0).y); // Evidence vs Character
+  });
+
+  it("collapses to a single lane (y = 0) when no types are given", () => {
+    const positions = computeTimeOrientedPositions([T0, T1, T2]);
+    for (let i = 0; i < 3; i++) expect(xy(positions, i).y).toBe(0);
+  });
+
+  it("is deterministic / reproducible", () => {
+    const a = computeTimeOrientedPositions([T2, T0, T3], ["A", "B", "A"]);
+    const b = computeTimeOrientedPositions([T2, T0, T3], ["A", "B", "A"]);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("handles the empty graph (length 0)", () => {
+    expect(computeTimeOrientedPositions([]).length).toBe(0);
+  });
+
+  it("is registered and selectable via the registry", () => {
+    expect(hasLayout(TIME_ORIENTED_LAYOUT_ID)).toBe(true);
+    expect(TIME_ORIENTED_LAYOUT_ID).toBe("time-oriented");
+    expect(listLayouts()).toContain("time-oriented");
+  });
+
+  it("is invoked through the registry via LayoutOptions.nodeTimes (+ nodeTypes)", () => {
+    const graph = buildRenderGraphBuffers({
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      edges: [],
+    });
+    const fn = getLayout(TIME_ORIENTED_LAYOUT_ID) as LayoutFn;
+    const out = fn(graph, { nodeTimes: [T2, T0, T1], nodeTypes: ["X", "X", "X"] });
+    expect(out.length).toBe(graph.nodeIds.length * 2);
+    // Ordered by t on X: b (T0) < c (T1) < a (T2).
+    expect(xy(out, 1).x).toBeLessThan(xy(out, 2).x);
+    expect(xy(out, 2).x).toBeLessThan(xy(out, 0).x);
+    // One type ⇒ one lane.
+    expect(xy(out, 0).y).toBe(xy(out, 1).y);
+  });
+});

--- a/src/scene-layout.ts
+++ b/src/scene-layout.ts
@@ -7,39 +7,51 @@
  * or shaders. A "variant" is just a different positions set, pinned (`fx`/`fy`)
  * the same way the force layout already is.
  *
- * Two layouts:
- *   • `"force"`       — the DEFAULT. Delegates to {@link attachLayoutPositions}
- *                       (deterministic Barnes-Hut FA2). UNCHANGED behaviour: when
- *                       force is selected nothing here runs and the scene is
- *                       BYTE-IDENTICAL to before (no `layout_id` stamped).
- *   • `"typed-layer"` — Variant A swimlane (OPT-IN). Bands nodes into horizontal
- *                       lanes by `type`, pins the positions, and stamps the
- *                       shared scene contract `layout_id: "typed-layer"` +
- *                       `layout_dims: 2` (#234).
+ * Three layouts:
+ *   • `"force"`         — the DEFAULT. Delegates to {@link attachLayoutPositions}
+ *                         (deterministic Barnes-Hut FA2). UNCHANGED behaviour: when
+ *                         force is selected nothing here runs and the scene is
+ *                         BYTE-IDENTICAL to before (no `layout_id` stamped).
+ *   • `"typed-layer"`   — Variant A swimlane (OPT-IN). Bands nodes into horizontal
+ *                         lanes by `type`, pins the positions, and stamps the
+ *                         shared scene contract `layout_id: "typed-layer"` +
+ *                         `layout_dims: 2` (#234).
+ *   • `"time-oriented"` — Variant E (OPT-IN). Places nodes by the shared-contract
+ *                         `t` on the X (time) axis (oldest left → newest right),
+ *                         banded into `type` lanes on Y; untimed nodes parked on a
+ *                         deterministic rail left of the timeline. Pins the
+ *                         positions and stamps `layout_id: "time-oriented"` +
+ *                         `layout_dims: 2`.
  *
  * SELECTION (opt-in; default stays force):
- *   • env `GRAPHIFY_LAYOUT=typed-layer` — mirrors the existing `GRAPHIFY_FAST_LAYOUT`
- *     opt-in style; read by {@link resolveSceneLayoutId} on the export path; OR
- *   • call {@link applySceneLayout}(scene, "typed-layer") directly with an
- *     explicit id (e.g. from a programmatic build).
- * Anything other than `"typed-layer"` (including unset) ⇒ `"force"`.
+ *   • env `GRAPHIFY_LAYOUT=typed-layer` | `time-oriented` — mirrors the existing
+ *     `GRAPHIFY_FAST_LAYOUT` opt-in style; read by {@link resolveSceneLayoutId}
+ *     on the export path; OR
+ *   • call {@link applySceneLayout}(scene, "typed-layer" | "time-oriented")
+ *     directly with an explicit id (e.g. from a programmatic build).
+ * Anything else (including unset) ⇒ `"force"`.
  */
 
-import { computeTypedLayerPositions } from "@sentropic/graph";
-import type { TypedLayerLayoutOptions } from "@sentropic/graph";
+import { computeTimeOrientedPositions, computeTypedLayerPositions } from "@sentropic/graph";
+import type { TimeOrientedLayoutOptions, TypedLayerLayoutOptions } from "@sentropic/graph";
 
 import { attachLayoutPositions } from "./graph-layout.js";
 
 /** Selectable build-time layout ids. `"force"` is the default. */
-export type SceneLayoutId = "force" | "typed-layer";
+export type SceneLayoutId = "force" | "typed-layer" | "time-oriented";
 
 /** Shared scene-contract layout id stamped when typed-layer is selected (#234). */
 export const TYPED_LAYER_SCENE_LAYOUT_ID = "typed-layer";
+
+/** Shared scene-contract layout id stamped when time-oriented is selected (#234). */
+export const TIME_ORIENTED_SCENE_LAYOUT_ID = "time-oriented";
 
 /** A scene node that can be positioned + pinned (loose, build-time shape). */
 interface LayoutableSceneNode {
   id: string;
   type?: unknown;
+  /** Shared scene contract — interval start, epoch-ms (#234). Read by Variant E. */
+  t?: unknown;
   x?: number;
   y?: number;
   fx?: number;
@@ -68,7 +80,9 @@ export function resolveSceneLayoutId(explicit?: string): SceneLayoutId {
     explicit ??
     (typeof process !== "undefined" && process.env ? process.env.GRAPHIFY_LAYOUT : undefined);
   const value = String(raw ?? "").trim().toLowerCase();
-  return value === "typed-layer" ? "typed-layer" : "force";
+  if (value === "typed-layer") return "typed-layer";
+  if (value === "time-oriented") return "time-oriented";
+  return "force";
 }
 
 /**
@@ -107,11 +121,50 @@ export function attachTypedLayerPositions<T extends LayoutableScene>(
 }
 
 /**
+ * Variant E wiring — compute time-oriented positions from each scene node's
+ * shared-contract `t` (the X / time axis) and `type` (Y type-lanes), PIN them
+ * (`x`/`y` AND `fx`/`fy`, like the force / typed-layer paths), and stamp the
+ * shared scene contract `layout_id` / `layout_dims = 2` (#234). Nodes lacking a
+ * finite `t` are parked on the deterministic "untimed" rail left of the
+ * timeline. Mutates and returns the scene. Pure O(n); no renderer change.
+ */
+export function attachTimeOrientedPositions<T extends LayoutableScene>(
+  scene: T,
+  options: TimeOrientedLayoutOptions = {},
+): T {
+  if (!scene || !Array.isArray(scene.nodes) || scene.nodes.length === 0) return scene;
+
+  const nodeTimes = scene.nodes.map((node) =>
+    typeof node.t === "number" && Number.isFinite(node.t) ? node.t : null,
+  );
+  const nodeTypes = scene.nodes.map((node) =>
+    typeof node.type === "string" && node.type.trim() !== "" ? node.type : null,
+  );
+  const positions = computeTimeOrientedPositions(nodeTimes, nodeTypes, options);
+
+  for (let i = 0; i < scene.nodes.length; i++) {
+    const node = scene.nodes[i];
+    if (!node) continue;
+    const x = positions[i * 2] ?? 0;
+    const y = positions[i * 2 + 1] ?? 0;
+    node.x = x;
+    node.y = y;
+    node.fx = x;
+    node.fy = y;
+  }
+
+  scene.layout_id = TIME_ORIENTED_SCENE_LAYOUT_ID;
+  scene.layout_dims = 2;
+  return scene;
+}
+
+/**
  * Apply the selected build-time layout to a scene and return it.
  *
  *   • `"force"` (default) → {@link attachLayoutPositions} (FA2), UNCHANGED — no
  *     `layout_id` stamped, byte-identical to the pre-Lot-1 export.
  *   • `"typed-layer"`     → {@link attachTypedLayerPositions} (Variant A).
+ *   • `"time-oriented"`   → {@link attachTimeOrientedPositions} (Variant E).
  */
 export function applySceneLayout<T extends LayoutableScene>(
   scene: T,
@@ -119,6 +172,9 @@ export function applySceneLayout<T extends LayoutableScene>(
 ): T {
   if (layoutId === "typed-layer") {
     return attachTypedLayerPositions(scene);
+  }
+  if (layoutId === "time-oriented") {
+    return attachTimeOrientedPositions(scene);
   }
   return attachLayoutPositions(scene);
 }

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -30,6 +30,8 @@
   import {
     buildScene,
     applyWeakFilter,
+    applyTimeFilter,
+    sceneTimeRange,
     attachForceLayout,
     resolveSelectedIds,
     communityStats,
@@ -63,6 +65,7 @@
     setActiveView,
     setQuery,
     setShowWeakLinks,
+    setTimeCursor,
     toggleGroupOntology,
     toggleGroupCommunity,
     toggleGroupType,
@@ -223,7 +226,8 @@
   // section's Ungroup all (spec §4/§5).
   const ontologyGrouped = $derived(hasOntologyGrouping(viewerState));
   const communityGrouped = $derived(hasCommunityGrouping(viewerState));
-  const scene = $derived(
+  // BASE scene (pre time-scrub) — the existing weak-link / group-by path.
+  const baseScene = $derived(
     hasAnyGroup
       ? // B2/A4: the grouped scene is rebuilt from graph.json (no positions) —
         // attach a force layout so it doesn't render as a ring.
@@ -235,6 +239,14 @@
           applyWeakFilter(sceneData, viewerState.options.showWeakLinks)
         : buildScene(graph, { showWeakLinks: viewerState.options.showWeakLinks }),
   );
+  // Temporal bounds of the BASE scene (#234 `t`); null on a non-temporal scene →
+  // the time-scrub control hides. Read from the base so the bounds stay STABLE
+  // while the cursor moves (the filtered scene must not shrink the range).
+  const timeRange = $derived(sceneTimeRange(baseScene));
+  // Time-scrub: filter the base scene to elements with `t <= cursor`. With the
+  // default cursor (null = OFF) this returns the base scene UNCHANGED, so the
+  // default view is byte-identical to before.
+  const scene = $derived(applyTimeFilter(baseScene, viewerState.options.timeCursor));
   // BUG A: facet / selection source. The left rail (Types / Communities /
   // Entities), the selection panel, and the selected-id resolution all read a
   // graph-like. Normally that is the hydrated raw `graph` (richest source). But
@@ -308,6 +320,9 @@
   }
   function handleToggleWeak(value) {
     viewerState = setShowWeakLinks(viewerState, value);
+  }
+  function handleSetTimeCursor(value) {
+    viewerState = setTimeCursor(viewerState, value);
   }
   // B2 (per-item): group-by callbacks. Every groupable rail item owns a checkbox
   // that GROUPS (collapses) the item when checked. Ontology classes and
@@ -579,6 +594,9 @@
             onToggleEntity={handleToggleEntity}
             onSetQuery={handleSetQuery}
             onToggleWeak={handleToggleWeak}
+            {timeRange}
+            timeCursor={viewerState.options.timeCursor}
+            onSetTimeCursor={handleSetTimeCursor}
             onToggleGroupOntology={handleToggleGroupOntology}
             onToggleGroupCommunity={handleToggleGroupCommunity}
             onToggleGroupType={handleToggleGroupType}

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -14,6 +14,7 @@
     Collapsible,
   } from "@sentropic/design-system-svelte";
   import TypeShapeGlyph from "./TypeShapeGlyph.svelte";
+  import TimeScrub from "./TimeScrub.svelte";
   import {
     graphNodes,
     nodeType,
@@ -57,6 +58,12 @@
     onToggleEntity,
     onSetQuery,
     onToggleWeak,
+    // Time-scrub (opt-in, #234): the scene's temporal bounds ({min,max} epoch-ms
+    // or null = non-temporal scene ⇒ the control hides), the current cursor
+    // (epoch-ms or null = OFF), and the cursor setter.
+    timeRange = null,
+    timeCursor = null,
+    onSetTimeCursor,
     // B2 (per-item) group-by callbacks.
     onToggleGroupOntology,
     onToggleGroupCommunity,
@@ -569,6 +576,11 @@
       />
       Show weak (inferred) links
     </label>
+
+    <!-- Time-scrub (opt-in): hidden unless the scene carries temporal `t` (#234).
+         Moving the cursor filters the graph to elements with t ≤ cursor via the
+         existing scene → render path (graphAdapter.applyTimeFilter). -->
+    <TimeScrub range={timeRange} cursor={timeCursor} onSetCursor={onSetTimeCursor} />
 
     <!-- B2 (per-item): group-by is NOT a separate axis sub-menu anymore — every
          groupable Ontology class / Community owns its OWN checkbox inline in its

--- a/studio/src/components/TimeScrub.svelte
+++ b/studio/src/components/TimeScrub.svelte
@@ -1,0 +1,153 @@
+<script>
+  /**
+   * TIME-SCRUB playback control (opt-in, 2D, additive). A slider + play/pause
+   * over the scene's temporal range (#234 `t`, epoch-ms). Moving the cursor
+   * FILTERS the displayed graph to elements with `t <= cursor` — the filtering
+   * itself lives in graphAdapter.applyTimeFilter and flows through the SAME scene
+   * → render path the weak-link / group-by filters use (no renderer API).
+   *
+   * Hides itself (renders nothing) when `range` is null — i.e. no node/edge in
+   * the scene carries a `t`, so the control is a strict no-op on non-temporal
+   * graphs. A null `cursor` is the OFF state (whole graph shown); the parent's
+   * default cursor is null so the default view is unchanged.
+   */
+  let { range = null, cursor = null, onSetCursor } = $props();
+
+  let playing = $state(false);
+
+  // Playback divides the temporal span into ~STEPS frames advanced every TICK_MS.
+  const STEPS = 60;
+  const TICK_MS = 200;
+
+  // The slider position: the cursor, or the span's max when OFF (cursor null) so
+  // the initial, unfiltered view sits at "now" (everything visible).
+  const value = $derived(range ? (cursor ?? range.max) : 0);
+  const sliderStep = $derived(range ? (range.max - range.min) / 200 || 1 : 1);
+
+  function nextCursor() {
+    if (!range) return cursor;
+    const inc = (range.max - range.min) / STEPS || 1;
+    return Math.min(range.max, (cursor ?? range.min) + inc);
+  }
+
+  // Playback loop. The effect only re-subscribes on `playing` / `range`; the
+  // interval reads the latest `cursor` via closure each tick, so updating the
+  // parent state does not tear the timer down.
+  $effect(() => {
+    if (!playing || !range) return;
+    const id = setInterval(() => {
+      const next = nextCursor();
+      onSetCursor?.(next);
+      if (next >= range.max) playing = false;
+    }, TICK_MS);
+    return () => clearInterval(id);
+  });
+
+  function onInput(e) {
+    playing = false;
+    onSetCursor?.(Number(e.currentTarget.value));
+  }
+
+  function togglePlay() {
+    if (!range) return;
+    // Restart from the oldest instant when at / past the end.
+    if ((cursor ?? range.max) >= range.max) onSetCursor?.(range.min);
+    playing = !playing;
+  }
+
+  function reset() {
+    playing = false;
+    onSetCursor?.(null);
+  }
+
+  function fmt(ms) {
+    const d = new Date(ms);
+    return Number.isFinite(d.getTime()) ? d.toISOString().slice(0, 10) : String(ms);
+  }
+</script>
+
+{#if range}
+  <div class="time-scrub">
+    <div class="time-scrub-head">
+      <span class="time-scrub-title">Time scrub</span>
+      <span class="time-scrub-now">{cursor == null ? "all" : fmt(cursor)}</span>
+    </div>
+    <div class="time-scrub-row">
+      <button
+        type="button"
+        class="time-scrub-btn"
+        aria-pressed={playing}
+        onclick={togglePlay}
+      >
+        {playing ? "Pause" : "Play"}
+      </button>
+      <input
+        type="range"
+        class="time-scrub-range"
+        min={range.min}
+        max={range.max}
+        step={sliderStep}
+        value={value}
+        oninput={onInput}
+        aria-label="Time cursor"
+      />
+      <button
+        type="button"
+        class="time-scrub-btn"
+        disabled={cursor == null}
+        onclick={reset}
+      >
+        Off
+      </button>
+    </div>
+    <div class="time-scrub-bounds">
+      <span>{fmt(range.min)}</span>
+      <span>{fmt(range.max)}</span>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .time-scrub {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px 0;
+    font-size: 12px;
+  }
+  .time-scrub-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .time-scrub-title {
+    font-weight: 600;
+  }
+  .time-scrub-now {
+    color: var(--st-semantic-text-subtle, #64748b);
+    font-variant-numeric: tabular-nums;
+  }
+  .time-scrub-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .time-scrub-range {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .time-scrub-btn {
+    flex: 0 0 auto;
+    cursor: pointer;
+  }
+  .time-scrub-btn:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+  .time-scrub-bounds {
+    display: flex;
+    justify-content: space-between;
+    color: var(--st-semantic-text-subtle, #64748b);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -630,6 +630,85 @@ export function applyWeakFilter(scene, showWeak) {
 }
 
 /**
+ * Finite epoch-ms reader for the shared scene contract `t` (#234). Anything
+ * non-numeric / non-finite is treated as UNTIMED (no temporal coordinate).
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function finiteTime(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Temporal bounds of a scene — the [min, max] of every finite `t` (#234) across
+ * nodes AND edges. Returns null when NO element carries a finite `t`; the
+ * time-scrub control reads this to HIDE itself (no-op on non-temporal graphs).
+ * @param {{ nodes?: object[], edges?: object[] } | null | undefined} scene
+ * @returns {{ min: number, max: number } | null}
+ */
+export function sceneTimeRange(scene) {
+  if (!scene) return null;
+  let min = Infinity;
+  let max = -Infinity;
+  const scan = (items) => {
+    for (const it of items ?? []) {
+      const t = finiteTime(it && it.t);
+      if (t === null) continue;
+      if (t < min) min = t;
+      if (t > max) max = t;
+    }
+  };
+  scan(scene.nodes);
+  scan(scene.edges);
+  return Number.isFinite(min) ? { min, max } : null;
+}
+
+/**
+ * Time-scrub filter — restrict a scene to what is visible AT a cursor instant
+ * (epoch-ms). An element is shown iff it is UNTIMED (no finite `t` — timeless
+ * scaffolding) OR its `t` ≤ cursor; an edge additionally needs both endpoints
+ * visible. Mirrors {@link applyWeakFilter}: it takes the FULL scene and returns
+ * a NEW scene with the same node attributes but a filtered node/edge set +
+ * updated stats, re-fed through the SAME render path (no renderer API).
+ *
+ * A null / non-finite cursor is the OFF state → the scene is returned UNCHANGED
+ * (the same object), so the default view stays byte-identical until the user
+ * scrubs.
+ *
+ * @param {{ nodes?: object[], edges?: object[], stats?: object } | null} scene
+ * @param {number | null | undefined} cursor  epoch-ms; null = off (no filter)
+ * @returns {object} a new scene (or the same scene when off)
+ */
+export function applyTimeFilter(scene, cursor) {
+  if (!scene) return scene;
+  const c = finiteTime(cursor);
+  if (c === null) return scene;
+
+  const visibleByTime = (t) => {
+    const ft = finiteTime(t);
+    return ft === null || ft <= c;
+  };
+
+  const nodes = (scene.nodes ?? []).filter((n) => visibleByTime(n && n.t));
+  const keptIds = new Set(nodes.map((n) => n.id));
+  const edges = (scene.edges ?? []).filter(
+    (e) => keptIds.has(e.source) && keptIds.has(e.target) && visibleByTime(e && e.t),
+  );
+
+  return {
+    ...scene,
+    nodes,
+    edges,
+    stats: {
+      ...scene.stats,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      weakEdgeCount: edges.filter((e) => e.weak).length,
+    },
+  };
+}
+
+/**
  * Index nodes by id for O(1) lookups in the entity panel / relations.
  * @returns {Map<string, object>}
  */

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -106,7 +106,9 @@ export function createDefaultViewerState() {
     query: "",
     selection: { types: [], communities: [], entities: [] },
     focusId: null,
-    options: { showWeakLinks: true, groupBy: createDefaultGroupBy() },
+    // `timeCursor`: time-scrub cursor (epoch-ms) or null = OFF (no temporal
+    // filter). Default null so the scene is unfiltered until the user scrubs.
+    options: { showWeakLinks: true, timeCursor: null, groupBy: createDefaultGroupBy() },
   };
 }
 
@@ -175,6 +177,11 @@ export function normalizeViewerState(partial = {}) {
   next.focusId = typeof next.focusId === "string" && next.focusId ? next.focusId : null;
   if (next.activeView !== "reconciliation") next.activeView = "workspace";
   next.options.showWeakLinks = Boolean(next.options.showWeakLinks);
+  // Time-scrub cursor (epoch-ms) — coerce any non-finite value to null (OFF).
+  next.options.timeCursor =
+    typeof next.options.timeCursor === "number" && Number.isFinite(next.options.timeCursor)
+      ? next.options.timeCursor
+      : null;
   // Normalize from the RAW partial options (not the base-merged one) so the
   // absence of `groupBy` is genuinely detectable and the legacy migration fires.
   next.options.groupBy = normalizeGroupBy(partial.options ?? {});
@@ -269,6 +276,19 @@ export function setShowWeakLinks(state, value) {
   return normalizeViewerState({
     ...state,
     options: { ...state.options, showWeakLinks: Boolean(value) },
+  });
+}
+
+/**
+ * Set the time-scrub cursor (epoch-ms) or null to turn scrubbing OFF. A
+ * non-finite value coerces to null. Additive & opt-in — the default cursor is
+ * null so the scene is unfiltered until the user scrubs.
+ */
+export function setTimeCursor(state, value) {
+  const t = typeof value === "number" && Number.isFinite(value) ? value : null;
+  return normalizeViewerState({
+    ...state,
+    options: { ...state.options, timeCursor: t },
   });
 }
 

--- a/tests/scene-time-oriented.test.ts
+++ b/tests/scene-time-oriented.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applySceneLayout,
+  attachTimeOrientedPositions,
+  resolveSceneLayoutId,
+} from "../src/scene-layout.js";
+import { buildStudioScene, type StudioSceneGraphLike } from "../src/studio-scene.js";
+
+// Epoch-ms instants (out of chronological node order so X ordering is observable).
+const T_1887 = Date.UTC(1887, 2, 1);
+const T_1891 = Date.UTC(1891, 4, 4);
+const T_1893 = Date.UTC(1893, 11, 1);
+
+// A small typed + temporal corpus. buildStudioScene carries `t` (#234) onto each
+// scene node and resolves `type`, which Variant E bands on (Y) / orders by (X).
+const GRAPH: StudioSceneGraphLike = {
+  nodes: [
+    { id: "n1", label: "Sherlock", type: "Character", t: T_1891 },
+    { id: "n2", label: "Baker Street", type: "Location", t: T_1887 },
+    { id: "n3", label: "Watson", type: "Character", t: T_1893 },
+    { id: "n4", label: "Untimed Clue", type: "Evidence" }, // no `t` ⇒ untimed
+  ],
+  links: [{ source: "n1", target: "n2", relation: "lives_at" }],
+};
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe("scene layout selection — Variant E time-oriented", () => {
+  it("selecting 'time-oriented' STAMPS layout_id + layout_dims on the scene", () => {
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "time-oriented");
+    expect(scene.layout_id).toBe("time-oriented");
+    expect(scene.layout_dims).toBe(2);
+  });
+
+  it("pins x/y AND fx/fy, ordering timed nodes by `t` on X", () => {
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "time-oriented");
+    const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+    for (const node of scene.nodes) {
+      expect(typeof node.x).toBe("number");
+      expect(typeof node.y).toBe("number");
+      expect(node.fx).toBe(node.x);
+      expect(node.fy).toBe(node.y);
+    }
+    // n2 (1887) is oldest, n3 (1893) is newest ⇒ x(n2) < x(n1) < x(n3).
+    expect(byId.get("n2")!.x!).toBeLessThan(byId.get("n1")!.x!);
+    expect(byId.get("n1")!.x!).toBeLessThan(byId.get("n3")!.x!);
+  });
+
+  it("bands by type on Y (same type shares a lane)", () => {
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "time-oriented");
+    const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+    expect(byId.get("n1")!.y).toBe(byId.get("n3")!.y); // both Character
+    expect(byId.get("n1")!.y).not.toBe(byId.get("n2")!.y); // Character vs Location
+  });
+
+  it("parks an UNTIMED node left of every timed node (deterministic untimed rail)", () => {
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "time-oriented");
+    const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+    const untimedX = byId.get("n4")!.x!;
+    expect(Number.isFinite(untimedX)).toBe(true);
+    for (const id of ["n1", "n2", "n3"]) {
+      expect(untimedX).toBeLessThan(byId.get(id)!.x!);
+    }
+  });
+
+  it("the DEFAULT ('force') does NOT stamp layout_id (back-compat byte-identity)", () => {
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "force");
+    expect("layout_id" in scene).toBe(false);
+    expect("layout_dims" in scene).toBe(false);
+  });
+
+  it("attachTimeOrientedPositions stamps the contract directly", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(GRAPH)));
+    expect(scene.layout_id).toBe("time-oriented");
+    expect(scene.layout_dims).toBe(2);
+  });
+});
+
+describe("resolveSceneLayoutId — time-oriented opt-in (default stays force)", () => {
+  const prior = process.env.GRAPHIFY_LAYOUT;
+  afterEach(() => {
+    if (prior === undefined) delete process.env.GRAPHIFY_LAYOUT;
+    else process.env.GRAPHIFY_LAYOUT = prior;
+  });
+
+  it("defaults to 'force' when unset", () => {
+    delete process.env.GRAPHIFY_LAYOUT;
+    expect(resolveSceneLayoutId()).toBe("force");
+  });
+
+  it("reads GRAPHIFY_LAYOUT=time-oriented (case-insensitive)", () => {
+    process.env.GRAPHIFY_LAYOUT = "Time-Oriented";
+    expect(resolveSceneLayoutId()).toBe("time-oriented");
+  });
+
+  it("still reads typed-layer + falls back to force for anything else", () => {
+    process.env.GRAPHIFY_LAYOUT = "typed-layer";
+    expect(resolveSceneLayoutId()).toBe("typed-layer");
+    process.env.GRAPHIFY_LAYOUT = "bogus";
+    expect(resolveSceneLayoutId()).toBe("force");
+  });
+
+  it("an explicit arg overrides the env", () => {
+    process.env.GRAPHIFY_LAYOUT = "time-oriented";
+    expect(resolveSceneLayoutId("force")).toBe("force");
+  });
+});

--- a/tests/studio-time-scrub.test.ts
+++ b/tests/studio-time-scrub.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+// The time-scrub filter lives in the studio scene adapter and flows through the
+// SAME scene → render path the weak-link filter uses (no renderer API). Root
+// vitest resolves the studio JS via the configured aliases (see vitest.config.ts).
+import { applyTimeFilter, sceneTimeRange } from "../studio/src/lib/graphAdapter.js";
+
+const T0 = Date.UTC(1887, 2, 1);
+const T1 = Date.UTC(1891, 4, 4);
+const T2 = Date.UTC(1893, 11, 1);
+
+/** A scene with temporal `t` (#234) on nodes + edges, plus one UNTIMED node. */
+function temporalScene() {
+  return {
+    nodes: [
+      { id: "a", t: T0 },
+      { id: "b", t: T1 },
+      { id: "c", t: T2 },
+      { id: "u" }, // untimed (timeless scaffolding)
+    ],
+    edges: [
+      { source: "a", target: "b", t: T1 },
+      { source: "b", target: "c", t: T2 },
+      { source: "a", target: "u" }, // untimed edge
+    ],
+    stats: { nodeCount: 4, edgeCount: 3, weakEdgeCount: 0, communityCount: 0 },
+  };
+}
+
+/** A scene WITHOUT any `t` — the non-temporal baseline. */
+function plainScene() {
+  return {
+    nodes: [{ id: "a" }, { id: "b" }],
+    edges: [{ source: "a", target: "b" }],
+    stats: { nodeCount: 2, edgeCount: 1, weakEdgeCount: 0, communityCount: 0 },
+  };
+}
+
+describe("sceneTimeRange — control visibility source", () => {
+  it("returns [min, max] across timed nodes AND edges", () => {
+    expect(sceneTimeRange(temporalScene())).toEqual({ min: T0, max: T2 });
+  });
+
+  it("returns null when NO element carries a `t` (control hides itself)", () => {
+    expect(sceneTimeRange(plainScene())).toBeNull();
+    expect(sceneTimeRange({ nodes: [], edges: [] })).toBeNull();
+    expect(sceneTimeRange(null)).toBeNull();
+  });
+});
+
+describe("applyTimeFilter — filter the displayed graph to t <= cursor", () => {
+  it("keeps elements with t <= cursor (and untimed), drops t > cursor", () => {
+    const filtered = applyTimeFilter(temporalScene(), T1);
+    const ids = filtered.nodes.map((n: { id: string }) => n.id).sort();
+    // a (T0) and b (T1) are <= cursor; u is untimed (kept); c (T2) is dropped.
+    expect(ids).toEqual(["a", "b", "u"]);
+    // Edges: a-b (T1) kept; b-c (T2) dropped (and endpoint c gone); a-u (untimed) kept.
+    const edgeKeys = filtered.edges
+      .map((e: { source: string; target: string }) => `${e.source}-${e.target}`)
+      .sort();
+    expect(edgeKeys).toEqual(["a-b", "a-u"]);
+    // Stats reflect the filtered subset.
+    expect(filtered.stats.nodeCount).toBe(3);
+    expect(filtered.stats.edgeCount).toBe(2);
+  });
+
+  it("drops an edge whose endpoint is filtered out even if the edge is untimed", () => {
+    const filtered = applyTimeFilter(temporalScene(), T0);
+    const ids = filtered.nodes.map((n: { id: string }) => n.id).sort();
+    expect(ids).toEqual(["a", "u"]); // only T0 + untimed survive
+    // a-b drops (b gone), b-c drops, a-u survives (both endpoints present).
+    expect(filtered.edges.map((e: { source: string; target: string }) => `${e.source}-${e.target}`)).toEqual([
+      "a-u",
+    ]);
+  });
+
+  it("a null / non-finite cursor is OFF — returns the SAME scene unchanged", () => {
+    const scene = temporalScene();
+    expect(applyTimeFilter(scene, null)).toBe(scene);
+    expect(applyTimeFilter(scene, undefined)).toBe(scene);
+    expect(applyTimeFilter(scene, Number.NaN)).toBe(scene);
+  });
+
+  it("at the max cursor every element is visible (whole graph)", () => {
+    const filtered = applyTimeFilter(temporalScene(), T2);
+    expect(filtered.nodes).toHaveLength(4);
+    expect(filtered.edges).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## What

Two **additive, opt-in, golden-safe** display pieces on top of the scene contract (#234), agent-stats T0 (#237), and the pluggable layout registry + Variant A (#238). **No renderer draw-path / shader change** — `git diff --name-only` touches no `renderer.ts` / `webgl-*.ts` / shader.

### 1. Temporal LAYOUT — Variant E (`"time-oriented"`)
`packages/graph/src/layout-registry.ts` — `computeTimeOrientedPositions(nodeTimes, nodeTypes?, opts?)` + `timeOrientedLayout` LayoutFn, registered as `TIME_ORIENTED_LAYOUT_ID = "time-oriented"`. Pure O(n), same `Float32Array(2*N)` shape.
- **X** = node interval-start `t` (#234), normalized across `[tMin,tMax]` into `[-width/2,+width/2]` (oldest left → newest right); a single shared instant collapses to `x=0`.
- **Y-lane choice**: type lanes, banded exactly like Variant A (`laneOrder` → alpha; untyped last); no `nodeTypes` ⇒ one lane (`y=0`). Time-oriented = a temporal swimlane.
- **Untimed handling**: nullish / non-finite `t` ⇒ parked deterministically at `x = -width/2 - untimedGap`, a rail left of the timeline, keeping its type lane on Y.
- Reads `t` via a new additive `LayoutOptions.nodeTimes`.
- `src/scene-layout.ts`: `attachTimeOrientedPositions` pins `x/y`+`fx/fy` and stamps `layout_id="time-oriented"` / `layout_dims=2`; selectable via `GRAPHIFY_LAYOUT=time-oriented` + `applySceneLayout`. **Default UNCHANGED** (force stamps nothing, byte-identical).

### 2. Time SCRUB control (studio)
Opt-in slider + play/pause in the LeftRail **Options** panel, filtering through the **existing scene → render path** (the same client-side mechanism the weak-link filter uses — no renderer API).
- `studio/src/lib/graphAdapter.js`: `applyTimeFilter(scene, cursor)` mirrors `applyWeakFilter` — keeps untimed + `t<=cursor` nodes (and edges whose endpoints survive), updates stats, returns a NEW scene re-fed via `setGraph/setStyle`; a `null` cursor is OFF (returns the same scene → default view byte-identical). `sceneTimeRange(scene)` → `{min,max}|null`; `null` hides the control.
- `studio/src/components/TimeScrub.svelte`: renders nothing when range is `null` (no-op on non-temporal graphs).
- `viewerState` gains `options.timeCursor` (default `null`) + `setTimeCursor`; `App.svelte` derives `baseScene → timeRange → scene = applyTimeFilter(base, cursor)`.

## Verify (run, all green)
- `npm run build` → exit 0 (prebuild builds packages/graph; new export resolves)
- `npm run lint` (`tsc --noEmit`) → exit 0
- `npm run build:studio` → exit 0
- graph layout tests (`packages/graph/tests/layout-time-oriented.test.ts` + registry/typed-layer): 25 passed
- scene + scrub tests (`tests/scene-time-oriented.test.ts`, `tests/studio-time-scrub.test.ts`): 16 passed
- `git diff --name-only origin/main | grep -iE 'renderer\.ts|webgl|shader'` → **NONE** (renderer/shaders untouched)

## Notes
Default view unchanged on every path. Renderer/shaders untouched, so golden-webgl stays green.