### PR TITLE
feat(layout): time-oriented lanes by project/repo + optional type sub-lanes

### DIFF
--- a/packages/graph/src/layout-registry.ts
+++ b/packages/graph/src/layout-registry.ts
@@ -145,6 +145,25 @@ function normalizeType(raw: string | null | undefined): string | null {
 }
 
 /**
+ * Deterministic lane ordering shared by the banded layouts: keys named in
+ * `explicit` (and actually present) come first in that order, then every
+ * remaining present key ascending (alpha). Pure; never mutates its inputs.
+ */
+function orderLaneKeys(present: readonly string[], explicit?: readonly string[]): string[] {
+  const presentSet = new Set(present);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const key of explicit ?? []) {
+    if (presentSet.has(key) && !seen.has(key)) {
+      ordered.push(key);
+      seen.add(key);
+    }
+  }
+  for (const key of present.filter((k) => !seen.has(k)).sort()) ordered.push(key);
+  return ordered;
+}
+
+/**
  * Variant A core — place nodes in horizontal bands ("swimlanes") by type.
  *
  *   • one lane per distinct `node_type`; lanes ordered deterministically
@@ -241,6 +260,12 @@ export const typedLayerLayout: LayoutFn = (graph, options) => {
 // Variant E — time-oriented layout (deterministic, O(n)). X = normalized time.
 // ---------------------------------------------------------------------------
 
+/** Which per-node attribute drives the PRIMARY horizontal lane on Y. */
+export type TimeOrientedLaneBy = "node_type" | "repo";
+
+/** Which per-node attribute sub-bands a primary lane into closely-spaced sub-lines. */
+export type TimeOrientedSubLaneBy = "node_type";
+
 /** Tuning for {@link computeTimeOrientedPositions}. */
 export interface TimeOrientedLayoutOptions {
   /**
@@ -249,21 +274,53 @@ export interface TimeOrientedLayoutOptions {
    * right. Default 1000.
    */
   width?: number;
-  /** Vertical distance between adjacent type-lane CENTRES (default 120). */
+  /** Vertical distance between adjacent PRIMARY-lane CENTRES (default 120). */
   laneGap?: number;
   /**
-   * Explicit lane ordering (top→bottom) by type name — identical semantics to
-   * Variant A. Types present but absent here are appended ascending (alpha); the
-   * untyped lane is always last. Default: all lanes alpha-sorted.
+   * Explicit PRIMARY lane ordering (top→bottom) by lane key. Keys present but
+   * absent here are appended ascending (alpha); the unkeyed lane is always last.
+   * With `laneBy: "node_type"` the keys are type names (Variant-A semantics); with
+   * `laneBy: "repo"` they are repo/project lane keys (see {@link deriveRepoLaneKeys}).
+   * Default: all lanes alpha-sorted.
    */
   laneOrder?: readonly string[];
   /**
    * Horizontal gap LEFT of the timeline where UNTIMED nodes are parked. An
    * untimed node (nullish / non-finite `t`) gets a deterministic x =
    * `-width/2 - untimedGap`, sitting on a "park rail" just left of the oldest
-   * timed node, while keeping its type lane on Y. Default 80.
+   * timed node, while keeping its lane on Y. Default 80.
    */
   untimedGap?: number;
+  /**
+   * Which per-node attribute drives the PRIMARY Y lane:
+   *   • `"node_type"` (DEFAULT) — band by `nodeTypes` (the Variant-A type lanes);
+   *     byte-identical to the historical behaviour.
+   *   • `"repo"` — band by `nodeLanes` (each node's owning REPO/PROJECT), so one
+   *     horizontal lane per project/repo. Intra-repo nodes stay together (loops are
+   *     local) and inter-repo edges span lanes. Requires `nodeLanes`; when it is
+   *     absent every node lands in the single unkeyed lane.
+   */
+  laneBy?: TimeOrientedLaneBy;
+  /**
+   * Per-node PRIMARY lane key (the owning repo/project id), node-order keyed
+   * (parallel to `nodeTimes`). Consumed ONLY when `laneBy === "repo"`. Derive it
+   * from the graph topology with {@link deriveRepoLaneKeys}. A nullish / blank
+   * entry lands in the unkeyed (parked) lane.
+   */
+  nodeLanes?: readonly (string | null | undefined)[];
+  /**
+   * When `"node_type"`, each PRIMARY lane is split into closely-spaced SUB-lines
+   * by `nodeTypes` — a thin stack of the 6 types inside one project/repo lane. The
+   * same type sits at the SAME sub-offset in every primary lane (a global sub-order)
+   * so the sub-lines read across lanes. Off by default (one row per primary lane).
+   */
+  subLaneBy?: TimeOrientedSubLaneBy;
+  /**
+   * Vertical distance between adjacent SUB-lane centres within a primary lane.
+   * Default `laneGap / 8` — intentionally tight so the sub-stack reads as one band
+   * and (for the default `laneGap`) never overlaps the neighbouring primary lane.
+   */
+  subLaneGap?: number;
 }
 
 const DEFAULT_TIME_WIDTH = 1000;
