### PR TITLE
feat(renderer): mat4 unified camera (2D ortho, byte-parity; 3D-ready)

### DIFF
--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -2,6 +2,7 @@ export * from "./buffers";
 export * from "./edge-geometry";
 export * from "./layout";
 export * from "./layout-registry";
+export * from "./mat4";
 export * from "./positions";
 export * from "./render-geometry";
 export * from "./renderer";

--- a/packages/graph/src/mat4.ts
+++ b/packages/graph/src/mat4.ts
@@ -1,0 +1,144 @@
+/**
+ * Minimal 4x4 COLUMN-MAJOR matrix helpers for the renderer's UNIFIED CAMERA
+ * (mat4 view-projection). This is the FOUNDATION for a future perspective(3D)
+ * camera: today every GPU world->clip vertex transform is driven by ONE
+ * `u_viewProj` mat4 built from the 2D camera `{x, y, zoom}` via an ORTHOGRAPHIC
+ * projection that is mathematically EQUIVALENT to the old hand-rolled affine
+ * (pan + zoom + viewport -> clip). Swapping a perspective matrix in later is a
+ * one-function change (`cameraToViewProjection`) with no shader churn.
+ *
+ * Convention: a `Mat4` is a `Float32Array(16)` in OpenGL COLUMN-MAJOR order, so
+ * `m[col * 4 + row]` is element (row, col). This matches `gl.uniformMatrix4fv`
+ * with `transpose = false` and GLSL `mat4 * vec4` — so {@link transformVec4}
+ * below computes the SAME product the vertex shader does.
+ */
+
+/** A 4x4 matrix in column-major order (OpenGL convention), length 16. */
+export type Mat4 = Float32Array;
+
+/** The 4x4 identity matrix. */
+export function identity(): Mat4 {
+  const m = new Float32Array(16);
+  m[0] = 1;
+  m[5] = 1;
+  m[10] = 1;
+  m[15] = 1;
+  return m;
+}
+
+/**
+ * Matrix product `a · b` (both column-major). `out(r,c) = Σ_k a(r,k)·b(k,c)`.
+ * Applying the result to a vector is `a · (b · v)` — i.e. `b` acts first.
+ */
+export function multiply(a: Mat4, b: Mat4): Mat4 {
+  const out = new Float32Array(16);
+  for (let col = 0; col < 4; col += 1) {
+    for (let row = 0; row < 4; row += 1) {
+      let sum = 0;
+      for (let k = 0; k < 4; k += 1) {
+        // a(row,k) = a[k*4 + row]; b(k,col) = b[col*4 + k]
+        sum += (a[k * 4 + row] ?? 0) * (b[col * 4 + k] ?? 0);
+      }
+      out[col * 4 + row] = sum;
+    }
+  }
+  return out;
+}
+
+/** Translation matrix by (tx, ty, tz). */
+export function translate(tx: number, ty: number, tz: number): Mat4 {
+  const m = identity();
+  m[12] = tx;
+  m[13] = ty;
+  m[14] = tz;
+  return m;
+}
+
+/** Non-uniform scale matrix by (sx, sy, sz). */
+export function scale(sx: number, sy: number, sz: number): Mat4 {
+  const m = new Float32Array(16);
+  m[0] = sx;
+  m[5] = sy;
+  m[10] = sz;
+  m[15] = 1;
+  return m;
+}
+
+/**
+ * Orthographic projection (classic `glOrtho`, column-major). Maps the box
+ * `[left,right] × [bottom,top] × [near,far]` to the clip cube `[-1,1]^3`.
+ */
+export function ortho(
+  left: number,
+  right: number,
+  bottom: number,
+  top: number,
+  near: number,
+  far: number,
+): Mat4 {
+  const m = new Float32Array(16);
+  m[0] = 2 / (right - left);
+  m[5] = 2 / (top - bottom);
+  m[10] = -2 / (far - near);
+  m[12] = -(right + left) / (right - left);
+  m[13] = -(top + bottom) / (top - bottom);
+  m[14] = -(far + near) / (far - near);
+  m[15] = 1;
+  return m;
+}
+
+/**
+ * Apply a column-major matrix to a homogeneous vector: returns `m · [x,y,z,w]`.
+ * This is the EXACT computation a GLSL `mat4 * vec4(x,y,z,w)` performs, so the
+ * camera-parity unit test can assert the GPU transform against the old affine.
+ */
+export function transformVec4(
+  m: Mat4,
+  x: number,
+  y: number,
+  z: number,
+  w: number,
+): [number, number, number, number] {
+  return [
+    (m[0] ?? 0) * x + (m[4] ?? 0) * y + (m[8] ?? 0) * z + (m[12] ?? 0) * w,
+    (m[1] ?? 0) * x + (m[5] ?? 0) * y + (m[9] ?? 0) * z + (m[13] ?? 0) * w,
+    (m[2] ?? 0) * x + (m[6] ?? 0) * y + (m[10] ?? 0) * z + (m[14] ?? 0) * w,
+    (m[3] ?? 0) * x + (m[7] ?? 0) * y + (m[11] ?? 0) * z + (m[15] ?? 0) * w,
+  ];
+}
+
+/**
+ * Build the UNIFIED 2D view-projection matrix from the camera `{x, y, zoom}` and
+ * the DEVICE viewport size, equivalent to the old per-shader affine:
+ *
+ *   screen = (world - camera) · zoom               // device px, origin = view centre
+ *   clip   = (screen.x · 2/vw, -screen.y · 2/vh)   // y flipped to clip space
+ *
+ * i.e. for a world point `(wx, wy)` and z = 0:
+ *   clip.x =  (wx - camera.x) · zoom · 2 / viewportWidth
+ *   clip.y = -(wy - camera.y) · zoom · 2 / viewportHeight
+ *   clip.z =  0,  clip.w = 1
+ *
+ * Composed as `ortho · scale(zoom) · translate(-camera)` so it reads as a real
+ * orthographic camera. The near/far is symmetric (-1..1) so a z = 0 input maps
+ * to clip.z = 0 — byte-identical to the legacy `gl_Position = vec4(clip, 0, 1)`.
+ * A future perspective camera replaces THIS function and nothing else.
+ */
+export function cameraToViewProjection(
+  camera: { x: number; y: number; zoom: number },
+  viewportWidth: number,
+  viewportHeight: number,
+): Mat4 {
+  // ortho box: x in [-vw/2, vw/2], y in [vh/2, -vh/2] (flip), z in [-1, 1].
+  const proj = ortho(
+    -viewportWidth / 2,
+    viewportWidth / 2,
+    viewportHeight / 2,
+    -viewportHeight / 2,
+    -1,
+    1,
+  );
+  // view = pan to camera origin, then zoom (scale acts AFTER translate on a vec).
+  const view = multiply(scale(camera.zoom, camera.zoom, 1), translate(-camera.x, -camera.y, 0));
+  return multiply(proj, view);
+}

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -1,6 +1,7 @@
 import { computePositionBounds, copyPositions } from "./positions";
 import { BOX_GLYPH_CORNER_RATIO, SQUARE_INSET_RATIO, shapePolygonPoints } from "./shape-geometry";
 import { boxDimensions } from "./render-geometry";
