### PR TITLE
chore(upstream): v0.8.49→v0.9.4 parity census + Lot 1 (Ruby/PowerShell/ObjC inheritance edges)

### DIFF
--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -41,6 +41,63 @@ Observed on 2026-06-25 after merging `@sentropic/graphify@0.17.2`:
 | Reflection/work-memory | `1a14e94`, `d193b62`, `6d9617a`, `89dd00f` | `defer / product decision` | Python `graphify reflect` and LESSONS.md workflow are not in the current TS product contract. |
 | Release/changelog-only | `29fd98f`, `f87011b`, `6d3c959`, `bc362cb`, `e4ff54f` | `release-only` | Do not mirror Python package version bumps into the TS line. |
 
+## Active Drift Intake (v0.8.49 → v1.0.0 / upstream-v8)
+
+Observed on 2026-07-01 (this pass) against `origin/main` at `@sentropic/graphify@0.17.2`.
+
+- Safi Python Graphify: `upstream/v8` HEAD at `5190a4e` (`docs: point LinkedIn badge to Graphify Labs company page`), which `git describe` resolves as **`v0.9.4-20-g5190a4e`** (20 untagged commits past the highest reachable release tag `v0.9.4` at `b7f88af`).
+- **Window = `v0.8.49..upstream/v8` = 120 commits.** The first 7 (`e4ff54f`, `5d63aad`, `7278e24`, `68dba89`, `7dc5d96`, `1e3270a`, `9b583a0`) were already recorded in the prior `0.8.49` intake above (that intake was observed at `9b583a0`, which is 7 commits *ahead* of tag `v0.8.49 = 6d3c959`); they are re-classified here for completeness and carry their prior status. The genuinely-new slice is `9b583a0..upstream/v8` = 113 commits.
+- Reachable release tags in-window: `v0.8.50` (`b17e88c`), `v0.8.51` (`8e98b91`), `v0.9.0` (`92e682f`), `v0.9.1` (`b7e256f`), `v0.9.2` (`544f95e`), `v0.9.3` (`0c551ac`), `v0.9.4` (`b7f88af`).
+- **Title caveat (verified):** the task-supplied premise of `v0.9.5…v0.9.8` and `v1.0.0` upstream tags does **not** hold. `v0.9.5`/`v0.9.6` do not resolve; `v0.9.7` (`5d38117`) and `v0.9.8` (`efc46f8`) are **our own `rhanka` fork release-merge tags, NOT upstream** (both are `NOT-in-v8`). `v1.0.0` (`0a31c08`, "add git commit hook") remains a **non-target** — it is not an ancestor of `upstream/v8` (a divergent lightweight tag), confirming the standing note in this file. The real upstream frontier is `v0.9.4 + 20 untagged commits`.
+
+**Key grounding finding (drives lot sizing):** the TS extractor is a single `src/extract.ts` (5.4k lines). Most languages route through `_extractGeneric(config)`; Groovy/PowerShell/Objc/Julia/Elixir have bespoke walkers; `.sv`/`.svh`/`.v`/`.f*`/`.vue`/`.dart`/`.r` route to `extractRegexBackedCode` (regex, no tree-sitter). Crucially, **`_extractGeneric` has NO type-reference subsystem at all** — there is no `references`-edge emission for class fields/properties/generic args (the only `relation: "references"` edges in the file are SQL foreign keys, `src/extract.ts:2982-3045`, and MCP/sdk concept refs). Upstream's `_swift_collect_type_refs` / `_csharp_collect_type_refs` / `_cpp_collect_type_refs` / `field_declaration`/`property_declaration`/`val|var_definition` handlers are entirely absent. Therefore every upstream "emit type/field/generic_arg references" fix is a **subsystem port**, not a one-line branch add, and is deliberately *not* in the cheap lot.
+
+Per-bucket census (sums to 120):
+
+| Bucket | Count | Representative SHAs |
+| --- | --- | --- |
+| `ported (this pass)` | 3 | `a19b9e9` ruby-inherits, `a129ff2` powershell-inherits/implements, `cd3a376` objc-protocol-implements |
+| `ported (early / prior intake)` | 1 | `68dba89` `*_BASE_URL` (already merged) |
+| `must-audit → already-covered` | 1 | `64a6093` groovy inherits/implements (TS `extractGroovy` is regex-backed and already emits both, `src/extract.ts:2827-2837`) |
+| `port` (TS genuinely lacks, portable) | 18 | type-ref subsystem: `31b3752`,`9b49bfd`,`8b9a998`,`981e2b9`,`674184d`,`7eb847b`,`67b4525`,`51f805e`,`bb5e519`,`21bcb43`,`ad70152`; `indirect_call`: `19e7a31`,`cf747ab`,`8288829`,`6dc1cb0`,`311e63a`,`e34e27c`; `652ba42` Metal shaders |
+| `must-audit` (needs check vs existing TS) | 54 | cross-file/type resolution `76b6eab`,`b9d8067`,`49252d3`,`3bc3fee`,`36b76ce`,`6509d0c`,`784e9c8`; ids `b46634e`,`3999dbc`,`35fb437`,`73710d3`,`5320aa8`; origin_file `afa4ade`,`d177f04`; build/update `0080d8a`,`4f40967`,`4a8d6ba`,`de7d362`,`6eb7c01`; hyperedge `bd885cc`; llm `ff47316`,`64c1f21`,`4e4935a`; export/wiki `5d63aad`,`7278e24`,`8b177cb`,`407a7f1`,`7a94f72`; cluster `1aab291`,`8127ff9`; js-imports `2133539`,`e8dabad`,`5746964`,`c8c604d`,`1801da0`; objc/swift `8994b55`,`1652dad`,`0792b41`,`51fc00a`; java `940cb53`,`1f3f1c1`; ruby `86ecb76`; regex-lang `b8f41c7`,`297075c`; julia `984a6a8`; elixir `f2ea6a6`; cli/skill `f7f89d7`,`47033c8`,`a16b5bd`,`1b99496`; cache `7a9cda2`; hooks `9b583a0`,`879c058`; `.vue` grammar `349465b` |
+| `n-a` (Python-only: uv.lock, deps, packaging, str-decode, test-infra, skill/doc) | 13 | `6a45263`,`21a9f1f`,`faa9218` (uv.lock); `738c9ce`,`36b5e5c` (py deps); `11dc819`,`1225677`,`7592244` (uv/install docs); `0e8d92c` (GBK decode; TS reads UTF-8); `12193a8` (.DS_Store); `bee3849` (py test mock); `1e3270a`,`e3e4198` (skill text) |
+| `defer` (product decision) | 8 | `7dc5d96`,`905e0a7` (WPF/XAML — not in TS surface); `75a5e6d`,`5779767`,`00e00a0`,`2cdc212`,`c865a3c` (`reflect`/work-memory overlay — Python-only product); `8fdbf50` (`getattr()` indirect_call — Python idiom) |
+| `release-only` (changelog/version/badges) | 22 | `e4ff54f`,`b17e88c`,`8e98b91`,`92e682f`,`544f95e`,`0c551ac`,`b7f88af` (releases); `388d1b6`,`94e5baf`,`67d8c53`,`22a5afb`,`0ca73bd`,`1d8d278`,`69b3997`,`20547c4`,`93e8e44`,`7e24c3b`,`532a20e`,`f4a7994` (changelog); `1990612`,`5190a4e` (badges) |
+
+Thematic mapping of the actionable (`port`/`must-audit`) buckets to TS files:
+
+| Theme | Bucket | TS file(s) | Notes / next action |
+| --- | --- | --- | --- |
+| Class inheritance edges (Ruby/PowerShell/ObjC) | `ported (this pass)` | `src/extract.ts` `_extractGeneric` (ruby), `extractPowershell`, `extractObjc` | **Closed this pass** — see below. Groovy was `already-covered`. |
+| Language type/field/generic-arg references | `port` | `src/extract.ts` `_extractGeneric` + new per-lang `collectTypeRefs` helpers | Requires porting the absent `references`-edge subsystem (`field_declaration`/`property_declaration`/`val|var_definition`/enum-assoc/base-template-args). Big, coherent, high-value. Blocked for swift/csharp/scala verification by absent optional grammars locally. |
+| Indirect dispatch → `indirect_call` edges | `port` | `src/extract.ts` (all walkers) + `src/types.ts` (edge relation), consumers in `src/analyze.ts`/`src/build.ts` | New edge relation `indirect_call` not present in TS. Medium/large; touches many extractors + downstream. |
+| Cross-file member/type resolution (C++/ObjC/C#/Go) | `must-audit` | `src/extract.ts` post-extract resolution pass | Partial cross-file resolution exists; audit header/impl routing (`3bc3fee`), sourceless stubs (`36b76ce`,`6509d0c`), case-sensitivity (`784e9c8`). |
+| Node-ID / origin_file / dedup hardening | `must-audit` | `src/extract.ts` id logic, `src/build.ts` | TS already uses project-relative ids (`qualifiedFileStem`); check legacy-id warnings (`3999dbc`), separator-collision salting (`35fb437`), `origin_file` leak/stub (`afa4ade`/`d177f04`). |
+| build_merge / graph-JSON corruption hardening | `must-audit` | `src/build.ts`, `src/hyperedges.ts`, `src/graph.ts` | Preserve hyperedges + prune-root hardening (`4f40967`), corruption-tolerant load (`4a8d6ba`,`6eb7c01`), symlink-root relativize (`de7d362`). |
+| LLM dispatch robustness | `must-audit` | `src/llm-execution.ts` | Non-streaming OpenAI-compat (`ff47316`), 429 retry (`64c1f21`), secondary-path timeout (`4e4935a`). Several may already be covered — audit before porting. |
+| Export / wiki / GraphML | `must-audit` | `src/export.ts`, `src/wiki.ts`, `src/studio-*.ts`, `src/cli.ts` | Filename case-fold dedup (`5d63aad`), canvas grid (`7278e24`), vault-safety (`8b177cb`), GraphML null-attr + `--answer-file` (`407a7f1`), portable md links (`7a94f72`). |
+| Community-label determinism | `must-audit` | `src/community-labels.ts`, `src/cluster.ts` | Deterministic hub labels (`1aab291`), stale-label detection on re-cluster (`8127ff9`), `--missing-only` (`a16b5bd`). |
+| JS/TS import resolution | `must-audit`/`port` | `src/extract.ts` (`resolveJsImportTarget*`, tsconfig alias loader) | Wildcard aliases (`5746964`), namespace re-exports (`c8c604d`), `this.field.method()` ctor-injection (`1801da0`), package.json `exports` subpaths (`e8dabad`), workspace alias edges (`2133539`). |
+
+### Proposed port-lot list
+
+1. **Lot 1 — Class-inheritance edges (cheap, high-value).** Ruby / PowerShell / ObjC `inherits`/`implements`. Size **S** (3 small branches, existing patterns). Risk **low**. **CLOSED THIS PASS** (Groovy already-covered). Verified: Ruby asserts green locally; PowerShell/ObjC ports written against real TS source with soft-skip integration tests (optional grammar WASM absent in sandbox — assert in CI).
+2. **Lot 2 — Language type/field/generic-arg references subsystem.** Port the absent `references`-edge machinery + per-language collectors (java field/annotation/record, csharp property, scala var, php promoted ctor, swift enum-assoc, cpp base-template-args, rust tuple/enum field) = `port` bucket ×11. Size **L**. Risk **medium** (new subsystem + downstream analyze/dedup interplay; some langs unverifiable locally without optional grammars). Highest structural value.
+3. **Lot 3 — `indirect_call` dispatch edges.** New edge relation + capture across Python/JS-TS/cross-file, plus `getattr` slice as Python-only `defer`. Size **M/L**. Risk **medium** (touches every walker + `src/types.ts` + downstream consumers). Do after Lot 2 so the edge-type plumbing is settled.
+4. **Lot 4 — build_merge / graph-JSON corruption + ids/origin_file hardening.** `4f40967`,`4a8d6ba`,`6eb7c01`,`de7d362`,`3999dbc`,`35fb437`,`afa4ade`,`d177f04`,`5320aa8`. Size **M**. Risk **low/medium**, mostly additive robustness + regression tests. Good "correctness" lot independent of extractor work.
+5. **Lot 5 — LLM dispatch + export/wiki robustness.** `ff47316`,`64c1f21`,`4e4935a` (llm) and `5d63aad`,`7278e24`,`8b177cb`,`407a7f1`,`7a94f72` (export/wiki/GraphML). Size **M**. Risk **low**. Several likely `already-covered` — audit-first lot.
+6. **Lot 6 — Cross-file resolution + community-label determinism.** `3bc3fee`,`36b76ce`,`6509d0c`,`784e9c8` (resolution) + `1aab291`,`8127ff9`,`a16b5bd` (labels). Size **M**. Risk **medium**. Depends partly on Lot 2 groundwork.
+
+### Closed this pass — Lot 1a (class-inheritance edges)
+
+| Upstream | TS target | Status |
+| --- | --- | --- |
+| `a19b9e9` fix(ruby) superclass inherits | `_extractGeneric` ruby branch, `src/extract.ts` | **ported + verified** (grammar present; 2 regression tests assert green) |
+| `a129ff2` fix(powershell) inherits/implements | `extractPowershell`, `src/extract.ts` | **ported** (mirrors upstream; integration test soft-skips locally — `tree-sitter-powershell` WASM absent in sandbox, asserts in CI) |
+| `cd3a376` fix(objc) protocol-to-protocol implements | `extractObjc`, `src/extract.ts` | **ported** (mirrors upstream; integration test soft-skips locally — `tree-sitter-objc` WASM absent in sandbox, asserts in CI) |
+| `64a6093` fix(groovy) inherits/implements | `extractGroovy`, `src/extract.ts:2827-2837` | **already-covered** (regex extractor already emits both) |
+
 ## Source Lock Notes
 
 - `git ls-remote` is the authority for Safi Python tags while local tag clobber risk exists.

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1741,6 +1741,42 @@ async function _extractGeneric(
         }
       }
 