@@ -281,18 +338,27 @@ function finiteTime(value: number | null | undefined): value is number {
  *     When every timed node shares one instant (tMax === tMin) they sit at x = 0.
  *     UNTIMED nodes (nullish / non-finite `t`) are parked deterministically at
  *     x = `-width/2 - untimedGap`, just left of the timeline.
- *   • y = a type LANE centre (one band per distinct type), ordered exactly like
- *     Variant A (`laneOrder` first, then ascending alpha; untyped lane last), so
- *     the time-oriented view is a temporal swimlane. With no `nodeTypes` every
- *     node shares one lane (y = 0).
+ *   • y = a PRIMARY lane centre, ordered deterministically (`laneOrder` first,
+ *     then ascending alpha; the unkeyed lane last). The lane key is chosen by
+ *     `laneBy`:
+ *       – `"node_type"` (DEFAULT) → one band per distinct `nodeTypes` value, a
+ *         temporal swimlane exactly like Variant A. With no `nodeTypes` every node
+ *         shares one lane (y = 0). BYTE-IDENTICAL to the historical behaviour.
+ *       – `"repo"` → one band per `nodeLanes` value (the owning repo/project), so
+ *         intra-repo nodes share a band (loops stay local) and inter-repo edges
+ *         span bands.
+ *     When `subLaneBy === "node_type"` each primary lane is additionally split into
+ *     closely-spaced SUB-lines by `nodeTypes` (a thin 6-type stack inside the lane);
+ *     a global sub-order keeps a given type at the same sub-offset across lanes.
  *
  * Pure, deterministic, O(n) (+ O(L log L) to sort the L ≤ n lanes). Returns a
  * fresh node-order-keyed `Float32Array` of length `2 * nodeTimes.length`.
  *
  * @param nodeTimes per-node interval start (epoch-ms), node-order keyed. A
  *                  nullish / non-finite entry is "untimed".
- * @param nodeTypes optional per-node type, node-order keyed (parallel). Absent ⇒
- *                  one lane (y = 0).
+ * @param nodeTypes optional per-node type, node-order keyed (parallel). Drives the
+ *                  type lanes (`laneBy: "node_type"`) and/or the type sub-lanes
+ *                  (`subLaneBy: "node_type"`). Absent ⇒ one lane (y = 0).
  */
 export function computeTimeOrientedPositions(
   nodeTimes: readonly (number | null | undefined)[],
@@ -330,54 +396,220 @@ export function computeTimeOrientedPositions(
     out[i * 2] = (frac - 0.5) * width;
   }
 
-  // --- Y: type lanes, ordered exactly like Variant A. ---
+  // --- Y: PRIMARY lanes (by type OR repo) + optional type SUB-lanes. ---
+  const laneBy: TimeOrientedLaneBy = options.laneBy ?? "node_type";
+  const subLaneBy = options.subLaneBy;
+  const subLaneGap = options.subLaneGap ?? laneGap / 8;
+
+  // PRIMARY lane key per node: the owning repo (laneBy "repo") or the type.
+  const primaryKeyOf = (i: number): string | null =>
+    laneBy === "repo" ? normalizeType(options.nodeLanes?.[i]) : normalizeType(nodeTypes?.[i]);
+
+  // Bucket node indices by primary key, preserving node order within each lane.
   const buckets = new Map<string, number[]>();
-  const untyped: number[] = [];
+  const unkeyed: number[] = [];
   for (let i = 0; i < n; i++) {
-    const type = normalizeType(nodeTypes?.[i]);
-    if (type === null) {
-      untyped.push(i);
+    const key = primaryKeyOf(i);
+    if (key === null) {
+      unkeyed.push(i);
       continue;
     }
-    let arr = buckets.get(type);
+    let arr = buckets.get(key);
     if (!arr) {
       arr = [];
-      buckets.set(type, arr);
+      buckets.set(key, arr);
     }
     arr.push(i);
   }
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  for (const type of options.laneOrder ?? []) {
-    if (buckets.has(type) && !seen.has(type)) {
-      ordered.push(type);
-      seen.add(type);
-    }
-  }
-  for (const type of [...buckets.keys()].filter((t) => !seen.has(t)).sort()) {
-    ordered.push(type);
-  }
-  const lanes: number[][] = ordered.map((type) => buckets.get(type) as number[]);
-  if (untyped.length > 0) lanes.push(untyped);
-
+  const ordered = orderLaneKeys([...buckets.keys()], options.laneOrder);
+  const lanes: number[][] = ordered.map((key) => buckets.get(key) as number[]);
+  if (unkeyed.length > 0) lanes.push(unkeyed);
   const laneCount = lanes.length;
+
+  // GLOBAL type sub-lane order, so a given type sits at the SAME sub-offset in
+  // every primary lane (the sub-lines read across lanes). Built once over all
+  // nodes; an untyped sub-lane (if any) sorts last. Empty when sub-lanes are off.
+  let subOffsetOf: (i: number) => number = () => 0;
+  if (subLaneBy === "node_type") {
+    const presentTypes = new Set<string>();
+    let hasUntypedSub = false;
+    for (let i = 0; i < n; i++) {
+      const type = normalizeType(nodeTypes?.[i]);
+      if (type === null) hasUntypedSub = true;
+      else presentTypes.add(type);
+    }
+    const subOrder = orderLaneKeys([...presentTypes]);
+    const subIndex = new Map<string, number>();
+    subOrder.forEach((type, idx) => subIndex.set(type, idx));
+    const untypedSubIdx = subOrder.length; // untyped sub-lane after the named ones
+    const subCount = subOrder.length + (hasUntypedSub ? 1 : 0);
+    subOffsetOf = (i: number): number => {
+      const type = normalizeType(nodeTypes?.[i]);
+      const idx = type === null ? untypedSubIdx : (subIndex.get(type) ?? untypedSubIdx);
+      return (idx - (subCount - 1) / 2) * subLaneGap;
+    };
+  }
+
   for (let lane = 0; lane < laneCount; lane++) {
-    // Centre the stack of lanes vertically around y = 0 (single lane ⇒ y = 0).
-    const y = (lane - (laneCount - 1) / 2) * laneGap;
+    // Centre the stack of primary lanes vertically around y = 0 (single lane ⇒ 0).
+    const laneY = (lane - (laneCount - 1) / 2) * laneGap;
     for (const idx of lanes[lane] as number[]) {
-      out[idx * 2 + 1] = y;
+      out[idx * 2 + 1] = laneY + subOffsetOf(idx);
     }
   }
 
   return out;
 }
 
+// ---------------------------------------------------------------------------
+// Repo/project lane derivation — pure graph topology → per-node lane key.
+// ---------------------------------------------------------------------------
+
+/** Minimal node shape {@link deriveRepoLaneKeys} reads (id + `node_type`). */
+export interface RepoLaneNode {
+  id: string;
+  /** The node's type (`node_type` / scene `type`); compared case-insensitively. */
+  type?: string | null;
+}
+
+/** Minimal directed edge shape {@link deriveRepoLaneKeys} reads. */
+export interface RepoLaneEdge {
+  source: string;
+  target: string;
+}
+
+/** Result of {@link deriveRepoLaneKeys}: per-node lane key + a suggested order. */
+export interface RepoLaneResult {
+  /**
+   * Per-node PRIMARY lane key, parallel to the input `nodes`. A Repo/Project node
+   * keys to its OWN id; an Agent keys to {@link AGENT_LANE_KEY}; a
+   * Session/Branch/Commit inherits the repo it reaches first; anything unresolved
+   * is `null` (parked / unkeyed lane). Feed straight to `nodeLanes`.
+   */
+  laneKeys: (string | null)[];
+  /**
+   * Suggested top→bottom PRIMARY lane order for `laneOrder`: repos in graph order
+   * (the rename-lineage / chronological order), then project lanes, then the
+   * single agents lane. Stable + deterministic.
+   */
+  laneOrder: string[];
+}
+
+/** Lane key that GROUPS every Agent node into one shared lane. */
+export const AGENT_LANE_KEY = "__agents__";
+
+const REPO_TYPE = "repo";
+const PROJECT_TYPE = "project";
+const AGENT_TYPE = "agent";
+
+/**
+ * Derive each node's owning REPO/PROJECT lane key from graph topology — the data
+ * `computeTimeOrientedPositions` needs for `laneBy: "repo"`.
+ *
+ * Rules (the agent-stats project-graph shape, but generic):
+ *   • a `Repo`/`Project` node keys to its OWN id (its own lane);
+ *   • every `Agent` node groups into one {@link AGENT_LANE_KEY} lane (agents span
+ *     repos — keeping them in one lane makes their cross-repo edges read as
+ *     lane-spanning rather than polluting a repo lane);
+ *   • a `Session`/`Branch`/`Commit` (anything else) INHERITS a repo by a
+ *     multi-source BFS seeded from every Repo node, over an adjacency that EXCLUDES
+ *     Project + Agent nodes (the cross-repo hubs) so a repo cannot leak through the
+ *     shared project/agent into another repo. Sessions sit one hop from their
+ *     `worked-in` repo; branches/commits two hops via the session that
+ *     touched/produced them. Ties (e.g. a branch shared across rename incarnations)
+ *     resolve to the earliest repo in graph order — deterministic — and the losing
+ *     repo's edge to it then reads as a cross-lane (inter-incarnation) link.
+ *   • unresolved nodes stay `null` (the parked / unkeyed lane).
+ *
+ * Pure & deterministic: O(V + E). Never mutates its inputs.
+ */
+export function deriveRepoLaneKeys(
+  nodes: readonly RepoLaneNode[],
+  edges: readonly RepoLaneEdge[],
+): RepoLaneResult {
+  const n = nodes.length;
+  const laneKeys: (string | null)[] = new Array(n).fill(null);
+  const laneOrder: string[] = [];
+  if (n === 0) return { laneKeys, laneOrder };
+
+  const idToIndex = new Map<string, number>();
+  for (let i = 0; i < n; i++) idToIndex.set(nodes[i]!.id, i);
+
+  const typeOf = (i: number): string => {
+    const t = nodes[i]?.type;
+    return typeof t === "string" ? t.trim().toLowerCase() : "";
+  };
+  const isRepo = (i: number) => typeOf(i) === REPO_TYPE;
+  const isProject = (i: number) => typeOf(i) === PROJECT_TYPE;
+  const isAgent = (i: number) => typeOf(i) === AGENT_TYPE;
+  const isHub = (i: number) => isProject(i) || isAgent(i);
+
+  // Seed special lanes + collect the deterministic lane order.
+  const repoOrder: string[] = [];
+  const projectKeys: string[] = [];
+  let hasAgent = false;
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      repoOrder.push(nodes[i]!.id);
+    } else if (isProject(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      projectKeys.push(nodes[i]!.id);
+    } else if (isAgent(i)) {
+      laneKeys[i] = AGENT_LANE_KEY;
+      hasAgent = true;
+    }
+  }
+
+  // Adjacency EXCLUDING Project + Agent nodes (cross-repo hubs).
+  const adj: number[][] = Array.from({ length: n }, () => []);
+  for (const e of edges) {
+    const a = idToIndex.get(e.source);
+    const b = idToIndex.get(e.target);
+    if (a === undefined || b === undefined) continue;
+    if (isHub(a) || isHub(b)) continue;
+    adj[a]!.push(b);
+    adj[b]!.push(a);
+  }
+
+  // Multi-source BFS from the Repo seeds, enqueued in graph order so equal-distance
+  // ties resolve to the earlier repo.
+  const repoOf: (string | null)[] = new Array(n).fill(null);
+  const queue: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      repoOf[i] = nodes[i]!.id;
+      queue.push(i);
+    }
+  }
+  for (let head = 0; head < queue.length; head++) {
+    const u = queue[head]!;
+    const repo = repoOf[u]!;
+    for (const v of adj[u]!) {
+      if (repoOf[v] === null && !isRepo(v) && !isHub(v)) {
+        repoOf[v] = repo;
+        queue.push(v);
+      }
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    const r = repoOf[i];
+    if (laneKeys[i] === null && r != null) laneKeys[i] = r;
+  }
+
+  laneOrder.push(...repoOrder, ...projectKeys);
+  if (hasAgent) laneOrder.push(AGENT_LANE_KEY);
+  return { laneKeys, laneOrder };
+}
+
 /**
  * Variant E as a {@link LayoutFn}. Reads per-node start times from
  * {@link LayoutOptions.nodeTimes} and optional types from
- * {@link LayoutOptions.nodeTypes} (both node-order keyed). Absent times ⇒ every
- * node untimed (all parked on the left rail); absent types ⇒ one lane. Length
- * always matches `graph.nodeIds.length`.
+ * {@link LayoutOptions.nodeTypes} (both node-order keyed), and forwards the
+ * lane controls (`laneBy` / `nodeLanes` / `subLaneBy`) when present so a caller
+ * can drive repo lanes + type sub-lanes through the registry too. Absent times ⇒
+ * every node untimed (all parked on the left rail); absent types ⇒ one lane.
+ * Length always matches `graph.nodeIds.length`.
  */
 export const timeOrientedLayout: LayoutFn = (graph, options) => {
   const n = graph.nodeIds.length;
@@ -387,7 +619,11 @@ export const timeOrientedLayout: LayoutFn = (graph, options) => {
     const t = times?.[i];
     nodeTimes[i] = finiteTime(t) ? t : null;
   }
-  return computeTimeOrientedPositions(nodeTimes, options?.nodeTypes);
+  const opts: TimeOrientedLayoutOptions = {};
+  if (options?.laneBy !== undefined) opts.laneBy = options.laneBy;
+  if (options?.nodeLanes !== undefined) opts.nodeLanes = options.nodeLanes;
+  if (options?.subLaneBy !== undefined) opts.subLaneBy = options.subLaneBy;
+  return computeTimeOrientedPositions(nodeTimes, options?.nodeTypes, opts);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -157,6 +157,23 @@ export interface LayoutOptions {
    * additive — a nullish / non-finite entry is treated as "untimed".
    */
   nodeTimes?: readonly (number | null | undefined)[];
+  /**
+   * Per-node PRIMARY lane key (the owning repo/project id), node-order keyed.
+   * Consumed by the time-oriented layout when `laneBy === "repo"` to band nodes
+   * into one lane per project/repo; ignored otherwise. Optional & additive.
+   */
+  nodeLanes?: readonly (string | null | undefined)[];
+  /**
+   * Which per-node attribute drives the time-oriented PRIMARY Y lane:
+   * `"node_type"` (default — band by `nodeTypes`) or `"repo"` (band by
+   * `nodeLanes`). Ignored by every other layout.
+   */
+  laneBy?: "node_type" | "repo";
+  /**
+   * When `"node_type"`, the time-oriented layout sub-bands each primary lane into
+   * closely-spaced sub-lines by `nodeTypes`. Ignored by every other layout.
+   */
+  subLaneBy?: "node_type";
 }
 
 export interface LayoutEngine {

--- a/packages/graph/tests/layout-time-oriented.test.ts
+++ b/packages/graph/tests/layout-time-oriented.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AGENT_LANE_KEY,
   buildRenderGraphBuffers,
   computeTimeOrientedPositions,
+  deriveRepoLaneKeys,
   getLayout,
   hasLayout,
   listLayouts,
@@ -120,5 +122,163 @@ describe("Variant E — time-oriented layout", () => {
     expect(xy(out, 2).x).toBeLessThan(xy(out, 0).x);
     // One type ⇒ one lane.
     expect(xy(out, 0).y).toBe(xy(out, 1).y);
+  });
+});
+
+describe("Variant E — lanes by REPO (laneBy: 'repo') + type SUB-lanes", () => {
+  // Two repos (A older lane, B newer lane); types mixed so banding can't be a type
+  // accident. node order: [repoA/Session, repoA/Branch, repoB/Session, repoB/Commit].
+  const times = [T0, T1, T2, T3];
+  const types = ["Session", "Branch", "Session", "Commit"];
+  const lanes = ["repoA", "repoA", "repoB", "repoB"];
+
+  it("bands PRIMARILY by the owning repo, NOT by type", () => {
+    const pos = computeTimeOrientedPositions(times, types, { laneBy: "repo", nodeLanes: lanes });
+    // Same repo ⇒ same y lane (even though types differ); different repo ⇒ different lane.
+    expect(xy(pos, 0).y).toBe(xy(pos, 1).y); // both repoA
+    expect(xy(pos, 2).y).toBe(xy(pos, 3).y); // both repoB
+    expect(xy(pos, 0).y).not.toBe(xy(pos, 2).y); // repoA vs repoB
+  });
+
+  it("still orders nodes by `t` on the X axis under repo lanes", () => {
+    // node order [T2, T0, T3, T1] (NOT chronological) → x increases with t.
+    const t = [T2, T0, T3, T1];
+    const pos = computeTimeOrientedPositions(t, types, { laneBy: "repo", nodeLanes: lanes });
+    const xByT = new Map(t.map((v, i) => [v, xy(pos, i).x]));
+    expect(xByT.get(T0)!).toBeLessThan(xByT.get(T1)!);
+    expect(xByT.get(T1)!).toBeLessThan(xByT.get(T2)!);
+    expect(xByT.get(T2)!).toBeLessThan(xByT.get(T3)!);
+  });
+
+  it("honors laneOrder (top→bottom) for the repo lanes", () => {
+    const pos = computeTimeOrientedPositions(times, types, {
+      laneBy: "repo",
+      nodeLanes: lanes,
+      laneOrder: ["repoB", "repoA"], // repoB on top now
+      laneGap: 100,
+    });
+    expect(xy(pos, 2).y).toBeLessThan(xy(pos, 0).y); // repoB lane above repoA lane
+  });
+
+  it("collapses to one lane when laneBy='repo' but nodeLanes is absent (graceful)", () => {
+    const pos = computeTimeOrientedPositions(times, types, { laneBy: "repo" });
+    for (let i = 1; i < 4; i++) expect(xy(pos, i).y).toBe(xy(pos, 0).y);
+  });
+
+  it("subLaneBy='node_type' splits each repo lane into closely-spaced type sub-lines", () => {
+    const subTypes = ["Session", "Branch", "Session", "Branch"];
+    const pos = computeTimeOrientedPositions(times, subTypes, {
+      laneBy: "repo",
+      nodeLanes: lanes,
+      laneGap: 120,
+      subLaneBy: "node_type",
+    });
+    const y0 = xy(pos, 0).y; // repoA / Session
+    const y1 = xy(pos, 1).y; // repoA / Branch
+    const y2 = xy(pos, 2).y; // repoB / Session
+    const y3 = xy(pos, 3).y; // repoB / Branch
+    // Within a repo lane, the two types now sit on DIFFERENT sub-lines.
+    expect(y0).not.toBe(y1);
+    // The SAME type keeps the SAME sub-offset across lanes (global sub-order):
+    // Session→Session and Branch→Branch differ only by the lane gap.
+    expect(y1 - y0).toBeCloseTo(y3 - y2, 6);
+    // Sub-lane separation is strictly TIGHTER than the primary lane separation.
+    expect(Math.abs(y1 - y0)).toBeLessThan(Math.abs(y2 - y0));
+  });
+
+  it("is deterministic under repo lanes + sub-lanes", () => {
+    const opts = { laneBy: "repo" as const, nodeLanes: lanes, subLaneBy: "node_type" as const };
+    const a = computeTimeOrientedPositions(times, types, opts);
+    const b = computeTimeOrientedPositions(times, types, opts);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+});
+
+describe("deriveRepoLaneKeys — repo membership from graph topology", () => {
+  // A mini agent-stats project graph: one Project, two Repos (rename lineage),
+  // one Agent, two Sessions, a Branch SHARED across both repos, one Commit.
+  const nodes = [
+    { id: "project_p", type: "Project" },
+    { id: "repo_a", type: "Repo" },
+    { id: "repo_b", type: "Repo" },
+    { id: "agent_x", type: "Agent" },
+    { id: "sess_1", type: "Session" },
+    { id: "sess_2", type: "Session" },
+    { id: "branch_shared", type: "Branch" },
+    { id: "commit_1", type: "Commit" },
+  ];
+  const edges = [
+    { source: "repo_a", target: "project_p" }, // belongs-to
+    { source: "repo_b", target: "project_p" },
+    { source: "repo_a", target: "repo_b" }, // rename-lineage
+    { source: "sess_1", target: "repo_a" }, // worked-in
+    { source: "sess_2", target: "repo_b" },
+    { source: "sess_1", target: "agent_x" }, // conducted-by (hub — excluded)
+    { source: "sess_2", target: "agent_x" },
+    { source: "sess_1", target: "branch_shared" }, // touched-branch
+    { source: "sess_2", target: "branch_shared" }, // shared across both repos
+    { source: "sess_1", target: "commit_1" }, // produced
+  ];
+
+  it("keys Repo/Project nodes to their own lane and groups Agents into AGENT_LANE_KEY", () => {
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    expect(byId.get("repo_a")).toBe("repo_a");
+    expect(byId.get("repo_b")).toBe("repo_b");
+    expect(byId.get("project_p")).toBe("project_p");
+    expect(byId.get("agent_x")).toBe(AGENT_LANE_KEY);
+  });
+
+  it("inherits each Session's repo (worked-in) and its Commit's repo (produced)", () => {
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    expect(byId.get("sess_1")).toBe("repo_a");
+    expect(byId.get("sess_2")).toBe("repo_b");
+    expect(byId.get("commit_1")).toBe("repo_a"); // produced by sess_1
+  });
+
+  it("resolves a SHARED branch deterministically to the earliest repo (tie-break)", () => {
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    // branch touched by both sessions → claimed by repo_a (seeded first);
+    // sess_2 (repo_b) → branch_shared then reads as a cross-lane (inter-repo) link.
+    expect(byId.get("branch_shared")).toBe("repo_a");
+  });
+
+  it("does NOT leak a repo across the shared Project/Agent hubs", () => {
+    // If the hubs were traversable, sess_2's repo could bleed into repo_a's nodes.
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    expect(byId.get("sess_2")).toBe("repo_b"); // stayed in its own repo
+  });
+
+  it("suggests a stable laneOrder: repos (graph order) → projects → agents", () => {
+    const { laneOrder } = deriveRepoLaneKeys(nodes, edges);
+    expect(laneOrder).toEqual(["repo_a", "repo_b", "project_p", AGENT_LANE_KEY]);
+  });
+
+  it("feeds straight into computeTimeOrientedPositions as nodeLanes (repo lanes)", () => {
+    const { laneKeys, laneOrder } = deriveRepoLaneKeys(nodes, edges);
+    const nodeTimes = nodes.map((_, i) => T0 + i * 1000);
+    const nodeTypes = nodes.map((nd) => nd.type);
+    const pos = computeTimeOrientedPositions(nodeTimes, nodeTypes, {
+      laneBy: "repo",
+      nodeLanes: laneKeys,
+      laneOrder,
+    });
+    const yById = new Map(nodes.map((nd, i) => [nd.id, xy(pos, i).y]));
+    // sess_1, branch_shared, commit_1 all in the repo_a lane (loops stay local).
+    expect(yById.get("sess_1")).toBe(yById.get("repo_a"));
+    expect(yById.get("branch_shared")).toBe(yById.get("repo_a"));
+    expect(yById.get("commit_1")).toBe(yById.get("repo_a"));
+    // sess_2 in the repo_b lane → its branch_shared edge spans lanes (inter-repo).
+    expect(yById.get("sess_2")).toBe(yById.get("repo_b"));
+    expect(yById.get("sess_2")).not.toBe(yById.get("branch_shared"));
+  });
+
+  it("handles the empty graph", () => {
+    const { laneKeys, laneOrder } = deriveRepoLaneKeys([], []);
+    expect(laneKeys).toEqual([]);
+    expect(laneOrder).toEqual([]);
   });
 });

--- a/src/scene-layout.ts
+++ b/src/scene-layout.ts
@@ -23,6 +23,13 @@
  *                         positions and stamps `layout_id: "time-oriented"` +
  *                         `layout_dims: 2`.
  *
+ * For `time-oriented`, two further env knobs (read by
+ * {@link resolveTimeOrientedSceneOptions}) shape the Y lanes — `GRAPHIFY_LANE_BY=repo`
+ * bands by each node's owning REPO/PROJECT instead of by type (surfacing
+ * inter-project edges across lanes + intra-project loops within a lane), and
+ * `GRAPHIFY_SUBLANE_BY=node_type` splits each lane into 6 tight type sub-lines.
+ * Both unset ⇒ the historical type lanes (byte-identical).
+ *
  * SELECTION (opt-in; default stays force):
  *   • env `GRAPHIFY_LAYOUT=typed-layer` | `time-oriented` — mirrors the existing
  *     `GRAPHIFY_FAST_LAYOUT` opt-in style; read by {@link resolveSceneLayoutId}
@@ -41,8 +48,10 @@
 import {
   computeTimeOrientedPositions,
   computeTypedLayerPositions,
+  deriveRepoLaneKeys,
 } from "./typed-layer-layout.js";
 import type {
+  RepoLaneNode,
   TimeOrientedLayoutOptions,
   TypedLayerLayoutOptions,
 } from "./typed-layer-layout.js";
@@ -95,6 +104,27 @@ export function resolveSceneLayoutId(explicit?: string): SceneLayoutId {
   if (value === "typed-layer") return "typed-layer";
   if (value === "time-oriented") return "time-oriented";
   return "force";
+}
+
+/**
+ * Resolve the Variant-E lane controls from the environment (the export path):
+ *   • `GRAPHIFY_LANE_BY=repo` (or `project`) → primary lanes by owning repo/project;
+ *     `node_type` / `type` → primary lanes by type (the default). Anything else /
+ *     unset ⇒ undefined (→ the layout default `node_type`, byte-identical).
+ *   • `GRAPHIFY_SUBLANE_BY=node_type` (or `type`) → split each primary lane into
+ *     closely-spaced type sub-lines. Unset ⇒ off.
+ * Returns only the keys that were explicitly requested, so an unset environment
+ * yields `{}` and the historical (type-lane) behaviour is preserved.
+ */
+export function resolveTimeOrientedSceneOptions(): TimeOrientedLayoutOptions {
+  const env = typeof process !== "undefined" && process.env ? process.env : {};
+  const laneByRaw = String(env.GRAPHIFY_LANE_BY ?? "").trim().toLowerCase();
+  const subRaw = String(env.GRAPHIFY_SUBLANE_BY ?? "").trim().toLowerCase();
+  const options: TimeOrientedLayoutOptions = {};
+  if (laneByRaw === "repo" || laneByRaw === "project") options.laneBy = "repo";
+  else if (laneByRaw === "node_type" || laneByRaw === "type") options.laneBy = "node_type";
+  if (subRaw === "node_type" || subRaw === "type") options.subLaneBy = "node_type";
+  return options;
 }
 
 /**
@@ -152,7 +182,26 @@ export function attachTimeOrientedPositions<T extends LayoutableScene>(
   const nodeTypes = scene.nodes.map((node) =>
     typeof node.type === "string" && node.type.trim() !== "" ? node.type : null,
   );
-  const positions = computeTimeOrientedPositions(nodeTimes, nodeTypes, options);
+
+  // When laneBy="repo", derive each node's owning repo/project lane from the
+  // graph topology (scene nodes + edges) and band PRIMARILY by it; the optional
+  // type sub-lanes (subLaneBy) still come from node.type. Default (node_type)
+  // skips derivation entirely → byte-identical to the historical behaviour.
+  let layoutOptions: TimeOrientedLayoutOptions = options;
+  if (options.laneBy === "repo") {
+    const laneNodes: RepoLaneNode[] = scene.nodes.map((node) => ({
+      id: node.id,
+      type: typeof node.type === "string" ? node.type : null,
+    }));
+    const { laneKeys, laneOrder } = deriveRepoLaneKeys(laneNodes, scene.edges);
+    layoutOptions = {
+      ...options,
+      nodeLanes: laneKeys,
+      // Stack repo lanes in graph order unless the caller pinned an order.
+      laneOrder: options.laneOrder ?? laneOrder,
+    };
+  }
+  const positions = computeTimeOrientedPositions(nodeTimes, nodeTypes, layoutOptions);
 
   for (let i = 0; i < scene.nodes.length; i++) {
     const node = scene.nodes[i];
@@ -186,7 +235,9 @@ export function applySceneLayout<T extends LayoutableScene>(
     return attachTypedLayerPositions(scene);
   }
   if (layoutId === "time-oriented") {
-    return attachTimeOrientedPositions(scene);
+    // Honour GRAPHIFY_LANE_BY / GRAPHIFY_SUBLANE_BY on the export path (the call
+    // site passes no explicit options); unset ⇒ {} ⇒ type lanes (back-compat).
+    return attachTimeOrientedPositions(scene, resolveTimeOrientedSceneOptions());
   }
   return attachLayoutPositions(scene);
 }

--- a/src/typed-layer-layout.ts
+++ b/src/typed-layer-layout.ts
@@ -49,6 +49,25 @@ function normalizeType(raw: string | null | undefined): string | null {
 }
 
 /**
+ * Deterministic lane ordering shared by the banded layouts: keys named in
+ * `explicit` (and actually present) come first in that order, then every
+ * remaining present key ascending (alpha). Pure; never mutates its inputs.
+ */
+function orderLaneKeys(present: readonly string[], explicit?: readonly string[]): string[] {
+  const presentSet = new Set(present);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const key of explicit ?? []) {
+    if (presentSet.has(key) && !seen.has(key)) {
+      ordered.push(key);
+      seen.add(key);
+    }
+  }
+  for (const key of present.filter((k) => !seen.has(k)).sort()) ordered.push(key);
+  return ordered;
+}
+
+/**
  * Variant A core — place nodes in horizontal bands ("swimlanes") by type.
  *
  *   • one lane per distinct `node_type`; lanes ordered deterministically
@@ -126,6 +145,12 @@ export function computeTypedLayerPositions(
   return out;
 }
 
+/** Which per-node attribute drives the PRIMARY horizontal lane on Y. */
+export type TimeOrientedLaneBy = "node_type" | "repo";
+
+/** Which per-node attribute sub-bands a primary lane into closely-spaced sub-lines. */
+export type TimeOrientedSubLaneBy = "node_type";
+
 /** Tuning for {@link computeTimeOrientedPositions}. */
 export interface TimeOrientedLayoutOptions {
   /**
@@ -134,21 +159,53 @@ export interface TimeOrientedLayoutOptions {
    * right. Default 1000.
    */
   width?: number;
-  /** Vertical distance between adjacent type-lane CENTRES (default 120). */
+  /** Vertical distance between adjacent PRIMARY-lane CENTRES (default 120). */
   laneGap?: number;
   /**
-   * Explicit lane ordering (top→bottom) by type name — identical semantics to
-   * Variant A. Types present but absent here are appended ascending (alpha); the
-   * untyped lane is always last. Default: all lanes alpha-sorted.
+   * Explicit PRIMARY lane ordering (top→bottom) by lane key. Keys present but
+   * absent here are appended ascending (alpha); the unkeyed lane is always last.
+   * With `laneBy: "node_type"` the keys are type names (Variant-A semantics); with
+   * `laneBy: "repo"` they are repo/project lane keys (see {@link deriveRepoLaneKeys}).
+   * Default: all lanes alpha-sorted.
    */
   laneOrder?: readonly string[];
   /**
    * Horizontal gap LEFT of the timeline where UNTIMED nodes are parked. An
    * untimed node (nullish / non-finite `t`) gets a deterministic x =
    * `-width/2 - untimedGap`, sitting on a "park rail" just left of the oldest
-   * timed node, while keeping its type lane on Y. Default 80.
+   * timed node, while keeping its lane on Y. Default 80.
    */
   untimedGap?: number;
+  /**
+   * Which per-node attribute drives the PRIMARY Y lane:
+   *   • `"node_type"` (DEFAULT) — band by `nodeTypes` (the Variant-A type lanes);
+   *     byte-identical to the historical behaviour.
+   *   • `"repo"` — band by `nodeLanes` (each node's owning REPO/PROJECT), so one
+   *     horizontal lane per project/repo. Intra-repo nodes stay together (loops are
+   *     local) and inter-repo edges span lanes. Requires `nodeLanes`; when it is
+   *     absent every node lands in the single unkeyed lane.
+   */
+  laneBy?: TimeOrientedLaneBy;
+  /**
+   * Per-node PRIMARY lane key (the owning repo/project id), node-order keyed
+   * (parallel to `nodeTimes`). Consumed ONLY when `laneBy === "repo"`. Derive it
+   * from the graph topology with {@link deriveRepoLaneKeys}. A nullish / blank
+   * entry lands in the unkeyed (parked) lane.
+   */
+  nodeLanes?: readonly (string | null | undefined)[];
+  /**
+   * When `"node_type"`, each PRIMARY lane is split into closely-spaced SUB-lines
+   * by `nodeTypes` — a thin stack of the 6 types inside one project/repo lane. The
+   * same type sits at the SAME sub-offset in every primary lane (a global sub-order)
+   * so the sub-lines read across lanes. Off by default (one row per primary lane).
+   */
+  subLaneBy?: TimeOrientedSubLaneBy;
+  /**
+   * Vertical distance between adjacent SUB-lane centres within a primary lane.
+   * Default `laneGap / 8` — intentionally tight so the sub-stack reads as one band
+   * and (for the default `laneGap`) never overlaps the neighbouring primary lane.
+   */
+  subLaneGap?: number;
 }
 
 const DEFAULT_TIME_WIDTH = 1000;
