### PR TITLE
feat(agent-stats): T2 committer-date + derived Branch/Agent temporal spans

### DIFF
--- a/src/agent-stats/correlate.ts
+++ b/src/agent-stats/correlate.ts
@@ -32,6 +32,14 @@ export interface GitCommitMeta {
   sha: string; // full or abbreviated
   branch?: string;
   subject?: string;
+  /**
+   * Committer date (`git log %cI`) as epoch-MILLISECONDS, when known. T2: the
+   * ground-truth point-in-time for the commit, stamped onto Commit nodes as the
+   * shared-scene-contract `t` (see project-graph.ts). COMMITTER-date — not
+   * author-date — because rebase / cherry-pick rewrite the committer-date to
+   * when the commit actually landed, which is what a timeline should show.
+   */
+  committedAtMs?: number;
 }
 
 /**

--- a/src/agent-stats/index.ts
+++ b/src/agent-stats/index.ts
@@ -83,16 +83,23 @@ export interface SyncResult {
 /** Read `git log --all` for the repo as correlation ground truth. */
 export function readGitCommits(repoRoot: string): GitCommitMeta[] {
   // Reuse the project's ESM-safe git helper (the bundler cannot dynamic-require
-  // child_process). Pipe-delimited so subjects with spaces survive intact.
-  const out = safeExecGit(repoRoot, ["log", "--all", "--format=%H|%s"]);
+  // child_process). Pipe-delimited; `%cI` (strict ISO-8601) sits BETWEEN the sha
+  // and the subject. ISO-8601 contains no pipe, so a subject that itself holds
+  // pipes still survives intact (everything after the 2nd pipe is the subject).
+  const out = safeExecGit(repoRoot, ["log", "--all", "--format=%H|%cI|%s"]);
   if (!out) return [];
   const commits: GitCommitMeta[] = [];
   for (const line of out.split("\n")) {
-    const idx = line.indexOf("|");
-    if (idx < 7) continue;
-    const sha = line.slice(0, idx);
-    const subject = line.slice(idx + 1);
-    if (sha.length >= 7) commits.push({ sha, subject });
+    const i1 = line.indexOf("|");
+    if (i1 < 7) continue;
+    const i2 = line.indexOf("|", i1 + 1);
+    if (i2 < 0) continue;
+    const sha = line.slice(0, i1);
+    if (sha.length < 7) continue;
+    const dateIso = line.slice(i1 + 1, i2);
+    const subject = line.slice(i2 + 1);
+    const ms = Date.parse(dateIso);
+    commits.push({ sha, subject, committedAtMs: Number.isFinite(ms) ? ms : undefined });
   }
   return commits;
 }