+      // Ruby-specific: `class Dog < Animal` puts the base class in the
+      // `superclass` field (a `<` token followed by a `constant` or a
+      // `scope_resolution`). There was no Ruby branch, so every Ruby inherits
+      // edge was silently dropped. Port of upstream safishamsi a19b9e9.
+      if (config.tsModule === "tree_sitter_ruby") {
+        const sup = node.childForFieldName("superclass");
+        if (sup) {
+          let base = "";
+          for (const sub of sup.children) {
+            if (sub.type === "constant") {
+              base = _readText(sub, source);
+              break;
+            }
+            if (sub.type === "scope_resolution") {
+              const consts = sub.children.filter((c) => c.type === "constant");
+              if (consts.length > 0) base = _readText(consts[consts.length - 1]!, source);
+              break;
+            }
+          }
+          if (base) {
+            let baseNid = _makeId(stem, base);
+            if (!seenIds.has(baseNid)) {
+              baseNid = _makeId(base);
+              if (!seenIds.has(baseNid)) {
+                nodes.push({
+                  id: baseNid, label: base, file_type: "code",
+                  source_file: "", source_location: "",
+                });
+                seenIds.add(baseNid);
+              }
+            }
+            addEdge(classNid, baseNid, "inherits", line);
+          }
+        }
+      }
+
       // Java-specific: superclass / interface inheritance and implementation.
       if (config.tsModule === "tree_sitter_java") {
         const emitJavaParent = (baseName: string, relation: string): void => {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -3975,6 +3975,22 @@ export async function extractPowershell(filePath: string, rootDir?: string): Pro
   const fileNid = _makeId(stem);
   addNode(fileNid, basename(filePath), 1);
 
+  // Resolve a bare type name to a node id: prefer an in-file definition
+  // (stem-qualified), otherwise emit a SOURCELESS stub so the corpus-level
+  // rewire can collapse it onto the real definition. Mirrors upstream's
+  // `ensure_named_node`; addNode is idempotent so this is safe to call
+  // before or after the referenced type is walked.
+  function ensureNamedNode(name: string, line: number): string {
+    const qualified = _makeId(stem, name);
+    if (seenIds.has(qualified)) return qualified;
+    const global = _makeId(name);
+    if (!seenIds.has(global)) {
+      seenIds.add(global);
+      nodes.push({ id: global, label: name, file_type: "code", source_file: "", source_location: "" });
+    }
+    return global;
+  }
+
   const _PS_SKIP = new Set([
     "using", "return", "if", "else", "elseif", "foreach", "for",
     "while", "do", "switch", "try", "catch", "finally", "throw",
@@ -4018,6 +4034,24 @@ export async function extractPowershell(filePath: string, rootDir?: string): Pro
         const classNid = _makeId(stem, className);
         addNode(classNid, className, line);
         addEdge(fileNid, classNid, "contains", line);
+        // Base type(s) after ':'. The handler previously read only the class
+        // name and dropped every `class Dog : Animal` inheritance edge.
+        // PowerShell has no syntactic base-vs-interface split, so (matching the
+        // C# convention) the first base is emitted as `inherits` and the rest
+        // as `implements`. Port of upstream safishamsi a129ff2.
+        let colonSeen = false;
+        let baseIndex = 0;
+        for (const child of node.children) {
+          if (child.type === ":") {
+            colonSeen = true;
+          } else if (colonSeen && child.type === "simple_name") {
+            const baseNid = ensureNamedNode(_readText(child, source), line);
+            if (baseNid !== classNid) {
+              addEdge(classNid, baseNid, baseIndex === 0 ? "inherits" : "implements", line);
+            }
+            baseIndex++;
+          }
+        }
         for (const child of node.children) {
           walk(child, classNid);
         }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -4204,6 +4204,21 @@ export async function extractObjc(filePath: string, rootDir?: string): Promise<E
     return source.slice(node.startIndex, node.endIndex);
   }
 
+  // Resolve a bare type/protocol name to a node id: prefer an in-file
+  // definition (stem-qualified), otherwise emit a SOURCELESS stub so the
+  // corpus-level rewire can collapse it onto the real definition. Mirrors
+  // upstream's `ensure_named_node`.
+  function ensureNamedNode(name: string): string {
+    const qualified = _makeId(stem, name);
+    if (seenIds.has(qualified)) return qualified;
+    const global = _makeId(name);
+    if (!seenIds.has(global)) {
+      seenIds.add(global);
+      nodes.push({ id: global, label: name, file_type: "code", source_file: "", source_location: "" });
+    }
+    return global;
+  }
+
   function walk(node: SyntaxNode, parentNid: string | null = null): void {
     const t = node.type;
     const line = node.startPosition.row + 1;
@@ -4301,6 +4316,22 @@ export async function extractObjc(filePath: string, rootDir?: string): Promise<E
         const protoNid = _makeId(stem, name);
         addNode(protoNid, `<${name}>`, line);
         addEdge(fileNid, protoNid, "contains", line);
+        // Protocol-to-protocol adoption: `@protocol Foo <Bar>` exposes the
+        // adopted protocols in a `protocol_reference_list`. Emit an `implements`
+        // edge for each so protocol hierarchies aren't dropped. Port of
+        // upstream safishamsi cd3a376.
+        for (const child of node.children) {
+          if (child.type === "protocol_reference_list") {
+            for (const sub of child.children) {
+              if (sub.type === "identifier") {
+                const baseNid = ensureNamedNode(_read(sub));
+                if (baseNid !== protoNid) {
+                  addEdge(protoNid, baseNid, "implements", line);
+                }
+              }
+            }
+          }
+        }
         for (const child of node.children) walk(child, protoNid);
       }
       return;

--- a/tests/language-surface.test.ts
+++ b/tests/language-surface.test.ts
@@ -1058,4 +1058,27 @@ class PaymentService extends BaseService implements Billable {}
     expect(relations).toContain("shapes_circle:inherits:shapes_shape");
     expect(relations).toContain("shapes_circle:implements:shapes_idrawable");
   });
+
+  // Integration test via the real grammar. tree-sitter-objc is an optional peer
+  // dep; soft-skip when its WASM isn't installed (see convention above).
+  it("extracts Objective-C protocol-to-protocol adoption edges", async () => {
+    writeFileSync(join(dir, "Serializable.m"), [
+      "@protocol Codable",
+      "@end",
+      "",
+      "@protocol Serializable <Codable>",
+      "- (NSData *)serialize;",
+      "@end",
+      "",
+    ].join("\n"));
+
+    const result = await extract([join(dir, "Serializable.m")]);
+    if (!result.nodes.some((n) => n.id === "serializable_serializable")) {
+      // grammar absent — nothing extracted; covered in CI where the grammar is present
+      return;
+    }
+    const relations = result.edges.map((edge) => `${edge.source}:${edge.relation}:${edge.target}`);
+
+    expect(relations).toContain("serializable_serializable:implements:serializable_codable");
+  });
 });