+import { cameraToViewProjection } from "./mat4";
 import { createWebGLShapeRenderer, type WebGLShapeRenderer } from "./webgl-shapes";
 import { createWebGLEdgeRenderer, type WebGLEdgeRenderer } from "./webgl-edges";
 import { createWebGLBoxRenderer, type BoxTextDraw, type WebGLBoxRenderer } from "./webgl-boxes";
@@ -37,9 +38,13 @@ interface AttributeLocations {
 }
 
 interface UniformLocations {
-  camera: WebGLUniformLocation | null;
-  viewport: WebGLUniformLocation | null;
-  zoom: WebGLUniformLocation | null;
+  // UNIFIED CAMERA: the single mat4 view-projection that drives the world->clip
+  // vertex transform (mat4.ts). It replaces the old raw `u_camera`/`u_zoom`/
+  // `u_viewport` affine. `zoom`/`pixelRatio` survive ONLY to size the legacy
+  // point sprite (gl_PointSize), which is a screen-space quantity, not a
+  // world->clip transform.
+  viewProj: WebGLUniformLocation | null;
+  zoom?: WebGLUniformLocation | null;
   pixelRatio?: WebGLUniformLocation | null;
 }
 
@@ -57,18 +62,21 @@ interface RenderResources {
   sizeBuffer: WebGLBuffer;
 }
 
