### PR TITLE
feat(view): time-oriented inflected S-edges + lanes by project/repo

### DIFF
--- a/packages/graph/src/layout-registry.ts
+++ b/packages/graph/src/layout-registry.ts
@@ -145,6 +145,25 @@ function normalizeType(raw: string | null | undefined): string | null {
 }
 
 /**
+ * Deterministic lane ordering shared by the banded layouts: keys named in
+ * `explicit` (and actually present) come first in that order, then every
+ * remaining present key ascending (alpha). Pure; never mutates its inputs.
+ */
+function orderLaneKeys(present: readonly string[], explicit?: readonly string[]): string[] {
+  const presentSet = new Set(present);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const key of explicit ?? []) {
+    if (presentSet.has(key) && !seen.has(key)) {
+      ordered.push(key);
+      seen.add(key);
+    }
+  }
+  for (const key of present.filter((k) => !seen.has(k)).sort()) ordered.push(key);
+  return ordered;
+}
+
+/**
  * Variant A core — place nodes in horizontal bands ("swimlanes") by type.
  *
  *   • one lane per distinct `node_type`; lanes ordered deterministically
@@ -241,6 +260,12 @@ export const typedLayerLayout: LayoutFn = (graph, options) => {
 // Variant E — time-oriented layout (deterministic, O(n)). X = normalized time.
 // ---------------------------------------------------------------------------
 
+/** Which per-node attribute drives the PRIMARY horizontal lane on Y. */
+export type TimeOrientedLaneBy = "node_type" | "repo";
+
+/** Which per-node attribute sub-bands a primary lane into closely-spaced sub-lines. */
+export type TimeOrientedSubLaneBy = "node_type";
+
 /** Tuning for {@link computeTimeOrientedPositions}. */
 export interface TimeOrientedLayoutOptions {
   /**
@@ -249,21 +274,53 @@ export interface TimeOrientedLayoutOptions {
    * right. Default 1000.
    */
   width?: number;
-  /** Vertical distance between adjacent type-lane CENTRES (default 120). */
+  /** Vertical distance between adjacent PRIMARY-lane CENTRES (default 120). */
   laneGap?: number;
   /**
-   * Explicit lane ordering (top→bottom) by type name — identical semantics to
-   * Variant A. Types present but absent here are appended ascending (alpha); the
-   * untyped lane is always last. Default: all lanes alpha-sorted.
+   * Explicit PRIMARY lane ordering (top→bottom) by lane key. Keys present but
+   * absent here are appended ascending (alpha); the unkeyed lane is always last.
+   * With `laneBy: "node_type"` the keys are type names (Variant-A semantics); with
+   * `laneBy: "repo"` they are repo/project lane keys (see {@link deriveRepoLaneKeys}).
+   * Default: all lanes alpha-sorted.
    */
   laneOrder?: readonly string[];
   /**
    * Horizontal gap LEFT of the timeline where UNTIMED nodes are parked. An
    * untimed node (nullish / non-finite `t`) gets a deterministic x =
    * `-width/2 - untimedGap`, sitting on a "park rail" just left of the oldest
-   * timed node, while keeping its type lane on Y. Default 80.
+   * timed node, while keeping its lane on Y. Default 80.
    */
   untimedGap?: number;
+  /**
+   * Which per-node attribute drives the PRIMARY Y lane:
+   *   • `"node_type"` (DEFAULT) — band by `nodeTypes` (the Variant-A type lanes);
+   *     byte-identical to the historical behaviour.
+   *   • `"repo"` — band by `nodeLanes` (each node's owning REPO/PROJECT), so one
+   *     horizontal lane per project/repo. Intra-repo nodes stay together (loops are
+   *     local) and inter-repo edges span lanes. Requires `nodeLanes`; when it is
+   *     absent every node lands in the single unkeyed lane.
+   */
+  laneBy?: TimeOrientedLaneBy;
+  /**
+   * Per-node PRIMARY lane key (the owning repo/project id), node-order keyed
+   * (parallel to `nodeTimes`). Consumed ONLY when `laneBy === "repo"`. Derive it
+   * from the graph topology with {@link deriveRepoLaneKeys}. A nullish / blank
+   * entry lands in the unkeyed (parked) lane.
+   */
+  nodeLanes?: readonly (string | null | undefined)[];
+  /**
+   * When `"node_type"`, each PRIMARY lane is split into closely-spaced SUB-lines
+   * by `nodeTypes` — a thin stack of the 6 types inside one project/repo lane. The
+   * same type sits at the SAME sub-offset in every primary lane (a global sub-order)
+   * so the sub-lines read across lanes. Off by default (one row per primary lane).
+   */
+  subLaneBy?: TimeOrientedSubLaneBy;
+  /**
+   * Vertical distance between adjacent SUB-lane centres within a primary lane.
+   * Default `laneGap / 8` — intentionally tight so the sub-stack reads as one band
+   * and (for the default `laneGap`) never overlaps the neighbouring primary lane.
+   */
+  subLaneGap?: number;
 }
 
 const DEFAULT_TIME_WIDTH = 1000;