--- a/tests/language-surface.test.ts
+++ b/tests/language-surface.test.ts
@@ -994,4 +994,38 @@ class PaymentService extends BaseService implements Billable {}
       }),
     ]));
   });
+
+  it("extracts Ruby class superclass inheritance edges", async () => {
+    writeFileSync(join(dir, "Dog.rb"), [
+      "class Animal",
+      "  def speak",
+      "  end",
+      "end",
+      "",
+      "class Dog < Animal",
+      "  def bark",
+      "  end",
+      "end",
+      "",
+    ].join("\n"));
+
+    const result = await extract([join(dir, "Dog.rb")]);
+    const relations = result.edges.map((edge) => `${edge.source}:${edge.relation}:${edge.target}`);
+
+    expect(relations).toContain("dog_dog:inherits:dog_animal");
+  });
+
+  it("extracts Ruby scope-resolved superclass inheritance edges", async () => {
+    writeFileSync(join(dir, "Widget.rb"), [
+      "class Widget < Gtk::Container",
+      "end",
+      "",
+    ].join("\n"));
+
+    const result = await extract([join(dir, "Widget.rb")]);
+    const inherits = result.edges.filter((e) => e.relation === "inherits");
+    const targetLabels = inherits.map((e) => result.nodes.find((n) => n.id === e.target)?.label);
+
+    expect(targetLabels).toContain("Container");
+  });
 });

