### PR TITLE
feat(renderer/labels): main-graph box-label truncation + top-K character labels at zoom

### DIFF
--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -11,6 +11,7 @@
     interpolateMergeStyle,
     interpolateMergePositions,
     isBoxShape,
+    LABEL_ZOOM_THRESHOLD,
     truncateLabel,
   } from "../lib/graphRendererPayload.js";
   import {
@@ -177,6 +178,12 @@
   let labels = $state([]);
   // Suppress label rendering during an active interaction on dense graphs.
   let labelsHidden = $state(false);
+  // Principal-character label LOD bucket of the last payload build: "out" =
+  // top-K hub names only (zoomed out), "in" = all gated hub names (zoomed in).
+  // A wheel that moves zoom across LABEL_ZOOM_THRESHOLD flips the bucket and
+  // triggers a payload rebuild so the in-box name set follows the zoom.
+  let lastLabelZoomBucket = null;
+  const labelZoomBucket = (zoom) => (zoom > LABEL_ZOOM_THRESHOLD ? "in" : "out");
 
   // Node-drag state — not reactive, managed imperatively.
   let draggingNodeId = null;
@@ -401,7 +408,15 @@
       if (zoomSettleTimer !== null) window.clearTimeout(zoomSettleTimer);
       zoomSettleTimer = window.setTimeout(() => {
         zoomSettleTimer = null;
-        if (renderer && skipEdgesOnInteract) renderNow();
+        // Crossed the principal-character LOD threshold (zoomed in/out past it)?
+        // Rebuild the payload so the in-box hub-name set follows the zoom, then
+        // re-style without re-fitting. Otherwise just restore skipped edges.
+        if (renderer && labelZoomBucket(camera.zoom) !== lastLabelZoomBucket) {
+          rebuildPayload();
+          applyPayloadNoFit();
+        } else if (renderer && skipEdgesOnInteract) {
+          renderNow();
+        }
         setLabelsHidden(false);
       }, ZOOM_SETTLE_MS);
     }
@@ -488,8 +503,13 @@
       focusId,
       hoveredNodeId,
       nodeRadius: NODE_RADIUS,
+      // Current zoom drives the principal-character label LOD (top-K names at
+      // zoom-out). Sync the bucket so a wheel that crosses the threshold knows
+      // to rebuild (see handleWheel's settle callback).
+      zoom: camera.zoom,
       ...(Number.isFinite(labelMaxChars) ? { labelMaxChars } : {}),
     });
+    lastLabelZoomBucket = labelZoomBucket(camera.zoom);
     clearHoveredEdge({ notify: false, render: false });
     computeNodeDegrees();
     reapplyDraggedPositions();

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -150,6 +150,77 @@ export function truncateLabel(label, maxChars = DEFAULT_LABEL_MAX_CHARS) {
   return text.slice(0, maxChars).replace(/\s+$/u, "") + "…";
 }
 