@@ -281,18 +338,27 @@ function finiteTime(value: number | null | undefined): value is number {
  *     When every timed node shares one instant (tMax === tMin) they sit at x = 0.
  *     UNTIMED nodes (nullish / non-finite `t`) are parked deterministically at
  *     x = `-width/2 - untimedGap`, just left of the timeline.
- *   • y = a type LANE centre (one band per distinct type), ordered exactly like
- *     Variant A (`laneOrder` first, then ascending alpha; untyped lane last), so
- *     the time-oriented view is a temporal swimlane. With no `nodeTypes` every
- *     node shares one lane (y = 0).
+ *   • y = a PRIMARY lane centre, ordered deterministically (`laneOrder` first,
+ *     then ascending alpha; the unkeyed lane last). The lane key is chosen by
+ *     `laneBy`:
+ *       – `"node_type"` (DEFAULT) → one band per distinct `nodeTypes` value, a
+ *         temporal swimlane exactly like Variant A. With no `nodeTypes` every node
+ *         shares one lane (y = 0). BYTE-IDENTICAL to the historical behaviour.
+ *       – `"repo"` → one band per `nodeLanes` value (the owning repo/project), so
+ *         intra-repo nodes share a band (loops stay local) and inter-repo edges
+ *         span bands.
+ *     When `subLaneBy === "node_type"` each primary lane is additionally split into
+ *     closely-spaced SUB-lines by `nodeTypes` (a thin 6-type stack inside the lane);
+ *     a global sub-order keeps a given type at the same sub-offset across lanes.
  *
  * Pure, deterministic, O(n) (+ O(L log L) to sort the L ≤ n lanes). Returns a
  * fresh node-order-keyed `Float32Array` of length `2 * nodeTimes.length`.
  *
  * @param nodeTimes per-node interval start (epoch-ms), node-order keyed. A
  *                  nullish / non-finite entry is "untimed".
- * @param nodeTypes optional per-node type, node-order keyed (parallel). Absent ⇒
- *                  one lane (y = 0).
+ * @param nodeTypes optional per-node type, node-order keyed (parallel). Drives the
+ *                  type lanes (`laneBy: "node_type"`) and/or the type sub-lanes
+ *                  (`subLaneBy: "node_type"`). Absent ⇒ one lane (y = 0).
  */
 export function computeTimeOrientedPositions(
   nodeTimes: readonly (number | null | undefined)[],
@@ -330,54 +396,220 @@ export function computeTimeOrientedPositions(
     out[i * 2] = (frac - 0.5) * width;
   }
 
-  // --- Y: type lanes, ordered exactly like Variant A. ---
+  // --- Y: PRIMARY lanes (by type OR repo) + optional type SUB-lanes. ---
+  const laneBy: TimeOrientedLaneBy = options.laneBy ?? "node_type";
+  const subLaneBy = options.subLaneBy;
+  const subLaneGap = options.subLaneGap ?? laneGap / 8;
+
+  // PRIMARY lane key per node: the owning repo (laneBy "repo") or the type.
+  const primaryKeyOf = (i: number): string | null =>
+    laneBy === "repo" ? normalizeType(options.nodeLanes?.[i]) : normalizeType(nodeTypes?.[i]);
+
+  // Bucket node indices by primary key, preserving node order within each lane.
   const buckets = new Map<string, number[]>();
-  const untyped: number[] = [];
+  const unkeyed: number[] = [];
   for (let i = 0; i < n; i++) {
-    const type = normalizeType(nodeTypes?.[i]);
-    if (type === null) {
-      untyped.push(i);
+    const key = primaryKeyOf(i);
+    if (key === null) {
+      unkeyed.push(i);
       continue;
     }
-    let arr = buckets.get(type);
+    let arr = buckets.get(key);
     if (!arr) {
       arr = [];
-      buckets.set(type, arr);
+      buckets.set(key, arr);
     }
     arr.push(i);
   }
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  for (const type of options.laneOrder ?? []) {
-    if (buckets.has(type) && !seen.has(type)) {
-      ordered.push(type);
-      seen.add(type);
-    }
-  }
-  for (const type of [...buckets.keys()].filter((t) => !seen.has(t)).sort()) {
-    ordered.push(type);
-  }
-  const lanes: number[][] = ordered.map((type) => buckets.get(type) as number[]);
-  if (untyped.length > 0) lanes.push(untyped);
-
+  const ordered = orderLaneKeys([...buckets.keys()], options.laneOrder);
+  const lanes: number[][] = ordered.map((key) => buckets.get(key) as number[]);
+  if (unkeyed.length > 0) lanes.push(unkeyed);
   const laneCount = lanes.length;
+
+  // GLOBAL type sub-lane order, so a given type sits at the SAME sub-offset in
+  // every primary lane (the sub-lines read across lanes). Built once over all
+  // nodes; an untyped sub-lane (if any) sorts last. Empty when sub-lanes are off.
+  let subOffsetOf: (i: number) => number = () => 0;
+  if (subLaneBy === "node_type") {
+    const presentTypes = new Set<string>();
+    let hasUntypedSub = false;
+    for (let i = 0; i < n; i++) {
+      const type = normalizeType(nodeTypes?.[i]);
+      if (type === null) hasUntypedSub = true;
+      else presentTypes.add(type);
+    }
+    const subOrder = orderLaneKeys([...presentTypes]);
+    const subIndex = new Map<string, number>();
+    subOrder.forEach((type, idx) => subIndex.set(type, idx));
+    const untypedSubIdx = subOrder.length; // untyped sub-lane after the named ones
+    const subCount = subOrder.length + (hasUntypedSub ? 1 : 0);
+    subOffsetOf = (i: number): number => {
+      const type = normalizeType(nodeTypes?.[i]);
+      const idx = type === null ? untypedSubIdx : (subIndex.get(type) ?? untypedSubIdx);
+      return (idx - (subCount - 1) / 2) * subLaneGap;
+    };
+  }
+
   for (let lane = 0; lane < laneCount; lane++) {
-    // Centre the stack of lanes vertically around y = 0 (single lane ⇒ y = 0).
-    const y = (lane - (laneCount - 1) / 2) * laneGap;
+    // Centre the stack of primary lanes vertically around y = 0 (single lane ⇒ 0).
+    const laneY = (lane - (laneCount - 1) / 2) * laneGap;
     for (const idx of lanes[lane] as number[]) {
-      out[idx * 2 + 1] = y;
+      out[idx * 2 + 1] = laneY + subOffsetOf(idx);
     }
   }
 
   return out;
 }
 
+// ---------------------------------------------------------------------------
+// Repo/project lane derivation — pure graph topology → per-node lane key.
+// ---------------------------------------------------------------------------
+
+/** Minimal node shape {@link deriveRepoLaneKeys} reads (id + `node_type`). */
+export interface RepoLaneNode {
+  id: string;
+  /** The node's type (`node_type` / scene `type`); compared case-insensitively. */
+  type?: string | null;
+}
+
+/** Minimal directed edge shape {@link deriveRepoLaneKeys} reads. */
+export interface RepoLaneEdge {
+  source: string;
+  target: string;
+}
+
+/** Result of {@link deriveRepoLaneKeys}: per-node lane key + a suggested order. */
+export interface RepoLaneResult {
+  /**
+   * Per-node PRIMARY lane key, parallel to the input `nodes`. A Repo/Project node
+   * keys to its OWN id; an Agent keys to {@link AGENT_LANE_KEY}; a
+   * Session/Branch/Commit inherits the repo it reaches first; anything unresolved
+   * is `null` (parked / unkeyed lane). Feed straight to `nodeLanes`.
+   */
+  laneKeys: (string | null)[];
+  /**
+   * Suggested top→bottom PRIMARY lane order for `laneOrder`: repos in graph order
+   * (the rename-lineage / chronological order), then project lanes, then the
+   * single agents lane. Stable + deterministic.
+   */
+  laneOrder: string[];
+}
+
+/** Lane key that GROUPS every Agent node into one shared lane. */
+export const AGENT_LANE_KEY = "__agents__";
+
+const REPO_TYPE = "repo";
+const PROJECT_TYPE = "project";
+const AGENT_TYPE = "agent";
+
+/**
+ * Derive each node's owning REPO/PROJECT lane key from graph topology — the data
+ * `computeTimeOrientedPositions` needs for `laneBy: "repo"`.
+ *
+ * Rules (the agent-stats project-graph shape, but generic):
+ *   • a `Repo`/`Project` node keys to its OWN id (its own lane);
+ *   • every `Agent` node groups into one {@link AGENT_LANE_KEY} lane (agents span
+ *     repos — keeping them in one lane makes their cross-repo edges read as
+ *     lane-spanning rather than polluting a repo lane);
+ *   • a `Session`/`Branch`/`Commit` (anything else) INHERITS a repo by a
+ *     multi-source BFS seeded from every Repo node, over an adjacency that EXCLUDES
+ *     Project + Agent nodes (the cross-repo hubs) so a repo cannot leak through the
+ *     shared project/agent into another repo. Sessions sit one hop from their
+ *     `worked-in` repo; branches/commits two hops via the session that
+ *     touched/produced them. Ties (e.g. a branch shared across rename incarnations)
+ *     resolve to the earliest repo in graph order — deterministic — and the losing
+ *     repo's edge to it then reads as a cross-lane (inter-incarnation) link.
+ *   • unresolved nodes stay `null` (the parked / unkeyed lane).
+ *
+ * Pure & deterministic: O(V + E). Never mutates its inputs.
+ */
+export function deriveRepoLaneKeys(
+  nodes: readonly RepoLaneNode[],
+  edges: readonly RepoLaneEdge[],
+): RepoLaneResult {
+  const n = nodes.length;
+  const laneKeys: (string | null)[] = new Array(n).fill(null);
+  const laneOrder: string[] = [];
+  if (n === 0) return { laneKeys, laneOrder };
+
+  const idToIndex = new Map<string, number>();
+  for (let i = 0; i < n; i++) idToIndex.set(nodes[i]!.id, i);
+
+  const typeOf = (i: number): string => {
+    const t = nodes[i]?.type;
+    return typeof t === "string" ? t.trim().toLowerCase() : "";
+  };
+  const isRepo = (i: number) => typeOf(i) === REPO_TYPE;
+  const isProject = (i: number) => typeOf(i) === PROJECT_TYPE;
+  const isAgent = (i: number) => typeOf(i) === AGENT_TYPE;
+  const isHub = (i: number) => isProject(i) || isAgent(i);
+
+  // Seed special lanes + collect the deterministic lane order.
+  const repoOrder: string[] = [];
+  const projectKeys: string[] = [];
+  let hasAgent = false;
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      repoOrder.push(nodes[i]!.id);
+    } else if (isProject(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      projectKeys.push(nodes[i]!.id);
+    } else if (isAgent(i)) {
+      laneKeys[i] = AGENT_LANE_KEY;
+      hasAgent = true;
+    }
+  }
+
+  // Adjacency EXCLUDING Project + Agent nodes (cross-repo hubs).
+  const adj: number[][] = Array.from({ length: n }, () => []);
+  for (const e of edges) {
+    const a = idToIndex.get(e.source);
+    const b = idToIndex.get(e.target);
+    if (a === undefined || b === undefined) continue;
+    if (isHub(a) || isHub(b)) continue;
+    adj[a]!.push(b);
+    adj[b]!.push(a);
+  }
+
+  // Multi-source BFS from the Repo seeds, enqueued in graph order so equal-distance
+  // ties resolve to the earlier repo.
+  const repoOf: (string | null)[] = new Array(n).fill(null);
+  const queue: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      repoOf[i] = nodes[i]!.id;
+      queue.push(i);
+    }
+  }
+  for (let head = 0; head < queue.length; head++) {
+    const u = queue[head]!;
+    const repo = repoOf[u]!;
+    for (const v of adj[u]!) {
+      if (repoOf[v] === null && !isRepo(v) && !isHub(v)) {
+        repoOf[v] = repo;
+        queue.push(v);
+      }
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    const r = repoOf[i];
+    if (laneKeys[i] === null && r != null) laneKeys[i] = r;
+  }
+
+  laneOrder.push(...repoOrder, ...projectKeys);
+  if (hasAgent) laneOrder.push(AGENT_LANE_KEY);
+  return { laneKeys, laneOrder };
+}
+
 /**
  * Variant E as a {@link LayoutFn}. Reads per-node start times from
  * {@link LayoutOptions.nodeTimes} and optional types from
- * {@link LayoutOptions.nodeTypes} (both node-order keyed). Absent times ⇒ every
- * node untimed (all parked on the left rail); absent types ⇒ one lane. Length
- * always matches `graph.nodeIds.length`.
+ * {@link LayoutOptions.nodeTypes} (both node-order keyed), and forwards the
+ * lane controls (`laneBy` / `nodeLanes` / `subLaneBy`) when present so a caller
+ * can drive repo lanes + type sub-lanes through the registry too. Absent times ⇒
+ * every node untimed (all parked on the left rail); absent types ⇒ one lane.
+ * Length always matches `graph.nodeIds.length`.
  */
 export const timeOrientedLayout: LayoutFn = (graph, options) => {
   const n = graph.nodeIds.length;
@@ -387,7 +619,11 @@ export const timeOrientedLayout: LayoutFn = (graph, options) => {
     const t = times?.[i];
     nodeTimes[i] = finiteTime(t) ? t : null;
   }
-  return computeTimeOrientedPositions(nodeTimes, options?.nodeTypes);
+  const opts: TimeOrientedLayoutOptions = {};
+  if (options?.laneBy !== undefined) opts.laneBy = options.laneBy;
+  if (options?.nodeLanes !== undefined) opts.nodeLanes = options.nodeLanes;
+  if (options?.subLaneBy !== undefined) opts.subLaneBy = options.subLaneBy;
+  return computeTimeOrientedPositions(nodeTimes, options?.nodeTypes, opts);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/graph/src/render-geometry.ts
+++ b/packages/graph/src/render-geometry.ts
@@ -17,6 +17,7 @@
  */
 
 import { BOX_SHAPE_CODE, shapePolygonPoints, SQUARE_INSET_RATIO } from "./shape-geometry";
+import type { EdgeCurveStyle } from "./types";
 
 // Re-export the single-sourced box shape code for callers that import box
 // metrics from this module.
@@ -383,6 +384,15 @@ export function coerceFinitePositions(
 export const EDGE_CURVE_FACTOR = 0.5;
 
 /**
+ * Lateral amplitude (as an effective curvature) of an INFLECTED (S-curve) edge
+ * when its per-edge `curvature` is 0 — so a time-oriented scene whose edges carry
+ * no explicit curvature still reads as a clear S. A set per-edge curvature wins.
+ * The two cubic control points sit ±(amp = thisOrCurvature·dist·EDGE_CURVE_FACTOR)
+ * off the chord, at 1/3 and 2/3 along it.
+ */
+export const DEFAULT_INFLECT_CURVATURE = 0.5;
+
+/**
  * Arrowhead length in world units per unit of edge width (renderer.ts:543).
  * Device-space length = ARROW_LENGTH · width · pixelRatio · zoom (world-space,
  * scales with zoom like every glyph).
@@ -416,11 +426,20 @@ export interface EdgeGeometry {
   degenerate: boolean;
   /** Endpoints clip to the node borders; false ⇒ raw segment + NO arrow (E13). */
   clipped: boolean;
-  /** Whether the edge is curved (curvature !== 0). */
+  /** Whether the edge is curved (curvature !== 0, OR inflected style). */
   curved: boolean;
-  /** Quadratic control point (device px); only meaningful when `curved`. */
+  /**
+   * Whether the curve is a CUBIC Bézier (two control points — the inflected
+   * S-curve) rather than the convex quadratic. When false, `control2*` are 0 and
+   * the convex single-control quadratic is drawn.
+   */
+  cubic: boolean;
+  /** First control point (device px): quadratic control (convex) / cubic c1 (inflected). */
   controlX: number;
   controlY: number;
+  /** Second cubic control point (device px); only meaningful when `cubic`. */
+  control2X: number;
+  control2Y: number;
   /** Outgoing unit tangent at the source (curve start tangent / chord). */
   outSx: number;
   outSy: number;
@@ -449,28 +468,62 @@ export function edgeGeometry(
   target: { x: number; y: number },
   curvature: number,
   offsetForDir: (end: "source" | "target", dirX: number, dirY: number) => number,
+  curveStyle: EdgeCurveStyle = "convex",
 ): EdgeGeometry {
   const dx = target.x - source.x;
   const dy = target.y - source.y;
   const distance = Math.hypot(dx, dy);
   const degenerate = distance < 1e-6;
-  const curved = curvature !== 0;
+  const inflected = curveStyle === "inflected" && !degenerate;
+  // Inflected edges are always curved (even at curvature 0); convex edges curve
+  // only when a per-edge curvature is set — the historical predicate.
+  const curved = inflected || curvature !== 0;
 
   let controlX = 0;
   let controlY = 0;
-  if (curved && !degenerate) {
-    const midX = (source.x + target.x) / 2;
-    const midY = (source.y + target.y) / 2;
-    // control = mid + (-dy/d, dx/d)·d·curvature·EDGE_CURVE_FACTOR (renderer.ts:865)
-    controlX = midX + (-dy / distance) * distance * curvature * EDGE_CURVE_FACTOR;
-    controlY = midY + (dx / distance) * distance * curvature * EDGE_CURVE_FACTOR;
-  }
+  let control2X = 0;
+  let control2Y = 0;
+  let cubic = false;
 
   let outSx = degenerate ? 0 : dx / distance;
   let outSy = degenerate ? 0 : dy / distance;
   let inTx = outSx;
   let inTy = outSy;
-  if (curved && !degenerate) {
+
+  if (inflected) {
+    // INFLECTED S-curve: a cubic Bézier whose two control points sit on OPPOSITE
+    // sides of the chord (at 1/3 and 2/3 along it), so the stroke leaves the
+    // source bending one way and reaches the target bending the other — an
+    // inflection point near the midpoint. Tangents come from the near control.
+    const ux = dx / distance;
+    const uy = dy / distance;
+    const nx = -uy;
+    const ny = ux;
+    const amp =
+      (curvature !== 0 ? curvature : DEFAULT_INFLECT_CURVATURE) * distance * EDGE_CURVE_FACTOR;
+    const third = distance / 3;
+    controlX = source.x + ux * third + nx * amp;
+    controlY = source.y + uy * third + ny * amp;
+    control2X = target.x - ux * third - nx * amp;
+    control2Y = target.y - uy * third - ny * amp;
+    cubic = true;
+    const sLen = Math.hypot(controlX - source.x, controlY - source.y);
+    const tLen = Math.hypot(target.x - control2X, target.y - control2Y);
+    if (sLen > 1e-6) {
+      outSx = (controlX - source.x) / sLen;
+      outSy = (controlY - source.y) / sLen;
+    }
+    if (tLen > 1e-6) {
+      inTx = (target.x - control2X) / tLen;
+      inTy = (target.y - control2Y) / tLen;
+    }
+  } else if (curvature !== 0 && !degenerate) {
+    // CONVEX bow (historical, byte-identical): a single quadratic control point.
+    const midX = (source.x + target.x) / 2;
+    const midY = (source.y + target.y) / 2;
+    // control = mid + (-dy/d, dx/d)·d·curvature·EDGE_CURVE_FACTOR (renderer.ts:865)
+    controlX = midX + (-dy / distance) * distance * curvature * EDGE_CURVE_FACTOR;
+    controlY = midY + (dx / distance) * distance * curvature * EDGE_CURVE_FACTOR;
     const sLen = Math.hypot(controlX - source.x, controlY - source.y);
     const tLen = Math.hypot(target.x - controlX, target.y - controlY);
     if (sLen > 1e-6) {
@@ -496,8 +549,11 @@ export function edgeGeometry(
     degenerate,
     clipped,
     curved,
+    cubic,
     controlX,
     controlY,
+    control2X,
+    control2Y,
     outSx,
     outSy,
     inTx,
@@ -529,10 +585,22 @@ export function tessellateEdge(geom: EdgeGeometry, segments = 16): Array<[number
   for (let i = 0; i <= steps; i += 1) {
     const t = i / steps;
     const mt = 1 - t;
-    // Quadratic Bézier with the CLIPPED endpoints and the shared control point.
-    const x = mt * mt * geom.startX + 2 * mt * t * geom.controlX + t * t * geom.endX;
-    const y = mt * mt * geom.startY + 2 * mt * t * geom.controlY + t * t * geom.endY;
-    points.push([x, y]);
+    if (geom.cubic) {
+      // CUBIC Bézier (inflected S-curve) with the CLIPPED endpoints + both
+      // control points. B(t) = mt³·P0 + 3·mt²·t·C1 + 3·mt·t²·C2 + t³·P1.
+      const a = mt * mt * mt;
+      const b = 3 * mt * mt * t;
+      const c = 3 * mt * t * t;
+      const d = t * t * t;
+      const x = a * geom.startX + b * geom.controlX + c * geom.control2X + d * geom.endX;
+      const y = a * geom.startY + b * geom.controlY + c * geom.control2Y + d * geom.endY;
+      points.push([x, y]);
+    } else {
+      // Quadratic Bézier with the CLIPPED endpoints and the shared control point.
+      const x = mt * mt * geom.startX + 2 * mt * t * geom.controlX + t * t * geom.endX;
+      const y = mt * mt * geom.startY + 2 * mt * t * geom.controlY + t * t * geom.endY;
+      points.push([x, y]);
+    }
   }
   return points;
 }

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -532,6 +532,12 @@ function applyDash(context: Graph2DContext, dash: number, pixelRatio: number): v
 
 const EDGE_CURVE_FACTOR = 0.5;
 
+// Lateral amplitude (effective curvature) of an INFLECTED (S-curve) edge when its
+// per-edge curvature is 0 — mirrors render-geometry.DEFAULT_INFLECT_CURVATURE so
+// the Canvas2D fallback and the WebGL2 edge path draw the SAME S. A set per-edge
+// curvature wins. Only consulted when the scene's edgeCurve style is "inflected".
+const DEFAULT_INFLECT_CURVATURE = 0.5;
+
 // Legacy vis-network `shape:box` parity. The box IS the node glyph drawn by the
 // Canvas2D fallback: a rounded rectangle, white-translucent fill, node-coloured
 // border, dark centred text. SCALE rule: the box HEIGHT equals the node's drawn
@@ -899,6 +905,40 @@ function drawFallback2D(
       }
     }
 
+    // INFLECTED (S-curve) override: when the scene's edge-curve style is
+    // "inflected" the edge is drawn as a cubic Bézier whose two control points sit
+    // on OPPOSITE sides of the chord, so it leaves the source bending one way and
+    // reaches the target bending the other (an inflection near the midpoint).
+    // Default ("convex" / unset) leaves the control point + tangents above
+    // byte-identical, so the golden suite is unaffected. Mirrors
+    // render-geometry.edgeGeometry's inflected branch (single-sourced shape).
+    const inflected = state.style?.edgeCurve === "inflected";
+    let control2X = 0;
+    let control2Y = 0;
+    if (inflected) {
+      const ux = dx / distance;
+      const uy = dy / distance;
+      const nx = -uy;
+      const ny = ux;
+      const amp =
+        (curvature !== 0 ? curvature : DEFAULT_INFLECT_CURVATURE) * distance * EDGE_CURVE_FACTOR;
+      const third = distance / 3;
+      controlX = source.x + ux * third + nx * amp;
+      controlY = source.y + uy * third + ny * amp;
+      control2X = target.x - ux * third - nx * amp;
+      control2Y = target.y - uy * third - ny * amp;
+      const sLen = Math.hypot(controlX - source.x, controlY - source.y);
+      const tLen = Math.hypot(target.x - control2X, target.y - control2Y);
+      if (sLen > 1e-6) {
+        outSx = (controlX - source.x) / sLen;
+        outSy = (controlY - source.y) / sLen;
+      }
+      if (tLen > 1e-6) {
+        inTx = (target.x - control2X) / tLen;
+        inTy = (target.y - control2Y) / tLen;
+      }
+    }
+
     // Legacy parity: the line STOPS at each node's drawn border and the
     // arrowhead tip sits ON the target border. Overlapping nodes (combined
     // border offsets exceed the centre distance) draw the raw segment — the
@@ -917,7 +957,9 @@ function drawFallback2D(
     context.lineWidth = Math.max(1, width * pixelRatio);
     applyDash(context, state.style?.edgeDash[edgeIndex] ?? 0, pixelRatio);
     context.moveTo(startX, startY);
-    if (curvature !== 0) {
+    if (inflected) {
+      context.bezierCurveTo(controlX, controlY, control2X, control2Y, endX, endY);
+    } else if (curvature !== 0) {
       context.quadraticCurveTo(controlX, controlY, endX, endY);
     } else {
       context.lineTo(endX, endY);

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -157,6 +157,23 @@ export interface LayoutOptions {
    * additive — a nullish / non-finite entry is treated as "untimed".
    */
   nodeTimes?: readonly (number | null | undefined)[];
+  /**
+   * Per-node PRIMARY lane key (the owning repo/project id), node-order keyed.
+   * Consumed by the time-oriented layout when `laneBy === "repo"` to band nodes
+   * into one lane per project/repo; ignored otherwise. Optional & additive.
+   */
+  nodeLanes?: readonly (string | null | undefined)[];
+  /**
+   * Which per-node attribute drives the time-oriented PRIMARY Y lane:
+   * `"node_type"` (default — band by `nodeTypes`) or `"repo"` (band by
+   * `nodeLanes`). Ignored by every other layout.
+   */
+  laneBy?: "node_type" | "repo";
+  /**
+   * When `"node_type"`, the time-oriented layout sub-bands each primary lane into
+   * closely-spaced sub-lines by `nodeTypes`. Ignored by every other layout.
+   */
+  subLaneBy?: "node_type";
 }
 
 export interface LayoutEngine {

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -72,6 +72,18 @@ export interface RenderGraphInput {
   attrs?: Float32Array;
 }
 
+/**
+ * Per-SCENE edge-curve drawing style (display Lot — time-oriented v3).
+ *   • `"convex"`    — the DEFAULT bow: a single quadratic control point offset to
+ *     one side of the chord (a C-shaped arc). Byte-identical to the historical
+ *     edge rendering; the golden suite renders this style.
+ *   • `"inflected"` — an S-curve with an INFLECTION point: a cubic Bézier whose
+ *     two control points sit on OPPOSITE sides of the chord, so the stroke leaves
+ *     the source bending one way and reaches the target bending the other. OPT-IN,
+ *     used by the time-oriented lane view to disentangle dense cross-lane bundles.
+ */
+export type EdgeCurveStyle = "convex" | "inflected";
+
 export interface GraphStyleBuffers {
   nodeSizes: Float32Array;
   nodeColors: Uint8Array;
@@ -98,6 +110,13 @@ export interface GraphStyleBuffers {
   edgeColors: Uint8Array;
   edgeDash: Uint8Array;
   edgeCurvatures: Float32Array;
+  /**
+   * Optional per-SCENE edge-curve style (default `"convex"` when omitted). When
+   * `"inflected"`, both the Canvas2D fallback and the WebGL2 edge path draw each
+   * curved/straight edge as an S-shaped cubic Bézier (see {@link EdgeCurveStyle}).
+   * Additive: absent ⇒ the historical convex/straight rendering (golden-stable).
+   */
+  edgeCurve?: EdgeCurveStyle;
 }
 
 export interface GraphStyleDefaults {

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -352,6 +352,10 @@ export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
   const edgeCount = frame.edges.length / 2;
   if (edgeCount === 0) return { capsules, arrows };
 
+  // Per-SCENE edge-curve style (default convex). When "inflected" every edge is
+  // an S-shaped cubic Bézier — the time-oriented lane view's opt-in style.
+  const edgeCurve = style?.edgeCurve ?? "convex";
+
   // Shared node geometry (radii + box extents) in device px, so the edge clip
   // reads the SAME border offsets the node pass draws. Boxes need a measureText
   // service; edges to boxes use their rect extents (box label measuring is a
@@ -377,8 +381,13 @@ export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
     const curvature = style?.edgeCurvatures?.[edgeIndex] ?? 0;
     const width = style?.edgeWidths?.[edgeIndex] ?? 1;
 
-    const geom = edgeGeometry(source, target, curvature, (end, dx, dy) =>
-      borderOffset(geometry, style?.nodeShapes, end === "source" ? sourceIndex : targetIndex, dx, dy),
+    const geom = edgeGeometry(
+      source,
+      target,
+      curvature,
+      (end, dx, dy) =>
+        borderOffset(geometry, style?.nodeShapes, end === "source" ? sourceIndex : targetIndex, dx, dy),
+      edgeCurve,
     );
     if (geom.degenerate) continue;
 

--- a/packages/graph/tests/edge-inflected.test.ts
+++ b/packages/graph/tests/edge-inflected.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Inflected (S-curve) edge style — time-oriented v3.
+ *
+ * The time-oriented lane view draws edges as an INFLECTED cubic Bézier (leaves
+ * the source bending one way, reaches the target bending the other) instead of
+ * the historical CONVEX quadratic bow. This pins the shared render-geometry shape
+ * (two control points on OPPOSITE sides of the chord; a tessellated polyline that
+ * CROSSES the chord) and that the opt-in flows through the WebGL instance builder
+ * — while the DEFAULT ("convex"/unset) style stays byte-identical (golden-stable).
+ */
+
+import { describe, expect, it } from "vitest";
+import { edgeGeometry, tessellateEdge } from "../src/render-geometry";
+import { buildEdgeInstances, type WebGLEdgeFrame } from "../src/webgl-edges";
+
+const S = { x: 0, y: 0 };
+const T = { x: 100, y: 0 }; // horizontal chord ⇒ perpendicular is the Y axis
+const noClip = () => 0; // no border clip: start=source, end=target
+
+describe("inflected edge geometry (render-geometry)", () => {
+  it("DEFAULT (convex) is unchanged: single control, NOT cubic", () => {
+    const straight = edgeGeometry(S, T, 0, noClip);
+    expect(straight.curved).toBe(false);
+    expect(straight.cubic).toBe(false);
+
+    const bow = edgeGeometry(S, T, 0.3, noClip);
+    expect(bow.curved).toBe(true);
+    expect(bow.cubic).toBe(false);
+    expect(bow.control2X).toBe(0);
+    expect(bow.control2Y).toBe(0);
+    // A convex bow stays on ONE side of the chord (no inflection).
+    const poly = tessellateEdge(bow, 16);
+    const ys = poly.map((p) => p[1]);
+    expect(ys.every((y) => y >= -1e-9)).toBe(true);
+  });
+
+  it("inflected is a CUBIC with the two controls on OPPOSITE sides of the chord", () => {
+    const geom = edgeGeometry(S, T, 0, noClip, "inflected");
+    expect(geom.curved).toBe(true);
+    expect(geom.cubic).toBe(true);
+    // c1 near source, c2 near target, offset to opposite sides (S-shape).
+    expect(geom.controlY).not.toBe(0);
+    expect(geom.control2Y).not.toBe(0);
+    expect(Math.sign(geom.controlY)).toBe(-Math.sign(geom.control2Y));
+    // Controls sit ~1/3 and ~2/3 along the chord.
+    expect(geom.controlX).toBeGreaterThan(0);
+    expect(geom.controlX).toBeLessThan(geom.control2X);
+    expect(geom.control2X).toBeLessThan(100);
+  });
+
+  it("a set per-edge curvature overrides the default inflection amplitude", () => {
+    const weak = edgeGeometry(S, T, 0.1, noClip, "inflected");
+    const strong = edgeGeometry(S, T, 0.6, noClip, "inflected");
+    expect(Math.abs(strong.controlY)).toBeGreaterThan(Math.abs(weak.controlY));
+  });
+
+  it("tessellated inflected polyline CROSSES the chord (has an inflection)", () => {
+    const geom = edgeGeometry(S, T, 0, noClip, "inflected");
+    const poly = tessellateEdge(geom, 16);
+    const ys = poly.map((p) => p[1]);
+    expect(Math.max(...ys)).toBeGreaterThan(0); // bulges one way
+    expect(Math.min(...ys)).toBeLessThan(0); // then the other ⇒ inflection
+    // By symmetry the midpoint sits essentially on the chord.
+    const mid = poly[Math.floor(poly.length / 2)]!;
+    expect(Math.abs(mid[1])).toBeLessThan(1e-6);
+  });
+});
+
+function singleEdgeFrame(edgeCurve?: "convex" | "inflected"): WebGLEdgeFrame {
+  return {
+    positions: new Float32Array([-120, 0, 120, 0]),
+    nodeCount: 2,
+    edges: new Uint32Array([0, 1]),
+    style: {
+      nodeSizes: new Float32Array([8, 8]),
+      nodeColors: new Uint8Array([200, 200, 200, 255, 200, 200, 200, 255]),
+      nodeShapes: new Uint8Array([0, 0]),
+      nodeLabels: ["", ""],
+      edgeWidths: new Float32Array([4]),
+      edgeColors: new Uint8Array([29, 78, 216, 255]),
+      edgeDash: new Uint8Array([0]),
+      edgeCurvatures: new Float32Array([0]), // straight unless inflected
+      ...(edgeCurve ? { edgeCurve } : {}),
+    },
+    camera: { x: 0, y: 0, zoom: 1 },
+    pixelRatio: 2,
+    viewportWidth: 400,
+    viewportHeight: 400,
+  };
+}
+
+describe("inflected edge style flows through the WebGL instance builder", () => {
+  it("a STRAIGHT edge (default) ⇒ a single capsule segment", () => {
+    const set = buildEdgeInstances(singleEdgeFrame());
+    expect(set.capsules.length / 12).toBe(1);
+  });
+
+  it("edgeCurve='inflected' tessellates the same straight edge into many segments", () => {
+    const set = buildEdgeInstances(singleEdgeFrame("inflected"));
+    expect(set.capsules.length / 12).toBeGreaterThan(8);
+  });
+});

--- a/packages/graph/tests/layout-time-oriented.test.ts
+++ b/packages/graph/tests/layout-time-oriented.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AGENT_LANE_KEY,
   buildRenderGraphBuffers,
   computeTimeOrientedPositions,
+  deriveRepoLaneKeys,
   getLayout,
   hasLayout,
   listLayouts,
@@ -120,5 +122,163 @@ describe("Variant E — time-oriented layout", () => {
     expect(xy(out, 2).x).toBeLessThan(xy(out, 0).x);
     // One type ⇒ one lane.
     expect(xy(out, 0).y).toBe(xy(out, 1).y);
+  });
+});
+
+describe("Variant E — lanes by REPO (laneBy: 'repo') + type SUB-lanes", () => {
+  // Two repos (A older lane, B newer lane); types mixed so banding can't be a type
+  // accident. node order: [repoA/Session, repoA/Branch, repoB/Session, repoB/Commit].
+  const times = [T0, T1, T2, T3];
+  const types = ["Session", "Branch", "Session", "Commit"];
+  const lanes = ["repoA", "repoA", "repoB", "repoB"];
+
+  it("bands PRIMARILY by the owning repo, NOT by type", () => {
+    const pos = computeTimeOrientedPositions(times, types, { laneBy: "repo", nodeLanes: lanes });
+    // Same repo ⇒ same y lane (even though types differ); different repo ⇒ different lane.
+    expect(xy(pos, 0).y).toBe(xy(pos, 1).y); // both repoA
+    expect(xy(pos, 2).y).toBe(xy(pos, 3).y); // both repoB
+    expect(xy(pos, 0).y).not.toBe(xy(pos, 2).y); // repoA vs repoB
+  });
+
+  it("still orders nodes by `t` on the X axis under repo lanes", () => {
+    // node order [T2, T0, T3, T1] (NOT chronological) → x increases with t.
+    const t = [T2, T0, T3, T1];
+    const pos = computeTimeOrientedPositions(t, types, { laneBy: "repo", nodeLanes: lanes });
+    const xByT = new Map(t.map((v, i) => [v, xy(pos, i).x]));
+    expect(xByT.get(T0)!).toBeLessThan(xByT.get(T1)!);
+    expect(xByT.get(T1)!).toBeLessThan(xByT.get(T2)!);
+    expect(xByT.get(T2)!).toBeLessThan(xByT.get(T3)!);
+  });
+
+  it("honors laneOrder (top→bottom) for the repo lanes", () => {
+    const pos = computeTimeOrientedPositions(times, types, {
+      laneBy: "repo",
+      nodeLanes: lanes,
+      laneOrder: ["repoB", "repoA"], // repoB on top now
+      laneGap: 100,
+    });
+    expect(xy(pos, 2).y).toBeLessThan(xy(pos, 0).y); // repoB lane above repoA lane
+  });
+
+  it("collapses to one lane when laneBy='repo' but nodeLanes is absent (graceful)", () => {
+    const pos = computeTimeOrientedPositions(times, types, { laneBy: "repo" });
+    for (let i = 1; i < 4; i++) expect(xy(pos, i).y).toBe(xy(pos, 0).y);
+  });
+
+  it("subLaneBy='node_type' splits each repo lane into closely-spaced type sub-lines", () => {
+    const subTypes = ["Session", "Branch", "Session", "Branch"];
+    const pos = computeTimeOrientedPositions(times, subTypes, {
+      laneBy: "repo",
+      nodeLanes: lanes,
+      laneGap: 120,
+      subLaneBy: "node_type",
+    });
+    const y0 = xy(pos, 0).y; // repoA / Session
+    const y1 = xy(pos, 1).y; // repoA / Branch
+    const y2 = xy(pos, 2).y; // repoB / Session
+    const y3 = xy(pos, 3).y; // repoB / Branch
+    // Within a repo lane, the two types now sit on DIFFERENT sub-lines.
+    expect(y0).not.toBe(y1);
+    // The SAME type keeps the SAME sub-offset across lanes (global sub-order):
+    // Session→Session and Branch→Branch differ only by the lane gap.
+    expect(y1 - y0).toBeCloseTo(y3 - y2, 6);
+    // Sub-lane separation is strictly TIGHTER than the primary lane separation.
+    expect(Math.abs(y1 - y0)).toBeLessThan(Math.abs(y2 - y0));
+  });
+
+  it("is deterministic under repo lanes + sub-lanes", () => {
+    const opts = { laneBy: "repo" as const, nodeLanes: lanes, subLaneBy: "node_type" as const };
+    const a = computeTimeOrientedPositions(times, types, opts);
+    const b = computeTimeOrientedPositions(times, types, opts);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+});
+
+describe("deriveRepoLaneKeys — repo membership from graph topology", () => {
+  // A mini agent-stats project graph: one Project, two Repos (rename lineage),
+  // one Agent, two Sessions, a Branch SHARED across both repos, one Commit.
+  const nodes = [
+    { id: "project_p", type: "Project" },
+    { id: "repo_a", type: "Repo" },
+    { id: "repo_b", type: "Repo" },
+    { id: "agent_x", type: "Agent" },
+    { id: "sess_1", type: "Session" },
+    { id: "sess_2", type: "Session" },
+    { id: "branch_shared", type: "Branch" },
+    { id: "commit_1", type: "Commit" },
+  ];
+  const edges = [
+    { source: "repo_a", target: "project_p" }, // belongs-to
+    { source: "repo_b", target: "project_p" },
+    { source: "repo_a", target: "repo_b" }, // rename-lineage
+    { source: "sess_1", target: "repo_a" }, // worked-in
+    { source: "sess_2", target: "repo_b" },
+    { source: "sess_1", target: "agent_x" }, // conducted-by (hub — excluded)
+    { source: "sess_2", target: "agent_x" },
+    { source: "sess_1", target: "branch_shared" }, // touched-branch
+    { source: "sess_2", target: "branch_shared" }, // shared across both repos
+    { source: "sess_1", target: "commit_1" }, // produced
+  ];
+
+  it("keys Repo/Project nodes to their own lane and groups Agents into AGENT_LANE_KEY", () => {
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    expect(byId.get("repo_a")).toBe("repo_a");
+    expect(byId.get("repo_b")).toBe("repo_b");
+    expect(byId.get("project_p")).toBe("project_p");
+    expect(byId.get("agent_x")).toBe(AGENT_LANE_KEY);
+  });
+
+  it("inherits each Session's repo (worked-in) and its Commit's repo (produced)", () => {
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    expect(byId.get("sess_1")).toBe("repo_a");
+    expect(byId.get("sess_2")).toBe("repo_b");
+    expect(byId.get("commit_1")).toBe("repo_a"); // produced by sess_1
+  });
+
+  it("resolves a SHARED branch deterministically to the earliest repo (tie-break)", () => {
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    // branch touched by both sessions → claimed by repo_a (seeded first);
+    // sess_2 (repo_b) → branch_shared then reads as a cross-lane (inter-repo) link.
+    expect(byId.get("branch_shared")).toBe("repo_a");
+  });
+
+  it("does NOT leak a repo across the shared Project/Agent hubs", () => {
+    // If the hubs were traversable, sess_2's repo could bleed into repo_a's nodes.
+    const { laneKeys } = deriveRepoLaneKeys(nodes, edges);
+    const byId = new Map(nodes.map((nd, i) => [nd.id, laneKeys[i]]));
+    expect(byId.get("sess_2")).toBe("repo_b"); // stayed in its own repo
+  });
+
+  it("suggests a stable laneOrder: repos (graph order) → projects → agents", () => {
+    const { laneOrder } = deriveRepoLaneKeys(nodes, edges);
+    expect(laneOrder).toEqual(["repo_a", "repo_b", "project_p", AGENT_LANE_KEY]);
+  });
+
+  it("feeds straight into computeTimeOrientedPositions as nodeLanes (repo lanes)", () => {
+    const { laneKeys, laneOrder } = deriveRepoLaneKeys(nodes, edges);
+    const nodeTimes = nodes.map((_, i) => T0 + i * 1000);
+    const nodeTypes = nodes.map((nd) => nd.type);
+    const pos = computeTimeOrientedPositions(nodeTimes, nodeTypes, {
+      laneBy: "repo",
+      nodeLanes: laneKeys,
+      laneOrder,
+    });
+    const yById = new Map(nodes.map((nd, i) => [nd.id, xy(pos, i).y]));
+    // sess_1, branch_shared, commit_1 all in the repo_a lane (loops stay local).
+    expect(yById.get("sess_1")).toBe(yById.get("repo_a"));
+    expect(yById.get("branch_shared")).toBe(yById.get("repo_a"));
+    expect(yById.get("commit_1")).toBe(yById.get("repo_a"));
+    // sess_2 in the repo_b lane → its branch_shared edge spans lanes (inter-repo).
+    expect(yById.get("sess_2")).toBe(yById.get("repo_b"));
+    expect(yById.get("sess_2")).not.toBe(yById.get("branch_shared"));
+  });
+
+  it("handles the empty graph", () => {
+    const { laneKeys, laneOrder } = deriveRepoLaneKeys([], []);
+    expect(laneKeys).toEqual([]);
+    expect(laneOrder).toEqual([]);
   });
 });

--- a/src/scene-layout.ts
+++ b/src/scene-layout.ts
@@ -23,6 +23,13 @@
  *                         positions and stamps `layout_id: "time-oriented"` +
  *                         `layout_dims: 2`.
  *
+ * For `time-oriented`, two further env knobs (read by
+ * {@link resolveTimeOrientedSceneOptions}) shape the Y lanes — `GRAPHIFY_LANE_BY=repo`
+ * bands by each node's owning REPO/PROJECT instead of by type (surfacing
+ * inter-project edges across lanes + intra-project loops within a lane), and
+ * `GRAPHIFY_SUBLANE_BY=node_type` splits each lane into 6 tight type sub-lines.
+ * Both unset ⇒ the historical type lanes (byte-identical).
+ *
  * SELECTION (opt-in; default stays force):
  *   • env `GRAPHIFY_LAYOUT=typed-layer` | `time-oriented` — mirrors the existing
  *     `GRAPHIFY_FAST_LAYOUT` opt-in style; read by {@link resolveSceneLayoutId}
@@ -41,8 +48,10 @@
 import {
   computeTimeOrientedPositions,
   computeTypedLayerPositions,
+  deriveRepoLaneKeys,
 } from "./typed-layer-layout.js";
 import type {
+  RepoLaneNode,
   TimeOrientedLayoutOptions,
   TypedLayerLayoutOptions,
 } from "./typed-layer-layout.js";
@@ -95,6 +104,27 @@ export function resolveSceneLayoutId(explicit?: string): SceneLayoutId {
   if (value === "typed-layer") return "typed-layer";
   if (value === "time-oriented") return "time-oriented";
   return "force";
+}
+
+/**
+ * Resolve the Variant-E lane controls from the environment (the export path):
+ *   • `GRAPHIFY_LANE_BY=repo` (or `project`) → primary lanes by owning repo/project;
+ *     `node_type` / `type` → primary lanes by type (the default). Anything else /
+ *     unset ⇒ undefined (→ the layout default `node_type`, byte-identical).
+ *   • `GRAPHIFY_SUBLANE_BY=node_type` (or `type`) → split each primary lane into
+ *     closely-spaced type sub-lines. Unset ⇒ off.
+ * Returns only the keys that were explicitly requested, so an unset environment
+ * yields `{}` and the historical (type-lane) behaviour is preserved.
+ */
+export function resolveTimeOrientedSceneOptions(): TimeOrientedLayoutOptions {
+  const env = typeof process !== "undefined" && process.env ? process.env : {};
+  const laneByRaw = String(env.GRAPHIFY_LANE_BY ?? "").trim().toLowerCase();
+  const subRaw = String(env.GRAPHIFY_SUBLANE_BY ?? "").trim().toLowerCase();
+  const options: TimeOrientedLayoutOptions = {};
+  if (laneByRaw === "repo" || laneByRaw === "project") options.laneBy = "repo";
+  else if (laneByRaw === "node_type" || laneByRaw === "type") options.laneBy = "node_type";
+  if (subRaw === "node_type" || subRaw === "type") options.subLaneBy = "node_type";
+  return options;
 }
 
 /**
@@ -152,7 +182,26 @@ export function attachTimeOrientedPositions<T extends LayoutableScene>(
   const nodeTypes = scene.nodes.map((node) =>
     typeof node.type === "string" && node.type.trim() !== "" ? node.type : null,
   );
-  const positions = computeTimeOrientedPositions(nodeTimes, nodeTypes, options);
+
+  // When laneBy="repo", derive each node's owning repo/project lane from the
+  // graph topology (scene nodes + edges) and band PRIMARILY by it; the optional
+  // type sub-lanes (subLaneBy) still come from node.type. Default (node_type)
+  // skips derivation entirely → byte-identical to the historical behaviour.
+  let layoutOptions: TimeOrientedLayoutOptions = options;
+  if (options.laneBy === "repo") {
+    const laneNodes: RepoLaneNode[] = scene.nodes.map((node) => ({
+      id: node.id,
+      type: typeof node.type === "string" ? node.type : null,
+    }));
+    const { laneKeys, laneOrder } = deriveRepoLaneKeys(laneNodes, scene.edges);
+    layoutOptions = {
+      ...options,
+      nodeLanes: laneKeys,
+      // Stack repo lanes in graph order unless the caller pinned an order.
+      laneOrder: options.laneOrder ?? laneOrder,
+    };
+  }
+  const positions = computeTimeOrientedPositions(nodeTimes, nodeTypes, layoutOptions);
 
   for (let i = 0; i < scene.nodes.length; i++) {
     const node = scene.nodes[i];
@@ -186,7 +235,9 @@ export function applySceneLayout<T extends LayoutableScene>(
     return attachTypedLayerPositions(scene);
   }
   if (layoutId === "time-oriented") {
-    return attachTimeOrientedPositions(scene);
+    // Honour GRAPHIFY_LANE_BY / GRAPHIFY_SUBLANE_BY on the export path (the call
+    // site passes no explicit options); unset ⇒ {} ⇒ type lanes (back-compat).
+    return attachTimeOrientedPositions(scene, resolveTimeOrientedSceneOptions());
   }
   return attachLayoutPositions(scene);
 }

--- a/src/scene-layout.ts
+++ b/src/scene-layout.ts
@@ -89,7 +89,12 @@ interface LayoutableScene {
   edges: Array<{ source: string; target: string }>;
   layout_id?: string;
   layout_dims?: 2 | 3;
+  /** Per-scene edge-curve style stamped by the time-oriented layout (v3). */
+  edgeCurve?: "convex" | "inflected";
 }
+
+/** Per-scene edge-curve style stamped on the time-oriented export. */
+export type SceneEdgeCurve = "convex" | "inflected";
 
 /**
  * Resolve the build-time layout id. Explicit arg wins; otherwise read env
@@ -125,6 +130,19 @@ export function resolveTimeOrientedSceneOptions(): TimeOrientedLayoutOptions {
   else if (laneByRaw === "node_type" || laneByRaw === "type") options.laneBy = "node_type";
   if (subRaw === "node_type" || subRaw === "type") options.subLaneBy = "node_type";
   return options;
+}
+
+/**
+ * Resolve the time-oriented edge-curve style from the environment. The v3
+ * time-oriented view defaults to `"inflected"` (S-curves disentangle the dense
+ * cross-lane bundles); set `GRAPHIFY_EDGE_CURVE=convex` to fall back to the
+ * historical bow. Only `"convex"` opts out — anything else (incl. unset) ⇒
+ * `"inflected"`.
+ */
+export function resolveEdgeCurveStyle(): SceneEdgeCurve {
+  const env = typeof process !== "undefined" && process.env ? process.env : {};
+  const raw = String(env.GRAPHIFY_EDGE_CURVE ?? "").trim().toLowerCase();
+  return raw === "convex" ? "convex" : "inflected";
 }
 
 /**
@@ -237,7 +255,11 @@ export function applySceneLayout<T extends LayoutableScene>(
   if (layoutId === "time-oriented") {
     // Honour GRAPHIFY_LANE_BY / GRAPHIFY_SUBLANE_BY on the export path (the call
     // site passes no explicit options); unset ⇒ {} ⇒ type lanes (back-compat).
-    return attachTimeOrientedPositions(scene, resolveTimeOrientedSceneOptions());
+    const positioned = attachTimeOrientedPositions(scene, resolveTimeOrientedSceneOptions());
+    // The time-oriented view draws INFLECTED (S-curve) edges by default (v3) to
+    // disentangle dense cross-lane bundles; GRAPHIFY_EDGE_CURVE=convex opts out.
+    positioned.edgeCurve = resolveEdgeCurveStyle();
+    return positioned;
   }
   return attachLayoutPositions(scene);
 }

--- a/src/studio-scene.ts
+++ b/src/studio-scene.ts
@@ -191,6 +191,14 @@ export interface StudioScene {
    * otherwise. Not consumed here.
    */
   snapshot_id?: string;
+  /**
+   * Per-SCENE edge-curve style (display Lot — time-oriented v3). `"inflected"`
+   * draws every edge as an S-shaped cubic (an inflection near the midpoint);
+   * `"convex"` / unset keeps the historical bow. Stamped by the time-oriented
+   * layout (see scene-layout.attachTimeOrientedPositions); the studio reads it
+   * into the renderer style buffer. Omitted otherwise (back-compat byte-identity).
+   */
+  edgeCurve?: "convex" | "inflected";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/typed-layer-layout.ts
+++ b/src/typed-layer-layout.ts
@@ -49,6 +49,25 @@ function normalizeType(raw: string | null | undefined): string | null {
 }
 
 /**
+ * Deterministic lane ordering shared by the banded layouts: keys named in
+ * `explicit` (and actually present) come first in that order, then every
+ * remaining present key ascending (alpha). Pure; never mutates its inputs.
+ */
+function orderLaneKeys(present: readonly string[], explicit?: readonly string[]): string[] {
+  const presentSet = new Set(present);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const key of explicit ?? []) {
+    if (presentSet.has(key) && !seen.has(key)) {
+      ordered.push(key);
+      seen.add(key);
+    }
+  }
+  for (const key of present.filter((k) => !seen.has(k)).sort()) ordered.push(key);
+  return ordered;
+}
+
+/**
  * Variant A core — place nodes in horizontal bands ("swimlanes") by type.
  *
  *   • one lane per distinct `node_type`; lanes ordered deterministically
@@ -126,6 +145,12 @@ export function computeTypedLayerPositions(
   return out;
 }
 
+/** Which per-node attribute drives the PRIMARY horizontal lane on Y. */
+export type TimeOrientedLaneBy = "node_type" | "repo";
+
+/** Which per-node attribute sub-bands a primary lane into closely-spaced sub-lines. */
+export type TimeOrientedSubLaneBy = "node_type";
+
 /** Tuning for {@link computeTimeOrientedPositions}. */
 export interface TimeOrientedLayoutOptions {
   /**
@@ -134,21 +159,53 @@ export interface TimeOrientedLayoutOptions {
    * right. Default 1000.
    */
   width?: number;
-  /** Vertical distance between adjacent type-lane CENTRES (default 120). */
+  /** Vertical distance between adjacent PRIMARY-lane CENTRES (default 120). */
   laneGap?: number;
   /**
-   * Explicit lane ordering (top→bottom) by type name — identical semantics to
-   * Variant A. Types present but absent here are appended ascending (alpha); the
-   * untyped lane is always last. Default: all lanes alpha-sorted.
+   * Explicit PRIMARY lane ordering (top→bottom) by lane key. Keys present but
+   * absent here are appended ascending (alpha); the unkeyed lane is always last.
+   * With `laneBy: "node_type"` the keys are type names (Variant-A semantics); with
+   * `laneBy: "repo"` they are repo/project lane keys (see {@link deriveRepoLaneKeys}).
+   * Default: all lanes alpha-sorted.
    */
   laneOrder?: readonly string[];
   /**
    * Horizontal gap LEFT of the timeline where UNTIMED nodes are parked. An
    * untimed node (nullish / non-finite `t`) gets a deterministic x =
    * `-width/2 - untimedGap`, sitting on a "park rail" just left of the oldest
-   * timed node, while keeping its type lane on Y. Default 80.
+   * timed node, while keeping its lane on Y. Default 80.
    */
   untimedGap?: number;
+  /**
+   * Which per-node attribute drives the PRIMARY Y lane:
+   *   • `"node_type"` (DEFAULT) — band by `nodeTypes` (the Variant-A type lanes);
+   *     byte-identical to the historical behaviour.
+   *   • `"repo"` — band by `nodeLanes` (each node's owning REPO/PROJECT), so one
+   *     horizontal lane per project/repo. Intra-repo nodes stay together (loops are
+   *     local) and inter-repo edges span lanes. Requires `nodeLanes`; when it is
+   *     absent every node lands in the single unkeyed lane.
+   */
+  laneBy?: TimeOrientedLaneBy;
+  /**
+   * Per-node PRIMARY lane key (the owning repo/project id), node-order keyed
+   * (parallel to `nodeTimes`). Consumed ONLY when `laneBy === "repo"`. Derive it
+   * from the graph topology with {@link deriveRepoLaneKeys}. A nullish / blank
+   * entry lands in the unkeyed (parked) lane.
+   */
+  nodeLanes?: readonly (string | null | undefined)[];
+  /**
+   * When `"node_type"`, each PRIMARY lane is split into closely-spaced SUB-lines
+   * by `nodeTypes` — a thin stack of the 6 types inside one project/repo lane. The
+   * same type sits at the SAME sub-offset in every primary lane (a global sub-order)
+   * so the sub-lines read across lanes. Off by default (one row per primary lane).
+   */
+  subLaneBy?: TimeOrientedSubLaneBy;
+  /**
+   * Vertical distance between adjacent SUB-lane centres within a primary lane.
+   * Default `laneGap / 8` — intentionally tight so the sub-stack reads as one band
+   * and (for the default `laneGap`) never overlaps the neighbouring primary lane.
+   */
+  subLaneGap?: number;
 }
 
 const DEFAULT_TIME_WIDTH = 1000;
@@ -166,18 +223,27 @@ function finiteTime(value: number | null | undefined): value is number {
  *     When every timed node shares one instant (tMax === tMin) they sit at x = 0.
  *     UNTIMED nodes (nullish / non-finite `t`) are parked deterministically at
  *     x = `-width/2 - untimedGap`, just left of the timeline.
- *   • y = a type LANE centre (one band per distinct type), ordered exactly like
- *     Variant A (`laneOrder` first, then ascending alpha; untyped lane last), so
- *     the time-oriented view is a temporal swimlane. With no `nodeTypes` every
- *     node shares one lane (y = 0).
+ *   • y = a PRIMARY lane centre, ordered deterministically (`laneOrder` first,
+ *     then ascending alpha; the unkeyed lane last). The lane key is chosen by
+ *     `laneBy`:
+ *       – `"node_type"` (DEFAULT) → one band per distinct `nodeTypes` value, a
+ *         temporal swimlane exactly like Variant A. With no `nodeTypes` every node
+ *         shares one lane (y = 0). BYTE-IDENTICAL to the historical behaviour.
+ *       – `"repo"` → one band per `nodeLanes` value (the owning repo/project), so
+ *         intra-repo nodes share a band (loops stay local) and inter-repo edges
+ *         span bands.
+ *     When `subLaneBy === "node_type"` each primary lane is additionally split into
+ *     closely-spaced SUB-lines by `nodeTypes` (a thin 6-type stack inside the lane);
+ *     a global sub-order keeps a given type at the same sub-offset across lanes.
  *
  * Pure, deterministic, O(n) (+ O(L log L) to sort the L ≤ n lanes). Returns a
  * fresh node-order-keyed `Float32Array` of length `2 * nodeTimes.length`.
  *
  * @param nodeTimes per-node interval start (epoch-ms), node-order keyed. A
  *                  nullish / non-finite entry is "untimed".
- * @param nodeTypes optional per-node type, node-order keyed (parallel). Absent ⇒
- *                  one lane (y = 0).
+ * @param nodeTypes optional per-node type, node-order keyed (parallel). Drives the
+ *                  type lanes (`laneBy: "node_type"`) and/or the type sub-lanes
+ *                  (`subLaneBy: "node_type"`). Absent ⇒ one lane (y = 0).
  */
 export function computeTimeOrientedPositions(
   nodeTimes: readonly (number | null | undefined)[],
@@ -215,44 +281,209 @@ export function computeTimeOrientedPositions(
     out[i * 2] = (frac - 0.5) * width;
   }
 
-  // --- Y: type lanes, ordered exactly like Variant A. ---
+  // --- Y: PRIMARY lanes (by type OR repo) + optional type SUB-lanes. ---
+  const laneBy: TimeOrientedLaneBy = options.laneBy ?? "node_type";
+  const subLaneBy = options.subLaneBy;
+  const subLaneGap = options.subLaneGap ?? laneGap / 8;
+
+  // PRIMARY lane key per node: the owning repo (laneBy "repo") or the type.
+  const primaryKeyOf = (i: number): string | null =>
+    laneBy === "repo" ? normalizeType(options.nodeLanes?.[i]) : normalizeType(nodeTypes?.[i]);
+
+  // Bucket node indices by primary key, preserving node order within each lane.
   const buckets = new Map<string, number[]>();
-  const untyped: number[] = [];
+  const unkeyed: number[] = [];
   for (let i = 0; i < n; i++) {
-    const type = normalizeType(nodeTypes?.[i]);
-    if (type === null) {
-      untyped.push(i);
+    const key = primaryKeyOf(i);
+    if (key === null) {
+      unkeyed.push(i);
       continue;
     }
-    let arr = buckets.get(type);
+    let arr = buckets.get(key);
     if (!arr) {
       arr = [];
-      buckets.set(type, arr);
+      buckets.set(key, arr);
     }
     arr.push(i);
   }
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  for (const type of options.laneOrder ?? []) {
-    if (buckets.has(type) && !seen.has(type)) {
-      ordered.push(type);
-      seen.add(type);
-    }
-  }
-  for (const type of [...buckets.keys()].filter((t) => !seen.has(t)).sort()) {
-    ordered.push(type);
-  }
-  const lanes: number[][] = ordered.map((type) => buckets.get(type) as number[]);
-  if (untyped.length > 0) lanes.push(untyped);
-
+  const ordered = orderLaneKeys([...buckets.keys()], options.laneOrder);
+  const lanes: number[][] = ordered.map((key) => buckets.get(key) as number[]);
+  if (unkeyed.length > 0) lanes.push(unkeyed);
   const laneCount = lanes.length;
+
+  // GLOBAL type sub-lane order, so a given type sits at the SAME sub-offset in
+  // every primary lane (the sub-lines read across lanes). Built once over all
+  // nodes; an untyped sub-lane (if any) sorts last. Empty when sub-lanes are off.
+  let subOffsetOf: (i: number) => number = () => 0;
+  if (subLaneBy === "node_type") {
+    const presentTypes = new Set<string>();
+    let hasUntypedSub = false;
+    for (let i = 0; i < n; i++) {
+      const type = normalizeType(nodeTypes?.[i]);
+      if (type === null) hasUntypedSub = true;
+      else presentTypes.add(type);
+    }
+    const subOrder = orderLaneKeys([...presentTypes]);
+    const subIndex = new Map<string, number>();
+    subOrder.forEach((type, idx) => subIndex.set(type, idx));
+    const untypedSubIdx = subOrder.length; // untyped sub-lane after the named ones
+    const subCount = subOrder.length + (hasUntypedSub ? 1 : 0);
+    subOffsetOf = (i: number): number => {
+      const type = normalizeType(nodeTypes?.[i]);
+      const idx = type === null ? untypedSubIdx : (subIndex.get(type) ?? untypedSubIdx);
+      return (idx - (subCount - 1) / 2) * subLaneGap;
+    };
+  }
+
   for (let lane = 0; lane < laneCount; lane++) {
-    // Centre the stack of lanes vertically around y = 0 (single lane ⇒ y = 0).
-    const y = (lane - (laneCount - 1) / 2) * laneGap;
+    // Centre the stack of primary lanes vertically around y = 0 (single lane ⇒ 0).
+    const laneY = (lane - (laneCount - 1) / 2) * laneGap;
     for (const idx of lanes[lane] as number[]) {
-      out[idx * 2 + 1] = y;
+      out[idx * 2 + 1] = laneY + subOffsetOf(idx);
     }
   }
 
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Repo/project lane derivation — pure graph topology → per-node lane key.
+// (Vendored alongside the layout cores; KEEP IN SYNC with layout-registry.ts.)
+// ---------------------------------------------------------------------------
+
+/** Minimal node shape {@link deriveRepoLaneKeys} reads (id + `node_type`). */
+export interface RepoLaneNode {
+  id: string;
+  /** The node's type (`node_type` / scene `type`); compared case-insensitively. */
+  type?: string | null;
+}
+
+/** Minimal directed edge shape {@link deriveRepoLaneKeys} reads. */
+export interface RepoLaneEdge {
+  source: string;
+  target: string;
+}
+
+/** Result of {@link deriveRepoLaneKeys}: per-node lane key + a suggested order. */
+export interface RepoLaneResult {
+  /**
+   * Per-node PRIMARY lane key, parallel to the input `nodes`. A Repo/Project node
+   * keys to its OWN id; an Agent keys to {@link AGENT_LANE_KEY}; a
+   * Session/Branch/Commit inherits the repo it reaches first; anything unresolved
+   * is `null` (parked / unkeyed lane). Feed straight to `nodeLanes`.
+   */
+  laneKeys: (string | null)[];
+  /**
+   * Suggested top→bottom PRIMARY lane order for `laneOrder`: repos in graph order
+   * (the rename-lineage / chronological order), then project lanes, then the
+   * single agents lane. Stable + deterministic.
+   */
+  laneOrder: string[];
+}
+
+/** Lane key that GROUPS every Agent node into one shared lane. */
+export const AGENT_LANE_KEY = "__agents__";
+
+const REPO_TYPE = "repo";
+const PROJECT_TYPE = "project";
+const AGENT_TYPE = "agent";
+
+/**
+ * Derive each node's owning REPO/PROJECT lane key from graph topology — the data
+ * `computeTimeOrientedPositions` needs for `laneBy: "repo"`.
+ *
+ * Rules (the agent-stats project-graph shape, but generic):
+ *   • a `Repo`/`Project` node keys to its OWN id (its own lane);
+ *   • every `Agent` node groups into one {@link AGENT_LANE_KEY} lane (agents span
+ *     repos — keeping them in one lane makes their cross-repo edges read as
+ *     lane-spanning rather than polluting a repo lane);
+ *   • a `Session`/`Branch`/`Commit` (anything else) INHERITS a repo by a
+ *     multi-source BFS seeded from every Repo node, over an adjacency that EXCLUDES
+ *     Project + Agent nodes (the cross-repo hubs) so a repo cannot leak through the
+ *     shared project/agent into another repo. Sessions sit one hop from their
+ *     `worked-in` repo; branches/commits two hops via the session that
+ *     touched/produced them. Ties (e.g. a branch shared across rename incarnations)
+ *     resolve to the earliest repo in graph order — deterministic — and the losing
+ *     repo's edge to it then reads as a cross-lane (inter-incarnation) link.
+ *   • unresolved nodes stay `null` (the parked / unkeyed lane).
+ *
+ * Pure & deterministic: O(V + E). Never mutates its inputs.
+ */
+export function deriveRepoLaneKeys(
+  nodes: readonly RepoLaneNode[],
+  edges: readonly RepoLaneEdge[],
+): RepoLaneResult {
+  const n = nodes.length;
+  const laneKeys: (string | null)[] = new Array(n).fill(null);
+  const laneOrder: string[] = [];
+  if (n === 0) return { laneKeys, laneOrder };
+
+  const idToIndex = new Map<string, number>();
+  for (let i = 0; i < n; i++) idToIndex.set(nodes[i]!.id, i);
+
+  const typeOf = (i: number): string => {
+    const t = nodes[i]?.type;
+    return typeof t === "string" ? t.trim().toLowerCase() : "";
+  };
+  const isRepo = (i: number) => typeOf(i) === REPO_TYPE;
+  const isProject = (i: number) => typeOf(i) === PROJECT_TYPE;
+  const isAgent = (i: number) => typeOf(i) === AGENT_TYPE;
+  const isHub = (i: number) => isProject(i) || isAgent(i);
+
+  // Seed special lanes + collect the deterministic lane order.
+  const repoOrder: string[] = [];
+  const projectKeys: string[] = [];
+  let hasAgent = false;
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      repoOrder.push(nodes[i]!.id);
+    } else if (isProject(i)) {
+      laneKeys[i] = nodes[i]!.id;
+      projectKeys.push(nodes[i]!.id);
+    } else if (isAgent(i)) {
+      laneKeys[i] = AGENT_LANE_KEY;
+      hasAgent = true;
+    }
+  }
+
+  // Adjacency EXCLUDING Project + Agent nodes (cross-repo hubs).
+  const adj: number[][] = Array.from({ length: n }, () => []);
+  for (const e of edges) {
+    const a = idToIndex.get(e.source);
+    const b = idToIndex.get(e.target);
+    if (a === undefined || b === undefined) continue;
+    if (isHub(a) || isHub(b)) continue;
+    adj[a]!.push(b);
+    adj[b]!.push(a);
+  }
+
+  // Multi-source BFS from the Repo seeds, enqueued in graph order so equal-distance
+  // ties resolve to the earlier repo.
+  const repoOf: (string | null)[] = new Array(n).fill(null);
+  const queue: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (isRepo(i)) {
+      repoOf[i] = nodes[i]!.id;
+      queue.push(i);
+    }
+  }
+  for (let head = 0; head < queue.length; head++) {
+    const u = queue[head]!;
+    const repo = repoOf[u]!;
+    for (const v of adj[u]!) {
+      if (repoOf[v] === null && !isRepo(v) && !isHub(v)) {
+        repoOf[v] = repo;
+        queue.push(v);
+      }
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    const r = repoOf[i];
+    if (laneKeys[i] === null && r != null) laneKeys[i] = r;
+  }
+
+  laneOrder.push(...repoOrder, ...projectKeys);
+  if (hasAgent) laneOrder.push(AGENT_LANE_KEY);
+  return { laneKeys, laneOrder };
 }

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -236,6 +236,9 @@ function cloneStyle(style) {
     edgeColors: new Uint8Array(style.edgeColors),
     edgeDash: new Uint8Array(style.edgeDash),
     edgeCurvatures: new Float32Array(style.edgeCurvatures),
+    // Per-scene edge-curve style (convex | inflected) survives dim / merge
+    // re-styling so the time-oriented S-curves persist on hover / selection.
+    edgeCurve: style.edgeCurve,
   };
 }
 
@@ -349,6 +352,13 @@ export function buildGraphRendererPayload(scene, options = {}) {
     node: { size: nodeRadius },
     edge: { width: 1, color: EDGE_COLOR, dash: "solid", curvature: 0.15 },
   });
+  // Per-SCENE edge-curve style (time-oriented v3). "inflected" makes both the
+  // Canvas2D fallback and the WebGL2 edge path draw S-shaped cubic edges; unset /
+  // "convex" keeps the historical bow. Stamped on the scene by the time-oriented
+  // layout (scene-layout.applySceneLayout) and read straight into the style.
+  if (scene?.edgeCurve === "inflected" || scene?.edgeCurve === "convex") {
+    baseStyle.edgeCurve = scene.edgeCurve;
+  }
   const nodeIndexById = new Map(nodes.map((node, index) => [node.id, index]));
 
   // Recon focal-pair parity: nodes flagged `forceBoxLabel` (the two entities

--- a/tests/scene-time-oriented.test.ts
+++ b/tests/scene-time-oriented.test.ts
@@ -4,6 +4,7 @@ import {
   applySceneLayout,
   attachTimeOrientedPositions,
   resolveSceneLayoutId,
+  resolveTimeOrientedSceneOptions,
 } from "../src/scene-layout.js";
 import { buildStudioScene, type StudioSceneGraphLike } from "../src/studio-scene.js";
 
@@ -106,5 +107,128 @@ describe("resolveSceneLayoutId — time-oriented opt-in (default stays force)", 
   it("an explicit arg overrides the env", () => {
     process.env.GRAPHIFY_LAYOUT = "time-oriented";
     expect(resolveSceneLayoutId("force")).toBe("force");
+  });
+});
+
+// A mini agent-stats PROJECT graph: 1 Project, 2 Repos (rename lineage), 1 Agent,
+// 2 Sessions, a Branch + Commit owned by repoA's session. buildStudioScene carries
+// `type` (from node_type) + `t` onto scene nodes; the derivation reads scene edges.
+const T_JAN = Date.UTC(2026, 0, 1);
+const T_FEB = Date.UTC(2026, 1, 1);
+const T_MAR = Date.UTC(2026, 2, 1);
+const T_APR = Date.UTC(2026, 3, 1);
+const PROJECT_GRAPH: StudioSceneGraphLike = {
+  nodes: [
+    { id: "proj", label: "Project", type: "Project" },
+    { id: "repo_a", label: "repoA", type: "Repo" },
+    { id: "repo_b", label: "repoB", type: "Repo" },
+    { id: "agent_1", label: "agent", type: "Agent" },
+    { id: "sess_a", label: "sa", type: "Session", t: T_JAN },
+    { id: "branch_a", label: "ba", type: "Branch", t: T_FEB },
+    { id: "commit_a", label: "ca", type: "Commit", t: T_APR },
+    { id: "sess_b", label: "sb", type: "Session", t: T_MAR },
+  ],
+  links: [
+    { source: "repo_a", target: "proj", relation: "belongs-to" },
+    { source: "repo_b", target: "proj", relation: "belongs-to" },
+    { source: "repo_a", target: "repo_b", relation: "rename-lineage" },
+    { source: "sess_a", target: "repo_a", relation: "worked-in" },
+    { source: "sess_b", target: "repo_b", relation: "worked-in" },
+    { source: "sess_a", target: "agent_1", relation: "conducted-by" },
+    { source: "sess_b", target: "agent_1", relation: "conducted-by" },
+    { source: "sess_a", target: "branch_a", relation: "touched-branch" },
+    { source: "sess_a", target: "commit_a", relation: "produced" },
+  ],
+};
+
+describe("scene Variant E — lanes by REPO (laneBy: 'repo')", () => {
+  it("bands each node into its owning repo lane (intra-repo nodes share a band)", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)), {
+      laneBy: "repo",
+    });
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y]));
+    // repoA's session + the branch/commit it owns all sit in ONE lane (loops local).
+    expect(y.get("sess_a")).toBe(y.get("repo_a"));
+    expect(y.get("branch_a")).toBe(y.get("repo_a"));
+    expect(y.get("commit_a")).toBe(y.get("repo_a"));
+    // repoB's session sits in a DIFFERENT lane → inter-repo edges span lanes.
+    expect(y.get("sess_b")).toBe(y.get("repo_b"));
+    expect(y.get("repo_a")).not.toBe(y.get("repo_b"));
+    // The Agent groups into its own lane, distinct from both repos.
+    expect(y.get("agent_1")).not.toBe(y.get("repo_a"));
+    expect(y.get("agent_1")).not.toBe(y.get("repo_b"));
+  });
+
+  it("still orders timed nodes by `t` on X under repo lanes", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)), {
+      laneBy: "repo",
+    });
+    const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+    // sess_a (Jan) older than sess_b (Mar) → x(sess_a) < x(sess_b).
+    expect(byId.get("sess_a")!.x!).toBeLessThan(byId.get("sess_b")!.x!);
+    for (const n of scene.nodes) {
+      expect(n.fx).toBe(n.x);
+      expect(n.fy).toBe(n.y);
+    }
+  });
+
+  it("subLaneBy='node_type' splits a repo lane into closely-spaced type sub-lines", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)), {
+      laneBy: "repo",
+      subLaneBy: "node_type",
+    });
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y!]));
+    // Inside repoA's lane the three types now sit on distinct sub-lines.
+    const ys = [y.get("sess_a")!, y.get("branch_a")!, y.get("commit_a")!];
+    expect(new Set(ys).size).toBe(3);
+    // …but they stay CLOSE: the sub-spread within repoA is tighter than the gap
+    // to repoB's lane.
+    const subSpread = Math.max(...ys) - Math.min(...ys);
+    const laneGap = Math.abs(y.get("repo_b")! - y.get("repo_a")!);
+    expect(subSpread).toBeLessThan(laneGap);
+  });
+
+  it("DEFAULT (no options) still bands by TYPE — back-compat for the project graph", () => {
+    const scene = attachTimeOrientedPositions(buildStudioScene(clone(PROJECT_GRAPH)));
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y]));
+    // Both Sessions share the type lane regardless of repo.
+    expect(y.get("sess_a")).toBe(y.get("sess_b"));
+    expect(y.get("sess_a")).not.toBe(y.get("branch_a"));
+  });
+});
+
+describe("resolveTimeOrientedSceneOptions — env-driven lane controls", () => {
+  const priorLane = process.env.GRAPHIFY_LANE_BY;
+  const priorSub = process.env.GRAPHIFY_SUBLANE_BY;
+  afterEach(() => {
+    if (priorLane === undefined) delete process.env.GRAPHIFY_LANE_BY;
+    else process.env.GRAPHIFY_LANE_BY = priorLane;
+    if (priorSub === undefined) delete process.env.GRAPHIFY_SUBLANE_BY;
+    else process.env.GRAPHIFY_SUBLANE_BY = priorSub;
+  });
+
+  it("returns {} (type lanes, byte-identical default) when unset", () => {
+    delete process.env.GRAPHIFY_LANE_BY;
+    delete process.env.GRAPHIFY_SUBLANE_BY;
+    expect(resolveTimeOrientedSceneOptions()).toEqual({});
+  });
+
+  it("maps GRAPHIFY_LANE_BY=repo|project → laneBy:'repo' and the sub-lane flag", () => {
+    process.env.GRAPHIFY_LANE_BY = "repo";
+    process.env.GRAPHIFY_SUBLANE_BY = "node_type";
+    expect(resolveTimeOrientedSceneOptions()).toEqual({ laneBy: "repo", subLaneBy: "node_type" });
+    process.env.GRAPHIFY_LANE_BY = "PROJECT";
+    expect(resolveTimeOrientedSceneOptions().laneBy).toBe("repo");
+  });
+
+  it("applySceneLayout('time-oriented') honors GRAPHIFY_LANE_BY=repo on the export path", () => {
+    process.env.GRAPHIFY_LANE_BY = "repo";
+    delete process.env.GRAPHIFY_SUBLANE_BY;
+    const scene = applySceneLayout(buildStudioScene(clone(PROJECT_GRAPH)), "time-oriented");
+    const y = new Map(scene.nodes.map((n) => [n.id, n.y]));
+    // Repo lanes (not type lanes): the two Sessions land in DIFFERENT lanes.
+    expect(y.get("sess_a")).not.toBe(y.get("sess_b"));
+    expect(y.get("sess_a")).toBe(y.get("repo_a"));
+    expect(scene.layout_id).toBe("time-oriented");
   });
 });