--- a/src/agent-stats/index.ts
+++ b/src/agent-stats/index.ts
@@ -691,14 +691,33 @@ export type ProjectGraphIdentity = ProjectIdentity & { repoRootForRegistry?: str
  */
 export function buildProjectGraphForIdentity(
   identity: ProjectGraphIdentity,
-  opts: { home?: string; includeCommits?: boolean; includeBranches?: boolean } = {},
+  opts: {
+    home?: string;
+    includeCommits?: boolean;
+    includeBranches?: boolean;
+    /** Inject git commits (skips `git log`); else read from the registry root. */
+    commits?: GitCommitMeta[];
+  } = {},
 ): { graph: ProjectGraph; sessions: number } {
-  const sessions = loadSessionsForIdentity({ identity, home: opts.home });
+  const home = opts.home ?? homedir();
+  const sessions = loadSessionsForIdentity({ identity, home });
+  // T2: stamp Commit nodes (and widen derived Branch/Agent/Project spans) from
+  // git committer-dates. Read `git log` from the registry / current-incarnation
+  // root (the same root loadSessionsForIdentity uses for the h2a registry). A
+  // missing / non-repo root degrades to [] (safeExecGit returns "") — the graph
+  // then stays byte-identical to pre-T2 output.
+  const gitRoot =
+    identity.repoRootForRegistry ??
+    (identity.aliases[0]?.pathPrefixes[0]
+      ? identity.aliases[0]!.pathPrefixes[0]!.replace(/^~/, home)
+      : undefined);
+  const commits = opts.commits ?? (gitRoot ? readGitCommits(gitRoot) : []);
   const graph = buildProjectGraph({
     identity,
     sessions,
     includeCommits: opts.includeCommits,
     includeBranches: opts.includeBranches,
+    commits,
     provenance: {
       tool: "graphify agent-stats project-graph",
       schema: PROJECT_GRAPH_SCHEMA,

--- a/src/agent-stats/project-graph.ts
+++ b/src/agent-stats/project-graph.ts
@@ -23,6 +23,7 @@
  */
 
 import type { SessionFact } from "./types.js";
+import type { GitCommitMeta } from "./correlate.js";
 
 export const PROJECT_GRAPH_SCHEMA = "graphify.agent-stats.project-graph/v1";
 
@@ -126,6 +127,15 @@ export interface BuildProjectGraphOptions {
   includeCommits?: boolean;
   /** Include branch nodes. Default true. */
   includeBranches?: boolean;
+  /**
+   * T2 temporal ground-truth: git-log commits (only `sha` + `committedAtMs` are
+   * read). When supplied, a Commit node whose sha matches gets a point-in-time
+   * `t` (= committer-date) and the derived Branch / Agent / Project spans widen
+   * to include it. Absent / unmatched commits stay timeless (no `t` key), so the
+   * graph is byte-identical to the pre-T2 output. Structurally satisfied by
+   * `readGitCommits()` output (GitCommitMeta[]).
+   */
+  commits?: Pick<GitCommitMeta, "sha" | "committedAtMs">[];
   /** Provenance to stamp on graph.graph.provenance. */
   provenance?: unknown;
 }
@@ -228,6 +238,16 @@ function nodeId(kind: string, key: string): string {
 /** Provenance tag for the T0 session-derived temporal stamp (`t`/`t_end`). */
 const SESSION_TIME_SRC = "session.started_at";
 
+/** T2 provenance: a Commit node's `t` came from its git committer-date. */
+const COMMIT_TIME_SRC = "git.committer_date";
+
+/**
+ * T2 provenance: a container node's span (`t`/`t_end`) was DERIVED as the
+ * [min, max] envelope of its owned children's timestamps (not measured
+ * directly). See the derived-span second pass in {@link buildProjectGraph}.
+ */
+const DERIVED_SPAN_SRC = "derived.children_span";
+
 /**
  * Shared-scene-contract temporal stamp (epoch-ms). `t`/`t_end` are allowlisted
  * by src/studio-scene.ts and flow through to the studio scene; `t_src` is
@@ -267,6 +287,28 @@ function sessionTemporal(s: SessionInput): TemporalStamp {
 }
 
 /**
+ * T2 derived span: the [min, max] envelope over a node's owned children's
+ * timestamps. Pools EVERY known bound (a child's `t` and `t_end`) and returns
+ * `t` = earliest (FIRST activity), `t_end` = latest (LAST activity) — i.e. the
+ * outer hull of the children's intervals. An open-interval child (a running
+ * session: `t` but no `t_end`) contributes only its start, since that is its
+ * only known bound. Returns `{}` (NO keys) when no child carries a timestamp,
+ * so a container with only timeless children stays byte-identical (no `t`).
+ * Order-independent (pure min/max) → deterministic regardless of child order.
+ */
+function envelope(bounds: Iterable<number | undefined>): TemporalStamp {
+  let lo: number | undefined;
+  let hi: number | undefined;
+  for (const v of bounds) {
+    if (typeof v !== "number" || !Number.isFinite(v)) continue;
+    if (lo === undefined || v < lo) lo = v;
+    if (hi === undefined || v > hi) hi = v;
+  }
+  if (lo === undefined) return {};
+  return { t: lo, t_end: hi, t_src: DERIVED_SPAN_SRC };
+}
+
+/**
  * Build the project/conversation graph from reconciled session inputs.
  *
  * Only sessions that match an alias of the given identity are included — this is
@@ -278,6 +320,18 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
   const { identity } = opts;
   const includeCommits = opts.includeCommits !== false;
   const includeBranches = opts.includeBranches !== false;
+
+  // T2: index git committer-dates by 7-char sha prefix (the form sessions print
+  // and `sessionFactToInput` stores). FIRST-TOUCH on collision — a duplicate
+  // prefix keeps the first date — but the value is git ground-truth, NOT session
+  // order, so a Commit node's `t` is deterministic regardless of which session
+  // happened to create the node first.
+  const commitTimeBySha7 = new Map<string, number>();
+  for (const c of opts.commits ?? []) {
+    if (c.committedAtMs === undefined) continue;
+    const k = c.sha.slice(0, 7).toLowerCase();
+    if (!commitTimeBySha7.has(k)) commitTimeBySha7.set(k, c.committedAtMs);
+  }
 
   const nodes = new Map<string, GraphNodeOut>();
   const links: GraphEdgeOut[] = [];
@@ -447,6 +501,14 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
     // commits (ground-truth shas the session printed)
     if (includeCommits) {
       for (const sha of s.commitShas) {
+        // T2: a commit is a POINT in time — stamp `t` = `t_end` = its git
+        // committer-date (epoch-ms) when known. Setting `t_end === t` (vs
+        // omitting it) is the scene contract's point-in-time form and
+        // disambiguates a commit from an OPEN session (which omits `t_end` to
+        // mean "still running"). No matching git date → `{}` → no `t` key.
+        const ct = commitTimeBySha7.get(sha.slice(0, 7).toLowerCase());
+        const commitStamp: TemporalStamp =
+          ct !== undefined ? { t: ct, t_end: ct, t_src: COMMIT_TIME_SRC } : {};
         const cId = addNode({
           id: nodeId("commit", sha),
           label: sha,
@@ -456,6 +518,7 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
           community_name: COMMUNITY_LABELS["5"]!,
           node_type: "Commit",
           sha,
+          ...commitStamp,
         });
         addEdge({
           source: sessId,
@@ -487,6 +550,68 @@ export function buildProjectGraph(opts: BuildProjectGraphOptions): ProjectGraph 
         // child declared a parent, so it carries the child session's t/t_end.
         ...(temporalBySessionId.get(s.sessionId) ?? {}),
       });
+    }
+  }
+
+  // 5. T2 DERIVED-SPAN second pass — pure over the structure built above, so the
+  //    builder stays deterministic. Container nodes get t = min / t_end = max
+  //    (FIRST / LAST activity) over their owned children's timestamps:
+  //      • Branch  ← the sessions that touched it (touched-branch) PLUS the
+  //                  commits those sessions produced — a branch's span covers
+  //                  both its sessions' intervals and its commits' points;
+  //      • Agent   ← the sessions it conducted (conducted-by);
+  //      • Project ← every in-identity session (global envelope; cheap, single
+  //                  project node).
+  //    A container with no timestamped child gets NO `t` key (byte-identical
+  //    back-compat). This stamps NODES ONLY — no new EDGE timestamps are
+  //    introduced, so the T0 edge dedup / first-touch semantics are untouched.
+  const nodeBound = (id: string, key: "t" | "t_end"): number | undefined => {
+    const v = nodes.get(id)?.[key];
+    return typeof v === "number" ? v : undefined;
+  };
+  const producedBySession = new Map<string, string[]>(); // session → commit ids
+  const sessionsByBranch = new Map<string, string[]>(); //  branch  → session ids
+  const sessionsByAgent = new Map<string, string[]>(); //   agent   → session ids
+  const pushTo = (m: Map<string, string[]>, k: string, v: string) => {
+    const arr = m.get(k);
+    if (arr) arr.push(v);
+    else m.set(k, [v]);
+  };
+  for (const e of links) {
+    if (e.relation === "produced") pushTo(producedBySession, e.source, e.target);
+    else if (e.relation === "touched-branch") pushTo(sessionsByBranch, e.target, e.source);
+    else if (e.relation === "conducted-by") pushTo(sessionsByAgent, e.target, e.source);
+  }
+  const applySpan = (id: string, stamp: TemporalStamp) => {
+    if (stamp.t === undefined) return; // no timestamped child → stay timeless
+    const n = nodes.get(id);
+    if (!n) return;
+    n.t = stamp.t;
+    if (stamp.t_end !== undefined) n.t_end = stamp.t_end;
+    n.t_src = stamp.t_src;
+  };
+  // Every in-identity session's bounds, collected once for the Project envelope.
+  const allSessionBounds: (number | undefined)[] = [];
+  for (const n of nodes.values()) {
+    if (n.node_type !== "Session") continue;
+    allSessionBounds.push(nodeBound(n.id, "t"), nodeBound(n.id, "t_end"));
+  }
+  for (const n of nodes.values()) {
+    if (n.node_type === "Branch") {
+      const bounds: (number | undefined)[] = [];
+      for (const sid of sessionsByBranch.get(n.id) ?? []) {
+        bounds.push(nodeBound(sid, "t"), nodeBound(sid, "t_end"));
+        for (const cid of producedBySession.get(sid) ?? []) bounds.push(nodeBound(cid, "t"));
+      }
+      applySpan(n.id, envelope(bounds));
+    } else if (n.node_type === "Agent") {
+      const bounds: (number | undefined)[] = [];
+      for (const sid of sessionsByAgent.get(n.id) ?? []) {
+        bounds.push(nodeBound(sid, "t"), nodeBound(sid, "t_end"));
+      }
+      applySpan(n.id, envelope(bounds));
+    } else if (n.node_type === "Project") {
+      applySpan(n.id, envelope(allSessionBounds));
     }
   }
 

--- a/tests/agent-stats-project-graph.test.ts
+++ b/tests/agent-stats-project-graph.test.ts
@@ -327,6 +327,139 @@ describe("agent-stats → studio scene carries t/t_end", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// T2 temporal: git committer-date on Commit nodes + DERIVED [min,max] spans on
+// the container nodes (Branch / Agent / Project). Commit `t` is a point in time
+// (t_end === t); container spans are the first/last-activity envelope of their
+// owned children. Provenance: t_src = "git.committer_date" / "derived.children_span".
+// ---------------------------------------------------------------------------
+const COMMIT_MS = Date.parse("2026-01-01T00:30:00.000Z");
+
+describe("buildProjectGraph — T2 git committer-date on Commit nodes", () => {
+  it("stamps a Commit node with t = t_end = its git committer-date", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({ cwds: ["~/src/graphify"], commitShas: ["abc1234"], startedAt: START_ISO, endedAt: END_ISO }),
+      ],
+      commits: [{ sha: "abc1234def", committedAtMs: COMMIT_MS }],
+    });
+    const commit = g.nodes.find((n) => n.node_type === "Commit")!;
+    expect(commit.t).toBe(COMMIT_MS);
+    expect(commit.t_end).toBe(COMMIT_MS); // a commit is a point in time
+    expect(commit.t_src).toBe("git.committer_date");
+  });
+
+  it("leaves a Commit node timeless when no git committer-date matches its sha", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [mkSession({ cwds: ["~/src/graphify"], commitShas: ["abc1234"] })],
+      commits: [{ sha: "fffffff", committedAtMs: COMMIT_MS }],
+    });
+    const commit = g.nodes.find((n) => n.node_type === "Commit")!;
+    expect("t" in commit).toBe(false);
+    expect("t_src" in commit).toBe(false);
+  });
+});
+
+describe("buildProjectGraph — T2 derived container spans", () => {
+  it("derives a Branch span [min,max] over BOTH its sessions and their commits", () => {
+    const S1_START = Date.parse("2026-01-01T00:00:00.000Z");
+    const S1_END = Date.parse("2026-01-01T01:00:00.000Z");
+    const S2_START = Date.parse("2026-01-02T00:00:00.000Z");
+    const S2_END = Date.parse("2026-01-02T01:00:00.000Z");
+    const C_LATE = Date.parse("2026-01-03T00:00:00.000Z"); // commit AFTER both sessions
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({ factId: "s1", sessionId: "s1", cwds: ["~/src/graphify"], branches: ["feat/x"], startedAtMs: S1_START, endedAtMs: S1_END }),
+        mkSession({ factId: "s2", sessionId: "s2", cwds: ["~/src/graphify"], branches: ["feat/x"], commitShas: ["abc1234"], startedAtMs: S2_START, endedAtMs: S2_END }),
+      ],
+      commits: [{ sha: "abc1234", committedAtMs: C_LATE }],
+    });
+    const branch = g.nodes.find((n) => n.node_type === "Branch" && n.label === "feat/x")!;
+    expect(branch.t).toBe(S1_START); // earliest = first session's start
+    expect(branch.t_end).toBe(C_LATE); // latest = the commit, after both sessions
+    expect(branch.t_src).toBe("derived.children_span");
+  });
+
+  it("derives an Agent span [min,max] over the sessions it conducted", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({ factId: "s1", sessionId: "s1", agentId: "claude:graphify:111", cwds: ["~/src/graphify"], startedAtMs: 1000, endedAtMs: 2000 }),
+        mkSession({ factId: "s2", sessionId: "s2", agentId: "claude:graphify:111", cwds: ["~/src/graphify"], startedAtMs: 5000, endedAtMs: 9000 }),
+      ],
+    });
+    const agent = g.nodes.find((n) => n.node_type === "Agent")!;
+    expect(agent.t).toBe(1000);
+    expect(agent.t_end).toBe(9000);
+    expect(agent.t_src).toBe("derived.children_span");
+  });
+
+  it("derives the Project span as the global session envelope", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({ factId: "s1", sessionId: "s1", cwds: ["~/src/sentropic"], startedAtMs: 3000, endedAtMs: 4000 }),
+        mkSession({ factId: "s2", sessionId: "s2", cwds: ["~/src/graphify"], startedAtMs: 1000, endedAtMs: 8000 }),
+      ],
+    });
+    const project = g.nodes.find((n) => n.node_type === "Project")!;
+    expect(project.t).toBe(1000);
+    expect(project.t_end).toBe(8000);
+    expect(project.t_src).toBe("derived.children_span");
+  });
+
+  it("leaves Branch / Agent / Project timeless when no child carries a timestamp", () => {
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({ cwds: ["~/src/graphify"], branches: ["feat/x"], commitShas: ["abc1234"], agentId: "claude:graphify:111" }),
+      ],
+    });
+    for (const type of ["Branch", "Agent", "Project"]) {
+      const n = g.nodes.find((x) => x.node_type === type)!;
+      expect("t" in n).toBe(false);
+      expect("t_end" in n).toBe(false);
+      expect("t_src" in n).toBe(false);
+    }
+  });
+});
+
+describe("agent-stats → studio scene carries the T2 commit/branch t", () => {
+  it("carries the commit committer-date and derived branch span through buildStudioScene", () => {
+    const C_LATE = Date.parse("2026-01-01T02:00:00.000Z"); // after the session end
+    const g = buildProjectGraph({
+      identity: sentropicIdentity,
+      sessions: [
+        mkSession({
+          factId: "claude:a",
+          sessionId: "a",
+          cwds: ["~/src/graphify"],
+          startedAt: START_ISO,
+          endedAt: END_ISO,
+          branches: ["feat/x"],
+          commitShas: ["abc1234"],
+        }),
+      ],
+      commits: [{ sha: "abc1234", committedAtMs: C_LATE }],
+    });
+    const scene = buildStudioScene(g);
+    // Commit node: committer-date survives as a point-in-time.
+    const sceneCommit = scene.nodes.find((n) => n.type === "Commit")!;
+    expect(sceneCommit.t).toBe(C_LATE);
+    expect(sceneCommit.t_end).toBe(C_LATE);
+    // Branch node: derived span [session start, commit] survives the allowlist.
+    const sceneBranch = scene.nodes.find((n) => n.type === "Branch")!;
+    expect(sceneBranch.t).toBe(START_MS);
+    expect(sceneBranch.t_end).toBe(C_LATE); // widened by the later commit
+    // t_src is graph-only provenance — NOT carried into the scene.
+    expect("t_src" in sceneBranch).toBe(false);
+    expect("t_src" in sceneCommit).toBe(false);
+  });
+});
+
 describe("graph.json shape", () => {
   it("produces a valid node-link graph the studio can read", () => {
     const g = buildProjectGraph({ identity: sentropicIdentity, sessions: [mkSession({ cwds: ["~/src/graphify"] })], provenance: { tool: "test" } });


### PR DESCRIPTION
## T2: derived temporal spans + git committer-date

Builds on the merged T0 (#237). **Additive, golden-safe** — every change is opt-in; an element with no timestamped input emits no `t` key, so timeless graphs are byte-identical to pre-T2 output.

### 1. Git committer-date plumbed
- `readGitCommits` now reads `%H|%cI|%s` (strict ISO-8601 sits *between* sha and subject, so pipes inside subjects still survive) and parses the committer-date into `GitCommitMeta.committedAtMs` (epoch-ms). *(src/agent-stats/index.ts, src/agent-stats/correlate.ts)*
- Committer-date (not author-date): rebase/cherry-pick rewrite it to when the commit actually landed — what a timeline should show.
- `Commit` nodes stamp a **point-in-time** `t = t_end = committedAtMs`, `t_src="git.committer_date"`. Setting `t_end === t` (vs omitting) is the scene-contract point form and disambiguates a commit from an **open session** (which omits `t_end` to mean "still running").

### 2. Derived spans (deterministic second pass)
A pure post-pass over the built structure stamps container nodes with `t = min` / `t_end = max` (**first / last activity** envelope) over their owned children, `t_src="derived.children_span"`:
- **Branch** ← its `touched-branch` sessions **plus the commits those sessions produced**
- **Agent** ← its `conducted-by` sessions
- **Project** ← every in-identity session (global envelope)

A container with no timestamped child keeps no `t` key. Order-independent (pure min/max) → deterministic.

### 3. Dedup-edge semantics
The derived spans stamp **nodes only** — no new **edge** timestamps are introduced, so the T0 `source|target|relation` first-touch edge dedup is untouched. The commit `t` is sourced from git ground-truth (not session order), so a `Commit` node's stamp is deterministic regardless of which session first created the node.

### 4. Tests (tests/agent-stats-project-graph.test.ts)
Commit nodes carry `t` from committer-date (and stay timeless on a sha miss); Branch span spans both sessions and their commits; Agent + Project spans; container nodes stay timeless when no child is timestamped; `buildStudioScene` carries the commit/branch `t` (`t_src` stays graph-only). All T0 tests unchanged and green.

### queryWindow stretch — DEFERRED
The optional `queryWindow(from,to)` GraphStore-port capability is **deferred**: it touches the storage adapter layer (new capability flag + Postgres impl + its own tests), which balloons this builder-focused PR. Kept to the builder side per the task's defer guidance.

### Verify (real)
- `npm run build` → exit 0
- `npm run lint` (tsc --noEmit) → exit 0
- `npx vitest run tests/agent-stats-project-graph.test.ts tests/studio-scene.test.ts tests/studio-scene-temporal-contract.test.ts` → 52 passed, 1 skipped (pre-existing), exit 0

No renderer/storage draw path touched.
