### PR TITLE
docs(spec): S.5 ratified — @sentropic/cited-source-viewer, Lots 2/3 greenlit, interim GO

### DIFF
--- a/spec/SPEC_WP_CITED_SOURCE_VIZ.md
+++ b/spec/SPEC_WP_CITED_SOURCE_VIZ.md
@@ -433,3 +433,30 @@ UI to the viewer, (3) any auth/layout. No graphify coupling required for the vie
 > **Modality tiering:** v1 (MD + PDF text-layer) and v2 (DOCX + PPTX) are pure text-match (no key, no
 > detection); **v3 (image-bbox) needs a YOLO-style/layout detection step and is excluded from Lot 1** —
 > only its contract (`bbox`/`region`/`modality`) lands early so the viewer can render image citations.
+
+### S.5 — RATIFIED_WITH_CONDITIONS (architect, 2026-07-04)
+
+Formal h2a trace `env:architect-s5-ratification-to-graphify-live-20260704T1147Z`; reconciles the
+2026-06-26 double-consensus SPEC_EVOL_PDF_CANEVA_VIEWER (owner=architect, seam=graphify, seed=lift radar).
+
+- **Name/home AMENDED**: the viewer lib is **`@sentropic/cited-source-viewer`**, home = sentropic
+  monorepo `packages/cited-source-viewer`, **ARCHITECT-owned**, **DS-THEMED** (consumes DS tokens) —
+  NOT DS-governed. `@sentropic/pdf-*` and the "under DS governance" clause are **dropped** (a
+  multi-modal document viewer is application code, not a DS primitive).
+- **(b) Purity**: no graphify runtime dep — enforced as a CI gate in the package (+ a
+  no-radar/no-`$lib` import gate).
+- **(c) Frozen contract = the SEAM** (`OntologyCitation`/`CitedSourceRef`), not a phantom viewer
+  API. Core seam types export from the public barrel since PR #260. **Scope v1 = MD + PDF
+  text-layer ONLY.**
+- **(d) Seed**: lift radar `SignalPdfOverlay.svelte` + `pdf-citation-match.ts`, with a radar
+  **parity acceptance gate** (radar deletes its bespoke overlay only at parity).
+- **(e) Deps ratified for v1 only**: pdf.js + markdown; v2 (DOCX/PPTX: mammoth/pptx) and v3
+  (image-bbox) deferred to their lots. **(f)** Quote-less image-bbox stays v3, gated on
+  producer-side detection.
+- **Lots 2 + 3: GREENLIT** at v1 scope under these conditions.
+- **Role split**: graphify owns the Lot-0 seam + producers and **codes the first Lot-2 cut** in the
+  sentropic monorepo under architect API review; the architect governs the exported surface.
+- **Interim GO**: a thin app-local interim viewer under the frozen seam ships in the graphify
+  studio immediately (pure component: `CitedSourceRef[]` props + source-resolver callback, DS
+  tokens, zero graphify runtime import inside the component) so the later rebase into
+  `packages/cited-source-viewer` is mechanical.

--- a/spec/SPEC_WP_CITED_SOURCE_VIZ.md
+++ b/spec/SPEC_WP_CITED_SOURCE_VIZ.md
@@ -460,3 +460,24 @@ Formal h2a trace `env:architect-s5-ratification-to-graphify-live-20260704T1147Z`
   studio immediately (pure component: `CitedSourceRef[]` props + source-resolver callback, DS
   tokens, zero graphify runtime import inside the component) so the later rebase into
   `packages/cited-source-viewer` is mechanical.
+
+### S.6 — Viewer UX: QUALIFIED REQUIREMENTS (principal UAT, 2026-07-04 — immo parity)
+
+The principal qualified the viewer UX **once**, against the immo/radar production viewer
+(SignalPdfOverlay UX). These requirements are **binding for the interim viewer AND for
+`@sentropic/cited-source-viewer`** — the qualification is NOT to be re-run per consumer
+(canevas, immo, graphify studio, aclp-am all inherit it).
+
+1. **Central overlay, NOT a modal.** The viewer takes the place of the CENTRAL view, as an
+   overlay over the canvas area only. Side panels (left rail, right selection panel) stay
+   visible AND interactive — clicking elsewhere keeps working; a click on another citation
+   RETARGETS the open overlay (no stacking). No blocking backdrop. X closes.
+2. **Rich toolbar** (immo reference: `≪ Signal 1/2 ≫ | PDF 1/2 | ‹ Page 11/15 › | − 136% + | Ouvrir ↗`):
+   citation navigator `‹ Citation x/y ›` · **document navigator `Doc x/y`** when refs span
+   multiple source files · page navigator `‹ Page x/y ›` · **zoom `− NN% +`** (re-renders page +
+   highlights at scale) · **`Ouvrir ↗`** (raw source in a new tab). One compact DS bar under the header.
+3. **Citation affordance in panels**: a FULL-WIDTH button UNDER the quote —
+   `📄 Voir la source · p.N` (immo pattern) — never a right-aligned truncatable inline button.
+4. **Generic multi-modal frame**: the overlay + toolbar are COMMON to all modalities (MD + PDF
+   text-layer in v1; DOCX/PPTX v2; image-bbox v3); only the body swaps per modality. The frame
+   is qualified once — modality lots may not fork the frame UX.


### PR DESCRIPTION
Records the architect's formal §S.5 RATIFY_WITH_CONDITIONS (2026-07-04, h2a trace env:architect-s5-ratification-to-graphify-live-20260704T1147Z) in SPEC_WP_CITED_SOURCE_VIZ.md: viewer renamed **@sentropic/cited-source-viewer** (sentropic monorepo packages/, architect-owned, DS-themed not DS-governed — @sentropic/pdf-* dropped), purity CI gate, frozen seam contract (v1 = MD + PDF text-layer only), radar-lift seed with parity gate, v1 deps (pdf.js + markdown) only, **Lots 2/3 greenlit**, graphify codes the first Lot-2 cut under architect API review, **interim app-local viewer GO** (in build now). Docs-only.