+/**
+ * Principal-character label LOD (top-K names at zoom-out).
+ *
+ * The god-class label gate (degree >= LABEL_DEGREE_FRACTION × maxDegree, applied
+ * inside @sentropic/graph buildStyleBuffers) can mark MANY Character hubs as
+ * labelled boxes on a dense corpus, so a zoomed-OUT main graph paints a wall of
+ * overlapping names. Instead we keep only the K highest-degree hubs labelled
+ * when zoomed out — the "principal cast" — and reveal the long tail once the
+ * user zooms past {@link LABEL_ZOOM_THRESHOLD}. Only the in-box NAME is gated:
+ * the hub glyph is untouched and the full name stays on node.label for hover.
+ */
+/** K — how many principal-character names stay visible when zoomed out. */
+export const MAX_PRINCIPAL_CHARACTER_LABELS = 5;
+/**
+ * world→screen zoom at/below which the long-tail hub names are HIDDEN (only the
+ * top-K principal names show). Above it the graph is zoomed in enough that every
+ * gated hub name fits, so all are revealed. The renderer maps world to screen as
+ * `screen = (world − camera) · zoom`, so zoom > 1 means a node's world unit spans
+ * more than one device pixel (a deliberate zoom-in past the default fit).
+ */
+export const LABEL_ZOOM_THRESHOLD = 1;
+
+/**
+ * Choose which god-class hub boxes keep their in-box NAME at the given zoom.
+ * Pure + deterministic (degree desc, ties by node index asc) so the studio and
+ * the unit tests agree. Above `zoomThreshold` every hub is kept; at/below it
+ * only the top-K by degree.
+ * @param {Array<{index:number, degree:number}>} hubs labelled hub candidates
+ * @param {number} zoom current world→screen zoom
+ * @param {{k?:number, zoomThreshold?:number}} [opts]
+ * @returns {Set<number>} the node indices whose name should stay visible
+ */
+export function selectPrincipalHubLabels(
+  hubs,
+  zoom,
+  { k = MAX_PRINCIPAL_CHARACTER_LABELS, zoomThreshold = LABEL_ZOOM_THRESHOLD } = {},
+) {
+  const keep = new Set();
+  if (!Array.isArray(hubs) || hubs.length === 0) return keep;
+  // Zoomed in past the threshold → reveal every gated hub name.
+  if (Number.isFinite(zoom) && zoom > zoomThreshold) {
+    for (const hub of hubs) keep.add(hub.index);
+    return keep;
+  }
+  // Zoomed out (the default fit) → only the K highest-degree principal hubs.
+  const ranked = [...hubs].sort((a, b) => b.degree - a.degree || a.index - b.index);
+  const limit = Math.min(Number.isFinite(k) && k > 0 ? k : 0, ranked.length);
+  for (let i = 0; i < limit; i += 1) keep.add(ranked[i].index);
+  return keep;
+}
+
+/**
+ * Undirected degree per node INDEX from a render-graph's flat edge index buffer
+ * (`edges` = [src0, tgt0, src1, tgt1, …]). Mirrors @sentropic/graph styles.ts
+ * computeNodeDegrees so the LOD ranks hubs by the SAME degree the label gate did.
+ * @param {{nodeIds?:ArrayLike<unknown>, edges?:ArrayLike<number>}} graph
+ * @returns {Uint32Array} degree by node index
+ */
+function computeDegreesByIndex(graph) {
+  const count = graph?.nodeIds?.length ?? 0;
+  const degrees = new Uint32Array(count);
+  const edges = graph?.edges ?? [];
+  for (let i = 0; i < edges.length; i += 1) {
+    const endpoint = edges[i];
+    if (Number.isInteger(endpoint) && endpoint >= 0 && endpoint < count) {
+      degrees[endpoint] += 1;
+    }
+  }
+  return degrees;
+}
+
 function cloneStyle(style) {
   return {
     nodeSizes: new Float32Array(style.nodeSizes),
@@ -223,6 +294,10 @@ export function buildGraphRendererPayload(scene, options = {}) {
   const labelMaxChars = Number.isFinite(options.labelMaxChars)
     ? options.labelMaxChars
     : DEFAULT_LABEL_MAX_CHARS;
+  // Current world→screen zoom drives the principal-character label LOD (top-K
+  // names at zoom-out). Undefined ⇒ treat as zoomed OUT so the default fit view
+  // already shows only the principal cast (see selectPrincipalHubLabels).
+  const labelZoom = Number.isFinite(options.zoom) ? options.zoom : 0;
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
 
@@ -305,6 +380,32 @@ export function buildGraphRendererPayload(scene, options = {}) {
       if (!forced && !hasExisting) continue;
       const source = forced ? (node.label || String(node.id)) : existing;
       baseStyle.nodeLabels[index] = truncateLabel(source, labelMaxChars);
+    }
+  }
+
+  // Principal-character label LOD: when zoomed out keep only the top-K
+  // highest-degree god-class hub NAMES (declutter the wall of names a dense
+  // corpus produces); reveal the long tail once zoomed past LABEL_ZOOM_THRESHOLD.
+  // forceBoxLabel (recon focal pair) is EXEMPT — those twins always read as
+  // identical labelled boxes. The hub glyph is untouched; only the in-box name
+  // is cleared, and node.label keeps the full name for the hover tooltip.
+  if (baseStyle.nodeLabels) {
+    const degreesByIndex = computeDegreesByIndex(renderGraph);
+    const hubs = [];
+    for (const node of nodes) {
+      if (node.forceBoxLabel === true) continue;
+      const index = nodeIndexById.get(node.id);
+      if (!Number.isInteger(index)) continue;
+      const label = baseStyle.nodeLabels[index];
+      if (typeof label === "string" && label.length > 0) {
+        hubs.push({ index, degree: degreesByIndex[index] ?? 0 });
+      }
+    }
+    if (hubs.length > 0) {
+      const keep = selectPrincipalHubLabels(hubs, labelZoom);
+      for (const hub of hubs) {
+        if (!keep.has(hub.index)) baseStyle.nodeLabels[hub.index] = "";
+      }
     }
   }
   const renderedEdges = Array.from(renderGraph.edgeInputIndices ?? [], (inputIndex) => edges[inputIndex]);

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -13,6 +13,9 @@ import {
   interpolateMergeStyle,
   interpolateMergePositions,
   isBoxShape,
+  LABEL_ZOOM_THRESHOLD,
+  MAX_PRINCIPAL_CHARACTER_LABELS,
+  selectPrincipalHubLabels,
   truncateLabel,
 } from "../lib/graphRendererPayload.js";
 import { buildScene, communityStats, nodeGroup } from "../lib/graphAdapter.js";
@@ -306,6 +309,103 @@ describe("buildGraphRendererPayload main-graph box label truncation (regression)
     const payload = buildGraphRendererPayload(makeMainScene(), { nodeRadius: 3, labelMaxChars: 8 });
     const idx = payload.nodeIndexById.get("chap");
     expect([...payload.baseStyle.nodeLabels[idx]].length).toBeLessThanOrEqual(9);
+  });
+});
+
+// --- Principal-character label LOD: top-K names at zoom-out, all when zoomed in.
+// The god-class gate can label MANY Character hubs on a dense corpus; at zoom-out
+// we keep only the K most important (highest-degree) names — the principal cast —
+// and reveal the long tail past LABEL_ZOOM_THRESHOLD. ---
+describe("selectPrincipalHubLabels (pure top-K-by-degree selection)", () => {
+  // 8 hubs with DISTINCT degrees 1..8 (so the ranking is unambiguous).
+  const hubs = Array.from({ length: 8 }, (_, i) => ({ index: i, degree: i + 1 }));
+
+  it("keeps exactly the top-K highest-degree hubs when zoomed OUT", () => {
+    const keep = selectPrincipalHubLabels(hubs, 0); // zoom 0 ≤ threshold
+    expect(keep.size).toBe(MAX_PRINCIPAL_CHARACTER_LABELS);
+    // degrees 8,7,6,5,4 → indices 7,6,5,4,3
+    expect([...keep].sort((a, b) => a - b)).toEqual([3, 4, 5, 6, 7]);
+    // the low-degree tail (indices 0,1,2) is dropped
+    expect(keep.has(0)).toBe(false);
+    expect(keep.has(2)).toBe(false);
+  });
+
+  it("reveals ALL gated hubs once zoomed in past the threshold", () => {
+    const keep = selectPrincipalHubLabels(hubs, LABEL_ZOOM_THRESHOLD + 0.5);
+    expect(keep.size).toBe(8);
+  });
+
+  it("is exactly at the threshold still treated as zoomed OUT (top-K only)", () => {
+    const keep = selectPrincipalHubLabels(hubs, LABEL_ZOOM_THRESHOLD);
+    expect(keep.size).toBe(MAX_PRINCIPAL_CHARACTER_LABELS);
+  });
+
+  it("breaks degree ties by lowest node index (deterministic)", () => {
+    const tied = [
+      { index: 5, degree: 10 },
+      { index: 2, degree: 10 },
+      { index: 9, degree: 10 },
+    ];
+    const keep = selectPrincipalHubLabels(tied, 0, { k: 2 });
+    expect([...keep].sort((a, b) => a - b)).toEqual([2, 5]);
+  });
+
+  it("does not exceed the candidate count (fewer hubs than K)", () => {
+    const keep = selectPrincipalHubLabels([{ index: 1, degree: 3 }], 0);
+    expect(keep.size).toBe(1);
+  });
+});
+
+describe("buildGraphRendererPayload principal-character label LOD (integration)", () => {
+  // A clique of `hubCount` Character hubs (so each becomes a god-class labelled
+  // box) plus `i` dedicated leaves on hub i, giving DISTINCT degrees
+  // (hubCount-1)+i. Leaves are untyped degree-1 nodes (not boxes, not labelled).
+  const characterHubGraph = (hubCount = 8) => {
+    const nodes = [];
+    const links = [];
+    for (let i = 0; i < hubCount; i += 1) {
+      nodes.push({ id: `c${i}`, label: `Character number ${i}`, node_type: "Character" });
+    }
+    for (let i = 0; i < hubCount; i += 1) {
+      for (let j = i + 1; j < hubCount; j += 1) links.push({ source: `c${i}`, target: `c${j}` });
+    }
+    for (let i = 0; i < hubCount; i += 1) {
+      for (let k = 0; k < i; k += 1) {
+        const leaf = `c${i}_leaf${k}`;
+        nodes.push({ id: leaf });
+        links.push({ source: `c${i}`, target: leaf });
+      }
+    }
+    return { nodes, links };
+  };
+
+  const labelOf = (payload, id) => payload.baseStyle.nodeLabels[payload.nodeIndexById.get(id)];
+  const countLabels = (payload) =>
+    payload.baseStyle.nodeLabels.filter((l) => typeof l === "string" && l.length > 0).length;
+
+  it("labels exactly the top-K principal characters at the default (zoomed-out) view", () => {
+    const scene = buildScene(characterHubGraph(8));
+    const payload = buildGraphRendererPayload(scene, { nodeRadius: 3 }); // zoom omitted ⇒ out
+    expect(countLabels(payload)).toBe(MAX_PRINCIPAL_CHARACTER_LABELS);
+    // Highest-degree hubs c7..c3 keep their name; the c0..c2 tail is cleared.
+    for (const id of ["c7", "c6", "c5", "c4", "c3"]) expect(labelOf(payload, id)).toBeTruthy();
+    for (const id of ["c2", "c1", "c0"]) expect(labelOf(payload, id)).toBe("");
+  });
+
+  it("reveals every gated character name when zoomed in past the threshold", () => {
+    const scene = buildScene(characterHubGraph(8));
+    const payload = buildGraphRendererPayload(scene, {
+      nodeRadius: 3,
+      zoom: LABEL_ZOOM_THRESHOLD + 1,
+    });
+    expect(countLabels(payload)).toBe(8);
+    for (let i = 0; i < 8; i += 1) expect(labelOf(payload, `c${i}`)).toBeTruthy();
+  });
+
+  it("does not regress a graph with ≤ K hubs (all stay labelled at any zoom)", () => {
+    const scene = buildScene(characterHubGraph(3));
+    const payload = buildGraphRendererPayload(scene, { nodeRadius: 3 });
+    expect(countLabels(payload)).toBe(3);
   });
 });
 


