### PR TITLE
feat(cli): `graphify store push` + serve-with-store wiring (productionize DB group-counts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,27 @@ graphify ontology studio --config graphify.yaml --write         # token-gated ap
 
 The same write-guarded core is also exposed over MCP — the default `graphify serve` graph server is read-only, and mutation tools require the explicit `graphify ontology serve --config graphify.yaml --write`.
 
+### Store mirrors (instant server-side group counts)
+
+`graph.json` stays the source of truth, but you can mirror it into a database backend (Postgres/neo4j/…) so the studio reads precomputed, O(#groups) group-by counts and a windowed first-paint slice from the backend instead of recomputing them over every node in the browser. On a real 47k-node graph the server group-counts are ~600x faster than a client recompute.
+
+```bash
+# Push the graph to the configured backend in REPLACE mode (rebuilds the
+# group-by aggregate + windowed positions — the source of the instant counts).
+GRAPHIFY_STORE=postgres GRAPHIFY_POSTGRES_URL=postgres://user:pass@host/db \
+  graphify store push --config graphify.yaml          # or: --graph .graphify/graph.json
+graphify store status --store postgres                # capabilities + latest snapshot
+
+# Serve the studio with the store wired in: GET /api/ontology/groups is then
+# answered from the backend aggregate. The store is picked up from --store, then
+# GRAPHIFY_STORE, then storage.mirrors[0] in the config.
+GRAPHIFY_STORE=postgres GRAPHIFY_POSTGRES_URL=postgres://user:pass@host/db \
+  graphify ontology studio --config graphify.yaml
+graphify ontology studio --config graphify.yaml --store postgres
+```
+
+The store comes from `--store`, the `GRAPHIFY_STORE` / `GRAPHIFY_POSTGRES_URL` environment variables, or a `storage.mirrors[]` entry in the project config. `store push` defaults to `--mode replace` because the group-by aggregate and windowed positions are only valid against a committed full snapshot (a `--mode merge` upsert leaves them untouched). With no store configured the studio is unchanged: the route 404s and the SPA falls back to its in-memory group-by.
+
 ## Multimodal ingestion
 
 The same semantic pass handles non-code inputs:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3160,12 +3160,18 @@ export async function main(): Promise<void> {
 
   ontology
     .command("studio")
-    .description("Start a local ontology reconciliation studio API; --write enables patch mutation routes (loopback only)")
+    .description(
+      "Start a local ontology reconciliation studio API; --write enables patch mutation routes (loopback only). " +
+        "When --store (or GRAPHIFY_STORE / storage.mirrors) names an aggregate-capable GraphStore that has been " +
+        "`graphify store push`ed, GET /api/ontology/groups serves O(#groups) counts from the store instead of an " +
+        "O(#nodes) client recompute.",
+    )
     .requiredOption("--config <path>", "Graphify project config path")
     .option("--host <host>", "Host to bind", "127.0.0.1")
     .option("--port <port>", "Port to bind; defaults to an ephemeral port")
     .option("--write", "Enable POST /api/ontology/patch/{validate,dry-run,apply} routes (loopback only)")
     .option("--token <token>", "Bearer token for write routes (default: random hex24 generated at startup)")
+    .option("--store <id>", "GraphStore backend id to serve group counts from (default: GRAPHIFY_STORE or storage.mirrors[0].backend)")
     .action(async (opts) => {
       const projectConfig = loadProjectConfig(resolve(opts.config));
       const profileStatePath = join(projectConfig.outputs.state_dir, "profile", "profile-state.json");
@@ -3185,7 +3191,7 @@ export async function main(): Promise<void> {
         | import("./ontology-studio.js").StudioGroupCountsStore
         | undefined;
       const storeBackendId =
-        process.env.GRAPHIFY_STORE ?? projectConfig.storage?.mirrors?.[0]?.backend;
+        opts.store ?? process.env.GRAPHIFY_STORE ?? projectConfig.storage?.mirrors?.[0]?.backend;
       if (storeBackendId) {
         try {
           const { resolveStoreConfig } = await import("./storage/config.js");
@@ -3238,6 +3244,63 @@ export async function main(): Promise<void> {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`error: ${message}`);
+        process.exit(1);
+      }
+    });
+
+  // -------------------------------------------------------------------------
+  // `store` — push the graph to a configured GraphStore mirror and inspect it.
+  // Productionizes the DB instant-grouping path (storage LOTs 1/2/3): a REPLACE
+  // push rebuilds the O(#groups) group-by aggregate + windowed positions so the
+  // studio serves them instead of an O(#nodes) client recompute. No bespoke
+  // script — the store comes from --store / GRAPHIFY_STORE / storage.mirrors.
+  // -------------------------------------------------------------------------
+  const storeCommand = program
+    .command("store")
+    .description("Push the graph to a configured GraphStore mirror (Postgres/neo4j/…) and inspect it");
+
+  storeCommand
+    .command("push")
+    .description(
+      "Push the graph to the configured GraphStore in REPLACE mode so it rebuilds the O(#groups) " +
+        "group-by counts + windowed positions. Store = --store, else GRAPHIFY_STORE " +
+        "(+ GRAPHIFY_POSTGRES_URL for postgres), else storage.mirrors[0].backend.",
+    )
+    .option("--graph <path>", "Path to graph.json (default: --config's state dir, else .graphify/graph.json)")
+    .option("--config <path>", "Graphify project config path (resolves the graph dir + storage.mirrors)")
+    .option("--store <id>", "Store backend id (default: GRAPHIFY_STORE or storage.mirrors[0].backend)")
+    .option("--mode <mode>", "Push mode: replace (default; rebuilds the aggregate + positions) or merge", "replace")
+    .option("--dry-run", "Plan and report counts without writing to the backend")
+    .action(async (opts) => {
+      try {
+        const { runStorePush } = await import("./store-cli.js");
+        await runStorePush({
+          ...(opts.graph ? { graph: String(opts.graph) } : {}),
+          ...(opts.config ? { config: String(opts.config) } : {}),
+          ...(opts.store ? { store: String(opts.store) } : {}),
+          ...(opts.mode ? { mode: String(opts.mode) } : {}),
+          ...(opts.dryRun ? { dryRun: true } : {}),
+        });
+      } catch (err) {
+        console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+
+  storeCommand
+    .command("status")
+    .description("Show the configured GraphStore's capabilities + latest snapshot meta (cheap; no full scan)")
+    .option("--config <path>", "Graphify project config path (resolves storage.mirrors)")
+    .option("--store <id>", "Store backend id (default: GRAPHIFY_STORE or storage.mirrors[0].backend)")
+    .action(async (opts) => {
+      try {
+        const { runStoreStatus } = await import("./store-cli.js");
+        await runStoreStatus({
+          ...(opts.config ? { config: String(opts.config) } : {}),
+          ...(opts.store ? { store: String(opts.store) } : {}),
+        });
+      } catch (err) {
+        console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
         process.exit(1);
       }
     });

--- a/src/store-cli.ts
+++ b/src/store-cli.ts
@@ -1,0 +1,342 @@
+/**
+ * `graphify store push` / `graphify store status` — CLI glue that productionizes
+ * the DB instant-grouping path (storage LOTs 1/2/3, PRs #235/#239/#247).
+ *
+ * `store push` loads a `.graphify` graph and pushes it to the configured
+ * GraphStore mirror in REPLACE mode so the backend rebuilds its precomputed
+ * `graph_group_counts` aggregate (O(#groups) group-by, #235) and `graph_positions`
+ * windowed loader (#247). The studio then serves `GET /api/ontology/groups`
+ * straight from the aggregate (#239) instead of an O(#nodes) client recompute.
+ *
+ * This module owns NO push logic: it resolves the store via the existing
+ * `resolveStoreConfig` + `resolveGraphStore` wiring and calls the adapter's
+ * `pushGraph` — the same code path the bespoke UAT script exercised, now a
+ * first-class command. The store/graph resolution and summary are extracted here
+ * (not inlined in cli.ts) so they are unit-testable against the storage
+ * fake-driver harness with no live DB.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { loadGraphFromData } from "./graph.js";
+import { communitiesFromGraph } from "./graph-communities.js";
+import { resolveGraphInputPath } from "./paths.js";
+import { loadProjectConfig } from "./project-config.js";
+import { resolveStoreConfig } from "./storage/config.js";
+import { resolveGraphStore } from "./storage/registry.js";
+import type {
+  GraphStore,
+  GraphStoreConfig,
+  StoreTestDeps,
+} from "./storage/types.js";
+import type { NormalizedProjectConfig } from "./types.js";
+
+/** Options accepted by `graphify store push`. */
+export interface StorePushCliOptions {
+  /** Explicit graph.json path; overrides the config-derived path. */
+  graph?: string;
+  /** Graphify project config path; resolves the graph dir + storage.mirrors. */
+  config?: string;
+  /** Store backend id; overrides GRAPHIFY_STORE / storage.mirrors[0]. */
+  store?: string;
+  /** Push mode; defaults to `replace` so the aggregate + positions are rebuilt. */
+  mode?: string;
+  /** Plan and report without writing to the backend. */
+  dryRun?: boolean;
+}
+
+/** Options accepted by `graphify store status`. */
+export interface StoreStatusCliOptions {
+  /** Graphify project config path; resolves storage.mirrors. */
+  config?: string;
+  /** Store backend id; overrides GRAPHIFY_STORE / storage.mirrors[0]. */
+  store?: string;
+}
+
+/** Structured result of a push (also printed as a human summary). */
+export interface StorePushSummary {
+  storeId: string;
+  mode: "merge" | "replace";
+  nodes: number;
+  edges: number;
+  communities: number;
+  /** Group-by axes the backend rebuilt (replace + aggregate-capable only). */
+  axes: string[];
+  /** Windowed-loader layouts the backend rebuilt (replace + window-capable). */
+  layouts: string[];
+  durationMs: number;
+  dryRun: boolean;
+  warnings: string[];
+}
+
+/** Structured result of a status probe. */
+export interface StoreStatusSummary {
+  storeId: string;
+  reachable: boolean;
+  capabilities: GraphStore["capabilities"];
+  snapshot?: {
+    topologySignature: string;
+    pushedAt: string;
+    toolVersion: string;
+  };
+  /** Cheap O(#groups) node total per axis (only when an aggregate exists). */
+  axisTotals: Record<string, number>;
+}
+
+/** Injection points: hermetic env + store resolution for tests. */
+export interface StoreCliDeps {
+  /** Env map (defaults to process.env) so resolution is hermetic under test. */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Store resolver override. Default resolves via resolveStoreConfig +
+   * resolveGraphStore, forwarding {@link storeTestDeps}. Tests inject a
+   * fake-driver store here (or rely on storeTestDeps).
+   */
+  resolveStore?: (id: string, config: GraphStoreConfig) => Promise<GraphStore>;
+  /** Driver injection forwarded to resolveGraphStore (storage fake-driver harness). */
+  storeTestDeps?: StoreTestDeps;
+  /** Output sink (defaults to console.log). */
+  log?: (line: string) => void;
+}
+
+function normalizeMode(raw: string | undefined): "merge" | "replace" {
+  const mode = String(raw ?? "replace").trim().toLowerCase();
+  if (mode === "merge" || mode === "replace") return mode;
+  throw new Error(`--mode must be 'replace' or 'merge' (got '${raw}')`);
+}
+
+function loadConfig(configPath: string | undefined): NormalizedProjectConfig | undefined {
+  if (!configPath) return undefined;
+  return loadProjectConfig(resolve(configPath));
+}
+
+/**
+ * Effective backend id: explicit `--store` > GRAPHIFY_STORE env >
+ * storage.mirrors[0].backend. Returns undefined when nothing is configured so
+ * the caller can emit a single actionable error.
+ */
+export function resolveStoreBackendId(
+  opts: { store?: string },
+  projectConfig: NormalizedProjectConfig | undefined,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  return (
+    opts.store ??
+    env["GRAPHIFY_STORE"] ??
+    projectConfig?.storage?.mirrors?.[0]?.backend
+  );
+}
+
+/**
+ * Effective graph path: explicit `--graph` > `<config state_dir>/graph.json` >
+ * the default `.graphify/graph.json` (with legacy fallback).
+ */
+function resolveStoreGraphPath(
+  opts: StorePushCliOptions,
+  projectConfig: NormalizedProjectConfig | undefined,
+): string {
+  if (opts.graph) return resolve(opts.graph);
+  if (projectConfig) return join(projectConfig.outputs.state_dir, "graph.json");
+  return resolveGraphInputPath();
+}
+
+async function openStore(
+  storeId: string,
+  storeConfig: GraphStoreConfig,
+  deps: StoreCliDeps,
+): Promise<GraphStore> {
+  if (deps.resolveStore) return deps.resolveStore(storeId, storeConfig);
+  return resolveGraphStore(storeId, storeConfig, deps.storeTestDeps);
+}
+
+const NO_STORE_ERROR =
+  "no GraphStore configured. Set GRAPHIFY_STORE (and GRAPHIFY_POSTGRES_URL for " +
+  "the postgres backend), add a storage.mirrors[] entry to your graphify config, " +
+  "or pass --store <id>.";
+
+/**
+ * Push a `.graphify` graph to the configured GraphStore. REPLACE mode (the
+ * default) is what makes the aggregate + windowed positions valid — they are
+ * rebuilt only inside a full-snapshot replace. Reuses the adapter's pushGraph;
+ * never reimplements the push.
+ */
+export async function runStorePush(
+  opts: StorePushCliOptions,
+  deps: StoreCliDeps = {},
+): Promise<StorePushSummary> {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? ((line: string) => console.log(line));
+  const mode = normalizeMode(opts.mode);
+
+  const projectConfig = loadConfig(opts.config);
+  const storeId = resolveStoreBackendId(opts, projectConfig, env);
+  if (!storeId) {
+    throw new Error(NO_STORE_ERROR);
+  }
+
+  const graphPath = resolveStoreGraphPath(opts, projectConfig);
+  if (!existsSync(graphPath)) {
+    throw new Error(
+      `graph file not found: ${graphPath}. Build it first (graphify extract) ` +
+        "or pass --graph <path>.",
+    );
+  }
+  const G = loadGraphFromData(JSON.parse(readFileSync(graphPath, "utf-8")));
+  const communities = communitiesFromGraph(G);
+
+  const storeConfig = resolveStoreConfig(storeId, { projectConfig, env });
+  const store = await openStore(storeId, storeConfig, deps);
+  try {
+    const result = await store.pushGraph(G, communities, {
+      mode,
+      ...(opts.dryRun ? { dryRun: true } : {}),
+    });
+    // Aggregate + positions are REPLACE-snapshot scoped: only a replace push
+    // rebuilds them (a merge leaves the previous counts/positions in place).
+    const rebuilt = mode === "replace" && !opts.dryRun;
+    const axes = rebuilt ? [...(store.capabilities.aggregate?.axes ?? [])] : [];
+    const layouts = rebuilt ? [...(store.capabilities.window?.layouts ?? [])] : [];
+
+    const summary: StorePushSummary = {
+      storeId,
+      mode,
+      nodes: result.nodes,
+      edges: result.edges,
+      communities: communities.size,
+      axes,
+      layouts,
+      durationMs: result.durationMs,
+      dryRun: opts.dryRun === true,
+      warnings: result.warnings,
+    };
+    printPushSummary(log, summary);
+    return summary;
+  } finally {
+    await store.close();
+  }
+}
+
+function printPushSummary(log: (line: string) => void, s: StorePushSummary): void {
+  const dry = s.dryRun ? " [DRY-RUN — nothing written]" : "";
+  log(
+    `Pushed ${s.nodes} nodes, ${s.edges} edges (${s.communities} communities) ` +
+      `to the '${s.storeId}' store in ${s.mode} mode${dry}.`,
+  );
+  if (s.mode === "replace" && !s.dryRun) {
+    log(
+      s.axes.length > 0
+        ? `  Group-by aggregate rebuilt for axes: ${s.axes.join(", ")} (O(#groups) counts).`
+        : "  Store declares no group-by aggregate capability (counts stay client-side).",
+    );
+    if (s.layouts.length > 0) {
+      log(`  Windowed-loader positions rebuilt for layouts: ${s.layouts.join(", ")}.`);
+    }
+  } else if (s.mode === "merge") {
+    log(
+      "  Merge mode: the group-by aggregate + windowed positions are NOT rebuilt. " +
+        "Use --mode replace to refresh them.",
+    );
+  }
+  for (const warning of s.warnings) log(`  warning: ${warning}`);
+  log(`  Took ${s.durationMs} ms.`);
+}
+
+/**
+ * Probe a configured GraphStore: report its capabilities and latest snapshot
+ * meta (both cheap — capabilities are static, snapshot meta is a single row).
+ * When an aggregate exists, also report the O(#groups) node total per axis.
+ */
+export async function runStoreStatus(
+  opts: StoreStatusCliOptions,
+  deps: StoreCliDeps = {},
+): Promise<StoreStatusSummary> {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? ((line: string) => console.log(line));
+
+  const projectConfig = loadConfig(opts.config);
+  const storeId = resolveStoreBackendId(opts, projectConfig, env);
+  if (!storeId) {
+    throw new Error(NO_STORE_ERROR);
+  }
+
+  const storeConfig = resolveStoreConfig(storeId, { projectConfig, env });
+  const store = await openStore(storeId, storeConfig, deps);
+  try {
+    let reachable = true;
+    try {
+      await store.verifyConnection();
+    } catch (error) {
+      reachable = false;
+      const message = error instanceof Error ? error.message : String(error);
+      log(`Store '${storeId}' unreachable: ${message}`);
+    }
+
+    const caps = store.capabilities;
+    const axisTotals: Record<string, number> = {};
+    let snapshot: StoreStatusSummary["snapshot"];
+    if (reachable) {
+      const meta = await store.readSnapshotMeta().catch(() => undefined);
+      if (meta) {
+        snapshot = {
+          topologySignature: meta.topologySignature,
+          pushedAt: meta.pushedAt,
+          toolVersion: meta.toolVersion,
+        };
+      }
+      // Cheap O(#groups) totals: read the precomputed aggregate, never the nodes.
+      if (caps.aggregate && typeof store.groupCounts === "function") {
+        for (const axis of caps.aggregate.axes) {
+          try {
+            const counts = await store.groupCounts(axis);
+            axisTotals[axis] = counts.groups.reduce((sum, g) => sum + g.count, 0);
+          } catch {
+            /* an axis the snapshot lacks → skip; status stays best-effort */
+          }
+        }
+      }
+    }
+
+    const summary: StoreStatusSummary = {
+      storeId,
+      reachable,
+      capabilities: caps,
+      ...(snapshot ? { snapshot } : {}),
+      axisTotals,
+    };
+    printStatusSummary(log, summary);
+    return summary;
+  } finally {
+    await store.close();
+  }
+}
+
+function printStatusSummary(log: (line: string) => void, s: StoreStatusSummary): void {
+  const c = s.capabilities;
+  log(`Store '${s.storeId}' — reachable=${s.reachable}`);
+  log(
+    `  capabilities: push=${c.push} query=${c.query} clear=${c.clear} ` +
+      `snapshotMeta=${c.snapshotMeta}`,
+  );
+  log(
+    c.aggregate
+      ? `  group-by aggregate: v${c.aggregate.version} axes [${c.aggregate.axes.join(", ")}]`
+      : "  group-by aggregate: none (counts computed client-side)",
+  );
+  log(
+    c.window
+      ? `  windowed loader: v${c.window.version} layouts [${c.window.layouts.join(", ")}] ` +
+          `strategies [${c.window.strategies.join(", ")}]`
+      : "  windowed loader: none (full scene shipped)",
+  );
+  if (s.snapshot) {
+    log(
+      `  latest snapshot: pushedAt=${s.snapshot.pushedAt} ` +
+        `toolVersion=${s.snapshot.toolVersion} topology=${s.snapshot.topologySignature}`,
+    );
+  } else if (s.reachable) {
+    log("  latest snapshot: none pushed yet");
+  }
+  for (const [axis, total] of Object.entries(s.axisTotals)) {
+    log(`  aggregate total nodes (${axis}): ${total}`);
+  }
+}

--- a/tests/cli-store-push.test.ts
+++ b/tests/cli-store-push.test.ts
@@ -1,0 +1,273 @@
+/**
+ * `graphify store push` / `store status` CLI tests.
+ *
+ * These drive the extracted `runStorePush` / `runStoreStatus` against the REAL
+ * postgres adapter wired through the production `resolveStoreConfig` +
+ * `resolveGraphStore` chain — the driver is the storage fake-driver harness (an
+ * in-memory `pg` module that records SQL), so no live DB and no `pg` package are
+ * required (mirroring tests/storage-postgres*.test.ts). The push artifact dir is
+ * redirected to a tmp dir so nothing is written into the repo tree.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runStorePush, runStoreStatus, type StoreCliDeps } from "../src/store-cli.js";
+import type { GraphStore, GraphStoreConfig } from "../src/storage/types.js";
+
+// ---------------------------------------------------------------------------
+// Fake `pg` driver (records every statement) — same shape as storage-postgres.
+// ---------------------------------------------------------------------------
+
+interface RecordedSql {
+  text: string;
+  params?: unknown[];
+}
+interface FakePgState {
+  queries: RecordedSql[];
+  metaRows: Array<Record<string, unknown>>;
+  groupRows: Array<Record<string, unknown>>;
+  poolEnded: boolean;
+}
+
+function freshState(): FakePgState {
+  return { queries: [], metaRows: [], groupRows: [], poolEnded: false };
+}
+
+function answer(state: FakePgState, text: string) {
+  const upper = text.toUpperCase();
+  if (text.includes("graph_meta") && upper.includes("SELECT")) {
+    return { rows: state.metaRows, rowCount: state.metaRows.length };
+  }
+  if (text.includes("graph_group_counts") && upper.includes("SELECT")) {
+    return { rows: state.groupRows, rowCount: state.groupRows.length };
+  }
+  return { rows: [], rowCount: 0 };
+}
+
+function makeFakePgModule(state: FakePgState) {
+  class FakePool {
+    constructor(_config?: Record<string, unknown>) {}
+    query(text: string, params?: unknown[]) {
+      state.queries.push({ text, params });
+      return Promise.resolve(answer(state, text));
+    }
+    connect() {
+      const client = {
+        query: (text: string, params?: unknown[]) => {
+          state.queries.push({ text, params });
+          return Promise.resolve(answer(state, text));
+        },
+        release() {
+          /* no-op */
+        },
+      };
+      return Promise.resolve(client);
+    }
+    end() {
+      state.poolEnded = true;
+      return Promise.resolve();
+    }
+  }
+  return { Pool: FakePool };
+}
+
+// ---------------------------------------------------------------------------
+// Test scaffolding: a graph.json fixture + a redirected artifact dir.
+// ---------------------------------------------------------------------------
+
+const tmpDirs: string[] = [];
+function freshTmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Write a tiny graph.json (3 nodes / 2 edges / 2 communities) and return its path. */
+function writeGraphFixture(): string {
+  const dir = freshTmp("graphify-storecli-graph-");
+  const graphPath = join(dir, "graph.json");
+  writeFileSync(
+    graphPath,
+    JSON.stringify({
+      directed: false,
+      nodes: [
+        // Baked layout coords (x/y) so the windowed-loader positions get built.
+        { id: "a", label: "Alpha", node_type: "Character", community: 0, x: 0.1, y: 0.2 },
+        { id: "b", label: "Beta", node_type: "Character", community: 0, x: 0.3, y: 0.4 },
+        { id: "c", label: "Gamma", node_type: "Place", community: 1, x: 0.5, y: 0.6 },
+      ],
+      links: [
+        { source: "a", target: "b", relation: "knows" },
+        { source: "b", target: "c", relation: "at" },
+      ],
+    }),
+  );
+  return graphPath;
+}
+
+/**
+ * Build StoreCliDeps that route store resolution through the REAL production
+ * chain (resolveStoreConfig already ran to produce `cfg`); we only inject the
+ * fake `pg` driver and redirect the artifact `target` to a tmp dir.
+ */
+function deps(state: FakePgState, lines: string[]): StoreCliDeps {
+  return {
+    env: {
+      GRAPHIFY_STORE: "postgres",
+      GRAPHIFY_POSTGRES_URL: "postgres://user:pass@localhost:5432/testdb",
+    } as NodeJS.ProcessEnv,
+    log: (line) => lines.push(line),
+    resolveStore: async (id: string, cfg: GraphStoreConfig): Promise<GraphStore> => {
+      // Assert the production resolveStoreConfig fed the DSN from the env map.
+      expect(id).toBe("postgres");
+      expect(cfg.connectionString).toBe("postgres://user:pass@localhost:5432/testdb");
+      const { resolveGraphStore } = await import("../src/storage/registry.js");
+      return resolveGraphStore(
+        id,
+        { ...cfg, citySlug: "storecli_test", target: freshTmp("graphify-storecli-art-") },
+        { driverModule: makeFakePgModule(state) },
+      );
+    },
+  };
+}
+
+const allSql = (state: FakePgState) => state.queries.map((q) => q.text);
+
+// ---------------------------------------------------------------------------
+// store push — replace mode rebuilds the aggregate + positions.
+// ---------------------------------------------------------------------------
+
+describe("graphify store push (replace mode)", () => {
+  it("pushes in replace mode and rebuilds group_counts + positions, reporting a summary", async () => {
+    const state = freshState();
+    const lines: string[] = [];
+    const graph = writeGraphFixture();
+
+    const summary = await runStorePush({ graph, mode: "replace" }, deps(state, lines));
+
+    // Summary reflects the pushed snapshot.
+    expect(summary.storeId).toBe("postgres");
+    expect(summary.mode).toBe("replace");
+    expect(summary.nodes).toBe(3);
+    expect(summary.edges).toBe(2);
+    expect(summary.communities).toBe(2);
+    expect(summary.axes).toContain("node_type");
+    expect(summary.axes).toContain("community");
+    expect(summary.layouts).toContain("force");
+    expect(typeof summary.durationMs).toBe("number");
+    expect(summary.dryRun).toBe(false);
+
+    // Replace pushed through pushGraph: delete-then-load + aggregate + positions.
+    const sql = allSql(state);
+    expect(sql.some((s) => s.includes("DELETE FROM graph_nodes"))).toBe(true);
+    expect(sql.some((s) => s.includes("INSERT INTO graph_group_counts"))).toBe(true);
+    expect(sql.some((s) => s.includes("INSERT INTO graph_positions"))).toBe(true);
+
+    // Human summary was printed.
+    expect(lines.join("\n")).toMatch(/Pushed 3 nodes, 2 edges .*replace mode/);
+    expect(lines.join("\n")).toMatch(/Group-by aggregate rebuilt for axes: node_type, community/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// store push — merge mode does NOT rebuild the aggregate.
+// ---------------------------------------------------------------------------
+
+describe("graphify store push (merge mode)", () => {
+  it("merges without DELETE and without rebuilding the aggregate", async () => {
+    const state = freshState();
+    const lines: string[] = [];
+    const graph = writeGraphFixture();
+
+    const summary = await runStorePush({ graph, mode: "merge" }, deps(state, lines));
+
+    expect(summary.mode).toBe("merge");
+    expect(summary.axes).toEqual([]);
+    expect(summary.layouts).toEqual([]);
+
+    const sql = allSql(state);
+    expect(sql.some((s) => s.includes("DELETE FROM"))).toBe(false);
+    expect(sql.some((s) => s.includes("INSERT INTO graph_group_counts"))).toBe(false);
+    expect(lines.join("\n")).toMatch(/Merge mode: the group-by aggregate .* NOT rebuilt/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// store push — dry-run reports counts without writing.
+// ---------------------------------------------------------------------------
+
+describe("graphify store push (dry-run)", () => {
+  it("reports counts but performs no INSERTs", async () => {
+    const state = freshState();
+    const lines: string[] = [];
+    const graph = writeGraphFixture();
+
+    const summary = await runStorePush({ graph, mode: "replace", dryRun: true }, deps(state, lines));
+
+    expect(summary.dryRun).toBe(true);
+    expect(summary.nodes).toBe(3);
+    // Dry-run rebuilds nothing and writes nothing.
+    expect(summary.axes).toEqual([]);
+    expect(allSql(state).some((s) => s.includes("INSERT INTO graph_nodes"))).toBe(false);
+    expect(lines.join("\n")).toMatch(/DRY-RUN/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// store push — clean error when no store is configured.
+// ---------------------------------------------------------------------------
+
+describe("graphify store push (no store configured)", () => {
+  it("throws an actionable error when nothing names a backend", async () => {
+    const graph = writeGraphFixture();
+    await expect(
+      runStorePush({ graph }, { env: {} as NodeJS.ProcessEnv, log: () => {} }),
+    ).rejects.toThrow(/no GraphStore configured/i);
+  });
+
+  it("errors before touching the graph when --store/env/config are all absent", async () => {
+    // No --graph either: resolution must fail on the store, not the graph.
+    await expect(
+      runStorePush({}, { env: {} as NodeJS.ProcessEnv, log: () => {} }),
+    ).rejects.toThrow(/GRAPHIFY_STORE|storage\.mirrors|--store/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// store status — reports capabilities + cheap aggregate totals.
+// ---------------------------------------------------------------------------
+
+describe("graphify store status", () => {
+  it("reports the store's capabilities and aggregate totals", async () => {
+    const state = freshState();
+    state.metaRows = [
+      { topology_signature: "n=3;e=2;x|", pushed_at: "2026-06-30T00:00:00.000Z", tool_version: "9.9.9" },
+    ];
+    state.groupRows = [
+      { key: "Character", label: "Character", count: 2, parent_key: null },
+      { key: "Place", label: "Place", count: 1, parent_key: null },
+    ];
+    const lines: string[] = [];
+
+    const summary = await runStoreStatus({}, deps(state, lines));
+
+    expect(summary.storeId).toBe("postgres");
+    expect(summary.reachable).toBe(true);
+    expect(summary.capabilities.aggregate?.axes).toContain("node_type");
+    expect(summary.snapshot?.toolVersion).toBe("9.9.9");
+    // groupCounts summed across buckets = 3 nodes for each aggregate axis.
+    expect(summary.axisTotals["node_type"]).toBe(3);
+    expect(lines.join("\n")).toMatch(/group-by aggregate: v1 axes \[node_type, community\]/);
+  });
+
+  it("throws an actionable error when no store is configured", async () => {
+    await expect(
+      runStoreStatus({}, { env: {} as NodeJS.ProcessEnv, log: () => {} }),
+    ).rejects.toThrow(/no GraphStore configured/i);
+  });
+});


### PR DESCRIPTION
## What

Productionizes the DB instant-grouping path so it works **without a hand-written script**. A prior UAT proved server group-counts are ~628x faster than client recompute on the real 47k aclp-am graph, but pushing the graph to Postgres required a bespoke script because there was no `graphify store push`. This adds that command and wires the studio serve-with-store path on the CLI, making the existing #235/#239/#247 pieces usable.

## Deliverables

1. **`graphify store push`** (`src/cli.ts`, action delegates to `src/store-cli.ts:runStorePush`). Loads the graph for a `.graphify` state/config and pushes it to the configured GraphStore in **REPLACE mode** (default), so `graph_group_counts` (#235) + `graph_positions` (#247) get rebuilt. Flags: `--graph <path>`, `--config <path>`, `--store <id>`, `--mode replace|merge` (default `replace`), `--dry-run`. Store comes from `--store` / `GRAPHIFY_STORE` (+ `GRAPHIFY_POSTGRES_URL`) / `storage.mirrors[0]`. Prints a summary (nodes/edges/communities pushed, axes + layouts rebuilt, ms). **Reuses `resolveGraphStore` + the adapter `pushGraph`** — no duplicated push logic.
2. **`graphify store status`** — store capabilities + latest snapshot meta + cheap O(#groups) aggregate totals per axis.
3. **Serve-with-store**: added `--store <id>` to `graphify ontology studio` (it already resolved from env/`storage.mirrors`; the flag makes it explicit). Documented in command help + a new README "Store mirrors" section.
4. **Tests** (`tests/cli-store-push.test.ts`): drive the commands through the real `resolveStoreConfig` + `resolveGraphStore` chain with the storage **fake-driver harness** (in-memory `pg`, no live DB). Assert replace rebuilds `graph_group_counts` + `graph_positions` and reports the summary; merge does neither; dry-run writes nothing; clean error when no store is configured; status reports caps + aggregate totals.

## Scope (honest)

- **Deferred**: the studio client windowed-loading rewrite (a later lot). This PR is the push CLI + the serve-with-store wiring + tests, making #235/#239/#247 usable from the CLI.

## Verification

- `npm run build` → exit 0
- `npm run lint` (`tsc --noEmit`) → exit 0
- `npx vitest run tests/storage-postgres*.test.ts tests/ontology-studio*.test.ts tests/cli-store-push.test.ts` → 82 passed, 1 skipped (live-DB suite)
- **Live docker smoke (bonus)**: real `postgres:16-alpine`, `store push` → 4 nodes/3 edges/2 communities in replace mode rebuilt `graph_group_counts` (node_type Character/Place=2, community 0/1=2) + 4 `graph_positions`; `store status` read back the snapshot + aggregate totals; container torn down.