@@ -166,18 +223,27 @@ function finiteTime(value: number | null | undefined): value is number {
  *     When every timed node shares one instant (tMax === tMin) they sit at x = 0.
  *     UNTIMED nodes (nullish / non-finite `t`) are parked deterministically at
  *     x = `-width/2 - untimedGap`, just left of the timeline.
- *   • y = a type LANE centre (one band per distinct type), ordered exactly like
- *     Variant A (`laneOrder` first, then ascending alpha; untyped lane last), so
- *     the time-oriented view is a temporal swimlane. With no `nodeTypes` every
- *     node shares one lane (y = 0).
+ *   • y = a PRIMARY lane centre, ordered deterministically (`laneOrder` first,
+ *     then ascending alpha; the unkeyed lane last). The lane key is chosen by
+ *     `laneBy`:
+ *       – `"node_type"` (DEFAULT) → one band per distinct `nodeTypes` value, a
+ *         temporal swimlane exactly like Variant A. With no `nodeTypes` every node
+ *         shares one lane (y = 0). BYTE-IDENTICAL to the historical behaviour.
+ *       – `"repo"` → one band per `nodeLanes` value (the owning repo/project), so
+ *         intra-repo nodes share a band (loops stay local) and inter-repo edges
+ *         span bands.
+ *     When `subLaneBy === "node_type"` each primary lane is additionally split into
+ *     closely-spaced SUB-lines by `nodeTypes` (a thin 6-type stack inside the lane);
+ *     a global sub-order keeps a given type at the same sub-offset across lanes.
  *
  * Pure, deterministic, O(n) (+ O(L log L) to sort the L ≤ n lanes). Returns a
  * fresh node-order-keyed `Float32Array` of length `2 * nodeTimes.length`.
  *
  * @param nodeTimes per-node interval start (epoch-ms), node-order keyed. A
  *                  nullish / non-finite entry is "untimed".
- * @param nodeTypes optional per-node type, node-order keyed (parallel). Absent ⇒
- *                  one lane (y = 0).
+ * @param nodeTypes optional per-node type, node-order keyed (parallel). Drives the
+ *                  type lanes (`laneBy: "node_type"`) and/or the type sub-lanes
+ *                  (`subLaneBy: "node_type"`). Absent ⇒ one lane (y = 0).
  */
 export function computeTimeOrientedPositions(
   nodeTimes: readonly (number | null | undefined)[],
@@ -215,44 +281,209 @@ export function computeTimeOrientedPositions(
     out[i * 2] = (frac - 0.5) * width;
   }
 
-  // --- Y: type lanes, ordered exactly like Variant A. ---
+  // --- Y: PRIMARY lanes (by type OR repo) + optional type SUB-lanes. ---
+  const laneBy: TimeOrientedLaneBy = options.laneBy ?? "node_type";
+  const subLaneBy = options.subLaneBy;
+  const subLaneGap = options.subLaneGap ?? laneGap / 8;
+
+  // PRIMARY lane key per node: the owning repo (laneBy "repo") or the type.
+  const primaryKeyOf = (i: number): string | null =>
+    laneBy === "repo" ? normalizeType(options.nodeLanes?.[i]) : normalizeType(nodeTypes?.[i]);
+
+  // Bucket node indices by primary key, preserving node order within each lane.
   const buckets = new Map<string, number[]>();
-  const untyped: number[] = [];
+  const unkeyed: number[] = [];
   for (let i = 0; i < n; i++) {
-    const type = normalizeType(nodeTypes?.[i]);
-    if (type === null) {
-      untyped.push(i);
+    const key = primaryKeyOf(i);
+    if (key === null) {
+      unkeyed.push(i);
       continue;
     }
-    let arr = buckets.get(type);
+    let arr = buckets.get(key);
     if (!arr) {
       arr = [];
-      buckets.set(type, arr);
+      buckets.set(key, arr);
     }
     arr.push(i);
   }
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  for (const type of options.laneOrder ?? []) {
-    if (buckets.has(type) && !seen.has(type)) {
-      ordered.push(type);
-      seen.add(type);
-    }
-  }
-  for (const type of [...buckets.keys()].filter((t) => !seen.has(t)).sort()) {
-    ordered.push(type);
-  }
-  const lanes: number[][] = ordered.map((type) => buckets.get(type) as number[]);
-  if (untyped.length > 0) lanes.push(untyped);
-
+  const ordered = orderLaneKeys([...buckets.keys()], options.laneOrder);
+  const lanes: number[][] = ordered.map((key) => buckets.get(key) as number[]);
+  if (unkeyed.length > 0) lanes.push(unkeyed);
   const laneCount = lanes.length;
+
+  // GLOBAL type sub-lane order, so a given type sits at the SAME sub-offset in
+  // every primary lane (the sub-lines read across lanes). Built once over all
+  // nodes; an untyped sub-lane (if any) sorts last. Empty when sub-lanes are off.
+  let subOffsetOf: (i: number) => number = () => 0;
+  if (subLaneBy === "node_type") {
+    const presentTypes = new Set<string>();
+    let hasUntypedSub = false;
+    for (let i = 0; i < n; i++) {
+      const type = normalizeType(nodeTypes?.[i]);
+      if (type === null) hasUntypedSub = true;
+      else presentTypes.add(type);
+    }
+    const subOrder = orderLaneKeys([...presentTypes]);
+    const subIndex = new Map<string, number>();
+    subOrder.forEach((type, idx) => subIndex.set(type, idx));
+    const untypedSubIdx = subOrder.length; // untyped sub-lane after the named ones
+    const subCount = subOrder.length + (hasUntypedSub ? 1 : 0);
+    subOffsetOf = (i: number): number => {
+      const type = normalizeType(nodeTypes?.[i]);
+      const idx = type === null ? untypedSubIdx : (subIndex.get(type) ?? untypedSubIdx);
+      return (idx - (subCount - 1) / 2) * subLaneGap;
+    };
+  }
+
   for (let lane = 0; lane < laneCount; lane++) {
-    // Centre the stack of lanes vertically around y = 0 (single lane ⇒ y = 0).
-    const y = (lane - (laneCount - 1) / 2) * laneGap;
+    // Centre the stack of primary lanes vertically around y = 0 (single lane ⇒ 0).
+    const laneY = (lane - (laneCount - 1) / 2) * laneGap;
     for (const idx of lanes[lane] as number[]) {
-      out[idx * 2 + 1] = y;
+      out[idx * 2 + 1] = laneY + subOffsetOf(idx);
     }
   }
 
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Repo/project lane derivation — pure graph topology → per-node lane key.
+// (Vendored alongside the layout cores; KEEP IN SYNC with layout-registry.ts.)
+// ---------------------------------------------------------------------------
+
+/** Minimal node shape {@link deriveRepoLaneKeys} reads (id + `node_type`). */
+export interface RepoLaneNode {
+  id: string;
+  /** The node's type (`node_type` / scene `type`); compared case-insensitively. */
+  type?: string | null;
+}
+
+/** Minimal directed edge shape {@link deriveRepoLaneKeys} reads. */
+export interface RepoLaneEdge {
+  source: string;
+  target: string;
+}
+
+/** Result of {@link deriveRepoLaneKeys}: per-node lane key + a suggested order. */
+export interface RepoLaneResult {
+  /**
+   * Per-node PRIMARY lane key, parallel to the input `nodes`. A Repo/Project node
+   * keys to its OWN id; an Agent keys to {@link AGENT_LANE_KEY}; a
+   * Session/Branch/Commit inherits the repo it reaches first; anything unresolved
+   * is `null` (parked / unkeyed lane). Feed straight to `nodeLanes`.
+   */
+  laneKeys: (string | null)[];
+  /**
+   * Suggested top→bottom PRIMARY lane order for `laneOrder`: repos in graph order
+   * (the rename-lineage / chronological order), then project lanes, then the
+   * single agents lane. Stable + deterministic.
+   */
+  laneOrder: string[];
+}
+
+/** Lane key that GROUPS every Agent node into one shared lane. */
+export const AGENT_LANE_KEY = "__agents__";
+
+const REPO_TYPE = "repo";
+const PROJECT_TYPE = "project";
+const AGENT_TYPE = "agent";
+
+/**
+ * Derive each node's owning REPO/PROJECT lane key from graph topology — the data
+ * `computeTimeOrientedPositions` needs for `laneBy: "repo"`.
+ *
+ * Rules (the agent-stats project-graph shape, but generic):
+ *   • a `Repo`/`Project` node keys to its OWN id (its own lane);
+ *   • every `Agent` node groups into one {@link AGENT_LANE_KEY} lane (agents span
+ *     repos — keeping them in one lane makes their cross-repo edges read as
+ *     lane-spanning rather than polluting a repo lane);
+ *   • a `Session`/`Branch`/`Commit` (anything else) INHERITS a repo by a
+ *     multi-source BFS seeded from every Repo node, over an adjacency that EXCLUDES
+ *     Project + Agent nodes (the cross-repo hubs) so a repo cannot leak through the
+ *     shared project/agent into another repo. Sessions sit one hop from their
+ *     `worked-in` repo; branches/commits two hops via the session that
+ *     touched/produced them. Ties (e.g. a branch shared across rename incarnations)
+ *     resolve to the earliest repo in graph order — deterministic — and the losing
+ *     repo's edge to it then reads as a cross-lane (inter-incarnation) link.
+ *   • unresolved nodes stay `null` (the parked / unkeyed lane).
+ *
+ * Pure & deterministic: O(V + E). Never mutates its inputs.
+ */
+export function deriveRepoLaneKeys(
+  nodes: readonly RepoLaneNode[],
+  edges: readonly RepoLaneEdge[],
+): RepoLaneResult {
+  const n = nodes.length;
+  const laneKeys: (string | null)[] = new Array(n).fill(null);
+  const laneOrder: string[] = [];
+  if (n === 0) return { laneKeys, laneOrder };
+
+  const idToIndex = new Map<string, number>();
+  for (let i = 0; i < n; i++) idToIndex.set(nodes[i]!.id, i);
+
+  const typeOf = (i: number): string => {
+    const t = nodes[i]?.type;
+    return typeof t === "string" ? t.trim().toLowerCase() : "";
+  };
+  const isRepo = (i: number) => typeOf(i) === REPO_TYPE;
+  const isProject = (i: number) => typeOf(i) === PROJECT_TYPE;
+  const isAgent = (i: number) => typeOf(i) === AGENT_TYPE;
+  const isHub = (i: number) => isProject(i) || isAgent(i);
+
+  // Seed special lanes + collect the deterministic lane order.
+  const repoOrder: string[] = [];
+  const projectKeys: string[] = [];
+  let hasAgent = false;
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      repoOrder.push(nodes[i]!.id);
+    } else if (isProject(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      projectKeys.push(nodes[i]!.id);
+    } else if (isAgent(i)) {
+      laneKeys[i] = AGENT_LANE_KEY;
+      hasAgent = true;
+    }
+  }
+
+  // Adjacency EXCLUDING Project + Agent nodes (cross-repo hubs).
+  const adj: number[][] = Array.from({ length: n }, () => []);
+  for (const e of edges) {
+    const a = idToIndex.get(e.source);
+    const b = idToIndex.get(e.target);
+    if (a === undefined || b === undefined) continue;
+    if (isHub(a) || isHub(b)) continue;
+    adj[a]!.push(b);
+    adj[b]!.push(a);
+  }
+
+  // Multi-source BFS from the Repo seeds, enqueued in graph order so equal-distance
+  // ties resolve to the earlier repo.
+  const repoOf: (string | null)[] = new Array(n).fill(null);
+  const queue: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      repoOf[i] = nodes[i]!.id;
+      queue.push(i);
+    }
+  }
+  for (let head = 0; head < queue.length; head++) {
+    const u = queue[head]!;
+    const repo = repoOf[u]!;
+    for (const v of adj[u]!) {
+      if (repoOf[v] === null && !isRepo(v) && !isHub(v)) {
+        repoOf[v] = repo;
+        queue.push(v);
+      }
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    const r = repoOf[i];
+    if (laneKeys[i] === null && r != null) laneKeys[i] = r;
+  }
+
+  laneOrder.push(...repoOrder, ...projectKeys);
+  if (hasAgent) laneOrder.push(AGENT_LANE_KEY);
+  return { laneKeys, laneOrder };
 }

--- a/tests/scene-time-oriented.test.ts
+++ b/tests/scene-time-oriented.test.ts
@@ -4,6 +4,7 @@ import {
   applySceneLayout,
   attachTimeOrientedPositions,
   resolveSceneLayoutId,
+  resolveTimeOrientedSceneOptions,
 } from "../src/scene-layout.js";
 import { buildStudioScene, type StudioSceneGraphLike } from "../src/studio-scene.js";
 
@@ -106,5 +107,128 @@ describe("resolveSceneLayoutId — time-oriented opt-in (default stays force)", 
   it("an explicit arg overrides the env", () => {
     process.env.GRAPHIFY_LAYOUT = "time-oriented";
     expect(resolveSceneLayoutId("force")).toBe("force");
+  });
+});
+
+// A mini agent-stats PROJECT graph: 1 Project, 2 Repos (rename lineage), 1 Agent,
+// 2 Sessions, a Branch + Commit owned by repoA's session. buildStudioScene carries
+// `type` (from node_type) + `t` onto scene nodes; the derivation reads scene edges.
+const T_JAN = Date.UTC(2026, 0, 1);
+const T_FEB = Date.UTC(2026, 1, 1);
+const T_MAR = Date.UTC(2026, 2, 1);
+const T_APR = Date.UTC(2026, 3, 1);
+const PROJECT_GRAPH: StudioSceneGraphLike = {
+  nodes: [
+    { id: "proj", label: "Project", type: "Project" },
+    { id: "repo_a", label: "repoA", type: "Repo" },
+    { id: "repo_b", label: "repoB", type: "Repo" },
+    { id: "agent_1", label: "agent", type: "Agent" },
+    { id: "sess_a", label: "sa", type: "Session", t: T_JAN },
+    { id: "branch_a", label: "ba", type: "Branch", t: T_FEB },
+    { id: "commit_a", label: "ca", type: "Commit", t: T_APR },
+    { id: "sess_b", label: "sb", type: "Session", t: T_MAR },
+  ],
+  links: [
+    { source: "repo_a", target: "proj", relation: "belongs-to" },
+    { source: "repo_b", target: "proj", relation: "belongs-to" },
+    { source: "repo_a", target: "repo_b", relation: "rename-lineage" },
+    { source: "sess_a", target: "repo_a", relation: "worked-in" },
+    { source: "sess_b", target: "repo_b", relation: "worked-in" },
+    { source: "sess_a", target: "agent_1", relation: "conducted-by" },
+    { source: "sess_b", target: "agent_1", relation: "conducted-by" },
+    { source: "sess_a", target: "branch_a", relation: "touched-branch" },
+    { source: "sess_a", target: "commit_a", relation: "produced" },
+  ],
+};
+
+describe("scene Variant E — lanes by REPO (laneBy: 'repo')", () => {
+  it("bands each node into its owning repo lane (intra-repo nodes share a band)", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)), {
+      laneBy: "repo",
+    });
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y]));
+    // repoA's session + the branch/commit it owns all sit in ONE lane (loops local).
+    expect(y.get("sess_a")).toBe(y.get("repo_a"));
+    expect(y.get("branch_a")).toBe(y.get("repo_a"));
+    expect(y.get("commit_a")).toBe(y.get("repo_a"));
+    // repoB's session sits in a DIFFERENT lane → inter-repo edges span lanes.
+    expect(y.get("sess_b")).toBe(y.get("repo_b"));
+    expect(y.get("repo_a")).not.toBe(y.get("repo_b"));
+    // The Agent groups into its own lane, distinct from both repos.
+    expect(y.get("agent_1")).not.toBe(y.get("repo_a"));
+    expect(y.get("agent_1")).not.toBe(y.get("repo_b"));
+  });
+
+  it("still orders timed nodes by `t` on X under repo lanes", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)), {
+      laneBy: "repo",
+    });
+    const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+    // sess_a (Jan) older than sess_b (Mar) → x(sess_a) < x(sess_b).
+    expect(byId.get("sess_a")!.x!).toBeLessThan(byId.get("sess_b")!.x!);
+    for (const n of scene.nodes) {
+      expect(n.fx).toBe(n.x);
+      expect(n.fy).toBe(n.y);
+    }
+  });
+
+  it("subLaneBy='node_type' splits a repo lane into closely-spaced type sub-lines", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)), {
+      laneBy: "repo",
+      subLaneBy: "node_type",
+    });
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y!]));
+    // Inside repoA's lane the three types now sit on distinct sub-lines.
+    const ys = [y.get("sess_a")!, y.get("branch_a")!, y.get("commit_a")!];
+    expect(new Set(ys).size).toBe(3);
+    // …but they stay CLOSE: the sub-spread within repoA is tighter than the gap
+    // to repoB's lane.
+    const subSpread = Math.max(...ys) - Math.min(...ys);
+    const laneGap = Math.abs(y.get("repo_b")! - y.get("repo_a")!);
+    expect(subSpread).toBeLessThan(laneGap);
+  });
+
+  it("DEFAULT (no options) still bands by TYPE — back-compat for the project graph", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)));
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y]));
+    // Both Sessions share the type lane regardless of repo.
+    expect(y.get("sess_a")).toBe(y.get("sess_b"));
+    expect(y.get("sess_a")).not.toBe(y.get("branch_a"));
+  });
+});
+
+describe("resolveTimeOrientedSceneOptions — env-driven lane controls", () => {
+  const priorLane = process.env.GRAPHIFY_LANE_BY;
+  const priorSub = process.env.GRAPHIFY_SUBLANE_BY;
+  afterEach(() => {
+    if (priorLane === undefined) delete process.env.GRAPHIFY_LANE_BY;
+    else process.env.GRAPHIFY_LANE_BY = priorLane;
+    if (priorSub === undefined) delete process.env.GRAPHIFY_SUBLANE_BY;
+    else process.env.GRAPHIFY_SUBLANE_BY = priorSub;
+  });
+
+  it("returns {} (type lanes, byte-identical default) when unset", () => {
+    delete process.env.GRAPHIFY_LANE_BY;
+    delete process.env.GRAPHIFY_SUBLANE_BY;
+    expect(resolveTimeOrientedSceneOptions()).toEqual({});
+  });
+
+  it("maps GRAPHIFY_LANE_BY=repo|project → laneBy:'repo' and the sub-lane flag", () => {
+    process.env.GRAPHIFY_LANE_BY = "repo";
+    process.env.GRAPHIFY_SUBLANE_BY = "node_type";
+    expect(resolveTimeOrientedSceneOptions()).toEqual({ laneBy: "repo", subLaneBy: "node_type" });
+    process.env.GRAPHIFY_LANE_BY = "PROJECT";
+    expect(resolveTimeOrientedSceneOptions().laneBy).toBe("repo");
+  });
+
+  it("applySceneLayout('time-oriented') honors GRAPHIFY_LANE_BY=repo on the export path", () => {
+    process.env.GRAPHIFY_LANE_BY = "repo";
+    delete process.env.GRAPHIFY_SUBLANE_BY;
+    const scene = applySceneLayout(buildStudioScene(clone(PROJECT_GRAPH)), "time-oriented");
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y]));
+    // Repo lanes (not type lanes): the two Sessions land in DIFFERENT lanes.
+    expect(y.get("sess_a")).not.toBe(y.get("sess_b"));
+    expect(y.get("sess_a")).toBe(y.get("repo_a"));
+    expect(scene.layout_id).toBe("time-oriented");
   });
 });