### PR DESCRIPTION
## What

Two WP1 label-fidelity items.

### (A) Main-graph box-label truncation — already shipped, now locked by a test
Investigation found this is **already in `main`**, so no code change was needed:
- **#160** (`bb847de`) added `truncateLabel` (char-cap + ellipsis, `DEFAULT_LABEL_MAX_CHARS=22`) for the **recon focal box** overlay.
- The **main-graph** extension already exists in `studio/src/lib/graphRendererPayload.js:370-384` (the "BUG-1 regression fix"): `truncateLabel(source, labelMaxChars)` runs for **every** box node (not just the `forceBoxLabel` recon pair), so chapter/entity/Character boxes truncate too.
- The renderer additionally pixel-fits via **#199** `fitLabelToWidth`/`boxDimensions` (`packages/graph/src/render-geometry.ts:95-160`), capping box width to `BOX_MAX_WIDTH_RATIO×height`.
- An existing test already covers it: `graphRendererPayload.test.js` → "main-graph box label truncation (regression)".

So the truncation tracked item was stale; this PR does **not** churn it, and the new LOD below is careful to preserve it (long names still truncate; the long tail is hidden, not overflowing).

### (B) Top-K principal-character labels at zoom — the actual new work
On a dense corpus the god-class gate (`degree >= 15% of max`) can label many Character hubs, so a zoomed-out main graph paints a wall of names. New **pure, deterministic** LOD:

