### PR TITLE
feat(upstream): 2026-07-06 python port wave — 4 live bugs + 19 port rows across 7 lots (WP6)

### DIFF
--- a/UPSTREAM_GAP.md
+++ b/UPSTREAM_GAP.md
@@ -68,7 +68,35 @@ Lot roll-up of the 30 actionable rows:
 | New-lot: inheritance follow-up (Lot-1 style) | `9b04022` |
 | Unassigned must-audit (likely covered, test-confirm) | `1256d65`, `b70a6d7` |
 
-Honesty caveats (unchanged from prior passes): optional tree-sitter WASM grammars (kotlin, swift, c#, ruby, objc) are absent in this sandbox — language-gap rows were verified by reading `src/extract.ts`, not by running extraction; `9811def`/`1256d65`/`b70a6d7` look already-covered but are kept `must-audit` pending test confirmation.
+Honesty caveats (unchanged from prior passes): optional tree-sitter WASM grammars (kotlin, swift, c#, ruby, objc) are absent in this sandbox — language-gap rows were verified by reading `src/extract.ts`, not by running extraction; `9811def`/`1256d65`/`b70a6d7` look already-covered but are kept `must-audit` pending test confirmation. (2026-07-06 port pass correction: `tree-sitter-ruby` WASM **is** present in this sandbox — the ruby ports below were verified by live extraction; kotlin/swift/c# remain absent.)
+
+### Closed this pass — 2026-07-06 port wave (WP6 upstream-ports branch)
+
+Verified-local = regression test ran green in this sandbox; CI-only = integration test soft-skips locally (optional grammar absent) and asserts where the grammar installs.
+
+| Upstream | TS change | Test | Status |
+| --- | --- | --- | --- |
+| `aa1bbda` case-insensitive suffix filter | `collectFiles` + dispatch lowercase fallback, `src/extract.ts` | `tests/language-surface.test.ts` | **ported + verified-local** (bug was live) |
+| `54825b6` skill/opencode fixes (2 of 3 slices) | `src/skills/skill-windows.md` name, opencode `;` separator `src/cli.ts` | `tests/skills.test.ts`, `tests/opencode-integration.test.ts` | **ported + verified-local** (bugs were live; #1657 report slice n/a — no Import Cycles section in TS) |
+| `e2ef4ef` (#1638 slice) phantom bare-import ids | ref-namespaced external-import fallback, `src/extract.ts` | `tests/extract-phantom-external-import.test.ts` | **ported + verified-local** (bug was live) |
+| `2ba07e8` to_canvas guard | member `hasNode`+filename filter in `toCanvas`, `src/export.ts` | `tests/public-api.test.ts` | **ported + verified-local** (bug was live; toObsidian half n/a) |
+| `2ab0867` shebang routing | `_SHEBANG_DISPATCH` + `_getExtractor`, `src/extract.ts` | `tests/extract-dispatch-parity.test.ts` | **ported + verified-local** |
+| `1226c34` `.mts`/`.cts` | detect + dispatch + TS grammar + import candidates | `tests/extract-dispatch-parity.test.ts` | **ported + verified-local** |
+| `6e97088` query stopwords | `QUERY_STOPWORDS`/`dropQueryStopwords` (`src/search.ts`), query paths only | `tests/serve-query-terms.test.ts` | **ported + verified-local** (index side intentionally unfiltered) |
+| `d56ee83` per-term BFS seeds | exported `pickSeeds` (`src/serve.ts`), MCP top-3 + CLI top-5 | `tests/serve-seed-diversity.test.ts` | **ported + verified-local** (unit + MCP e2e) |
+| `9e7fbcb` multi-project MCP | optional `project_path` on every tool, per-graph store cache | `tests/serve-multi-project.test.ts` | **ported + verified-local**; deliberate delta: strict default-graph startup kept |
+| `92edf78` java stdlib suppression | `_JAVA_BUILTIN_TYPES` in `_javaCollectTypeRefs` | `tests/extract-type-references.test.ts` | **ported + verified-local** |
+| `3540416` TS/JS decorator refs | `_tsEmitDecoratorEdges` in the class branch | `tests/extract-ts-decorators.test.ts` | **ported + verified-local** (abstract classes follow the pre-existing classTypes gap) |
+| `869aaf7` TS namespace/module nodes | `_tsExtraWalk` (internal_module/module) | `tests/extract-ts-namespace.test.ts` | **ported + verified-local** |
+| `09aeb97` generator nodes | `generator_function_declaration` + `_JS_FUNCTION_VALUE_TYPES` | `tests/extract-ts-generators.test.ts` | **ported + verified-local** (also closes `const x = function(){}`) |
+| `6d3a6f1` JS/TS rationale + ADR/RFC refs | `_extractJsRationale` post-pass; `doc_ref` file_type | `tests/extract-js-rationale.test.ts` | **ported + verified-local** |
+| `1288a55` zero-node cache guard | `_shouldCacheExtraction` gate + warning | `tests/extract-cache-zero-node.test.ts` | **ported + verified-local** |
+| `9b04022` kotlin `by` delegation | full kotlin delegation_specifier branch (TS had none) + `_kotlinUserTypeName` | `tests/extract-kotlin-delegation.test.ts` | **ported**; helper unit verified-local, integration **CI-only** (kotlin WASM absent) |
+| `13e2bdd` (#1640 slice) ruby containers | `module` classType; Struct.new/Class.new/Data.define synthesis + inherits | `tests/extract-ruby-containers.test.ts` | **ported + verified-local** (ruby WASM present) |
+| `6631af7` (#1668 slice) ruby mixes_in | include/extend/prepend scan in class/module body, stub targets | `tests/extract-ruby-containers.test.ts` | **ported + verified-local** |
+| `9811def` import-equals | none needed — `readStringSpecifier` recurses | `tests/extract-ts-import-equals.test.ts` | **already-covered, test-pinned** |
+
+Deferred from the 21-port bucket — all blocked on the same absent subsystem (cross-file member-call resolution / receiver typing; TS has no `resolve_*_member_calls` analog at all): `4744dfe` (extends the #1316 JS receiver-type table), `eebc406` (C# receiver calls), `44c0a5e` (Swift singleton receiver), `62b8eb1` (import-evidence gate on the #1553 single-candidate resolver — the phantom-edge failure mode does not exist in TS because that resolver is absent; the gate becomes relevant when the resolver lands), plus the `13e2bdd` #1634 constant-receiver slice and the `6631af7` #1669 affected-seeding slice (TS has no `affected` command). These form one coherent next structural lot alongside Lot 3 `indirect_call` (still unstarted).
 
 ### CRG recheck (`tirth8205/code-review-graph`)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -751,8 +751,12 @@ export const GraphifyPlugin = async ({ directory }) => {
       if (!existsSync(join(directory, ".graphify", "graph.json"))) return;
 
       if (input.tool === "bash") {
+        // Separate with ';' not '&&' — Windows PowerShell 5.1 rejects '&&' as a
+        // statement separator, which broke the first bash command of every
+        // OpenCode session on Windows. ';' works in PowerShell 5.1, Bash, and
+        // POSIX shells alike. Port of upstream 54825b6 (#1646).
         output.args.command =
-          'echo "[graphify] Knowledge graph at .graphify/. For focused questions, run graphify query \\"<question>\\" (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context." && ' +
+          'echo "[graphify] Knowledge graph at .graphify/. For focused questions, run graphify query \\"<question>\\" (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context." ; ' +
           output.args.command;
         reminded = true;
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5530,7 +5530,12 @@ export async function main(): Promise<void> {
           process.exit(0);
         }
 
-        const startNodes = scored.slice(0, 5).map(([, nid]) => nid);
+        // Per-term seed diversity (upstream d56ee83 / #1445): keep the
+        // historical top-5 slice, then guarantee at least one seed per
+        // distinct matched query term so one term's incidental top match
+        // cannot starve the others.
+        const { pickSeeds } = await import("./serve.js");
+        const startNodes = pickSeeds(G, scored, terms, 5);
         const budget = parseInt(opts.budget, 10) || 2000;
         const useDfs = opts.dfs ?? false;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5493,7 +5493,7 @@ export async function main(): Promise<void> {
     .action(async (question, opts) => {
       const { readFileSync: rf } = await import("node:fs");
       const { resolve: res } = await import("node:path");
-      const { scoreSearchText } = await import("./search.js");
+      const { dropQueryStopwords, scoreSearchText } = await import("./search.js");
       const gp = res(opts.graph);
       if (!existsSync(gp)) {
         console.error(`error: graph file not found: ${gp}`);
@@ -5508,7 +5508,12 @@ export async function main(): Promise<void> {
         const raw = JSON.parse(rf(gp, "utf-8"));
         const G = loadGraphFromData(raw);
 
-        const terms = normalizeSearchText(question).split(/\s+/).filter((t: string) => t.length > 2);
+        // Question/filler stopwords are dropped from the QUERY terms only
+        // (node text is never filtered) so content words drive seeding —
+        // port of upstream 6e97088.
+        const terms = dropQueryStopwords(
+          normalizeSearchText(question).split(/\s+/).filter((t: string) => t.length > 2),
+        );
         const scored: [number, string][] = [];
         G.forEachNode((nid: string, data: Record<string, unknown>) => {
           const score = scoreSearchText(

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -24,6 +24,8 @@ export const CODE_EXTENSIONS = new Set([
   ".lua", ".toc", ".zig", ".ps1", ".ex", ".exs", ".m", ".mm", ".jl", ".vue",
   ".svelte", ".astro", ".dart", ".v", ".sv", ".svh", ".mjs", ".ejs", ".sql", ".r", ".groovy",
   ".gradle", ".luau", ".f", ".f90", ".f95", ".f03", ".f08",
+  // TypeScript module/CommonJS variants — port of upstream 1226c34.
+  ".mts", ".cts",
   // ArkTS — TypeScript-superset used by HarmonyOS / OpenHarmony app development.
   // Tree-sitter TypeScript already handles .ets AST extraction; detect just
   // needed to recognize the extension. Port of upstream safishamsi 52d75bd / #926.

--- a/src/export.ts
+++ b/src/export.ts
@@ -900,10 +900,17 @@ export function toCanvas(
 
   const sortedCids = [...communityMap.keys()].sort((a, b) => a - b);
 
+  // Skip dangling community members with no backing node / filename, so box
+  // sizing matches the cards actually laid out and the label/filename deref
+  // below never touches a missing node (graphology getNodeAttribute throws on
+  // unknown ids). Port of upstream 2ba07e8 (#1236 follow-up).
+  const presentMembers = (cid: number): string[] =>
+    (communityMap.get(cid) ?? []).filter((m) => G.hasNode(m) && filenameMap.has(m));
+
   // Precompute group sizes
   const groupSizes = new Map<number, [number, number]>();
   for (const cid of sortedCids) {
-    const members = communityMap.get(cid) ?? [];
+    const members = presentMembers(cid);
     const memberCount = members.length;
     const w = Math.max(600, memberCount > 0 ? 220 * Math.ceil(Math.sqrt(memberCount)) : 600);
     const h = Math.max(400, memberCount > 0 ? 100 * Math.ceil(memberCount / 3) + 120 : 400);
@@ -961,7 +968,9 @@ export function toCanvas(
   // Generate group and node canvas entries
   for (let idx = 0; idx < sortedCids.length; idx++) {
     const cid = sortedCids[idx]!;
-    const members = communityMap.get(cid) ?? [];
+    // Same dangling-member guard as the sizing loop (#1236 follow-up): a
+    // community id absent from G / filenameMap would throw in the sort below.
+    const members = presentMembers(cid);
     const communityName = communityLabels?.get(cid) ?? `Community ${cid}`;
     const [gx, gy, gw, gh] = groupLayout.get(cid) ?? [0, 0, 600, 400];
     const canvasColor = CANVAS_COLORS[idx % CANVAS_COLORS.length]!;

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1746,6 +1746,18 @@ function _requireImportsJs(
   return found;
 }
 
+/**
+ * Node types whose value is a callable, for the JS/TS `const x = <fn>` form
+ * below. Older tree-sitter-javascript grammars label a function expression
+ * `function`; current ones use `function_expression`. `generator_function`
+ * (`const h = function*(){}`) — port of upstream safishamsi 09aeb97; the
+ * function/function_expression members close the same long-standing gap for
+ * plain function expressions (upstream `_JS_FUNCTION_VALUE_TYPES`).
+ */
+const _JS_FUNCTION_VALUE_TYPES = new Set<string>([
+  "arrow_function", "function_expression", "function", "generator_function",
+]);
+
 function _jsExtraWalk(
   node: SyntaxNode, source: string, fileNid: string, stem: string, strPath: string,
   _nodes: GraphNode[], edges: GraphEdge[], _seenIds: Set<string>,
@@ -1780,7 +1792,7 @@ function _jsExtraWalk(
         if (child.type === "variable_declarator") {
           const value = child.childForFieldName("value");
           const nameNode = child.childForFieldName("name");
-          if (value && value.type === "arrow_function") {
+          if (value && _JS_FUNCTION_VALUE_TYPES.has(value.type)) {
             if (nameNode) {
               const funcName = _readText(nameNode, source);
               const line = child.startPosition.row + 1;
@@ -1810,6 +1822,74 @@ function _jsExtraWalk(
       }
     }
     return node.type === "lexical_declaration" || requireFound || arrowFound || constFound;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// TS extra walk for namespace / module declarations
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit a container node for a TS `namespace`/`module` declaration.
+ *
+ * `namespace Foo {}` parses as `internal_module` (with `name`/`body` fields);
+ * `module Bar {}` and ambient `declare module "pkg" {}` parse as a named
+ * `module` node that exposes no fields, so its name and body are found
+ * positionally. Without this the container was never a node — its members
+ * were still reached by the default recurse but the namespace itself was
+ * invisible to the graph. Members stay file-contained (parity with
+ * `_csharpExtraWalk`); the namespace becomes a sibling marker node so it is
+ * queryable. Returns true if handled.
+ *
+ * The guard requires `isNamed` because the anonymous `module` keyword token
+ * shares the `module` type string and would otherwise match here.
+ * Port of upstream safishamsi 869aaf7.
+ */
+function _tsExtraWalk(
+  node: SyntaxNode, source: string, fileNid: string, stem: string,
+  parentClassNid: string | null,
+  addNodeFn: (nid: string, label: string, line: number) => void,
+  addEdgeFn: (src: string, tgt: string, relation: string, line: number) => void,
+  walkFn: (node: SyntaxNode, parentClassNid: string | null) => void,
+): boolean {
+  if (node.isNamed && (node.type === "internal_module" || node.type === "module")) {
+    let nameNode = node.childForFieldName("name");
+    if (!nameNode) {
+      for (const child of node.children) {
+        if (child.isNamed && (child.type === "identifier" || child.type === "nested_identifier" || child.type === "string")) {
+          nameNode = child;
+          break;
+        }
+      }
+    }
+    let body = node.childForFieldName("body");
+    if (!body) {
+      for (const child of node.children) {
+        if (child.type === "statement_block") {
+          body = child;
+          break;
+        }
+      }
+    }
+    if (nameNode) {
+      let nsName = _readText(nameNode, source);
+      if (nameNode.type === "string") {
+        nsName = nsName.replace(/^['"`]+|['"`]+$/g, "");
+      }
+      if (nsName) {
+        const nsNid = _makeId(stem, nsName);
+        const line = node.startPosition.row + 1;
+        addNodeFn(nsNid, nsName, line);
+        addEdgeFn(fileNid, nsNid, "contains", line);
+      }
+    }
+    if (body) {
+      for (const child of body.children) {
+        walkFn(child, parentClassNid);
+      }
+    }
+    return true;
   }
   return false;
 }
@@ -2062,7 +2142,10 @@ const _JS_CONFIG: LanguageConfig = defaultConfig({
   tsGrammarName: "javascript",
   tsModule: "tree_sitter_javascript",
   classTypes: new Set(["class_declaration"]),
-  functionTypes: new Set(["function_declaration", "method_definition"]),
+  // generator_function_declaration: `function* g()` — absent from
+  // function_types upstream too until 09aeb97; generator *methods* already
+  // parse as method_definition. Port of upstream safishamsi 09aeb97.
+  functionTypes: new Set(["function_declaration", "generator_function_declaration", "method_definition"]),
   // export_statement is included so the walker hands re-exports
   // (`export { X } from './m'`) to _importJs. Pure exports (no `from`)
   // fall through to walk children in _extract_generic. Port of upstream
@@ -2072,7 +2155,7 @@ const _JS_CONFIG: LanguageConfig = defaultConfig({
   callFunctionField: "function",
   callAccessorNodeTypes: new Set(["member_expression"]),
   callAccessorField: "property",
-  functionBoundaryTypes: new Set(["function_declaration", "arrow_function", "method_definition"]),
+  functionBoundaryTypes: new Set(["function_declaration", "generator_function_declaration", "arrow_function", "method_definition"]),
   importHandler: _importJs,
 });
 
@@ -2080,7 +2163,8 @@ const _TS_CONFIG: LanguageConfig = defaultConfig({
   tsGrammarName: "typescript",
   tsModule: "tree_sitter_typescript",
   classTypes: new Set(["class_declaration", "interface_declaration", "enum_declaration", "type_alias_declaration"]),
-  functionTypes: new Set(["function_declaration", "method_definition"]),
+  // generator_function_declaration — port of upstream safishamsi 09aeb97.
+  functionTypes: new Set(["function_declaration", "generator_function_declaration", "method_definition"]),
   // export_statement is included so the walker hands re-exports
   // (`export { X } from './m'`) to _importJs. Pure exports (no `from`)
   // fall through to walk children in _extract_generic. Port of upstream
@@ -2090,7 +2174,7 @@ const _TS_CONFIG: LanguageConfig = defaultConfig({
   callFunctionField: "function",
   callAccessorNodeTypes: new Set(["member_expression"]),
   callAccessorField: "property",
-  functionBoundaryTypes: new Set(["function_declaration", "arrow_function", "method_definition"]),
+  functionBoundaryTypes: new Set(["function_declaration", "generator_function_declaration", "arrow_function", "method_definition"]),
   importHandler: _importJs,
 });
 
@@ -2826,6 +2910,14 @@ async function _extractGeneric(
       if (_jsExtraWalk(node, source, fileNid, stem, strPath,
         nodes, edges, seenIds, functionBodies,
         parentClassNid, addNode, addEdge, rootDir)) {
+        return;
+      }
+    }
+
+    // TS namespace / module containers (internal_module, module) — port of
+    // upstream safishamsi 869aaf7.
+    if (config.tsModule === "tree_sitter_typescript") {
+      if (_tsExtraWalk(node, source, fileNid, stem, parentClassNid, addNode, addEdge, walk)) {
         return;
       }
     }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -12,6 +12,7 @@ import { createRequire } from "node:module";
 import type { GraphNode, GraphEdge, Extraction } from "./types.js";
 import { loadCached, saveCached } from "./cache.js";
 import { sanitizeLabel } from "./security.js";
+import { shebangInterpreter } from "./detect.js";
 
 // ---------------------------------------------------------------------------
 // web-tree-sitter types  (re-exported from the package)
@@ -409,6 +410,8 @@ function normalizeJsImportTarget(resolvedImport: string): string {
   const candidates = [
     `${resolvedImport}.ts`,
     `${resolvedImport}.tsx`,
+    `${resolvedImport}.mts`,
+    `${resolvedImport}.cts`,
     `${resolvedImport}.js`,
     `${resolvedImport}.jsx`,
     `${resolvedImport}.mjs`,
@@ -3073,8 +3076,15 @@ export async function extractPython(filePath: string, rootDir?: string): Promise
 }
 
 export async function extractJs(filePath: string, rootDir?: string): Promise<ExtractionResult> {
-  const ext = extname(filePath);
-  const config = ext === ".tsx" ? _TSX_CONFIG : ext === ".ts" ? _TS_CONFIG : _JS_CONFIG;
+  const ext = extname(filePath).toLowerCase();
+  // `.mts`/`.cts` are TypeScript module/CommonJS variants — parse with the TS
+  // grammar (the JS grammar drops `type`/`interface` declarations). Port of
+  // upstream 1226c34.
+  const config = ext === ".tsx"
+    ? _TSX_CONFIG
+    : ext === ".ts" || ext === ".mts" || ext === ".cts"
+      ? _TS_CONFIG
+      : _JS_CONFIG;
   return _extractGeneric(filePath, config, rootDir);
 }
 
@@ -6007,6 +6017,9 @@ const _DISPATCH: Record<string, ExtractorFn> = {
   ".mjs": extractJs,
   ".ts": extractJs,
   ".tsx": extractJs,
+  // TypeScript module/CommonJS variants — port of upstream 1226c34.
+  ".mts": extractJs,
+  ".cts": extractJs,
   ".vue": extractRegexBackedCode,
   ".svelte": extractSvelte,
   ".astro": extractAstro,
@@ -6061,6 +6074,42 @@ const _DISPATCH: Record<string, ExtractorFn> = {
   ".props": _extractCsprojAsync,
   ".targets": _extractCsprojAsync,
 };
+
+// Extensionless executables (CLI entry points like `devctl` or `manage`) carry
+// their language in the shebang, not the suffix. detect.classifyFile already
+// routes them to the CODE path via shebangInterpreter; extraction dispatch must
+// honor the same signal or these files are classified as code and then
+// silently dropped. Only interpreters with a real TS extractor are mapped —
+// detect's wider set (bash-family, perl, fish, tcsh, Rscript) stays unmapped
+// and skipped rather than being mis-parsed by a wrong grammar (the TS port has
+// no bash extractor, unlike upstream). Port of upstream 2ab0867.
+const _SHEBANG_DISPATCH: Record<string, ExtractorFn> = {
+  "python": extractPython,
+  "python2": extractPython,
+  "python3": extractPython,
+  "node": extractJs,
+  "nodejs": extractJs,
+  "ruby": extractRuby,
+  "lua": extractLua,
+  "php": extractPhp,
+  "julia": extractJulia,
+};
+
+/**
+ * Return the extractor for a file: filename-based MCP/blade routing first,
+ * then the lowercased-suffix dispatch table, then (for extensionless files)
+ * shebang-interpreter routing mirroring detect.classifyFile.
+ */
+function _getExtractor(filePath: string): ExtractorFn | undefined {
+  if (isMcpConfigPath(filePath)) return _extractMcpConfigAsync;
+  if (basename(filePath).toLowerCase().endsWith(".blade.php")) return extractRegexBackedCode;
+  const ext = extname(filePath).toLowerCase();
+  if (!ext) {
+    const interp = shebangInterpreter(filePath);
+    return interp ? _SHEBANG_DISPATCH[interp] : undefined;
+  }
+  return _DISPATCH[ext];
+}
 
 /**
  * Collapse cross-file Swift `extension Foo` nodes into the canonical `Foo`.
@@ -6173,15 +6222,11 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
       process.stderr.write(`  AST extraction: ${i}/${total} files (${Math.floor(i * 100 / total)}%)\n`);
     }
     const filePath = normalizedPaths[i]!;
-    const ext = extname(filePath).toLowerCase();
     // Filename-based dispatch takes precedence over the suffix lookup so an
     // MCP config (`.mcp.json`, `mcp.json`, …) is not swallowed by generic
-    // `.json` handling. Port of upstream 2c01a89 (dispatched-by-filename).
-    const extractor = isMcpConfigPath(filePath)
-      ? _extractMcpConfigAsync
-      : basename(filePath).toLowerCase().endsWith(".blade.php")
-        ? extractRegexBackedCode
-        : _DISPATCH[ext];
+    // `.json` handling (port of upstream 2c01a89); extensionless files route
+    // by shebang (port of upstream 2ab0867).
+    const extractor = _getExtractor(filePath);
     if (!extractor) continue;
 
     const cached = loadCached(filePath, root);
@@ -6261,7 +6306,7 @@ export async function extract(paths: string[]): Promise<Extraction> {
 // ---------------------------------------------------------------------------
 
 const _EXTENSIONS = new Set([
-  ".py", ".js", ".jsx", ".mjs", ".ts", ".tsx", ".go", ".rs",
+  ".py", ".js", ".jsx", ".mjs", ".ts", ".tsx", ".mts", ".cts", ".go", ".rs",
   ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp",
   ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
   ".lua", ".toc", ".zig", ".ps1",
@@ -6366,6 +6411,6 @@ export function collectFiles(target: string, options?: { followSymlinks?: boolea
  */
 export const __testing = {
   resolveLuaImportTarget: _resolveLuaImportTarget,
-  /** Return the dispatch-table extractor function for a given file path (by extension). */
-  getExtractor: (filePath: string): ExtractorFn | undefined => _DISPATCH[extname(filePath).toLowerCase()],
+  /** Return the extractor for a given file path (real dispatch: filename, suffix, then shebang). */
+  getExtractor: (filePath: string): ExtractorFn | undefined => _getExtractor(filePath),
 };

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -3395,7 +3395,121 @@ export async function extractJs(filePath: string, rootDir?: string): Promise<Ext
     : ext === ".ts" || ext === ".mts" || ext === ".cts"
       ? _TS_CONFIG
       : _JS_CONFIG;
-  return _extractGeneric(filePath, config, rootDir);
+  const result = await _extractGeneric(filePath, config, rootDir);
+  if (!result.error) {
+    _extractJsRationale(filePath, result, rootDir);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// JS/TS rationale + doc-reference extraction
+//
+// Parity with _extractPythonRationale (port of upstream safishamsi 6d3a6f1):
+// Python files get rationale nodes from docstrings and `# NOTE:`-style
+// comments, but JS/TS comments were discarded entirely. That silently drops
+// two high-value signals in mixed corpora:
+//   1. rationale comments (`// NOTE:`, `// WHY:`, …) — same as Python;
+//   2. architecture-decision references (`ADR-0011`, `RFC 793`) that teams
+//      conventionally cite in file/function headers. These are the natural
+//      join points between code and design docs in the same graph — without
+//      them, code<->ADR edges never form even when the code cites the ADR.
+// ---------------------------------------------------------------------------
+
+const _JS_RATIONALE_PREFIXES = [
+  "// NOTE:", "// IMPORTANT:", "// HACK:", "// WHY:", "// RATIONALE:",
+  "// TODO:", "// FIXME:",
+  "* NOTE:", "* IMPORTANT:", "* HACK:", "* WHY:", "* RATIONALE:",
+  "* TODO:", "* FIXME:",
+];
+
+// Doc-reference tokens worth first-classing as graph nodes. Deliberately
+// conservative: ADR-NNNN (any zero padding) and RFC NNNN / RFC-NNNN.
+const _JS_DOC_REF_RE = /\b(ADR[- ]?\d{1,5}|RFC[- ]?\d{1,5})\b/gi;
+
+// Only look for doc references inside comments, not string literals or code.
+const _JS_COMMENT_LINE_RE = /^\s*(\/\/|\/\*|\*)/;
+
+/**
+ * Post-pass: extract rationale comments and ADR/RFC doc references from JS/TS
+ * source. Mutates `result` in place (appends nodes/edges). Text-based, no
+ * parser needed. Port of upstream safishamsi 6d3a6f1.
+ */
+function _extractJsRationale(
+  filePath: string,
+  result: ExtractionResult,
+  rootDir: string = dirname(resolve(filePath)),
+): void {
+  let sourceText: string;
+  try {
+    sourceText = readFileSync(filePath, "utf-8");
+  } catch {
+    return;
+  }
+
+  const stem = qualifiedFileStem(filePath, rootDir);
+  const strPath = filePath;
+  const { nodes, edges } = result;
+  const seenIds = new Set(nodes.map((n) => n.id));
+  const fileNid = _makeId(stem);
+  const seenDocRefs = new Set<string>();
+
+  const addRationale = (text: string, line: number): void => {
+    const label = text.slice(0, 80).replace(/[\r\n]+/g, " ").trim();
+    const rid = _makeId(stem, "rationale", String(line));
+    if (!seenIds.has(rid)) {
+      seenIds.add(rid);
+      nodes.push({
+        id: rid, label, file_type: "rationale",
+        source_file: strPath, source_location: `L${line}`,
+      });
+    }
+    edges.push({
+      source: rid, target: fileNid, relation: "rationale_for",
+      confidence: "EXTRACTED", source_file: strPath,
+      source_location: `L${line}`, weight: 1.0,
+    });
+  };
+
+  const addDocRef = (token: string, line: number): void => {
+    // Normalize "adr 11" / "ADR-0011" spellings to a canonical "ADR-0011"
+    // style label so references to the same document collapse to one node.
+    const m = /^([A-Za-z]+)[- ]?(\d+)$/.exec(token);
+    if (!m) return;
+    const kind = m[1]!.toUpperCase();
+    const num = m[2]!;
+    const label = kind === "ADR" ? `${kind}-${num.padStart(4, "0")}` : `${kind}-${num}`;
+    if (seenDocRefs.has(label)) return;
+    seenDocRefs.add(label);
+    const rid = _makeId("docref", label);
+    if (!seenIds.has(rid)) {
+      seenIds.add(rid);
+      nodes.push({
+        id: rid, label, file_type: "doc_ref",
+        source_file: strPath, source_location: `L${line}`,
+      });
+    }
+    edges.push({
+      source: fileNid, target: rid, relation: "cites",
+      confidence: "EXTRACTED", source_file: strPath,
+      source_location: `L${line}`, weight: 1.0,
+    });
+  };
+
+  const lines = sourceText.split(/\r\n|\r|\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const lineText = lines[i]!;
+    const lineno = i + 1;
+    const stripped = lineText.trim();
+    if (_JS_RATIONALE_PREFIXES.some((p) => stripped.startsWith(p))) {
+      addRationale(stripped.replace(/^[/* ]+/, ""), lineno);
+    }
+    if (_JS_COMMENT_LINE_RE.test(lineText)) {
+      for (const match of stripped.matchAll(_JS_DOC_REF_RE)) {
+        addDocRef(match[1]!, lineno);
+      }
+    }
+  }
 }
 
 export async function extractJava(filePath: string, rootDir?: string): Promise<ExtractionResult> {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -457,7 +457,16 @@ function resolveJsImportTargetInfo(raw: string, importerPath: string): JsImportT
   }
 
   const moduleName = raw.split("/").pop() ?? "";
-  return moduleName ? { targetId: _makeId(moduleName) } : null;
+  // Unresolved: relative/absolute and tsconfig-alias resolution have run and
+  // failed, so this is an external package (or a dangling local path).
+  // Namespace the id with the "ref" prefix so it can NEVER collapse to the
+  // same _makeId as a local file/symbol node. Without it, the bare
+  // last-segment id (e.g. "tailwindcss/colors" -> "colors") collides with any
+  // unrelated local file of that stem, producing a confident (EXTRACTED)
+  // cross-language phantom imports_from edge. The ref-namespaced target has
+  // no node, so build drops it as an external reference — the correct outcome
+  // for a third-party import. Port of upstream e2ef4ef (#1638).
+  return moduleName ? { targetId: _makeId("ref", raw) } : null;
 }
 
 function resolveJsImportTarget(raw: string, importerPath: string): string | null {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1918,6 +1918,146 @@ const _PYTHON_CONFIG: LanguageConfig = defaultConfig({
   importHandler: _importPython,
 });
 
+/**
+ * Return the head symbol of a TS/JS `decorator` node: `@Injectable` → the
+ * identifier; `@Component({...})` / `@Input()` → the `function` of the
+ * call_expression; `@ng.Component()` / `@core.Injectable` → the `property` of
+ * the member_expression (the imported symbol, not the namespace alias).
+ * Port of upstream safishamsi 3540416.
+ */
+function _tsDecoratorName(decoNode: SyntaxNode, source: string): string | null {
+  for (const child of decoNode.children) {
+    if (!child.isNamed) continue;
+    let target: SyntaxNode = child;
+    if (target.type === "call_expression") {
+      target = target.childForFieldName("function") ?? target;
+    }
+    if (target.type === "member_expression") {
+      const prop = target.childForFieldName("property");
+      return prop ? _readText(prop, source) : null;
+    }
+    if (target.type === "identifier") {
+      return _readText(target, source);
+    }
+    return null;
+  }
+  return null;
+}
+
+/** Name of a `method_definition`, matching the id the function-types branch builds. */
+function _tsMethodName(methodNode: SyntaxNode, source: string): string | null {
+  const nameNode = methodNode.childForFieldName("name");
+  return nameNode ? _readText(nameNode, source) : null;
+}
+
+/**
+ * Collect `decorator` nodes under `node` (e.g. parameter decorators inside a
+ * method's formal_parameters, or a field's own decorator), without crossing
+ * into a nested class or a nested method, which own their own decorators.
+ */
+function _tsDescendantDecorators(node: SyntaxNode): SyntaxNode[] {
+  const out: SyntaxNode[] = [];
+  const rec = (n: SyntaxNode, top: boolean): void => {
+    for (const child of n.children) {
+      const ct = child.type;
+      if (ct === "decorator") {
+        out.push(child);
+      } else if (ct === "class_declaration" || ct === "abstract_class_declaration") {
+        continue;
+      } else if (ct === "method_definition" && !top) {
+        continue;
+      } else {
+        rec(child, false);
+      }
+    }
+  };
+  rec(node, true);
+  return out;
+}
+
+/**
+ * Emit `references` edges (context="decorator") from a class and its members
+ * to the symbols of the TS/JS decorators applied to them (`@Component`,
+ * `@Injectable`, `@Input`, `@Inject`, `@Entity`, …). Decorators occur only on
+ * classes, class members, and parameters, so a single pass over the class
+ * declaration covers them. Members that are graph nodes (methods) own their
+ * decorators and their parameter decorators; members that are not nodes
+ * (fields, parameters) attribute to the enclosing class. Targets go through
+ * `ensureNamedNode`, so a decorator imported from another module becomes a
+ * sourceless stub the corpus rewire collapses onto the real definition.
+ * Port of upstream safishamsi 3540416.
+ */
+function _tsEmitDecoratorEdges(
+  classNode: SyntaxNode,
+  classNid: string,
+  source: string,
+  ensureNamedNode: (name: string, line: number) => string,
+  addEdge: (
+    src: string, tgt: string, relation: string, line: number,
+    confidence?: "EXTRACTED" | "INFERRED", weight?: number, context?: string,
+  ) => void,
+): void {
+  const emit = (decoNode: SyntaxNode, ownerNid: string): void => {
+    const name = _tsDecoratorName(decoNode, source);
+    if (!name) return;
+    const line = decoNode.startPosition.row + 1;
+    const target = ensureNamedNode(name, line);
+    if (target !== ownerNid) {
+      addEdge(ownerNid, target, "references", line, "EXTRACTED", 1.0, "decorator");
+    }
+  };
+
+  // Class-level decorators: direct children of the class node (`@Deco class C`),
+  // plus — when exported (`@Deco export class C`) — the decorators that sit on
+  // the wrapping export_statement, before the class.
+  for (const child of classNode.children) {
+    if (child.type === "decorator") emit(child, classNid);
+  }
+  const parent = classNode.parent;
+  if (parent !== null && parent.type === "export_statement") {
+    for (const child of parent.children) {
+      if (child.type === "decorator") {
+        emit(child, classNid);
+      } else if (child.type === "class_declaration" || child.type === "abstract_class_declaration") {
+        break;
+      }
+    }
+  }
+
+  // Member decorators inside the class body.
+  const body = classNode.children.find((c) => c.type === "class_body");
+  if (!body) return;
+  for (const member of body.children) {
+    const mt = member.type;
+    if (mt === "decorator") {
+      // A method decorator is a sibling preceding the method; skip past any
+      // stacked decorators to find it.
+      let owner = classNid;
+      let sib: SyntaxNode | null = member.nextNamedSibling;
+      while (sib !== null && sib.type === "decorator") {
+        sib = sib.nextNamedSibling;
+      }
+      if (sib !== null && sib.type === "method_definition") {
+        const mname = _tsMethodName(sib, source);
+        if (mname) owner = _makeId(classNid, mname);
+      }
+      emit(member, owner);
+    } else if (mt === "method_definition") {
+      const mname = _tsMethodName(member, source);
+      const mNid = mname ? _makeId(classNid, mname) : classNid;
+      for (const deco of _tsDescendantDecorators(member)) {
+        emit(deco, mNid);
+      }
+    } else {
+      // Fields / accessors: the member is not a node, so attribute its
+      // decorators (e.g. `@Input()`, `@Column()`) to the class.
+      for (const deco of _tsDescendantDecorators(member)) {
+        emit(deco, classNid);
+      }
+    }
+  }
+}
+
 const _JS_CONFIG: LanguageConfig = defaultConfig({
   tsGrammarName: "javascript",
   tsModule: "tree_sitter_javascript",
@@ -2275,6 +2415,13 @@ async function _extractGeneric(
       const line = node.startPosition.row + 1;
       addNode(classNid, className, line);
       addEdge(fileNid, classNid, "contains", line);
+
+      // TS/JS decorators on the class and its members (@Component,
+      // @Injectable, @Input, @Inject, @Entity, …). Decorators live only in
+      // class subtrees. Port of upstream safishamsi 3540416.
+      if (config.tsModule === "tree_sitter_javascript" || config.tsModule === "tree_sitter_typescript") {
+        _tsEmitDecoratorEdges(node, classNid, source, ensureNamedNode, addEdge);
+      }
 
       // Swift extension dedup: tree-sitter-swift parses both `class Foo` and
       // `extension Foo` as `class_declaration`, with `extension Foo` carrying

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -601,10 +601,75 @@ function _javaTypeParametersInScope(node: SyntaxNode, source: string): Set<strin
 }
 
 /**
- * Walk a Java type expression; append `[name, role]` tuples. Skips primitives
- * and any in-scope type parameter, and resolves the unqualified tail of a
+ * java.lang (auto-imported) plus the ubiquitous java.util / java.io /
+ * java.time / java.util.{stream,function,concurrent} / java.math /
+ * java.nio.file types that appear as field, parameter, return, and
+ * generic-argument annotations. They never resolve to a project node, so
+ * emitting `references` edges to them is pure noise. Suppressed at the
+ * type-ref walker so they are never created as nodes or emitted as edges;
+ * primitives are already dropped by grammar node type. Port of upstream
+ * safishamsi 92edf78 (#1603).
+ */
+const _JAVA_BUILTIN_TYPES = new Set<string>([
+  // java.lang — core
+  "Object", "String", "CharSequence", "StringBuilder", "StringBuffer",
+  "Number", "Byte", "Short", "Integer", "Long", "Float", "Double",
+  "Boolean", "Character", "Void", "Class", "Enum", "Record", "Math",
+  "System", "Thread", "Runnable", "Comparable", "Iterable", "Cloneable",
+  "AutoCloseable", "Appendable", "Readable", "Process", "ProcessBuilder",
+  "Runtime", "Package", "ThreadLocal", "InheritableThreadLocal",
+  // java.lang — throwables
+  "Throwable", "Exception", "RuntimeException", "Error",
+  "IllegalArgumentException", "IllegalStateException", "NullPointerException",
+  "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException",
+  "ClassCastException", "NumberFormatException", "ArithmeticException",
+  "UnsupportedOperationException", "InterruptedException",
+  "CloneNotSupportedException", "SecurityException", "StackOverflowError",
+  "OutOfMemoryError", "AssertionError",
+  // java.util — collections & core
+  "Collection", "List", "ArrayList", "LinkedList", "Vector", "Stack",
+  "Set", "HashSet", "LinkedHashSet", "TreeSet", "SortedSet", "NavigableSet",
+  "EnumSet", "Map", "HashMap", "LinkedHashMap", "TreeMap", "SortedMap",
+  "NavigableMap", "Hashtable", "EnumMap", "Properties", "Queue", "Deque",
+  "ArrayDeque", "PriorityQueue", "Iterator", "ListIterator", "Comparator",
+  "Optional", "OptionalInt", "OptionalLong", "OptionalDouble", "Collections",
+  "Arrays", "Objects", "Date", "Calendar", "Random", "UUID", "Scanner",
+  "StringJoiner", "StringTokenizer", "BitSet", "Spliterator", "Locale",
+  "NoSuchElementException", "ConcurrentModificationException",
+  // java.util.stream
+  "Stream", "IntStream", "LongStream", "DoubleStream", "Collector",
+  "Collectors",
+  // java.util.function
+  "Function", "BiFunction", "Consumer", "BiConsumer", "Supplier",
+  "Predicate", "BiPredicate", "UnaryOperator", "BinaryOperator",
+  "IntFunction", "ToIntFunction", "ToLongFunction", "ToDoubleFunction",
+  // java.util.concurrent
+  "Callable", "Future", "CompletableFuture", "CompletionStage", "Executor",
+  "ExecutorService", "Executors", "ScheduledExecutorService", "TimeUnit",
+  "ConcurrentHashMap", "ConcurrentMap", "CopyOnWriteArrayList",
+  "BlockingQueue", "CountDownLatch", "Semaphore", "CyclicBarrier",
+  "AtomicInteger", "AtomicLong", "AtomicBoolean", "AtomicReference",
+  // java.time
+  "Instant", "Duration", "Period", "LocalDate", "LocalTime", "LocalDateTime",
+  "ZonedDateTime", "OffsetDateTime", "ZoneId", "ZoneOffset", "DayOfWeek",
+  "Month", "Year", "Clock", "DateTimeFormatter",
+  // java.io / java.nio.file
+  "IOException", "UncheckedIOException", "FileNotFoundException", "File",
+  "InputStream", "OutputStream", "Reader", "Writer", "BufferedReader",
+  "BufferedWriter", "InputStreamReader", "OutputStreamWriter", "FileReader",
+  "FileWriter", "PrintStream", "PrintWriter", "ByteArrayInputStream",
+  "ByteArrayOutputStream", "Serializable", "Closeable", "Path", "Paths",
+  "Files",
+  // java.math
+  "BigDecimal", "BigInteger",
+]);
+
+/**
+ * Walk a Java type expression; append `[name, role]` tuples. Skips primitives,
+ * any in-scope type parameter, and java stdlib builtins
+ * (`_JAVA_BUILTIN_TYPES`), and resolves the unqualified tail of a
  * `scoped_type_identifier` (`java.util.List` → `List`). Ports of upstream
- * safishamsi 31b3752 (#1485) + 8b9a998 (#1518).
+ * safishamsi 31b3752 (#1485) + 8b9a998 (#1518) + 92edf78 (#1603).
  */
 function _javaCollectTypeRefs(
   node: SyntaxNode | null,
@@ -621,19 +686,25 @@ function _javaCollectTypeRefs(
   }
   if (t === "type_identifier") {
     const name = _readText(node, source);
-    if (name && !skipSet.has(name)) out.push([name, generic ? "generic_arg" : "type"]);
+    if (name && !skipSet.has(name) && !_JAVA_BUILTIN_TYPES.has(name)) {
+      out.push([name, generic ? "generic_arg" : "type"]);
+    }
     return;
   }
   if (t === "scoped_type_identifier") {
     const text = _readText(node, source).split(".").pop() ?? "";
-    if (text) out.push([text, generic ? "generic_arg" : "type"]);
+    if (text && !_JAVA_BUILTIN_TYPES.has(text)) out.push([text, generic ? "generic_arg" : "type"]);
     return;
   }
   if (t === "generic_type") {
     for (const c of node.children) {
       if (c.type === "type_identifier" || c.type === "scoped_type_identifier") {
         const text = _readText(c, source).split(".").pop() ?? "";
-        if (text && (c.type === "scoped_type_identifier" || !skipSet.has(text))) {
+        if (
+          text &&
+          !_JAVA_BUILTIN_TYPES.has(text) &&
+          (c.type === "scoped_type_identifier" || !skipSet.has(text))
+        ) {
           out.push([text, generic ? "generic_arg" : "type"]);
         }
         break;

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -2253,7 +2253,10 @@ const _CPP_CONFIG: LanguageConfig = defaultConfig({
 const _RUBY_CONFIG: LanguageConfig = defaultConfig({
   tsGrammarName: "ruby",
   tsModule: "tree_sitter_ruby",
-  classTypes: new Set(["class"]),
+  // "module": plain `module Foo` produced no container node — its methods
+  // hung off the file with dot-less labels and no edge could target the
+  // module. Port of upstream safishamsi 13e2bdd (#1640).
+  classTypes: new Set(["class", "module"]),
   functionTypes: new Set(["method", "singleton_method"]),
   importTypes: new Set(),
   callTypes: new Set(["call"]),
@@ -2715,6 +2718,51 @@ async function _extractGeneric(
             addEdge(classNid, baseNid, "inherits", line);
           }
         }
+
+        // `include`/`extend`/`prepend <Const>` in the class/module body ->
+        // a `mixes_in` edge to the module (port of upstream 6631af7 #1668).
+        // Only bare/namespaced constant arguments count; `extend self`,
+        // `include some_var`, etc. are skipped. Upstream resolves the target
+        // through its cross-file Ruby resolver; the TS analog is the
+        // sourceless-stub + corpus-rewire pattern already used for inherits.
+        // Class-body calls are never walked by the call pass (it only walks
+        // function bodies), so these markers cannot be mislabeled as calls.
+        const rubyBody = _findBody(node, config);
+        if (rubyBody) {
+          for (const stmt of rubyBody.children) {
+            if (stmt.type !== "call") continue;
+            if (stmt.childForFieldName("receiver")) continue;
+            const methodNode = stmt.childForFieldName("method");
+            const methodName = methodNode ? _readText(methodNode, source) : "";
+            if (methodName !== "include" && methodName !== "extend" && methodName !== "prepend") continue;
+            const argList = stmt.childForFieldName("arguments");
+            if (!argList) continue;
+            for (const arg of argList.children) {
+              let moduleName = "";
+              if (arg.type === "constant") {
+                moduleName = _readText(arg, source);
+              } else if (arg.type === "scope_resolution") {
+                const consts = arg.children.filter((c) => c.type === "constant");
+                if (consts.length > 0) moduleName = _readText(consts[consts.length - 1]!, source);
+              }
+              if (!moduleName) continue; // `extend self`, variables, …
+              let moduleNid = _makeId(stem, moduleName);
+              if (!seenIds.has(moduleNid)) {
+                moduleNid = _makeId(moduleName);
+                if (!seenIds.has(moduleNid)) {
+                  nodes.push({
+                    id: moduleNid, label: moduleName, file_type: "code",
+                    source_file: "", source_location: "",
+                  });
+                  seenIds.add(moduleNid);
+                }
+              }
+              if (moduleNid !== classNid) {
+                addEdge(classNid, moduleNid, "mixes_in", stmt.startPosition.row + 1);
+              }
+            }
+          }
+        }
       }
 
       // Java-specific: superclass / interface inheritance and implementation.
@@ -2914,6 +2962,64 @@ async function _extractGeneric(
         }
       }
       return;
+    }
+
+    // Ruby: a constant assignment whose RHS is `Struct.new(...)`,
+    // `Class.new(...)` or `Data.define(...)` defines a class in everything
+    // but syntax — synthesize a class node named after the constant, attach
+    // block-defined methods to it, and emit `inherits` for
+    // `Class.new(Super)`. Plain constant assignments (MAX = 100, X = Foo.new)
+    // are untouched. Port of upstream safishamsi 13e2bdd (#1640).
+    if (config.tsModule === "tree_sitter_ruby" && t === "assignment") {
+      const left = node.childForFieldName("left");
+      const right = node.childForFieldName("right");
+      if (left?.type === "constant" && right?.type === "call") {
+        const recvNode = right.childForFieldName("receiver");
+        const methNode = right.childForFieldName("method");
+        const recv = recvNode ? _readText(recvNode, source) : "";
+        const meth = methNode ? _readText(methNode, source) : "";
+        const isClassFactory =
+          ((recv === "Struct" || recv === "Class") && meth === "new") ||
+          (recv === "Data" && meth === "define");
+        if (isClassFactory) {
+          const className = _readText(left, source);
+          const classNid = _makeId(stem, className);
+          const line = node.startPosition.row + 1;
+          addNode(classNid, className, line);
+          addEdge(fileNid, classNid, "contains", line);
+
+          // `Class.new(Super)` — first constant argument is the superclass.
+          if (recv === "Class") {
+            const argList = right.childForFieldName("arguments");
+            const firstConst = argList?.children.find((c) => c.type === "constant");
+            if (firstConst) {
+              const base = _readText(firstConst, source);
+              let baseNid = _makeId(stem, base);
+              if (!seenIds.has(baseNid)) {
+                baseNid = _makeId(base);
+                if (!seenIds.has(baseNid)) {
+                  nodes.push({
+                    id: baseNid, label: base, file_type: "code",
+                    source_file: "", source_location: "",
+                  });
+                  seenIds.add(baseNid);
+                }
+              }
+              addEdge(classNid, baseNid, "inherits", line);
+            }
+          }
+
+          // Methods defined in the do-block attach to the synthesized class.
+          const block = right.children.find((c) => c.type === "do_block" || c.type === "block");
+          if (block) {
+            const blockBody = block.children.find((c) => c.type === "body_statement") ?? block;
+            for (const child of blockBody.children) {
+              walk(child, classNid);
+            }
+          }
+          return;
+        }
+      }
     }
 
     // PHP 8 constructor property promotion: `__construct(private Repo $repo)`

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1038,6 +1038,29 @@ function _scalaCollectTypeRefs(
 }
 
 /**
+ * Return the head identifier text from a Kotlin `user_type` node (without
+ * generics). Port of upstream safishamsi `_kotlin_user_type_name`.
+ */
+function _kotlinUserTypeName(userTypeNode: SyntaxNode | null, source: string): string | null {
+  if (userTypeNode === null) return null;
+  for (const c of userTypeNode.children) {
+    if (c.type === "type_identifier" || c.type === "identifier") {
+      const text = _readText(c, source);
+      return text || null;
+    }
+    if (c.type === "simple_user_type") {
+      for (const sub of c.children) {
+        if (sub.type === "identifier" || sub.type === "type_identifier") {
+          const text = _readText(sub, source);
+          return text || null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Walk a Swift type expression; append `[name, role]` tuples. Unwraps
  * `type_annotation` / optional / array / dictionary / tuple wrappers and reads
  * the `type_identifier` head + `type_arguments` of a `user_type`. Port of
@@ -2593,6 +2616,67 @@ async function _extractGeneric(
                 addEdge(classNid, baseNid, "inherits", line);
               }
             }
+          }
+        }
+      }
+
+      // Kotlin-specific: delegation_specifiers → inherits
+      // (constructor_invocation) / implements (user_type), including the
+      // `class Foo : Bar by baz` form which wraps the delegated interface in
+      // an `explicit_delegation` node. Port of upstream safishamsi kotlin
+      // delegation handling + 9b04022 (by-delegation branch). Generic-arg
+      // reference recovery is deferred with the kotlin type-refs collector
+      // (Lot 2 kotlin slice not yet ported).
+      if (config.tsModule === "tree_sitter_kotlin") {
+        for (const child of node.children) {
+          if (child.type !== "delegation_specifiers") continue;
+          for (const spec of child.children) {
+            if (spec.type !== "delegation_specifier") continue;
+            let relation = "implements";
+            let userTypeNode: SyntaxNode | null = null;
+            for (const sub of spec.children) {
+              if (sub.type === "constructor_invocation") {
+                relation = "inherits";
+                for (const inner of sub.children) {
+                  if (inner.type === "user_type") {
+                    userTypeNode = inner;
+                    break;
+                  }
+                }
+                break;
+              }
+              if (sub.type === "user_type") {
+                userTypeNode = sub;
+                break;
+              }
+              // `class Foo : Bar by baz` wraps the delegated interface `Bar`
+              // in an `explicit_delegation` node; grab its first `user_type`
+              // descendant so the implements edge still fires (9b04022).
+              if (sub.type === "explicit_delegation") {
+                for (const inner of sub.children) {
+                  if (inner.type === "user_type") {
+                    userTypeNode = inner;
+                    break;
+                  }
+                }
+                break;
+              }
+            }
+            if (!userTypeNode) continue;
+            const base = _kotlinUserTypeName(userTypeNode, source);
+            if (!base) continue;
+            let baseNid = _makeId(stem, base);
+            if (!seenIds.has(baseNid)) {
+              baseNid = _makeId(base);
+              if (!seenIds.has(baseNid)) {
+                nodes.push({
+                  id: baseNid, label: base, file_type: "code",
+                  source_file: "", source_location: "",
+                });
+                seenIds.add(baseNid);
+              }
+            }
+            addEdge(classNid, baseNid, relation, line);
           }
         }
       }
@@ -6868,4 +6952,6 @@ export const __testing = {
   getExtractor: (filePath: string): ExtractorFn | undefined => _getExtractor(filePath),
   /** Cache-write gate for extraction results (upstream 1288a55 / #1666). */
   shouldCacheExtraction: _shouldCacheExtraction,
+  /** Kotlin user_type head-name reader (upstream _kotlin_user_type_name). */
+  kotlinUserTypeName: _kotlinUserTypeName,
 };

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -6632,10 +6632,20 @@ export interface ExtractWithDiagnosticsResult {
   diagnostics: ExtractionDiagnostic[];
 }
 
+/**
+ * Whether a non-error extraction result is safe to cache: every extractable
+ * file yields at least a file node, so a zero-node result is anomalous and
+ * must not be persisted (upstream 1288a55 / #1666).
+ */
+function _shouldCacheExtraction(result: ExtractionResult): boolean {
+  return !result.error && (result.nodes?.length ?? 0) > 0;
+}
+
 export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWithDiagnosticsResult> {
   const normalizedPaths = paths.map((filePath) => resolve(filePath));
   const perFile: ExtractionResult[] = [];
   const diagnostics: ExtractionDiagnostic[] = [];
+  const zeroNodeFiles: string[] = [];
   const root = inferCommonRoot(normalizedPaths);
 
   const total = normalizedPaths.length;
@@ -6669,7 +6679,17 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
       continue;
     }
     if (!result.error) {
-      saveCached(filePath, result as unknown as Record<string, unknown>, root);
+      // Never cache a zero-node result for an extractable file. Every
+      // supported source produces at least a file node, so an empty node list
+      // is anomalous (e.g. a transient hiccup). Caching it makes the empty
+      // byte-stable across runs and silently blinds downstream queries to and
+      // through the file; skipping the write lets a rerun self-heal. Port of
+      // upstream safishamsi 1288a55 (#1666).
+      if (_shouldCacheExtraction(result)) {
+        saveCached(filePath, result as unknown as Record<string, unknown>, root);
+      } else {
+        zeroNodeFiles.push(filePath);
+      }
     } else {
       diagnostics.push({ filePath, error: result.error });
     }
@@ -6678,6 +6698,15 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
 
   if (total >= _PROGRESS_INTERVAL) {
     process.stderr.write(`  AST extraction: ${total}/${total} files (100%)\n`);
+  }
+
+  // Surface previously-silent blindness: an accepted source file that landed
+  // in the graph with zero nodes (port of upstream 1288a55 / #1666).
+  if (zeroNodeFiles.length > 0) {
+    process.stderr.write(
+      `warning: ${zeroNodeFiles.length} source file(s) extracted with zero nodes (not cached, rerun self-heals):\n` +
+      zeroNodeFiles.map((f) => `  - ${f}\n`).join(""),
+    );
   }
 
   let allNodes: GraphNode[] = [];
@@ -6837,4 +6866,6 @@ export const __testing = {
   resolveLuaImportTarget: _resolveLuaImportTarget,
   /** Return the extractor for a given file path (real dispatch: filename, suffix, then shebang). */
   getExtractor: (filePath: string): ExtractorFn | undefined => _getExtractor(filePath),
+  /** Cache-write gate for extraction results (upstream 1288a55 / #1666). */
+  shouldCacheExtraction: _shouldCacheExtraction,
 };

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -6170,7 +6170,7 @@ export async function extractWithDiagnostics(paths: string[]): Promise<ExtractWi
     // `.json` handling. Port of upstream 2c01a89 (dispatched-by-filename).
     const extractor = isMcpConfigPath(filePath)
       ? _extractMcpConfigAsync
-      : basename(filePath).endsWith(".blade.php")
+      : basename(filePath).toLowerCase().endsWith(".blade.php")
         ? extractRegexBackedCode
         : _DISPATCH[ext];
     if (!extractor) continue;
@@ -6335,7 +6335,12 @@ export function collectFiles(target: string, options?: { followSymlinks?: boolea
         // is intentionally skipped here (the `entry.startsWith(".")` guard
         // above), consistent with graphify's hidden-file policy — it is still
         // extracted when passed as an explicit single-file target.
-        if (_EXTENSIONS.has(ext) || _MCP_CONFIG_FILENAMES.has(entry)) {
+        // Case-insensitive suffix fallback (raw match first so exact entries
+        // like `.R`/`.F90` are untouched): the extractor dispatch lowercases
+        // its extension, but this filter compared the raw suffix — so
+        // capitalized/mixed-case extensions (`.PY`, `.Ts`) were silently
+        // skipped at collection time. Port of upstream aa1bbda (#1671).
+        if (_EXTENSIONS.has(ext) || _EXTENSIONS.has(ext.toLowerCase()) || _MCP_CONFIG_FILENAMES.has(entry)) {
           results.push(fullPath);
         }
       }
@@ -6353,5 +6358,5 @@ export function collectFiles(target: string, options?: { followSymlinks?: boolea
 export const __testing = {
   resolveLuaImportTarget: _resolveLuaImportTarget,
   /** Return the dispatch-table extractor function for a given file path (by extension). */
-  getExtractor: (filePath: string): ExtractorFn | undefined => _DISPATCH[extname(filePath)],
+  getExtractor: (filePath: string): ExtractorFn | undefined => _DISPATCH[extname(filePath).toLowerCase()],
 };

--- a/src/search.ts
+++ b/src/search.ts
@@ -46,6 +46,42 @@ export function queryTerms(question: string): string[] {
   return out;
 }
 
+/**
+ * English question/filler words dropped from QUERY terms so content words
+ * drive BFS seeding. Without this, "how does the frontier cache work" seeds
+ * on "how"/"the"/"work" (which prefix-match prose labels like "Working
+ * Principles") instead of "frontier"/"cache", and lands in the wrong part of
+ * the graph. Port of upstream safishamsi 6e97088.
+ *
+ * IMPORTANT: applied to query terms only, never to node/index text — the
+ * BM25 index side (`src/retrieval/bm25.ts` tokenizeField) keeps calling the
+ * unfiltered `queryTerms`, so a symbol literally named `work` stays findable.
+ * `work`/`works`/`working` are included because "how does X work" is the most
+ * common question phrasing. Tokens of length <= 2 ("is", "be", …) are already
+ * dropped by `queryTerms`' short-English filter but stay listed for parity
+ * with the upstream set (harmless).
+ */
+export const QUERY_STOPWORDS: ReadonlySet<string> = new Set([
+  "how", "what", "why", "when", "where", "which", "who", "whom", "whose",
+  "does", "did", "is", "are", "was", "were", "be", "been", "being",
+  "can", "could", "should", "would", "will", "shall", "may", "might", "must",
+  "has", "have", "had", "the", "and", "but", "not", "for", "from", "with",
+  "without", "into", "onto", "off", "that", "this", "these", "those", "there",
+  "here", "its", "their", "them", "they", "about", "any", "all", "some",
+  "work", "works", "working",
+]);
+
+/**
+ * Drop question/filler stopwords from already-tokenized QUERY terms, falling
+ * back to the unfiltered terms when the query is all stopwords ("how does it
+ * work" still seeds on something). Port of upstream 6e97088; see
+ * `QUERY_STOPWORDS` for scope (query side only).
+ */
+export function dropQueryStopwords(terms: string[]): string[] {
+  const content = terms.filter((term) => !QUERY_STOPWORDS.has(term));
+  return content.length > 0 ? content : terms;
+}
+
 export function textMatchesQuery(text: string, query: string): boolean {
   const normalizedText = normalizeSearchText(text);
   const terms = normalizeSearchText(query).split(/\s+/).filter(Boolean);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -16,7 +16,7 @@ import {
 import { resolveGraphInputPath } from "./paths.js";
 import { validateGraphPath, sanitizeLabel } from "./security.js";
 import { assertGraphJsonFileSize } from "./graph-size-guard.js";
-import { normalizeSearchText, queryTerms, scoreSearchText, textMatchesQuery } from "./search.js";
+import { dropQueryStopwords, normalizeSearchText, queryTerms, scoreSearchText, textMatchesQuery } from "./search.js";
 import {
   godNodes as computeGodNodes,
   surprisingConnections,
@@ -342,7 +342,9 @@ function toolQueryGraph(G: Graph, args: Record<string, unknown>): string {
   // Track F F-0816-P2 row 12 (port safishamsi 020cca2 / #964):
   // queryTerms() centralises the "filter short English noise only" rule
   // so two-character non-English query tokens (e.g. 前端) remain searchable.
-  const terms = queryTerms(question).map(normalizeSearchText);
+  // Question/filler stopwords are then dropped (query side only) so content
+  // words drive seeding — port of upstream 6e97088.
+  const terms = dropQueryStopwords(queryTerms(question).map(normalizeSearchText));
 
   const scored = scoreNodes(G, terms);
   const startNodes = scored.slice(0, 3).map(([, nid]) => nid);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -237,6 +237,44 @@ function scoreNodes(G: Graph, terms: string[]): Array<[number, string]> {
   return scored;
 }
 
+/**
+ * Select BFS seed nodes: the global top-`maxK` scored candidates plus at
+ * least one seed per distinct query term that has any match at all.
+ *
+ * Taking only the global top slice has a failure mode on multi-term
+ * natural-language queries: one term's incidental high-scoring label match
+ * (e.g. a common word also used as an unrelated identifier) can occupy every
+ * top slot, so the traversal only ever explores the neighborhood of that one
+ * unrelated match and the query's other, actually-relevant terms are starved
+ * out. Guaranteeing one seed per matched term prevents that; ties within a
+ * term are broken by node degree (structural centrality), so an isolated
+ * incidental match doesn't out-rank a real, well-connected hub for that
+ * term. Port of upstream safishamsi d56ee83 (#1445).
+ *
+ * Exported for the CLI `query` command and tests.
+ */
+export function pickSeeds(
+  G: Graph,
+  scored: Array<[number, string]>,
+  terms: string[],
+  maxK: number = 3,
+): string[] {
+  const seeds = scored.slice(0, maxK).map(([, nid]) => nid);
+  if (seeds.length === 0 || terms.length === 0) return seeds;
+  const normTerms = [...new Set(terms)].sort();
+  for (const term of normTerms) {
+    const termScored = scoreNodes(G, [term]);
+    if (termScored.length === 0) continue;
+    const bestScore = termScored[0]![0];
+    const tied = termScored.filter(([score]) => score === bestScore).map(([, nid]) => nid);
+    const bestNid = tied.length > 1
+      ? tied.reduce((a, b) => (G.degree(b) > G.degree(a) ? b : a))
+      : termScored[0]![1];
+    if (!seeds.includes(bestNid)) seeds.push(bestNid);
+  }
+  return seeds;
+}
+
 function bfs(
   G: Graph,
   startNodes: string[],
@@ -347,7 +385,9 @@ function toolQueryGraph(G: Graph, args: Record<string, unknown>): string {
   const terms = dropQueryStopwords(queryTerms(question).map(normalizeSearchText));
 
   const scored = scoreNodes(G, terms);
-  const startNodes = scored.slice(0, 3).map(([, nid]) => nid);
+  // Per-term seed diversity: one term's incidental top match cannot starve
+  // the other terms' seeds — port of upstream d56ee83 (#1445).
+  const startNodes = pickSeeds(G, scored, terms);
   if (startNodes.length === 0) return "No matching nodes found.";
 
   const { visited, edges } =

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import Graph from "graphology";
 import { bidirectional } from "graphology-shortest-path/unweighted.js";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import pkg from "../package.json";
 import {
   forEachTraversalNeighbor,
@@ -165,16 +165,14 @@ function loadGraphSnapshot(safePath: string): GraphSnapshot {
   };
 }
 
-function createReloadingGraphStore(graphPath: string): ReloadingGraphStore {
-  const safePath = validateGraphFilePath(graphPath);
-  let snapshot: GraphSnapshot;
-  try {
-    snapshot = loadGraphSnapshot(safePath);
-  } catch (err) {
-    console.error(`error: ${err instanceof Error ? err.message : err}`);
-    process.exit(1);
-  }
-
+/**
+ * Build a hot-reloading store for an already-validated graph path. Throws on
+ * a missing/corrupt graph instead of exiting — required for per-call
+ * project_path routing where a bad project graph must surface as a tool
+ * error, not a process exit (upstream 9e7fbcb `_load_ctx`).
+ */
+function createGraphStoreAt(safePath: string): ReloadingGraphStore {
+  let snapshot = loadGraphSnapshot(safePath);
   return {
     graphPath: safePath,
     get(): GraphSnapshot {
@@ -185,6 +183,16 @@ function createReloadingGraphStore(graphPath: string): ReloadingGraphStore {
       return snapshot;
     },
   };
+}
+
+function createReloadingGraphStore(graphPath: string): ReloadingGraphStore {
+  const safePath = validateGraphFilePath(graphPath);
+  try {
+    return createGraphStoreAt(safePath);
+  } catch (err) {
+    console.error(`error: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
 }
 
 function getVersion(): string {
@@ -836,6 +844,33 @@ export async function serve(
   }
 
   const graphStore = createReloadingGraphStore(graphPath);
+
+  // Multi-project routing (upstream 9e7fbcb): per-graph store cache keyed by
+  // resolved graph path, unified across the default graph and every
+  // project_path graph. Graphs load lazily; each store keeps its own
+  // mtime+size hot-reload. A missing/corrupt project graph is a tool error
+  // (thrown here, caught by the CallTool handler), never a process exit.
+  const projectStores = new Map<string, ReloadingGraphStore>([[graphStore.graphPath, graphStore]]);
+  const selectStore = (args: Record<string, unknown>): ReloadingGraphStore => {
+    const projectPath = args.project_path;
+    if (projectPath === undefined || projectPath === null || projectPath === "") {
+      return graphStore;
+    }
+    if (typeof projectPath !== "string") {
+      throw new Error("project_path must be a string (absolute project root path)");
+    }
+    if (!isAbsolute(projectPath)) {
+      throw new Error(`project_path must be an absolute path, got: ${projectPath}`);
+    }
+    const candidate = resolveGraphInputPath(undefined, projectPath);
+    const safePath = validateGraphPath(candidate, dirname(resolve(candidate)));
+    const existing = projectStores.get(safePath);
+    if (existing) return existing;
+    const store = createGraphStoreAt(safePath);
+    projectStores.set(safePath, store);
+    return store;
+  };
+
   const ontologyWrite = options.ontology?.write === true;
   if (ontologyWrite && !options.ontology?.profileStatePath) {
     throw new Error("ontology write mode requires profileStatePath");
@@ -1161,6 +1196,23 @@ export async function serve(
     );
   }
 
+  // Inject the optional multi-project routing field on every tool (upstream
+  // 9e7fbcb): omitted -> the server's default graph (fully backward
+  // compatible); an absolute project_path -> that project's graph.json.
+  // Ontology tools accept the field for schema uniformity but their handlers
+  // are bound to the server's profile state and ignore it.
+  for (const tool of tools) {
+    const schema = tool.inputSchema as { properties?: Record<string, unknown> };
+    schema.properties = {
+      ...(schema.properties ?? {}),
+      project_path: {
+        type: "string",
+        description:
+          "Optional absolute path to another graphify project root; routes this call to that project's graph.json. Omit to use the server's default graph.",
+      },
+    };
+  }
+
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
     resources: MCP_RESOURCES,
@@ -1181,43 +1233,46 @@ export async function serve(
     };
   });
 
+  // Graph-backed handlers take the per-call store (selected from the optional
+  // project_path, upstream 9e7fbcb); ontology handlers are bound to the
+  // server's profile state and ignore routing.
   const handlers: Record<
     string,
-    (args: Record<string, unknown>) => string
+    (store: ReloadingGraphStore, args: Record<string, unknown>) => string
   > = {
-    first_hop_summary: () => toolFirstHopSummary(graphStore.get().graph),
-    review_delta: (a) => toolReviewDelta(graphStore.get().graph, a),
-    review_analysis: (a) => toolReviewAnalysis(graphStore.get().graph, a),
-    recommend_commits: (a) => toolRecommendCommits(graphStore.get().graph, a),
-    query_graph: (a) => toolQueryGraph(graphStore.get().graph, a),
-    answer_graph: (a) => toolAnswerGraph(graphStore.get().graph, a),
-    get_node: (a) => toolGetNode(graphStore.get().graph, a),
-    get_neighbors: (a) => toolGetNeighbors(graphStore.get().graph, a),
-    get_community: (a) => {
-      const { graph, communities } = graphStore.get();
+    first_hop_summary: (s) => toolFirstHopSummary(s.get().graph),
+    review_delta: (s, a) => toolReviewDelta(s.get().graph, a),
+    review_analysis: (s, a) => toolReviewAnalysis(s.get().graph, a),
+    recommend_commits: (s, a) => toolRecommendCommits(s.get().graph, a),
+    query_graph: (s, a) => toolQueryGraph(s.get().graph, a),
+    answer_graph: (s, a) => toolAnswerGraph(s.get().graph, a),
+    get_node: (s, a) => toolGetNode(s.get().graph, a),
+    get_neighbors: (s, a) => toolGetNeighbors(s.get().graph, a),
+    get_community: (s, a) => {
+      const { graph, communities } = s.get();
       return toolGetCommunity(communities, graph, a);
     },
-    god_nodes: (a) => toolGodNodes(graphStore.get().graph, a),
-    graph_stats: () => {
-      const { graph, communities } = graphStore.get();
+    god_nodes: (s, a) => toolGodNodes(s.get().graph, a),
+    graph_stats: (s) => {
+      const { graph, communities } = s.get();
       return toolGraphStats(graph, communities);
     },
-    shortest_path: (a) => toolShortestPath(graphStore.get().graph, a),
+    shortest_path: (s, a) => toolShortestPath(s.get().graph, a),
   };
   if (ontologyPatchContext) {
-    handlers.list_reconciliation_candidates = (a) =>
+    handlers.list_reconciliation_candidates = (_s, a) =>
       toolListReconciliationCandidates(ontologyPatchContext, a);
-    handlers.get_reconciliation_candidate = (a) =>
+    handlers.get_reconciliation_candidate = (_s, a) =>
       toolGetReconciliationCandidate(ontologyPatchContext, a);
-    handlers.preview_ontology_decision_log = (a) =>
+    handlers.preview_ontology_decision_log = (_s, a) =>
       toolPreviewOntologyDecisionLog(ontologyPatchContext, a);
     handlers.ontology_rebuild_status = () =>
       toolOntologyRebuildStatus(ontologyPatchContext);
   }
   if (ontologyPatchContext && ontologyWrite) {
-    handlers.validate_ontology_patch = (a) =>
+    handlers.validate_ontology_patch = (_s, a) =>
       JSON.stringify(validateOntologyPatch(a.patch, ontologyPatchContext), null, 2);
-    handlers.apply_ontology_patch = (a) =>
+    handlers.apply_ontology_patch = (_s, a) =>
       JSON.stringify(
         applyOntologyPatch(a.patch, ontologyPatchContext, {
           dryRun: a.write === true ? false : true,
@@ -1235,7 +1290,12 @@ export async function serve(
       return { content: [{ type: "text" as const, text: `Unknown tool: ${name}` }] };
     }
     try {
-      const text = handler((args ?? {}) as Record<string, unknown>);
+      const rawArgs = (args ?? {}) as Record<string, unknown>;
+      // Route to the requested project graph (or the default); strip the
+      // routing field so tool handlers never see it.
+      const store = selectStore(rawArgs);
+      const { project_path: _projectPath, ...toolArgs } = rawArgs;
+      const text = handler(store, toolArgs);
       return { content: [{ type: "text" as const, text }] };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/skills/skill-windows.md
+++ b/src/skills/skill-windows.md
@@ -1,5 +1,5 @@
 ---
-name: graphify-windows
+name: graphify
 description: "any input (code, docs, papers, images) -> knowledge graph -> clustered communities -> static Ontology Studio + JSON + audit report. Use when user asks any question about a codebase, project content, architecture, or file relationships, especially if .graphify/ exists. Provides persistent graph with god nodes, community detection, and BFS/DFS query tools."
 trigger: /graphify
 ---

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,9 @@ export interface GitDetectionWindow {
 export interface GraphNode {
   id: string;
   label: string;
-  file_type: "code" | "document" | "paper" | "image" | "concept" | "rationale";
+  // "doc_ref": architecture-decision references (ADR-NNNN / RFC NNNN) cited
+  // from code comments — port of upstream safishamsi 6d3a6f1.
+  file_type: "code" | "document" | "paper" | "image" | "concept" | "rationale" | "doc_ref";
   source_file: string;
   source_location?: string;
   confidence?: Confidence;

--- a/tests/extract-cache-zero-node.test.ts
+++ b/tests/extract-cache-zero-node.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Zero-node results are never cached — port of upstream safishamsi 1288a55
+ * (#1666). Every extractable file yields at least a file node, so an empty
+ * node list is anomalous (a transient hiccup); caching it makes the empty
+ * byte-stable across runs and silently blinds downstream queries. The cache
+ * write is skipped so a rerun self-heals.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../src/cache.js", () => ({
+  loadCached: vi.fn(() => null),
+  saveCached: vi.fn(),
+}));
+
+import { extractWithDiagnostics, __testing } from "../src/extract.js";
+import { saveCached } from "../src/cache.js";
+
+describe("zero-node cache guard (upstream 1288a55 / #1666)", () => {
+  beforeEach(() => {
+    vi.mocked(saveCached).mockClear();
+  });
+
+  it("shouldCacheExtraction rejects zero-node and error results, accepts real ones", () => {
+    const { shouldCacheExtraction } = __testing;
+    expect(shouldCacheExtraction({ nodes: [], edges: [] })).toBe(false);
+    expect(shouldCacheExtraction({ nodes: [], edges: [], error: "boom" })).toBe(false);
+    expect(
+      shouldCacheExtraction({
+        nodes: [{ id: "f", label: "f.py", file_type: "code", source_file: "f.py" }],
+        edges: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("caches a normal extraction (node-producing) through the gate", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-cache-guard-"));
+    const file = join(dir, "mod.py");
+    writeFileSync(file, "def run():\n    return 1\n");
+
+    const { extraction } = await extractWithDiagnostics([file]);
+    expect(extraction.nodes.length).toBeGreaterThan(0);
+    // The cache write happened for the node-producing result.
+    expect(vi.mocked(saveCached)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(saveCached).mock.calls[0]![0]).toBe(file);
+  });
+});

--- a/tests/extract-dispatch-parity.test.ts
+++ b/tests/extract-dispatch-parity.test.ts
@@ -1,0 +1,98 @@
+// Lot: dispatch/collect parity — upstream 2ab0867 (shebang routing for
+// extensionless executables) and 1226c34 (.mts/.cts TypeScript variants).
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { extract, extractJs, extractPython, __testing } from "../src/extract.js";
+import { CODE_EXTENSIONS } from "../src/detect.js";
+
+describe("shebang routing for extensionless executables (upstream 2ab0867)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "graphify-shebang-dispatch-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("routes a python3 shebang to the python extractor", () => {
+    const file = join(dir, "devctl");
+    writeFileSync(file, "#!/usr/bin/env python3\ndef main():\n    pass\n");
+    chmodSync(file, 0o755);
+    expect(__testing.getExtractor(file)).toBe(extractPython);
+  });
+
+  it("routes a node shebang to the JS extractor", () => {
+    const file = join(dir, "cli");
+    writeFileSync(file, "#!/usr/bin/env node\nfunction main() {}\n");
+    expect(__testing.getExtractor(file)).toBe(extractJs);
+  });
+
+  it("leaves unmapped interpreters (perl) and shebang-less files unrouted", () => {
+    const perl = join(dir, "legacy");
+    writeFileSync(perl, "#!/usr/bin/env perl\nprint 1;\n");
+    expect(__testing.getExtractor(perl)).toBeUndefined();
+
+    const plain = join(dir, "README");
+    writeFileSync(plain, "just text\n");
+    expect(__testing.getExtractor(plain)).toBeUndefined();
+  });
+
+  it("extracts an extensionless python CLI end-to-end", async () => {
+    const file = join(dir, "manage");
+    writeFileSync(file, "#!/usr/bin/env python3\ndef run_task():\n    return 1\n");
+    chmodSync(file, 0o755);
+
+    const extraction = await extract([file]);
+    expect(extraction.nodes.map((n) => n.label)).toContain("run_task()");
+  });
+});
+
+describe(".mts/.cts TypeScript module extensions (upstream 1226c34)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "graphify-mts-cts-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("classifies .mts/.cts as code extensions", () => {
+    expect(CODE_EXTENSIONS.has(".mts")).toBe(true);
+    expect(CODE_EXTENSIONS.has(".cts")).toBe(true);
+  });
+
+  it("dispatches .mts/.cts to the JS/TS extractor", () => {
+    expect(__testing.getExtractor("mod.mts")).toBe(extractJs);
+    expect(__testing.getExtractor("mod.cts")).toBe(extractJs);
+  });
+
+  const SOURCE = [
+    "export type WidgetId = string;",
+    "export interface Widget { id: WidgetId; }",
+    "export function makeWidget(): Widget { return { id: \"w\" }; }",
+    "",
+  ].join("\n");
+
+  it("parses .mts and .cts with the TS grammar (type/interface preserved)", async () => {
+    writeFileSync(join(dir, "mod.ts"), SOURCE);
+    writeFileSync(join(dir, "mod2.mts"), SOURCE);
+    writeFileSync(join(dir, "mod3.cts"), SOURCE);
+
+    const labelsFor = async (name: string): Promise<string[]> => {
+      const extraction = await extract([join(dir, name)]);
+      return extraction.nodes.map((n) => n.label).filter((l) => l !== name).sort();
+    };
+
+    const tsLabels = await labelsFor("mod.ts");
+    expect(tsLabels.length).toBeGreaterThan(0);
+    expect(await labelsFor("mod2.mts")).toEqual(tsLabels);
+    expect(await labelsFor("mod3.cts")).toEqual(tsLabels);
+  });
+});

--- a/tests/extract-js-rationale.test.ts
+++ b/tests/extract-js-rationale.test.ts
@@ -1,0 +1,97 @@
+/**
+ * JS/TS rationale comments + ADR/RFC doc references — port of upstream
+ * safishamsi 6d3a6f1. Parity with the Python rationale pass: JS/TS comments
+ * were previously discarded entirely, so `// NOTE:`-style rationale and
+ * ADR/RFC citations never joined the graph.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractJs, type ExtractionResult } from "../src/extract.js";
+
+function rationaleNodes(result: ExtractionResult) {
+  return result.nodes.filter((n) => n.file_type === "rationale");
+}
+
+function docRefNodes(result: ExtractionResult) {
+  return result.nodes.filter((n) => n.file_type === "doc_ref");
+}
+
+describe("JS/TS rationale + doc references (upstream 6d3a6f1)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-js-rationale-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("extracts a line rationale comment with a rationale_for edge to the file node", async () => {
+    const file = join(dir, "build.ts");
+    writeFileSync(file, [
+      "// NOTE: must run before compile() or the linker will fail",
+      "export function build(): void {}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const rationale = rationaleNodes(result);
+    expect(rationale.some((n) => n.label.includes("NOTE"))).toBe(true);
+    const edge = result.edges.find((e) => e.relation === "rationale_for");
+    expect(edge).toBeDefined();
+    // The edge target is the real file node emitted by the extractor.
+    expect(result.nodes.some((n) => n.id === edge!.target && n.label === "build.ts")).toBe(true);
+  });
+
+  it("extracts block-comment rationale variants (* WHY:)", async () => {
+    const file = join(dir, "fetch.ts");
+    writeFileSync(file, [
+      "/**",
+      " * WHY: retries are capped because the upstream rate-limits at 10 rps.",
+      " */",
+      "export function fetchData(): void {}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(rationaleNodes(result).some((n) => n.label.includes("rate-limits"))).toBe(true);
+  });
+
+  it("first-classes ADR references with cites edges", async () => {
+    const file = join(dir, "route.ts");
+    writeFileSync(file, [
+      "// Gateway pattern per ADR-0002; provider selection per ADR-0015.",
+      "export function route(): void {}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    const labels = docRefNodes(result).map((n) => n.label);
+    expect(labels).toContain("ADR-0002");
+    expect(labels).toContain("ADR-0015");
+    expect(result.edges.filter((e) => e.relation === "cites")).toHaveLength(2);
+  });
+
+  it("normalizes and dedupes ADR spellings to one node", async () => {
+    const file = join(dir, "guard.ts");
+    writeFileSync(file, [
+      "// See ADR-11 for the trust boundary.",
+      "// ADR 0011 also governs the injection containment below.",
+      "export function guard(): void {}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(docRefNodes(result).map((n) => n.label)).toEqual(["ADR-0011"]);
+    expect(result.edges.filter((e) => e.relation === "cites")).toHaveLength(1);
+  });
+
+  it("keeps RFC numbers unpadded and ignores ADRs in string literals", async () => {
+    const file = join(dir, "tcp.ts");
+    writeFileSync(file, [
+      "// Sequence numbers follow RFC 793.",
+      "const msg = 'see ADR-0099 for details';",
+      "export function connect(): void { return void msg; }",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    const labels = docRefNodes(result).map((n) => n.label);
+    expect(labels).toContain("RFC-793");
+    // Non-comment lines never contribute doc refs.
+    expect(labels).not.toContain("ADR-0099");
+  });
+});

--- a/tests/extract-kotlin-delegation.test.ts
+++ b/tests/extract-kotlin-delegation.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Kotlin delegation_specifiers → inherits/implements edges, including
+ * interface delegation (`class Foo : Bar by baz`) — port of upstream
+ * safishamsi kotlin delegation handling + 9b04022 (explicit_delegation).
+ *
+ * tree-sitter-kotlin ships no prebuilt WASM in this repo, so the integration
+ * tests soft-skip locally and assert in CI (same pattern as
+ * tests/extract-swift-extensions.test.ts / the Lot-1a PowerShell/ObjC ports).
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractKotlin, __testing, type ExtractionResult } from "../src/extract.js";
+
+function grammarAvailable(result: ExtractionResult): boolean {
+  return !result.error && result.nodes.length > 0;
+}
+
+/** Minimal SyntaxNode stand-in for the pure-text helper below. */
+function fakeNode(type: string, start: number, end: number, children: unknown[] = []): unknown {
+  return { type, startIndex: start, endIndex: end, children };
+}
+
+describe("_kotlinUserTypeName (locally-asserted unit, grammar-independent)", () => {
+  it("reads the head identifier from type_identifier / simple_user_type shapes", () => {
+    const source = "MutableList<T>";
+    // user_type -> type_identifier("MutableList")
+    const direct = fakeNode("user_type", 0, 14, [fakeNode("type_identifier", 0, 11)]);
+    // user_type -> simple_user_type -> identifier("MutableList")
+    const nested = fakeNode("user_type", 0, 14, [
+      fakeNode("simple_user_type", 0, 11, [fakeNode("identifier", 0, 11)]),
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const read = (n: unknown) => __testing.kotlinUserTypeName(n as any, source);
+    expect(read(direct)).toBe("MutableList");
+    expect(read(nested)).toBe("MutableList");
+    expect(read(fakeNode("user_type", 0, 0, []))).toBeNull();
+  });
+});
+
+function edgeLabels(result: ExtractionResult, relation: string): Array<[string, string]> {
+  const labelById = new Map(result.nodes.map((n) => [n.id, n.label]));
+  return result.edges
+    .filter((e) => e.relation === relation)
+    .map((e) => [labelById.get(e.source) ?? e.source, labelById.get(e.target) ?? e.target]);
+}
+
+describe("Kotlin delegation specifiers (upstream 9b04022 + base handling)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-kotlin-delegation-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("splits inherits (constructor_invocation) and implements (user_type)", async () => {
+    const file = join(dir, "processor.kt");
+    writeFileSync(file, [
+      "open class BaseProcessor {}",
+      "interface Loggable { fun log() }",
+      "class DataProcessor : BaseProcessor(), Loggable {",
+      "    override fun log() {}",
+      "}",
+    ].join("\n"));
+
+    const result = await extractKotlin(file);
+    if (!grammarAvailable(result)) return; // grammar absent locally — asserts in CI
+
+    expect(edgeLabels(result, "inherits")).toContainEqual(["DataProcessor", "BaseProcessor"]);
+    expect(edgeLabels(result, "implements")).toContainEqual(["DataProcessor", "Loggable"]);
+  });
+
+  it("emits implements for interface delegation (`by`) — upstream 9b04022", async () => {
+    const file = join(dir, "logging.kt");
+    writeFileSync(file, [
+      "class LoggingList<T>(inner: MutableList<T>) : MutableList<T> by inner",
+    ].join("\n"));
+
+    const result = await extractKotlin(file);
+    if (!grammarAvailable(result)) return; // grammar absent locally — asserts in CI
+
+    expect(edgeLabels(result, "implements")).toContainEqual(["LoggingList", "MutableList"]);
+  });
+});

--- a/tests/extract-phantom-external-import.test.ts
+++ b/tests/extract-phantom-external-import.test.ts
@@ -1,0 +1,98 @@
+// Upstream e2ef4ef (#1638) — an unresolved bare npm import must not alias onto
+// an unrelated same-named local file, producing a confident cross-language
+// phantom edge.
+//
+// `import colors from "tailwindcss/colors"` in a .tsx file used to emit an
+// `imports_from` edge to the bare id `colors`, which could collide with any
+// unrelated local file/symbol of that stem. The fix namespaces the
+// external-import fallback id with the `ref` prefix, so it can never collapse
+// to a local node id; the ref target has no node, so build drops it as an
+// external reference.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { extract } from "../src/extract.js";
+import { buildFromJson } from "../src/build.js";
+
+describe("phantom external import (upstream e2ef4ef #1638)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "graphify-phantom-import-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(relative: string, text: string): string {
+    const path = join(dir, relative);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, text);
+    return path;
+  }
+
+  it("namespaces an unresolved bare npm import with the ref prefix", async () => {
+    const tsx = write(
+      "frontend/src/SomeChart.tsx",
+      'import colors from "tailwindcss/colors";\n\nexport const CHART_COLOR = colors;\n',
+    );
+
+    const extraction = await extract([tsx]);
+    const importEdges = extraction.edges.filter((e) => e.relation === "imports_from");
+    expect(importEdges.length).toBeGreaterThan(0);
+    for (const edge of importEdges) {
+      // Must not be the bare last-segment id that collides with a local
+      // `colors` file/symbol node.
+      expect(edge.target).not.toBe("colors");
+      expect(edge.target.startsWith("ref_")).toBe(true);
+    }
+  });
+
+  it("namespaces an unresolved scoped package import with the ref prefix", async () => {
+    const ts = write("src/thing.ts", 'import { util } from "@scope/utils";\n');
+
+    const extraction = await extract([ts]);
+    const importEdges = extraction.edges.filter((e) => e.relation === "imports_from");
+    expect(importEdges.length).toBeGreaterThan(0);
+    for (const edge of importEdges) {
+      expect(edge.target).not.toBe("utils");
+      expect(edge.target.startsWith("ref_")).toBe(true);
+    }
+  });
+
+  it("emits no phantom imports_from edge from a .tsx onto an unrelated same-stem python file", async () => {
+    const py = write(
+      "backend/utils/colors.py",
+      "def hex_to_rgb(value):\n    return (0, 0, 0)\n",
+    );
+    const tsx = write(
+      "frontend/src/SomeChart.tsx",
+      'import colors from "tailwindcss/colors";\n\nexport const CHART_COLOR = colors.blue;\n',
+    );
+
+    const extraction = await extract([py, tsx]);
+    const G = buildFromJson(extraction, { root: dir });
+
+    const pyIds = new Set<string>();
+    G.forEachNode((node, attrs) => {
+      if (String(attrs.source_file ?? "").endsWith("colors.py")) pyIds.add(node);
+    });
+    expect(pyIds.size).toBeGreaterThan(0);
+
+    G.forEachEdge((_edge, attrs, source, target) => {
+      if (attrs.relation !== "imports_from") return;
+      const endpoints = [source, target];
+      if (!endpoints.some((n) => pyIds.has(n))) return;
+      for (const other of endpoints.filter((n) => !pyIds.has(n))) {
+        const sf = String(G.getNodeAttribute(other, "source_file") ?? "");
+        expect(
+          sf.endsWith(".tsx") || sf.endsWith(".ts"),
+          `phantom cross-language imports_from edge onto colors.py: ${source} -> ${target}`,
+        ).toBe(false);
+      }
+    });
+  });
+});

--- a/tests/extract-ruby-containers.test.ts
+++ b/tests/extract-ruby-containers.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Ruby containers + mixins — ports of upstream safishamsi 13e2bdd (#1640
+ * extraction slice) and 6631af7 (#1668 mixes_in slice).
+ *
+ * - `module Foo` becomes a container node (methods attach via `method`).
+ * - `Foo = Struct.new(...) do … end`, `Foo = Class.new(Super)`,
+ *   `Result = Data.define(...)` synthesize a class node named after the
+ *   constant; `Class.new(Super)` also emits `inherits`.
+ * - `include`/`extend`/`prepend <Const>` in a class/module body emits a
+ *   `mixes_in` edge (constant args only; `extend self` is skipped).
+ *
+ * Upstream resolves mixin/receiver targets through its cross-file Ruby
+ * resolver; the TS analog is the sourceless-stub + corpus-rewire pattern
+ * already used by the inherits ports. The #1634 constant-receiver call
+ * resolution and #1669 affected seeding require the (absent) TS member-call
+ * resolver subsystem and are NOT ported here.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractRuby, type ExtractionResult } from "../src/extract.js";
+
+function grammarAvailable(result: ExtractionResult): boolean {
+  return !result.error && result.nodes.length > 0;
+}
+
+function edgeLabels(result: ExtractionResult, relation: string): Array<[string, string]> {
+  const labelById = new Map(result.nodes.map((n) => [n.id, n.label]));
+  return result.edges
+    .filter((e) => e.relation === relation)
+    .map((e) => [labelById.get(e.source) ?? e.source, labelById.get(e.target) ?? e.target]);
+}
+
+describe("Ruby module/factory containers (upstream 13e2bdd / #1640)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-ruby-containers-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits a container node for `module Foo` with attached methods", async () => {
+    const file = join(dir, "tax_calculator.rb");
+    writeFileSync(file, [
+      "module TaxCalculator",
+      "  def self.rate_for(region)",
+      "    0.2",
+      "  end",
+      "end",
+    ].join("\n"));
+
+    const result = await extractRuby(file);
+    if (!grammarAvailable(result)) return; // grammar absent — asserts in CI
+
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("TaxCalculator");
+    expect(labels).toContain(".rate_for()");
+    expect(edgeLabels(result, "method")).toContainEqual(["TaxCalculator", ".rate_for()"]);
+  });
+
+  it("synthesizes a class from Struct.new with block methods attached", async () => {
+    const file = join(dir, "point.rb");
+    writeFileSync(file, [
+      "Point = Struct.new(:x, :y) do",
+      "  def area",
+      "    x * y",
+      "  end",
+      "end",
+    ].join("\n"));
+
+    const result = await extractRuby(file);
+    if (!grammarAvailable(result)) return;
+
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("Point");
+    expect(labels).toContain(".area()");
+    expect(edgeLabels(result, "method")).toContainEqual(["Point", ".area()"]);
+  });
+
+  it("synthesizes Class.new(Super) with an inherits edge, and Data.define", async () => {
+    const file = join(dir, "factories.rb");
+    writeFileSync(file, [
+      "SpecialError = Class.new(StandardError)",
+      "Result = Data.define(:code, :body)",
+      "MAX = 100",
+    ].join("\n"));
+
+    const result = await extractRuby(file);
+    if (!grammarAvailable(result)) return;
+
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("SpecialError");
+    expect(labels).toContain("Result");
+    // Plain constant assignments stay untouched.
+    expect(labels).not.toContain("MAX");
+    expect(edgeLabels(result, "inherits")).toContainEqual(["SpecialError", "StandardError"]);
+  });
+});
+
+describe("Ruby mixes_in edges (upstream 6631af7 / #1668)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-ruby-mixins-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits mixes_in for include/extend/prepend with constant args", async () => {
+    const file = join(dir, "payment.rb");
+    writeFileSync(file, [
+      "module Taxable",
+      "end",
+      "class Payment",
+      "  include Taxable",
+      "  extend Billing::Helpers",
+      "  prepend Auditable",
+      "  def process",
+      "  end",
+      "end",
+    ].join("\n"));
+
+    const result = await extractRuby(file);
+    if (!grammarAvailable(result)) return;
+
+    const mixes = edgeLabels(result, "mixes_in");
+    expect(mixes).toContainEqual(["Payment", "Taxable"]);
+    // Namespaced constant resolves by its bare tail name.
+    expect(mixes).toContainEqual(["Payment", "Helpers"]);
+    expect(mixes).toContainEqual(["Payment", "Auditable"]);
+    // Mixins are never mislabeled as calls.
+    const calls = edgeLabels(result, "calls");
+    expect(calls.some(([, tgt]) => tgt === "Taxable")).toBe(false);
+  });
+
+  it("skips `extend self` and non-constant arguments", async () => {
+    const file = join(dir, "util.rb");
+    writeFileSync(file, [
+      "module Util",
+      "  extend self",
+      "  include some_dynamic_module",
+      "  def helper",
+      "  end",
+      "end",
+    ].join("\n"));
+
+    const result = await extractRuby(file);
+    if (!grammarAvailable(result)) return;
+
+    expect(edgeLabels(result, "mixes_in")).toEqual([]);
+  });
+});

--- a/tests/extract-ts-decorators.test.ts
+++ b/tests/extract-ts-decorators.test.ts
@@ -1,0 +1,96 @@
+/**
+ * TypeScript/JavaScript decorator references — port of upstream safishamsi
+ * 3540416. `@Component`, `@Injectable`, `@Input`, `@Inject`, `@Entity`, …
+ * previously produced no edge: the `decorator` node kind was never walked.
+ * Decorators are framework-critical (Angular, NestJS, TypeORM): they are the
+ * primary signal of what a class is and does.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractJs, type ExtractionResult } from "../src/extract.js";
+import type { GraphEdge } from "../src/types.js";
+
+/** Collect decorator `references` edges as { sourceLabel, targetLabel }. */
+function decoratorRefs(result: ExtractionResult): Array<{ source: string; target: string }> {
+  const labelById = new Map(result.nodes.map((n) => [n.id, n.label]));
+  return result.edges
+    .filter((e: GraphEdge) => e.relation === "references" && e.context === "decorator")
+    .map((e) => ({
+      source: labelById.get(e.source) ?? e.source,
+      target: labelById.get(e.target) ?? e.target,
+    }));
+}
+
+describe("TS/JS decorator references (upstream 3540416)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-ts-decorators-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits class-level decorator references (bare, factory, namespaced, exported)", async () => {
+    const file = join(dir, "widgets.ts");
+    writeFileSync(file, [
+      "import { Component, Injectable } from '@angular/core';",
+      "import * as orm from 'typeorm';",
+      "",
+      "@Injectable",
+      "class PlainService {}",
+      "",
+      "@Component({ selector: 'app-widget' })",
+      "export class WidgetComponent {}",
+      "",
+      "@orm.Entity()",
+      "class OrderRow {}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+
+    const refs = decoratorRefs(result);
+    expect(refs).toContainEqual({ source: "PlainService", target: "Injectable" });
+    // Decorator factory on an exported class (decorator wraps the export).
+    expect(refs).toContainEqual({ source: "WidgetComponent", target: "Component" });
+    // Namespaced decorator resolves to the imported symbol, not the alias.
+    expect(refs).toContainEqual({ source: "OrderRow", target: "Entity" });
+    expect(refs.some((r) => r.target === "orm")).toBe(false);
+  });
+
+  it("attributes method decorators to the method node and field/param decorators to the class", async () => {
+    const file = join(dir, "controller.ts");
+    writeFileSync(file, [
+      "import { Get, Input, Inject } from 'somewhere';",
+      "",
+      "class UsersController {",
+      "  @Input() name: string;",
+      "",
+      "  @Get('/users')",
+      "  list(@Inject(TOKEN) svc: Service): void {}",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+
+    const refs = decoratorRefs(result);
+    // Method decorator → owned by the method node (label `.list()`).
+    expect(refs).toContainEqual({ source: ".list()", target: "Get" });
+    // Field decorator (field is not a node) → attributed to the class.
+    expect(refs).toContainEqual({ source: "UsersController", target: "Input" });
+    // Parameter decorator inside the method → owned by the method node.
+    expect(refs).toContainEqual({ source: ".list()", target: "Inject" });
+  });
+
+  it("emits no decorator references for undecorated classes", async () => {
+    const file = join(dir, "plain.ts");
+    writeFileSync(file, [
+      "class NothingSpecial {",
+      "  run(): void {}",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    expect(decoratorRefs(result)).toEqual([]);
+  });
+});

--- a/tests/extract-ts-generators.test.ts
+++ b/tests/extract-ts-generators.test.ts
@@ -1,0 +1,86 @@
+/**
+ * TS/JS generator functions as nodes — port of upstream safishamsi 09aeb97.
+ *
+ * `function* g()` parses as `generator_function_declaration` (absent from
+ * function_types → no node); `const h = function*(){}` parses as
+ * `generator_function` (absent from the function-value types → never
+ * captured at module level). Generator methods (`*gen()` in a class) were
+ * already covered — they parse as `method_definition`.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractJs } from "../src/extract.js";
+
+describe("TS/JS generator functions (upstream 09aeb97)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-ts-generators-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits a node for a generator function declaration", async () => {
+    const file = join(dir, "gen.ts");
+    writeFileSync(file, [
+      "export function* walkTree(): Generator<number> {",
+      "  yield 1;",
+      "}",
+      "function plain(): void {}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("walkTree()");
+    expect(labels).toContain("plain()");
+  });
+
+  it("captures a module-level generator (and plain function) expression const", async () => {
+    const file = join(dir, "genexpr.js");
+    writeFileSync(file, [
+      "const pump = function* () {",
+      "  yield 1;",
+      "};",
+      "const legacy = function () { return 2; };",
+      "module.exports = { pump, legacy };",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("pump()");
+    expect(labels).toContain("legacy()");
+  });
+
+  it("still extracts generator methods inside classes (already-covered path)", async () => {
+    const file = join(dir, "genmethod.ts");
+    writeFileSync(file, [
+      "class Store {",
+      "  *entries(): Generator<string> {",
+      "    yield 'a';",
+      "  }",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    expect(result.nodes.map((n) => n.label)).toContain(".entries()");
+  });
+
+  it("resolves calls made from inside a generator body", async () => {
+    const file = join(dir, "gencalls.ts");
+    writeFileSync(file, [
+      "function helper(): number { return 1; }",
+      "export function* produce(): Generator<number> {",
+      "  yield helper();",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const labelById = new Map(result.nodes.map((n) => [n.id, n.label]));
+    const calls = result.edges
+      .filter((e) => e.relation === "calls")
+      .map((e) => [labelById.get(e.source), labelById.get(e.target)]);
+    expect(calls).toContainEqual(["produce()", "helper()"]);
+  });
+});

--- a/tests/extract-ts-import-equals.test.ts
+++ b/tests/extract-ts-import-equals.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Test-confirmation for upstream safishamsi 9811def (must-audit row of the
+ * 2026-07-06 drift re-scan): the TS import-equals form
+ * `import x = require("./m")` must emit an imports_from edge.
+ *
+ * Upstream's `_import_js` scanned only DIRECT children for the module string
+ * and missed the one nested in `import_require_clause`. The TS port's
+ * `readStringSpecifier` recurses through descendants, so the form was
+ * already covered — this test pins that coverage.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractJs } from "../src/extract.js";
+
+describe("TS import-equals form (upstream 9811def — already covered, pinned)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-import-equals-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits imports_from for `import x = require('./m')`", async () => {
+    writeFileSync(join(dir, "m.ts"), "export function helper(): number { return 1; }\n");
+    const file = join(dir, "main.ts");
+    writeFileSync(file, [
+      "import m = require('./m');",
+      "export function run(): number { return m.helper(); }",
+    ].join("\n"));
+
+    const result = await extractJs(file, dir);
+    expect(result.error).toBeUndefined();
+    const importEdges = result.edges.filter((e) => e.relation === "imports_from");
+    expect(importEdges).toHaveLength(1);
+    // Per-file ids carry the resolved path of m.ts (the corpus pass remaps
+    // them to project-relative form); the tail uniquely identifies the module.
+    expect(/(^|_)m_ts$/.test(importEdges[0]!.target)).toBe(true);
+  });
+});

--- a/tests/extract-ts-namespace.test.ts
+++ b/tests/extract-ts-namespace.test.ts
@@ -1,0 +1,71 @@
+/**
+ * TypeScript namespace/module container nodes — port of upstream safishamsi
+ * 869aaf7. `namespace Foo {}` parses as `internal_module`, `module Bar {}`
+ * and ambient `declare module "pkg" {}` as `module`. None was in
+ * class_types/function_types nor handled by an extra-walk, so the container
+ * produced no node — members were still reached by the default recurse but
+ * the namespace itself was invisible.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractJs } from "../src/extract.js";
+
+describe("TS namespace/module containers (upstream 869aaf7)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "graphify-ts-namespace-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits a node for `namespace Foo {}` and keeps extracting its members", async () => {
+    const file = join(dir, "ns.ts");
+    writeFileSync(file, [
+      "namespace Geometry {",
+      "  export function area(r: number): number { return r * r; }",
+      "  export class Circle {}",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("Geometry");
+    // Members are still reached (file-contained, parity with C# namespaces).
+    expect(labels).toContain("area()");
+    expect(labels).toContain("Circle");
+  });
+
+  it("emits a node for `module Bar {}` and ambient `declare module \"pkg\"`", async () => {
+    const file = join(dir, "mod.ts");
+    writeFileSync(file, [
+      "module Legacy {",
+      "  export const VERSION = { major: 1 };",
+      "}",
+      "declare module \"left-pad\" {",
+      "  export default function leftPad(s: string, n: number): string;",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("Legacy");
+    // Ambient module: quoted name is unwrapped.
+    expect(labels).toContain("left-pad");
+  });
+
+  it("handles nested namespace names (`namespace A.B {}`)", async () => {
+    const file = join(dir, "nested.ts");
+    writeFileSync(file, [
+      "namespace App.Models {",
+      "  export interface User { id: string; }",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJs(file);
+    expect(result.error).toBeUndefined();
+    const labels = result.nodes.map((n) => n.label);
+    expect(labels).toContain("App.Models");
+    expect(labels).toContain("User");
+  });
+});

--- a/tests/extract-type-references.test.ts
+++ b/tests/extract-type-references.test.ts
@@ -62,8 +62,8 @@ describe("Lot 2: Java field type references (#1485, #1518)", () => {
     const refs = typeReferences(result);
     // Head field types -> context "field"
     expect(refs).toContainEqual({ context: "field", target: "Logger" });
-    expect(refs).toContainEqual({ context: "field", target: "List" });
-    // Generic argument -> context "generic_arg"
+    // Generic argument -> context "generic_arg" (the `List` head itself is a
+    // java stdlib builtin, suppressed since upstream 92edf78 / #1603).
     expect(refs).toContainEqual({ context: "generic_arg", target: "Config" });
     // Primitive `int` is never referenced
     expect(refs.some((r) => r.target === "int")).toBe(false);
@@ -74,7 +74,7 @@ describe("Lot 2: Java field type references (#1485, #1518)", () => {
     writeFileSync(file, [
       "class Container<T> {",
       "    T value;",
-      "    List<T> items;",
+      "    CustomList<T> items;",
       "}",
     ].join("\n"));
 
@@ -84,8 +84,41 @@ describe("Lot 2: Java field type references (#1485, #1518)", () => {
     const refs = typeReferences(result);
     // `T` is a type parameter, not a real type: never referenced (head or arg).
     expect(refs.some((r) => r.target === "T")).toBe(false);
-    // The real container type `List` is still referenced.
-    expect(refs).toContainEqual({ context: "field", target: "List" });
+    // The real (user) container type is still referenced.
+    expect(refs).toContainEqual({ context: "field", target: "CustomList" });
+  });
+
+  it("suppresses java stdlib builtins from references (upstream 92edf78 / #1603)", async () => {
+    const file = join(dir, "Svc.java");
+    writeFileSync(file, [
+      "package com.app;",
+      "import java.util.List;",
+      "import java.util.Map;",
+      "import java.util.Optional;",
+      "public class Svc {",
+      "    private String name;",
+      "    private List<Order> orders;",
+      "    private Map<String, Customer> byId;",
+      "    private Optional<Config> cfg;",
+      "    private OrderValidator validator;",
+      "}",
+    ].join("\n"));
+
+    const result = await extractJava(file);
+    if (!grammarAvailable(result)) return; // grammar absent — asserts in CI
+
+    const refs = typeReferences(result);
+    // Stdlib heads/args never emit references (they can't resolve to a
+    // project node — pure noise).
+    for (const builtin of ["String", "List", "Map", "Optional"]) {
+      expect(refs.some((r) => r.target === builtin), builtin).toBe(false);
+    }
+    // Nested user types inside stdlib generics still resolve…
+    expect(refs).toContainEqual({ context: "generic_arg", target: "Order" });
+    expect(refs).toContainEqual({ context: "generic_arg", target: "Customer" });
+    expect(refs).toContainEqual({ context: "generic_arg", target: "Config" });
+    // …and plain user field types are untouched.
+    expect(refs).toContainEqual({ context: "field", target: "OrderValidator" });
   });
 });
 

--- a/tests/language-surface.test.ts
+++ b/tests/language-surface.test.ts
@@ -54,6 +54,27 @@ describe("upstream v4 language surface", () => {
     expect(collectFiles(dir).map((p) => p.split("/").pop()).sort()).toEqual(files.sort());
   });
 
+  it("collects capitalized/mixed-case extensions case-insensitively (upstream aa1bbda #1671)", () => {
+    const files = ["MAIN.PY", "Widget.TSX", "Notes.Md", "Template.BLADE.PHP"];
+
+    for (const file of files) {
+      writeFileSync(join(dir, file), "# fixture\n");
+    }
+
+    expect(collectFiles(dir).map((p) => p.split("/").pop()).sort()).toEqual(files.sort());
+  });
+
+  it("extracts a capitalized-extension source file end-to-end (upstream aa1bbda #1671)", async () => {
+    writeFileSync(join(dir, "SOLVER.PY"), "def solve():\n    return 1\n");
+
+    const collected = collectFiles(dir);
+    expect(collected.map((p) => p.split("/").pop())).toContain("SOLVER.PY");
+
+    const extraction = await extract(collected);
+    const labels = extraction.nodes.map((n) => n.label);
+    expect(labels).toContain("solve()");
+  });
+
   it("collects files when the explicit project root is inside a hidden parent", () => {
     const worktreeRoot = join(dir, ".worktrees", "feature-branch");
     mkdirSync(join(worktreeRoot, "src"), { recursive: true });

--- a/tests/opencode-integration.test.ts
+++ b/tests/opencode-integration.test.ts
@@ -28,6 +28,11 @@ describe("OpenCode integration contract", () => {
     expect(plugin).toContain("tool.execute.before");
     expect(plugin).toContain("graphify query");
     expect(plugin).toContain("Read GRAPH_REPORT.md only for broad architecture context");
+    // The reminder must be joined with ';', never '&&' — Windows PowerShell 5.1
+    // rejects '&&' as a statement separator, breaking the first bash command of
+    // every session (upstream 54825b6 #1646).
+    expect(plugin).toContain('." ; ');
+    expect(plugin).not.toContain('." && ');
     expect(config.plugin).toEqual([".opencode/plugins/graphify.js"]);
   });
 

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -208,6 +208,29 @@ describe("public API compatibility", () => {
     expect(graphJson.links).toContainEqual(expect.objectContaining({ source: "alpha", target: "beta" }));
   });
 
+  it("skips dangling community members in toCanvas instead of throwing (upstream 2ba07e8, #1236 follow-up)", () => {
+    const dir = makeTempDir();
+    const G = new Graph({ type: "undirected" });
+    G.addNode("alpha", {
+      label: "AlphaService",
+      source_file: "src/alpha.ts",
+      file_type: "code",
+    });
+
+    // "ghost" is a community member with no backing node in G — this used to
+    // throw in the card-layout sort (getNodeAttribute on an unknown id).
+    api.toCanvas(G, { 0: ["alpha", "ghost"] }, join(dir, "graph.canvas"));
+
+    const canvas = JSON.parse(readFileSync(join(dir, "graph.canvas"), "utf-8")) as {
+      nodes: Array<{ id: string; type: string; width?: number }>;
+    };
+    expect(canvas.nodes.some((node) => node.id === "n_alpha")).toBe(true);
+    expect(canvas.nodes.some((node) => node.id === "n_ghost")).toBe(false);
+    // The group box must be sized for the one real card, not the dangling id.
+    const group = canvas.nodes.find((node) => node.type === "group");
+    expect(group?.width).toBe(600);
+  });
+
   it("normalizes CRLF labels when generating canvas filenames", () => {
     const dir = makeTempDir();
     const G = new Graph({ type: "undirected" });

--- a/tests/serve-multi-project.test.ts
+++ b/tests/serve-multi-project.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Multi-project MCP serving — port of upstream safishamsi 9e7fbcb (#1594).
+ *
+ * Every graph-backed MCP tool accepts an optional absolute `project_path`;
+ * omitted, the server answers against its default graph (fully backward
+ * compatible); supplied, the call is routed to that project's
+ * `.graphify/graph.json` with its own mtime+size hot-reload. A missing or
+ * corrupt project graph is a tool error, never a process exit.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { serve } from "../src/serve.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function graphJson(nodeId: string, label: string): string {
+  return JSON.stringify({
+    directed: false,
+    graph: {},
+    nodes: [
+      { id: nodeId, label, source_file: `src/${nodeId}.ts`, file_type: "code", community: 0 },
+    ],
+    links: [],
+  });
+}
+
+async function withServer(
+  graphPath: string,
+  run: (client: Client) => Promise<void>,
+): Promise<void> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const serverPromise = serve(graphPath, serverTransport);
+  const client = new Client({ name: "graphify-multi-project-test", version: "0.0.0" });
+  try {
+    await client.connect(clientTransport);
+    await run(client);
+  } finally {
+    await client.close().catch(() => undefined);
+    await clientTransport.close().catch(() => undefined);
+    await serverPromise.catch(() => undefined);
+  }
+}
+
+function toolText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  return (result.content as Array<{ type: string; text: string }>)
+    .map((c) => c.text)
+    .join("\n");
+}
+
+describe("multi-project MCP serving (upstream 9e7fbcb)", () => {
+  it("exposes an optional project_path on every tool", async () => {
+    const dir = makeTempDir("graphify-mp-tools-");
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(graphPath, graphJson("alpha", "AlphaService"));
+
+    await withServer(graphPath, async (client) => {
+      const { tools } = await client.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+      for (const tool of tools) {
+        const schema = tool.inputSchema as {
+          properties?: Record<string, unknown>;
+          required?: string[];
+        };
+        expect(schema.properties?.project_path, `tool ${tool.name}`).toBeDefined();
+        expect(schema.required ?? []).not.toContain("project_path");
+      }
+    });
+  });
+
+  it("routes a call to the requested project graph and defaults without it", async () => {
+    const defaultDir = makeTempDir("graphify-mp-default-");
+    const defaultGraph = join(defaultDir, "graph.json");
+    writeFileSync(defaultGraph, graphJson("alpha", "AlphaService"));
+
+    const projectRoot = makeTempDir("graphify-mp-project-");
+    mkdirSync(join(projectRoot, ".graphify"), { recursive: true });
+    writeFileSync(join(projectRoot, ".graphify", "graph.json"), graphJson("beta", "BetaRepository"));
+
+    await withServer(defaultGraph, async (client) => {
+      const defaultAnswer = toolText(await client.callTool({
+        name: "get_node",
+        arguments: { label: "AlphaService" },
+      }));
+      expect(defaultAnswer).toContain("AlphaService");
+
+      const routed = toolText(await client.callTool({
+        name: "get_node",
+        arguments: { label: "BetaRepository", project_path: projectRoot },
+      }));
+      expect(routed).toContain("BetaRepository");
+
+      // The routed project does not know the default graph's node…
+      const missOnProject = toolText(await client.callTool({
+        name: "get_node",
+        arguments: { label: "AlphaService", project_path: projectRoot },
+      }));
+      expect(missOnProject).toContain("No node matching");
+
+      // …and the default graph is still served when project_path is omitted.
+      const stillDefault = toolText(await client.callTool({
+        name: "graph_stats",
+        arguments: {},
+      }));
+      expect(stillDefault).toContain("Nodes: 1");
+    });
+  });
+
+  it("treats a bad project_path as a tool error and keeps serving", async () => {
+    const defaultDir = makeTempDir("graphify-mp-bad-");
+    const defaultGraph = join(defaultDir, "graph.json");
+    writeFileSync(defaultGraph, graphJson("alpha", "AlphaService"));
+
+    await withServer(defaultGraph, async (client) => {
+      const missing = toolText(await client.callTool({
+        name: "get_node",
+        arguments: { label: "AlphaService", project_path: join(defaultDir, "no-such-project") },
+      }));
+      expect(missing).toContain("Error executing get_node");
+
+      const relative = toolText(await client.callTool({
+        name: "get_node",
+        arguments: { label: "AlphaService", project_path: "relative/path" },
+      }));
+      expect(relative).toContain("project_path must be an absolute path");
+
+      // The server survives both errors and still answers on the default graph.
+      const alive = toolText(await client.callTool({
+        name: "get_node",
+        arguments: { label: "AlphaService" },
+      }));
+      expect(alive).toContain("AlphaService");
+    });
+  });
+});

--- a/tests/serve-query-terms.test.ts
+++ b/tests/serve-query-terms.test.ts
@@ -12,7 +12,8 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { queryTerms } from "../src/search.js";
+import { dropQueryStopwords, queryTerms } from "../src/search.js";
+import { tokenizeField } from "../src/retrieval/bm25.js";
 
 describe("Track F F-0816-P2 (row 12) — queryTerms", () => {
   it("keeps two-character non-English terms (CJK)", () => {
@@ -57,5 +58,31 @@ describe("Track F F-0816-P2 (row 12) — queryTerms", () => {
     // We follow the upstream rule: short non-English (length <= 2) tokens
     // that contain ANY non-ASCII char are kept.
     expect(queryTerms("é 前 ok hello")).toEqual(["é", "前", "hello"]);
+  });
+});
+
+describe("query stopwords (upstream 6e97088)", () => {
+  it("drops question/filler words so content terms drive seeding", () => {
+    // "how does the frontier cache work" must reduce to the content terms,
+    // or it seeds on "how"/"the"/"work" (which prefix-match prose labels
+    // like "Working Principles") instead of "frontier"/"cache".
+    expect(dropQueryStopwords(queryTerms("how does the frontier cache work")))
+      .toEqual(["frontier", "cache"]);
+    expect(dropQueryStopwords(queryTerms("what calls extract?")))
+      .toEqual(["calls", "extract"]);
+  });
+
+  it("falls back to the unfiltered terms when the query is all stopwords", () => {
+    // queryTerms drops "it" (short English), leaving all-stopword terms;
+    // the fallback keeps them rather than seeding on nothing.
+    expect(dropQueryStopwords(queryTerms("how does it work")))
+      .toEqual(["how", "does", "work"]);
+  });
+
+  it("never filters the index side: node text keeps stopword tokens", () => {
+    // The BM25F index tokenizer must stay unfiltered so a symbol literally
+    // named `work` (or a "Working Principles" doc heading) stays findable.
+    expect(tokenizeField("Working Principles")).toEqual(["working", "principles"]);
+    expect(queryTerms("workQueue does_work")).toEqual(["workqueue", "does_work"]);
   });
 });

--- a/tests/serve-seed-diversity.test.ts
+++ b/tests/serve-seed-diversity.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-term BFS seed diversity — port of upstream safishamsi d56ee83 (#1445).
+ *
+ * Taking only the global top-K scored candidates as BFS seeds has a failure
+ * mode on multi-term queries: one term's matches can occupy every top slot,
+ * so the traversal never explores the neighborhood of the other, actually
+ * relevant terms and `query_graph` returns confidently-wrong results.
+ * `pickSeeds` guarantees at least one seed per distinct term that has any
+ * match at all; ties within a term break by node degree.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Graph from "graphology";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { pickSeeds, serve } from "../src/serve.js";
+import { scoreSearchText } from "../src/search.js";
+
+function scoreAll(G: Graph, terms: string[]): Array<[number, string]> {
+  const scored: Array<[number, string]> = [];
+  G.forEachNode((nid, data) => {
+    const score = scoreSearchText(
+      (data.label as string) ?? "",
+      (data.source_file as string) ?? "",
+      terms,
+    );
+    if (score > 0) scored.push([score, nid]);
+  });
+  scored.sort((a, b) => b[0] - a[0]);
+  return scored;
+}
+
+/** #1445 reproduction shape: three "alpha" nodes (label + source_file match,
+ * 1.5 each) occupy the whole top-3; the only "widget" node scores 1.0. */
+function starvationGraph(): Graph {
+  const G = new Graph();
+  G.addNode("a1", { label: "alpha core", source_file: "src/alpha/core.ts" });
+  G.addNode("a2", { label: "alpha util", source_file: "src/alpha/util.ts" });
+  G.addNode("a3", { label: "alpha extra", source_file: "src/alpha/extra.ts" });
+  G.addNode("w1", { label: "WidgetHelper", source_file: "src/ui/helper.ts" });
+  G.addNode("w2", { label: "widget renderer detail", source_file: "src/ui/render.ts" });
+  G.addEdge("a1", "a2");
+  G.addEdge("w1", "w2");
+  return G;
+}
+
+describe("pickSeeds per-term diversity (upstream d56ee83 / #1445)", () => {
+  it("without terms behaves exactly like the legacy top-K slice", () => {
+    const G = starvationGraph();
+    const scored = scoreAll(G, ["alpha", "widget"]);
+    expect(pickSeeds(G, scored, [])).toEqual(scored.slice(0, 3).map(([, nid]) => nid));
+    expect(pickSeeds(G, [], ["alpha"])).toEqual([]);
+  });
+
+  it("guarantees a seed for a term starved out of the global top-K", () => {
+    const G = starvationGraph();
+    const terms = ["alpha", "widget"];
+    const scored = scoreAll(G, terms);
+
+    // Pre-condition: the legacy top-3 slice is all alpha nodes (the bug).
+    const legacy = scored.slice(0, 3).map(([, nid]) => nid);
+    expect(legacy.sort()).toEqual(["a1", "a2", "a3"]);
+
+    // pickSeeds recovers the widget cluster's best node as a seed.
+    const seeds = pickSeeds(G, scored, terms);
+    expect(seeds.slice(0, 3).sort()).toEqual(["a1", "a2", "a3"]);
+    expect(seeds.some((nid) => nid.startsWith("w"))).toBe(true);
+  });
+
+  it("breaks per-term score ties by node degree", () => {
+    const G = new Graph();
+    // Three "orange" nodes (label + source match, 1.5 each) fill the top-3;
+    // the two "cache" nodes tie at 1.0 (label substring only), but hub has
+    // degree 2 and loner degree 0 — the diversity pass must pick hub.
+    G.addNode("o1", { label: "orange core", source_file: "src/orange/core.ts" });
+    G.addNode("o2", { label: "orange util", source_file: "src/orange/util.ts" });
+    G.addNode("o3", { label: "orange extra", source_file: "src/orange/extra.ts" });
+    G.addNode("loner", { label: "CacheReader", source_file: "" });
+    G.addNode("hub", { label: "CacheWriter", source_file: "" });
+    G.addNode("n1", { label: "other one", source_file: "" });
+    G.addNode("n2", { label: "other two", source_file: "" });
+    G.addEdge("hub", "n1");
+    G.addEdge("hub", "n2");
+
+    const terms = ["orange", "cache"];
+    const scored = scoreAll(G, terms);
+    expect(scored.slice(0, 3).map(([, nid]) => nid).sort()).toEqual(["o1", "o2", "o3"]);
+
+    const seeds = pickSeeds(G, scored, terms);
+    expect(seeds).toContain("hub");
+    expect(seeds).not.toContain("loner");
+  });
+});
+
+describe("query_graph end-to-end seed diversity", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reaches the second term's cluster despite a dominant first term", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-seed-diversity-"));
+    tempDirs.push(dir);
+    const graphPath = join(dir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "a1", label: "alpha core", source_file: "src/alpha/core.ts", file_type: "code", community: 0 },
+          { id: "a2", label: "alpha util", source_file: "src/alpha/util.ts", file_type: "code", community: 0 },
+          { id: "a3", label: "alpha extra", source_file: "src/alpha/extra.ts", file_type: "code", community: 0 },
+          { id: "w1", label: "WidgetHelper", source_file: "src/ui/helper.ts", file_type: "code", community: 1 },
+          { id: "w2", label: "widget renderer detail", source_file: "src/ui/render.ts", file_type: "code", community: 1 },
+        ],
+        links: [
+          { source: "a1", target: "a2", relation: "calls", confidence: "EXTRACTED" },
+          { source: "w1", target: "w2", relation: "calls", confidence: "EXTRACTED" },
+        ],
+      }),
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const serverPromise = serve(graphPath, serverTransport);
+    const client = new Client({ name: "graphify-seed-test", version: "0.0.0" });
+    try {
+      await client.connect(clientTransport);
+      const result = await client.callTool({
+        name: "query_graph",
+        arguments: { question: "alpha widget", depth: 1 },
+      });
+      const text = (result.content as Array<{ type: string; text: string }>)
+        .map((c) => c.text)
+        .join("\n");
+      // The widget cluster is disconnected from the alpha cluster: without
+      // per-term seeding it could only appear if seeded directly.
+      expect(text).toContain("WidgetHelper");
+    } finally {
+      await client.close().catch(() => undefined);
+      await clientTransport.close().catch(() => undefined);
+      await serverPromise.catch(() => undefined);
+    }
+  });
+});

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -288,6 +288,17 @@ describe("skill cache examples", () => {
     }
   });
 
+  it("declares frontmatter name 'graphify' in every distributed markdown skill (upstream 54825b6 #1635)", () => {
+    // Claude Code requires the skill folder name to equal the frontmatter
+    // `name`. Every install destination is a `skills/graphify/` folder, so a
+    // suffixed name (e.g. `graphify-windows`) silently breaks discovery.
+    for (const relativePath of DISTRIBUTED_SKILL_DOCS) {
+      if (!relativePath.endsWith(".md")) continue;
+      const content = readFileSync(new URL(relativePath, import.meta.url), "utf-8");
+      expect(content, relativePath).toMatch(/^name: graphify$/m);
+    }
+  });
+
   it("keeps the Windows skill usage lines aligned with upstream v0.3.28", () => {
     const content = readFileSync(new URL("../src/skills/skill-windows.md", import.meta.url), "utf-8");
 


### PR DESCRIPTION
Python-upstream port wave for the 2026-07-06 drift re-scan (`5190a4e..31211a0`, track WP6). Base `a4024b5`. Additive TS-only, no python deps, no version bump. 17 code commits, one behavior per commit, one regression test per behavior.

## Bugs fixed (the 4 re-scan-verified live TS bugs + 1)

- **Extension case-filter** (`aa1bbda` #1671): `collectFiles` matched raw suffixes while dispatch lowercases — `.PY`/`.TSX`/`.BLADE.PHP` silently skipped. `src/extract.ts` (collectFiles + blade dispatch).
- **Windows skill name** (`54825b6` #1635): `skill-windows.md` declared `name: graphify-windows` but installs into `.claude/skills/graphify/` — discovery broken on Windows. `src/skills/skill-windows.md:2`.
- **OpenCode `&&` separator** (`54825b6` #1646): PowerShell 5.1 rejects `&&`; first bash command of every session failed. Now `;`. `src/cli.ts`.
- **Phantom bare-import ids** (`e2ef4ef` #1638): unresolved bare npm imports fell back to `_makeId(moduleName)` and could collide with unrelated local nodes — confident EXTRACTED phantom edges. Now ref-namespaced, dropped by build's nodeSet guard. `src/extract.ts`.
- **toCanvas dangling members** (`2ba07e8`): community member ids absent from G threw in card-layout sort. Both loops now filter to present-with-filename members. `src/export.ts`.

## Per-lot table

Verified-local = test ran green in this sandbox. CI-only = integration test soft-skips locally (optional grammar WASM absent) and asserts where the grammar installs — same pattern as the Lot-1a PowerShell/ObjC ports.

| Upstream sha | TS change | Test | Verified |
| --- | --- | --- | --- |
| **dispatch/collect parity** | | | |
| `aa1bbda` | case-insensitive suffix fallback in `collectFiles` + dispatch | `tests/language-surface.test.ts` | local |
| `2ab0867` | `_SHEBANG_DISPATCH` + `_getExtractor` for extensionless CLIs | `tests/extract-dispatch-parity.test.ts` | local |
| `1226c34` | `.mts`/`.cts` → detect + TS grammar + import candidates | `tests/extract-dispatch-parity.test.ts` | local |
| **skill/install parity** | | | |
| `54825b6` | windows skill name; opencode `;` (3rd slice n/a — no Import Cycles section) | `tests/skills.test.ts`, `tests/opencode-integration.test.ts` | local |
| **serve/query parity** | | | |
| `6e97088` | `QUERY_STOPWORDS` + `dropQueryStopwords`, query paths only (BM25F index side intentionally unfiltered) | `tests/serve-query-terms.test.ts` | local |
| `d56ee83` | exported `pickSeeds`: top-K slice + one seed per matched term, degree tie-break (MCP top-3, CLI top-5) | `tests/serve-seed-diversity.test.ts` (unit + MCP e2e) | local |
| `9e7fbcb` | optional `project_path` on every MCP tool; per-graph store cache w/ mtime+size hot-reload; bad path = tool error | `tests/serve-multi-project.test.ts` | local |
| **Lot-2 follow-ups** | | | |
| `92edf78` | `_JAVA_BUILTIN_TYPES` suppression in `_javaCollectTypeRefs` (existing pins updated: `List` now suppressed by design) | `tests/extract-type-references.test.ts` | local |
| `3540416` | `_tsEmitDecoratorEdges`: class/method/field/param decorators → `references(context=decorator)` | `tests/extract-ts-decorators.test.ts` | local |
| **JS/TS extractor parity** | | | |
| `869aaf7` | `_tsExtraWalk`: `namespace`/`module`/ambient `declare module` container nodes | `tests/extract-ts-namespace.test.ts` | local |
| `09aeb97` | `generator_function_declaration` in functionTypes/boundaries; `_JS_FUNCTION_VALUE_TYPES` (also closes `const x = function(){}`) | `tests/extract-ts-generators.test.ts` | local |
| `6d3a6f1` | `_extractJsRationale`: `// NOTE:`-family rationale nodes + ADR/RFC `doc_ref` nodes with `cites` edges (comment lines only, normalized+deduped) | `tests/extract-js-rationale.test.ts` | local |
| `9811def` | none needed — `readStringSpecifier` already recurses through `import_require_clause` | `tests/extract-ts-import-equals.test.ts` | local (already-covered, pinned) |
| **Lot 4 hardening** | | | |
| `1288a55` | `_shouldCacheExtraction` gate: zero-node results never cached + stderr warning | `tests/extract-cache-zero-node.test.ts` | local |
| **Lot 5** | | | |
| `2ba07e8` | toCanvas dangling-member guard | `tests/public-api.test.ts` | local |
| `e2ef4ef` #1638 | ref-namespaced unresolved bare imports | `tests/extract-phantom-external-import.test.ts` | local |
| **Lot 6 (extraction-side slices)** | | | |
| `13e2bdd` #1640 | ruby `module` containers; `Struct.new`/`Class.new(Super)`/`Data.define` class synthesis + inherits | `tests/extract-ruby-containers.test.ts` | local (ruby WASM present) |
| `6631af7` #1668 | ruby `include`/`extend`/`prepend <Const>` → `mixes_in` (stub + corpus-rewire targets; `extend self` skipped) | `tests/extract-ruby-containers.test.ts` | local |
| **Inheritance follow-up** | | | |
| `9b04022` | full kotlin `delegation_specifiers` branch (TS had none): `inherits`/`implements` incl. `by` delegation; `_kotlinUserTypeName` | `tests/extract-kotlin-delegation.test.ts` | helper unit local; integration CI-only |

## Deliberate deltas (named honestly)

- `9e7fbcb`: upstream also makes startup tolerant with no default graph (pure multi-project mode). Kept strict — the TS CLI contract pins the error-exit UX; additive-only lot.
- `9b04022`: generic-arg reference recovery deferred with the kotlin Lot-2 collector (not yet ported).
- `3540416`: decorators on `abstract class` follow the pre-existing TS classTypes gap (abstract_class_declaration is not a class type in TS today).
- Kotlin integration tests soft-skip locally (`tree-sitter-kotlin` optional dep does not install in this sandbox); the ruby caveat in the re-scan was wrong — ruby WASM IS present and those ports are live-verified.

## What remains (next structural lot)

`4744dfe` (JS/TS receiver typing), `eebc406` (C# receiver calls), `44c0a5e` (Swift singleton receiver), `62b8eb1` (import-evidence gate), ruby `#1634` constant-receiver slice, `#1669` affected seeding — **all blocked on the same absent subsystem: cross-file member-call resolution / receiver typing** (TS has no `resolve_*_member_calls` analog). `62b8eb1`'s phantom-edge failure mode cannot occur in TS today (the vulnerable single-candidate resolver is absent); the gate belongs in the resolver lot. This forms one coherent next lot alongside **Lot 3 `indirect_call`** (unstarted, deliberately not half-landed here). Lot-4 must-audit rows (`f917494`, `8d8d2b8`, `cf4b4ef`, `009a98b`), `62f49ba`, `1256d65`, `b70a6d7` remain open must-audits.

## Verification

- Per-lot: narrowest vitest + `npm run lint` (tsc --noEmit) green on every commit.
- Full `npm test` on the branch: **2354 passed | 2 failed | 17 skipped** — the 2 failures are `tests/agent-stats.test.ts` environment issues (HOME/cache-path tilde normalization), reproduced **identically on clean main** (`9aa3964`): pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