--- a/tests/scene-time-oriented.test.ts
+++ b/tests/scene-time-oriented.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   applySceneLayout,
   attachTimeOrientedPositions,
+  resolveEdgeCurveStyle,
   resolveSceneLayoutId,
   resolveTimeOrientedSceneOptions,
 } from "../src/scene-layout.js";
@@ -230,5 +231,42 @@ describe("resolveTimeOrientedSceneOptions — env-driven lane controls", () => {
     expect(y.get("sess_a")).not.toBe(y.get("sess_b"));
     expect(y.get("sess_a")).toBe(y.get("repo_a"));
     expect(scene.layout_id).toBe("time-oriented");
+  });
+});
+
+describe("edge-curve style — time-oriented stamps inflected (v3)", () => {
+  const prior = process.env.GRAPHIFY_EDGE_CURVE;
+  afterEach(() => {
+    if (prior === undefined) delete process.env.GRAPHIFY_EDGE_CURVE;
+    else process.env.GRAPHIFY_EDGE_CURVE = prior;
+  });
+
+  it("defaults to 'inflected', opts out only on GRAPHIFY_EDGE_CURVE=convex", () => {
+    delete process.env.GRAPHIFY_EDGE_CURVE;
+    expect(resolveEdgeCurveStyle()).toBe("inflected");
+    process.env.GRAPHIFY_EDGE_CURVE = "Convex";
+    expect(resolveEdgeCurveStyle()).toBe("convex");
+    process.env.GRAPHIFY_EDGE_CURVE = "bogus";
+    expect(resolveEdgeCurveStyle()).toBe("inflected");
+  });
+
+  it("time-oriented export stamps scene.edgeCurve='inflected' by default", () => {
+    delete process.env.GRAPHIFY_EDGE_CURVE;
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "time-oriented");
+    expect(scene.edgeCurve).toBe("inflected");
+  });
+
+  it("GRAPHIFY_EDGE_CURVE=convex stamps the historical bow", () => {
+    process.env.GRAPHIFY_EDGE_CURVE = "convex";
+    const scene = applySceneLayout(buildStudioScene(clone(GRAPH)), "time-oriented");
+    expect(scene.edgeCurve).toBe("convex");
+  });
+
+  it("force / typed-layer layouts never stamp edgeCurve (back-compat)", () => {
+    delete process.env.GRAPHIFY_EDGE_CURVE;
+    const force = applySceneLayout(buildStudioScene(clone(GRAPH)), "force");
+    expect(force.edgeCurve).toBeUndefined();
+    const typed = applySceneLayout(buildStudioScene(clone(GRAPH)), "typed-layer");
+    expect(typed.edgeCurve).toBeUndefined();
   });
 });


### PR DESCRIPTION
Time-oriented refinement per principal feedback: (1) INFLECTED (S-curve) edge style, opt-in per scene, used by the time-oriented view (default edge style unchanged → golden must stay green; CI verifies); (2) lanes by project/repo + optional type sub-lanes (supersedes #254). Touches packages/graph edge geometry (render-geometry/renderer/webgl-edges) + a new edge-inflected test. The multi-project visual UAT (agent-stats across graphify/track/radar/aclp-am) is pending a render capture (server rate-limits kept cutting the headless render); the code is complete. Do NOT merge until the principal judges the visual.