### PR TITLE
fix(graph): repository field for npm provenance publish

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "Fast WebGL-oriented graph rendering primitives for known-position graphs.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rhanka/graphify.git",
+    "directory": "packages/graph"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
The publish-graph CI job (now authorized via the new trusted publisher) failed with E422: npm provenance requires packages/graph/package.json to carry a repository.url matching github.com/rhanka/graphify. Adds the repository field (mirrors root, + directory: packages/graph). Unblocks the @sentropic/graph 0.2.0 publish.