### PR TITLE
ci(release): publish @sentropic/graph on graph-v* tag (trusted publishing)

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -3,7 +3,7 @@ name: TypeScript CI
 on:
   push:
     branches: ["v1", "v2", "v3", "v3-typescript", "main"]
-    tags: ["v*"]
+    tags: ["v*", "graph-v*"]
   pull_request:
     branches: ["v1", "v2", "v3", "v3-typescript", "main"]
 
@@ -310,3 +310,56 @@ jobs:
           cd /tmp/post-publish
           npx graphify install --platform claude || true
           echo "Skill install command executed"
+
+  # Publish the @sentropic/graph sub-package on a graph-v<X> tag (decoupled from the
+  # root @sentropic/graphify release cadence). OIDC Trusted Publishing + provenance.
+  publish-graph:
+    needs: [test, smoke-test]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/graph-v')
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is merged into default branch
+        run: |
+          git fetch origin "${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/${RELEASE_BRANCH}"; then
+            echo "::error::Refusing to publish ${GITHUB_REF_NAME}: ${GITHUB_SHA} is not merged into origin/${RELEASE_BRANCH}."
+            exit 1
+          fi
+
+      - name: Verify packages/graph version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#graph-v}"
+          PACKAGE_VERSION="$(node -p "require('./packages/graph/package.json').version")"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match packages/graph version ${PACKAGE_VERSION}."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for Trusted Publishing
+        run: |
+          npm install -g npm@11.6.2
+          node --version
+          npm --version
+
+      - name: Install and build
+        run: |
+          npm ci --legacy-peer-deps
+          npm run build
+
+      - name: Publish @sentropic/graph to npm
+        working-directory: packages/graph
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Adds a CI publish path for the @sentropic/graph sub-package, decoupled from the root @sentropic/graphify release. On a `graph-v<X>` tag merged into main, a new `publish-graph` job verifies the tag is on main + packages/graph version matches, then `npm publish --provenance` via OIDC Trusted Publishing (same mechanism as the root, no NPM_TOKEN). Lets us publish @sentropic/graph 0.2.0 (the layout-registry exports) from CI so graphify can un-vendor (#246) — instead of a manual npm publish.