+// UNIFIED CAMERA (mat4 view-projection). The world->clip transform is a single
+// `u_viewProj * vec4(world, 0, 1)` — for 2D it is the ORTHO matrix built from the
+// camera {x,y,zoom} (mat4.cameraToViewProjection), mathematically equivalent to
+// the old `screen = (a_position - u_camera)*u_zoom; clip = screen*(2/vw,-2/vh)`
+// affine, so the pixels are unchanged. z = 0 maps to clip.z = 0 (symmetric
+// near/far), identical to the legacy `vec4(clip, 0, 1)`. The door to a future
+// perspective(3D) matrix is now open (swap the matrix, the shader is unchanged).
 const EDGE_VERTEX_SHADER = `
 attribute vec2 a_position;
 attribute vec4 a_color;
-uniform vec2 u_camera;
-uniform vec2 u_viewport;
-uniform float u_zoom;
+uniform mat4 u_viewProj;
 varying vec4 v_color;
 
 void main() {
-  vec2 screen = (a_position - u_camera) * u_zoom;
-  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x, -screen.y * 2.0 / u_viewport.y);
-  gl_Position = vec4(clip, 0.0, 1.0);
+  gl_Position = u_viewProj * vec4(a_position, 0.0, 1.0);
   v_color = a_color;
 }
 `;
