### PR TITLE
feat(studio): interim cited-source viewer — MD + PDF text-layer with quote highlight (S.5 interim GO)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4834,6 +4834,8 @@ export async function main(): Promise<void> {
     .option("--profile <path>", "Optional ontology profile YAML; emits class-hierarchies.json when the profile carries a class_hierarchies block")
     .option("--no-single-file", "Skip the self-contained studio.html; emit only the multi-file bundle")
     .option("--full-offline", "Inline graph.json + entities.json into studio.html too (not just the scene) so the offline studio needs zero network")
+    .option("--include-sources", "Copy the CITED source documents into <out>/sources/ so the cited-source viewer can open them from the served bundle (opt-in; only files referenced by citations)")
+    .option("--sources-root <dir>", "Root the relative source_file locators resolve against (default: the parent of --state)")
     .action(async (out, opts) => {
       try {
         const stateDir = resolve(opts.state ?? DEFAULT_GRAPHIFY_STATE_DIR);
@@ -4850,6 +4852,10 @@ export async function main(): Promise<void> {
             // and --full-offline -> fullOffline:true (default false).
             singleFile: opts.singleFile !== false,
             fullOffline: opts.fullOffline === true,
+            includeSources: opts.includeSources === true,
+            ...(typeof opts.sourcesRoot === "string" && opts.sourcesRoot.trim()
+              ? { sourcesRoot: resolve(opts.sourcesRoot.trim()) }
+              : {}),
             onWarning: (message) => console.warn(message),
           });
           console.log(`Static studio written to ${result.outDir}`);
@@ -4872,6 +4878,13 @@ export async function main(): Promise<void> {
             );
           } else {
             console.log("  offline studio.html: skipped (--no-single-file)");
+          }
+          if (result.sources) {
+            const mb = (result.sources.bytes / (1024 * 1024)).toFixed(1);
+            console.log(
+              `  cited sources: ${result.sources.copied} file(s) (${mb} MB) under sources/` +
+                (result.sources.missing > 0 ? ` — ${result.sources.missing} missing (see warnings)` : ""),
+            );
           }
           console.log(`  open: serve ${result.outDir} with any static file server (index.html)`);
         } catch (err) {

--- a/src/studio-export.ts
+++ b/src/studio-export.ts
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -92,6 +93,21 @@ export interface BuildStaticStudioOptions {
    * graph hydration. Default `false` (scene-only). Implies `singleFile`.
    */
   fullOffline?: boolean;
+  /**
+   * Copy every CITED source file (node.source_file + citations[].source_file,
+   * incl. the Level-2 sidecar) into `<out>/sources/<project-relative-path>` so
+   * the cited-source viewer can fetch the actual documents from the served
+   * bundle. OPT-IN (default `false`) and size-conscious: only files actually
+   * referenced by citations are copied; missing files warn, never fail.
+   */
+  includeSources?: boolean;
+  /**
+   * Root the relative `source_file` locators resolve against (typically the
+   * project root the graph was extracted from). Default: the parent of
+   * `stateDir` (source_file values like `corpus/x.pdf` or
+   * `.graphify/converted/pdf/x.md` are project-root-relative).
+   */
+  sourcesRoot?: string;
   /** Emit a warning (non-fatal). Defaults to console.warn. */
   onWarning?: (message: string) => void;
 }
@@ -116,6 +132,8 @@ export interface BuildStaticStudioResult {
   studioHtmlPath: string | null;
   /** Byte size of the emitted `studio.html`, or null when skipped. */
   studioHtmlBytes: number | null;
+  /** `--include-sources` summary, or null when the option was off. */
+  sources: { copied: number; missing: number; bytes: number } | null;
 }
 
 const GENERATED_DATA_FILES = [
@@ -139,7 +157,7 @@ const GENERATED_DATA_FILES = [
 ];
 
 /** Stale directories a previous (possibly multi-model) export may have left. */
-const GENERATED_DATA_DIRS = ["assets", "ontology", "models"];
+const GENERATED_DATA_DIRS = ["assets", "ontology", "models", "sources"];
 
 /**
  * Below this fraction of real descriptions (per describable node), the export
@@ -240,6 +258,102 @@ export function removeLegacyGraphViz(stateDir: string): boolean {
     return true;
   }
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// `--include-sources` — bundle the CITED source documents (cited-source viewer).
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect every relative `source_file` locator referenced by the graph's nodes
+ * (node.source_file + node.citations[].source_file) and by the Level-2
+ * citations sidecar (deep-scanned for `source_file` string values, so the set
+ * covers files cited beyond the inline top-K).
+ */
+export function collectCitedSourceFiles(
+  nodes: Array<Record<string, unknown>>,
+  citationsSidecarJson: unknown,
+): string[] {
+  const files = new Set<string>();
+  const add = (value: unknown): void => {
+    if (typeof value === "string" && value.trim()) files.add(value.trim());
+  };
+  for (const node of nodes) {
+    add(node.source_file);
+    const citations = node.citations;
+    if (Array.isArray(citations)) {
+      for (const c of citations) add((c as Record<string, unknown> | null)?.source_file);
+    }
+  }
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+    } else if (value && typeof value === "object") {
+      for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+        if (key === "source_file") add(item);
+        else walk(item);
+      }
+    }
+  };
+  walk(citationsSidecarJson);
+  return [...files].sort();
+}
+
+/**
+ * Normalize a cited locator to the bundle-relative `sources/` path. Returns
+ * null for locators that cannot be safely mirrored (absolute paths, URLs, or
+ * paths escaping the root after normalization).
+ */
+export function normalizeSourceRelPath(locator: string): string | null {
+  const trimmed = locator.trim().replace(/^\.\//, "");
+  if (!trimmed || isAbsolute(trimmed) || /^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
+  const normalized = trimmed.split(/[\\/]+/).filter((seg) => seg && seg !== ".");
+  if (normalized.includes("..")) return null;
+  return normalized.join("/");
+}
+
+/**
+ * Copy the cited source files into `<outDir>/sources/`, preserving their
+ * project-relative paths (the SPA glue fetches `./sources/<source_file>`).
+ * Each locator is resolved against `roots` in order (project root first, then
+ * the state dir). Missing / unsafe locators are counted and warned, never fatal.
+ */
+function emitCitedSources(
+  files: string[],
+  roots: string[],
+  outDir: string,
+  warn: (message: string) => void,
+): { copied: number; missing: number; bytes: number } {
+  let copied = 0;
+  let missing = 0;
+  let bytes = 0;
+  const missingSamples: string[] = [];
+  for (const locator of files) {
+    const rel = normalizeSourceRelPath(locator);
+    if (!rel) {
+      missing += 1;
+      if (missingSamples.length < 5) missingSamples.push(`${locator} (unsafe/non-relative)`);
+      continue;
+    }
+    const from = roots.map((root) => join(root, rel)).find((p) => existsSync(p));
+    if (!from) {
+      missing += 1;
+      if (missingSamples.length < 5) missingSamples.push(rel);
+      continue;
+    }
+    const to = join(outDir, "sources", rel);
+    mkdirSync(dirname(to), { recursive: true });
+    cpSync(from, to);
+    copied += 1;
+    bytes += statSync(to).size;
+  }
+  if (missing > 0) {
+    warn(
+      `studio export: --include-sources could not bundle ${missing} cited file(s) ` +
+        `(searched ${roots.join(", ")}): ${missingSamples.join("; ")}${missing > missingSamples.length ? "; …" : ""}`,
+    );
+  }
+  return { copied, missing, bytes };
 }
 
 // ---------------------------------------------------------------------------
@@ -523,6 +637,29 @@ export function buildStaticStudio(
     writeFileSync(outCitationsPath, citationsRaw);
   }
 
+  // 5c. sources/: OPT-IN copy of the cited source documents themselves, so the
+  //     cited-source viewer can fetch `./sources/<source_file>` from the served
+  //     bundle. Locators resolve against the project root (parent of stateDir,
+  //     overridable via sourcesRoot), then the state dir. Size-conscious: only
+  //     files actually referenced by citations; missing files warn, never fail.
+  let sources: BuildStaticStudioResult["sources"] = null;
+  if (options.includeSources) {
+    let citationsSidecarJson: unknown = null;
+    if (citationsRaw !== null) {
+      try {
+        citationsSidecarJson = JSON.parse(citationsRaw.toString("utf-8"));
+      } catch {
+        warn("studio export: could not parse ontology/citations.json for --include-sources; using graph citations only.");
+      }
+    }
+    const citedFiles = collectCitedSourceFiles(
+      nodes as Array<Record<string, unknown>>,
+      citationsSidecarJson,
+    );
+    const roots = [resolve(options.sourcesRoot ?? dirname(resolve(stateDir))), resolve(stateDir)];
+    sources = emitCitedSources(citedFiles, roots, outDir, warn);
+  }
+
   // 6. workspace-manifest.json: the bundle descriptor (hashes the final bytes of
   //    every artifact above). Emitted LAST of the MULTI-FILE bundle. studio.html
   //    is NOT one of its artifacts, so the manifest bytes are identical whether
@@ -600,5 +737,6 @@ export function buildStaticStudio(
     manifestArtifactCount: manifestResult.manifest.artifacts.length,
     studioHtmlPath,
     studioHtmlBytes,
+    sources,
   };
 }

--- a/studio/README.md
+++ b/studio/README.md
@@ -78,3 +78,36 @@ The legacy server-rendered studio at `/` is untouched — the two coexist.
 - **Group filtering**: the rail filters the Results list by type/community; the
   center graph is not yet sliced to the active group (BFS focus subgraph from
   `graph-selection.ts` is the intended next step).
+
+## Cited-source viewer (INTERIM, architect-ratified §S.5)
+
+`components/CitedSourceViewer.svelte` is the app-local interim build of the
+future `@sentropic/cited-source-viewer` package. Contract:
+
+- **Pure component** (mechanical-rebase seam): props are
+  `refs: CitedSourceRef[]` + `resolveSource(ref) => Promise<{kind:"pdf",data}|{kind:"markdown",text}>`
+  (+ `activeIndex`, `title`, `onClose`). It imports ONLY `lib/cited-source/*`
+  (quote matcher lifted from radar `pdf-citation-match.ts`, pdf.js engine seeded
+  from radar `SignalPdfOverlay.svelte`) and Svelte — **no graphify import**.
+- **Impure glue** lives in `lib/citedSources.js` + `App.svelte`: converts
+  `node.citations` via the frozen public projection
+  (`citationToCitedSourceRef`, `src/cited-source-refs.ts`), fills the
+  `source_file` locator, and resolves bytes.
+- **v1 scope**: MD/OCR-markdown/plain-text + PDF text-layer. No DOCX/PPTX (v2),
+  no image-bbox (v3).
+
+### Source-byte resolution (distribution pathing)
+
+`graphify studio export <out> --include-sources` copies every cited file into
+`<out>/sources/<project-relative source_file>` (opt-in, only files actually
+referenced by citations; `--sources-root` overrides the project root, default =
+parent of `--state`). The SPA glue fetches `./sources/<source_file>` relative to
+the bundle.
+
+What works where:
+
+| Mode | Viewer |
+| --- | --- |
+| Served multi-file bundle (any static server / Pages) | **Full**: PDF render + text-layer highlight, markdown highlight |
+| Live `graphify ontology studio` server | Panel affordance shows; sources 404 (no `/api` source route yet — follow-up) |
+| `file://` (double-clicked `studio.html` / `index.html`) | Viewer opens, shows its explicit "Source unavailable" state (browser blocks sibling `file://` fetches; pdf.js worker cannot load either) |

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@sentropic/design-system-svelte": "^0.34.33",
         "@sentropic/design-system-themes": "^0.11.0",
-        "@sentropic/design-system-tokens": "^0.11.0"
+        "@sentropic/design-system-tokens": "^0.11.0",
+        "pdfjs-dist": "^4.10.38"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -644,6 +645,271 @@
       "license": "ISC",
       "peerDependencies": {
         "svelte": "^5"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2092,6 +2358,18 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/studio/package.json
+++ b/studio/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@sentropic/design-system-svelte": "^0.34.33",
     "@sentropic/design-system-themes": "^0.11.0",
-    "@sentropic/design-system-tokens": "^0.11.0"
+    "@sentropic/design-system-tokens": "^0.11.0",
+    "pdfjs-dist": "^4.10.38"
   }
 }

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -13,11 +13,13 @@
   import { AppChrome, Button, ButtonGroup, Select } from "@sentropic/design-system-svelte";
 
   import AnswerPanel from "./components/AnswerPanel.svelte";
+  import CitedSourceViewer from "./components/CitedSourceViewer.svelte";
   import GraphCanvas from "./components/GraphCanvas.svelte";
   import LeftRail from "./components/LeftRail.svelte";
   import ReconciliationView from "./components/ReconciliationView.svelte";
   import SelectionPanel from "./components/SelectionPanel.svelte";
   import WorkspaceShell from "./components/WorkspaceShell.svelte";
+  import { refsForCitations, resolveBundleSource } from "./lib/citedSources.js";
   import {
     fetchClassHierarchies,
     fetchEntity,
@@ -439,6 +441,28 @@
     searchIndex = await fetchSearchIndex();
   }
 
+  // ----- cited-source viewer (INTERIM, architect-ratified §S.5) --------------
+  // IMPURE studio glue: the EntityPanel affordance hands the node's raw
+  // OntologyCitation list here; the frozen public projection converts it to
+  // CitedSourceRef[] and the DS-styled modal hosts the PURE CitedSourceViewer
+  // with the bundle resolver (sources/ dir, `--include-sources` export).
+  // null = closed; { refs, activeIndex, title } = open.
+  let sourceView = $state(null);
+  function handleOpenSource({ citations, index, fallbackSourceFile, label }) {
+    const refs = refsForCitations(citations, fallbackSourceFile);
+    if (refs.length === 0) return;
+    const active = Number.isInteger(index) && index >= 0 && index < refs.length ? index : 0;
+    const locator = refs[active]?.rawRef ?? refs[active]?.sourceUrl ?? "";
+    sourceView = {
+      refs,
+      activeIndex: active,
+      title: label ? `${label} — ${locator}` : locator,
+    };
+  }
+  function handleCloseSource() {
+    sourceView = null;
+  }
+
   // Open an entity surfaced by the Answer view IN the graph: switch to the
   // workspace view, add it to the selection + focus it (highlight + detail), and
   // hydrate its sidecar — no graph reload (mirrors handleFocusEntity).
@@ -689,9 +713,32 @@
             onToggleCommunity={handleToggleCommunity}
             onToggleEntity={handleToggleEntity}
             onClear={handleClear}
+            onOpenSource={handleOpenSource}
           />
         </div>
       </WorkspaceShell>