### PR DESCRIPTION
## Why

Principal feedback on the current time-oriented view (which lanes by `node_type`):

> *la décomposition en ligne ne doit PAS se faire par type, mais plutôt par
> PROJET/REPO. Éventuellement chaque ligne projet décomposée en ses 6 types (6
> sous-lignes rapprochées). Ce qui est intéressant c'est les LIENS INTER-PROJETS,
> et au sein du projet les éventuelles BOUCLES sur des features.*

So the primary Y lane becomes the node's owning **repo/project**, each lane can be
split into its **6 type sub-lines**, and the layout is arranged so **inter-project
edges cross lanes** and **intra-project loops stay local** within a lane.

## What changed (scene-layer + layout-registry only — no renderer/shader change)

**`packages/graph/src/layout-registry.ts`** (canonical) + vendored mirror
**`src/typed-layer-layout.ts`**:
- `computeTimeOrientedPositions` Y-banding generalized to a **PRIMARY lane key**
  (`laneBy: "node_type"` default | `"repo"` via `nodeLanes`) plus an optional
  `subLaneBy: "node_type"` that splits each lane into closely-spaced type sub-lines
  on a **global sub-order** (same type → same sub-offset across lanes). `layout-registry.ts:406` (primary key), `:433` (sub-lanes). X (time) unchanged; default path **byte-identical**.
