### PR TITLE
feat(storage): windowed loader + per-layout positions (kill full-scene transfer at scale)

### DIFF
--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -38,6 +38,22 @@ const POST_BODY_MAX_BYTES = 256 * 1024;
  */
 export type StudioGroupCountsStore = Pick<GraphStore, "capabilities" | "groupCounts">;
 
+/**
+ * The slice of a {@link GraphStore} the `/api/ontology/window` route reads: the
+ * capability descriptor (to gate on the optional `window`) plus the windowed
+ * readers. The readers are OPTIONAL (a backend may omit the capability), so a
+ * plain {@link StudioGroupCountsStore} also satisfies it — the default flat-JSON
+ * studio (no store) is unchanged, and a store without the `window` capability
+ * 404s the route.
+ */
+export type StudioWindowStore = Pick<
+  GraphStore,
+  "capabilities" | "layoutPositions" | "graphWindow"
+>;
+
+/** The store slice the studio routes consume: group-counts AND window readers. */
+export type StudioStore = StudioGroupCountsStore & StudioWindowStore;
+
 export interface OntologyStudioWriteOptions {
   token: string;
 }
@@ -48,13 +64,14 @@ export interface OntologyStudioHandlerOptions {
   /** Bind host; when loopback, same-origin writes are trusted without a token. */
   host?: string;
   /**
-   * Optional GraphStore mirror (storage LOT 1/2). Present ONLY when a backend
-   * declaring the `aggregate` capability is configured; the
+   * Optional GraphStore mirror (storage LOT 1/2/3). Present ONLY when a backend
+   * declaring the `aggregate` and/or `window` capability is configured; the
    * `GET /api/ontology/groups` route then serves O(#groups) precomputed counts
-   * from it. Absent for the default flat-JSON studio, where the route 404s and
-   * the SPA falls back to its in-memory group-by — so the default is unchanged.
+   * and `GET /api/ontology/window` serves a bounded first-paint slice. Absent for
+   * the default flat-JSON studio, where both routes 404 and the SPA falls back to
+   * its in-memory group-by + full scene — so the default is unchanged.
    */
-  store?: StudioGroupCountsStore;
+  store?: StudioStore;
 }
 
 export interface StartOntologyStudioServerOptions {
@@ -64,11 +81,12 @@ export interface StartOntologyStudioServerOptions {
   write?: boolean;
   token?: string;
   /**
-   * Optional aggregate-capable GraphStore for the `/api/ontology/groups` route
-   * (storage LOT 2). Omitted by the default studio, which keeps serving flat
-   * JSON only; the route then 404s and the SPA falls back to client group-by.
+   * Optional aggregate-/window-capable GraphStore for the
+   * `/api/ontology/groups` + `/api/ontology/window` routes (storage LOT 2/3).
+   * Omitted by the default studio, which keeps serving flat JSON only; the routes
+   * then 404 and the SPA falls back to client group-by + the full scene.
    */
-  store?: StudioGroupCountsStore;
+  store?: StudioStore;
 }
 
 export interface StartedOntologyStudioServer {
@@ -384,6 +402,61 @@ export async function handleOntologyGroupsRequest(
   }
 }
 
+/**
+ * GET /api/ontology/window?strategy=degree-top-n&layout=force&limit=N — storage
+ * LOT 3, the windowed scene loader that kills the full multi-MB scene transfer.
+ *
+ * Capability-gated, READ-ONLY. Serves a BOUNDED first-paint slice from a
+ * configured window-capable GraphStore mirror: the strategy is `degree-top-n`
+ * (the simplest useful window — the N highest-degree nodes + the edges induced
+ * among them, annotated with the layout's precomputed x/y), chosen because the
+ * coarse high-degree core is exactly what first paint needs and it is a single
+ * indexed scan over `graph_positions`, never an O(#nodes) sort. The studio
+ * PREFERS this for first paint and falls back to the full scene whenever the
+ * route is unavailable, so the default flat-JSON studio (no store) is unaffected.
+ *
+ * Any gating miss returns 404 so the SPA cleanly falls back to the full scene:
+ *   - no store / no `window` capability / no `graphWindow` reader;
+ *   - the requested strategy or layout is not one the capability advertises.
+ *
+ * Async because `graphWindow()` is async; dispatched from the (async) request
+ * handler ahead of the synchronous route table, like `/api/ontology/groups`.
+ */
+export async function handleOntologyWindowRequest(
+  options: OntologyStudioHandlerOptions,
+  requestUrl: string,
+): Promise<OntologyStudioRouteResult> {
+  const url = new URL(requestUrl, "http://127.0.0.1");
+  const store = options.store;
+  const window = store?.capabilities?.window;
+  if (!store || !window || typeof store.graphWindow !== "function") {
+    return jsonResult(404, {
+      error: "window unavailable: no windowed-loader store configured",
+    });
+  }
+  const strategy =
+    optionalString(url.searchParams.get("strategy")) ?? window.strategies[0] ?? "degree-top-n";
+  if (!window.strategies.includes(strategy)) {
+    return jsonResult(404, { error: `window unavailable for strategy '${strategy}'` });
+  }
+  const layout = optionalString(url.searchParams.get("layout")) ?? window.layouts[0] ?? "force";
+  if (!window.layouts.includes(layout)) {
+    return jsonResult(404, { error: `window unavailable for layout '${layout}'` });
+  }
+  const limit = optionalInteger(url.searchParams.get("limit"));
+  try {
+    const slice = await store.graphWindow({
+      strategy,
+      layout,
+      ...(limit !== undefined ? { limit } : {}),
+    });
+    return jsonResult(200, slice);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return jsonResult(500, { error: message });
+  }
+}
+
 export function createOntologyStudioRequestHandler(options: OntologyStudioHandlerOptions) {
   return async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
     const method = request.method ?? "GET";
@@ -460,6 +533,14 @@ export function createOntologyStudioRequestHandler(options: OntologyStudioHandle
       // its in-memory group-by, so the default studio path is unchanged.
       if (url.pathname === "/api/ontology/groups") {
         sendResult(response, await handleOntologyGroupsRequest(options, requestUrl));
+        return;
+      }
+      // Storage LOT 3: the async, store-backed windowed scene loader. Handled
+      // here (not in the synchronous route table) because `graphWindow()` is
+      // async. With no window-capable store it returns 404 and the SPA falls back
+      // to the full scene, so the default studio path is unchanged.
+      if (url.pathname === "/api/ontology/window") {
+        sendResult(response, await handleOntologyWindowRequest(options, requestUrl));
         return;
       }
     }

--- a/src/storage/postgres.ts
+++ b/src/storage/postgres.ts
@@ -26,11 +26,16 @@ import type Graph from "graphology";
 import { toJson } from "../export.js";
 import type {
   GraphGroupCounts,
+  GraphLayoutPosition,
   GraphPushOptions,
   GraphPushResult,
   GraphStore,
   GraphStoreConfig,
   GraphStoreSnapshotMeta,
+  GraphWindow,
+  GraphWindowEdge,
+  GraphWindowNode,
+  GraphWindowOptions,
   StoreTestDeps,
 } from "./types.js";
 
@@ -43,6 +48,8 @@ const EDGE_TABLE = "graph_edges";
 const META_TABLE = "graph_meta";
 /** Precomputed group-by aggregate (storage LOT 1); rebuilt on replace pushes. */
 const COUNT_TABLE = "graph_group_counts";
+/** Precomputed per-layout positions (storage LOT 3); rebuilt on replace pushes. */
+const POSITION_TABLE = "graph_positions";
 
 /**
  * Axes the precomputed aggregate serves in LOT 1. `node_type` + `community` are
@@ -51,6 +58,25 @@ const COUNT_TABLE = "graph_group_counts";
  * fields are lifted out of the props jsonb into queryable columns.
  */
 const AGGREGATE_AXES = ["node_type", "community"] as const;
+
+/**
+ * The single pinned layout LOT 3 persists. The graph carries exactly one baked
+ * layout today (`x`/`y` node attributes from `attachLayoutPositions`), so the
+ * adapter mirrors those into `graph_positions` under this layout id. Additional
+ * layouts (typed-layer / dag / 3d / time) are DEFERRED to LOT 6.
+ */
+const DEFAULT_LAYOUT = "force";
+
+/**
+ * Window strategies LOT 3 serves. `degree-top-n` returns the N highest-degree
+ * nodes (the coarse first-paint slice) + the edges induced among them.
+ */
+const WINDOW_STRATEGIES = ["degree-top-n"] as const;
+
+/** Default node cap for a windowed slice when the caller pins none. */
+const DEFAULT_WINDOW_LIMIT = 2000;
+/** Hard ceiling on a windowed slice, so no request can ship the full scene. */
+const MAX_WINDOW_LIMIT = 20000;
 
 /** Schema columns lifted into typed node columns; the rest go into props jsonb. */
 const NODE_SCHEMA_COLS = ["id", "label", "type", "node_type", "community"];
@@ -183,6 +209,8 @@ function chunk<T>(arr: T[], size: number): T[][] {
  *   - graph_meta(city_slug) PRIMARY KEY — one snapshot row per city_slug
  *   - graph_group_counts(city_slug, axis, key) PRIMARY KEY — precomputed
  *       group-by aggregate (LOT 1); rebuilt only inside a replace-mode push
+ *   - graph_positions(city_slug, layout_id, node_id) PRIMARY KEY — precomputed
+ *       per-layout positions + degree (LOT 3); rebuilt only inside a replace push
  *
  * Indexes:
  *   - (city_slug, type) composite, for type-scoped scans
@@ -270,6 +298,35 @@ export function postgresDdlStatements(schema?: string): string[] {
     ].join("\n"),
   );
 
+  // graph_positions — precomputed per-layout positions (storage LOT 3). Rebuilt
+  // ONLY inside a replace-mode push (delete-all-then-load per city), so it holds
+  // exactly one snapshot's positions per (city_slug, layout_id). `degree` is
+  // precomputed at push (drives node weight/size and the degree-top-n window
+  // without a join) and `snapshot_id` stamps the producing push for staleness
+  // cross-checks. The (city_slug, layout_id, node_id) primary key enforces one
+  // row per node per layout; the (city_slug, layout_id, degree) index serves the
+  // top-N-by-degree window read as an indexed scan.
+  statements.push(
+    [
+      `CREATE TABLE IF NOT EXISTS ${q(POSITION_TABLE)} (`,
+      "  city_slug text NOT NULL,",
+      "  snapshot_id text NOT NULL,",
+      "  layout_id text NOT NULL,",
+      "  node_id text NOT NULL,",
+      "  x double precision NOT NULL,",
+      "  y double precision NOT NULL,",
+      "  degree integer NOT NULL,",
+      "  PRIMARY KEY (city_slug, layout_id, node_id)",
+      ")",
+    ].join("\n"),
+  );
+
+  // Degree-ordered index for the degree-top-n window read (per city + layout).
+  statements.push(
+    `CREATE INDEX IF NOT EXISTS ${ix("graph_positions_city_layout_degree_idx")} ` +
+      `ON ${q(POSITION_TABLE)} (city_slug, layout_id, degree DESC)`,
+  );
+
   // Composite (city_slug, type) — type-scoped scans within a city.
   statements.push(
     `CREATE INDEX IF NOT EXISTS ${ix("graph_nodes_city_type_idx")} ` +
@@ -341,6 +398,18 @@ export interface PostgresGraphStore extends GraphStore {
    * axes: see `AGGREGATE_AXES`. Unknown axes return an empty group list.
    */
   groupCounts(axis: string): Promise<GraphGroupCounts>;
+  /**
+   * All precomputed positions for one layout (storage LOT 3), read from the
+   * `graph_positions` table. Scoped to the latest REPLACE snapshot. An unknown
+   * layout returns an empty array.
+   */
+  layoutPositions(layout: string): Promise<GraphLayoutPosition[]>;
+  /**
+   * A BOUNDED windowed slice (storage LOT 3): the top-N nodes by precomputed
+   * degree for a layout + the edges induced among them. Scoped to the latest
+   * REPLACE snapshot. The node cap is clamped to `MAX_WINDOW_LIMIT`.
+   */
+  graphWindow(options?: GraphWindowOptions): Promise<GraphWindow>;
 }
 
 // ---------------------------------------------------------------------------
@@ -529,6 +598,40 @@ export async function createPostgresGraphStore(
     return rows;
   }
 
+  /** Columns written for graph_positions, in order. */
+  const POSITION_COLUMNS = [
+    "city_slug",
+    "snapshot_id",
+    "layout_id",
+    "node_id",
+    "x",
+    "y",
+    "degree",
+  ];
+
+  /**
+   * Mirror the graph's single baked layout into position rows (storage LOT 3).
+   * `attachLayoutPositions` writes numeric `x`/`y` node attributes; this persists
+   * exactly those under `DEFAULT_LAYOUT`, alongside the node's degree (computed in
+   * one pass, drives node weight/size and the degree-top-n window without a join).
+   * Nodes WITHOUT finite x/y (no baked layout) are skipped — the window then has
+   * no positions for them and the studio keeps the full-scene fallback. Computed
+   * from the same in-memory snapshot being loaded, so the rows are exactly
+   * consistent with the post-replace graph_nodes.
+   */
+  function buildPositionRows(G: Graph, snapshotId: string): unknown[][] {
+    const rows: unknown[][] = [];
+    G.forEachNode((nodeId, attrs) => {
+      const a = attrs as Record<string, unknown>;
+      const x = a.x;
+      const y = a.y;
+      if (typeof x !== "number" || !Number.isFinite(x)) return;
+      if (typeof y !== "number" || !Number.isFinite(y)) return;
+      rows.push([citySlug, snapshotId, DEFAULT_LAYOUT, nodeId, x, y, G.degree(nodeId)]);
+    });
+    return rows;
+  }
+
   function buildEdgeRows(G: Graph): unknown[][] {
     const rows: unknown[][] = [];
     G.forEachEdge((_edgeKey, attrs, source, target) => {
@@ -666,6 +769,13 @@ export async function createPostgresGraphStore(
       snapshotMeta: true,
       // Precomputed group-by aggregate (storage LOT 1), replace-snapshot scoped.
       aggregate: { version: 1, axes: [...AGGREGATE_AXES] },
+      // Precomputed per-layout positions + degree-top-n window (storage LOT 3),
+      // replace-snapshot scoped. Advertises the one baked layout LOT 3 persists.
+      window: {
+        version: 1,
+        layouts: [DEFAULT_LAYOUT],
+        strategies: [...WINDOW_STRATEGIES],
+      },
     },
 
     async verifyConnection(): Promise<void> {
@@ -737,6 +847,20 @@ export async function createPostgresGraphStore(
             COUNT_COLUMNS,
             ["city_slug", "axis", "key"],
             buildGroupCountRows(G, communityMap, pushedAt),
+            batchSize,
+          );
+          // Per-layout positions are REPLACE-snapshot scoped too (storage LOT 3):
+          // same staleness guard as the aggregate — rebuild graph_positions ONLY
+          // in replace mode, from the full snapshot just loaded, so a merge never
+          // leaves positions for deleted nodes behind. Delete-all-then-upsert
+          // keeps exactly one snapshot of positions per (city, layout).
+          await deleteCityRows(client, q(POSITION_TABLE), citySlug);
+          await upsertBatched(
+            client,
+            q(POSITION_TABLE),
+            POSITION_COLUMNS,
+            ["city_slug", "layout_id", "node_id"],
+            buildPositionRows(G, pushedAt),
             batchSize,
           );
         }
@@ -823,6 +947,92 @@ export async function createPostgresGraphStore(
       return { axis, groups };
     },
 
+    async layoutPositions(layout: string): Promise<GraphLayoutPosition[]> {
+      // Storage LOT 3: every precomputed position for one layout, scoped to the
+      // latest REPLACE snapshot. An unknown layout yields an empty array.
+      await ensureSchema();
+      const result = await pool.query(
+        `SELECT node_id, x, y FROM ${q(POSITION_TABLE)} ` +
+          `WHERE city_slug = $1 AND layout_id = $2 ORDER BY node_id ASC`,
+        [citySlug, layout],
+      );
+      return (result.rows ?? []).map((row) => ({
+        node_id: String(row.node_id),
+        x: Number(row.x),
+        y: Number(row.y),
+      }));
+    },
+
+    async graphWindow(options: GraphWindowOptions = {}): Promise<GraphWindow> {
+      // Storage LOT 3: a BOUNDED first-paint slice. The top-N nodes by precomputed
+      // degree (an indexed scan over graph_positions — never the 47k node rows),
+      // annotated with their layout x/y, plus the edges induced among them. The
+      // node cap is clamped so no request can ship the full scene.
+      await ensureSchema();
+      const strategy = options.strategy ?? "degree-top-n";
+      const layout = options.layout ?? DEFAULT_LAYOUT;
+      const requested = options.limit ?? DEFAULT_WINDOW_LIMIT;
+      const limit = Math.max(1, Math.min(MAX_WINDOW_LIMIT, Math.floor(requested)));
+
+      // (1) top-N nodes by degree for the layout (indexed by (city, layout, degree)).
+      const posResult = await pool.query(
+        `SELECT node_id, x, y, degree FROM ${q(POSITION_TABLE)} ` +
+          `WHERE city_slug = $1 AND layout_id = $2 ORDER BY degree DESC, node_id ASC LIMIT $3`,
+        [citySlug, layout, limit],
+      );
+      const posRows = posResult.rows ?? [];
+      const ids = posRows.map((r) => String(r.node_id));
+
+      // (2) label/type for the windowed ids (one round-trip, ANY($ids)).
+      const attrById = new Map<string, { label: string; node_type?: string }>();
+      if (ids.length > 0) {
+        const nodeResult = await pool.query(
+          `SELECT id, label, type FROM ${q(NODE_TABLE)} WHERE city_slug = $1 AND id = ANY($2)`,
+          [citySlug, ids],
+        );
+        for (const row of nodeResult.rows ?? []) {
+          const id = String(row.id);
+          const label = typeof row.label === "string" && row.label.length > 0 ? row.label : id;
+          const entry: { label: string; node_type?: string } = { label };
+          if (typeof row.type === "string" && row.type.length > 0) entry.node_type = row.type;
+          attrById.set(id, entry);
+        }
+      }
+
+      const nodes: GraphWindowNode[] = posRows.map((r) => {
+        const id = String(r.node_id);
+        const attr = attrById.get(id);
+        const node: GraphWindowNode = {
+          id,
+          label: attr?.label ?? id,
+          degree: typeof r.degree === "number" ? r.degree : Number(r.degree ?? 0),
+        };
+        if (attr?.node_type !== undefined) node.node_type = attr.node_type;
+        if (r.x != null) node.x = Number(r.x);
+        if (r.y != null) node.y = Number(r.y);
+        return node;
+      });
+
+      // (3) induced edges: both endpoints inside the window (one round-trip).
+      const edges: GraphWindowEdge[] = [];
+      if (ids.length > 0) {
+        const edgeResult = await pool.query(
+          `SELECT source_id, target_id, relation FROM ${q(EDGE_TABLE)} ` +
+            `WHERE city_slug = $1 AND source_id = ANY($2) AND target_id = ANY($2)`,
+          [citySlug, ids],
+        );
+        for (const row of edgeResult.rows ?? []) {
+          edges.push({
+            source: String(row.source_id),
+            target: String(row.target_id),
+            relation: typeof row.relation === "string" ? row.relation : "RELATES_TO",
+          });
+        }
+      }
+
+      return { strategy, layout, limit, nodes, edges };
+    },
+
     async clear(options?: string | PostgresClearOptions): Promise<void> {
       const opts = typeof options === "string" ? { namespace: options } : options ?? {};
       if (!opts.force) {
@@ -838,6 +1048,7 @@ export async function createPostgresGraphStore(
         await deleteCityRows(client, q(EDGE_TABLE), targetSlug);
         await deleteCityRows(client, q(META_TABLE), targetSlug);
         await deleteCityRows(client, q(COUNT_TABLE), targetSlug);
+        await deleteCityRows(client, q(POSITION_TABLE), targetSlug);
         await client.query("COMMIT");
       } catch (err) {
         try {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -26,6 +26,24 @@ export interface GraphStoreCapabilities {
    * adapter owns when and how it maintains its table.
    */
   aggregate?: GraphStoreAggregateCapability;
+  /**
+   * Optional, VERSIONED windowed-loader capability (storage LOT 3). Absent on
+   * backends that do not precompute per-layout positions (neo4j/spanner/file
+   * simply omit it). When present, the adapter maintains a
+   * `graph_positions(layout_id, node_id, x, y, degree)` table and exposes
+   * `layoutPositions(layout)` (all positions for a layout) plus `graphWindow(opts)`
+   * (a BOUNDED slice — top-N by degree — of nodes + the edges induced among
+   * them). The studio loads the window for first paint instead of the full
+   * multi-MB scene; backends omitting the capability omit both methods and the
+   * studio keeps shipping the full scene unchanged.
+   *
+   * Like the aggregate, positions are tied to REPLACE / full-snapshot semantics:
+   * rebuilt ONLY inside a `mode: "replace"` push, never on a `merge`. A merge is
+   * an upsert that may leave stale rows behind, so rebuilding positions after a
+   * merge could surface deleted nodes; gating on replace keeps the window
+   * coherent with a committed full snapshot.
+   */
+  window?: GraphStoreWindowCapability;
 }
 
 /** Versioned descriptor for the optional group-by aggregate capability (LOT 1). */
@@ -34,6 +52,68 @@ export interface GraphStoreAggregateCapability {
   version: 1;
   /** Axes the backend can serve from its precomputed table (e.g. `node_type`). */
   axes: readonly string[];
+}
+
+/** Versioned descriptor for the optional windowed-loader capability (LOT 3). */
+export interface GraphStoreWindowCapability {
+  /** Schema/behaviour version of the window contract; consumers gate on it. */
+  version: 1;
+  /** Layout ids the backend has precomputed positions for (e.g. `force`). */
+  layouts: readonly string[];
+  /**
+   * Window strategies the backend can serve. LOT 3 ships `degree-top-n` only —
+   * the coarse first-paint slice (the N highest-degree nodes + induced edges).
+   */
+  strategies: readonly string[];
+}
+
+/** One precomputed node position for a given layout. */
+export interface GraphLayoutPosition {
+  node_id: string;
+  x: number;
+  y: number;
+}
+
+/** Parameters for {@link GraphStore.graphWindow}. */
+export interface GraphWindowOptions {
+  /** Window strategy; LOT 3 supports `degree-top-n` (the default). */
+  strategy?: string;
+  /** Layout id whose positions annotate the window nodes (e.g. `force`). */
+  layout?: string;
+  /** Upper bound on the number of nodes returned. */
+  limit?: number;
+}
+
+/** One node in a windowed slice: id + degree + (optional) layout position. */
+export interface GraphWindowNode {
+  id: string;
+  label: string;
+  node_type?: string;
+  /** Layout x, present when the requested layout has a position for this node. */
+  x?: number;
+  /** Layout y, present when the requested layout has a position for this node. */
+  y?: number;
+  /** Precomputed degree, drives node weight/size without a join. */
+  degree: number;
+}
+
+/** One edge in a windowed slice (induced among the window's nodes). */
+export interface GraphWindowEdge {
+  source: string;
+  target: string;
+  relation: string;
+}
+
+/** Result of {@link GraphStore.graphWindow}: a BOUNDED nodes+edges slice. */
+export interface GraphWindow {
+  /** Strategy that produced this slice (e.g. `degree-top-n`). */
+  strategy: string;
+  /** Layout the positions came from, when one was requested + available. */
+  layout?: string;
+  /** The effective node cap applied. */
+  limit: number;
+  nodes: GraphWindowNode[];
+  edges: GraphWindowEdge[];
 }
 
 /** One group bucket: a distinct value of an axis and its node count. */
@@ -107,6 +187,20 @@ export interface GraphStore {
    * `GraphStoreCapabilities.aggregate`.
    */
   groupCounts?(axis: string): Promise<GraphGroupCounts>;
+  /**
+   * Capability-gated read of every precomputed position for one layout (storage
+   * LOT 3). Present ONLY when `capabilities.window` is set. Reads the
+   * backend-maintained `graph_positions` table scoped to the latest REPLACE
+   * snapshot — see `GraphStoreCapabilities.window`.
+   */
+  layoutPositions?(layout: string): Promise<GraphLayoutPosition[]>;
+  /**
+   * Capability-gated windowed read (storage LOT 3). Present ONLY when
+   * `capabilities.window` is set. Returns a BOUNDED slice — the top-N nodes by
+   * precomputed degree plus the edges induced among them — so first paint never
+   * ships the full multi-MB scene. Scoped to the latest REPLACE snapshot.
+   */
+  graphWindow?(options?: GraphWindowOptions): Promise<GraphWindow>;
   close(): Promise<void>;
 }
 

--- a/studio/src/lib/api.js
+++ b/studio/src/lib/api.js
@@ -289,6 +289,53 @@ export async function fetchGroupCounts(axis) {
   }
 }
 
+/**
+ * Storage LOT 3: fetch a BOUNDED windowed scene slice from a configured,
+ * window-capable GraphStore mirror via
+ * `GET /api/ontology/window?strategy=&layout=&limit=`. The payload is a
+ * `graphify` window document `{ strategy, layout?, limit, nodes: [{ id, label,
+ * node_type?, x?, y?, degree }], edges: [{ source, target, relation }] }` — the
+ * N highest-degree nodes (degree-top-n) + the edges induced among them, with the
+ * active layout's precomputed positions. The studio PREFERS this for first paint
+ * over shipping the full multi-MB scene; whenever the route is unavailable — the
+ * default flat-JSON studio (no store), an offline bundle, a 404 (no
+ * window-capable store / off-strategy / off-layout), or any network error — this
+ * resolves `null` so the caller keeps loading the full `fetchScene()`. Never
+ * throws (mirrors fetchGroupCounts).
+ *
+ * Like the counts there is NO bundle-relative static fallback: the window is a
+ * live store projection, not a build-time artifact, so an offline export simply
+ * has none and the client loads its inlined full scene.
+ *
+ * CLIENT-RENDER INTEGRATION IS DEFERRED (see WP3 note): this accessor + its
+ * server route are the windowed-loader primitive; wiring App.svelte's first paint
+ * to PREFER the window and hydrate the rest lazily touches the renderer/scene
+ * draw path, which is explicitly out of scope here. With no store wired the
+ * accessor returns null on every call, so the default scene path is unchanged.
+ *
+ * @param {{ strategy?: string, layout?: string, limit?: number }} [params]
+ * @returns {Promise<{ strategy: string, layout?: string, limit: number,
+ *   nodes: { id: string, label: string, node_type?: string, x?: number,
+ *     y?: number, degree: number }[],
+ *   edges: { source: string, target: string, relation: string }[] } | null>}
+ */
+export async function fetchWindow(params = {}) {
+  // Offline export ships no store window; the caller loads the full scene.
+  if (bundlePresent()) return null;
+  const search = new URLSearchParams();
+  if (params.strategy) search.set("strategy", params.strategy);
+  if (params.layout) search.set("layout", params.layout);
+  if (params.limit != null) search.set("limit", String(params.limit));
+  const qs = search.toString();
+  const url = qs ? `/api/ontology/window?${qs}` : "/api/ontology/window";
+  try {
+    return await getJson(url);
+  } catch {
+    // 404 (no window-capable store / off-strategy / off-layout) or network error.
+    return null;
+  }
+}
+
 export async function fetchReconciliationCandidates() {
   // Offline: serve the inlined queue if present (only with `--full-offline`),
   // else an empty queue (no doomed file:// fetch).

--- a/studio/src/tests/api.test.js
+++ b/studio/src/tests/api.test.js
@@ -10,6 +10,7 @@ import {
   fetchModelsManifest,
   fetchReconciliationCandidates,
   fetchScene,
+  fetchWindow,
 } from "../lib/api.js";
 
 function jsonResponse(body, ok = true) {
@@ -186,6 +187,63 @@ describe("fetchGroupCounts (storage LOT 2)", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(fetchGroupCounts("node_type")).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchWindow (storage LOT 3)", () => {
+  // NB: not named `window` — that would shadow the global the offline test sets.
+  const windowDoc = {
+    strategy: "degree-top-n",
+    layout: "force",
+    limit: 2,
+    nodes: [
+      { id: "hub", label: "Hub", node_type: "code", x: 10, y: 20, degree: 3 },
+      { id: "a", label: "Node A", node_type: "doc", x: 1, y: 1, degree: 2 },
+    ],
+    edges: [{ source: "hub", target: "a", relation: "links" }],
+  };
+
+  it("returns the store window from the same-origin route with the given params", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url === "/api/ontology/window?strategy=degree-top-n&layout=force&limit=2")
+        return jsonResponse(windowDoc);
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchWindow({ strategy: "degree-top-n", layout: "force", limit: 2 }),
+    ).resolves.toEqual(windowDoc);
+  });
+
+  it("requests the bare route when called with no params", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url === "/api/ontology/window") return jsonResponse(windowDoc);
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWindow()).resolves.toEqual(windowDoc);
+    expect(fetchMock).toHaveBeenCalledWith("/api/ontology/window", expect.anything());
+  });
+
+  it("returns null when the route 404s (default flat-JSON studio, no store)", async () => {
+    // No bundle-relative static fallback: the window is a live store projection.
+    const fetchMock = vi.fn(async () => jsonResponse({ error: "no store" }, false));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWindow({ layout: "force" })).resolves.toBeNull();
+  });
+
+  it("returns null in an offline bundle WITHOUT issuing any fetch", async () => {
+    window.__GRAPHIFY_BUNDLE__ = { "scene.json": { nodes: [], edges: [] } };
+    const fetchMock = vi.fn(() => {
+      throw new Error("fetch must not be called in an offline bundle");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWindow({ layout: "force" })).resolves.toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/ontology-studio-window-route.test.ts
+++ b/tests/ontology-studio-window-route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * GET /api/ontology/window — storage LOT 3 server route (windowed loader).
+ *
+ * The route serves the studio's BOUNDED first-paint slice from a configured,
+ * window-capable GraphStore mirror (degree-top-n; a single indexed scan). When
+ * no such store is wired the route 404s so the SPA falls back to the full scene
+ * — i.e. the default flat-JSON studio is unchanged. These tests inject a MINIMAL
+ * fake store (the `StudioWindowStore` slice) directly; no live DB and no postgres
+ * driver, mirroring tests/ontology-studio-groups-route.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  handleOntologyWindowRequest,
+  type OntologyStudioHandlerOptions,
+  type StudioStore,
+} from "../src/ontology-studio.js";
+import type { GraphWindow, GraphWindowOptions } from "../src/storage/types.js";
+
+const WINDOW: GraphWindow = {
+  strategy: "degree-top-n",
+  layout: "force",
+  limit: 2,
+  nodes: [
+    { id: "hub", label: "Hub", node_type: "code", x: 10, y: 20, degree: 3 },
+    { id: "a", label: "Node A", node_type: "doc", x: 1, y: 1, degree: 2 },
+  ],
+  edges: [{ source: "hub", target: "a", relation: "links" }],
+};
+
+/** A minimal window-capable store: declares the capability + serves WINDOW. */
+function fakeStore(
+  layouts: string[],
+  strategies: string[],
+  opts: { onCall?: (options: GraphWindowOptions) => void; result?: GraphWindow } = {},
+): StudioStore {
+  return {
+    capabilities: {
+      push: true,
+      query: true,
+      clear: true,
+      snapshotMeta: true,
+      window: { version: 1, layouts, strategies },
+    },
+    async graphWindow(options: GraphWindowOptions = {}): Promise<GraphWindow> {
+      opts.onCall?.(options);
+      return opts.result ?? WINDOW;
+    },
+  };
+}
+
+/** A store WITHOUT the window capability (and no graphWindow), e.g. neo4j. */
+const noWindowStore: StudioStore = {
+  capabilities: { push: true, query: true, clear: true, snapshotMeta: true },
+};
+
+function options(store?: StudioStore): OntologyStudioHandlerOptions {
+  return store ? { profileStatePath: "/unused", store } : { profileStatePath: "/unused" };
+}
+
+describe("GET /api/ontology/window (window-capable store)", () => {
+  it("returns the store's bounded slice for an advertised strategy + layout", async () => {
+    const calls: GraphWindowOptions[] = [];
+    const store = fakeStore(["force"], ["degree-top-n"], { onCall: (o) => calls.push(o) });
+
+    const result = await handleOntologyWindowRequest(
+      options(store),
+      "/api/ontology/window?strategy=degree-top-n&layout=force&limit=2",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.contentType).toBe("application/json; charset=utf-8");
+    expect(JSON.parse(result.body)).toEqual(WINDOW);
+    // The read hit the store exactly once, with the parsed window options.
+    expect(calls).toEqual([{ strategy: "degree-top-n", layout: "force", limit: 2 }]);
+  });
+
+  it("defaults to the first advertised strategy + layout when params are omitted", async () => {
+    const calls: GraphWindowOptions[] = [];
+    const store = fakeStore(["force"], ["degree-top-n"], { onCall: (o) => calls.push(o) });
+
+    const result = await handleOntologyWindowRequest(options(store), "/api/ontology/window");
+
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual(WINDOW);
+    // No ?limit → graphWindow called without an explicit cap (the store defaults).
+    expect(calls).toEqual([{ strategy: "degree-top-n", layout: "force" }]);
+  });
+
+  it("404s for a strategy the capability does not advertise (client keeps the full scene)", async () => {
+    const calls: GraphWindowOptions[] = [];
+    const store = fakeStore(["force"], ["degree-top-n"], { onCall: (o) => calls.push(o) });
+
+    const result = await handleOntologyWindowRequest(
+      options(store),
+      "/api/ontology/window?strategy=bbox",
+    );
+
+    expect(result.status).toBe(404);
+    // Gated BEFORE any store read — the window reader is never invoked.
+    expect(calls).toEqual([]);
+  });
+
+  it("404s for a layout the capability does not advertise", async () => {
+    const calls: GraphWindowOptions[] = [];
+    const store = fakeStore(["force"], ["degree-top-n"], { onCall: (o) => calls.push(o) });
+
+    const result = await handleOntologyWindowRequest(
+      options(store),
+      "/api/ontology/window?layout=dag",
+    );
+
+    expect(result.status).toBe(404);
+    expect(calls).toEqual([]);
+  });
+
+  it("500s when the store read throws (the SPA can still fall back)", async () => {
+    const store: StudioStore = {
+      capabilities: {
+        push: true,
+        query: true,
+        clear: true,
+        snapshotMeta: true,
+        window: { version: 1, layouts: ["force"], strategies: ["degree-top-n"] },
+      },
+      async graphWindow(): Promise<GraphWindow> {
+        throw new Error("connection refused");
+      },
+    };
+
+    const result = await handleOntologyWindowRequest(
+      options(store),
+      "/api/ontology/window?layout=force",
+    );
+
+    expect(result.status).toBe(500);
+    expect(JSON.parse(result.body).error).toContain("connection refused");
+  });
+});
+
+describe("GET /api/ontology/window (no window-capable store)", () => {
+  it("404s when NO store is configured (default flat-JSON studio)", async () => {
+    const result = await handleOntologyWindowRequest(options(), "/api/ontology/window");
+    expect(result.status).toBe(404);
+    expect(JSON.parse(result.body).error).toMatch(/no windowed-loader store/);
+  });
+
+  it("404s when a store is configured but omits the window capability", async () => {
+    const result = await handleOntologyWindowRequest(options(noWindowStore), "/api/ontology/window");
+    expect(result.status).toBe(404);
+  });
+});

--- a/tests/storage-postgres-windowed-loader.test.ts
+++ b/tests/storage-postgres-windowed-loader.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Postgres windowed-loader tests (storage LOT 3).
+ *
+ * Mirrors tests/storage-postgres-group-counts.test.ts: an in-memory fake `pg`
+ * module injected via StoreTestDeps — no real Postgres connection. The fake
+ * maintains tiny in-memory `graph_positions`, `graph_nodes` and `graph_edges`
+ * tables (reconstructed from INSERT params, cleared on DELETE, filtered on
+ * SELECT) so the replace push → layoutPositions / graphWindow round-trip is
+ * exercised end-to-end.
+ *
+ * Coverage:
+ *   - the capability is a versioned `window` over the `force` layout +
+ *     `degree-top-n` strategy;
+ *   - after a REPLACE push, layoutPositions('force') returns exactly the baked
+ *     positions (nodes WITHOUT x/y are skipped);
+ *   - graphWindow returns the top-N nodes by precomputed degree + ONLY the edges
+ *     induced among them, annotated with layout x/y + degree + label/type;
+ *   - the limit is clamped (bounded slice — never the full scene);
+ *   - the positions rebuild happens INSIDE the replace transaction;
+ *   - a MERGE push leaves graph_positions untouched (the staleness guard), so the
+ *     window stays scoped to the last REPLACE snapshot;
+ *   - FileGraphStore neither declares `window` nor exposes the readers.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import Graph from "graphology";
+import type { GraphStore, StoreTestDeps } from "../src/storage/types.js";
+import type { PostgresGraphStore } from "../src/storage/postgres.js";
+
+// ---------------------------------------------------------------------------
+// Fake driver with real graph_positions / graph_nodes / graph_edges round-trips
+// ---------------------------------------------------------------------------
+
+interface RecordedSql {
+  via: "pool" | "client";
+  text: string;
+  params?: unknown[];
+}
+
+interface PositionRow {
+  city_slug: string;
+  snapshot_id: string;
+  layout_id: string;
+  node_id: string;
+  x: number;
+  y: number;
+  degree: number;
+}
+interface NodeRow {
+  city_slug: string;
+  id: string;
+  label: string | null;
+  type: string | null;
+}
+interface EdgeRow {
+  city_slug: string;
+  source_id: string;
+  target_id: string;
+  relation: string;
+}
+
+interface InMemoryPgState {
+  queries: RecordedSql[];
+  positions: PositionRow[];
+  nodes: NodeRow[];
+  edges: EdgeRow[];
+}
+
+function freshState(): InMemoryPgState {
+  return { queries: [], positions: [], nodes: [], edges: [] };
+}
+
+const POSITION_COLS = 7; // city_slug, snapshot_id, layout_id, node_id, x, y, degree
+const NODE_COLS = 6; // city_slug, id, label, type, community, props
+const EDGE_COLS = 6; // city_slug, source_id, target_id, relation, confidence, props
+
+function ingestPositions(state: InMemoryPgState, params: unknown[] | undefined) {
+  if (!params) return;
+  for (let i = 0; i + POSITION_COLS <= params.length; i += POSITION_COLS) {
+    const row: PositionRow = {
+      city_slug: String(params[i]),
+      snapshot_id: String(params[i + 1]),
+      layout_id: String(params[i + 2]),
+      node_id: String(params[i + 3]),
+      x: Number(params[i + 4]),
+      y: Number(params[i + 5]),
+      degree: Number(params[i + 6]),
+    };
+    const idx = state.positions.findIndex(
+      (r) => r.city_slug === row.city_slug && r.layout_id === row.layout_id && r.node_id === row.node_id,
+    );
+    if (idx >= 0) state.positions[idx] = row;
+    else state.positions.push(row);
+  }
+}
+
+function ingestNodes(state: InMemoryPgState, params: unknown[] | undefined) {
+  if (!params) return;
+  for (let i = 0; i + NODE_COLS <= params.length; i += NODE_COLS) {
+    const row: NodeRow = {
+      city_slug: String(params[i]),
+      id: String(params[i + 1]),
+      label: params[i + 2] == null ? null : String(params[i + 2]),
+      type: params[i + 3] == null ? null : String(params[i + 3]),
+    };
+    const idx = state.nodes.findIndex((r) => r.city_slug === row.city_slug && r.id === row.id);
+    if (idx >= 0) state.nodes[idx] = row;
+    else state.nodes.push(row);
+  }
+}
+
+function ingestEdges(state: InMemoryPgState, params: unknown[] | undefined) {
+  if (!params) return;
+  for (let i = 0; i + EDGE_COLS <= params.length; i += EDGE_COLS) {
+    const row: EdgeRow = {
+      city_slug: String(params[i]),
+      source_id: String(params[i + 1]),
+      target_id: String(params[i + 2]),
+      relation: String(params[i + 3]),
+    };
+    state.edges.push(row);
+  }
+}
+
+function answer(state: InMemoryPgState, text: string, params?: unknown[]) {
+  const upper = text.toUpperCase();
+
+  // ---- DELETEs (replace rebuild / clear) ------------------------------------
+  if (text.includes("DELETE FROM graph_positions")) {
+    const slug = String(params?.[0]);
+    state.positions = state.positions.filter((r) => r.city_slug !== slug);
+    return { rows: [], rowCount: 0 };
+  }
+  if (text.includes("DELETE FROM graph_nodes")) {
+    const slug = String(params?.[0]);
+    state.nodes = state.nodes.filter((r) => r.city_slug !== slug);
+    return { rows: [], rowCount: 0 };
+  }
+  if (text.includes("DELETE FROM graph_edges")) {
+    const slug = String(params?.[0]);
+    state.edges = state.edges.filter((r) => r.city_slug !== slug);
+    return { rows: [], rowCount: 0 };
+  }
+
+  // ---- INSERTs --------------------------------------------------------------
+  if (text.includes("INSERT INTO graph_positions")) {
+    ingestPositions(state, params);
+    return { rows: [], rowCount: 0 };
+  }
+  if (text.includes("INSERT INTO graph_nodes")) {
+    ingestNodes(state, params);
+    return { rows: [], rowCount: 0 };
+  }
+  if (text.includes("INSERT INTO graph_edges")) {
+    ingestEdges(state, params);
+    return { rows: [], rowCount: 0 };
+  }
+
+  // ---- SELECTs --------------------------------------------------------------
+  // graphWindow top-N by degree: ORDER BY degree DESC, node_id ASC LIMIT $3.
+  if (text.includes("FROM graph_positions") && upper.includes("DEGREE") && upper.includes("LIMIT")) {
+    const slug = String(params?.[0]);
+    const layout = String(params?.[1]);
+    const limit = Number(params?.[2]);
+    const rows = state.positions
+      .filter((r) => r.city_slug === slug && r.layout_id === layout)
+      .sort((a, b) => b.degree - a.degree || a.node_id.localeCompare(b.node_id))
+      .slice(0, limit)
+      .map((r) => ({ node_id: r.node_id, x: r.x, y: r.y, degree: r.degree }));
+    return { rows, rowCount: rows.length };
+  }
+  // layoutPositions: ORDER BY node_id ASC (no degree column projected).
+  if (text.includes("FROM graph_positions") && upper.includes("SELECT")) {
+    const slug = String(params?.[0]);
+    const layout = String(params?.[1]);
+    const rows = state.positions
+      .filter((r) => r.city_slug === slug && r.layout_id === layout)
+      .sort((a, b) => a.node_id.localeCompare(b.node_id))
+      .map((r) => ({ node_id: r.node_id, x: r.x, y: r.y }));
+    return { rows, rowCount: rows.length };
+  }
+  // graphWindow node attrs: SELECT id, label, type ... WHERE id = ANY($2).
+  if (text.includes("FROM graph_nodes") && upper.includes("ANY")) {
+    const slug = String(params?.[0]);
+    const ids = new Set((params?.[1] as string[]).map(String));
+    const rows = state.nodes
+      .filter((r) => r.city_slug === slug && ids.has(r.id))
+      .map((r) => ({ id: r.id, label: r.label, type: r.type }));
+    return { rows, rowCount: rows.length };
+  }
+  // graphWindow induced edges: source_id = ANY($2) AND target_id = ANY($2).
+  if (text.includes("FROM graph_edges") && upper.includes("ANY")) {
+    const slug = String(params?.[0]);
+    const ids = new Set((params?.[1] as string[]).map(String));
+    const rows = state.edges
+      .filter((r) => r.city_slug === slug && ids.has(r.source_id) && ids.has(r.target_id))
+      .map((r) => ({ source_id: r.source_id, target_id: r.target_id, relation: r.relation }));
+    return { rows, rowCount: rows.length };
+  }
+
+  // graph_group_counts / graph_meta writes + anything else: accepted, no rows.
+  return { rows: [], rowCount: 0 };
+}
+
+function makeFakePgModule(state: InMemoryPgState) {
+  class FakePool {
+    constructor(_config?: Record<string, unknown>) {}
+    query(text: string, params?: unknown[]) {
+      state.queries.push({ via: "pool", text, params });
+      return Promise.resolve(answer(state, text, params));
+    }
+    connect() {
+      const client = {
+        query(text: string, params?: unknown[]) {
+          state.queries.push({ via: "client", text, params });
+          return Promise.resolve(answer(state, text, params));
+        },
+        release() {
+          /* no-op */
+        },
+      };
+      return Promise.resolve(client);
+    }
+    end() {
+      return Promise.resolve();
+    }
+  }
+  return { Pool: FakePool };
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox for the S3-replayable latest.json writes
+// ---------------------------------------------------------------------------
+
+const tempDirs: string[] = [];
+function freshArtifactBase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-pgwindow-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function makePostgresStore(
+  state: InMemoryPgState,
+  citySlug: string,
+): Promise<PostgresGraphStore> {
+  const { createPostgresGraphStore } = await import("../src/storage/postgres.js");
+  const deps: StoreTestDeps = { driverModule: makeFakePgModule(state) };
+  return createPostgresGraphStore(
+    {
+      connectionString: "postgres://user:pass@localhost:5432/testdb",
+      citySlug,
+      target: freshArtifactBase(),
+    },
+    deps,
+  );
+}
+
+/**
+ * A small positioned graph. Degrees: hub=3, a=2, b=2, c=1, lonely=0. `lonely`
+ * has NO x/y (no baked layout) so it must be skipped from graph_positions.
+ */
+function positionedGraph(): { G: Graph; communities: Map<number, string[]> } {
+  const G = new Graph();
+  G.addNode("hub", { label: "Hub", node_type: "code", x: 10, y: 20 });
+  G.addNode("a", { label: "Node A", node_type: "doc", x: 1, y: 1 });
+  G.addNode("b", { label: "Node B", node_type: "doc", x: 2, y: 2 });
+  G.addNode("c", { label: "Node C", node_type: "code", x: 3, y: 3 });
+  G.addNode("lonely", { label: "Lonely", node_type: "code" }); // no x/y
+  G.addEdge("hub", "a", { relation: "links" });
+  G.addEdge("hub", "b", { relation: "links" });
+  G.addEdge("hub", "c", { relation: "links" });
+  G.addEdge("a", "b", { relation: "links" });
+  return { G, communities: new Map([[0, ["hub", "a", "b", "c", "lonely"]]]) };
+}
+
+// ---------------------------------------------------------------------------
+// Capability surface
+// ---------------------------------------------------------------------------
+
+describe("Postgres windowed loader: capability", () => {
+  it("declares a versioned window capability over the force layout + degree-top-n", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "caps_win");
+    expect(store.capabilities.window).toBeDefined();
+    expect(store.capabilities.window!.version).toBe(1);
+    expect(store.capabilities.window!.layouts).toContain("force");
+    expect(store.capabilities.window!.strategies).toContain("degree-top-n");
+    await store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REPLACE push → layoutPositions
+// ---------------------------------------------------------------------------
+
+describe("Postgres windowed loader: per-layout positions", () => {
+  it("layoutPositions('force') returns the baked positions; un-positioned nodes are skipped", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_positions");
+    const { G, communities } = positionedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const positions = await store.layoutPositions("force");
+    await store.close();
+
+    // 4 positioned nodes (lonely skipped — no x/y), ordered by node_id ASC.
+    expect(positions).toEqual([
+      { node_id: "a", x: 1, y: 1 },
+      { node_id: "b", x: 2, y: 2 },
+      { node_id: "c", x: 3, y: 3 },
+      { node_id: "hub", x: 10, y: 20 },
+    ]);
+  });
+
+  it("layoutPositions returns [] for an unknown layout", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_unknown_layout");
+    const { G, communities } = positionedGraph();
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const positions = await store.layoutPositions("dag");
+    await store.close();
+    expect(positions).toEqual([]);
+  });
+
+  it("rebuilds graph_positions INSIDE the replace transaction (on the txn client)", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_in_txn");
+    const { G, communities } = positionedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    await store.close();
+
+    const posWrites = state.queries.filter((q) => q.text.includes("INSERT INTO graph_positions"));
+    expect(posWrites).toHaveLength(1);
+    // The position rebuild commits/rolls back WITH the snapshot: on the client.
+    expect(posWrites[0]!.via).toBe("client");
+    const clientSql = state.queries.filter((q) => q.via === "client").map((q) => q.text);
+    expect(clientSql).toContain("BEGIN");
+    expect(clientSql).toContain("COMMIT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REPLACE push → graphWindow (degree-top-n)
+// ---------------------------------------------------------------------------
+
+describe("Postgres windowed loader: degree-top-n window", () => {
+  it("returns the top-N nodes by degree + ONLY the induced edges", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_window_topn");
+    const { G, communities } = positionedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const window = await store.graphWindow({ layout: "force", limit: 2 });
+    await store.close();
+
+    expect(window.strategy).toBe("degree-top-n");
+    expect(window.layout).toBe("force");
+    expect(window.limit).toBe(2);
+    // Top-2 by degree: hub (3), then a/b tie → node_id ASC → 'a'.
+    expect(window.nodes.map((n) => n.id)).toEqual(["hub", "a"]);
+    // hub carries its layout position + label + type + degree.
+    expect(window.nodes[0]).toEqual({
+      id: "hub",
+      label: "Hub",
+      node_type: "code",
+      x: 10,
+      y: 20,
+      degree: 3,
+    });
+    // Induced edges among {hub, a}: only hub→a (hub→b, hub→c, a→b excluded).
+    expect(window.edges).toEqual([{ source: "hub", target: "a", relation: "links" }]);
+  });
+
+  it("a larger window returns every positioned node + every induced edge", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_window_full");
+    const { G, communities } = positionedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const window = await store.graphWindow({ layout: "force", limit: 100 });
+    await store.close();
+
+    // 4 positioned nodes by degree desc, node_id asc (lonely excluded).
+    expect(window.nodes.map((n) => n.id)).toEqual(["hub", "a", "b", "c"]);
+    // All 4 edges are induced (every endpoint is in the window).
+    expect(window.edges).toHaveLength(4);
+    expect(window.edges.map((e) => `${e.source}->${e.target}`).sort()).toEqual([
+      "a->b",
+      "hub->a",
+      "hub->b",
+      "hub->c",
+    ]);
+  });
+
+  it("clamps the node cap so a window can never ship the full scene", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_window_clamp");
+    const { G, communities } = positionedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const window = await store.graphWindow({ limit: 10_000_000 });
+    await store.close();
+
+    // The effective limit is clamped to the adapter's hard ceiling (20000).
+    expect(window.limit).toBe(20000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Staleness guard: a MERGE push never rebuilds the positions
+// ---------------------------------------------------------------------------
+
+describe("Postgres windowed loader: merge staleness guard", () => {
+  it("a MERGE push leaves graph_positions untouched, so the window stays on the last REPLACE snapshot", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "wl_merge_guard");
+    const { G, communities } = positionedGraph();
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const afterReplace = await store.graphWindow({ layout: "force", limit: 100 });
+    expect(afterReplace.nodes.map((n) => n.id)).toEqual(["hub", "a", "b", "c"]);
+
+    const writesBeforeMerge = state.queries.length;
+
+    // MERGE push that introduces a NEW high-degree positioned node. A merge is
+    // upsert-only — it lands the node row but, by design, does NOT rebuild
+    // graph_positions; the guard keeps the stale position out of the window.
+    const merged = new Graph();
+    merged.addNode("zeta", { label: "Zeta", node_type: "code", x: 9, y: 9 });
+    merged.addNode("hub", { label: "Hub", node_type: "code", x: 10, y: 20 });
+    merged.addEdge("zeta", "hub", { relation: "links" });
+    await store.pushGraph(merged, new Map(), { mode: "merge" });
+
+    const mergeQueries = state.queries.slice(writesBeforeMerge);
+    expect(
+      mergeQueries.filter((q) => q.text.includes("INSERT INTO graph_positions")),
+    ).toHaveLength(0);
+    expect(
+      mergeQueries.filter((q) => q.text.includes("DELETE FROM graph_positions")),
+    ).toHaveLength(0);
+
+    // The window still reflects the REPLACE snapshot — 'zeta' is absent.
+    const afterMerge = await store.graphWindow({ layout: "force", limit: 100 });
+    await store.close();
+    expect(afterMerge.nodes.map((n) => n.id)).toEqual(["hub", "a", "b", "c"]);
+    expect(afterMerge.nodes.some((n) => n.id === "zeta")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability absent / no-op on a backend that doesn't implement it
+// ---------------------------------------------------------------------------
+
+describe("Postgres windowed loader: capability gating on other backends", () => {
+  it("FileGraphStore neither declares window nor exposes the readers", async () => {
+    const { createFileGraphStore } = await import("../src/storage/file.js");
+    const base = freshArtifactBase();
+    const store: GraphStore = createFileGraphStore({ target: join(base, "graph.json") });
+
+    expect(store.capabilities.window).toBeUndefined();
+    expect(store.layoutPositions).toBeUndefined();
+    expect(store.graphWindow).toBeUndefined();
+    await store.close();
+  });
+});


### PR DESCRIPTION
## WP3 — windowed loader: kill the full-scene transfer at scale

Additive, capability-gated (mirrors #235 `groupCounts` / #239 `/api/ontology/groups`). aclp-am ships a **33.8 MB scene.json** for **47,762 nodes** today; this lands the server-side primitive to serve a **bounded first-paint slice + per-layout positions** from the store, with the full-scene path **byte-for-byte unchanged** when no store is wired.

### What ships (LOT 3, server-side first)

1. **Port extension** — `src/storage/types.ts`: optional, versioned `GraphStoreWindowCapability` (`{ version, layouts, strategies }`) + optional readers `layoutPositions(layout)` and `graphWindow(opts)` with their result types. Backends that don't precompute positions omit the capability and both methods.

2. **Per-layout positions table (Postgres only)** — `src/storage/postgres.ts`: new `graph_positions(city_slug, snapshot_id, layout_id, node_id, x, y, degree)` PK `(city_slug, layout_id, node_id)` + a `(city_slug, layout_id, degree DESC)` index. At push the adapter mirrors the graph's one baked layout (numeric `x`/`y` node attrs from `attachLayoutPositions`) under layout `force`, with `degree` precomputed in one pass; un-positioned nodes are skipped. **Replace-staleness guard**: rebuilt (delete-all-then-load) **only** in `mode: "replace"`, inside the push transaction — a `merge` never touches it (same guard as `graph_group_counts`). `clear()` drops positions too.

3. **Windowed read route** — `GET /api/ontology/window?strategy=&layout=&limit=` in `src/ontology-studio.ts`. **Strategy chosen: `degree-top-n`** (the simplest useful first-paint window — the N highest-degree nodes + the edges induced among them, annotated with the layout's `x`/`y`; a single indexed scan over `graph_positions`, never an O(#nodes) sort). Capability-gated: **404** when no store / no `window` capability / no `graphWindow` reader, or an unadvertised strategy/layout → the SPA falls back to the full scene. Node cap clamped (≤ 20000) so no window can ship the full scene.

4. **Studio accessor** — `studio/src/lib/api.js` `fetchWindow({strategy,layout,limit})`, mirroring `fetchGroupCounts`: offline / 404 / network error → `null`, never throws, no static fallback. **Client render-path integration is deferred by design** (wiring App.svelte first paint touches the renderer/scene draw path, out of scope here); with no store wired the accessor returns `null` on every call, so the default scene path is unchanged.

### Tests
- `tests/storage-postgres-windowed-loader.test.ts` — pg-mock round-trip: positions rebuilt on REPLACE (stale-guarded on merge), `layoutPositions` correctness, `graphWindow` top-N + induced edges + clamp, rebuild-in-txn, FileGraphStore omits the capability.
- `tests/ontology-studio-window-route.test.ts` — store-with-capability → 200 window; off-strategy/off-layout/no-store/no-capability → 404; store error → 500.
- `studio/src/tests/api.test.js` — `fetchWindow` accessor (route hit, 404→null, offline→null, no fetch).

### Verification (local, all green)
- `npm run build` → exit 0
- `npm run lint` → exit 0
- `npx vitest run tests/storage-postgres* tests/ontology-studio*` → 8 files, 75 pass / 1 skip
- studio `npx vitest run src/tests/api.test.js` → 25 pass
- `npm run build:studio` → exit 0

Do NOT merge.