@@ -77,17 +85,15 @@ const NODE_VERTEX_SHADER = `
 attribute vec2 a_position;
 attribute vec4 a_color;
 attribute float a_size;
-uniform vec2 u_camera;
-uniform vec2 u_viewport;
+uniform mat4 u_viewProj;
 uniform float u_zoom;
 uniform float u_pixelRatio;
 varying vec4 v_color;
 
 void main() {
-  vec2 screen = (a_position - u_camera) * u_zoom;
-  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x, -screen.y * 2.0 / u_viewport.y);
-  gl_Position = vec4(clip, 0.0, 1.0);
-  // World-space sizing for legacy ForceGraph parity: glyphs scale with camera zoom.
+  gl_Position = u_viewProj * vec4(a_position, 0.0, 1.0);
+  // World-space sizing for legacy ForceGraph parity: the SPRITE (a screen-space
+  // billboard, not a world->clip transform) scales with camera zoom.
   gl_PointSize = max(1.0, a_size * u_pixelRatio * u_zoom);
   v_color = a_color;
 }
@@ -234,9 +240,10 @@ function createDrawProgram(
     program,
     attributes,
     uniforms: {
-      camera: context.getUniformLocation(program, "u_camera"),
-      viewport: context.getUniformLocation(program, "u_viewport"),
-      zoom: context.getUniformLocation(program, "u_zoom"),
+      viewProj: context.getUniformLocation(program, "u_viewProj"),
+      // Only the node (point-sprite) program needs zoom + pixelRatio, and ONLY to
+      // size gl_PointSize — never for the world->clip transform (that is u_viewProj).
+      zoom: includeSize ? context.getUniformLocation(program, "u_zoom") : null,
       pixelRatio: includeSize ? context.getUniformLocation(program, "u_pixelRatio") : null,
     },
   };
@@ -432,8 +439,12 @@ function bindCameraUniforms(
   canvas: GraphCanvasLike | null,
   pixelRatio: number,
 ): void {
-  if (uniforms.camera) context.uniform2f(uniforms.camera, camera.x, camera.y);
-  if (uniforms.viewport) context.uniform2f(uniforms.viewport, canvas?.width ?? 1, canvas?.height ?? 1);
+  // UNIFIED CAMERA: build the mat4 view-projection from {x,y,zoom} + the device
+  // viewport and upload it once. The world->clip transform is now matrix-driven
+  // (mat4.ts) instead of the hand-rolled per-shader affine.
+  const viewProj = cameraToViewProjection(camera, canvas?.width ?? 1, canvas?.height ?? 1);
+  if (uniforms.viewProj) context.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
+  // gl_PointSize sizing only (screen-space sprite), never the world transform.
   if (uniforms.zoom) context.uniform1f(uniforms.zoom, camera.zoom);
   if (uniforms.pixelRatio) context.uniform1f(uniforms.pixelRatio, pixelRatio);
 }
@@ -1284,6 +1295,12 @@ export function createGraphRenderer(
         edgeCount: state.edges.length / 2,
         positions: Array.from(state.positions),
         camera: { ...camera },
+        // UNIFIED CAMERA (mat4): the column-major view-projection the GPU vertex
+        // transform is driven by, DERIVED from {x,y,zoom} + the device viewport.
+        // {x,y,zoom} stays the public camera API; this exposes the matrix the
+        // renderer actually feeds the shaders, opening the door to a future
+        // perspective(3D) matrix without changing callers.
+        viewProjection: Array.from(cameraToViewProjection(camera, canvas?.width ?? 1, canvas?.height ?? 1)),
         destroyed,
         hasWebGL: context !== null,
         backend: activeBackend,

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -216,7 +216,19 @@ export interface GraphRendererSnapshot {
   nodeCount: number;
   edgeCount: number;
   positions: number[];
+  /**
+   * The 2D camera as the PUBLIC `{x, y, zoom}` pan/zoom API (unchanged). The
+   * renderer derives the mat4 view-projection from it (see {@link viewProjection}).
+   */
   camera: CameraState;
+  /**
+   * UNIFIED CAMERA: the column-major (16-element) mat4 VIEW-PROJECTION the GPU
+   * vertex shaders are driven by, DERIVED from {@link camera} + the device
+   * viewport. For 2D it is the ORTHOGRAPHIC matrix equivalent to the legacy
+   * pan/zoom affine; it is the seam a future perspective(3D) camera replaces.
+   * Additive & optional — callers that only need pan/zoom keep using {@link camera}.
+   */
+  viewProjection?: number[];
   destroyed: boolean;
   hasWebGL: boolean;
   backend: GraphRendererActiveBackend;

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -34,6 +34,7 @@
  * camera-relative → zoom → clip, y flipped to clip space.
  */
 
+import { cameraToViewProjection } from "./mat4";
 import {
   BORDER_WIDTH_BOLD,
   BORDER_WIDTH_NORMAL,
@@ -59,25 +60,27 @@ layout(location = 2) in float a_radius;    // instance: drawn radius (device px)
 layout(location = 3) in vec4 a_color;      // instance: drawn rgba (0..1)
 layout(location = 4) in float a_depth;     // instance: drawList index (interleave)
 
-uniform vec2 u_camera;
-uniform vec2 u_viewport;
-uniform float u_zoom;
+uniform mat4 u_viewProj;   // UNIFIED CAMERA: world -> clip (ortho for 2D, mat4.ts)
+uniform vec2 u_viewport;   // device size, for the screen-space radius billboard
 uniform float u_maxDepth;
 
 out vec4 v_color;
 
 void main() {
-  // World centre -> camera-relative -> zoom (positions are world coords; the
-  // radius is already in device px). Mirrors renderer.ts screenPoint/edge shader.
-  vec2 worldScreen = (a_center - u_camera) * u_zoom;
-  // The unit shape is scaled by the drawn radius (device px), so the disc radius
-  // IS the radius -- no gl_PointSize diameter trap.
-  vec2 screen = worldScreen + a_unit * a_radius;
-  vec2 clip = vec2(screen.x * 2.0 / u_viewport.x, -screen.y * 2.0 / u_viewport.y);
+  // UNIFIED CAMERA: the node CENTRE (world) goes through the SAME mat4 the legacy
+  // node/edge shaders use. The glyph RADIUS is a DEVICE-px billboard offset
+  // (screen-space, constant-pixel) added in clip space via the viewport -- exactly
+  // how a screen-aligned billboard works, which is also 3D-ready. This is
+  // mathematically equivalent to the old
+  //   screen = (a_center - u_camera)*u_zoom + a_unit*a_radius; clip = screen*(2/vw,-2/vh)
+  // (the *2/vw distributes over the centre + radius sum), so the pixels are unchanged.
+  vec4 centerClip = u_viewProj * vec4(a_center, 0.0, 1.0);
+  vec2 radiusClip = vec2(a_unit.x * a_radius * 2.0 / u_viewport.x,
+                        -a_unit.y * a_radius * 2.0 / u_viewport.y);
   // Map the drawList index to a depth in (-1,1): later ops sit nearer the camera
   // so a later node occludes an earlier one (byte-parity interleave plumbing).
   float z = u_maxDepth > 0.0 ? (a_depth / u_maxDepth) : 0.0;
-  gl_Position = vec4(clip, -z, 1.0);
+  gl_Position = vec4(centerClip.xy + radiusClip, -z, 1.0);
   v_color = a_color;
 }
 `;
