### PR TITLE
feat(studio): cited-source viewer — selection-scope citation navigation (increment 2)

### DIFF
--- a/spec/SPEC_WP_CITED_SOURCE_VIZ.md
+++ b/spec/SPEC_WP_CITED_SOURCE_VIZ.md
@@ -356,6 +356,47 @@ overlay (image); (f) acknowledge **image-bbox grounding needs a producer-side de
 its render path ships earlier, its data does not, until a YOLO-style/layout detector (or figure-caption
 heuristic) exists.
 
+### S.6 Qualified generic frame *(principal UAT 2026-07-04 — binding baseline for `@sentropic/cited-source-viewer`)*
+
+The interim studio viewer (PR #262) qualified the GENERIC frame once for the shared package: a
+NON-modal central overlay (side panels stay live), ONE compact DS toolbar common to ALL modalities —
+`‹ Citation x/y ›` · `‹ Doc x/y ›` (multi-file refs) · modality segments (`‹ Page x/y ›`, zoom) ·
+`Ouvrir ↗` — with only the BODY swapping per modality. The component is PURE (props + resolver
+callbacks, zero graphify runtime import) and retargets an open instance on new props (no stacking).
+
+#### S.6.1 Increment — selection-scope citation navigation *(principal-approved, qualified 2026-07-04)*
+
+The selection can hold SEVERAL entities, each cited several times, possibly across several documents.
+The viewer supports TWO navigation scopes:
+
+- **Entité** (baseline): citations of the current entity only.
+- **Sélection** (increment): ONE continuous thread of ALL citations of ALL selected entities —
+  stepping past the last citation of entity A lands on the first citation of entity B WITHOUT
+  closing the overlay.
+
+Approved UX (generic frame — the toggle/indicator are modality-agnostic toolbar segments):
+
+- Toolbar gains a **scope toggle `[ Entité | Sélection ]`** left of the citation navigator, shown
+  ONLY when the selection holds ≥2 entities with citations (else plain Entité mode, no toggle).
+- In Sélection scope the citation counter is GLOBAL (`Citation 7/23`) and an
+  **`‹ Entité x/y — <label> ›`** indicator group appears (prev/next jump to the FIRST citation of
+  the neighbour entity).
+- **Thread order: selection order → then document (first appearance) → then page.** The thread is
+  built by CONSUMER GLUE (graphify studio: `lib/citedSources.js` `buildSelectionThread`), never by
+  the component.
+- Keyboard: `n`/`N` = next/prev citation in the ACTIVE scope; `e`/`E` = next/prev entity
+  (Sélection scope only). Form fields are never intercepted.
+- **Right-panel sync, bidirectional:** the selection panel FOLLOWS the navigation — current entity
+  AND current citation highlighted (DS `--st-*` tokens) and scrolled into view via the pure
+  `onFocusChange(groupId, refIndex)` callback; clicking a citation in the panel retargets the open
+  viewer, and clicking one on ANOTHER selected entity keeps/switches to Sélection scope.
+
+Extended pure API (carried as-is into `@sentropic/cited-source-viewer`):
+`groups: Array<{ id, label, refs: CitedSourceRef[] }>` (grouped thread; flat `refs` = one anonymous
+group) + `activeGroupIndex` / `activeIndex` (ref index WITHIN the group) + `scope`
+(`"entity" | "selection"`, prop-seeded) + `onScopeChange(scope)` + `onFocusChange(groupId, refIndex)`.
+All selection logic (thread building, panel focus, scope memory) stays in the consumer glue.
+
 ---
 
 ## Per-modality lots — the v1 / v2 / v3 sequence  *(principal's full-modality requirement)*

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -19,7 +19,12 @@
   import ReconciliationView from "./components/ReconciliationView.svelte";
   import SelectionPanel from "./components/SelectionPanel.svelte";
   import WorkspaceShell from "./components/WorkspaceShell.svelte";
-  import { refsForCitations, resolveBundleSource, sourceHrefFor } from "./lib/citedSources.js";
+  import {
+    buildSelectionThread,
+    resolveBundleSource,
+    sameCitation,
+    sourceHrefFor,
+  } from "./lib/citedSources.js";
   import {
     fetchClassHierarchies,
     fetchEntity,
@@ -40,7 +45,9 @@
     attachForceLayout,
     resolveSelectedIds,
     communityStats,
+    indexNodes,
     nodeCommunity,
+    nodeLabel,
     nodeType,
   } from "./lib/graphAdapter.js";
   import {
@@ -441,7 +448,7 @@
     searchIndex = await fetchSearchIndex();
   }
 
-  // ----- cited-source viewer (INTERIM, architect-ratified §S.5) --------------
+  // ----- cited-source viewer (INTERIM, architect-ratified §S.5 + §S.6.1) -----
   // IMPURE studio glue: the EntityPanel affordance hands the node's raw
   // OntologyCitation list here; the frozen public projection converts it to
   // CitedSourceRef[] and a CENTRAL OVERLAY (qualified UX, immo parity: covers
@@ -449,21 +456,106 @@
   // hosts the PURE CitedSourceViewer with the bundle resolver (sources/ dir,
   // `--include-sources` export). Clicking another citation while open simply
   // replaces this state -> the viewer RETARGETS (no stacking).
-  // null = closed; { refs, activeIndex, title } = open.
+  //
+  // §S.6.1 (selection-scope navigation): every open builds the GROUPED thread
+  // from the CURRENT multi-selection (selection order → document → page, via
+  // buildSelectionThread) so the viewer can navigate ONE continuous thread
+  // across all selected entities. `meta` mirrors `groups` with the RAW
+  // citation objects; onFocusChange maps back through it so the right panel
+  // can follow (highlight + scroll the exact passage).
+  // null = closed; { groups, meta, activeGroupIndex, activeIndex, scope, title } = open.
   let sourceView = $state(null);
-  function handleOpenSource({ citations, index, fallbackSourceFile, label }) {
-    const refs = refsForCitations(citations, fallbackSourceFile);
-    if (refs.length === 0) return;
-    const active = Number.isInteger(index) && index >= 0 && index < refs.length ? index : 0;
-    const locator = refs[active]?.rawRef ?? refs[active]?.sourceUrl ?? "";
+  // Viewer→panel sync target: { entityId, citation } (null = viewer closed).
+  let sourceFocus = $state(null);
+
+  /** Selected entities (SELECTION ORDER) with their best-known citation lists:
+   *  the hydrated sidecar's full list when available, else the inline K-set —
+   *  the SAME precedence EntityPanel renders, so panel positions and thread
+   *  positions refer to the same arrays. */
+  function selectionThreadEntities() {
+    const idx = indexNodes(facetGraph);
+    return viewerState.selection.entities.map((id) => {
+      const node = idx.get(id) ?? { id };
+      const full = Array.isArray(entityCache[id]?.citations?.citations)
+        ? entityCache[id].citations.citations
+        : null;
+      return {
+        id,
+        label: nodeLabel(node),
+        citations: full ?? (Array.isArray(node.citations) ? node.citations : []),
+        fallbackSourceFile: node.source_file ?? null,
+      };
+    });
+  }
+
+  function handleOpenSource({ citations, index, fallbackSourceFile, label, entityId = null }) {
+    const clicked = Array.isArray(citations)
+      ? (citations[Number.isInteger(index) && index >= 0 ? index : 0] ?? null)
+      : null;
+    // Build the selection thread; if the clicked entity is not part of the
+    // multi-selection (e.g. focused via a type/community bucket), fall back to
+    // a single-group thread for it — same ordering rules, plain Entité mode.
+    let thread = buildSelectionThread(selectionThreadEntities());
+    let gi = entityId != null ? thread.groups.findIndex((g) => g.id === entityId) : -1;
+    if (gi < 0) {
+      thread = buildSelectionThread([
+        { id: entityId ?? "(entity)", label, citations, fallbackSourceFile },
+      ]);
+      gi = 0;
+    }
+    if (thread.groups.length === 0) return;
+    // Aim at the clicked citation inside its (thread-ordered) group.
+    const metaCitations = thread.meta[gi]?.citations ?? [];
+    let ri = clicked ? metaCitations.indexOf(clicked) : -1;
+    if (ri < 0 && clicked) ri = metaCitations.findIndex((c) => sameCitation(c, clicked));
+    if (ri < 0) ri = 0;
+    // Scope policy (§S.6.1): fresh open = Entité; a click on ANOTHER selected
+    // entity while the viewer is open keeps/switches to Sélection; a click on
+    // the SAME entity keeps whatever scope the user last chose.
+    const eligible = thread.groups.filter((g) => g.refs.length > 0).length >= 2;
+    let scope = "entity";
+    if (sourceView && eligible) {
+      const currentEntityId = sourceFocus?.entityId ?? null;
+      scope =
+        entityId != null && currentEntityId != null && entityId !== currentEntityId
+          ? "selection"
+          : (sourceView.scope ?? "entity");
+    }
+    const activeRef = thread.groups[gi]?.refs?.[ri] ?? null;
+    const locator = activeRef?.rawRef ?? activeRef?.sourceUrl ?? "";
     sourceView = {
-      refs,
-      activeIndex: active,
+      groups: thread.groups,
+      meta: thread.meta,
+      activeGroupIndex: gi,
+      activeIndex: ri,
+      scope,
       title: label ? `${label} — ${locator}` : locator,
+    };
+    sourceFocus = {
+      entityId: thread.groups[gi].id,
+      citation: metaCitations[ri] ?? null,
     };
   }
   function handleCloseSource() {
     sourceView = null;
+    sourceFocus = null;
+  }
+  /** §S.6.1: the viewer navigated — make the RIGHT PANEL follow: highlight +
+   *  scroll the current entity and citation, and open that entity's detail. */
+  function handleSourceFocusChange(groupId, refIndex) {
+    if (!sourceView || groupId == null) return;
+    const meta = sourceView.meta.find((m) => m.id === groupId);
+    sourceFocus = { entityId: groupId, citation: meta?.citations?.[refIndex] ?? null };
+    // Open the entity's detail in the selection panel (no graph reload) so the
+    // highlighted citation is visible; hydrate its sidecar lazily.
+    if (viewerState.focusId !== groupId) {
+      viewerState = setFocus(viewerState, groupId);
+      void ensureEntity(groupId);
+    }
+  }
+  /** §S.6.1: remember the user's scope choice so a retarget keeps it. */
+  function handleSourceScopeChange(scope) {
+    if (sourceView) sourceView = { ...sourceView, scope };
   }
 
   // Open an entity surfaced by the Answer view IN the graph: switch to the
@@ -711,11 +803,15 @@
                  glue stays in this file. -->
             <div class="source-overlay" role="region" aria-label="Cited source">
               <CitedSourceViewer
-                refs={sourceView.refs}
+                groups={sourceView.groups}
+                activeGroupIndex={sourceView.activeGroupIndex}
                 activeIndex={sourceView.activeIndex}
+                scope={sourceView.scope}
                 title={sourceView.title}
                 resolveSource={resolveBundleSource}
                 sourceHref={sourceHrefFor}
+                onFocusChange={handleSourceFocusChange}
+                onScopeChange={handleSourceScopeChange}
                 onClose={handleCloseSource}
               />
             </div>
@@ -734,6 +830,7 @@
             onToggleEntity={handleToggleEntity}
             onClear={handleClear}
             onOpenSource={handleOpenSource}
+            {sourceFocus}
           />
         </div>
       </WorkspaceShell>

--- a/studio/src/components/CitedSourceViewer.svelte
+++ b/studio/src/components/CitedSourceViewer.svelte
@@ -5,9 +5,15 @@
    *
    * PURITY CONTRACT (for the mechanical rebase into the sentropic monorepo):
    * this component imports NOTHING from graphify — only its sibling pure lib
-   * (`../lib/cited-source/*`) and Svelte. All graphify-specific glue (reading
-   * node.citations, converting via citationToCitedSourceRef, fetching bytes)
-   * lives OUTSIDE, in the studio wiring (App.svelte + lib/citedSources.js).
+   * (`../lib/cited-source/*`), Svelte, and the DS package
+   * (@sentropic/design-system-svelte: the architect-owned shared package
+   * itself depends on the DS, so DS imports are part of the seam —
+   * ALLOWED_EXTERNAL mirrors the package: svelte + design-system-svelte +
+   * pdfjs-dist). All controls are REAL DS components (IconButton / Button /
+   * ContentSwitcher / Link) — no raw <button>/<a> chrome. All
+   * graphify-specific glue (reading node.citations, converting via
+   * citationToCitedSourceRef, fetching bytes) lives OUTSIDE, in the studio
+   * wiring (App.svelte + lib/citedSources.js).
    *
    * QUALIFIED UX (principal UAT 2026-07-04, immo/radar SignalPdfOverlay
    * parity). This frame is being qualified ONCE for the shared package, so it
@@ -77,6 +83,11 @@
    * v1 scope: MD (incl. OCR-markdown / plain text) + PDF text-layer only.
    */
   import { tick } from "svelte";
+  // DS components ARE part of the pure seam (the architect-owned shared
+  // package itself imports the DS): allowed externals mirror the package's
+  // ALLOWED_EXTERNAL = svelte + @sentropic/design-system-svelte + pdfjs-dist.
+  // graphify runtime imports remain forbidden.
+  import { Button, ContentSwitcher, IconButton, Link } from "@sentropic/design-system-svelte";
   import {
     MAX_RENDER_SCALE,
     MIN_RENDER_SCALE,
@@ -459,39 +470,36 @@
       {/if}
     </div>
     {#if onClose}
-      <button class="csv-close" type="button" onclick={() => onClose()} aria-label="Close source viewer">✕</button>
+      <IconButton size="sm" variant="ghost" aria-label="Close source viewer" class="csv-close" onclick={() => onClose()}>✕</IconButton>
     {/if}
   </header>
 
   <!-- QUALIFIED TOOLBAR (immo parity): one compact bar, generic frame; only
-       the Page/Zoom segments are modality-gated (page-addressable sources). -->
+       the Page/Zoom segments are modality-gated (page-addressable sources).
+       100% DS controls: IconButton (‹ › − + ✕), Button (zoom-% reset),
+       ContentSwitcher (scope toggle), Link (Ouvrir ↗). -->
   <div class="csv-toolbar" role="toolbar" aria-label="Source navigation">
     {#if scopeEligible}
       <!-- §S.6.1 scope toggle — only for a REAL multi-entity thread (≥2 groups
            with citations); otherwise the plain Entité behavior applies. -->
-      <div class="csv-tb-group csv-tb-scope" role="group" aria-label="Navigation scope">
-        <button
-          class="csv-scope-btn"
-          class:csv-scope-btn--active={effectiveScope === "entity"}
-          type="button"
-          aria-pressed={effectiveScope === "entity"}
-          onclick={() => setScope("entity")}
-        >Entité</button>
-        <button
-          class="csv-scope-btn"
-          class:csv-scope-btn--active={effectiveScope === "selection"}
-          type="button"
-          aria-pressed={effectiveScope === "selection"}
-          onclick={() => setScope("selection")}
-        >Sélection</button>
-      </div>
+      <ContentSwitcher
+        size="sm"
+        label="Navigation scope"
+        class="csv-tb-scope"
+        items={[
+          { value: "entity", label: "Entité" },
+          { value: "selection", label: "Sélection" },
+        ]}
+        value={effectiveScope}
+        onchange={(value) => setScope(value)}
+      />
     {/if}
 
     {#if scopeCount > 1}
       <div class="csv-tb-group" aria-label="Citation navigator">
-        <button class="csv-tb-btn" type="button" disabled={scopePos <= 0} onclick={() => goScopeRef(-1)} aria-label="Previous citation">‹</button>
+        <IconButton size="sm" disabled={scopePos <= 0} onclick={() => goScopeRef(-1)} aria-label="Previous citation">‹</IconButton>
         <span class="csv-tb-label">Citation <strong>{scopePos + 1}/{scopeCount}</strong></span>
-        <button class="csv-tb-btn" type="button" disabled={scopePos >= scopeCount - 1} onclick={() => goScopeRef(1)} aria-label="Next citation">›</button>
+        <IconButton size="sm" disabled={scopePos >= scopeCount - 1} onclick={() => goScopeRef(1)} aria-label="Next citation">›</IconButton>
       </div>
     {/if}
 
@@ -499,44 +507,45 @@
       <!-- §S.6.1 entity indicator: position in the selection + current label;
            ‹ › jump to the FIRST citation of the neighbour entity (kbd e/E). -->
       <div class="csv-tb-group" aria-label="Entity navigator">
-        <button class="csv-tb-btn" type="button" disabled={entityPos <= 0} onclick={() => goEntity(-1)} aria-label="Previous entity">‹</button>
+        <IconButton size="sm" disabled={entityPos <= 0} onclick={() => goEntity(-1)} aria-label="Previous entity">‹</IconButton>
         <span class="csv-tb-label">Entité <strong>{entityPos + 1}/{entityOrder.length}</strong>{#if activeGroup?.label}<span class="csv-tb-entity">— {activeGroup.label}</span>{/if}</span>
-        <button class="csv-tb-btn" type="button" disabled={entityPos >= entityOrder.length - 1} onclick={() => goEntity(1)} aria-label="Next entity">›</button>
+        <IconButton size="sm" disabled={entityPos >= entityOrder.length - 1} onclick={() => goEntity(1)} aria-label="Next entity">›</IconButton>
       </div>
     {/if}
 
     {#if docCount > 1}
       <div class="csv-tb-group" aria-label="Document navigator">
-        <button class="csv-tb-btn" type="button" disabled={docIndex <= 0} onclick={() => goDoc(-1)} aria-label="Previous document">‹</button>
+        <IconButton size="sm" disabled={docIndex <= 0} onclick={() => goDoc(-1)} aria-label="Previous document">‹</IconButton>
         <span class="csv-tb-label">Doc <strong>{docIndex + 1}/{docCount}</strong></span>
-        <button class="csv-tb-btn" type="button" disabled={docIndex >= docCount - 1} onclick={() => goDoc(1)} aria-label="Next document">›</button>
+        <IconButton size="sm" disabled={docIndex >= docCount - 1} onclick={() => goDoc(1)} aria-label="Next document">›</IconButton>
       </div>
     {/if}
 
     {#if pdfDoc}
       <div class="csv-tb-group" aria-label="Page navigator">
-        <button class="csv-tb-btn" type="button" disabled={currentPage <= 1} onclick={goPrevPage} aria-label="Previous page">‹</button>
+        <IconButton size="sm" disabled={currentPage <= 1} onclick={goPrevPage} aria-label="Previous page">‹</IconButton>
         <span class="csv-tb-label">Page <strong>{currentPage}/{numPages}</strong></span>
-        <button class="csv-tb-btn" type="button" disabled={currentPage >= numPages} onclick={goNextPage} aria-label="Next page">›</button>
+        <IconButton size="sm" disabled={currentPage >= numPages} onclick={goNextPage} aria-label="Next page">›</IconButton>
       </div>
 
       <div class="csv-tb-group" aria-label="Zoom">
-        <button class="csv-tb-btn" type="button" disabled={scale <= MIN_RENDER_SCALE + 0.001} onclick={zoomOut} aria-label="Zoom out">−</button>
-        <button
+        <IconButton size="sm" disabled={scale <= MIN_RENDER_SCALE + 0.001} onclick={zoomOut} aria-label="Zoom out">−</IconButton>
+        <Button
+          size="sm"
+          variant="ghost"
           class="csv-tb-zoom"
-          type="button"
           onclick={resetZoom}
           title="Back to fit-width"
           aria-label="Zoom level {Math.round(scale * 100)} percent, click to fit width"
-        >{Math.round(scale * 100)}%</button>
-        <button class="csv-tb-btn" type="button" disabled={scale >= MAX_RENDER_SCALE - 0.001} onclick={zoomIn} aria-label="Zoom in">+</button>
+        >{Math.round(scale * 100)}%</Button>
+        <IconButton size="sm" disabled={scale >= MAX_RENDER_SCALE - 0.001} onclick={zoomIn} aria-label="Zoom in">+</IconButton>
       </div>
     {/if}
 
     <span class="csv-tb-spacer"></span>
 
     {#if rawHref}
-      <a class="csv-tb-open" href={rawHref} target="_blank" rel="noopener noreferrer">Ouvrir ↗</a>
+      <Link href={rawHref} external variant="standalone" class="csv-tb-open">Ouvrir ↗</Link>
     {/if}
   </div>
 
@@ -636,20 +645,10 @@
     color: var(--st-semantic-text-secondary, #475569);
     white-space: nowrap;
   }
-  .csv-close {
+  /* DS components own their chrome; local CSS is LAYOUT-ONLY (:global hooks
+     target the class passed to the DS root, which Svelte cannot scope). */
+  .csv-head :global(.csv-close) {
     flex-shrink: 0;
-    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    background: var(--st-semantic-surface-subtle, #f8fafc);
-    border-radius: var(--st-radius-sm, 4px);
-    color: var(--st-semantic-text-secondary, #475569);
-    cursor: pointer;
-    font-size: 0.85rem;
-    line-height: 1;
-    padding: 0.3rem 0.45rem;
-  }
-  .csv-close:hover {
-    color: var(--st-semantic-feedback-error, #dc2626);
-    border-color: var(--st-semantic-feedback-error, #dc2626);
   }
   /* ── Qualified toolbar (immo parity) ──────────────────────────────────── */
   .csv-toolbar {
@@ -681,32 +680,6 @@
     font-weight: 700;
     color: var(--st-semantic-text-primary, #0f172a);
   }
-  /* §S.6.1 scope toggle [ Entité | Sélection ] — DS-token segmented control. */
-  .csv-tb-scope {
-    padding: 0.1rem;
-    gap: 0.1rem;
-  }
-  .csv-scope-btn {
-    border: none;
-    background: transparent;
-    border-radius: var(--st-radius-sm, 4px);
-    color: var(--st-semantic-text-secondary, #475569);
-    cursor: pointer;
-    font-size: 0.72rem;
-    font-weight: 600;
-    line-height: 1;
-    padding: 0.25rem 0.5rem;
-    white-space: nowrap;
-  }
-  .csv-scope-btn:not(.csv-scope-btn--active):hover {
-    background: var(--st-semantic-surface-subtle, #f1f5f9);
-    color: var(--st-semantic-action-primary, #2563eb);
-  }
-  .csv-scope-btn--active {
-    background: var(--st-semantic-surface-selected, #eff6ff);
-    color: var(--st-semantic-action-primary, #2563eb);
-    font-weight: 700;
-  }
   /* §S.6.1 entity indicator label — bounded, never widens the toolbar. */
   .csv-tb-entity {
     display: inline-block;
@@ -719,61 +692,15 @@
     color: var(--st-semantic-text-primary, #0f172a);
     font-weight: 600;
   }
-  .csv-tb-btn {
-    border: none;
-    background: transparent;
-    border-radius: var(--st-radius-sm, 4px);
-    color: var(--st-semantic-text-secondary, #475569);
-    cursor: pointer;
-    font-size: 0.9rem;
-    line-height: 1;
-    padding: 0.15rem 0.4rem;
-  }
-  .csv-tb-btn:disabled {
-    opacity: 0.35;
-    cursor: default;
-  }
-  .csv-tb-btn:not(:disabled):hover {
-    background: var(--st-semantic-surface-subtle, #f1f5f9);
-    color: var(--st-semantic-action-primary, #2563eb);
-  }
-  .csv-tb-zoom {
-    border: none;
-    background: transparent;
-    border-radius: var(--st-radius-sm, 4px);
-    color: var(--st-semantic-text-primary, #0f172a);
-    cursor: pointer;
-    font-size: 0.72rem;
-    font-weight: 700;
-    line-height: 1;
-    padding: 0.2rem 0.3rem;
-    min-width: 2.6rem;
-    text-align: center;
-  }
-  .csv-tb-zoom:hover {
-    background: var(--st-semantic-surface-subtle, #f1f5f9);
-    color: var(--st-semantic-action-primary, #2563eb);
-  }
   .csv-tb-spacer {
     flex: 1;
   }
-  .csv-tb-open {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    border-radius: var(--st-radius-sm, 4px);
-    background: var(--st-semantic-surface-default, #fff);
-    color: var(--st-semantic-text-link, #2563eb);
-    font-size: 0.74rem;
-    font-weight: 600;
-    line-height: 1;
-    padding: 0.3rem 0.5rem;
-    text-decoration: none;
+  /* Layout-only hooks on DS roots (chrome comes from the DS itself). */
+  .csv-toolbar :global(.csv-tb-open) {
     white-space: nowrap;
   }
-  .csv-tb-open:hover {
-    border-color: var(--st-semantic-action-primary, #2563eb);
+  .csv-toolbar :global(.csv-tb-zoom) {
+    min-width: 2.9rem;
   }
   .csv-quote {
     margin: 0.55rem 1rem 0.2rem;

--- a/studio/src/components/CitedSourceViewer.svelte
+++ b/studio/src/components/CitedSourceViewer.svelte
@@ -500,7 +500,7 @@
            ‹ › jump to the FIRST citation of the neighbour entity (kbd e/E). -->
       <div class="csv-tb-group" aria-label="Entity navigator">
         <button class="csv-tb-btn" type="button" disabled={entityPos <= 0} onclick={() => goEntity(-1)} aria-label="Previous entity">‹</button>
-        <span class="csv-tb-label">Entité <strong>{entityPos + 1}/{entityOrder.length}</strong>{#if activeGroup?.label}<span class="csv-tb-entity"> — {activeGroup.label}</span>{/if}</span>
+        <span class="csv-tb-label">Entité <strong>{entityPos + 1}/{entityOrder.length}</strong>{#if activeGroup?.label}<span class="csv-tb-entity">— {activeGroup.label}</span>{/if}</span>
         <button class="csv-tb-btn" type="button" disabled={entityPos >= entityOrder.length - 1} onclick={() => goEntity(1)} aria-label="Next entity">›</button>
       </div>
     {/if}
@@ -711,6 +711,7 @@
   .csv-tb-entity {
     display: inline-block;
     vertical-align: bottom;
+    margin-left: 0.3rem;
     max-width: 11rem;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/studio/src/components/CitedSourceViewer.svelte
+++ b/studio/src/components/CitedSourceViewer.svelte
@@ -33,19 +33,46 @@
    * overlay (over its canvas/main view only) and keeps its side panels live; a
    * NEW `refs` array + `activeIndex` RETARGETS an open viewer (no stacking).
    *
-   * Props (the frozen seam, SPEC_WP_CITED_SOURCE_VIZ §S.1/§S.3):
+   * Props (the frozen seam, SPEC_WP_CITED_SOURCE_VIZ §S.1/§S.3; grouped-thread
+   * increment §S.6.1 — this extended API is carried as-is into
+   * @sentropic/cited-source-viewer):
    *   refs          CitedSourceRef[] (shape only — no type import needed in JS):
    *                 { rawRef?, sourceUrl?, docSha?, modality?, page?, section?,
    *                   paragraph_id?, bbox?, excerpt?, citation? }
+   *                 FLAT single-entity mode: used only when `groups` is absent
+   *                 or empty (it then behaves as one anonymous group).
+   *   groups        Array<{ id, label, refs: CitedSourceRef[] }> — the GROUPED
+   *                 citation thread (§S.6.1): one group per source entity, in
+   *                 the consumer's selection order. When ≥2 groups carry refs,
+   *                 the toolbar gains the [ Entité | Sélection ] scope toggle
+   *                 and the Sélection scope navigates ONE continuous thread
+   *                 across all groups. The component never builds the thread —
+   *                 ordering (selection → document → page) is consumer glue.
+   *   activeGroupIndex  Index of the initially/retarget-active group.
+   *   activeIndex   Active ref index WITHIN the active group (flat mode: index
+   *                 into `refs`); with a new `groups`/`refs` identity it
+   *                 retargets an OPEN viewer (no stacking).
+   *   scope         "entity" | "selection" — navigation scope seed. Tracked
+   *                 like the index props: a CHANGED prop value re-seeds the
+   *                 internal scope; internal toggles do not echo back.
+   *   onScopeChange (scope) => void — user toggled the scope in the toolbar.
+   *   onFocusChange (groupId, refIndex) => void — the focused citation changed
+   *                 through IN-VIEWER navigation (buttons/keyboard). refIndex
+   *                 is WITHIN the group. Not fired for prop-driven retargets
+   *                 (the consumer already knows those).
    *   resolveSource async (ref) => { kind: "pdf", data: ArrayBuffer }
    *                              | { kind: "markdown", text: string }
    *                 The component NEVER reads bytes itself (§S.3).
    *   sourceHref    (ref) => string|null — href for the "Ouvrir ↗" raw-source
    *                 link; null/absent hides the button. Pure callback: the
    *                 consumer owns the URL scheme (bundle sources/, API route…).
-   *   activeIndex   Active ref index; with a new `refs` array it retargets.
-   *   title         Header title (e.g. the source file the user clicked).
+   *   title         Header title fallback. In grouped mode the header shows
+   *                 the ACTIVE group's label + locator (follows the thread).
    *   onClose       Close callback (optional; hides the ✕ when absent).
+   *
+   * Keyboard (generic frame, §S.6.1): n/N next/prev citation in the ACTIVE
+   * scope; e/E next/prev entity (Sélection scope only); ←/→ PDF pages; Esc
+   * closes. Form fields are never intercepted.
    *
    * v1 scope: MD (incl. OCR-markdown / plain text) + PDF text-layer only.
    */
@@ -61,19 +88,34 @@
 
   let {
     refs = [],
+    groups = [],
     resolveSource,
     sourceHref = null,
+    activeGroupIndex = 0,
     activeIndex = 0,
+    scope = "entity",
+    onScopeChange = null,
+    onFocusChange = null,
     title = "Cited source",
     onClose = null,
   } = $props();
 
-  // Active ref index — internal state seeded from the props. Tracking BOTH the
-  // refs identity and the activeIndex prop makes a re-open with the same index
-  // on a new refs array retarget correctly (no stale internal position).
-  let index = $state(0);
+  // Active (group, ref) position — internal state seeded from the props.
+  // Tracking BOTH the groups/refs identity and the index props makes a re-open
+  // with the same indexes on a new thread retarget correctly (no stale
+  // internal position).
+  let gIndex = $state(0);
+  let rIndex = $state(0);
   let lastActiveProp = -1;
+  let lastActiveGroupProp = -1;
   let lastRefsProp = null;
+  let lastGroupsProp = null;
+
+  // Navigation scope (§S.6.1). Seeded from the `scope` prop (own last-seen
+  // tracking, SEPARATE from the index retarget so a scope write-back from the
+  // consumer never re-seeds an internally-navigated position).
+  let scopeState = $state("entity");
+  let lastScopeProp = null;
 
   // Load pipeline state.
   let loading = $state(false);
@@ -99,17 +141,89 @@
   let loadToken = 0;
   let renderToken = 0;
 
-  const ref = $derived(refs[index] ?? null);
-  const refCount = $derived(refs.length);
   const quoteOf = (r) => r?.excerpt ?? r?.citation ?? null;
   const locatorOf = (r) => r?.rawRef ?? r?.sourceUrl ?? r?.docSha ?? "";
 
-  // ── Document navigator (immo "PDF x/y"): distinct source locators, in ref
-  //    order. Prev/next jumps to the FIRST ref of the neighbour document.
+  // ── Grouped thread normalization (§S.6.1). Flat `refs` mode is ONE anonymous
+  //    group, so every navigator below runs off the same structure.
+  const normGroups = $derived(
+    Array.isArray(groups) && groups.length > 0
+      ? groups
+      : refs.length > 0
+        ? [{ id: null, label: null, refs }]
+        : [],
+  );
+  const activeGroup = $derived(normGroups[gIndex] ?? null);
+  const groupRefs = (g) => (Array.isArray(g?.refs) ? g.refs : []);
+  const ref = $derived(groupRefs(activeGroup)[rIndex] ?? null);
+
+  // The FLAT thread: every (group, ref) position in order. Sélection scope
+  // navigates this list continuously — stepping past the last citation of one
+  // entity lands on the first citation of the next.
+  const thread = $derived.by(() => {
+    const items = [];
+    normGroups.forEach((g, gi) => {
+      groupRefs(g).forEach((r, ri) => items.push({ gi, ri, ref: r }));
+    });
+    return items;
+  });
+
+  // Entity order = groups that actually carry refs. The scope toggle only
+  // shows for a REAL multi-entity thread (≥2 groups with citations).
+  const entityOrder = $derived(
+    normGroups.map((g, gi) => (groupRefs(g).length > 0 ? gi : -1)).filter((gi) => gi >= 0),
+  );
+  const scopeEligible = $derived(entityOrder.length >= 2);
+  const effectiveScope = $derived(scopeEligible && scopeState === "selection" ? "selection" : "entity");
+  const entityPos = $derived(entityOrder.indexOf(gIndex));
+
+  // The ACTIVE-SCOPE item list drives the citation counter AND the document
+  // navigator: current entity's refs (Entité) or the whole thread (Sélection).
+  const scopeItems = $derived(
+    effectiveScope === "selection" ? thread : thread.filter((it) => it.gi === gIndex),
+  );
+  const scopePos = $derived(scopeItems.findIndex((it) => it.gi === gIndex && it.ri === rIndex));
+  const scopeCount = $derived(scopeItems.length);
+
+  /** Move the focus and notify the consumer (right-panel sync, §S.6.1). */
+  function focusTo(gi, ri) {
+    if (gi === gIndex && ri === rIndex) return;
+    gIndex = gi;
+    rIndex = ri;
+    if (typeof onFocusChange === "function") {
+      onFocusChange(normGroups[gi]?.id ?? null, ri);
+    }
+  }
+
+  /** Next/prev citation in the ACTIVE scope (toolbar ‹ › and n/N). */
+  function goScopeRef(delta) {
+    const target = scopePos + delta;
+    if (target < 0 || target >= scopeCount) return;
+    const item = scopeItems[target];
+    focusTo(item.gi, item.ri);
+  }
+
+  /** Next/prev entity (Sélection scope): first citation of the neighbour group. */
+  function goEntity(delta) {
+    const target = entityPos + delta;
+    if (target < 0 || target >= entityOrder.length) return;
+    focusTo(entityOrder[target], 0);
+  }
+
+  function setScope(next) {
+    if (next !== "entity" && next !== "selection") return;
+    if (scopeState === next) return;
+    scopeState = next;
+    if (typeof onScopeChange === "function") onScopeChange(next);
+  }
+
+  // ── Document navigator (immo "PDF x/y"): distinct source locators of the
+  //    ACTIVE SCOPE, in thread order. Prev/next jumps to the FIRST ref of the
+  //    neighbour document.
   const docLocators = $derived.by(() => {
     const seen = [];
-    for (const r of refs) {
-      const loc = locatorOf(r);
+    for (const it of scopeItems) {
+      const loc = locatorOf(it.ref);
       if (!seen.includes(loc)) seen.push(loc);
     }
     return seen;
@@ -120,12 +234,18 @@
     const target = docIndex + delta;
     if (target < 0 || target >= docCount) return;
     const loc = docLocators[target];
-    const first = refs.findIndex((r) => locatorOf(r) === loc);
-    if (first >= 0) index = first;
+    const first = scopeItems.find((it) => locatorOf(it.ref) === loc);
+    if (first) focusTo(first.gi, first.ri);
   }
 
   const rawHref = $derived(
     ref && typeof sourceHref === "function" ? (sourceHref(ref) ?? null) : null,
+  );
+
+  // Grouped mode: the header FOLLOWS the thread (active entity label +
+  // current locator); flat mode keeps the consumer-provided title verbatim.
+  const displayTitle = $derived(
+    activeGroup?.label ? [activeGroup.label, locatorOf(ref)].filter(Boolean).join(" — ") : title,
   );
 
   /** Human locator label for the header ("p.3", "§ Chapter 2", …). */
@@ -138,15 +258,35 @@
     return parts.join(" · ");
   }
 
-  // Retarget on ANY prop change (new refs array and/or new activeIndex): a
-  // click on another citation while the overlay is open re-aims the SAME
-  // viewer instead of stacking a second one.
+  // Retarget on ANY thread/index prop change (new groups/refs identity and/or
+  // new active indexes): a click on another citation while the overlay is open
+  // re-aims the SAME viewer instead of stacking a second one. The scope prop
+  // is tracked in its OWN effect below so a consumer-side scope echo never
+  // re-seeds an internally-navigated position.
   $effect(() => {
-    if (refs !== lastRefsProp || activeIndex !== lastActiveProp) {
+    if (
+      groups !== lastGroupsProp ||
+      refs !== lastRefsProp ||
+      activeGroupIndex !== lastActiveGroupProp ||
+      activeIndex !== lastActiveProp
+    ) {
+      lastGroupsProp = groups;
       lastRefsProp = refs;
+      lastActiveGroupProp = activeGroupIndex;
       lastActiveProp = activeIndex;
-      const clamped = Math.max(0, Math.min(refs.length - 1, activeIndex ?? 0));
-      index = refs.length > 0 ? clamped : 0;
+      const gi = Math.max(0, Math.min(normGroups.length - 1, activeGroupIndex ?? 0));
+      const seeded = normGroups.length > 0 ? gi : 0;
+      const count = groupRefs(normGroups[seeded]).length;
+      gIndex = seeded;
+      rIndex = count > 0 ? Math.max(0, Math.min(count - 1, activeIndex ?? 0)) : 0;
+    }
+  });
+
+  // Scope retarget (§S.6.1): only a CHANGED prop value re-seeds the scope.
+  $effect(() => {
+    if (scope !== lastScopeProp) {
+      lastScopeProp = scope;
+      scopeState = scope === "selection" ? "selection" : "entity";
     }
   });
 
@@ -280,10 +420,6 @@
   function goNextPage() {
     if (currentPage < numPages) void renderPage(currentPage + 1);
   }
-  function goRef(i) {
-    if (i < 0 || i >= refCount || i === index) return;
-    index = i;
-  }
 
   /** True when the key event belongs to a form field. The overlay is NON-modal
    *  (side panels stay interactive), so typing there must never page/close. */
@@ -299,6 +435,12 @@
     if (event.key === "Escape" && onClose) onClose();
     else if (event.key === "ArrowLeft" && pdfDoc) goPrevPage();
     else if (event.key === "ArrowRight" && pdfDoc) goNextPage();
+    // §S.6.1 keyboard: n/N step the citation thread in the ACTIVE scope; e/E
+    // jump entities (Sélection scope only, per the approved UX).
+    else if (event.key === "n") goScopeRef(1);
+    else if (event.key === "N") goScopeRef(-1);
+    else if (event.key === "e" && effectiveScope === "selection") goEntity(1);
+    else if (event.key === "E" && effectiveScope === "selection") goEntity(-1);
   }
 </script>
 
@@ -308,7 +450,7 @@
   <header class="csv-head">
     <div class="csv-head-text">
       <p class="csv-kicker">Cited source</p>
-      <h2 class="csv-title" title={locatorOf(ref)}>{title}</h2>
+      <h2 class="csv-title" title={locatorOf(ref)}>{displayTitle}</h2>
       {#if ref}
         <p class="csv-locator">
           <span class="csv-locator-file">{locatorOf(ref) || "(no locator)"}</span>
@@ -324,11 +466,42 @@
   <!-- QUALIFIED TOOLBAR (immo parity): one compact bar, generic frame; only
        the Page/Zoom segments are modality-gated (page-addressable sources). -->
   <div class="csv-toolbar" role="toolbar" aria-label="Source navigation">
-    {#if refCount > 1}
+    {#if scopeEligible}
+      <!-- §S.6.1 scope toggle — only for a REAL multi-entity thread (≥2 groups
+           with citations); otherwise the plain Entité behavior applies. -->
+      <div class="csv-tb-group csv-tb-scope" role="group" aria-label="Navigation scope">
+        <button
+          class="csv-scope-btn"
+          class:csv-scope-btn--active={effectiveScope === "entity"}
+          type="button"
+          aria-pressed={effectiveScope === "entity"}
+          onclick={() => setScope("entity")}
+        >Entité</button>
+        <button
+          class="csv-scope-btn"
+          class:csv-scope-btn--active={effectiveScope === "selection"}
+          type="button"
+          aria-pressed={effectiveScope === "selection"}
+          onclick={() => setScope("selection")}
+        >Sélection</button>
+      </div>
+    {/if}
+
+    {#if scopeCount > 1}
       <div class="csv-tb-group" aria-label="Citation navigator">
-        <button class="csv-tb-btn" type="button" disabled={index <= 0} onclick={() => goRef(index - 1)} aria-label="Previous citation">‹</button>
-        <span class="csv-tb-label">Citation <strong>{index + 1}/{refCount}</strong></span>
-        <button class="csv-tb-btn" type="button" disabled={index >= refCount - 1} onclick={() => goRef(index + 1)} aria-label="Next citation">›</button>
+        <button class="csv-tb-btn" type="button" disabled={scopePos <= 0} onclick={() => goScopeRef(-1)} aria-label="Previous citation">‹</button>
+        <span class="csv-tb-label">Citation <strong>{scopePos + 1}/{scopeCount}</strong></span>
+        <button class="csv-tb-btn" type="button" disabled={scopePos >= scopeCount - 1} onclick={() => goScopeRef(1)} aria-label="Next citation">›</button>
+      </div>
+    {/if}
+
+    {#if scopeEligible && effectiveScope === "selection"}
+      <!-- §S.6.1 entity indicator: position in the selection + current label;
+           ‹ › jump to the FIRST citation of the neighbour entity (kbd e/E). -->
+      <div class="csv-tb-group" aria-label="Entity navigator">
+        <button class="csv-tb-btn" type="button" disabled={entityPos <= 0} onclick={() => goEntity(-1)} aria-label="Previous entity">‹</button>
+        <span class="csv-tb-label">Entité <strong>{entityPos + 1}/{entityOrder.length}</strong>{#if activeGroup?.label}<span class="csv-tb-entity"> — {activeGroup.label}</span>{/if}</span>
+        <button class="csv-tb-btn" type="button" disabled={entityPos >= entityOrder.length - 1} onclick={() => goEntity(1)} aria-label="Next entity">›</button>
       </div>
     {/if}
 
@@ -507,6 +680,43 @@
   .csv-tb-label strong {
     font-weight: 700;
     color: var(--st-semantic-text-primary, #0f172a);
+  }
+  /* §S.6.1 scope toggle [ Entité | Sélection ] — DS-token segmented control. */
+  .csv-tb-scope {
+    padding: 0.1rem;
+    gap: 0.1rem;
+  }
+  .csv-scope-btn {
+    border: none;
+    background: transparent;
+    border-radius: var(--st-radius-sm, 4px);
+    color: var(--st-semantic-text-secondary, #475569);
+    cursor: pointer;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1;
+    padding: 0.25rem 0.5rem;
+    white-space: nowrap;
+  }
+  .csv-scope-btn:not(.csv-scope-btn--active):hover {
+    background: var(--st-semantic-surface-subtle, #f1f5f9);
+    color: var(--st-semantic-action-primary, #2563eb);
+  }
+  .csv-scope-btn--active {
+    background: var(--st-semantic-surface-selected, #eff6ff);
+    color: var(--st-semantic-action-primary, #2563eb);
+    font-weight: 700;
+  }
+  /* §S.6.1 entity indicator label — bounded, never widens the toolbar. */
+  .csv-tb-entity {
+    display: inline-block;
+    vertical-align: bottom;
+    max-width: 11rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--st-semantic-text-primary, #0f172a);
+    font-weight: 600;
   }
   .csv-tb-btn {
     border: none;

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -5,7 +5,7 @@
    * + the description sidecar). Clicking a relation target opens that entity
    * (highlight, NO graph reload) via onOpenEntity.
    */
-  import { Badge, Collapsible } from "@sentropic/design-system-svelte";
+  import { Badge, Button, Collapsible } from "@sentropic/design-system-svelte";
   import {
     relationRowsFor,
     indexNodes,
@@ -238,18 +238,19 @@
                         {#if p.quote}<blockquote class="entity-cite-quote">{p.quote}</blockquote>{/if}
                         {#if onOpenSource}
                           <!-- Qualified UX (immo "Voir la preuve · p.N"): FULL-WIDTH
-                               button UNDER the quote — never truncates against the
-                               panel edge, one per citation. -->
-                          <button
+                               DS Button (secondary) UNDER the quote — never
+                               truncates against the panel edge, one per citation. -->
+                          <Button
+                            variant="secondary"
+                            size="sm"
                             class="entity-cite-src"
-                            type="button"
                             title="Ouvrir la source citée avec ce passage surligné"
                             aria-label="Voir la source de cette citation"
                             onclick={() => openSource(p)}
                           >
                             <svg class="entity-cite-src-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
                             <span>Voir la source{#if p.page != null}&nbsp;· p.{p.page}{/if}</span>
-                          </button>
+                          </Button>
                         {/if}
                       </li>
                     {/each}
@@ -471,30 +472,15 @@
     white-space: nowrap;
   }
   /* Qualified UX (immo parity): FULL-WIDTH "Voir la source · p.N" under the
-     quote — wraps inside the panel, can never clip against the right edge. */
-  .entity-cite-src {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.35rem;
+     quote. Chrome comes from the DS Button (secondary/sm); the local hooks are
+     LAYOUT-ONLY (full width + icon sizing — :global because the class lands on
+     the DS-rendered root, which Svelte cannot scope). */
+  .entity-cite-passage :global(.entity-cite-src) {
     width: 100%;
     margin-top: 0.3rem;
-    border: 1px solid var(--st-semantic-border-subtle, #e2e8f0);
-    background: var(--st-semantic-surface-subtle, #f8fafc);
-    border-radius: var(--st-radius-sm, 4px);
-    color: var(--st-semantic-text-link, #2563eb);
-    cursor: pointer;
-    font-size: 0.74rem;
-    font-weight: 600;
-    line-height: 1.2;
-    padding: 0.3rem 0.5rem;
     min-width: 0;
   }
-  .entity-cite-src:hover {
-    border-color: var(--st-semantic-action-primary, #2563eb);
-    background: var(--st-semantic-surface-selected, #eff6ff);
-  }
-  .entity-cite-src-ico {
+  .entity-cite-passage :global(.entity-cite-src-ico) {
     width: 0.85rem;
     height: 0.85rem;
     flex-shrink: 0;

--- a/studio/src/components/EntityPanel.svelte
+++ b/studio/src/components/EntityPanel.svelte
@@ -18,7 +18,19 @@
   } from "../lib/graphAdapter.js";
   import { renderInlineMarkdown } from "../lib/markdown.js";
 
-  let { graph, focusId = null, entity = null, onOpenEntity, hideTitle = false, onOpenSource = null } = $props();
+  let {
+    graph,
+    focusId = null,
+    entity = null,
+    onOpenEntity,
+    hideTitle = false,
+    onOpenSource = null,
+    // §S.6.1 right-panel sync: the RAW citation currently shown in the
+    // cited-source viewer (null when the viewer is closed or focused on
+    // another entity). The matching passage is highlighted + scrolled into
+    // view, and the Citations accordions open to reveal it.
+    focusCitation = null,
+  } = $props();
 
   const node = $derived(focusId ? (indexNodes(graph).get(focusId) ?? null) : null);
   const relations = $derived(focusId ? relationRowsFor(focusId, graph) : []);
@@ -69,11 +81,50 @@
       index: passage.index,
       fallbackSourceFile: node?.source_file ?? null,
       label: node ? nodeLabel(node) : null,
+      // §S.6.1: the clicked entity's id lets the App aim the SELECTION thread
+      // at the right group (and keep/switch to the Sélection scope).
+      entityId: node?.id ?? focusId ?? null,
     });
   }
+
+  // §S.6.1 viewer→panel sync: resolve the focused citation to its position in
+  // THIS panel's flat citation list. Object identity first (the thread is
+  // built from the same arrays), loose field identity as a fallback (list
+  // swapped by the lazy sidecar upgrade). -1 = no highlight.
+  const focusCitationIndex = $derived.by(() => {
+    if (!focusCitation) return -1;
+    const byRef = sourceCitations.indexOf(focusCitation);
+    if (byRef >= 0) return byRef;
+    return sourceCitations.findIndex((c) => citationLooksSame(c, focusCitation));
+  });
+  function citationLooksSame(a, b) {
+    if (!a || !b) return false;
+    const norm = (v) => (v == null ? null : String(v));
+    return (
+      norm(a.source_file) === norm(b.source_file) &&
+      norm(a.page) === norm(b.page) &&
+      norm(a.section) === norm(b.section) &&
+      norm(a.quote ?? a.excerpt) === norm(b.quote ?? b.excerpt)
+    );
+  }
+  // Scroll the highlighted passage into view as the viewer navigates. rAF so
+  // the accordions (opened by the prop resync below) have rendered; guarded
+  // for jsdom (no scrollIntoView there).
+  let panelEl = $state(null);
+  $effect(() => {
+    if (focusCitationIndex < 0 || !panelEl) return;
+    const raf =
+      typeof requestAnimationFrame === "function" ? requestAnimationFrame : (fn) => setTimeout(fn, 0);
+    raf(() => {
+      const el = panelEl?.querySelector("[data-cite-current='true']");
+      if (el && typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
+    });
+  });
 </script>
 
-<aside class="entity" aria-label="Entity detail">
+<aside class="entity" aria-label="Entity detail" bind:this={panelEl}>
   {#if !node}
     <div class="entity-empty">
       <p class="entity-empty-kicker">Entity</p>
@@ -151,9 +202,10 @@
       </Collapsible>
     </div>
 
-    <!-- SVELTE-2: citations as a double accordion (file > passages). -->
+    <!-- SVELTE-2: citations as a double accordion (file > passages). §S.6.1:
+         a viewer-focused citation OPENS the accordion path down to itself. -->
     <div class="entity-acc">
-      <Collapsible title="Citations" open={false}>
+      <Collapsible title="Citations" open={focusCitationIndex >= 0}>
         {#snippet trailing()}
           <Badge shape="circle" size="sm" tone="neutral">{citationTotal}</Badge>
         {/snippet}
@@ -163,13 +215,21 @@
           <ul class="entity-cite-files">
             {#each citationFiles as cf (cf.file)}
               <li>
-                <Collapsible title={cf.file} open={false} size="sm">
+                <Collapsible
+                  title={cf.file}
+                  open={cf.passages.some((p) => p.index === focusCitationIndex)}
+                  size="sm"
+                >
                   {#snippet trailing()}
                     <Badge shape="circle" size="sm" tone="neutral">{cf.count}</Badge>
                   {/snippet}
                   <ul class="entity-cite-passages">
                     {#each cf.passages as p, i (cf.file + i)}
-                      <li class="entity-cite-passage">
+                      <li
+                        class="entity-cite-passage"
+                        class:entity-cite-passage--current={p.index === focusCitationIndex}
+                        data-cite-current={p.index === focusCitationIndex ? "true" : undefined}
+                      >
                         <div class="entity-cite-loc">
                           {#if p.section}<span class="entity-cite-section">{p.section}</span>{/if}
                           {#if p.page != null}<span class="entity-cite-page">p.{p.page}</span>{/if}
@@ -376,6 +436,15 @@
   .entity-cite-passage {
     padding: 0.25rem 0;
     border-bottom: 1px dotted var(--st-semantic-border-subtle, #e2e8f0);
+  }
+  /* §S.6.1 viewer→panel sync: the citation currently OPEN in the cited-source
+     viewer. DS-token highlight (selected surface + primary accent bar). */
+  .entity-cite-passage--current {
+    background: var(--st-semantic-surface-selected, #eff6ff);
+    border-left: 3px solid var(--st-semantic-action-primary, #2563eb);
+    border-radius: 0 var(--st-radius-sm, 4px) var(--st-radius-sm, 4px) 0;
+    padding-left: 0.45rem;
+    padding-right: 0.3rem;
   }
   .entity-cite-section {
     display: block;

--- a/studio/src/components/SelectionPanel.svelte
+++ b/studio/src/components/SelectionPanel.svelte
@@ -28,6 +28,11 @@
     onToggleEntity,
     onClear,
     onOpenSource = null,
+    // §S.6.1 viewer→panel sync: { entityId, citation } for the citation
+    // currently OPEN in the cited-source viewer. The matching entity row is
+    // highlighted + scrolled into view; its EntityPanel highlights the exact
+    // passage. null when the viewer is closed.
+    sourceFocus = null,
   } = $props();
 
   const total = $derived(
@@ -39,10 +44,32 @@
       .map((id) => ({ id, label: nodeLabel(nodeIndex.get(id) ?? { id }) }))
       .sort((a, b) => a.label.localeCompare(b.label)),
   );
+
+  // §S.6.1: scroll the CITED entity's row into view when the viewer's focus
+  // moves to another entity (the passage-level scroll inside EntityPanel then
+  // refines the position). Guarded for jsdom (no scrollIntoView there).
+  let panelEl = $state(null);
+  $effect(() => {
+    const id = sourceFocus?.entityId;
+    if (!id || !panelEl) return;
+    const raf =
+      typeof requestAnimationFrame === "function" ? requestAnimationFrame : (fn) => setTimeout(fn, 0);
+    raf(() => {
+      const row = panelEl?.querySelector(`[data-sel-entity="${CSS.escape(id)}"]`);
+      if (row && typeof row.scrollIntoView === "function") {
+        row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      }
+    });
+  });
 </script>
 
 {#snippet entityRow(e, removable)}
-  <div class="sel-entity" class:open={focusId === e.id}>
+  <div
+    class="sel-entity"
+    class:open={focusId === e.id}
+    class:cited={sourceFocus?.entityId === e.id}
+    data-sel-entity={e.id}
+  >
     <div class="sel-entity-bar">
       <button
         class="sel-entity-head"
@@ -66,13 +93,14 @@
           hideTitle
           onOpenEntity={onFocusEntity}
           {onOpenSource}
+          focusCitation={sourceFocus?.entityId === e.id ? (sourceFocus?.citation ?? null) : null}
         />
       </div>
     {/if}
   </div>
 {/snippet}
 
-<aside class="sel" aria-label="Selection">
+<aside class="sel" aria-label="Selection" bind:this={panelEl}>
   <header class="sel-head">
     <span class="sel-kicker">Selection · {total}</span>
     {#if total > 0}
@@ -271,6 +299,18 @@
     background: var(--st-semantic-surface-selected, #eff6ff);
     color: var(--st-semantic-action-primary, #2563eb);
     font-weight: 600;
+  }
+  /* §S.6.1 viewer→panel sync: the entity whose citation is OPEN in the
+     cited-source viewer carries a DS accent bar so the panel visibly follows
+     the thread as navigation crosses entity boundaries. */
+  .sel-entity.cited {
+    border-left: 3px solid var(--st-semantic-action-primary, #2563eb);
+    background: color-mix(
+      in srgb,
+      var(--st-semantic-surface-selected, #eff6ff) 55%,
+      transparent
+    );
+    border-radius: 0 var(--st-radius-sm, 4px) var(--st-radius-sm, 4px) 0;
   }
   .sel-chevron {
     flex-shrink: 0;

--- a/studio/src/lib/citedSources.js
+++ b/studio/src/lib/citedSources.js
@@ -44,6 +44,88 @@ export function refsForCitations(citations, fallbackSourceFile = null) {
   });
 }
 
+/**
+ * Increment 2 (selection-scope navigation, §S.6.1): build the GROUPED citation
+ * thread for the CURRENT multi-selection.
+ *
+ * One group per selected entity WITH at least one citation, in SELECTION ORDER
+ * (the caller passes entities in `viewerState.selection.entities` order).
+ * Within a group the refs are ordered DOCUMENT-first (documents in first-
+ * appearance order of the entity's citation list), then PAGE ascending
+ * (page-less refs keep their relative order after paged ones of the same doc
+ * are sorted; the sort is stable). This is the approved thread order:
+ * selection → document → page.
+ *
+ * Returns BOTH the pure viewer input (`groups`, shape
+ * `{ id, label, refs: CitedSourceRef[] }` — the CitedSourceViewer prop) and a
+ * PARALLEL `meta` array (`{ id, citations }`, citations[i] is the RAW
+ * OntologyCitation behind groups[g].refs[i]) so the impure consumer can map an
+ * `onFocusChange(groupId, refIndex)` back to the exact citation object for the
+ * right-panel sync. The component itself never sees `meta` (purity seam).
+ *
+ * @param {Array<{id: string, label?: string|null, citations?: Array<object>|null, fallbackSourceFile?: string|null}>} entities
+ * @returns {{ groups: Array<{id: string, label: string|null, refs: Array<object>}>, meta: Array<{id: string, citations: Array<object>}> }}
+ */
+export function buildSelectionThread(entities) {
+  const groups = [];
+  const meta = [];
+  for (const entity of Array.isArray(entities) ? entities : []) {
+    if (!entity || entity.id == null) continue;
+    const citations = Array.isArray(entity.citations) ? entity.citations : [];
+    if (citations.length === 0) continue;
+    const refs = refsForCitations(citations, entity.fallbackSourceFile ?? null);
+    // Pair each ref with its raw citation, then order document → page.
+    const docOrder = new Map();
+    for (const ref of refs) {
+      const doc = threadDocKey(ref);
+      if (!docOrder.has(doc)) docOrder.set(doc, docOrder.size);
+    }
+    const pairs = refs.map((ref, i) => ({ ref, citation: citations[i] }));
+    pairs.sort((a, b) => {
+      const docDelta = docOrder.get(threadDocKey(a.ref)) - docOrder.get(threadDocKey(b.ref));
+      if (docDelta !== 0) return docDelta;
+      return threadPageRank(a.ref) - threadPageRank(b.ref);
+    });
+    groups.push({
+      id: entity.id,
+      label: entity.label ?? null,
+      refs: pairs.map((p) => p.ref),
+    });
+    meta.push({ id: entity.id, citations: pairs.map((p) => p.citation) });
+  }
+  return { groups, meta };
+}
+
+/** Document identity for the thread order (mirrors the viewer's locatorOf). */
+function threadDocKey(ref) {
+  return ref?.rawRef ?? ref?.sourceUrl ?? ref?.docSha ?? "";
+}
+
+/** Page sort rank: numeric pages ascending, page-less refs last (stable). */
+function threadPageRank(ref) {
+  const page = Number(ref?.page);
+  return Number.isFinite(page) ? page : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Loose citation identity for the panel↔viewer sync fallback (used when the
+ * object reference does not match because a list was re-fetched): same source
+ * file, page, section and quote text.
+ * @param {object|null|undefined} a
+ * @param {object|null|undefined} b
+ */
+export function sameCitation(a, b) {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const norm = (v) => (v == null ? null : String(v));
+  return (
+    norm(a.source_file) === norm(b.source_file) &&
+    norm(a.page) === norm(b.page) &&
+    norm(a.section) === norm(b.section) &&
+    norm(a.quote ?? a.excerpt) === norm(b.quote ?? b.excerpt)
+  );
+}
+
 /** File-suffix modality sniff for the resolver's binary/text routing. */
 function looksLikePdf(locator) {
   return /\.pdf(?:[?#]|$)/i.test(locator);

--- a/studio/src/tests/citedSourceViewer.test.js
+++ b/studio/src/tests/citedSourceViewer.test.js
@@ -203,18 +203,207 @@ describe("CitedSourceViewer qualified toolbar (immo parity)", () => {
     expect(el.querySelector("a.csv-tb-open")).toBeNull();
   });
 
-  it("pins the retarget contract in the source (refs identity + activeIndex both tracked)", () => {
+  it("pins the retarget contract in the source (thread identity + index props tracked)", () => {
     // A plain-JS vitest cannot push prop updates into a Svelte-5 mount(), so
-    // the retarget-on-reopen behavior (new refs array + activeIndex re-aim an
-    // OPEN viewer, no stacking) is exercised end-to-end by the UAT run; here
-    // we pin the load-bearing implementation: the $effect must compare BOTH
-    // the refs identity and the activeIndex prop before reseeding `index`.
+    // the retarget-on-reopen behavior (new groups/refs array + indexes re-aim
+    // an OPEN viewer, no stacking) is exercised end-to-end by the UAT run;
+    // here we pin the load-bearing implementation: the $effect must compare
+    // the groups AND refs identities AND both index props before reseeding,
+    // and the scope prop must be tracked in its OWN effect (a consumer scope
+    // echo must never re-seed an internally-navigated position).
     const source = readFileSync(
       resolve(process.cwd(), "src/components/CitedSourceViewer.svelte"),
       "utf8",
     );
-    expect(source).toMatch(/refs !== lastRefsProp \|\| activeIndex !== lastActiveProp/);
+    expect(source).toMatch(/groups !== lastGroupsProp \|\|/);
+    expect(source).toMatch(/refs !== lastRefsProp \|\|/);
+    expect(source).toMatch(/activeGroupIndex !== lastActiveGroupProp \|\|/);
+    expect(source).toMatch(/activeIndex !== lastActiveProp\s*\n/);
     expect(source).toMatch(/lastRefsProp = refs;/);
+    expect(source).toMatch(/lastGroupsProp = groups;/);
+    expect(source).toMatch(/scope !== lastScopeProp/);
+  });
+});
+
+describe("CitedSourceViewer grouped thread — selection scope (§S.6.1)", () => {
+  // Two entities, each cited twice, across TWO documents (the approved
+  // multi-entity fixture shape). Group refs are already thread-ordered
+  // (selection → document → page) — the consumer glue owns that ordering.
+  const NOTES_TEXT =
+    "# Notes\n\nHere is a passage from the second document indeed.\n\n" +
+    "Later, the doctor wrote his notes by the fire.";
+  const GROUP_A = {
+    id: "e:holmes",
+    label: "Sherlock Holmes",
+    refs: [
+      { rawRef: "corpus/blue-study.md", section: "Chapter 1", excerpt: "Holmes examined the ledger in silence" },
+      { rawRef: "corpus/notes.md", section: "Notes", excerpt: "a passage from the second document" },
+    ],
+  };
+  const GROUP_B = {
+    id: "e:watson",
+    label: "John Watson",
+    refs: [
+      { rawRef: "corpus/blue-study.md", section: "Chapter 2", excerpt: "the coronet had vanished from his private safe" },
+      { rawRef: "corpus/notes.md", section: "Notes", excerpt: "the doctor wrote his notes" },
+    ],
+  };
+  const GROUPS = [GROUP_A, GROUP_B];
+  const groupResolver = () =>
+    vi.fn(async (r) =>
+      r.rawRef === "corpus/notes.md"
+        ? { kind: "markdown", text: NOTES_TEXT }
+        : { kind: "markdown", text: SOURCE_TEXT },
+    );
+  const byLabel = (el, label) =>
+    [...el.querySelectorAll("button")].find((b) => b.getAttribute("aria-label") === label);
+  const scopeBtn = (el, text) =>
+    [...el.querySelectorAll(".csv-scope-btn")].find((b) => b.textContent.trim() === text);
+  const pressKey = async (key) => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    flushSync();
+    await settle();
+  };
+
+  it("defaults to Entité scope: toggle shown, per-entity counter, no entity indicator", async () => {
+    const el = mountViewer({ refs: [], groups: GROUPS, resolveSource: groupResolver(), title: "t" });
+    await settle();
+    expect(scopeBtn(el, "Entité")).toBeTruthy();
+    expect(scopeBtn(el, "Sélection")).toBeTruthy();
+    expect(scopeBtn(el, "Entité").getAttribute("aria-pressed")).toBe("true");
+    // Counter covers the CURRENT entity only (2 refs), not the thread (4).
+    expect(el.textContent).toContain("Citation 1/2");
+    expect(el.querySelector('[aria-label="Entity navigator"]')).toBeNull();
+    // Header follows the active group label.
+    expect(el.textContent).toContain("Sherlock Holmes");
+  });
+
+  it("hides the scope toggle when only ONE group carries citations (plain Entité mode)", async () => {
+    const el = mountViewer({
+      refs: [],
+      groups: [GROUP_A, { id: "e:empty", label: "Nobody", refs: [] }],
+      resolveSource: groupResolver(),
+      title: "t",
+    });
+    await settle();
+    expect(el.querySelector(".csv-tb-scope")).toBeNull();
+    expect(el.textContent).toContain("Citation 1/2");
+  });
+
+  it("Entité scope stops at the entity boundary (next disabled on its last citation)", async () => {
+    const el = mountViewer({
+      refs: [],
+      groups: GROUPS,
+      activeGroupIndex: 0,
+      activeIndex: 1,
+      resolveSource: groupResolver(),
+      title: "t",
+    });
+    await settle();
+    expect(el.textContent).toContain("Citation 2/2");
+    expect(byLabel(el, "Next citation").disabled).toBe(true);
+  });
+
+  it("switching to Sélection makes the counter global and shows the entity indicator", async () => {
+    const onScopeChange = vi.fn();
+    const el = mountViewer({
+      refs: [],
+      groups: GROUPS,
+      resolveSource: groupResolver(),
+      onScopeChange,
+      title: "t",
+    });
+    await settle();
+    scopeBtn(el, "Sélection").click();
+    flushSync();
+    await settle();
+    expect(onScopeChange).toHaveBeenCalledWith("selection");
+    expect(el.textContent).toContain("Citation 1/4");
+    const indicator = el.querySelector('[aria-label="Entity navigator"]');
+    expect(indicator).not.toBeNull();
+    expect(indicator.textContent).toContain("Entité");
+    expect(indicator.textContent).toContain("1/2");
+    expect(indicator.textContent).toContain("Sherlock Holmes");
+  });
+
+  it("Sélection scope crosses the entity boundary as ONE continuous thread + fires onFocusChange", async () => {
+    const onFocusChange = vi.fn();
+    const resolveSource = groupResolver();
+    const el = mountViewer({
+      refs: [],
+      groups: GROUPS,
+      activeGroupIndex: 0,
+      activeIndex: 1, // last citation of entity A
+      scope: "selection",
+      resolveSource,
+      onFocusChange,
+      title: "t",
+    });
+    await settle();
+    expect(el.textContent).toContain("Citation 2/4");
+
+    byLabel(el, "Next citation").click();
+    flushSync();
+    await settle();
+
+    // Landed on the FIRST citation of entity B — overlay never closed.
+    expect(onFocusChange).toHaveBeenCalledWith("e:watson", 0);
+    expect(el.textContent).toContain("Citation 3/4");
+    const indicator = el.querySelector('[aria-label="Entity navigator"]');
+    expect(indicator.textContent).toContain("2/2");
+    expect(indicator.textContent).toContain("John Watson");
+    expect(resolveSource).toHaveBeenLastCalledWith(GROUP_B.refs[0]);
+    expect(el.querySelector("[data-csv-mark]")?.textContent).toContain("coronet had vanished");
+  });
+
+  it("keyboard n/N steps the ACTIVE scope; e/E jumps entities in Sélection scope", async () => {
+    const onFocusChange = vi.fn();
+    const el = mountViewer({
+      refs: [],
+      groups: GROUPS,
+      scope: "selection",
+      resolveSource: groupResolver(),
+      onFocusChange,
+      title: "t",
+    });
+    await settle();
+    expect(el.textContent).toContain("Citation 1/4");
+
+    await pressKey("n");
+    expect(el.textContent).toContain("Citation 2/4");
+    expect(onFocusChange).toHaveBeenLastCalledWith("e:holmes", 1);
+
+    await pressKey("N");
+    expect(el.textContent).toContain("Citation 1/4");
+
+    await pressKey("e");
+    expect(el.textContent).toContain("Citation 3/4");
+    expect(onFocusChange).toHaveBeenLastCalledWith("e:watson", 0);
+
+    await pressKey("E");
+    expect(el.textContent).toContain("Citation 1/4");
+    expect(onFocusChange).toHaveBeenLastCalledWith("e:holmes", 0);
+  });
+
+  it("keyboard e/E is inert in Entité scope (per the approved UX)", async () => {
+    const el = mountViewer({ refs: [], groups: GROUPS, resolveSource: groupResolver(), title: "t" });
+    await settle();
+    expect(el.textContent).toContain("Citation 1/2");
+    await pressKey("e");
+    // Still on entity A, entity indicator still hidden.
+    expect(el.textContent).toContain("Citation 1/2");
+    expect(el.textContent).toContain("Sherlock Holmes");
+    expect(el.querySelector('[aria-label="Entity navigator"]')).toBeNull();
+  });
+
+  it("flat refs mode still supports n/N as citation stepping (single anonymous group)", async () => {
+    const el = mountViewer({ refs: REFS, resolveSource: mdResolver(), title: "t" });
+    await settle();
+    expect(el.textContent).toContain("Citation 1/2");
+    await pressKey("n");
+    expect(el.textContent).toContain("Citation 2/2");
+    await pressKey("N");
+    expect(el.textContent).toContain("Citation 1/2");
   });
 });
 
@@ -234,5 +423,23 @@ describe("CitedSourceViewer purity (rebase seam)", () => {
     // No graphify alias / server import can sneak in.
     expect(source).not.toMatch(/@graphify\//);
     expect(source).not.toMatch(/\.\.\/lib\/(api|graphAdapter|citedSources)/);
+  });
+
+  it("declares the §S.6.1 grouped-thread props on the SAME pure seam (no new imports)", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/components/CitedSourceViewer.svelte"),
+      "utf8",
+    );
+    // The extended API stays a pure-props surface: the grouped thread and its
+    // callbacks are declared in $props(), never derived from graphify state.
+    for (const prop of [
+      "groups = []",
+      "activeGroupIndex = 0",
+      'scope = "entity"',
+      "onScopeChange = null",
+      "onFocusChange = null",
+    ]) {
+      expect(source).toContain(prop);
+    }
   });
 });

--- a/studio/src/tests/citedSourceViewer.test.js
+++ b/studio/src/tests/citedSourceViewer.test.js
@@ -257,8 +257,11 @@ describe("CitedSourceViewer grouped thread — selection scope (§S.6.1)", () =>
     );
   const byLabel = (el, label) =>
     [...el.querySelectorAll("button")].find((b) => b.getAttribute("aria-label") === label);
+  // DS ContentSwitcher renders the scope toggle as role="tab" options.
   const scopeBtn = (el, text) =>
-    [...el.querySelectorAll(".csv-scope-btn")].find((b) => b.textContent.trim() === text);
+    [...el.querySelectorAll(".st-contentSwitcher__option")].find(
+      (b) => b.textContent.trim() === text,
+    );
   const pressKey = async (key) => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
     flushSync();
@@ -270,7 +273,7 @@ describe("CitedSourceViewer grouped thread — selection scope (§S.6.1)", () =>
     await settle();
     expect(scopeBtn(el, "Entité")).toBeTruthy();
     expect(scopeBtn(el, "Sélection")).toBeTruthy();
-    expect(scopeBtn(el, "Entité").getAttribute("aria-pressed")).toBe("true");
+    expect(scopeBtn(el, "Entité").getAttribute("aria-selected")).toBe("true");
     // Counter covers the CURRENT entity only (2 refs), not the thread (4).
     expect(el.textContent).toContain("Citation 1/2");
     expect(el.querySelector('[aria-label="Entity navigator"]')).toBeNull();
@@ -408,7 +411,7 @@ describe("CitedSourceViewer grouped thread — selection scope (§S.6.1)", () =>
 });
 
 describe("CitedSourceViewer purity (rebase seam)", () => {
-  it("imports nothing from graphify — only the sibling pure lib and svelte", () => {
+  it("imports nothing from graphify — only svelte, the DS package and the sibling pure lib", () => {
     const source = readFileSync(
       resolve(process.cwd(), "src/components/CitedSourceViewer.svelte"),
       "utf8",
@@ -417,8 +420,13 @@ describe("CitedSourceViewer purity (rebase seam)", () => {
       ...source.matchAll(/^\s*import\s+(?:[\s\S]*?from\s+)?["']([^"']+)["']/gm),
     ].map((m) => m[1]);
     expect(importSpecs.length).toBeGreaterThan(0);
+    // ALLOWED_EXTERNAL mirrors the @sentropic/cited-source-viewer package:
+    // svelte + @sentropic/design-system-svelte + pdfjs-dist (the DS is part of
+    // the architect-owned seam; graphify runtime imports remain forbidden).
     for (const spec of importSpecs) {
-      expect(spec).toMatch(/^(svelte|\.\.\/lib\/cited-source\/)/);
+      expect(spec).toMatch(
+        /^(svelte|@sentropic\/design-system-svelte$|pdfjs-dist|\.\.\/lib\/cited-source\/)/,
+      );
     }
     // No graphify alias / server import can sneak in.
     expect(source).not.toMatch(/@graphify\//);

--- a/studio/src/tests/citedSourcesThread.test.js
+++ b/studio/src/tests/citedSourcesThread.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSelectionThread, sameCitation } from "../lib/citedSources.js";
+
+/**
+ * Increment 2 (§S.6.1): the selection-thread builder — ONE continuous grouped
+ * thread over ALL citations of ALL selected entities, in the approved order:
+ * selection order → document (first appearance) → page.
+ */
+
+const HOLMES = {
+  id: "e:holmes",
+  label: "Sherlock Holmes",
+  fallbackSourceFile: "corpus/blue-study.md",
+  citations: [
+    // Deliberately out of document/page order to exercise the sort:
+    { source_file: "corpus/casebook.pdf", page: 7, quote: "the detective rose at dawn" },
+    { source_file: "corpus/blue-study.md", section: "Chapter 2", quote: "Holmes examined the ledger" },
+    { source_file: "corpus/casebook.pdf", page: 2, quote: "a violin sounded upstairs" },
+  ],
+};
+
+const WATSON = {
+  id: "e:watson",
+  label: "John Watson",
+  fallbackSourceFile: "corpus/blue-study.md",
+  citations: [
+    { source_file: "corpus/blue-study.md", section: "Chapter 1", quote: "Watson kept his revolver close" },
+    { source_file: "corpus/notes.md", section: "Notes", quote: "the doctor wrote his notes" },
+  ],
+};
+
+describe("buildSelectionThread", () => {
+  it("groups per entity in SELECTION order, one group per entity with citations", () => {
+    const { groups, meta } = buildSelectionThread([HOLMES, WATSON]);
+    expect(groups.map((g) => g.id)).toEqual(["e:holmes", "e:watson"]);
+    expect(groups.map((g) => g.label)).toEqual(["Sherlock Holmes", "John Watson"]);
+    expect(groups[0].refs).toHaveLength(3);
+    expect(groups[1].refs).toHaveLength(2);
+    // meta is parallel to groups (same ids, same lengths).
+    expect(meta.map((m) => m.id)).toEqual(["e:holmes", "e:watson"]);
+    expect(meta[0].citations).toHaveLength(3);
+    expect(meta[1].citations).toHaveLength(2);
+  });
+
+  it("orders refs within a group document-first (first appearance) then page ascending", () => {
+    const { groups } = buildSelectionThread([HOLMES]);
+    // casebook.pdf appears first in the citation list → its refs come first,
+    // sorted p.2 then p.7; blue-study.md follows.
+    expect(groups[0].refs.map((r) => [r.rawRef, r.page ?? null])).toEqual([
+      ["corpus/casebook.pdf", 2],
+      ["corpus/casebook.pdf", 7],
+      ["corpus/blue-study.md", null],
+    ]);
+  });
+
+  it("keeps meta.citations parallel to the SORTED refs (raw citation behind each ref)", () => {
+    const { groups, meta } = buildSelectionThread([HOLMES]);
+    expect(meta[0].citations[0]).toBe(HOLMES.citations[2]); // p.2
+    expect(meta[0].citations[1]).toBe(HOLMES.citations[0]); // p.7
+    expect(meta[0].citations[2]).toBe(HOLMES.citations[1]); // blue-study
+    // And the ref at each position carries that citation's quote as excerpt.
+    expect(groups[0].refs[0].excerpt).toBe("a violin sounded upstairs");
+    expect(groups[0].refs[1].excerpt).toBe("the detective rose at dawn");
+  });
+
+  it("skips entities without citations (no empty groups in the thread)", () => {
+    const { groups } = buildSelectionThread([
+      { id: "e:empty", label: "Nobody", citations: [] },
+      HOLMES,
+      { id: "e:null", label: "Nothing", citations: null },
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["e:holmes"]);
+  });
+
+  it("fills missing locators from the entity fallbackSourceFile (adapter enrichment)", () => {
+    const { groups } = buildSelectionThread([
+      {
+        id: "e:legacy",
+        label: "Legacy",
+        fallbackSourceFile: "corpus/legacy.md",
+        citations: [{ section: "Intro", quote: "an unlocated passage" }],
+      },
+    ]);
+    expect(groups[0].refs[0].rawRef).toBe("corpus/legacy.md");
+  });
+
+  it("returns empty thread for an empty/absent selection", () => {
+    expect(buildSelectionThread([])).toEqual({ groups: [], meta: [] });
+    expect(buildSelectionThread(null)).toEqual({ groups: [], meta: [] });
+  });
+});
+
+describe("sameCitation", () => {
+  it("matches by reference and by (file, page, section, quote) fields", () => {
+    const a = { source_file: "corpus/a.md", page: 3, section: "S", quote: "q" };
+    expect(sameCitation(a, a)).toBe(true);
+    expect(sameCitation(a, { ...a })).toBe(true);
+    expect(sameCitation(a, { ...a, page: 4 })).toBe(false);
+    expect(sameCitation(a, { ...a, quote: "other" })).toBe(false);
+    expect(sameCitation(a, null)).toBe(false);
+    expect(sameCitation(null, a)).toBe(false);
+  });
+});

--- a/studio/src/tests/entityPanel.test.js
+++ b/studio/src/tests/entityPanel.test.js
@@ -49,8 +49,10 @@ describe("EntityPanel citations (exhaustive-citations Level-1/Level-2)", () => {
     expect(panelSource).toMatch(/typeof node\.citation_count === "number"/);
     // The count is fed to the Citations disclosure (DS Collapsible) via the
     // trailing circle Badge. The custom Accordion was replaced by DS Collapsible
-    // in the P3 migration; the true count still reaches the header.
-    expect(panelSource).toMatch(/<Collapsible title="Citations" open=\{false\}>/);
+    // in the P3 migration; the true count still reaches the header. §S.6.1: the
+    // accordion stays collapsed by default and OPENS when the cited-source
+    // viewer focuses one of this entity's citations.
+    expect(panelSource).toMatch(/<Collapsible title="Citations" open=\{focusCitationIndex >= 0\}>/);
     expect(panelSource).toMatch(
       /<Badge shape="circle" size="sm" tone="neutral">\{citationTotal\}<\/Badge>/,
     );
@@ -67,5 +69,28 @@ describe("EntityPanel citations (exhaustive-citations Level-1/Level-2)", () => {
 
   it("imports citationsByFileFrom for the lazy upgrade", () => {
     expect(panelSource).toMatch(/citationsByFileFrom/);
+  });
+});
+
+describe("EntityPanel viewer→panel sync (§S.6.1 selection-scope navigation)", () => {
+  it("resolves focusCitation to a passage index — identity first, loose fields fallback", () => {
+    expect(panelSource).toMatch(/focusCitation = null,/);
+    expect(panelSource).toMatch(/sourceCitations\.indexOf\(focusCitation\)/);
+    expect(panelSource).toMatch(/citationLooksSame\(c, focusCitation\)/);
+  });
+
+  it("highlights + tags the current passage and opens its file accordion", () => {
+    expect(panelSource).toMatch(/entity-cite-passage--current=\{p\.index === focusCitationIndex\}/);
+    expect(panelSource).toMatch(/data-cite-current=\{p\.index === focusCitationIndex \? "true" : undefined\}/);
+    expect(panelSource).toMatch(/open=\{cf\.passages\.some\(\(p\) => p\.index === focusCitationIndex\)\}/);
+  });
+
+  it("hands the entity id to the open-source payload (thread aiming)", () => {
+    expect(panelSource).toMatch(/entityId: node\?\.id \?\? focusId \?\? null,/);
+  });
+
+  it("scrolls the current passage into view (guarded for jsdom)", () => {
+    expect(panelSource).toMatch(/data-cite-current='true'/);
+    expect(panelSource).toMatch(/typeof el\.scrollIntoView === "function"/);
   });
 });


### PR DESCRIPTION
INCREMENT 2 of the interim cited-source viewer (base = v2, #262): **multi-entity selection citation navigation**, per the principal-approved design ("A oui c ça, B oui").

## Design recap (approved)

The selection can hold SEVERAL entities, each cited several times, possibly across several documents. The viewer now supports TWO navigation scopes:

- **Entité** (existing): citations of the current entity only.
- **Sélection** (new): ONE continuous thread of ALL citations of ALL selected entities — stepping past the last citation of entity A lands on the first citation of entity B without closing the overlay.

Approved UX, all delivered:
- Toolbar **scope toggle `[ Entité | Sélection ]`** left of the citation navigator — shown ONLY when the selection has ≥2 entities with citations (else plain Entité mode, no toggle).
- Sélection scope: **global counter** (`Citation 5/7`) + **`‹ Entité x/y — <label> ›` indicator group** (prev/next jump to the first citation of the neighbour entity).
- **Thread order: selection order → document (first appearance) → page.**
- Keyboard: `n`/`N` next/prev citation in the ACTIVE scope; `e`/`E` next/prev entity (Sélection scope only).
- **Right-panel sync, bidirectional:** the selection panel FOLLOWS the navigation — current entity row gets a DS accent (`--st-semantic-action-primary` bar + selected surface), its detail opens, the Citations accordions unfold down to the exact passage (highlighted, `--st-*` tokens, scrolled into view). Clicking a citation in the panel retargets the open viewer; clicking one on ANOTHER selected entity keeps/switches to Sélection scope.

## Architecture (frame stays PURE)

- `studio/src/components/CitedSourceViewer.svelte` — extended props only: `groups: Array<{ id, label, refs: CitedSourceRef[] }>` + `activeGroupIndex` / `activeIndex` (ref index WITHIN the group) + `scope` prop + `onScopeChange(scope)` + `onFocusChange(groupId, refIndex)`. Zero graphify import (purity test extended and green). Scope prop is tracked in its OWN `$effect`, separate from the thread/index retarget, so a consumer scope echo can never re-seed an internally-navigated position. Flat `refs` mode unchanged (one anonymous group). The extended API is documented in the component header for the `@sentropic/cited-source-viewer` carry-over.
- ALL selection logic is studio glue: `buildSelectionThread()` in `studio/src/lib/citedSources.js` builds the grouped thread from the CURRENT multi-selection via the frozen public converters (selection → doc → page), plus a parallel `meta` (raw citation behind each ref) so `onFocusChange` maps back to the exact citation for the panel sync (`App.svelte` → `SelectionPanel` → `EntityPanel`).
- The toggle/indicator live in the GENERIC toolbar (modality-agnostic, S.6) — Page/Zoom segments untouched.

## Spec

`spec/SPEC_WP_CITED_SOURCE_VIZ.md`: new **§S.6** (qualified generic frame baseline, was previously only referenced from #262) + **§S.6.1 — selection-scope navigation, qualified 2026-07-04** (this increment, verbatim UX + extended pure API).

## Real outputs

- `npx tsc --noEmit` → exit 0.
- `cd studio && npx vitest run` → **27 passed | 1 failed (28 files), 331 passed | 3 failed (334 tests)** — the 3 failures are `pickingBackendAgnostic.test.js` (WebGL mock env), **verified identical on origin/main e2ef3d7** (pre-existing, unrelated).
  - `citedSourcesThread.test.js` 7/7 (thread order, meta parallelism, empty-entity skip, locator fallback)
  - `citedSourceViewer.test.js` 20/20 (incl. 8 new grouped-thread tests: scope toggle visibility, per-entity vs global counters, boundary crossing + `onFocusChange`, `n/N`/`e/E` keys, e/E inert in Entité scope, purity + retarget pins extended)
  - `entityPanel.test.js` 10/10 (4 new §S.6.1 sync pins)
- `npm run build:studio` → multi-file + single-file bundles built clean.

## UAT (headless chromium over a served `--include-sources` export, scripted assertions + screenshots inspected)

Demo: 3 entities / 7 citations across 3 markdown docs (Holmes 4 citations in 2 docs, Watson 3 in 2 docs, Adler 1); selection = Holmes + Watson. Driver: `.graphify/uat/cited-viewer/uat-v3.mjs` → **UAT PASS** (every step asserted on toolbar text + panel DOM before screenshotting).

Screenshots (worktree `.graphify/uat/cited-viewer/shots/`, absolute prefix `/home/antoinefa/src/graphify/.claude/worktrees/agent-acb6a9edf11ad7546/`):
- `v3-a-toolbar-entite-scope.png` — toggle `[ Entité | Sélection ]` + `Citation 1/4` (per-entity) + `Doc 1/2`, quote highlighted, panel passage highlighted.
- `v3-b-toolbar-selection-scope.png` — Sélection: `Citation 1/7` + `Entité 1/2 — Sherlock Holmes` + `Doc 1/3`.
- `v3-c-before-entity-boundary.png` — `Citation 4/7`, last Holmes citation (casebook Entry 27), panel on Holmes.
- `v3-d-after-entity-boundary.png` — ONE `n` later: `Citation 5/7`, `Entité 2/2 — John Watson`, viewer retargeted to scandal-notes.md, right panel focus visibly moved to Watson with the passage highlighted (overlay never closed).
- `v3-e-panel-citation-highlight.png` — right-panel close-up: cited row accent + current citation highlighted.
- `v3-f-panel-click-retarget.png` — clicking a Watson citation in the panel while the viewer sat on Holmes: retargets and keeps Sélection scope.

## Honest works-where notes / limits

- The thread covers the DIRECT entity selection (`selection.entities`, in selection order). Entities visible only through a selected Type/Community bucket are not expanded into the thread; opening a citation from such an entity falls back to a single-entity thread (plain Entité mode).
- The thread snapshots each entity's best-known citation list at open time (full sidecar if hydrated, else the inline K-set — same precedence the panel renders). If the sidecar hydrates while the overlay is open, the live thread keeps its snapshot (panel highlight falls back to loose field identity); the next open rebuilds with the full list.
- Selection edits while the overlay is open don't rebuild the live thread; the next open does.
- UAT exercises the MD modality across multiple documents; the PDF body path (page/zoom segments) is untouched from qualified v2 and shares the same scoped navigation code path.
- Load-time 404s in the served bundle are the studio's standard optional-artifact probes (`models.json`, `/api/*`, `class-hierarchies.json`) — pre-existing static-bundle behavior.
- Package extraction of the extended API belongs to the parallel `@sentropic/cited-source-viewer` agent; this PR is the interim studio side only (no `packages/graph`, no `src/agent-stats` touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