- **`deriveRepoLaneKeys(nodes, edges)`** — pure O(V+E) graph-topology → per-node repo
  lane key (`layout-registry.ts:526`, vendored `typed-layer-layout.ts:412`). Repo/Project
  keep their own lane; Agents group into one `AGENT_LANE_KEY` lane (`:499`);
  Session/Branch/Commit **inherit a repo** via a multi-source BFS from the Repo seeds
  (`:575`) over an adjacency that **excludes the Project/Agent hubs** (no cross-repo
  leak); ties resolve to the earliest repo → the loser's edge then reads as cross-lane.
- `LayoutOptions` gains `nodeLanes` / `laneBy` / `subLaneBy`; the registry `LayoutFn`
  forwards them.

**`src/scene-layout.ts`**:
- `attachTimeOrientedPositions(scene, opts)` — when `laneBy: "repo"`, derives the repo
  lane per node from `scene.nodes` + `scene.edges` and bands by it (`:191`–`:196`);
  type sub-lanes still come from `node.type`. Default skips derivation → byte-identical.
- `resolveTimeOrientedSceneOptions()` (`:119`) reads `GRAPHIFY_LANE_BY=repo|project`
  and `GRAPHIFY_SUBLANE_BY=node_type` on the export path (`applySceneLayout`, `:240`);
  both unset ⇒ historical type lanes. **studio-export.ts untouched.**