+    {/if}
+
+    {#if sourceView}
+      <!-- Cited-source viewer modal (DS-styled). The component is PURE: refs +
+           resolveSource only; all graphify glue stays in this file. -->
+      <div class="source-modal" role="dialog" aria-modal="true" aria-label="Cited source">
+        <button
+          class="source-modal-backdrop"
+          type="button"
+          aria-label="Close source viewer"
+          onclick={handleCloseSource}
+        ></button>
+        <div class="source-modal-panel">
+          <CitedSourceViewer
+            refs={sourceView.refs}
+            activeIndex={sourceView.activeIndex}
+            title={sourceView.title}
+            resolveSource={resolveBundleSource}
+            onClose={handleCloseSource}
+          />
+        </div>
+      </div>
     {/if}
   </main>
 </div>
@@ -731,6 +778,41 @@
   .app-body {
     flex: 1;
     min-height: 0;
+    /* Anchor for the cited-source modal overlay. */
+    position: relative;
+  }
+  /* Cited-source viewer modal: DS-token backdrop + centered panel. */
+  .source-modal {
+    position: absolute;
+    inset: 0;
+    z-index: 40;
+    display: grid;
+    place-items: center;
+    padding: var(--st-spacing-6, 1.5rem);
+  }
+  .source-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    background: color-mix(in srgb, var(--st-semantic-text-primary, #0f172a) 45%, transparent);
+  }
+  .source-modal-panel {
+    position: relative;
+    width: min(58rem, 100%);
+    height: min(46rem, 100%);
+    min-height: 0;
+    display: flex;
+    background: var(--st-semantic-surface-default, #fff);
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-lg, 10px);
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.35);
+    overflow: hidden;
+  }
+  .source-modal-panel > :global(.csv) {
+    flex: 1;
+    min-width: 0;
   }
   .col {
     min-height: 0;

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -19,7 +19,7 @@
   import ReconciliationView from "./components/ReconciliationView.svelte";
   import SelectionPanel from "./components/SelectionPanel.svelte";
   import WorkspaceShell from "./components/WorkspaceShell.svelte";
-  import { refsForCitations, resolveBundleSource } from "./lib/citedSources.js";
+  import { refsForCitations, resolveBundleSource, sourceHrefFor } from "./lib/citedSources.js";
   import {
     fetchClassHierarchies,
     fetchEntity,
@@ -444,8 +444,11 @@
   // ----- cited-source viewer (INTERIM, architect-ratified §S.5) --------------
   // IMPURE studio glue: the EntityPanel affordance hands the node's raw
   // OntologyCitation list here; the frozen public projection converts it to
-  // CitedSourceRef[] and the DS-styled modal hosts the PURE CitedSourceViewer
-  // with the bundle resolver (sources/ dir, `--include-sources` export).
+  // CitedSourceRef[] and a CENTRAL OVERLAY (qualified UX, immo parity: covers
+  // the graph canvas area ONLY — no backdrop, side panels stay interactive)
+  // hosts the PURE CitedSourceViewer with the bundle resolver (sources/ dir,
+  // `--include-sources` export). Clicking another citation while open simply
+  // replaces this state -> the viewer RETARGETS (no stacking).
   // null = closed; { refs, activeIndex, title } = open.
   let sourceView = $state(null);
   function handleOpenSource({ citations, index, fallbackSourceFile, label }) {
@@ -700,6 +703,23 @@
             onSelect={handleToggleEntity}
             onOpenEntity={handleFocusEntity}
           />
+          {#if sourceView}
+            <!-- Cited-source viewer as a CENTRAL OVERLAY (qualified UX, immo
+                 parity): covers the graph canvas area ONLY — no backdrop, the
+                 left rail + right selection panel stay visible and interactive.
+                 The component is PURE: refs + resolvers only; all graphify
+                 glue stays in this file. -->
+            <div class="source-overlay" role="region" aria-label="Cited source">
+              <CitedSourceViewer
+                refs={sourceView.refs}
+                activeIndex={sourceView.activeIndex}
+                title={sourceView.title}
+                resolveSource={resolveBundleSource}
+                sourceHref={sourceHrefFor}
+                onClose={handleCloseSource}
+              />
+            </div>
+          {/if}
         </div>
         <div class="col col-right">
           <SelectionPanel
@@ -717,28 +737,6 @@
           />
         </div>
       </WorkspaceShell>
-    {/if}
-
-    {#if sourceView}
-      <!-- Cited-source viewer modal (DS-styled). The component is PURE: refs +
-           resolveSource only; all graphify glue stays in this file. -->
-      <div class="source-modal" role="dialog" aria-modal="true" aria-label="Cited source">
-        <button
-          class="source-modal-backdrop"
-          type="button"
-          aria-label="Close source viewer"
-          onclick={handleCloseSource}
-        ></button>
-        <div class="source-modal-panel">
-          <CitedSourceViewer
-            refs={sourceView.refs}
-            activeIndex={sourceView.activeIndex}
-            title={sourceView.title}
-            resolveSource={resolveBundleSource}
-            onClose={handleCloseSource}
-          />
-        </div>
-      </div>
     {/if}
   </main>
 </div>
@@ -778,39 +776,24 @@
   .app-body {
     flex: 1;
     min-height: 0;
-    /* Anchor for the cited-source modal overlay. */
+  }
+  /* Central cited-source overlay (qualified UX, immo parity): fills the
+     CENTER column only, in surimpression over the graph canvas. NO backdrop —
+     the side rails stay visible and clickable. */
+  .col-center {
     position: relative;
   }
-  /* Cited-source viewer modal: DS-token backdrop + centered panel. */
-  .source-modal {
+  .source-overlay {
     position: absolute;
     inset: 0;
-    z-index: 40;
-    display: grid;
-    place-items: center;
-    padding: var(--st-spacing-6, 1.5rem);
-  }
-  .source-modal-backdrop {
-    position: absolute;
-    inset: 0;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    background: color-mix(in srgb, var(--st-semantic-text-primary, #0f172a) 45%, transparent);
-  }
-  .source-modal-panel {
-    position: relative;
-    width: min(58rem, 100%);
-    height: min(46rem, 100%);
-    min-height: 0;
+    z-index: 30;
     display: flex;
     background: var(--st-semantic-surface-default, #fff);
     border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    border-radius: var(--st-radius-lg, 10px);
-    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.35);
+    box-shadow: 0 8px 32px rgba(15, 23, 42, 0.22);
     overflow: hidden;
   }
-  .source-modal-panel > :global(.csv) {
+  .source-overlay > :global(.csv) {
     flex: 1;
     min-width: 0;
   }

--- a/studio/src/components/CitedSourceViewer.svelte
+++ b/studio/src/components/CitedSourceViewer.svelte
@@ -9,6 +9,30 @@
    * node.citations, converting via citationToCitedSourceRef, fetching bytes)
    * lives OUTSIDE, in the studio wiring (App.svelte + lib/citedSources.js).
    *
+   * QUALIFIED UX (principal UAT 2026-07-04, immo/radar SignalPdfOverlay
+   * parity). This frame is being qualified ONCE for the shared package, so it
+   * is GENERIC — toolbar/frame common to ALL modalities, only the body swaps:
+   *
+   *   header   kicker / title / active locator / ✕ close
+   *   toolbar  ONE compact DS bar, common to all modalities:
+   *              ‹ Citation x/y ›  active-ref navigator (shown when y > 1)
+   *              ‹ Doc x/y ›       source-document navigator (shown when the
+   *                                refs span MULTIPLE locators; prev/next jumps
+   *                                to the FIRST ref of the neighbour document)
+   *              ‹ Page x/y ›      modality segment (page-addressable only)
+   *              − NN% +           modality segment (render-scale zoom; the %
+   *                                button resets to fit-width)
+   *              Ouvrir ↗          opens the raw source in a new tab (shown
+   *                                when `sourceHref(ref)` resolves a URL)
+   *   body     the ONLY modality-specific region (pdf canvas + highlight
+   *            layer · markdown render + <mark>; image canvas later)
+   *   footer   degradation strip, shown ONLY when honesty requires it
+   *            ("quote not located — showing anyway")
+   *
+   * The component is NON-modal by design: the consumer hosts it as a central
+   * overlay (over its canvas/main view only) and keeps its side panels live; a
+   * NEW `refs` array + `activeIndex` RETARGETS an open viewer (no stacking).
+   *
    * Props (the frozen seam, SPEC_WP_CITED_SOURCE_VIZ §S.1/§S.3):
    *   refs          CitedSourceRef[] (shape only — no type import needed in JS):
    *                 { rawRef?, sourceUrl?, docSha?, modality?, page?, section?,
@@ -16,30 +40,40 @@
    *   resolveSource async (ref) => { kind: "pdf", data: ArrayBuffer }
    *                              | { kind: "markdown", text: string }
    *                 The component NEVER reads bytes itself (§S.3).
-   *   activeIndex   Initially-active ref index (optional).
+   *   sourceHref    (ref) => string|null — href for the "Ouvrir ↗" raw-source
+   *                 link; null/absent hides the button. Pure callback: the
+   *                 consumer owns the URL scheme (bundle sources/, API route…).
+   *   activeIndex   Active ref index; with a new `refs` array it retargets.
    *   title         Header title (e.g. the source file the user clicked).
    *   onClose       Close callback (optional; hides the ✕ when absent).
    *
    * v1 scope: MD (incl. OCR-markdown / plain text) + PDF text-layer only.
-   * PDF: render page + highlight the matched quote in the text layer; page
-   * navigation; "quote not found on this page" shows the page anyway.
-   * Markdown: full render, scroll-to + <mark> the quote.
    */
   import { tick } from "svelte";
-  import { computeHighlightRects, loadPdfDocument, renderPdfPage } from "../lib/cited-source/pdfEngine.js";
+  import {
+    MAX_RENDER_SCALE,
+    MIN_RENDER_SCALE,
+    computeHighlightRects,
+    loadPdfDocument,
+    renderPdfPage,
+  } from "../lib/cited-source/pdfEngine.js";
   import { renderSourceHtml } from "../lib/cited-source/markdownSource.js";
 
   let {
     refs = [],
     resolveSource,
+    sourceHref = null,
     activeIndex = 0,
     title = "Cited source",
     onClose = null,
   } = $props();
 
-  // Active ref index — internal state seeded from the prop (prev/next moves it).
+  // Active ref index — internal state seeded from the props. Tracking BOTH the
+  // refs identity and the activeIndex prop makes a re-open with the same index
+  // on a new refs array retarget correctly (no stale internal position).
   let index = $state(0);
   let lastActiveProp = -1;
+  let lastRefsProp = null;
 
   // Load pipeline state.
   let loading = $state(false);
@@ -55,6 +89,8 @@
   let currentPage = $state(1);
   let highlightRects = $state([]);
   let quoteOnPage = $state(true);
+  let scale = $state(1); // effective render scale (drives the toolbar %)
+  let userScale = $state(null); // manual zoom; null = fit-width (default)
   let canvasEl = $state(null);
   let scrollEl = $state(null);
   let mdEl = $state(null);
@@ -66,6 +102,31 @@
   const ref = $derived(refs[index] ?? null);
   const refCount = $derived(refs.length);
   const quoteOf = (r) => r?.excerpt ?? r?.citation ?? null;
+  const locatorOf = (r) => r?.rawRef ?? r?.sourceUrl ?? r?.docSha ?? "";
+
+  // ── Document navigator (immo "PDF x/y"): distinct source locators, in ref
+  //    order. Prev/next jumps to the FIRST ref of the neighbour document.
+  const docLocators = $derived.by(() => {
+    const seen = [];
+    for (const r of refs) {
+      const loc = locatorOf(r);
+      if (!seen.includes(loc)) seen.push(loc);
+    }
+    return seen;
+  });
+  const docCount = $derived(docLocators.length);
+  const docIndex = $derived(ref ? docLocators.indexOf(locatorOf(ref)) : -1);
+  function goDoc(delta) {
+    const target = docIndex + delta;
+    if (target < 0 || target >= docCount) return;
+    const loc = docLocators[target];
+    const first = refs.findIndex((r) => locatorOf(r) === loc);
+    if (first >= 0) index = first;
+  }
+
+  const rawHref = $derived(
+    ref && typeof sourceHref === "function" ? (sourceHref(ref) ?? null) : null,
+  );
 
   /** Human locator label for the header ("p.3", "§ Chapter 2", …). */
   function locatorLabel(r) {
@@ -76,13 +137,13 @@
     else if (r.paragraph_id) parts.push(`¶${r.paragraph_id}`);
     return parts.join(" · ");
   }
-  function sourceLabel(r) {
-    return r?.rawRef ?? r?.sourceUrl ?? r?.docSha ?? "(no locator)";
-  }
 
-  // React to the activeIndex prop (a new click while open re-targets the viewer).
+  // Retarget on ANY prop change (new refs array and/or new activeIndex): a
+  // click on another citation while the overlay is open re-aims the SAME
+  // viewer instead of stacking a second one.
   $effect(() => {
-    if (activeIndex !== lastActiveProp) {
+    if (refs !== lastRefsProp || activeIndex !== lastActiveProp) {
+      lastRefsProp = refs;
       lastActiveProp = activeIndex;
       const clamped = Math.max(0, Math.min(refs.length - 1, activeIndex ?? 0));
       index = refs.length > 0 ? clamped : 0;
@@ -106,6 +167,7 @@
     numPages = 0;
     highlightRects = [];
     quoteOnPage = true;
+    userScale = null; // a new source starts back in fit-width (radar #90)
     try {
       const payload = await resolveSource(target);
       if (token !== loadToken) return;
@@ -146,8 +208,9 @@
     await tick();
     if (!canvasEl) return;
     const containerWidth = scrollEl ? Math.max(120, scrollEl.clientWidth - 32) : 720;
-    const { viewport, scale } = await renderPdfPage(pdfPage, canvasEl, { containerWidth });
+    const rendered = await renderPdfPage(pdfPage, canvasEl, { containerWidth, userScale });
     if (token !== renderToken) return;
+    scale = rendered.scale;
 
     // Highlight only on the ref's own page (radar bug #83 guard: a generic
     // fallback window would otherwise re-highlight on EVERY page).
@@ -157,7 +220,7 @@
     if (quote && onRefPage) {
       const content = await pdfPage.getTextContent();
       if (token !== renderToken) return;
-      const { rects } = computeHighlightRects(content, viewport, scale, quote);
+      const { rects } = computeHighlightRects(content, rendered.viewport, rendered.scale, quote);
       highlightRects = rects;
       quoteOnPage = rects.length > 0;
       if (rects.length > 0) queueScrollToHighlight(rects[0]);
@@ -166,6 +229,26 @@
       // Off the ref page: nothing is expected to highlight — not a degradation.
       quoteOnPage = !quote || !onRefPage ? true : false;
     }
+  }
+
+  // ── Zoom (immo "− 136% +"): manual render-scale override; the % button
+  //    resets to fit-width. Re-renders the page + highlights at the new scale.
+  function setUserScale(next) {
+    const clamped = Math.max(MIN_RENDER_SCALE, Math.min(MAX_RENDER_SCALE, next));
+    if (userScale !== null && Math.abs(clamped - userScale) < 0.001) return;
+    userScale = clamped;
+    if (pdfDoc) void renderPage(currentPage);
+  }
+  function zoomIn() {
+    setUserScale((userScale ?? scale) + 0.2);
+  }
+  function zoomOut() {
+    setUserScale((userScale ?? scale) - 0.2);
+  }
+  function resetZoom() {
+    if (userScale === null) return;
+    userScale = null;
+    if (pdfDoc) void renderPage(currentPage);
   }
 
   /** rAF with a setTimeout fallback (jsdom test environments may lack rAF). */
@@ -201,7 +284,18 @@
     if (i < 0 || i >= refCount || i === index) return;
     index = i;
   }
+
+  /** True when the key event belongs to a form field. The overlay is NON-modal
+   *  (side panels stay interactive), so typing there must never page/close. */
+  function isEditableTarget(event) {
+    const el = event.target;
+    if (!el || typeof el.closest !== "function") return false;
+    return Boolean(
+      el.closest("input, textarea, select, [contenteditable=''], [contenteditable='true']"),
+    );
+  }
   function handleKeydown(event) {
+    if (isEditableTarget(event)) return;
     if (event.key === "Escape" && onClose) onClose();
     else if (event.key === "ArrowLeft" && pdfDoc) goPrevPage();
     else if (event.key === "ArrowRight" && pdfDoc) goNextPage();
@@ -214,10 +308,10 @@
   <header class="csv-head">
     <div class="csv-head-text">
       <p class="csv-kicker">Cited source</p>
-      <h2 class="csv-title" title={sourceLabel(ref)}>{title}</h2>
+      <h2 class="csv-title" title={locatorOf(ref)}>{title}</h2>
       {#if ref}
         <p class="csv-locator">
-          <span class="csv-locator-file">{sourceLabel(ref)}</span>
+          <span class="csv-locator-file">{locatorOf(ref) || "(no locator)"}</span>
           {#if locatorLabel(ref)}<span class="csv-locator-pos">{locatorLabel(ref)}</span>{/if}
         </p>
       {/if}
@@ -227,25 +321,51 @@
     {/if}
   </header>
 
-  {#if refCount > 1}
-    <nav class="csv-refs" aria-label="Citations in this source set">
-      <button
-        class="csv-refnav"
-        type="button"
-        disabled={index <= 0}
-        onclick={() => goRef(index - 1)}
-        aria-label="Previous citation"
-      >←</button>
-      <span class="csv-refcount">Citation {index + 1}/{refCount}</span>
-      <button
-        class="csv-refnav"
-        type="button"
-        disabled={index >= refCount - 1}
-        onclick={() => goRef(index + 1)}
-        aria-label="Next citation"
-      >→</button>
-    </nav>
-  {/if}
+  <!-- QUALIFIED TOOLBAR (immo parity): one compact bar, generic frame; only
+       the Page/Zoom segments are modality-gated (page-addressable sources). -->
+  <div class="csv-toolbar" role="toolbar" aria-label="Source navigation">
+    {#if refCount > 1}
+      <div class="csv-tb-group" aria-label="Citation navigator">
+        <button class="csv-tb-btn" type="button" disabled={index <= 0} onclick={() => goRef(index - 1)} aria-label="Previous citation">‹</button>
+        <span class="csv-tb-label">Citation <strong>{index + 1}/{refCount}</strong></span>
+        <button class="csv-tb-btn" type="button" disabled={index >= refCount - 1} onclick={() => goRef(index + 1)} aria-label="Next citation">›</button>
+      </div>
+    {/if}
+
+    {#if docCount > 1}
+      <div class="csv-tb-group" aria-label="Document navigator">
+        <button class="csv-tb-btn" type="button" disabled={docIndex <= 0} onclick={() => goDoc(-1)} aria-label="Previous document">‹</button>
+        <span class="csv-tb-label">Doc <strong>{docIndex + 1}/{docCount}</strong></span>
+        <button class="csv-tb-btn" type="button" disabled={docIndex >= docCount - 1} onclick={() => goDoc(1)} aria-label="Next document">›</button>
+      </div>
+    {/if}
+
+    {#if pdfDoc}
+      <div class="csv-tb-group" aria-label="Page navigator">
+        <button class="csv-tb-btn" type="button" disabled={currentPage <= 1} onclick={goPrevPage} aria-label="Previous page">‹</button>
+        <span class="csv-tb-label">Page <strong>{currentPage}/{numPages}</strong></span>
+        <button class="csv-tb-btn" type="button" disabled={currentPage >= numPages} onclick={goNextPage} aria-label="Next page">›</button>
+      </div>
+
+      <div class="csv-tb-group" aria-label="Zoom">
+        <button class="csv-tb-btn" type="button" disabled={scale <= MIN_RENDER_SCALE + 0.001} onclick={zoomOut} aria-label="Zoom out">−</button>
+        <button
+          class="csv-tb-zoom"
+          type="button"
+          onclick={resetZoom}
+          title="Back to fit-width"
+          aria-label="Zoom level {Math.round(scale * 100)} percent, click to fit width"
+        >{Math.round(scale * 100)}%</button>
+        <button class="csv-tb-btn" type="button" disabled={scale >= MAX_RENDER_SCALE - 0.001} onclick={zoomIn} aria-label="Zoom in">+</button>
+      </div>
+    {/if}
+
+    <span class="csv-tb-spacer"></span>
+
+    {#if rawHref}
+      <a class="csv-tb-open" href={rawHref} target="_blank" rel="noopener noreferrer">Ouvrir ↗</a>
+    {/if}
+  </div>
 
   {#if quoteOf(ref)}
     <blockquote class="csv-quote">{quoteOf(ref)}</blockquote>
@@ -258,7 +378,7 @@
       <div class="csv-error" role="alert">
         <p class="csv-error-title">Source unavailable</p>
         <p class="csv-error-detail">{loadError}</p>
-        <code class="csv-error-ref">{sourceLabel(ref)}</code>
+        <code class="csv-error-ref">{locatorOf(ref) || "(no locator)"}</code>
       </div>
     {:else if pdfDoc}
       <div class="csv-page-stage">
@@ -281,20 +401,15 @@
     {/if}
   </div>
 
-  <footer class="csv-foot">
-    {#if pdfDoc}
-      <div class="csv-pager" role="group" aria-label="Page navigation">
-        <button class="csv-refnav" type="button" onclick={goPrevPage} disabled={currentPage <= 1} aria-label="Previous page">←</button>
-        <span class="csv-page-ind">Page {currentPage}/{numPages}</span>
-        <button class="csv-refnav" type="button" onclick={goNextPage} disabled={currentPage >= numPages} aria-label="Next page">→</button>
-      </div>
-      {#if !quoteOnPage}
-        <span class="csv-degraded">Quote not located on this page — showing the page anyway.</span>
-      {/if}
-    {:else if mdPayload && quoteOf(ref) && !mdFound}
+  {#if pdfDoc && !quoteOnPage}
+    <footer class="csv-foot">
+      <span class="csv-degraded">Quote not located on this page — showing the page anyway.</span>
+    </footer>
+  {:else if mdPayload && quoteOf(ref) && !mdFound}
+    <footer class="csv-foot">
       <span class="csv-degraded">Quote not located in the source — showing the document anyway.</span>
-    {/if}
-  </footer>
+    </footer>
+  {/if}
 </section>
 
 <style>
@@ -363,36 +478,91 @@
     color: var(--st-semantic-feedback-error, #dc2626);
     border-color: var(--st-semantic-feedback-error, #dc2626);
   }
-  .csv-refs {
+  /* ── Qualified toolbar (immo parity) ──────────────────────────────────── */
+  .csv-toolbar {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 1rem;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    padding: 0.35rem 1rem;
     border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
     background: var(--st-semantic-surface-subtle, #f8fafc);
+    min-height: 2.1rem;
   }
-  .csv-refcount {
-    font-size: 0.74rem;
-    font-weight: 600;
-    color: var(--st-semantic-text-secondary, #475569);
-  }
-  .csv-refnav {
+  .csv-tb-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.1rem 0.2rem;
     border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-sm, 4px);
     background: var(--st-semantic-surface-default, #fff);
+  }
+  .csv-tb-label {
+    font-size: 0.72rem;
+    color: var(--st-semantic-text-secondary, #475569);
+    padding: 0 0.25rem;
+    white-space: nowrap;
+  }
+  .csv-tb-label strong {
+    font-weight: 700;
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .csv-tb-btn {
+    border: none;
+    background: transparent;
     border-radius: var(--st-radius-sm, 4px);
     color: var(--st-semantic-text-secondary, #475569);
     cursor: pointer;
-    font-size: 0.8rem;
+    font-size: 0.9rem;
     line-height: 1;
-    padding: 0.25rem 0.5rem;
+    padding: 0.15rem 0.4rem;
   }
-  .csv-refnav:disabled {
-    opacity: 0.4;
+  .csv-tb-btn:disabled {
+    opacity: 0.35;
     cursor: default;
   }
-  .csv-refnav:not(:disabled):hover {
-    border-color: var(--st-semantic-action-primary, #2563eb);
+  .csv-tb-btn:not(:disabled):hover {
+    background: var(--st-semantic-surface-subtle, #f1f5f9);
     color: var(--st-semantic-action-primary, #2563eb);
+  }
+  .csv-tb-zoom {
+    border: none;
+    background: transparent;
+    border-radius: var(--st-radius-sm, 4px);
+    color: var(--st-semantic-text-primary, #0f172a);
+    cursor: pointer;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0.2rem 0.3rem;
+    min-width: 2.6rem;
+    text-align: center;
+  }
+  .csv-tb-zoom:hover {
+    background: var(--st-semantic-surface-subtle, #f1f5f9);
+    color: var(--st-semantic-action-primary, #2563eb);
+  }
+  .csv-tb-spacer {
+    flex: 1;
+  }
+  .csv-tb-open {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-sm, 4px);
+    background: var(--st-semantic-surface-default, #fff);
+    color: var(--st-semantic-text-link, #2563eb);
+    font-size: 0.74rem;
+    font-weight: 600;
+    line-height: 1;
+    padding: 0.3rem 0.5rem;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .csv-tb-open:hover {
+    border-color: var(--st-semantic-action-primary, #2563eb);
   }
   .csv-quote {
     margin: 0.55rem 1rem 0.2rem;
@@ -493,19 +663,8 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.45rem 1rem;
+    padding: 0.35rem 1rem;
     border-top: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    min-height: 2.1rem;
-  }
-  .csv-pager {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-  }
-  .csv-page-ind {
-    font-size: 0.76rem;
-    font-weight: 600;
-    color: var(--st-semantic-text-secondary, #475569);
   }
   .csv-degraded {
     font-size: 0.74rem;

--- a/studio/src/components/CitedSourceViewer.svelte
+++ b/studio/src/components/CitedSourceViewer.svelte
@@ -1,0 +1,515 @@
+<script>
+  /**
+   * Cited-source viewer — INTERIM app-local build of the future
+   * `@sentropic/cited-source-viewer` (architect-ratified §S.5, 2026-07-04).
+   *
+   * PURITY CONTRACT (for the mechanical rebase into the sentropic monorepo):
+   * this component imports NOTHING from graphify — only its sibling pure lib
+   * (`../lib/cited-source/*`) and Svelte. All graphify-specific glue (reading
+   * node.citations, converting via citationToCitedSourceRef, fetching bytes)
+   * lives OUTSIDE, in the studio wiring (App.svelte + lib/citedSources.js).
+   *
+   * Props (the frozen seam, SPEC_WP_CITED_SOURCE_VIZ §S.1/§S.3):
+   *   refs          CitedSourceRef[] (shape only — no type import needed in JS):
+   *                 { rawRef?, sourceUrl?, docSha?, modality?, page?, section?,
+   *                   paragraph_id?, bbox?, excerpt?, citation? }
+   *   resolveSource async (ref) => { kind: "pdf", data: ArrayBuffer }
+   *                              | { kind: "markdown", text: string }
+   *                 The component NEVER reads bytes itself (§S.3).
+   *   activeIndex   Initially-active ref index (optional).
+   *   title         Header title (e.g. the source file the user clicked).
+   *   onClose       Close callback (optional; hides the ✕ when absent).
+   *
+   * v1 scope: MD (incl. OCR-markdown / plain text) + PDF text-layer only.
+   * PDF: render page + highlight the matched quote in the text layer; page
+   * navigation; "quote not found on this page" shows the page anyway.
+   * Markdown: full render, scroll-to + <mark> the quote.
+   */
+  import { tick } from "svelte";
+  import { computeHighlightRects, loadPdfDocument, renderPdfPage } from "../lib/cited-source/pdfEngine.js";
+  import { renderSourceHtml } from "../lib/cited-source/markdownSource.js";
+
+  let {
+    refs = [],
+    resolveSource,
+    activeIndex = 0,
+    title = "Cited source",
+    onClose = null,
+  } = $props();
+
+  // Active ref index — internal state seeded from the prop (prev/next moves it).
+  let index = $state(0);
+  let lastActiveProp = -1;
+
+  // Load pipeline state.
+  let loading = $state(false);
+  let loadError = $state(null);
+  /** @type {{kind:string, text?:string}|null} resolved non-pdf payload */
+  let mdPayload = $state(null);
+  let mdHtml = $state("");
+  let mdFound = $state(false);
+
+  // PDF state.
+  let pdfDoc = $state(null);
+  let numPages = $state(0);
+  let currentPage = $state(1);
+  let highlightRects = $state([]);
+  let quoteOnPage = $state(true);
+  let canvasEl = $state(null);
+  let scrollEl = $state(null);
+  let mdEl = $state(null);
+
+  // Token guards: a newer load/render invalidates in-flight older ones.
+  let loadToken = 0;
+  let renderToken = 0;
+
+  const ref = $derived(refs[index] ?? null);
+  const refCount = $derived(refs.length);
+  const quoteOf = (r) => r?.excerpt ?? r?.citation ?? null;
+
+  /** Human locator label for the header ("p.3", "§ Chapter 2", …). */
+  function locatorLabel(r) {
+    if (!r) return "";
+    const parts = [];
+    if (r.page != null) parts.push(`p.${r.page}`);
+    if (r.section) parts.push(r.section);
+    else if (r.paragraph_id) parts.push(`¶${r.paragraph_id}`);
+    return parts.join(" · ");
+  }
+  function sourceLabel(r) {
+    return r?.rawRef ?? r?.sourceUrl ?? r?.docSha ?? "(no locator)";
+  }
+
+  // React to the activeIndex prop (a new click while open re-targets the viewer).
+  $effect(() => {
+    if (activeIndex !== lastActiveProp) {
+      lastActiveProp = activeIndex;
+      const clamped = Math.max(0, Math.min(refs.length - 1, activeIndex ?? 0));
+      index = refs.length > 0 ? clamped : 0;
+    }
+  });
+
+  // (Re)load whenever the active ref changes.
+  $effect(() => {
+    if (ref && typeof resolveSource === "function") void load(ref);
+  });
+
+  async function load(target) {
+    const token = ++loadToken;
+    renderToken++;
+    loading = true;
+    loadError = null;
+    mdPayload = null;
+    mdHtml = "";
+    mdFound = false;
+    pdfDoc = null;
+    numPages = 0;
+    highlightRects = [];
+    quoteOnPage = true;
+    try {
+      const payload = await resolveSource(target);
+      if (token !== loadToken) return;
+      if (payload && payload.kind === "pdf") {
+        const doc = await loadPdfDocument(payload.data);
+        if (token !== loadToken) return;
+        pdfDoc = doc;
+        numPages = doc.numPages;
+        const wanted = Number(target.page);
+        const initial = Number.isFinite(wanted) && wanted >= 1 && wanted <= doc.numPages ? wanted : 1;
+        loading = false;
+        await renderPage(initial);
+      } else if (payload && (payload.kind === "markdown" || payload.kind === "text")) {
+        const rendered = renderSourceHtml(payload.text ?? "", quoteOf(target));
+        mdPayload = payload;
+        mdHtml = rendered.html;
+        mdFound = rendered.found;
+        loading = false;
+        await tick();
+        scrollToMark();
+      } else {
+        throw new Error("unsupported source payload (expected kind \"pdf\" or \"markdown\")");
+      }
+    } catch (err) {
+      if (token !== loadToken) return;
+      loading = false;
+      loadError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function renderPage(pageNumber) {
+    if (!pdfDoc) return;
+    const token = ++renderToken;
+    const clamped = Math.min(Math.max(pageNumber, 1), numPages || 1);
+    currentPage = clamped;
+    const pdfPage = await pdfDoc.getPage(clamped);
+    if (token !== renderToken) return;
+    await tick();
+    if (!canvasEl) return;
+    const containerWidth = scrollEl ? Math.max(120, scrollEl.clientWidth - 32) : 720;
+    const { viewport, scale } = await renderPdfPage(pdfPage, canvasEl, { containerWidth });
+    if (token !== renderToken) return;
+
+    // Highlight only on the ref's own page (radar bug #83 guard: a generic
+    // fallback window would otherwise re-highlight on EVERY page).
+    const quote = quoteOf(ref);
+    const refPage = Number(ref?.page);
+    const onRefPage = !Number.isFinite(refPage) || refPage === clamped;
+    if (quote && onRefPage) {
+      const content = await pdfPage.getTextContent();
+      if (token !== renderToken) return;
+      const { rects } = computeHighlightRects(content, viewport, scale, quote);
+      highlightRects = rects;
+      quoteOnPage = rects.length > 0;
+      if (rects.length > 0) queueScrollToHighlight(rects[0]);
+    } else {
+      highlightRects = [];
+      // Off the ref page: nothing is expected to highlight — not a degradation.
+      quoteOnPage = !quote || !onRefPage ? true : false;
+    }
+  }
+
+  /** rAF with a setTimeout fallback (jsdom test environments may lack rAF). */
+  function raf(fn) {
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(fn);
+    else setTimeout(fn, 0);
+  }
+
+  function queueScrollToHighlight(rect) {
+    raf(() => {
+      if (!scrollEl || typeof scrollEl.scrollTo !== "function") return;
+      const top = rect.top - scrollEl.clientHeight / 3;
+      scrollEl.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
+    });
+  }
+
+  function scrollToMark() {
+    raf(() => {
+      const mark = mdEl?.querySelector("[data-csv-mark]");
+      if (mark && typeof mark.scrollIntoView === "function") {
+        mark.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
+    });
+  }
+
+  function goPrevPage() {
+    if (currentPage > 1) void renderPage(currentPage - 1);
+  }
+  function goNextPage() {
+    if (currentPage < numPages) void renderPage(currentPage + 1);
+  }
+  function goRef(i) {
+    if (i < 0 || i >= refCount || i === index) return;
+    index = i;
+  }
+  function handleKeydown(event) {
+    if (event.key === "Escape" && onClose) onClose();
+    else if (event.key === "ArrowLeft" && pdfDoc) goPrevPage();
+    else if (event.key === "ArrowRight" && pdfDoc) goNextPage();
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<section class="csv" aria-label="Cited source viewer">
+  <header class="csv-head">
+    <div class="csv-head-text">
+      <p class="csv-kicker">Cited source</p>
+      <h2 class="csv-title" title={sourceLabel(ref)}>{title}</h2>
+      {#if ref}
+        <p class="csv-locator">
+          <span class="csv-locator-file">{sourceLabel(ref)}</span>
+          {#if locatorLabel(ref)}<span class="csv-locator-pos">{locatorLabel(ref)}</span>{/if}
+        </p>
+      {/if}
+    </div>
+    {#if onClose}
+      <button class="csv-close" type="button" onclick={() => onClose()} aria-label="Close source viewer">✕</button>
+    {/if}
+  </header>
+
+  {#if refCount > 1}
+    <nav class="csv-refs" aria-label="Citations in this source set">
+      <button
+        class="csv-refnav"
+        type="button"
+        disabled={index <= 0}
+        onclick={() => goRef(index - 1)}
+        aria-label="Previous citation"
+      >←</button>
+      <span class="csv-refcount">Citation {index + 1}/{refCount}</span>
+      <button
+        class="csv-refnav"
+        type="button"
+        disabled={index >= refCount - 1}
+        onclick={() => goRef(index + 1)}
+        aria-label="Next citation"
+      >→</button>
+    </nav>
+  {/if}
+
+  {#if quoteOf(ref)}
+    <blockquote class="csv-quote">{quoteOf(ref)}</blockquote>
+  {/if}
+
+  <div class="csv-body" bind:this={scrollEl}>
+    {#if loading}
+      <p class="csv-status" role="status">Loading source…</p>
+    {:else if loadError}
+      <div class="csv-error" role="alert">
+        <p class="csv-error-title">Source unavailable</p>
+        <p class="csv-error-detail">{loadError}</p>
+        <code class="csv-error-ref">{sourceLabel(ref)}</code>
+      </div>
+    {:else if pdfDoc}
+      <div class="csv-page-stage">
+        <canvas bind:this={canvasEl}></canvas>
+        <div class="csv-hl-layer" aria-hidden="true">
+          {#each highlightRects as r, i (i)}
+            <div
+              class="csv-hl"
+              style="left:{r.left}px; top:{r.top}px; width:{r.width}px; height:{r.height}px;"
+            ></div>
+          {/each}
+        </div>
+      </div>
+    {:else if mdPayload}
+      <!-- Safe: renderSourceHtml escapes everything before re-enabling minimal markup. -->
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      <div class="csv-md" bind:this={mdEl}>{@html mdHtml}</div>
+    {:else}
+      <p class="csv-status">No citation selected.</p>
+    {/if}
+  </div>
+
+  <footer class="csv-foot">
+    {#if pdfDoc}
+      <div class="csv-pager" role="group" aria-label="Page navigation">
+        <button class="csv-refnav" type="button" onclick={goPrevPage} disabled={currentPage <= 1} aria-label="Previous page">←</button>
+        <span class="csv-page-ind">Page {currentPage}/{numPages}</span>
+        <button class="csv-refnav" type="button" onclick={goNextPage} disabled={currentPage >= numPages} aria-label="Next page">→</button>
+      </div>
+      {#if !quoteOnPage}
+        <span class="csv-degraded">Quote not located on this page — showing the page anyway.</span>
+      {/if}
+    {:else if mdPayload && quoteOf(ref) && !mdFound}
+      <span class="csv-degraded">Quote not located in the source — showing the document anyway.</span>
+    {/if}
+  </footer>
+</section>
+
+<style>
+  .csv {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    background: var(--st-semantic-surface-default, #fff);
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .csv-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.8rem 1rem 0.6rem;
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  .csv-head-text {
+    flex: 1;
+    min-width: 0;
+  }
+  .csv-kicker {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .csv-title {
+    margin: 0.15rem 0 0.1rem;
+    font-size: 1rem;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+  }
+  .csv-locator {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    font-size: 0.72rem;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .csv-locator-file {
+    font-family: var(--st-font-mono, ui-monospace, monospace);
+    overflow-wrap: anywhere;
+  }
+  .csv-locator-pos {
+    font-weight: 600;
+    color: var(--st-semantic-text-secondary, #475569);
+    white-space: nowrap;
+  }
+  .csv-close {
+    flex-shrink: 0;
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border-radius: var(--st-radius-sm, 4px);
+    color: var(--st-semantic-text-secondary, #475569);
+    cursor: pointer;
+    font-size: 0.85rem;
+    line-height: 1;
+    padding: 0.3rem 0.45rem;
+  }
+  .csv-close:hover {
+    color: var(--st-semantic-feedback-error, #dc2626);
+    border-color: var(--st-semantic-feedback-error, #dc2626);
+  }
+  .csv-refs {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    border-bottom: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+  }
+  .csv-refcount {
+    font-size: 0.74rem;
+    font-weight: 600;
+    color: var(--st-semantic-text-secondary, #475569);
+  }
+  .csv-refnav {
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    background: var(--st-semantic-surface-default, #fff);
+    border-radius: var(--st-radius-sm, 4px);
+    color: var(--st-semantic-text-secondary, #475569);
+    cursor: pointer;
+    font-size: 0.8rem;
+    line-height: 1;
+    padding: 0.25rem 0.5rem;
+  }
+  .csv-refnav:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .csv-refnav:not(:disabled):hover {
+    border-color: var(--st-semantic-action-primary, #2563eb);
+    color: var(--st-semantic-action-primary, #2563eb);
+  }
+  .csv-quote {
+    margin: 0.55rem 1rem 0.2rem;
+    padding: 0.3rem 0.6rem;
+    border-left: 3px solid var(--st-semantic-action-primary, #2563eb);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border-radius: 0 var(--st-radius-sm, 4px) var(--st-radius-sm, 4px) 0;
+    font-size: 0.8rem;
+    font-style: italic;
+    line-height: 1.4;
+    color: var(--st-semantic-text-primary, #0f172a);
+    max-height: 5.6rem;
+    overflow-y: auto;
+    overflow-wrap: anywhere;
+  }
+  .csv-body {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    padding: 0.75rem 1rem;
+    background: var(--st-semantic-surface-sunken, #f1f5f9);
+  }
+  .csv-status {
+    margin: 2rem 0;
+    text-align: center;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+  .csv-error {
+    margin: 1.5rem auto;
+    max-width: 28rem;
+    text-align: center;
+    display: grid;
+    gap: 0.35rem;
+  }
+  .csv-error-title {
+    margin: 0;
+    font-weight: 700;
+    color: var(--st-semantic-feedback-error, #dc2626);
+  }
+  .csv-error-detail {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--st-semantic-text-secondary, #475569);
+    overflow-wrap: anywhere;
+  }
+  .csv-error-ref {
+    font-family: var(--st-font-mono, ui-monospace, monospace);
+    font-size: 0.72rem;
+    color: var(--st-semantic-text-muted, #64748b);
+    overflow-wrap: anywhere;
+  }
+  .csv-page-stage {
+    position: relative;
+    width: max-content;
+    margin: 0 auto;
+    box-shadow: 0 1px 6px rgba(15, 23, 42, 0.18);
+  }
+  .csv-page-stage canvas {
+    display: block;
+    background: #fff;
+  }
+  .csv-hl-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  .csv-hl {
+    position: absolute;
+    background: color-mix(in srgb, var(--st-semantic-feedback-warning, #eab308) 40%, transparent);
+    outline: 1px solid color-mix(in srgb, var(--st-semantic-feedback-warning, #eab308) 85%, transparent);
+    border-radius: 2px;
+  }
+  .csv-md {
+    max-width: 46rem;
+    margin: 0 auto;
+    background: var(--st-semantic-surface-default, #fff);
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    border-radius: var(--st-radius-md, 6px);
+    padding: 1rem 1.25rem;
+    font-size: 0.88rem;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+  }
+  .csv-md :global(.csv-md-h) {
+    margin: 1rem 0 0.4rem;
+    font-size: 0.95rem;
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .csv-md :global(.csv-md-p) {
+    margin: 0 0 0.6rem;
+  }
+  .csv-md :global(.csv-mark) {
+    background: color-mix(in srgb, var(--st-semantic-feedback-warning, #eab308) 38%, transparent);
+    border-radius: 2px;
+    padding: 0 0.1em;
+  }
+  .csv-foot {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.45rem 1rem;
+    border-top: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    min-height: 2.1rem;
+  }
+  .csv-pager {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+  .csv-page-ind {
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: var(--st-semantic-text-secondary, #475569);
+  }
+  .csv-degraded {
+    font-size: 0.74rem;
+    font-style: italic;
+    color: var(--st-semantic-text-muted, #64748b);
+  }
+</style>

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -170,23 +170,27 @@
                   <ul class="entity-cite-passages">
                     {#each cf.passages as p, i (cf.file + i)}
                       <li class="entity-cite-passage">
-                        <div class="entity-cite-row">
-                          <div class="entity-cite-loc">
-                            {#if p.section}<span class="entity-cite-section">{p.section}</span>{/if}
-                            {#if p.page != null}<span class="entity-cite-page">p.{p.page}</span>{/if}
-                            {#if !p.section && p.page == null && !p.quote}<span class="entity-cite-section">(passage)</span>{/if}
-                          </div>
-                          {#if onOpenSource}
-                            <button
-                              class="entity-cite-open"
-                              type="button"
-                              title="Open the cited source with this passage highlighted"
-                              aria-label="Open source for this citation"
-                              onclick={() => openSource(p)}
-                            >Open source ↗</button>
-                          {/if}
+                        <div class="entity-cite-loc">
+                          {#if p.section}<span class="entity-cite-section">{p.section}</span>{/if}
+                          {#if p.page != null}<span class="entity-cite-page">p.{p.page}</span>{/if}
+                          {#if !p.section && p.page == null && !p.quote}<span class="entity-cite-section">(passage)</span>{/if}
                         </div>
                         {#if p.quote}<blockquote class="entity-cite-quote">{p.quote}</blockquote>{/if}
+                        {#if onOpenSource}
+                          <!-- Qualified UX (immo "Voir la preuve · p.N"): FULL-WIDTH
+                               button UNDER the quote — never truncates against the
+                               panel edge, one per citation. -->
+                          <button
+                            class="entity-cite-src"
+                            type="button"
+                            title="Ouvrir la source citée avec ce passage surligné"
+                            aria-label="Voir la source de cette citation"
+                            onclick={() => openSource(p)}
+                          >
+                            <svg class="entity-cite-src-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
+                            <span>Voir la source{#if p.page != null}&nbsp;· p.{p.page}{/if}</span>
+                          </button>
+                        {/if}
                       </li>
                     {/each}
                   </ul>
@@ -383,14 +387,8 @@
     min-width: 0;
     overflow-wrap: anywhere;
   }
-  /* Cited-source viewer affordance: locator row + "Open source" button. */
-  .entity-cite-row {
-    display: flex;
-    align-items: baseline;
-    gap: 0.4rem;
-  }
+  /* Cited-source viewer affordance: locator row + full-width source button. */
   .entity-cite-loc {
-    flex: 1;
     min-width: 0;
     display: flex;
     flex-wrap: wrap;
@@ -403,20 +401,34 @@
     color: var(--st-semantic-text-muted, #64748b);
     white-space: nowrap;
   }
-  .entity-cite-open {
-    flex-shrink: 0;
+  /* Qualified UX (immo parity): FULL-WIDTH "Voir la source · p.N" under the
+     quote — wraps inside the panel, can never clip against the right edge. */
+  .entity-cite-src {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    width: 100%;
+    margin-top: 0.3rem;
     border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
     background: var(--st-semantic-surface-subtle, #f8fafc);
     border-radius: var(--st-radius-sm, 4px);
     color: var(--st-semantic-text-link, #2563eb);
     cursor: pointer;
-    font-size: 0.68rem;
+    font-size: 0.74rem;
+    font-weight: 600;
     line-height: 1.2;
-    padding: 0.1rem 0.35rem;
-    white-space: nowrap;
+    padding: 0.3rem 0.5rem;
+    min-width: 0;
   }
-  .entity-cite-open:hover {
+  .entity-cite-src:hover {
     border-color: var(--st-semantic-action-primary, #2563eb);
+    background: var(--st-semantic-surface-selected, #eff6ff);
+  }
+  .entity-cite-src-ico {
+    width: 0.85rem;
+    height: 0.85rem;
+    flex-shrink: 0;
   }
   /* BUG A: the citation FILE path renders as a DS Collapsible trigger title
      (e.g. ".graphify/converted/pdf/CONTRIBUATION_AI_AERONAUTIQUE_…md"). Its

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -18,7 +18,7 @@
   } from "../lib/graphAdapter.js";
   import { renderInlineMarkdown } from "../lib/markdown.js";
 
-  let { graph, focusId = null, entity = null, onOpenEntity, hideTitle = false } = $props();
+  let { graph, focusId = null, entity = null, onOpenEntity, hideTitle = false, onOpenSource = null } = $props();
 
   const node = $derived(focusId ? (indexNodes(graph).get(focusId) ?? null) : null);
   const relations = $derived(focusId ? relationRowsFor(focusId, graph) : []);
@@ -58,6 +58,19 @@
   const descriptionProvisional = $derived(
     entity?.description?.source === "rationale" && entity?.description?.provisional === true,
   );
+  // Cited-source viewer affordance: the FLAT citation list the rendered groups
+  // were derived from (full sidecar list when hydrated, else the inline K-set).
+  // Passage `index` positions refer to THIS list; the App converts it via the
+  // frozen CitedSourceRef projection and opens the viewer on the clicked one.
+  const sourceCitations = $derived(fullCitations ?? (Array.isArray(node?.citations) ? node.citations : []));
+  function openSource(passage) {
+    onOpenSource?.({
+      citations: sourceCitations,
+      index: passage.index,
+      fallbackSourceFile: node?.source_file ?? null,
+      label: node ? nodeLabel(node) : null,
+    });
+  }
 </script>
 
 <aside class="entity" aria-label="Entity detail">
@@ -157,9 +170,23 @@
                   <ul class="entity-cite-passages">
                     {#each cf.passages as p, i (cf.file + i)}
                       <li class="entity-cite-passage">
-                        {#if p.section}<span class="entity-cite-section">{p.section}</span>{/if}
+                        <div class="entity-cite-row">
+                          <div class="entity-cite-loc">
+                            {#if p.section}<span class="entity-cite-section">{p.section}</span>{/if}
+                            {#if p.page != null}<span class="entity-cite-page">p.{p.page}</span>{/if}
+                            {#if !p.section && p.page == null && !p.quote}<span class="entity-cite-section">(passage)</span>{/if}
+                          </div>
+                          {#if onOpenSource}
+                            <button
+                              class="entity-cite-open"
+                              type="button"
+                              title="Open the cited source with this passage highlighted"
+                              aria-label="Open source for this citation"
+                              onclick={() => openSource(p)}
+                            >Open source ↗</button>
+                          {/if}
+                        </div>
                         {#if p.quote}<blockquote class="entity-cite-quote">{p.quote}</blockquote>{/if}
-                        {#if !p.section && !p.quote}<span class="entity-cite-section">(passage)</span>{/if}
                       </li>
                     {/each}
                   </ul>
@@ -355,6 +382,41 @@
        inside the panel rather than clipping right. */
     min-width: 0;
     overflow-wrap: anywhere;
+  }
+  /* Cited-source viewer affordance: locator row + "Open source" button. */
+  .entity-cite-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+  }
+  .entity-cite-loc {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 0.4rem;
+    align-items: baseline;
+  }
+  .entity-cite-page {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--st-semantic-text-muted, #64748b);
+    white-space: nowrap;
+  }
+  .entity-cite-open {
+    flex-shrink: 0;
+    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
+    background: var(--st-semantic-surface-subtle, #f8fafc);
+    border-radius: var(--st-radius-sm, 4px);
+    color: var(--st-semantic-text-link, #2563eb);
+    cursor: pointer;
+    font-size: 0.68rem;
+    line-height: 1.2;
+    padding: 0.1rem 0.35rem;
+    white-space: nowrap;
+  }
+  .entity-cite-open:hover {
+    border-color: var(--st-semantic-action-primary, #2563eb);
   }
   /* BUG A: the citation FILE path renders as a DS Collapsible trigger title
      (e.g. ".graphify/converted/pdf/CONTRIBUATION_AI_AERONAUTIQUE_…md"). Its

--- a/studio/src/components/SelectionPanel.svelte
+++ b/studio/src/components/SelectionPanel.svelte
@@ -27,6 +27,7 @@
     onToggleCommunity,
     onToggleEntity,
     onClear,
+    onOpenSource = null,
   } = $props();
 
   const total = $derived(
@@ -64,6 +65,7 @@
           entity={entityCache[e.id] ?? null}
           hideTitle
           onOpenEntity={onFocusEntity}
+          {onOpenSource}
         />
       </div>
     {/if}

--- a/studio/src/lib/cited-source/markdownSource.js
+++ b/studio/src/lib/cited-source/markdownSource.js
@@ -1,0 +1,100 @@
+/**
+ * Markdown / plain-text source rendering with the cited quote highlighted.
+ *
+ * PURE (no DOM, no graphify import): given the raw source text and the quote,
+ * emit safe HTML — everything escaped, minimal markdown affordances re-enabled
+ * (headings + bold/italic), and the matched quote range wrapped in
+ * `<mark class="csv-mark">`. The viewer injects the result via {@html} and
+ * scrolls to the mark. Kept deliberately self-contained (no studio markdown.js
+ * import) so the module lifts into `@sentropic/cited-source-viewer` unchanged.
+ */
+
+import { findCitationInPage } from "./quoteMatch.js";
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+/** @param {unknown} value */
+export function escapeHtml(value) {
+  return String(value ?? "").replace(HTML_ESCAPE_RE, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+/** Escaped text with **bold** / *italic* runs re-enabled (mirrors studio markdown.js). */
+function inlineMd(escaped) {
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/(^|[^*])\*(?!\s)(.+?)\*(?!\*)/g, "$1<em>$2</em>");
+}
+
+/**
+ * Render ONE block (paragraph or heading) of already-sliced raw text to HTML.
+ * `marked` wraps the block in the highlight mark (block fully inside the match).
+ * @param {string} block
+ */
+function renderBlock(block) {
+  const heading = /^(#{1,6})\s+(.*)$/.exec(block.trim());
+  if (heading) {
+    const level = Math.min(heading[1].length + 2, 6); // demote: source h1 -> h3
+    return `<h${level} class="csv-md-h">${inlineMd(escapeHtml(heading[2]))}</h${level}>`;
+  }
+  return `<p class="csv-md-p">${inlineMd(escapeHtml(block)).replace(/\n/g, "<br>")}</p>`;
+}
+
+/**
+ * Render the whole source with the quote's matched range wrapped in a <mark>.
+ *
+ * The match runs over the RAW text (quoteMatch keeps a normalized->raw map), so
+ * the mark lands on the verbatim passage even when the quote differs by
+ * whitespace/accents/ligatures. When the quote cannot be located the source is
+ * rendered WITHOUT a mark and `found` is false (graceful degradation — the
+ * viewer says so instead of pretending).
+ *
+ * @param {string} text  Raw markdown / plain-text source.
+ * @param {string|null|undefined} quote  Verbatim quote to highlight.
+ * @param {{ minWords?: number, minCoverage?: number }} [matchOptions]
+ * @returns {{ html: string, found: boolean, coverage: number }}
+ */
+export function renderSourceHtml(text, quote, matchOptions = {}) {
+  const raw = String(text ?? "");
+  const match = quote ? findCitationInPage(raw, quote, matchOptions) : null;
+
+  // Split into blocks on blank lines, tracking each block's raw offset so the
+  // match interval can be projected into per-block mark ranges.
+  const blocks = [];
+  const re = /[^\n]+(?:\n(?!\s*\n)[^\n]*)*/g; // runs of non-blank lines
+  let m;
+  while ((m = re.exec(raw)) !== null) {
+    blocks.push({ start: m.index, end: m.index + m[0].length, text: m[0] });
+  }
+
+  const parts = [];
+  for (const block of blocks) {
+    if (!match || match.end <= block.start || match.start >= block.end) {
+      parts.push(renderBlock(block.text));
+      continue;
+    }
+    // Overlap: split the block into pre / marked / post, escape each side, and
+    // rebuild one paragraph (heading blocks with a partial match render as a
+    // paragraph too — precision over prettiness for the highlighted region).
+    const relStart = Math.max(0, match.start - block.start);
+    const relEnd = Math.min(block.text.length, match.end - block.start);
+    const pre = escapeHtml(block.text.slice(0, relStart)).replace(/\n/g, "<br>");
+    const hit = escapeHtml(block.text.slice(relStart, relEnd)).replace(/\n/g, "<br>");
+    const post = escapeHtml(block.text.slice(relEnd)).replace(/\n/g, "<br>");
+    parts.push(
+      `<p class="csv-md-p">${pre}<mark class="csv-mark" data-csv-mark="1">${hit}</mark>${post}</p>`,
+    );
+  }
+
+  return {
+    html: parts.join("\n"),
+    found: Boolean(match),
+    coverage: match?.coverage ?? 0,
+  };
+}

--- a/studio/src/lib/cited-source/pdfEngine.js
+++ b/studio/src/lib/cited-source/pdfEngine.js
@@ -41,6 +41,32 @@ export function getPdfjs() {
   return pdfjsPromise;
 }
 
+/** Zoom bounds shared by the fit-width computation and the toolbar zoom. */
+export const MIN_RENDER_SCALE = 0.4;
+export const MAX_RENDER_SCALE = 4;
+
+/**
+ * Resolve the effective render scale for a page. PURE (unit-tested):
+ * - `userScale` set (toolbar zoom) -> clamped user scale, container ignored;
+ * - else fit-width: containerWidth / baseWidth, clamped.
+ * Mirrors radar's two zoom regimes (#81 fit-width default, #85 manual zoom).
+ * @param {{ baseWidth: number, containerWidth?: number|null, userScale?: number|null,
+ *           minScale?: number, maxScale?: number }} options
+ * @returns {number}
+ */
+export function resolveRenderScale({
+  baseWidth,
+  containerWidth = null,
+  userScale = null,
+  minScale = MIN_RENDER_SCALE,
+  maxScale = MAX_RENDER_SCALE,
+}) {
+  const clamp = (v) => Math.max(minScale, Math.min(maxScale, v));
+  if (typeof userScale === "number" && Number.isFinite(userScale)) return clamp(userScale);
+  const available = Math.max(120, containerWidth ?? baseWidth);
+  return clamp(available / Math.max(1, baseWidth));
+}
+
 /**
  * Load a PDF document from raw bytes.
  * @param {ArrayBuffer|Uint8Array} data
@@ -60,15 +86,18 @@ export async function loadPdfDocument(data) {
  * needed by the highlight pass.
  * @param {import("pdfjs-dist").PDFPageProxy} pdfPage
  * @param {HTMLCanvasElement} canvas
- * @param {{ containerWidth?: number, minScale?: number, maxScale?: number }} [options]
+ * @param {{ containerWidth?: number, userScale?: number|null, minScale?: number, maxScale?: number }} [options]
  * @returns {Promise<{ viewport: object, scale: number }>}
  */
 export async function renderPdfPage(pdfPage, canvas, options = {}) {
-  const minScale = options.minScale ?? 0.4;
-  const maxScale = options.maxScale ?? 4;
   const baseViewport = pdfPage.getViewport({ scale: 1 });
-  const available = Math.max(120, options.containerWidth ?? baseViewport.width);
-  const scale = Math.max(minScale, Math.min(maxScale, available / baseViewport.width));
+  const scale = resolveRenderScale({
+    baseWidth: baseViewport.width,
+    containerWidth: options.containerWidth ?? null,
+    userScale: options.userScale ?? null,
+    ...(options.minScale != null ? { minScale: options.minScale } : {}),
+    ...(options.maxScale != null ? { maxScale: options.maxScale } : {}),
+  });
   const viewport = pdfPage.getViewport({ scale });
 
   const ctx = canvas.getContext("2d");

--- a/studio/src/lib/cited-source/pdfEngine.js
+++ b/studio/src/lib/cited-source/pdfEngine.js
@@ -1,0 +1,122 @@
+/**
+ * pdf.js engine for the cited-source viewer: lazy module + worker singleton,
+ * page rendering, and text-layer highlight-rect computation.
+ *
+ * NO graphify import (liftable into `@sentropic/cited-source-viewer`). Seeded
+ * from radar-immobilier `SignalPdfOverlay.svelte` (#82/#89 lessons kept):
+ *   - pdf.js + its worker are imported ONCE and memoized (module-level), so
+ *     reopening the viewer never re-imports nor re-wires the worker;
+ *   - highlight rect POSITION is projected through viewport.transform (which
+ *     already carries the render scale) while DIMENSIONS (item transform b/d +
+ *     item.width) are in PDF space and must be multiplied by the render scale
+ *     (radar bug #82 — mixing the two spaces skews highlights when zooming).
+ *
+ * Worker note: the worker is bundled by Vite via the `?url` asset import, so it
+ * works when the studio bundle is SERVED (http/https, dev or static export).
+ * Over `file://` (single-file studio.html) module workers cannot load — the
+ * caller should treat PDF rendering as unavailable there (the viewer surfaces
+ * the load error; sources are not inlined in single-file bundles anyway).
+ */
+
+import { buildPageText, findCitationInPage } from "./quoteMatch.js";
+
+/** @type {Promise<typeof import("pdfjs-dist")>|null} */
+let pdfjsPromise = null;
+
+/** Memoized pdf.js module with the bundled worker wired once. */
+export function getPdfjs() {
+  if (!pdfjsPromise) {
+    pdfjsPromise = (async () => {
+      const pdfjs = await import("pdfjs-dist");
+      // Worker served by Vite as a bundled asset URL (no CDN).
+      const worker = await import("pdfjs-dist/build/pdf.worker.min.mjs?url");
+      pdfjs.GlobalWorkerOptions.workerSrc = worker.default;
+      return pdfjs;
+    })();
+    // Do not memoize a failed import (lets a transient failure retry).
+    pdfjsPromise.catch(() => {
+      pdfjsPromise = null;
+    });
+  }
+  return pdfjsPromise;
+}
+
+/**
+ * Load a PDF document from raw bytes.
+ * @param {ArrayBuffer|Uint8Array} data
+ * @returns {Promise<import("pdfjs-dist").PDFDocumentProxy>}
+ */
+export async function loadPdfDocument(data) {
+  const pdfjs = await getPdfjs();
+  // pdf.js transfers the buffer to the worker; clone so callers can reuse it
+  // (e.g. re-render after an error or page a cached payload).
+  const bytes = data instanceof Uint8Array ? data.slice() : new Uint8Array(data.slice(0));
+  const task = pdfjs.getDocument({ data: bytes, isEvalSupported: false });
+  return task.promise;
+}
+
+/**
+ * Render one page into a canvas at fit-width scale and return the geometry
+ * needed by the highlight pass.
+ * @param {import("pdfjs-dist").PDFPageProxy} pdfPage
+ * @param {HTMLCanvasElement} canvas
+ * @param {{ containerWidth?: number, minScale?: number, maxScale?: number }} [options]
+ * @returns {Promise<{ viewport: object, scale: number }>}
+ */
+export async function renderPdfPage(pdfPage, canvas, options = {}) {
+  const minScale = options.minScale ?? 0.4;
+  const maxScale = options.maxScale ?? 4;
+  const baseViewport = pdfPage.getViewport({ scale: 1 });
+  const available = Math.max(120, options.containerWidth ?? baseViewport.width);
+  const scale = Math.max(minScale, Math.min(maxScale, available / baseViewport.width));
+  const viewport = pdfPage.getViewport({ scale });
+
+  const ctx = canvas.getContext("2d");
+  const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+  canvas.width = Math.floor(viewport.width * dpr);
+  canvas.height = Math.floor(viewport.height * dpr);
+  canvas.style.width = `${Math.floor(viewport.width)}px`;
+  canvas.style.height = `${Math.floor(viewport.height)}px`;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  await pdfPage.render({ canvasContext: ctx, viewport }).promise;
+  return { viewport, scale };
+}
+
+/**
+ * Compute the highlight rectangles for a quote on a page's text content.
+ * Pure geometry (testable with plain objects): locate the quote in the
+ * concatenated page text, then emit one CSS-pixel rect per overlapping item.
+ *
+ * @param {{ items: Array<object> }} content  pdf.js `getTextContent()` result.
+ * @param {{ transform: number[], width: number, height: number }} viewport
+ * @param {number} renderScale  The scale the page was rendered at.
+ * @param {string} quote  Verbatim quote (excerpt) to locate.
+ * @param {{ minWords?: number, minCoverage?: number }} [matchOptions]
+ * @returns {{ rects: { left: number, top: number, width: number, height: number }[], coverage: number }}
+ */
+export function computeHighlightRects(content, viewport, renderScale, quote, matchOptions = {}) {
+  const { pageText, offsets } = buildPageText(content?.items ?? []);
+  const match = findCitationInPage(pageText, quote ?? "", matchOptions);
+  if (!match) return { rects: [], coverage: 0 };
+
+  const vt = viewport.transform;
+  const rects = [];
+  for (const { start, end, item } of offsets) {
+    if (end <= match.start || start >= match.end) continue;
+    const [, b, , d, e, f] = item.transform;
+    // POSITION: projected into viewport space via viewport.transform (already
+    // carries renderScale). DIMENSIONS: item.transform (b, d) and item.width
+    // are PDF-space (scale 1) and MUST be multiplied by renderScale (radar #82).
+    const tx = vt[0] * e + vt[2] * f + vt[4];
+    const ty = vt[1] * e + vt[3] * f + vt[5];
+    const fontHeight = (Math.hypot(b, d) || item.height || 10) * renderScale;
+    const width = Math.max(item.width * renderScale, 4);
+    rects.push({
+      left: tx,
+      top: ty - fontHeight,
+      width,
+      height: fontHeight * 1.15,
+    });
+  }
+  return { rects, coverage: match.coverage };
+}

--- a/studio/src/lib/cited-source/quoteMatch.js
+++ b/studio/src/lib/cited-source/quoteMatch.js
@@ -1,0 +1,182 @@
+/**
+ * Verbatim quote matching against a source text (a pdf.js page text layer or a
+ * markdown/plain-text document).
+ *
+ * PURE logic — no pdf.js, no DOM, no graphify import — so it is testable
+ * offline and mechanically liftable into the shared
+ * `@sentropic/cited-source-viewer` package later (SPEC_WP_CITED_SOURCE_VIZ §S.2:
+ * "one matcher, two callers").
+ *
+ * Ported from radar-immobilier `ui/src/lib/signals/pdf-citation-match.ts`
+ * (SignalPdfOverlay seed, architect-ratified lift). Strategy, unchanged:
+ *   1. Normalize the quote and the source text the same way, keeping for the
+ *      source a normalized-index -> raw-index map.
+ *   2. Look for the normalized quote as a substring; when absent, fall back to
+ *      the longest window of consecutive quote words present in the source
+ *      (robust to OCR/pdftotext truncation and noisy heads/tails).
+ *   3. Return the [start, end) interval in the RAW source text, which callers
+ *      convert into highlight spans / <mark> ranges.
+ */
+
+/**
+ * @typedef {object} CitationMatch
+ * @property {number} start    Start index in the raw source text.
+ * @property {number} end      End index (exclusive) in the raw source text.
+ * @property {number} coverage Fraction of the quote (in words) actually found, in [0, 1].
+ */
+
+/**
+ * Normalize a text for matching: lowercase, accents stripped, ligatures
+ * decomposed, whitespace (and soft hyphen runs) collapsed to single spaces.
+ * Punctuation is kept but surrounding whitespace is normalized.
+ * @param {string} input
+ * @returns {string}
+ */
+export function normalizeForMatch(input) {
+  return input
+    .normalize("NFKD") // decompose accents + ligatures (œ -> oe via replacements below)
+    .replace(/œ/gu, "oe")
+    .replace(/Œ/gu, "OE")
+    .replace(/æ/gu, "ae")
+    .replace(/Æ/gu, "AE")
+    .replace(/[̀-ͯ]/gu, "") // combining diacritics
+    .replace(/[‘’‚‛′]/gu, "'") // typographic apostrophes
+    .replace(/[“”„‟″]/gu, '"') // quotes
+    .replace(/[‐-―]/gu, "-") // unicode dashes -> -
+    .toLowerCase()
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+/**
+ * Build the normalized source text + the normalized-index -> raw-index map
+ * (used to recover the original highlight interval).
+ * @param {string} raw
+ * @returns {{ normalized: string, map: number[] }}
+ */
+function buildNormalizedIndex(raw) {
+  const normalizedChars = [];
+  const map = [];
+  let prevWasSpace = true; // avoids a leading space
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    // Whitespace is detected on the RAW character: `normalizeForMatch` trims,
+    // which would reduce an isolated blank to "".
+    if (/\s/u.test(ch)) {
+      if (prevWasSpace) continue;
+      normalizedChars.push(" ");
+      map.push(i);
+      prevWasSpace = true;
+      continue;
+    }
+    const norm = normalizeForMatch(ch);
+    if (norm.length === 0) {
+      // Character that disappears under normalization (lone combining mark,
+      // soft hyphen…): absorbed into the previous character.
+      continue;
+    }
+    // A ligature can yield several characters (e.g. œ -> oe): all map to i.
+    for (const c of norm) {
+      normalizedChars.push(c);
+      map.push(i);
+    }
+    prevWasSpace = false;
+  }
+  // Strip a possible trailing space.
+  while (normalizedChars.length > 0 && normalizedChars[normalizedChars.length - 1] === " ") {
+    normalizedChars.pop();
+    map.pop();
+  }
+  return { normalized: normalizedChars.join(""), map };
+}
+
+/**
+ * Find the quote `excerpt` inside the raw `pageText` and return the raw
+ * highlightable interval, or `null` when nothing usable matches.
+ *
+ * - Exact (normalized) match first.
+ * - Else, the longest run of consecutive quote words present in the source:
+ *   the quote is eroded from the edges until a window of at least `minWords`
+ *   words matches. Covers heads/tails clipped by pdftotext/OCR.
+ *
+ * `minWords` defaults to 6 with a 0.4 minimum coverage (radar bug #83: a short
+ * generic window matched on several pages and produced stray highlights; the
+ * fallback must be BOTH long enough AND cover a significant share of the quote).
+ * @param {string} pageText
+ * @param {string} excerpt
+ * @param {{ minWords?: number, minCoverage?: number }} [options]
+ * @returns {CitationMatch|null}
+ */
+export function findCitationInPage(pageText, excerpt, options = {}) {
+  const minWords = options.minWords ?? 6;
+  const minCoverage = options.minCoverage ?? 0.4;
+
+  const cleanExcerpt = normalizeForMatch(excerpt ?? "");
+  if (cleanExcerpt.length === 0) return null;
+  const totalWords = cleanExcerpt.split(" ").filter(Boolean);
+  if (totalWords.length === 0) return null;
+
+  const { normalized, map } = buildNormalizedIndex(pageText ?? "");
+  if (normalized.length === 0) return null;
+
+  const toRawRange = (normStart, normEnd) => {
+    if (normStart < 0 || normEnd <= normStart || normEnd > map.length) return null;
+    const rawStart = map[normStart];
+    const rawEnd = (map[normEnd - 1] ?? rawStart) + 1;
+    return { start: rawStart, end: rawEnd, coverage: 0 };
+  };
+
+  // 1) Exact normalized match.
+  const exactIdx = normalized.indexOf(cleanExcerpt);
+  if (exactIdx >= 0) {
+    const range = toRawRange(exactIdx, exactIdx + cleanExcerpt.length);
+    if (range) return { ...range, coverage: 1 };
+  }
+
+  // 2) Longest window of consecutive quote words present in the source.
+  //    Try sub-sequences [i, j) of the quote, longest first, via a shrinking
+  //    sliding window. Cost bounded by capping the quote length considered.
+  const maxWindow = Math.min(totalWords.length, 60);
+  for (let windowLen = maxWindow; windowLen >= minWords; windowLen--) {
+    for (let i = 0; i + windowLen <= totalWords.length; i++) {
+      const candidate = totalWords.slice(i, i + windowLen).join(" ");
+      const idx = normalized.indexOf(candidate);
+      if (idx >= 0) {
+        const range = toRawRange(idx, idx + candidate.length);
+        if (range) {
+          const coverage = windowLen / totalWords.length;
+          // AND (not OR): the window must be long enough AND cover a
+          // significant share of the quote (radar bug #83).
+          if (coverage >= minCoverage && windowLen >= minWords) {
+            return { ...range, coverage };
+          }
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Concatenate a pdf.js `getTextContent()` item list into one page string,
+ * remembering each item's [start, end) offset so a {@link CitationMatch}
+ * interval can be mapped back to the items it overlaps. Pure (the caller
+ * passes plain objects); pdf.js mixes TextItem (with `str`) and
+ * TextMarkedContent (without) — only text-bearing items are kept.
+ * @param {Array<object>} items pdf.js text-content items.
+ * @returns {{ pageText: string, offsets: { start: number, end: number, item: object }[] }}
+ */
+export function buildPageText(items) {
+  let pageText = "";
+  const offsets = [];
+  for (const raw of Array.isArray(items) ? items : []) {
+    if (typeof raw?.str !== "string") continue;
+    const start = pageText.length;
+    pageText += raw.str;
+    offsets.push({ start, end: pageText.length, item: raw });
+    // Separator between items (pdf.js items carry no trailing space).
+    pageText += " ";
+  }
+  return { pageText, offsets };
+}

--- a/studio/src/lib/citedSources.js
+++ b/studio/src/lib/citedSources.js
@@ -1,0 +1,96 @@
+/**
+ * Studio-side (IMPURE) glue for the cited-source viewer.
+ *
+ * Everything graphify-specific lives HERE, outside the pure
+ * CitedSourceViewer component (rebase contract, SPEC_WP_CITED_SOURCE_VIZ
+ * §S.3 "per-consumer adapter"):
+ *   - node.citations (OntologyCitation[]) -> CitedSourceRef[] via the FROZEN
+ *     public converters (src/cited-source-refs.ts, exported since PR #260);
+ *   - the studio's ResolveSource: fetch the cited file's bytes from the
+ *     `sources/` directory the exporter emits with `--include-sources`.
+ */
+
+import { citationsToCitedSourceRefs } from "@graphify/cited-source-refs";
+
+/**
+ * Convert a node's citations to viewer refs.
+ *
+ * Adapter enrichment (consumer-owned, does NOT touch the frozen converter):
+ *   - locator: graphify citations usually carry only `source_file` (not the
+ *     Radar `rawRef`/`sourceUrl`), which the projection intentionally leaves to
+ *     the consumer. Fill `rawRef` from `source_file` (else the panel-level
+ *     fallback) so every ref resolves against the bundle's `sources/` dir.
+ *   - anchors: carry `modality` / `section` / `paragraph_id` over for display +
+ *     routing when present on the citation.
+ *
+ * @param {Array<object>|null|undefined} citations  OntologyCitation[]
+ * @param {string|null} [fallbackSourceFile]        node.source_file fallback
+ * @returns {Array<object>} CitedSourceRef[] (parallel to `citations`)
+ */
+export function refsForCitations(citations, fallbackSourceFile = null) {
+  const list = Array.isArray(citations) ? citations : [];
+  const refs = citationsToCitedSourceRefs(list);
+  return refs.map((ref, i) => {
+    const c = list[i] ?? {};
+    const out = { ...ref };
+    if (!out.rawRef && !out.sourceUrl && !out.docSha) {
+      const locator = typeof c.source_file === "string" && c.source_file ? c.source_file : fallbackSourceFile;
+      if (locator) out.rawRef = locator;
+    }
+    if (!out.modality && typeof c.modality === "string") out.modality = c.modality;
+    if (!out.section && typeof c.section === "string") out.section = c.section;
+    if (!out.paragraph_id && typeof c.paragraph_id === "string") out.paragraph_id = c.paragraph_id;
+    return out;
+  });
+}
+
+/** File-suffix modality sniff for the resolver's binary/text routing. */
+function looksLikePdf(locator) {
+  return /\.pdf(?:[?#]|$)/i.test(locator);
+}
+
+/**
+ * Normalize a citation locator (usually a project-relative `source_file` such
+ * as `corpus/report.pdf` or `.graphify/converted/pdf/report.md`) into the
+ * bundle-relative path under `sources/`. Mirrors the exporter's layout
+ * (src/studio-export.ts, `--include-sources`): the file keeps its
+ * project-relative path, minus any leading `./`.
+ * @param {string} locator
+ */
+export function bundleSourcePath(locator) {
+  const rel = String(locator).replace(/^\.\//, "");
+  return `./sources/${rel.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+/**
+ * The studio's ResolveSource (frozen seam §S.3): fetch the cited file relative
+ * to the export bundle.
+ *
+ * Works when the bundle is SERVED (any static file server over the exporter's
+ * multi-file output, e.g. `graphify studio export out --include-sources` +
+ * `npx serve out`). Over bare `file://` (double-clicked studio.html or
+ * index.html) sibling fetches are blocked by the browser (opaque origin), so
+ * the viewer shows its explicit "Source unavailable" state — same constraint
+ * as every other static artifact, documented in SPEC_STUDIO_OFFLINE_EXPORT.
+ *
+ * @param {object} ref  CitedSourceRef
+ * @returns {Promise<{kind:"pdf",data:ArrayBuffer}|{kind:"markdown",text:string}>}
+ */
+export async function resolveBundleSource(ref) {
+  const locator = ref?.rawRef ?? ref?.sourceUrl ?? null;
+  if (!locator) {
+    throw new Error("citation carries no source locator (rawRef/sourceUrl)");
+  }
+  const url = bundleSourcePath(locator);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `${res.status} ${res.statusText} — ${url}. ` +
+        "Re-export with `graphify studio export <out> --include-sources` to bundle cited files.",
+    );
+  }
+  if ((ref?.modality === "pdf") || (!ref?.modality && looksLikePdf(locator))) {
+    return { kind: "pdf", data: await res.arrayBuffer() };
+  }
+  return { kind: "markdown", text: await res.text() };
+}

--- a/studio/src/lib/citedSources.js
+++ b/studio/src/lib/citedSources.js
@@ -63,6 +63,19 @@ export function bundleSourcePath(locator) {
 }
 
 /**
+ * Href for the viewer's "Ouvrir ↗" raw-source link (qualified toolbar).
+ * Consumer-owned URL scheme (§S.3): the bundle-relative `sources/` copy.
+ * Returns null when the ref carries no resolvable locator (the toolbar then
+ * hides the button).
+ * @param {object} ref  CitedSourceRef
+ * @returns {string|null}
+ */
+export function sourceHrefFor(ref) {
+  const locator = ref?.rawRef ?? ref?.sourceUrl ?? null;
+  return locator ? bundleSourcePath(locator) : null;
+}
+
+/**
  * The studio's ResolveSource (frozen seam §S.3): fetch the cited file relative
  * to the export bundle.
  *

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -957,17 +957,24 @@ export function communityStats(graph) {
  * `quote` stays null on the new lazy path (the render guards on it).
  * @param {Array<object>|null|undefined} list
  * @param {string|null} [fallbackSourceFile]
- * @returns {{ file: string, count: number, passages: { section: string|null, quote: string|null }[] }[]}
+ * @returns {{ file: string, count: number, passages: { section: string|null, quote: string|null, page: number|string|null, index: number }[] }[]}
  */
 export function citationsByFileFrom(list, fallbackSourceFile = null) {
   const cites = Array.isArray(list) ? list : [];
   const byFile = new Map();
-  for (const c of cites) {
+  for (let i = 0; i < cites.length; i++) {
+    const c = cites[i];
     const file = displayValue(c?.source_file) ?? displayValue(fallbackSourceFile) ?? "(unknown source)";
     if (!byFile.has(file)) byFile.set(file, []);
     byFile.get(file).push({
       section: displayValue(c?.section) ?? null,
       quote: displayValue(c?.quote) ?? null,
+      // Cited-source viewer affordance (additive): `page` is shown next to the
+      // locator; `index` is the passage's position in the ORIGINAL citation
+      // list, so the open-source click can activate the exact citation after
+      // the list is converted via the frozen CitedSourceRef projection.
+      page: finiteNumber(c?.page) ? c.page : (displayValue(c?.page) ?? null),
+      index: i,
     });
   }
   return [...byFile.entries()]

--- a/studio/src/tests/citedSourcePdfEngine.test.js
+++ b/studio/src/tests/citedSourcePdfEngine.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { computeHighlightRects } from "../lib/cited-source/pdfEngine.js";
+
+/**
+ * Pure geometry half of the pdf.js engine: quote -> text-layer rects. Verifies
+ * the radar #82 space split (position via viewport.transform, dimensions via
+ * renderScale) without loading pdf.js (computeHighlightRects is plain math).
+ */
+describe("cited-source pdfEngine.computeHighlightRects", () => {
+  const scale = 2;
+  const pageHeight = 100; // PDF-space page height
+  // pdf.js viewport transform for scale s, top-left origin flip:
+  // [s, 0, 0, -s, 0, s*pageHeight]
+  const viewport = {
+    transform: [scale, 0, 0, -scale, 0, scale * pageHeight],
+    width: 200 * scale,
+    height: pageHeight * scale,
+  };
+  // Two items on one text line at PDF y=50: "the coronet had" + "vanished tonight".
+  const content = {
+    items: [
+      { str: "the coronet had", transform: [10, 0, 0, 10, 10, 50], width: 60, height: 10 },
+      { str: "vanished tonight", transform: [10, 0, 0, 10, 75, 50], width: 64, height: 10 },
+      { type: "marked-content" }, // ignored (no str)
+    ],
+  };
+
+  it("emits one rect per overlapping item, scaled correctly", () => {
+    const { rects, coverage } = computeHighlightRects(
+      content,
+      viewport,
+      scale,
+      "the coronet had vanished tonight",
+      { minWords: 3, minCoverage: 0.4 },
+    );
+    expect(coverage).toBe(1);
+    expect(rects).toHaveLength(2);
+    // First item: tx = s*e = 2*10 = 20; ty = -s*f + s*H = 2*(100-50) = 100.
+    // fontHeight = |d| * s = 10*2 = 20 -> top = ty - fontHeight = 80.
+    expect(rects[0].left).toBeCloseTo(20);
+    expect(rects[0].top).toBeCloseTo(80);
+    expect(rects[0].width).toBeCloseTo(60 * scale);
+    expect(rects[0].height).toBeCloseTo(20 * 1.15);
+    // Second item starts at e=75 -> left 150.
+    expect(rects[1].left).toBeCloseTo(150);
+  });
+
+  it("returns no rects when the quote is not on the page", () => {
+    const { rects, coverage } = computeHighlightRects(
+      content,
+      viewport,
+      scale,
+      "an entirely different passage about spacecraft telemetry frames",
+    );
+    expect(rects).toEqual([]);
+    expect(coverage).toBe(0);
+  });
+});

--- a/studio/src/tests/citedSourcePdfEngine.test.js
+++ b/studio/src/tests/citedSourcePdfEngine.test.js
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { computeHighlightRects } from "../lib/cited-source/pdfEngine.js";
+import {
+  MAX_RENDER_SCALE,
+  MIN_RENDER_SCALE,
+  computeHighlightRects,
+  resolveRenderScale,
+} from "../lib/cited-source/pdfEngine.js";
 
 /**
  * Pure geometry half of the pdf.js engine: quote -> text-layer rects. Verifies
@@ -55,5 +60,26 @@ describe("cited-source pdfEngine.computeHighlightRects", () => {
     );
     expect(rects).toEqual([]);
     expect(coverage).toBe(0);
+  });
+});
+
+describe("cited-source pdfEngine.resolveRenderScale (toolbar zoom)", () => {
+  it("defaults to fit-width: containerWidth / baseWidth, clamped", () => {
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 900 })).toBeCloseTo(1.5);
+    // Tiny container clamps to the minimum scale.
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 10 })).toBe(MIN_RENDER_SCALE);
+    // Huge container clamps to the maximum scale.
+    expect(resolveRenderScale({ baseWidth: 100, containerWidth: 100000 })).toBe(MAX_RENDER_SCALE);
+  });
+
+  it("userScale (manual zoom) overrides fit-width and is clamped", () => {
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 900, userScale: 1.36 })).toBeCloseTo(1.36);
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 900, userScale: 99 })).toBe(MAX_RENDER_SCALE);
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 900, userScale: 0.01 })).toBe(MIN_RENDER_SCALE);
+  });
+
+  it("null/NaN userScale falls back to fit-width", () => {
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 600, userScale: null })).toBeCloseTo(1);
+    expect(resolveRenderScale({ baseWidth: 600, containerWidth: 600, userScale: Number.NaN })).toBeCloseTo(1);
   });
 });

--- a/studio/src/tests/citedSourceQuoteMatch.test.js
+++ b/studio/src/tests/citedSourceQuoteMatch.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPageText,
+  findCitationInPage,
+  normalizeForMatch,
+} from "../lib/cited-source/quoteMatch.js";
+import { renderSourceHtml } from "../lib/cited-source/markdownSource.js";
+
+/**
+ * Pure quote-matcher port (radar pdf-citation-match lift) — the deterministic
+ * core shared by the PDF text-layer highlight and the markdown mark. Covers the
+ * viewer's three contract cases: exact match, normalized (whitespace/accents)
+ * match, and not-found (graceful degradation).
+ */
+describe("cited-source quoteMatch", () => {
+  const page =
+    "ATTENDU QUE la municipalité a adopté le règlement de zonage 2024-17;\n" +
+    "CONSIDÉRANT l'avis du comité consultatif d'urbanisme rendu le 4 mars,\n" +
+    "le conseil autorise la dérogation mineure pour le lot 5 431 220.";
+
+  it("finds an exact quote and returns its raw interval with coverage 1", () => {
+    const quote = "le conseil autorise la dérogation mineure";
+    const match = findCitationInPage(page, quote);
+    expect(match).not.toBeNull();
+    expect(match.coverage).toBe(1);
+    expect(page.slice(match.start, match.end)).toBe(quote);
+  });
+
+  it("matches across whitespace / accent / ligature normalization", () => {
+    // Quote differs from the page by case, collapsed whitespace and accents.
+    const quote = "considerant   l'avis du comite consultatif d'urbanisme";
+    const match = findCitationInPage(page, quote);
+    expect(match).not.toBeNull();
+    expect(match.coverage).toBe(1);
+    // The raw interval points at the ORIGINAL accented text.
+    expect(page.slice(match.start, match.end)).toMatch(/^CONSIDÉRANT l'avis du comité consultatif d'urbanisme$/);
+  });
+
+  it("falls back to the longest consecutive-word window when the quote is clipped", () => {
+    // Head is noise not present in the page; the 8-word tail is verbatim.
+    const quote = "xxxx yyyy zzzz la municipalité a adopté le règlement de zonage";
+    const match = findCitationInPage(page, quote, { minWords: 6, minCoverage: 0.4 });
+    expect(match).not.toBeNull();
+    expect(match.coverage).toBeGreaterThan(0.4);
+    expect(match.coverage).toBeLessThan(1);
+    expect(page.slice(match.start, match.end)).toContain("municipalité a adopté");
+  });
+
+  it("returns null when the quote is not on the page (no fake highlight)", () => {
+    expect(findCitationInPage(page, "totally unrelated sentence about spacecraft telemetry systems")).toBeNull();
+    expect(findCitationInPage(page, "")).toBeNull();
+    expect(findCitationInPage("", "le conseil autorise")).toBeNull();
+  });
+
+  it("normalizeForMatch folds accents, ligatures, quotes and whitespace", () => {
+    expect(normalizeForMatch("Œuvre  d’été\n—  cœur")).toBe("oeuvre d'ete - coeur");
+  });
+
+  it("buildPageText concatenates pdf.js items with offsets, skipping non-text items", () => {
+    const items = [
+      { str: "Hello", transform: [1, 0, 0, 1, 0, 0], width: 10, height: 10 },
+      { type: "beginMarkedContent" }, // TextMarkedContent — no `str`
+      { str: "world", transform: [1, 0, 0, 1, 20, 0], width: 10, height: 10 },
+    ];
+    const { pageText, offsets } = buildPageText(items);
+    expect(pageText).toBe("Hello world ");
+    expect(offsets).toHaveLength(2);
+    expect(offsets[0]).toMatchObject({ start: 0, end: 5 });
+    expect(offsets[1]).toMatchObject({ start: 6, end: 11 });
+    // A match over the concatenation overlaps both items.
+    const match = findCitationInPage(pageText, "hello world", { minWords: 2, minCoverage: 0.4 });
+    expect(match).not.toBeNull();
+  });
+});
+
+describe("cited-source markdownSource", () => {
+  const md =
+    "# The Adventure of the Blue Study\n" +
+    "\n" +
+    "Holmes examined the **ledger** in silence.\n" +
+    "\n" +
+    "## Chapter 2\n" +
+    "\n" +
+    "The banker, Mr. Holder, confessed that the coronet had vanished from his private safe during the night.";
+
+  it("renders the source with the quote wrapped in a <mark>", () => {
+    const quote = "the coronet had vanished from his private safe";
+    const { html, found } = renderSourceHtml(md, quote);
+    expect(found).toBe(true);
+    expect(html).toContain('<mark class="csv-mark"');
+    expect(html).toContain("coronet had vanished from his private safe</mark>");
+    // Headings and bold survive outside the mark.
+    expect(html).toContain('class="csv-md-h"');
+    expect(html).toContain("<strong>ledger</strong>");
+  });
+
+  it("escapes HTML in the source (safe for {@html})", () => {
+    const { html } = renderSourceHtml("evil <script>alert(1)</script> text", null);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("degrades gracefully when the quote is absent: renders, found=false, no mark", () => {
+    const { html, found } = renderSourceHtml(md, "a passage that simply is not in the document at all");
+    expect(found).toBe(false);
+    expect(html).not.toContain("<mark");
+    expect(html).toContain("Holmes examined");
+  });
+});

--- a/studio/src/tests/citedSourceViewer.test.js
+++ b/studio/src/tests/citedSourceViewer.test.js
@@ -134,6 +134,90 @@ describe("CitedSourceViewer (markdown path)", () => {
   });
 });
 
+describe("CitedSourceViewer qualified toolbar (immo parity)", () => {
+  // Refs spanning TWO source documents: 2 in blue-study.md + 1 in notes.md.
+  const MULTI_DOC_REFS = [
+    ...REFS,
+    { rawRef: "corpus/notes.md", section: "Notes", excerpt: "a passage from the second document" },
+  ];
+  const multiResolver = () =>
+    vi.fn(async (r) =>
+      r.rawRef === "corpus/notes.md"
+        ? { kind: "markdown", text: "# Notes\n\nHere is a passage from the second document indeed." }
+        : { kind: "markdown", text: SOURCE_TEXT },
+    );
+
+  it("shows the Doc x/y navigator only when refs span multiple documents", async () => {
+    const single = mountViewer({ refs: REFS, resolveSource: mdResolver(), title: "t" });
+    await settle();
+    expect(single.textContent).not.toContain("Doc");
+    unmount(instance);
+    instance = null;
+    host.remove();
+
+    const multi = mountViewer({ refs: MULTI_DOC_REFS, resolveSource: multiResolver(), title: "t" });
+    await settle();
+    expect(multi.textContent).toContain("Doc");
+    expect(multi.textContent).toContain("1/2");
+    expect(multi.textContent).toContain("Citation 1/3");
+  });
+
+  it("Next document jumps to the FIRST ref of the next source file and loads it", async () => {
+    const resolveSource = multiResolver();
+    const el = mountViewer({ refs: MULTI_DOC_REFS, resolveSource, activeIndex: 0, title: "t" });
+    await settle();
+
+    const nextDoc = [...el.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === "Next document",
+    );
+    expect(nextDoc).toBeTruthy();
+    nextDoc.click();
+    flushSync();
+    await settle();
+
+    // Jumped to ref index 2 (first ref of corpus/notes.md) -> Citation 3/3, Doc 2/2.
+    expect(el.textContent).toContain("Citation 3/3");
+    expect(el.textContent).toContain("Doc 2/2");
+    expect(resolveSource).toHaveBeenLastCalledWith(MULTI_DOC_REFS[2]);
+    expect(el.querySelector("[data-csv-mark]")?.textContent).toContain("passage from the second document");
+  });
+
+  it("renders the Ouvrir raw-source link from the sourceHref callback", async () => {
+    const el = mountViewer({
+      refs: REFS,
+      resolveSource: mdResolver(),
+      sourceHref: (r) => `./sources/${r.rawRef}`,
+      title: "t",
+    });
+    await settle();
+    const link = el.querySelector("a.csv-tb-open");
+    expect(link).not.toBeNull();
+    expect(link.textContent).toContain("Ouvrir");
+    expect(link.getAttribute("href")).toBe("./sources/corpus/blue-study.md");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("hides the Ouvrir link when sourceHref is absent or resolves null", async () => {
+    const el = mountViewer({ refs: REFS, resolveSource: mdResolver(), title: "t" });
+    await settle();
+    expect(el.querySelector("a.csv-tb-open")).toBeNull();
+  });
+
+  it("pins the retarget contract in the source (refs identity + activeIndex both tracked)", () => {
+    // A plain-JS vitest cannot push prop updates into a Svelte-5 mount(), so
+    // the retarget-on-reopen behavior (new refs array + activeIndex re-aim an
+    // OPEN viewer, no stacking) is exercised end-to-end by the UAT run; here
+    // we pin the load-bearing implementation: the $effect must compare BOTH
+    // the refs identity and the activeIndex prop before reseeding `index`.
+    const source = readFileSync(
+      resolve(process.cwd(), "src/components/CitedSourceViewer.svelte"),
+      "utf8",
+    );
+    expect(source).toMatch(/refs !== lastRefsProp \|\| activeIndex !== lastActiveProp/);
+    expect(source).toMatch(/lastRefsProp = refs;/);
+  });
+});
+
 describe("CitedSourceViewer purity (rebase seam)", () => {
   it("imports nothing from graphify — only the sibling pure lib and svelte", () => {
     const source = readFileSync(

--- a/studio/src/tests/citedSourceViewer.test.js
+++ b/studio/src/tests/citedSourceViewer.test.js
@@ -1,0 +1,154 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { flushSync, mount, unmount } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import CitedSourceViewer from "../components/CitedSourceViewer.svelte";
+
+/**
+ * Component render smoke for the INTERIM cited-source viewer. The markdown
+ * path mounts fully in jsdom (no canvas needed); the PDF path is covered by
+ * the pure engine tests (citedSourcePdfEngine) + UAT screenshots. Also pins
+ * the PURITY contract: the component must not import graphify runtime.
+ */
+
+const REFS = [
+  {
+    rawRef: "corpus/blue-study.md",
+    section: "Chapter 2",
+    excerpt: "the coronet had vanished from his private safe",
+  },
+  {
+    rawRef: "corpus/blue-study.md",
+    section: "Chapter 1",
+    excerpt: "Holmes examined the ledger in silence",
+  },
+];
+
+const SOURCE_TEXT =
+  "# The Adventure of the Blue Study\n\n" +
+  "Holmes examined the ledger in silence.\n\n" +
+  "## Chapter 2\n\n" +
+  "The banker confessed that the coronet had vanished from his private safe during the night.";
+
+function mdResolver() {
+  return vi.fn(async () => ({ kind: "markdown", text: SOURCE_TEXT }));
+}
+
+async function settle() {
+  // Let the $effect-driven async load resolve and the DOM update.
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+  flushSync();
+}
+
+let host;
+let instance;
+afterEach(() => {
+  if (instance) unmount(instance);
+  instance = null;
+  host?.remove();
+  host = null;
+});
+
+function mountViewer(props) {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  instance = mount(CitedSourceViewer, { target: host, props });
+  flushSync();
+  return host;
+}
+
+describe("CitedSourceViewer (markdown path)", () => {
+  it("renders refs, resolves the source and highlights the active quote", async () => {
+    const resolveSource = mdResolver();
+    const el = mountViewer({
+      refs: REFS,
+      resolveSource,
+      activeIndex: 0,
+      title: "corpus/blue-study.md",
+    });
+    await settle();
+
+    // Header + ref navigation reflect the ref list.
+    expect(el.textContent).toContain("corpus/blue-study.md");
+    expect(el.textContent).toContain("Citation 1/2");
+    // The active quote is shown and located in the rendered source.
+    expect(el.textContent).toContain("coronet had vanished");
+    const mark = el.querySelector("[data-csv-mark]");
+    expect(mark).not.toBeNull();
+    expect(mark.textContent).toContain("coronet had vanished from his private safe");
+    expect(resolveSource).toHaveBeenCalledTimes(1);
+    expect(resolveSource).toHaveBeenCalledWith(REFS[0]);
+  });
+
+  it("switches the active ref (next) and re-highlights the new quote", async () => {
+    const resolveSource = mdResolver();
+    const el = mountViewer({ refs: REFS, resolveSource, activeIndex: 0, title: "t" });
+    await settle();
+
+    const next = [...el.querySelectorAll("button")].find((b) => b.getAttribute("aria-label") === "Next citation");
+    expect(next).toBeTruthy();
+    next.click();
+    flushSync();
+    await settle();
+
+    expect(el.textContent).toContain("Citation 2/2");
+    const mark = el.querySelector("[data-csv-mark]");
+    expect(mark).not.toBeNull();
+    expect(mark.textContent).toContain("Holmes examined the ledger");
+    // One resolve per ref activation.
+    expect(resolveSource).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors the activeIndex prop for the initially-active citation", async () => {
+    const el = mountViewer({ refs: REFS, resolveSource: mdResolver(), activeIndex: 1, title: "t" });
+    await settle();
+    expect(el.textContent).toContain("Citation 2/2");
+    expect(el.querySelector("[data-csv-mark]")?.textContent).toContain("Holmes examined");
+  });
+
+  it("shows the graceful not-found note when the quote is not in the source", async () => {
+    const el = mountViewer({
+      refs: [{ rawRef: "corpus/blue-study.md", section: "X", excerpt: "a passage that is nowhere in this document" }],
+      resolveSource: mdResolver(),
+      title: "t",
+    });
+    await settle();
+    expect(el.querySelector("[data-csv-mark]")).toBeNull();
+    expect(el.textContent).toContain("Quote not located in the source");
+    // The document still renders (show anyway).
+    expect(el.textContent).toContain("Holmes examined the ledger");
+  });
+
+  it("surfaces resolver failures as a clear source-unavailable state", async () => {
+    const el = mountViewer({
+      refs: REFS,
+      resolveSource: vi.fn(async () => {
+        throw new Error("404 sources/corpus/blue-study.md");
+      }),
+      title: "t",
+    });
+    await settle();
+    expect(el.textContent).toContain("Source unavailable");
+    expect(el.textContent).toContain("404 sources/corpus/blue-study.md");
+  });
+});
+
+describe("CitedSourceViewer purity (rebase seam)", () => {
+  it("imports nothing from graphify — only the sibling pure lib and svelte", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/components/CitedSourceViewer.svelte"),
+      "utf8",
+    );
+    const importSpecs = [
+      ...source.matchAll(/^\s*import\s+(?:[\s\S]*?from\s+)?["']([^"']+)["']/gm),
+    ].map((m) => m[1]);
+    expect(importSpecs.length).toBeGreaterThan(0);
+    for (const spec of importSpecs) {
+      expect(spec).toMatch(/^(svelte|\.\.\/lib\/cited-source\/)/);
+    }
+    // No graphify alias / server import can sneak in.
+    expect(source).not.toMatch(/@graphify\//);
+    expect(source).not.toMatch(/\.\.\/lib\/(api|graphAdapter|citedSources)/);
+  });
+});

--- a/studio/vite.config.js
+++ b/studio/vite.config.js
@@ -28,10 +28,15 @@ async function singleFilePlugins() {
 // The built SPA is served by `graphify ontology studio` from a static route.
 // `base: "./"` keeps asset URLs relative so the bundle works regardless of the
 // mount path the studio server picks.
-export default defineConfig(async () => ({
+export default defineConfig(async ({ mode }) => ({
   base: "./",
   plugins: [svelte(), ...(await singleFilePlugins())],
   resolve: {
+    // Under vitest (mode "test"), prefer the BROWSER build of packages —
+    // otherwise `svelte` resolves to its server entry and `mount()` throws
+    // (needed by the component render smokes, e.g. citedSourceViewer.test.js).
+    // Additive condition, test-mode only: the build output is untouched.
+    ...(mode === "test" ? { conditions: ["browser"] } : {}),
     alias: {
       "@sentropic/graph": resolve(here, "../packages/graph/src/index.ts"),
       // Pure, DOM-free deterministic force layout (honors fx/fy pins). Reused by

--- a/studio/vite.config.js
+++ b/studio/vite.config.js
@@ -51,6 +51,12 @@ export default defineConfig(async ({ mode }) => ({
       // the SPA byte-for-byte with the Node build. search-index.ts is imported
       // type-only by the assembler, so its node:crypto value import is erased.
       "@graphify/retrieval": resolve(here, "../src/retrieval/answer-pack.ts"),
+      // Frozen cited-source seam (PR #260): OntologyCitation -> CitedSourceRef
+      // converters. Pure TS, type-only imports of types.ts — bundles clean.
+      // Consumed ONLY by the studio glue (lib/citedSources.js), NEVER by the
+      // CitedSourceViewer component itself (purity contract for the rebase
+      // into @sentropic/cited-source-viewer).
+      "@graphify/cited-source-refs": resolve(here, "../src/cited-source-refs.ts"),
     },
   },
   build: {

--- a/tests/studio-export-sources.test.ts
+++ b/tests/studio-export-sources.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `--include-sources` (cited-source viewer): the exporter copies the CITED
+ * source documents into `<out>/sources/<project-relative-path>` so the served
+ * bundle can open them. Opt-in, size-conscious (only cited files), missing
+ * files warn without failing, unsafe locators are never mirrored.
+ */
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildStaticStudio,
+  collectCitedSourceFiles,
+  normalizeSourceRelPath,
+} from "../src/studio-export.js";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function makeSpaDir(): string {
+  const spaDir = mkdtempSync(join(tmpdir(), "graphify-spa-"));
+  dirs.push(spaDir);
+  writeFileSync(
+    join(spaDir, "index.html"),
+    '<!doctype html><html><body><div id="app"></div>' +
+      '<script type="module" src="./assets/index.js"></script></body></html>',
+  );
+  mkdirSync(join(spaDir, "assets"), { recursive: true });
+  writeFileSync(join(spaDir, "assets", "index.js"), "/* app */\n");
+  return spaDir;
+}
+
+/**
+ * A project root with a corpus + a .graphify state dir whose graph carries
+ * citations pointing at project-root-relative source files (the graphify
+ * `cite` convention), plus one missing file and one absolute locator.
+ */
+function makeProject(): { root: string; stateDir: string } {
+  const root = mkdtempSync(join(tmpdir(), "graphify-proj-"));
+  dirs.push(root);
+  mkdirSync(join(root, "corpus"), { recursive: true });
+  writeFileSync(join(root, "corpus", "report.pdf"), "%PDF-1.4 fake\n");
+  writeFileSync(join(root, "corpus", "notes.md"), "# Notes\n\nA cited passage.\n");
+  const stateDir = join(root, ".graphify");
+  mkdirSync(join(stateDir, "ontology"), { recursive: true });
+  const nodes = [
+    {
+      id: "a",
+      label: "Alpha",
+      type: "Character",
+      source_file: "corpus/notes.md",
+      citations: [
+        { source_file: "corpus/report.pdf", page: 2, quote: "a cited passage" },
+        { source_file: "corpus/notes.md", section: "Notes", quote: "A cited passage." },
+        { source_file: "corpus/missing.md", section: "Gone", quote: "nope" },
+        { source_file: "/etc/passwd", section: "evil" },
+        { source_file: "../outside.md", section: "escape" },
+      ],
+    },
+    { id: "b", label: "Beta", type: "Place" },
+  ];
+  writeFileSync(join(stateDir, "graph.json"), JSON.stringify({ nodes, links: [] }));
+  // Level-2 sidecar citing one EXTRA file beyond the inline set.
+  mkdirSync(join(root, "corpus", "extra"), { recursive: true });
+  writeFileSync(join(root, "corpus", "extra", "appendix.md"), "# Appendix\n");
+  writeFileSync(
+    join(stateDir, "ontology", "citations.json"),
+    JSON.stringify({
+      schema: "graphify_ontology_citations_v1",
+      nodes: { a: { citations: [{ source_file: "corpus/extra/appendix.md", section: "Appendix" }] } },
+    }),
+  );
+  return { root, stateDir };
+}
+
+describe("collectCitedSourceFiles / normalizeSourceRelPath", () => {
+  it("collects node.source_file + inline citations + sidecar (deep scan), deduped", () => {
+    const files = collectCitedSourceFiles(
+      [
+        { source_file: "corpus/notes.md", citations: [{ source_file: "corpus/report.pdf" }] },
+        { citations: [{ source_file: "corpus/notes.md" }] },
+      ],
+      { nodes: { a: { citations: [{ source_file: "corpus/extra/appendix.md" }] } } },
+    );
+    expect(files).toEqual(["corpus/extra/appendix.md", "corpus/notes.md", "corpus/report.pdf"]);
+  });
+
+  it("rejects absolute, URL and root-escaping locators", () => {
+    expect(normalizeSourceRelPath("/etc/passwd")).toBeNull();
+    expect(normalizeSourceRelPath("../outside.md")).toBeNull();
+    expect(normalizeSourceRelPath("corpus/../../outside.md")).toBeNull();
+    expect(normalizeSourceRelPath("https://example.com/a.pdf")).toBeNull();
+    expect(normalizeSourceRelPath("./corpus/report.pdf")).toBe("corpus/report.pdf");
+  });
+});
+
+describe("buildStaticStudio --include-sources", () => {
+  it("is OFF by default: no sources/ dir, result.sources null", () => {
+    const { stateDir } = makeProject();
+    const outDir = mkdtempSync(join(tmpdir(), "graphify-out-"));
+    dirs.push(outDir);
+    const result = buildStaticStudio({ stateDir, outDir, spaDir: makeSpaDir(), singleFile: false });
+    expect(result.sources).toBeNull();
+    expect(existsSync(join(outDir, "sources"))).toBe(false);
+  });
+
+  it("copies cited files (incl. sidecar-only ones) under sources/, skips missing + unsafe", () => {
+    const { root, stateDir } = makeProject();
+    const outDir = mkdtempSync(join(tmpdir(), "graphify-out-"));
+    dirs.push(outDir);
+    const warnings: string[] = [];
+    const result = buildStaticStudio({
+      stateDir,
+      outDir,
+      spaDir: makeSpaDir(),
+      singleFile: false,
+      includeSources: true,
+      sourcesRoot: root,
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(result.sources).not.toBeNull();
+    // report.pdf + notes.md + extra/appendix.md copied.
+    expect(result.sources!.copied).toBe(3);
+    expect(readFileSync(join(outDir, "sources", "corpus", "report.pdf"), "utf-8")).toContain("%PDF");
+    expect(existsSync(join(outDir, "sources", "corpus", "notes.md"))).toBe(true);
+    expect(existsSync(join(outDir, "sources", "corpus", "extra", "appendix.md"))).toBe(true);
+    // missing.md + /etc/passwd + ../outside.md are counted missing, never copied.
+    expect(result.sources!.missing).toBe(3);
+    expect(existsSync(join(outDir, "sources", "etc"))).toBe(false);
+    expect(warnings.join("\n")).toMatch(/could not bundle 3 cited file/);
+    expect(result.sources!.bytes).toBeGreaterThan(0);
+  });
+
+  it("defaults the sources root to the parent of the state dir", () => {
+    const { stateDir } = makeProject();
+    const outDir = mkdtempSync(join(tmpdir(), "graphify-out-"));
+    dirs.push(outDir);
+    const result = buildStaticStudio({
+      stateDir,
+      outDir,
+      spaDir: makeSpaDir(),
+      singleFile: false,
+      includeSources: true,
+      onWarning: () => {},
+    });
+    expect(result.sources!.copied).toBe(3);
+  });
+
+  it("wipes a stale sources/ dir on re-export without the flag", () => {
+    const { root, stateDir } = makeProject();
+    const outDir = mkdtempSync(join(tmpdir(), "graphify-out-"));
+    dirs.push(outDir);
+    const spaDir = makeSpaDir();
+    buildStaticStudio({
+      stateDir,
+      outDir,
+      spaDir,
+      singleFile: false,
+      includeSources: true,
+      sourcesRoot: root,
+      onWarning: () => {},
+    });
+    expect(existsSync(join(outDir, "sources"))).toBe(true);
+    buildStaticStudio({ stateDir, outDir, spaDir, singleFile: false });
+    expect(existsSync(join(outDir, "sources"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## WP4 · Sources & Citations — INTERIM cited-source viewer (architect §S.5 interim GO, 2026-07-04)

The distributable cited-source viewer, app-local in the studio under the **frozen seam**, per the architect's ratification (PR #261): pure component now, mechanical rebase into `@sentropic/cited-source-viewer` (sentropic monorepo) later.

### What it does
Click **"Open source ↗"** on any citation in the entity panel → DS-styled modal:
- **PDF**: real pdf.js page render + **amber text-layer highlight on the exact quote**, page nav (←/→), citation prev/next (n/N), honest "quote not located — showing page anyway" degradation.
- **Markdown/plain-text**: rendered source, scroll-to + `<mark>` highlight of the quote, `p.N · section` locator.

### Architecture (rebase-ready, architect's conditions)
- `CitedSourceViewer.svelte` = **pure** (props: `refs: CitedSourceRef[]` + `resolveSource(ref)` callback; imports only svelte + pure libs; **purity pinned by a test**). DS `--st-*` tokens.
- Pure libs: `quoteMatch.js` (verbatim port of radar `pdf-citation-match.ts`: normalize→exact→word-window, #83 AND-gate), `pdfEngine.js` (radar `SignalPdfOverlay` lift: worker singleton #89, #82 position/dimension space split; bytes-based via the resolver seam), `markdownSource.js`.
- Impure glue outside the component: EntityPanel affordance, App modal, `citedSources.js` (public converters `citationsToCitedSourceRefs`).
- **`graphify studio export --include-sources [--sources-root]`**: copies only cited files under `sources/` (path-escape refused, missing files warn) so a distributable bundle carries its cited sources.

### Verified (real outputs)
- lint clean · root subset 61 passed/1 skipped · studio 303/306 (3 fails **pre-existing on main**, WebGL mock, verified by stash) · `npm run build` exit 0 (pdf.js = 335 KB lazy chunk).
- **UAT screenshots** (real pipeline; PDF quotes verified verbatim on-page 9/9 via pdftotext; MD grounded by real `graphify cite`): `.graphify/uat/cited-viewer/shots/{a,b,b2,c}*.png`.

### Works-where matrix (honest, in studio/README.md)
served bundle = full viewer · live `ontology studio` server = affordance but sources 404 (no source API route yet — follow-up) · `file://` = explicit "Source unavailable".

### Deferred
`/api/ontology/source` route; DOCX/PPTX (v2); image-bbox (v3); sub-item highlight granularity; `cite` skip-non-text guard for raw-PDF `source_file` (found during UAT — separate fix).

Hold merge for the principal's visual UAT verdict.