- `selectPrincipalHubLabels(hubs, zoom, {k, zoomThreshold})` — `studio/src/lib/graphRendererPayload.js`. Degree desc, ties by node index asc. At/below `zoomThreshold` → top-K; above → all.
- Constants (documented): **`MAX_PRINCIPAL_CHARACTER_LABELS = 5`** (K), **`LABEL_ZOOM_THRESHOLD = 1`**.
- Applied in `buildGraphRendererPayload` **after** the existing truncation and **before** the dim-style clone (so it survives dim/merge). `forceBoxLabel` (recon pair) is exempt; only the in-box NAME is cleared — the hub glyph is untouched and `node.label` keeps the full name for hover.
- `GraphCanvas.svelte` passes `camera.zoom` and rebuilds the label set when a wheel crosses the threshold bucket; the default zoomed-out view shows only the principal cast.

## Layer touched (golden status)
**Scene/selection layer only** (`studio/` JS + Svelte). The golden-tested `packages/graph` **draw/text path is untouched** — the golden suite renders synthetic fixtures with explicit `nodeLabels` straight into the renderer, bypassing this selection layer, so goldens are unaffected. No golden update.

## Tests / verification (all run)
- `npx vitest run studio/src/tests/graphRendererPayload.test.js` → **41 passed** (8 new: top-K both zoom directions, tie-break, ≤K no-op, 8-hub integration).
- Full studio suite → **273 passed (22 files)**.
- `npx vitest run tests/studio-scene*.test.ts` → **23 passed, 1 skipped**.
- `npm run lint` (tsc --noEmit) → **exit 0**.
- `npm run build` → **exit 0**; `npm run build:studio` → **exit 0**.
- `git diff --name-only origin/main` → exactly: `GraphCanvas.svelte`, `graphRendererPayload.js`, `graphRendererPayload.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)