## How a node's repo is derived

`Repo`/`Project` → own lane; `Agent` → one shared `__agents__` lane;
`Session` → its `worked-in` Repo (1 hop); `Branch`/`Commit` → the repo of the session
that `touched`/`produced` it (2 hops), via multi-source BFS that never traverses the
shared Project/Agent hubs. Deterministic tie-break = earliest repo in graph order.

## Verification

- `npm run build` ✅ exit 0 · `npm run lint` (tsc --noEmit) ✅ exit 0
- `@sentropic/graph` package: **196 tests** ✅ (+13: repo lanes, type sub-lanes,
  X-by-t under lanes, `deriveRepoLaneKeys`, shared-branch tie-break, determinism)
- `tests/scene-time-oriented.test.ts`: **17 tests** ✅ (+9: repo lanes on a mini
  project graph, X-by-t, sub-lanes, type-lane back-compat, env resolver, export path)
- `git diff --name-only` = layout-registry / types / scene-layout / typed-layer-layout
  + the two test files **only** → no renderer/shader → **golden stays green**.
- Pre-existing `tests/agent-stats.test.ts` (2 path/transcript-fixture failures) are
  unrelated — they fail identically on clean `main` (e0eb9b6).

## UAT (for the principal's verdict)

A refreshed agent-stats UAT lives at **`.graphify/uat/time-oriented-v2/`** (gitignored,
not in this diff) — the real 1062-node / 583-session graph re-exported with the new
layout, plus **real headless screenshots** `render.png` (repo lanes) and
`render-sublanes.png` (repo lanes + type sub-lanes). Data check: **5 clean Y bands**
(3 repos + Project + Agents), **0/79 800 X-by-t inversions**; sub-lanes → **12 bands**.
Serve: `node .graphify/uat/time-oriented-v2/serve.mjs .graphify/uat/time-oriented-v2/studio 8887`
— **let it settle ~20 s** (camera fit over 1062 nodes) before judging the lanes.

## ⚠️ Do NOT merge

The visual needs the principal's verdict via the UAT first.