--- a/tests/language-surface.test.ts
+++ b/tests/language-surface.test.ts
@@ -1028,4 +1028,34 @@ class PaymentService extends BaseService implements Billable {}
 
     expect(targetLabels).toContain("Container");
   });
+
+  // Integration test via the real grammar. tree-sitter-powershell is an
+  // optional peer dep, so when its WASM isn't installed the extractor returns
+  // empty nodes — soft-skip the assertion rather than fail (same convention as
+  // tests/extract-swift-extensions.test.ts).
+  it("extracts PowerShell class inheritance and interface edges", async () => {
+    writeFileSync(join(dir, "Shapes.ps1"), [
+      "class Shape {",
+      "    [string] Describe() { return 'shape' }",
+      "}",
+      "",
+      "class IDrawable {",
+      "}",
+      "",
+      "class Circle : Shape, IDrawable {",
+      "    [double] $Radius",
+      "}",
+      "",
+    ].join("\n"));
+
+    const result = await extract([join(dir, "Shapes.ps1")]);
+    if (!result.nodes.some((n) => n.id === "shapes_circle")) {
+      // grammar absent — nothing extracted; covered in CI where the grammar is present
+      return;
+    }
+    const relations = result.edges.map((edge) => `${edge.source}:${edge.relation}:${edge.target}`);
+
+    expect(relations).toContain("shapes_circle:inherits:shapes_shape");
+    expect(relations).toContain("shapes_circle:implements:shapes_idrawable");
+  });
 });


