### PR TITLE
fix(agent-stats): make ~-redaction opt-in; env-robust path handling

### DIFF
--- a/src/agent-stats/discover.ts
+++ b/src/agent-stats/discover.ts
@@ -57,8 +57,13 @@ export function discoverClaude(home: string, repoSlug: string): TranscriptFile[]
     return [];
   }
   const files: string[] = [];
+  const legacySlashSlug = repoSlug.replace(/--/g, "-");
   for (const name of entries) {
-    if (name !== repoSlug && !name.startsWith(repoSlug + "-")) continue;
+    const modernMatch = name === repoSlug || name.startsWith(repoSlug + "-");
+    const legacyMatch = name === legacySlashSlug || name.startsWith(legacySlashSlug + "-");
+    const legacyNonSlashMatch = repoSlug.length === name.length &&
+      Array.from(repoSlug).every((ch, i) => ch === name[i] || (ch === "-" && name[i] !== "/"));
+    if (!modernMatch && !legacyMatch && !legacyNonSlashMatch) continue;
     listFilesRec(join(projectsDir, name), (n) => n.endsWith(".jsonl"), files);
   }
   return files.map((path) => ({ host: "claude" as const, path, sessionId: basenameNoExt(path) }));

--- a/src/agent-stats/index.ts
+++ b/src/agent-stats/index.ts
@@ -168,16 +168,16 @@ function parseFile(
   }
   const parseOpts = { scopeRoot: scope?.repoRoot, originRepo: scope?.originRepo };
   if (file.host === "claude") {
-    return [{ fact: normalizeClaude(parseClaudeTranscript(content, file.sessionId, home, parseOpts)) }];
+    return [{ fact: normalizeClaude(parseClaudeTranscript(content, file.sessionId, home, parseOpts), home) }];
   }
   if (file.host === "codex") {
-    return [{ fact: normalizeCodex(parseCodexRollout(content, file.sessionId, home, parseOpts)) }];
+    return [{ fact: normalizeCodex(parseCodexRollout(content, file.sessionId, home, parseOpts), home) }];
   }
   // agy: a single chat file may hold several logical sessions.
   // projectHash is on the header; if absent, derive from the dir name.
   const projectHashFromDir = file.path.match(/\.gemini\/tmp\/([^/]+)\//)?.[1];
   return parseAgyChats(content, file.sessionId, home, parseOpts).map((raw) => ({
-    fact: normalizeAgy(raw),
+    fact: normalizeAgy(raw, home),
     agyHash: raw.projectHash ?? projectHashFromDir,
   }));
 }

--- a/src/agent-stats/normalize.ts
+++ b/src/agent-stats/normalize.ts
@@ -65,16 +65,20 @@ function dedup(arr: string[]): string[] {
 }
 
 /** Dedup + tilde-normalize a list of absolute paths (privacy + matching). */
-function dedupPaths(arr: string[], home = homedir()): string[] {
-  return Array.from(new Set(arr.filter((x) => typeof x === "string" && x).map((p) => pathToTilde(p, home))));
+function dedupPaths(arr: string[], home?: string): string[] {
+  const paths = arr.filter((x) => typeof x === "string" && x);
+  // In-memory parser/normalizer calls preserve absolute paths for tests and
+  // caller-side correlation. Sync/persistence passes an explicit home to opt in
+  // to `~` redaction before writing facts.jsonl.
+  return Array.from(new Set(home === undefined ? paths : paths.map((p) => pathToTilde(p, home))));
 }
 
-export function normalizeClaude(raw: RawClaudeSession): SessionFact {
+export function normalizeClaude(raw: RawClaudeSession, home?: string): SessionFact {
   return {
     factId: `claude:${raw.sessionId}`,
     host: "claude",
     sessionId: raw.sessionId,
-    cwds: dedupPaths(raw.cwds),
+    cwds: dedupPaths(raw.cwds, home),
     startedAt: raw.startedAt,
     endedAt: raw.endedAt,
     models: dedup(raw.models),
@@ -83,17 +87,17 @@ export function normalizeClaude(raw: RawClaudeSession): SessionFact {
     gitActions: raw.gitActions,
     groundTruth: raw.groundTruth,
     branchesObserved: dedup(raw.branches),
-    filesTouched: dedupPaths(raw.filesTouched),
+    filesTouched: dedupPaths(raw.filesTouched, home),
     evidence: raw.evidence,
   };
 }
 
-export function normalizeCodex(raw: RawCodexSession): SessionFact {
+export function normalizeCodex(raw: RawCodexSession, home?: string): SessionFact {
   return {
     factId: `codex:${raw.sessionId}`,
     host: "codex",
     sessionId: raw.sessionId,
-    cwds: dedupPaths(raw.cwds),
+    cwds: dedupPaths(raw.cwds, home),
     startedAt: raw.startedAt,
     endedAt: raw.endedAt,
     models: dedup(raw.models),
@@ -104,17 +108,17 @@ export function normalizeCodex(raw: RawCodexSession): SessionFact {
     gitActions: raw.gitActions,
     groundTruth: raw.groundTruth,
     branchesObserved: dedup(raw.branches),
-    filesTouched: dedupPaths(raw.filesTouched),
+    filesTouched: dedupPaths(raw.filesTouched, home),
     evidence: raw.evidence,
   };
 }
 
-export function normalizeAgy(raw: RawAgySession): SessionFact {
+export function normalizeAgy(raw: RawAgySession, home?: string): SessionFact {
   return {
     factId: `agy:${raw.sessionId}`,
     host: "agy",
     sessionId: raw.sessionId,
-    cwds: dedupPaths(raw.cwds),
+    cwds: dedupPaths(raw.cwds, home),
     startedAt: raw.startedAt,
     endedAt: raw.endedAt,
     models: dedup(raw.models),
@@ -122,7 +126,7 @@ export function normalizeAgy(raw: RawAgySession): SessionFact {
     gitActions: raw.gitActions,
     groundTruth: raw.groundTruth,
     branchesObserved: dedup(raw.branches),
-    filesTouched: dedupPaths(raw.filesTouched),
+    filesTouched: dedupPaths(raw.filesTouched, home),
     evidence: raw.evidence,
   };
 }


### PR DESCRIPTION
## What
`normalize*()` redacted absolute cwds/filesTouched to `~` **by default**. Locally `tmpdir()` is under `$HOME` so temp-repo paths got redacted → broke absolute-path test expectations; in CI `tmpdir()=/tmp` so redaction never fired and tests passed. Env-fragile (green CI / red local).

## Fix
- `dedupPaths(arr, home?)` redacts **only** when an explicit `home` is passed. In-memory `normalizeClaude/Codex/Agy` preserve absolute paths (tests + caller correlation).
- `sync`/persistence (`index.ts parseFile`) passes `home` explicitly → `facts.jsonl` write-time privacy unchanged.
- `discoverClaude` tolerates legacy project-dir slug variants.

## Verify
- `tests/agent-stats.test.ts` + `tests/agent-stats-phase15.test.ts`: 41/41
- full suite: 2308 pass; `tsc --noEmit` clean

Split out of the #269 worktree — unrelated to windowed-first-paint.