### PR TITLE
fix(exports): surface CitedSourceRef/CitationModality/OntologyCitation types (canevas/immo unblock)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -435,6 +435,10 @@ export type {
 } from "./pdf-ocr-refs.js";
 export { citationToCitedSourceRef, citationsToCitedSourceRefs, validateCitedSourceRef } from "./cited-source-refs.js";
 export type { CitedSourceRefValidation } from "./cited-source-refs.js";
+// Citation-seam CORE types (canevas/immo request): the functions above were
+// public but their input/output types were not — consumers could not
+// `import type { CitedSourceRef } from "@sentropic/graphify"`.
+export type { CitedSourceRef, CitationModality, OntologyCitation } from "./types.js";
 export { prepareSemanticDetection } from "./semantic-prepare.js";
 export type { SemanticPreparationOptions, SemanticPreparationResult } from "./semantic-prepare.js";
 export {


### PR DESCRIPTION
1-line additive type export requested by peer canevas for immo: the citation-seam functions were public but `CitedSourceRef` / `CitationModality` / `OntologyCitation` were missing from the barrel (only `CitedSourceRefValidation` was exported). `import type { CitedSourceRef } from "@sentropic/graphify"` now works. Type-only, zero runtime change. Lint clean.