### PR DESCRIPTION
## Upstream parity — census + first port lot (WP6 · Platform & Parity)

### Census (this PR documents it in `UPSTREAM_GAP.md`)
Full classification of the **120-commit** window `v0.8.49..upstream/v8`.

**Premise corrections (verified, not guessed):**
- `upstream/v8` HEAD = `5190a4e` = **`v0.9.4-20-g5190a4e`** (20 untagged commits past the highest reachable tag `v0.9.4`). There are **no** upstream `v0.9.5–v0.9.8` tags.
- `v0.9.7`/`v0.9.8` are **our own `rhanka` fork release tags** (not on the v8 line).
- `v1.0.0` (`0a31c08`) is **not an ancestor of `upstream/v8`** → non-target.

**Buckets (sum 120):** ported-this-pass 3 · ported-prior 1 · already-covered 1 · `port` 18 · `must-audit` 54 · `n-a` 13 · `defer` 8 · `release-only` 22.

**Key finding:** `src/extract.ts` `_extractGeneric` has **no type-reference edge subsystem** (the only `relation:"references"` edges are SQL FKs). So the upstream "emit type/field/generic_arg references" fixes are a *subsystem* port (proposed Lot 2), not one-liners.

**Proposed 6 port-lots:** (1) class-inheritance edges **[this PR]**; (2) type/field/generic-arg references subsystem [L]; (3) `indirect_call` dispatch [M/L]; (4) build_merge/JSON-corruption/ids hardening [M]; (5) LLM dispatch + export/wiki robustness [M, audit-first]; (6) cross-file resolution + community-label determinism [M].

