### PR TITLE
feat(studio): windowed FIRST PAINT from the DB-backed loader (LOT 3 client integration, WP1)

### DIFF
--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -33,12 +33,14 @@
     fetchModelsManifest,
     fetchScene,
     fetchSearchIndex,
+    fetchWindow,
     setStaticBaseProvider,
     __resetEntitiesIndexCache,
   } from "./lib/api.js";
   import { createModelStore } from "./lib/modelStore.svelte.js";
   import {
     buildScene,
+    buildWindowScene,
     applyWeakFilter,
     applyTimeFilter,
     sceneTimeRange,
@@ -61,7 +63,7 @@
     ontologyLevelState,
     ontologyAbsorption,
   } from "./lib/groupBy.js";
-  import { loadWorkspace } from "./lib/sceneLoader.js";
+  import { loadWorkspaceWindowed } from "./lib/sceneLoader.js";
   import {
     createDefaultViewerState,
     splitGroupedKeys,
@@ -575,7 +577,28 @@
    * are fetched fresh, and clears selection (ids don't carry across models).
    */
   async function loadActiveModel() {
-    const result = await loadWorkspace({
+    const result = await loadWorkspaceWindowed({
+      // Storage LOT 3 / WP1: when a window-capable GraphStore mirror is
+      // configured, PREFER its bounded window (N highest-degree nodes + induced
+      // edges + precomputed positions) for FIRST PAINT instead of waiting on
+      // the multi-MB scene. With no store (default flat-JSON studio / offline
+      // bundle / 404) the probe resolves null and this is EXACTLY the previous
+      // loadWorkspace path — full scene, unchanged.
+      fetchWindow,
+      // Built with DEFAULT options (weak edges kept + flagged), like the
+      // server-side scene.json: the derived applyWeakFilter(sceneData, …) owns
+      // the toggle, so the window scene behaves exactly like a full scene.
+      buildWindowScene: (win) => buildWindowScene(win),
+      onFirstPaint: (windowScene) => {
+        // Bounded first paint: render the window NOW. The full workspace load
+        // continues in the background and replaces it below (lazy hydration).
+        loadError = null;
+        // Never pair the new window with a stale (previous-model) graph.
+        graph = EMPTY_GRAPH;
+        sceneData = windowScene;
+        // Unlock the template (onMount only flips it after the FULL load).
+        loaded = true;
+      },
       fetchScene,
       fetchGraph,
       buildScene: (g) => buildScene(g, { showWeakLinks: viewerState.options.showWeakLinks }),

--- a/studio/src/lib/api.js
+++ b/studio/src/lib/api.js
@@ -333,11 +333,12 @@ export async function fetchGroupCounts(axis) {
  * live store projection, not a build-time artifact, so an offline export simply
  * has none and the client loads its inlined full scene.
  *
- * CLIENT-RENDER INTEGRATION IS DEFERRED (see WP3 note): this accessor + its
- * server route are the windowed-loader primitive; wiring App.svelte's first paint
- * to PREFER the window and hydrate the rest lazily touches the renderer/scene
- * draw path, which is explicitly out of scope here. With no store wired the
- * accessor returns null on every call, so the default scene path is unchanged.
+ * CLIENT-RENDER INTEGRATION (WP1, wired): App.svelte's first paint now PREFERS
+ * this window via `sceneLoader.loadWorkspaceWindowed` — the probe races the full
+ * workspace load, a non-empty window paints first (adapted by
+ * `graphAdapter.buildWindowScene`), and the full scene replaces it when its load
+ * settles (lazy hydration). With no store wired the accessor returns null on
+ * every call, so the default scene path is unchanged.
  *
  * @param {{ strategy?: string, layout?: string, limit?: number }} [params]
  * @returns {Promise<{ strategy: string, layout?: string, limit: number,

--- a/studio/src/lib/graphAdapter.js
+++ b/studio/src/lib/graphAdapter.js
@@ -547,6 +547,53 @@ export function communityColorMap(cstats) {
 }
 
 /**
+ * Storage LOT 3 / WP1 (windowed first paint): adapt a store window document —
+ * the `GET /api/ontology/window` payload `{ strategy, layout?, limit, nodes,
+ * edges }` (the N highest-degree nodes + the edges induced among them, annotated
+ * with a layout's precomputed x/y) — into a renderable Studio scene.
+ *
+ * The window's nodes/edges are a graph-like, so the scene comes from the SAME
+ * buildScene() as every other path: shapes, weights, dashes, weak flags and
+ * community colours stay consistent, and the precomputed x/y carry through
+ * (buildScene copies finite node positions verbatim). If ANY node lacks a
+ * position the whole window is force-laid-out client-side — the window is
+ * BOUNDED (N nodes), so this is cheap and it keeps the first paint from
+ * degenerating into the renderer's fallback ring.
+ *
+ * Honest sizing caveat: buildScene recomputes degrees over the INDUCED edges,
+ * so a window node's weight reflects its in-window degree, not its store-wide
+ * `degree` field. The full scene replaces the window at hydration (see
+ * sceneLoader.loadWorkspaceWindowed) and corrects any visual difference.
+ *
+ * The returned scene is tagged `scene.window = { strategy, layout?, limit }` so
+ * consumers and tests can tell a bounded first-paint scene from a full one.
+ * The tag is additive and survives applyWeakFilter / applyTimeFilter (both
+ * spread `...scene`).
+ *
+ * @param {{ strategy?: string, layout?: string, limit?: number,
+ *   nodes?: object[], edges?: object[] } | null | undefined} windowDoc
+ * @param {object} [options]  forwarded to buildScene (e.g. showWeakLinks)
+ * @returns {{ nodes: object[], edges: object[], stats: object,
+ *   window: { strategy: string, layout?: string, limit: number } }}
+ */
+export function buildWindowScene(windowDoc, options = {}) {
+  const scene = buildScene(
+    { nodes: windowDoc?.nodes ?? [], links: windowDoc?.edges ?? [] },
+    options,
+  );
+  const positioned =
+    scene.nodes.length > 0 &&
+    scene.nodes.every((n) => finiteNumber(n.x) && finiteNumber(n.y));
+  const out = positioned ? scene : attachForceLayout(scene);
+  out.window = {
+    strategy: windowDoc?.strategy ?? "degree-top-n",
+    ...(windowDoc?.layout != null ? { layout: windowDoc.layout } : {}),
+    limit: windowDoc?.limit ?? out.nodes.length,
+  };
+  return out;
+}
+
+/**
  * ÉTAPE 1b: re-apply the weak-link filter on an ALREADY-BUILT scene, without the
  * raw graph. The SPA mounts the light `scene.json` (the full scene, weak links
  * included), then the Options toggle flips weak links on/off purely on the scene

--- a/studio/src/lib/sceneLoader.js
+++ b/studio/src/lib/sceneLoader.js
@@ -56,3 +56,76 @@ export async function loadWorkspace({ fetchScene, fetchGraph, buildScene }) {
     };
   }
 }
+
+/** Race sentinel: the full workspace settled before the window probe did. */
+const WORKSPACE_SETTLED = Symbol("workspace-settled");
+
+/**
+ * Storage LOT 3 / WP1: workspace mount that PREFERS a bounded store window for
+ * FIRST PAINT, then hydrates the full workspace lazily. Wraps (and returns the
+ * exact result of) {@link loadWorkspace}, which stays byte-identical.
+ *
+ * Policy — a pure PREFERENCE with a clean fallback:
+ *   1. The full `loadWorkspace()` load and the `fetchWindow()` probe start
+ *      CONCURRENTLY, so the default path is never delayed by the probe.
+ *   2. If the window resolves FIRST with a non-empty node set, the bounded
+ *      scene (`buildWindowScene(window)` — N highest-degree nodes + induced
+ *      edges + precomputed layout positions) is handed to `onFirstPaint`; the
+ *      caller paints it immediately instead of waiting on the multi-MB scene.
+ *   3. When the full workspace resolves, its result is returned UNCHANGED —
+ *      the caller swaps in the full scene (lazy hydration of the remainder).
+ *   4. Whenever the window is unavailable — no store configured (the default
+ *      flat-JSON studio), an offline bundle, a 404, a fetch error, an empty
+ *      window, or simply losing the race to the full workspace — `onFirstPaint`
+ *      is NOT called and the behaviour is EXACTLY `loadWorkspace(deps)`. A
+ *      stale window can never downgrade an already-loaded full scene.
+ *
+ * @param {object} deps  {@link loadWorkspace} deps plus:
+ * @param {() => Promise<object|null>} [deps.fetchWindow]  resolves the store
+ *        window document, or null when no window-capable store is reachable
+ *        (never rejects in the api.js accessor; rejections are treated as null)
+ * @param {(windowDoc: object) => object} [deps.buildWindowScene]  adapts the
+ *        window document into a renderable scene (graphAdapter.buildWindowScene)
+ * @param {(scene: object, windowDoc: object) => void} [deps.onFirstPaint]
+ *        called AT MOST ONCE, before the returned promise resolves, with the
+ *        bounded scene; a throw here never breaks the full-scene load
+ * @returns {Promise<{ mode: "scene"|"graph"|"error", scene: object|null,
+ *   graph: object|null, error: string|null }>} the {@link loadWorkspace} result
+ */
+export async function loadWorkspaceWindowed({
+  fetchWindow,
+  buildWindowScene,
+  onFirstPaint,
+  fetchScene,
+  fetchGraph,
+  buildScene,
+}) {
+  const workspace = loadWorkspace({ fetchScene, fetchGraph, buildScene });
+  if (
+    typeof fetchWindow === "function" &&
+    typeof buildWindowScene === "function" &&
+    typeof onFirstPaint === "function"
+  ) {
+    // Never rejects: any probe failure means "no window" (the clean fallback).
+    const windowProbe = Promise.resolve()
+      .then(() => fetchWindow())
+      .catch(() => null);
+    const first = await Promise.race([
+      workspace.then(() => WORKSPACE_SETTLED),
+      windowProbe,
+    ]);
+    if (
+      first !== WORKSPACE_SETTLED &&
+      first &&
+      Array.isArray(first.nodes) &&
+      first.nodes.length > 0
+    ) {
+      try {
+        onFirstPaint(buildWindowScene(first), first);
+      } catch {
+        // A paint failure must never break the full-scene load.
+      }
+    }
+  }
+  return workspace;
+}

--- a/studio/src/tests/graphAdapter.test.js
+++ b/studio/src/tests/graphAdapter.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildScene,
+  buildWindowScene,
   communityStats,
   entitiesByCommunity,
   entitiesByType,
@@ -547,6 +548,79 @@ describe("applyWeakFilter (ÉTAPE 1b — scene.json parity)", () => {
     const snapshot = JSON.parse(JSON.stringify(full));
     applyWeakFilter(full, false);
     expect(full).toEqual(snapshot);
+  });
+});
+
+describe("buildWindowScene (storage LOT 3 / WP1 — windowed first paint)", () => {
+  // The GET /api/ontology/window payload shape: N highest-degree nodes with the
+  // layout's precomputed x/y + the edges induced among them.
+  const WINDOW = {
+    strategy: "degree-top-n",
+    layout: "force",
+    limit: 3,
+    nodes: [
+      { id: "hub", label: "Hub", node_type: "Character", x: 10, y: 20, degree: 7 },
+      { id: "a", label: "Node A", node_type: "Work", x: -3, y: 4, degree: 5 },
+      { id: "b", label: "Node B", node_type: "Location", x: 0, y: -8, degree: 4 },
+    ],
+    edges: [
+      { source: "hub", target: "a", relation: "appears_in" },
+      { source: "hub", target: "b", relation: "located_in" },
+    ],
+  };
+
+  it("renders the BOUNDED set through buildScene semantics", () => {
+    const scene = buildWindowScene(WINDOW);
+    expect(scene.stats.nodeCount).toBe(3);
+    expect(scene.stats.edgeCount).toBe(2);
+    expect(scene.nodes.map((n) => n.id)).toEqual(["hub", "a", "b"]);
+    // Same visual grammar as every other scene path: type-driven shape, a
+    // finite weight, and the relation carried on the edges.
+    expect(scene.nodes[0].type).toBe("Character");
+    expect(scene.nodes[0].shape).toBeTruthy();
+    expect(scene.nodes.every((n) => Number.isFinite(n.weight))).toBe(true);
+    expect(scene.edges[0].relation).toBe("appears_in");
+    // Window edges carry no confidence -> strong (never flagged weak).
+    expect(scene.edges.some((e) => e.weak)).toBe(false);
+  });
+
+  it("carries the precomputed layout positions through verbatim", () => {
+    const scene = buildWindowScene(WINDOW);
+    expect(scene.nodes.map((n) => [n.x, n.y])).toEqual([
+      [10, 20],
+      [-3, 4],
+      [0, -8],
+    ]);
+  });
+
+  it("tags the scene with the window meta (strategy / layout / limit)", () => {
+    const scene = buildWindowScene(WINDOW);
+    expect(scene.window).toEqual({ strategy: "degree-top-n", layout: "force", limit: 3 });
+  });
+
+  it("force-lays-out the window when a position is missing (never the fallback ring)", () => {
+    const noPositions = {
+      ...WINDOW,
+      nodes: WINDOW.nodes.map(({ x, y, ...node }) => node),
+    };
+    const scene = buildWindowScene(noPositions);
+    expect(scene.nodes.every((n) => Number.isFinite(n.x) && Number.isFinite(n.y))).toBe(true);
+    expect(scene.window.strategy).toBe("degree-top-n");
+  });
+
+  it("the window tag survives applyWeakFilter and applyTimeFilter", async () => {
+    const { applyWeakFilter, applyTimeFilter } = await import("../lib/graphAdapter.js");
+    const scene = buildWindowScene(WINDOW);
+    expect(applyWeakFilter(scene, false).window).toEqual(scene.window);
+    expect(applyTimeFilter(scene, 12345).window).toEqual(scene.window);
+  });
+
+  it("drops edges whose endpoints fall outside the window (defensive)", () => {
+    const scene = buildWindowScene({
+      ...WINDOW,
+      edges: [...WINDOW.edges, { source: "hub", target: "outside", relation: "links" }],
+    });
+    expect(scene.stats.edgeCount).toBe(2);
   });
 });
 

--- a/studio/src/tests/sceneLoader.test.js
+++ b/studio/src/tests/sceneLoader.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { loadWorkspace } from "../lib/sceneLoader.js";
+import { loadWorkspace, loadWorkspaceWindowed } from "../lib/sceneLoader.js";
 
 const LIGHT_SCENE = {
   nodes: [{ id: "a", label: "A", weight: 1, shape: "dot" }],
@@ -76,5 +76,193 @@ describe("loadWorkspace (ÉTAPE 1b mount orchestration)", () => {
     expect(result.scene).toEqual(LIGHT_SCENE);
     expect(result.graph).toBeNull();
     expect(result.error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Storage LOT 3 / WP1: windowed first paint (preference + clean fallback).
+// ---------------------------------------------------------------------------
+
+/** The GET /api/ontology/window payload the api.js accessor resolves. */
+const WINDOW_DOC = {
+  strategy: "degree-top-n",
+  layout: "force",
+  limit: 2,
+  nodes: [
+    { id: "hub", label: "Hub", node_type: "Character", x: 1, y: 2, degree: 3 },
+    { id: "a", label: "A", node_type: "Work", x: 3, y: 4, degree: 2 },
+  ],
+  edges: [{ source: "hub", target: "a", relation: "links" }],
+};
+
+// A buildWindowScene stand-in: marks its output so the tests can tell the
+// bounded first-paint scene from the full one without the real adapter.
+const buildWindowSceneStub = (win) => ({
+  __from: "buildWindowScene",
+  nodes: win.nodes,
+  edges: win.edges,
+  window: { strategy: win.strategy, layout: win.layout, limit: win.limit },
+});
+
+/** A manually-resolvable promise so tests control the race deterministically. */
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("loadWorkspaceWindowed (storage LOT 3 / WP1 — windowed first paint)", () => {
+  it("PREFERS the window for first paint, then hydrates the full scene lazily", async () => {
+    // The full scene is SLOW (a multi-MB payload); the window resolves first.
+    const scene = deferred();
+    const fetchScene = vi.fn(() => scene.promise);
+    const fetchGraph = vi.fn(async () => RAW_GRAPH);
+    const fetchWindow = vi.fn(async () => WINDOW_DOC);
+    const onFirstPaint = vi.fn();
+
+    const resultPromise = loadWorkspaceWindowed({
+      fetchWindow,
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint,
+      fetchScene,
+      fetchGraph,
+      buildScene: vi.fn(buildScene),
+    });
+
+    // The bounded window paints BEFORE the full workspace resolves.
+    await vi.waitFor(() => expect(onFirstPaint).toHaveBeenCalledTimes(1));
+    const [paintedScene, paintedDoc] = onFirstPaint.mock.calls[0];
+    expect(paintedScene.__from).toBe("buildWindowScene");
+    expect(paintedScene.nodes.map((n) => n.id)).toEqual(["hub", "a"]);
+    expect(paintedScene.window).toEqual({ strategy: "degree-top-n", layout: "force", limit: 2 });
+    expect(paintedDoc).toBe(WINDOW_DOC);
+
+    // The remainder hydrates lazily: the full scene load settles afterwards and
+    // the returned result is the FULL workspace, unchanged.
+    scene.resolve(LIGHT_SCENE);
+    const result = await resultPromise;
+    expect(result.mode).toBe("scene");
+    expect(result.scene).toEqual(LIGHT_SCENE);
+    expect(result.graph).toEqual(RAW_GRAPH);
+    expect(onFirstPaint).toHaveBeenCalledTimes(1);
+  });
+
+  it("REGRESSION PIN: no store (window null) — result identical to loadWorkspace, no paint", async () => {
+    const fetchScene = vi.fn(async () => LIGHT_SCENE);
+    const fetchGraph = vi.fn(async () => RAW_GRAPH);
+    const onFirstPaint = vi.fn();
+
+    const windowed = await loadWorkspaceWindowed({
+      fetchWindow: vi.fn(async () => null), // api.js resolves null: no store / 404
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint,
+      fetchScene,
+      fetchGraph,
+      buildScene: vi.fn(buildScene),
+    });
+    const plain = await loadWorkspace({
+      fetchScene: vi.fn(async () => LIGHT_SCENE),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: vi.fn(buildScene),
+    });
+
+    expect(onFirstPaint).not.toHaveBeenCalled();
+    expect(windowed).toEqual(plain);
+  });
+
+  it("REGRESSION PIN: legacy graph fallback still works under the windowed loader", async () => {
+    // No scene.json AND no window: the legacy fetchGraph + buildScene path.
+    const build = vi.fn(buildScene);
+    const result = await loadWorkspaceWindowed({
+      fetchWindow: vi.fn(async () => null),
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint: vi.fn(),
+      fetchScene: vi.fn(async () => {
+        throw new Error("404 scene.json");
+      }),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: build,
+    });
+    expect(result.mode).toBe("graph");
+    expect(build).toHaveBeenCalledWith(RAW_GRAPH);
+  });
+
+  it("treats a REJECTED window probe as no window (clean fallback)", async () => {
+    const onFirstPaint = vi.fn();
+    const result = await loadWorkspaceWindowed({
+      fetchWindow: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint,
+      fetchScene: vi.fn(async () => LIGHT_SCENE),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: vi.fn(buildScene),
+    });
+    expect(onFirstPaint).not.toHaveBeenCalled();
+    expect(result.mode).toBe("scene");
+  });
+
+  it("skips an EMPTY window (zero nodes would paint a blank canvas)", async () => {
+    const onFirstPaint = vi.fn();
+    const result = await loadWorkspaceWindowed({
+      fetchWindow: vi.fn(async () => ({ ...WINDOW_DOC, nodes: [], edges: [] })),
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint,
+      fetchScene: vi.fn(async () => LIGHT_SCENE),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: vi.fn(buildScene),
+    });
+    expect(onFirstPaint).not.toHaveBeenCalled();
+    expect(result.mode).toBe("scene");
+  });
+
+  it("never DOWNGRADES: a window that loses the race to the full scene is not painted", async () => {
+    // The full workspace resolves immediately; the window arrives later.
+    const win = deferred();
+    const onFirstPaint = vi.fn();
+    const result = await loadWorkspaceWindowed({
+      fetchWindow: vi.fn(() => win.promise),
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint,
+      fetchScene: vi.fn(async () => LIGHT_SCENE),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: vi.fn(buildScene),
+    });
+    expect(result.mode).toBe("scene");
+    // The late window must NOT clobber the already-loaded full scene.
+    win.resolve(WINDOW_DOC);
+    await win.promise;
+    await Promise.resolve();
+    expect(onFirstPaint).not.toHaveBeenCalled();
+  });
+
+  it("a throwing onFirstPaint never breaks the full-scene load", async () => {
+    const result = await loadWorkspaceWindowed({
+      fetchWindow: vi.fn(async () => WINDOW_DOC),
+      buildWindowScene: buildWindowSceneStub,
+      onFirstPaint: vi.fn(() => {
+        throw new Error("paint failed");
+      }),
+      fetchScene: vi.fn(async () => LIGHT_SCENE),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: vi.fn(buildScene),
+    });
+    expect(result.mode).toBe("scene");
+    expect(result.scene).toEqual(LIGHT_SCENE);
+  });
+
+  it("without the window deps it IS loadWorkspace (backwards-compatible)", async () => {
+    const result = await loadWorkspaceWindowed({
+      fetchScene: vi.fn(async () => LIGHT_SCENE),
+      fetchGraph: vi.fn(async () => RAW_GRAPH),
+      buildScene: vi.fn(buildScene),
+    });
+    expect(result.mode).toBe("scene");
+    expect(result.scene).toEqual(LIGHT_SCENE);
+    expect(result.graph).toEqual(RAW_GRAPH);
   });
 });


### PR DESCRIPTION
Wires the studio's FIRST PAINT to the DB-backed windowed loader (storage LOT 3 client integration — the part `fetchWindow`'s doc comment explicitly deferred). Track item `01KWVM5A34FYDPYPAPQJR3K3KS`, WP1.

## What changes

When a window-capable GraphStore mirror is configured, the studio's initial render now PREFERS the bounded window — the N highest-degree nodes + induced edges + precomputed layout positions from `GET /api/ontology/window` — instead of waiting on the full multi-MB scene, then hydrates the full workspace lazily and swaps it in-place. With no store (default flat-JSON studio, offline bundle, 404, network error), behavior is identical to today: the probe resolves `null` and the exact previous `loadWorkspace` path runs.

- `studio/src/lib/graphAdapter.js` — new `buildWindowScene(windowDoc)`: adapts the window document through the SAME `buildScene()` as every other path (shapes/weights/dashes/colors consistent, x/y carried through verbatim); force-lays-out the bounded set only if positions are missing (never the fallback ring); tags the scene `scene.window = { strategy, layout, limit }`.
- `studio/src/lib/sceneLoader.js` — new `loadWorkspaceWindowed(deps)`: races the `fetchWindow()` probe against the untouched `loadWorkspace()` (started CONCURRENTLY, so the default path is never delayed). A non-empty window that wins the race is handed to `onFirstPaint` exactly once; the returned result is always the full `loadWorkspace` result (lazy hydration). A late window can never downgrade an already-loaded full scene. `loadWorkspace` itself is byte-identical.
- `studio/src/App.svelte` — `loadActiveModel` uses the windowed orchestrator; `onFirstPaint` sets `sceneData` to the window scene, resets `graph` (never pairs a new window with a stale model's graph) and unlocks `loaded` so the window actually paints before the full load settles.
- `studio/src/lib/api.js` — `fetchWindow`'s "CLIENT-RENDER INTEGRATION IS DEFERRED" comment updated to the wired reality (accessor behavior unchanged).

Provider-neutral: purely the graph-window read path over the existing GraphStore port; no embedding/provider binding anywhere. Server routes, storage adapters, and the golden/offline export path are untouched (offline bundles short-circuit `fetchWindow` to `null` before any fetch, preserving INV-1).

## How the preference/fallback is decided

1. `loadWorkspace()` (full path) and `fetchWindow()` start concurrently.
2. `Promise.race`: if the full workspace settles first, the window is discarded (no downgrade). If the window resolves first AND is non-null with `nodes.length > 0`, it paints via `onFirstPaint(buildWindowScene(win), win)`.
3. The awaited return value is always the full-workspace result — App applies it exactly as before (scene mode / legacy graph mode / error mode).
4. Any probe failure (no store 404, offline, network error, empty window, throw inside paint) degrades to step 3 silently.

## Tests

- `studio/src/tests/graphAdapter.test.js` — `buildWindowScene`: bounded set through buildScene semantics, positions carried verbatim, window meta tag, force-layout when positions missing, tag survives weak/time filters, dangling induced edges dropped.
- `studio/src/tests/sceneLoader.test.js` — window-preferred path paints the bounded scene BEFORE the full workspace resolves then hydrates (deferred-promise ordering); REGRESSION PINS: null window ⇒ result deep-equals plain `loadWorkspace` with `onFirstPaint` never called, legacy graph fallback intact; rejected probe ⇒ fallback; empty window skipped; late window never painted; throwing `onFirstPaint` harmless; missing deps ⇒ plain `loadWorkspace`.

`studio: npx vitest run` → 345 passed, 3 failed — the 3 failures are `pickingBackendAgnostic.test.js` (jsdom WebGL stub, `context.uniformMatrix4fv is not a function`) and fail IDENTICALLY on unmodified main (verified side-by-side); unrelated to this diff.
Root: `vitest run tests/ontology-studio-window-route.test.ts tests/ontology-studio-groups-route.test.ts tests/studio-scene.test.ts` → 29 passed, 1 skipped; `tests/studio-export.test.ts tests/serve.test.ts tests/studio-assets.test.ts` → 37 passed. `npm run lint` (tsc --noEmit) clean. `npm run build:studio` OK.

## UAT (live postgres store, real 47,762-node ACLP-AM graph)

Followed the `.graphify/uat/db-grouping/` harness pattern: postgres:16 in Docker (:5434), layout baked into a COPY of the aclp graph (`attachLayoutPositions`, 47,762/47,762 nodes positioned in 8.6 s), `graphify store push` REPLACE (4.7 s, "Windowed-loader positions rebuilt for layouts: force"), studio served from this branch's dist twice: WITH store (:8899) and WITHOUT (:8891). DOM-observed via the left-rail node badge, sampled every 25 ms from document start; identical CDP-emulated 100 Mbps / 5 ms network on both:

| | BEFORE — no store | AFTER — postgres store |
|---|---|---|
| first graph paint | **15 916 ms** (full 47 762 nodes) | **1 035 ms** (window: 2 000 nodes / 693 edges, store layout positions) |
| full 47 762-node scene | 15 916 ms | 16 017 ms (lazy hydration, in-place swap) |
| payload before first paint | 41.8 MB scene + 124 MB graph | **589 KB** window |

≈ **15x faster to a usable graph**. Raw loopback (no emulation): windowed paint ~1.0 s vs no-store paint ~2.4 s. The no-store run showed NO intermediate state and its `/api/ontology/window` probe 404'd with a clean fallback — the regression pin observed live. Route-level: window 602 KB in ~52-77 ms vs scene.json 42.8 MB (~0.5 s warm, ~31 s cold server-side layout).

Full evidence (screenshots of both phases, logs, repro commands, honest caveats) in the runner worktree under `.graphify/uat/studio-windowed-first-paint/` (gitignored, db-grouping precedent).

Honest caveats: timings are loopback + CDP emulation, not a real WAN (the gap grows with real latency — the before path ships 166 MB before painting); the window scene's node sizing uses induced-edge degrees until hydration corrects it (documented in `buildWindowScene`); aclp-am's graph.json needed the layout bake only because it predates baked positions.

## Deferred

- Window params (strategy/layout/limit) are the server defaults; a studio-side control (or per-profile config) is future work.
- Progressive/streamed hydration beyond the single window→full swap (LOT 6 layouts, typed windows).
- The `.rail-stats` badge shows the window's counts during the windowed phase; a dedicated "loading full graph…" affordance could make the transient state more explicit.