@@ -100,9 +103,8 @@ void main() {
 interface ShapeProgram {
   program: WebGLProgram;
   uniforms: {
-    camera: WebGLUniformLocation | null;
+    viewProj: WebGLUniformLocation | null;
     viewport: WebGLUniformLocation | null;
-    zoom: WebGLUniformLocation | null;
     maxDepth: WebGLUniformLocation | null;
   };
 }
@@ -422,9 +424,8 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
   const shapeProgram: ShapeProgram = {
     program,
     uniforms: {
-      camera: gl.getUniformLocation(program, "u_camera"),
+      viewProj: gl.getUniformLocation(program, "u_viewProj"),
       viewport: gl.getUniformLocation(program, "u_viewport"),
-      zoom: gl.getUniformLocation(program, "u_zoom"),
       maxDepth: gl.getUniformLocation(program, "u_maxDepth"),
     },
   };
@@ -434,11 +435,19 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
     const { fill, border, nonFiniteCount } = buildShapeInstances(frame);
 
     gl.useProgram(shapeProgram.program);
-    if (shapeProgram.uniforms.camera) gl.uniform2f(shapeProgram.uniforms.camera, frame.camera.x, frame.camera.y);
+    // UNIFIED CAMERA: the same mat4 view-projection the legacy node/edge shaders
+    // use, built from {x,y,zoom} + the device viewport (mat4.cameraToViewProjection).
+    if (shapeProgram.uniforms.viewProj) {
+      gl.uniformMatrix4fv(
+        shapeProgram.uniforms.viewProj,
+        false,
+        cameraToViewProjection(frame.camera, frame.viewportWidth, frame.viewportHeight),
+      );
+    }
+    // Viewport stays for the screen-space radius billboard (device-px glyph extent).
     if (shapeProgram.uniforms.viewport) {
       gl.uniform2f(shapeProgram.uniforms.viewport, frame.viewportWidth, frame.viewportHeight);
     }
-    if (shapeProgram.uniforms.zoom) gl.uniform1f(shapeProgram.uniforms.zoom, frame.camera.zoom);
     if (shapeProgram.uniforms.maxDepth) gl.uniform1f(shapeProgram.uniforms.maxDepth, Math.max(1, frame.nodeCount));
 
     gl.enable(gl.BLEND);

--- a/packages/graph/tests/mat4.test.ts
+++ b/packages/graph/tests/mat4.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cameraToViewProjection,
+  identity,
+  multiply,
+  ortho,
+  scale,
+  transformVec4,
+  translate,
+} from "../src/mat4";
+
+/**
+ * The OLD hand-rolled 2D affine the renderer + shaders used before the mat4
+ * unified camera (renderer.ts EDGE/NODE shaders, webgl-shapes SHAPE shader):
+ *
+ *   screen = (world - camera) * zoom
+ *   clip   = (screen.x * 2/vw, -screen.y * 2/vh)
+ *   gl_Position = vec4(clip, 0, 1)
+ *
+ * The mat4 view-projection MUST reproduce this for 2D so the pixels are unchanged.
+ */
+function legacyAffineClip(
+  camera: { x: number; y: number; zoom: number },
+  vw: number,
+  vh: number,
+  wx: number,
+  wy: number,
+): [number, number, number, number] {
+  const screenX = (wx - camera.x) * camera.zoom;
+  const screenY = (wy - camera.y) * camera.zoom;
+  return [(screenX * 2) / vw, (-screenY * 2) / vh, 0, 1];
+}
+
+const CAMERAS = [
+  { x: 0, y: 0, zoom: 1 },
+  { x: 0, y: 0, zoom: 2.5 },
+  { x: 120, y: -45, zoom: 1 },
+  { x: -300.5, y: 88.25, zoom: 0.37 },
+  { x: 1e4, y: -1e4, zoom: 13 },
+];
+const VIEWPORTS = [
+  [200, 200],
+  [400, 250],
+  [600, 600],
+  [1280, 720],
+];
+const WORLD_POINTS = [
+  [0, 0],
+  [10, 10],
+  [-50, 25],
+  [123.5, -88.25],
+  [-1000, 1000],
+  [5000, 4000],
+];
+
+describe("mat4 helpers (building blocks)", () => {
+  it("identity is the neutral element and maps a point to itself", () => {
+    const i = identity();
+    expect(Array.from(i)).toEqual([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+    expect(transformVec4(i, 3, -7, 2, 1)).toEqual([3, -7, 2, 1]);
+  });
+
+  it("translate then scale compose as scale·translate (translate acts first on a vec)", () => {
+    // m = scale(2)·translate(10,20,0); applied to (1,1,0,1):
+    //   translate -> (11,21,0,1); scale -> (22,42,0,1).
+    const m = multiply(scale(2, 2, 1), translate(10, 20, 0));
+    expect(transformVec4(m, 1, 1, 0, 1)).toEqual([22, 42, 0, 1]);
+  });
+
+  it("ortho maps the box corners to the clip cube", () => {
+    const p = ortho(-100, 100, -50, 50, -1, 1);
+    const corners: Array<[[number, number, number, number], number[]]> = [
+      [transformVec4(p, 100, 50, 0, 1), [1, 1, 0, 1]],
+      [transformVec4(p, -100, -50, 0, 1), [-1, -1, 0, 1]],
+      [transformVec4(p, 0, 0, 0, 1), [0, 0, 0, 1]],
+    ];
+    // float32 storage rounds 1 to 0.99999997, so compare close (not byte-equal).
+    for (const [got, want] of corners) {
+      for (let i = 0; i < 4; i += 1) expect(got[i]).toBeCloseTo(want[i]!, 5);
+    }
+  });
+});
+
+describe("cameraToViewProjection — byte-parity with the legacy 2D affine", () => {
+  it("maps sample world points to the SAME clip coords as the old affine (within fp epsilon)", () => {
+    for (const camera of CAMERAS) {
+      for (const [vw, vh] of VIEWPORTS) {
+        const m = cameraToViewProjection(camera, vw!, vh!);
+        for (const [wx, wy] of WORLD_POINTS) {
+          const got = transformVec4(m, wx!, wy!, 0, 1);
+          const want = legacyAffineClip(camera, vw!, vh!, wx!, wy!);
+          // Float32 storage + the matrix multiply round a touch differently than
+          // the double-precision affine; 1e-4 is FAR below the golden pixel
+          // tolerance yet proves mathematical equivalence.
+          expect(got[0]).toBeCloseTo(want[0], 4);
+          expect(got[1]).toBeCloseTo(want[1], 4);
+          expect(got[2]).toBeCloseTo(want[2], 4);
+          expect(got[3]).toBeCloseTo(want[3], 4);
+        }
+      }
+    }
+  });
+
+  it("z = 0 maps to clip.z = 0 (legacy `vec4(clip, 0, 1)` parity, no depth shift)", () => {
+    const m = cameraToViewProjection({ x: 12, y: 34, zoom: 1.5 }, 800, 600);
+    for (const [wx, wy] of WORLD_POINTS) {
+      const clip = transformVec4(m, wx!, wy!, 0, 1);
+      expect(clip[2]).toBeCloseTo(0, 6);
+      expect(clip[3]).toBeCloseTo(1, 6);
+    }
+  });
+
+  it("camera centre maps to clip origin and the Y axis is flipped (world +y -> clip -y)", () => {
+    const camera = { x: 50, y: 50, zoom: 2 };
+    const m = cameraToViewProjection(camera, 400, 300);
+    // The camera centre sits at the viewport centre = clip (0,0).
+    const centre = transformVec4(m, camera.x, camera.y, 0, 1);
+    expect(centre[0]).toBeCloseTo(0, 5);
+    expect(centre[1]).toBeCloseTo(0, 5);
+    // A point ABOVE the camera in world (+y) is HIGHER on screen => clip.y > 0
+    // only if NOT flipped; the legacy affine flips Y, so world +y -> clip -y.
+    const above = transformVec4(m, camera.x, camera.y + 10, 0, 1);
+    expect(above[1]).toBeLessThan(0);
+  });
+
+  it("is purely affine in (x,y): the matrix has the expected ortho·zoom·pan structure", () => {
+    const camera = { x: 7, y: -3, zoom: 4 };
+    const vw = 200;
+    const vh = 100;
+    const m = cameraToViewProjection(camera, vw, vh);
+    // clip.x scale w.r.t world x = zoom*2/vw; clip.y scale w.r.t world y = -zoom*2/vh.
+    expect(m[0]).toBeCloseTo((camera.zoom * 2) / vw, 5); // d(clip.x)/d(wx)
+    expect(m[5]).toBeCloseTo((-camera.zoom * 2) / vh, 5); // d(clip.y)/d(wy)
+    // No cross terms / no z coupling into x,y.
+    expect(m[1]).toBeCloseTo(0, 6);
+    expect(m[4]).toBeCloseTo(0, 6);
+  });
+});

--- a/packages/graph/tests/renderer-api.test.ts
+++ b/packages/graph/tests/renderer-api.test.ts
@@ -56,6 +56,7 @@ function createFakeWebGlContext() {
     getUniformLocation: (_program: unknown, name: string) => ({ name }),
     uniform2f: () => undefined,
     uniform1f: () => undefined,
+    uniformMatrix4fv: () => undefined,
     enableVertexAttribArray: () => undefined,
     vertexAttribPointer: () => undefined,
     viewport: () => undefined,

--- a/packages/graph/tests/webgl-edges.test.ts
+++ b/packages/graph/tests/webgl-edges.test.ts
@@ -71,6 +71,7 @@ function createFakeGL2() {
     getUniformLocation: (_p: unknown, name: string) => ({ name }),
     uniform1f: () => undefined,
     uniform2f: () => undefined,
+    uniformMatrix4fv: () => undefined,
     createVertexArray: () => ({}),
     bindVertexArray: () => undefined,
     deleteVertexArray: () => undefined,

--- a/packages/graph/tests/webgl-shapes.test.ts
+++ b/packages/graph/tests/webgl-shapes.test.ts
@@ -83,6 +83,7 @@ function createFakeGL2() {
     getUniformLocation: (_p: unknown, name: string) => ({ name }),
     uniform1f: () => undefined,
     uniform2f: () => undefined,
+    uniformMatrix4fv: () => undefined,
     createVertexArray: () => ({}),
     bindVertexArray: () => undefined,
     deleteVertexArray: () => undefined,


### PR DESCRIPTION
## What

Replace the renderer's hand-rolled 2D affine camera with a single **mat4 view-projection** uniform (`u_viewProj`). For 2D it is an **orthographic** matrix built from the existing `{x, y, zoom}` + viewport that is mathematically equivalent to the old `screen = (world - camera)·zoom; clip = screen·(2/vw, -2/vh)` affine — so the GPU output is byte-identical and the golden pixel-parity lane stays green. This is the **foundation lot for 3D** (Option B): it adds **zero** 3D geometry / perspective / orbit / 3D picking (Option A, deferred). The door to a future perspective camera is now a one-function swap (`cameraToViewProjection`) with no shader churn.

## The mat4 view-projection (file:line)

- New helper module `packages/graph/src/mat4.ts` — `identity / multiply / translate / scale / ortho / transformVec4` and `cameraToViewProjection(camera, vw, vh)` (column-major `Float32Array(16)`), composed as `ortho · scale(zoom) · translate(-camera)` with symmetric near/far so `z=0 → clip.z=0`.
- Exported via `packages/graph/src/index.ts`.

## Shader transform change (world → clip)

The three **world→clip** vertex transforms now do `gl_Position = u_viewProj * vec4(world, 0.0, 1.0)`:
- `packages/graph/src/renderer.ts` — legacy point-sprite `EDGE_VERTEX_SHADER` + `NODE_VERTEX_SHADER` (uniform plumbing: `bindCameraUniforms` now uploads the mat4 via `uniformMatrix4fv`; `u_zoom`/`u_pixelRatio` survive only to size `gl_PointSize`, a screen-space sprite).
- `packages/graph/src/webgl-shapes.ts` — instanced `SHAPE_VERTEX_SHADER`: the node **centre** goes through `u_viewProj`; the glyph **radius** stays a device-px billboard offset added in clip space via the viewport (constant-pixel sizing — also exactly how a 3D billboard works).

## Moved to GPU vs left on CPU

- **Driven by the mat4 (GPU world→clip):** legacy node, legacy edge, instanced node-shape centre.
- **Left on the CPU (2D-first, least churn, documented):** the device-px pre-projection of **edges / boxes / text** (`webgl-edges.ts` capsule + arrow, `webgl-boxes.ts` box + text shaders keep their CPU `screenPoint` + `u_viewport` device→clip) and the entire **Canvas2D fallback** — all unchanged. The mat4 only needs to drive the GPU-instanced shape/edge world transform identically, which it does.

## Camera API

`{x, y, zoom}` stays the **public** camera API (callers / studio unchanged). The mat4 is **derived** internally; the renderer snapshot additionally exposes the derived `viewProjection` (optional, additive) so the unified matrix the GPU consumes is observable and a perspective(3D) matrix can be swapped in later without touching callers.

## Verification

- `cd packages/graph && npm run test:golden` (the CI Canvas2D oracle, `channelTolerance: 0`): **27/27 passed**.
- `npm run test:golden:webgl` (SwiftShader WebGL2 preflight OK → real GPU pixel diff of the changed `u_viewProj` shaders vs Canvas2D, within the existing tolerance): **111/111 passed**.
- New camera-parity unit test `packages/graph/tests/mat4.test.ts`: the mat4 maps sample world points to the same clip coords as the legacy affine (within fp epsilon) + `z=0 → clip.z=0`.
- Full graph unit suite: **190/190 passed**. `npm run build` exit 0, `npm run lint` (tsc --noEmit) exit 0, `npm run build:studio` exit 0.
- `git diff --name-only` limited to `packages/graph` (mat4/renderer/shaders/types + tests) — no studio behavior change.

No tolerances loosened, no goldens updated.