### Lot 1 — class-inheritance edges (implemented here)
| Port | Upstream | TS |
| --- | --- | --- |
| Ruby `class Dog < Animal` → `inherits` | `a19b9e9` | `_extractGeneric` ruby branch |
| PowerShell `class Circle : Shape, IDrawable` → `inherits`/`implements` | `a129ff2` | `extractPowershell` |
| ObjC `@protocol S <Codable>` → `implements` | `cd3a376` | `extractObjc` |

Groovy (`64a6093`) **not ported — already covered** (`extractGroovy` emits inherits/implements at `src/extract.ts:2827-2837`).

### Verification
- `tests/language-surface.test.ts`: **30 passed** (Ruby executes real assertions).
- Full extractor regression `tests/extract-*.test.ts` + language-surface: **137 passed (17 files)**.
- `npm run lint` (`tsc --noEmit`): **exit 0**.

### ⚠️ Verify-in-CI caveat
Only core tree-sitter grammars are installed locally. Optional grammars (`tree-sitter-powershell`, `tree-sitter-objc`) ship no prebuilt WASM, so their integration tests **soft-skip locally** (repo's own pattern) and **assert only in CI**. **Ruby is the only end-to-end-verified-locally port.** Do not merge until CI greens the PowerShell + ObjC assertions.

Additive, TypeScript-only. No PR merge until CI green.