### PR TITLE
feat(studio): codeflow-parity graph UX — parametric layouts + animated dynamics (Lots 1-7)

### DIFF
--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -3,6 +3,8 @@ export * from "./edge-geometry";
 export * from "./gitflow-labels";
 export * from "./layout";
 export * from "./layout-gitflow";
+export * from "./layout-grid";
+export * from "./layout-radial";
 export * from "./layout-registry";
 export * from "./mat4";
 export * from "./positions";

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -4,6 +4,7 @@ export * from "./gitflow-labels";
 export * from "./layout";
 export * from "./layout-gitflow";
 export * from "./layout-grid";
+export * from "./layout-metro";
 export * from "./layout-radial";
 export * from "./layout-registry";
 export * from "./mat4";

--- a/packages/graph/src/layout-grid.ts
+++ b/packages/graph/src/layout-grid.ts
@@ -1,0 +1,73 @@
+/**
+ * GRID layout (display Lot 2 — codeflow-parity "Grid").
+ *
+ * Regular square-ish grid placement — the legible, hairball-free arrangement:
+ *
+ *   • ORDER — nodes are placed in NODE-ID order (their index in `graph.nodeIds`),
+ *     a deterministic, O(n) ordering with no sort.
+ *   • SHAPE — `cols = ceil(√n)` columns, `rows = ceil(n / cols)` rows, so the grid
+ *     stays as square as possible; the final row may be partially filled.
+ *   • SPACING — adjacent cells are `gridGap` apart on both axes.
+ *   • CENTRE — the whole grid's bounding box is centred on the origin (x and y
+ *     each offset by the half-extent), matching Variant A's centred convention.
+ *
+ * Pure, deterministic (no randomness), O(n). Returns a fresh node-order-keyed
+ * `Float32Array` of `2 · nodeCount` floats, index-parallel to `graph.nodeIds` —
+ * exactly the shape {@link GraphRenderer.setPositions} consumes, so it morphs for
+ * free against any other registered layout (index-parallel buffers, §2.6).
+ */
+
+import type { LayoutFn } from "./layout-registry";
+import type { RenderGraphBuffers } from "./types";
+
+/** Tuning for {@link computeGridPositions}. */
+export interface GridLayoutOptions {
+  /** Distance between adjacent grid cells on both axes (default 60). */
+  gridGap?: number;
+}
+
+const DEFAULT_GRID_GAP = 60;
+
+/**
+ * GRID core — place nodes on a `ceil(√n)`-column grid, centred on the origin, in
+ * node-id order.
+ *
+ * @param graph   render-graph buffers; only `graph.nodeIds.length` (the node
+ *                COUNT) and the implicit node order are consulted — no edges.
+ * @param options cell spacing tuning (see {@link GridLayoutOptions}).
+ * @returns a fresh `Float32Array` of length `2 * graph.nodeIds.length`.
+ */
+export function computeGridPositions(
+  graph: RenderGraphBuffers,
+  options: GridLayoutOptions = {},
+): Float32Array {
+  const n = graph.nodeIds.length;
+  const out = new Float32Array(n * 2);
+  if (n === 0) return out;
+
+  const gridGap = options.gridGap ?? DEFAULT_GRID_GAP;
+  const cols = Math.ceil(Math.sqrt(n));
+  const rows = Math.ceil(n / cols);
+
+  // Centre the FULL grid bounding box on the origin (like Variant A centres its
+  // lanes / rows). The last row may be partially filled — the box is still keyed
+  // off the full cols × rows extent so the layout is stable as n grows.
+  const xOffset = ((cols - 1) / 2) * gridGap;
+  const yOffset = ((rows - 1) / 2) * gridGap;
+
+  for (let i = 0; i < n; i++) {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    out[i * 2] = col * gridGap - xOffset;
+    out[i * 2 + 1] = row * gridGap - yOffset;
+  }
+
+  return out;
+}
+
+/**
+ * GRID as a {@link LayoutFn}. Uses default cell spacing; the node COUNT + order
+ * fully determine the placement (no {@link LayoutOptions} consumed). Length
+ * always matches `graph.nodeIds.length`.
+ */
+export const gridLayout: LayoutFn = (graph) => computeGridPositions(graph);

--- a/packages/graph/src/layout-metro.ts
+++ b/packages/graph/src/layout-metro.ts
@@ -1,0 +1,147 @@
+/**
+ * METRO layout (display Lot 6 — codeflow-parity "Metro", MVP).
+ *
+ * A grid-snapped, lane-based arrangement that reads like a transit map:
+ *
+ *   • ROOT — the HIGHEST-DEGREE node (deterministic tie-break: earliest such
+ *     node in `graph.nodeIds` order).
+ *   • LANES — a breadth-first walk from the root assigns every reachable node a
+ *     BFS level `L`. Each level is a horizontal LANE at `y = L · laneGap`; within
+ *     a lane the `m` nodes are snapped to even grid columns `x = (j − (m−1)/2)·
+ *     colGap` in deterministic BFS-discovery order, so lanes are evenly spaced
+ *     and reproducible.
+ *   • DISCONNECTED — nodes unreachable from the root (a separate component, or a
+ *     graph with no edges) are parked on ONE extra lane below the deepest level,
+ *     node-id order, evenly gridded.
+ *
+ * MVP scope (D1): grid-snapped nodes only. TRUE octilinear/orthogonal EDGE
+ * routing (straight + 45° segments) is deliberately deferred — it touches the
+ * golden-tested draw path (`render-geometry.ts`) and belongs to its own
+ * golden-gated lot. Edges render with the existing straight/curved renderer, so
+ * this engine is purely additive and morphs for free (§2.6, index-parallel).
+ *
+ * Pure, deterministic (no randomness), O(n + e). Returns a fresh node-order-keyed
+ * `Float32Array` of `2 · nodeCount` floats, index-parallel to `graph.nodeIds`.
+ */
+
+import type { LayoutFn } from "./layout-registry";
+import type { RenderGraphBuffers } from "./types";
+
+/** Tuning for {@link computeMetroPositions}. */
+export interface MetroLayoutOptions {
+  /** Vertical distance between adjacent BFS lanes (default 120). */
+  laneGap?: number;
+  /** Horizontal grid step between adjacent nodes within a lane (default 90). */
+  colGap?: number;
+}
+
+const DEFAULT_LANE_GAP = 120;
+const DEFAULT_COL_GAP = 90;
+
+/**
+ * METRO core — place nodes on BFS lanes, grid-snapped within each lane.
+ *
+ * @param graph   render-graph buffers; `graph.edges` (flat `[src, tgt, …]` node
+ *                INDEX pairs) drives the degree count + BFS, `graph.nodeIds`
+ *                fixes the deterministic node order.
+ * @param options lane/column spacing tuning (see {@link MetroLayoutOptions}).
+ * @returns a fresh `Float32Array` of length `2 * graph.nodeIds.length`.
+ */
+export function computeMetroPositions(
+  graph: RenderGraphBuffers,
+  options: MetroLayoutOptions = {},
+): Float32Array {
+  const n = graph.nodeIds.length;
+  const out = new Float32Array(n * 2);
+  if (n === 0) return out;
+
+  const laneGap = options.laneGap ?? DEFAULT_LANE_GAP;
+  const colGap = options.colGap ?? DEFAULT_COL_GAP;
+
+  // --- Degree (undirected) + linked-list adjacency, single O(e) pass. ---
+  const degree = new Uint32Array(n);
+  const adjHead = new Int32Array(n).fill(-1);
+  const adjTo: number[] = [];
+  const adjNext: number[] = [];
+  const pushAdj = (u: number, v: number): void => {
+    adjTo.push(v);
+    adjNext.push(adjHead[u]!);
+    adjHead[u] = adjTo.length - 1;
+  };
+  const edges = graph.edges;
+  const e = edges.length; // 2 * edgeCount
+  for (let i = 0; i + 1 < e; i += 2) {
+    const s = edges[i]!;
+    const t = edges[i + 1]!;
+    if (s >= n || t >= n) continue; // defensive: never trust a stray index
+    degree[s]!++;
+    degree[t]!++;
+    pushAdj(s, t);
+    pushAdj(t, s);
+  }
+
+  // --- Root = highest degree; tie → earliest node in nodeIds (index) order. ---
+  let root = 0;
+  let bestDegree = degree[0]!;
+  for (let i = 1; i < n; i++) {
+    if (degree[i]! > bestDegree) {
+      bestDegree = degree[i]!;
+      root = i;
+    }
+  }
+
+  // --- BFS from the root: level = hop distance, grouped in discovery order. ---
+  const level = new Int32Array(n).fill(-1);
+  const lanes: number[][] = [];
+  const queue = new Int32Array(n);
+  let head = 0;
+  let tail = 0;
+  level[root] = 0;
+  queue[tail++] = root;
+  let maxLevel = 0;
+  while (head < tail) {
+    const u = queue[head++]!;
+    const lu = level[u]!;
+    if (lu > maxLevel) maxLevel = lu;
+    (lanes[lu] ??= []).push(u);
+    for (let k = adjHead[u]!; k !== -1; k = adjNext[k]!) {
+      const v = adjTo[k]!;
+      if (level[v] === -1) {
+        level[v] = lu + 1;
+        queue[tail++] = v;
+      }
+    }
+  }
+
+  // --- Place each lane: y = level·laneGap; x = centred grid columns. ---
+  const placeLane = (row: number[], y: number): void => {
+    const m = row.length;
+    for (let j = 0; j < m; j++) {
+      const idx = row[j]!;
+      out[idx * 2] = (j - (m - 1) / 2) * colGap;
+      out[idx * 2 + 1] = y;
+    }
+  };
+  for (let l = 0; l < lanes.length; l++) {
+    const lane = lanes[l];
+    if (lane) placeLane(lane, l * laneGap);
+  }
+
+  // --- Disconnected nodes: one extra lane below the deepest BFS level. ---
+  const disconnected: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (level[i] === -1) disconnected.push(i);
+  }
+  if (disconnected.length > 0) {
+    placeLane(disconnected, (maxLevel + 1) * laneGap);
+  }
+
+  return out;
+}
+
+/**
+ * METRO as a {@link LayoutFn}. Uses default lane/column spacing; the graph's
+ * edges + node order fully determine the placement (no {@link LayoutOptions}
+ * consumed). Length always matches `graph.nodeIds.length`.
+ */
+export const metroLayout: LayoutFn = (graph) => computeMetroPositions(graph);

--- a/packages/graph/src/layout-radial.ts
+++ b/packages/graph/src/layout-radial.ts
@@ -1,0 +1,163 @@
+/**
+ * RADIAL layout (display Lot 2 — codeflow-parity "Radial").
+ *
+ * Root/hub-centred concentric rings, the classic radial tree:
+ *
+ *   • ROOT — the HIGHEST-DEGREE node (deterministic tie-break: the earliest such
+ *     node in `graph.nodeIds` order). It sits at the origin (0, 0).
+ *   • LEVELS — a breadth-first walk from the root assigns every reachable node a
+ *     level `L` = its BFS hop-distance. Level `L` is placed on a concentric ring
+ *     of radius `L · ringGap`.
+ *   • ANGLE — within a level the `m` nodes are spread by EVEN angle
+ *     `2π · j / m` in deterministic BFS-discovery order (`j` = 0 … m−1), so the
+ *     ring is evenly fanned and reproducible.
+ *   • DISCONNECTED — nodes unreachable from the root (a separate component, or
+ *     the whole graph when there are no edges) are parked on ONE outer ring, just
+ *     beyond the deepest BFS level, evenly spread in node-id order.
+ *
+ * Pure, deterministic (no randomness), O(n + e). Returns a fresh node-order-keyed
+ * `Float32Array` of `2 · nodeCount` floats, index-parallel to `graph.nodeIds` —
+ * exactly the shape {@link GraphRenderer.setPositions} consumes, so it morphs for
+ * free against any other registered layout (index-parallel buffers, §2.6).
+ */
+
+import type { LayoutFn } from "./layout-registry";
+import type { RenderGraphBuffers } from "./types";
+
+/** Tuning for {@link computeRadialPositions}. */
+export interface RadialLayoutOptions {
+  /** Radial distance between adjacent concentric level-rings (default 120). */
+  ringGap?: number;
+  /**
+   * Extra radius ADDED beyond the deepest BFS level for the outer ring that
+   * holds DISCONNECTED nodes (unreachable from the root). Default: `ringGap`.
+   */
+  outerRingGap?: number;
+}
+
+const DEFAULT_RING_GAP = 120;
+
+/**
+ * RADIAL core — place nodes on concentric rings around the highest-degree hub.
+ *
+ * @param graph   render-graph buffers; `graph.edges` (flat `[src, tgt, …]` node
+ *                INDEX pairs) drives the degree count + BFS, `graph.nodeIds`
+ *                fixes the deterministic node order.
+ * @param options ring spacing tuning (see {@link RadialLayoutOptions}).
+ * @returns a fresh `Float32Array` of length `2 * graph.nodeIds.length`.
+ */
+export function computeRadialPositions(
+  graph: RenderGraphBuffers,
+  options: RadialLayoutOptions = {},
+): Float32Array {
+  const n = graph.nodeIds.length;
+  const out = new Float32Array(n * 2);
+  if (n === 0) return out;
+
+  const ringGap = options.ringGap ?? DEFAULT_RING_GAP;
+  const outerRingGap = options.outerRingGap ?? ringGap;
+
+  // --- Degree (undirected) + adjacency, single O(e) pass over the edge pairs. ---
+  const degree = new Uint32Array(n);
+  const adjHead = new Int32Array(n).fill(-1); // intrusive singly-linked adjacency
+  const edges = graph.edges;
+  const e = edges.length; // 2 * edgeCount
+  // Linked-list adjacency: adjNext[k] chains the k-th appended neighbour slot,
+  // adjTo[k] is its target node index. Keeps the whole layout O(n + e) — no
+  // per-node array growth, no sort.
+  const adjTo: number[] = [];
+  const adjNext: number[] = [];
+  const pushAdj = (u: number, v: number): void => {
+    adjTo.push(v);
+    adjNext.push(adjHead[u]!);
+    adjHead[u] = adjTo.length - 1;
+  };
+  for (let i = 0; i + 1 < e; i += 2) {
+    const s = edges[i]!;
+    const t = edges[i + 1]!;
+    if (s >= n || t >= n) continue; // defensive: never trust a stray index
+    degree[s]!++;
+    degree[t]!++;
+    // Push in a stable, edge-order-derived sequence (deterministic).
+    pushAdj(s, t);
+    pushAdj(t, s);
+  }
+
+  // --- Root = highest degree; tie → earliest node in nodeIds (index) order. ---
+  let root = 0;
+  let bestDegree = degree[0]!;
+  for (let i = 1; i < n; i++) {
+    if (degree[i]! > bestDegree) {
+      bestDegree = degree[i]!;
+      root = i;
+    }
+  }
+
+  // --- BFS from the root: level = hop distance, grouped in discovery order. ---
+  const level = new Int32Array(n).fill(-1);
+  const levels: number[][] = [];
+  const queue = new Int32Array(n);
+  let head = 0;
+  let tail = 0;
+  level[root] = 0;
+  queue[tail++] = root;
+  let maxLevel = 0;
+  while (head < tail) {
+    const u = queue[head++]!;
+    const lu = level[u]!;
+    if (lu > maxLevel) maxLevel = lu;
+    (levels[lu] ??= []).push(u);
+    for (let k = adjHead[u]!; k !== -1; k = adjNext[k]!) {
+      const v = adjTo[k]!;
+      if (level[v] === -1) {
+        level[v] = lu + 1;
+        queue[tail++] = v;
+      }
+    }
+  }
+
+  // --- Place each ring: level 0 = root at origin; level L on radius L·ringGap. ---
+  for (let l = 0; l < levels.length; l++) {
+    const ring = levels[l];
+    if (!ring) continue;
+    const radius = l * ringGap;
+    const m = ring.length;
+    for (let j = 0; j < m; j++) {
+      const idx = ring[j]!;
+      if (l === 0) {
+        // Root (and only the root) sits at the centre.
+        out[idx * 2] = 0;
+        out[idx * 2 + 1] = 0;
+      } else {
+        const angle = (2 * Math.PI * j) / m;
+        out[idx * 2] = radius * Math.cos(angle);
+        out[idx * 2 + 1] = radius * Math.sin(angle);
+      }
+    }
+  }
+
+  // --- Disconnected nodes: one outer ring, node-id order, evenly spread. ---
+  const disconnected: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (level[i] === -1) disconnected.push(i);
+  }
+  if (disconnected.length > 0) {
+    const outerRadius = maxLevel * ringGap + outerRingGap;
+    const m = disconnected.length;
+    for (let j = 0; j < m; j++) {
+      const idx = disconnected[j]!;
+      const angle = (2 * Math.PI * j) / m;
+      out[idx * 2] = outerRadius * Math.cos(angle);
+      out[idx * 2 + 1] = outerRadius * Math.sin(angle);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * RADIAL as a {@link LayoutFn}. Uses default ring spacing; the graph's edges +
+ * node order fully determine the placement (no {@link LayoutOptions} consumed).
+ * Length always matches `graph.nodeIds.length`.
+ */
+export const radialLayout: LayoutFn = (graph) => computeRadialPositions(graph);

--- a/packages/graph/src/layout-registry.ts
+++ b/packages/graph/src/layout-registry.ts
@@ -27,6 +27,8 @@
  */
 
 import { gitFlowLayout } from "./layout-gitflow";
+import { gridLayout } from "./layout-grid";
+import { radialLayout } from "./layout-radial";
 import { copyPositions, createPositionFrame } from "./positions";
 import type { LayoutEngine, LayoutOptions, PositionFrame, RenderGraphBuffers } from "./types";
 
@@ -52,6 +54,19 @@ export const TIME_ORIENTED_LAYOUT_ID = "time-oriented";
  * see `layout-gitflow.ts`). OPT-IN; never the default.
  */
 export const GIT_FLOW_LAYOUT_ID = "git-flow";
+
+/**
+ * Registered id of the RADIAL layout (root/hub-centred concentric rings: the
+ * highest-degree node at the origin, BFS levels on `L·ringGap` rings — see
+ * `layout-radial.ts`). OPT-IN; never the default.
+ */
+export const RADIAL_LAYOUT_ID = "radial";
+
+/**
+ * Registered id of the GRID layout (regular `ceil(√n)`-column grid centred on
+ * the origin, node-id order — see `layout-grid.ts`). OPT-IN; never the default.
+ */
+export const GRID_LAYOUT_ID = "grid";
 
 // ---------------------------------------------------------------------------
 // Registry
@@ -408,3 +423,5 @@ registerLayout(DEFAULT_LAYOUT_ID, forceLayout);
 registerLayout(TYPED_LAYER_LAYOUT_ID, typedLayerLayout);
 registerLayout(TIME_ORIENTED_LAYOUT_ID, timeOrientedLayout);
 registerLayout(GIT_FLOW_LAYOUT_ID, gitFlowLayout);
+registerLayout(RADIAL_LAYOUT_ID, radialLayout);
+registerLayout(GRID_LAYOUT_ID, gridLayout);

--- a/packages/graph/src/layout-registry.ts
+++ b/packages/graph/src/layout-registry.ts
@@ -28,6 +28,7 @@
 
 import { gitFlowLayout } from "./layout-gitflow";
 import { gridLayout } from "./layout-grid";
+import { metroLayout } from "./layout-metro";
 import { radialLayout } from "./layout-radial";
 import { copyPositions, createPositionFrame } from "./positions";
 import type { LayoutEngine, LayoutOptions, PositionFrame, RenderGraphBuffers } from "./types";
@@ -67,6 +68,13 @@ export const RADIAL_LAYOUT_ID = "radial";
  * the origin, node-id order — see `layout-grid.ts`). OPT-IN; never the default.
  */
 export const GRID_LAYOUT_ID = "grid";
+
+/**
+ * Registered id of the METRO layout (BFS lanes, grid-snapped nodes — see
+ * `layout-metro.ts`; MVP: octilinear edge routing deferred). OPT-IN; never the
+ * default.
+ */
+export const METRO_LAYOUT_ID = "metro";
 
 // ---------------------------------------------------------------------------
 // Registry
@@ -425,3 +433,4 @@ registerLayout(TIME_ORIENTED_LAYOUT_ID, timeOrientedLayout);
 registerLayout(GIT_FLOW_LAYOUT_ID, gitFlowLayout);
 registerLayout(RADIAL_LAYOUT_ID, radialLayout);
 registerLayout(GRID_LAYOUT_ID, gridLayout);
+registerLayout(METRO_LAYOUT_ID, metroLayout);

--- a/packages/graph/src/render-geometry.ts
+++ b/packages/graph/src/render-geometry.ts
@@ -58,9 +58,8 @@ export const BOX_TEXT_COLOR = "#0f172a";
 export const BORDER_WIDTH_NORMAL = 1.5;
 export const BORDER_WIDTH_BOLD = 3;
 
-/** Absolute floor / cap for the zoom-scaled border stroke (× pixelRatio / × base). */
-const BORDER_ZOOM_FLOOR_PX = 0.75;
-const BORDER_ZOOM_CAP_FACTOR = 3;
+/** Minimal absolute floor for the zoom-scaled border so it never fully vanishes. */
+const BORDER_ZOOM_FLOOR_PX = 0.5;
 
 /**
  * Border stroke FULL width in device px.
@@ -69,13 +68,16 @@ const BORDER_ZOOM_CAP_FACTOR = 3;
  * `(bold?BOLD:NORMAL)·pixelRatio`, byte-identical to the golden reference and
  * every existing consumer.
  *
- * When `scaleWithZoom` is on (interactive studio views), the stroke scales with
- * the camera zoom so a node's border stays PROPORTIONAL to its zoom-scaled
- * radius (`drawnRadius` is `size·PR·zoom`) instead of a fixed screen width that
- * over-dominates a tiny node when zoomed out. Clamped so it never vanishes
- * (floor 0.75·PR) nor explodes (cap 3× the base). At zoom=1 the scaled value
- * equals the base, so zoom=1 output — and thus every golden — is unchanged even
- * with the flag on.
+ * When `scaleWithZoom` is on (interactive studio views), the stroke scales
+ * LINEARLY with the camera zoom, exactly like the drawn radius (`size·PR·zoom`),
+ * so the border/radius RATIO is CONSTANT at every zoom — a bordered node reads
+ * the same at any scale instead of over-dominating when zoomed out (fixed screen
+ * width on a tiny node) or looking hairline when zoomed in. The ONLY clamp is a
+ * tiny floor (0.5·PR) so an extreme zoom-out doesn't drop the outline to nothing;
+ * there is deliberately NO upper cap — a cap would break the proportionality the
+ * moment it bit (the earlier 3×-base cap made zoomed-in borders read too thin).
+ * At zoom=1 the scaled width equals the base, so zoom=1 output — and thus every
+ * golden — is unchanged even with the flag on.
  */
 export function borderStrokeWidthPx(
   bold: boolean,
@@ -86,7 +88,7 @@ export function borderStrokeWidthPx(
   const base = (bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio;
   if (!scaleWithZoom) return base;
   const scaled = base * (Number.isFinite(zoom) && zoom > 0 ? zoom : 1);
-  return Math.min(Math.max(scaled, BORDER_ZOOM_FLOOR_PX * pixelRatio), base * BORDER_ZOOM_CAP_FACTOR);
+  return Math.max(scaled, BORDER_ZOOM_FLOOR_PX * pixelRatio);
 }
 
 /** Hollow glyph interior CSS string (alpha-independent translucent white). */

--- a/packages/graph/src/render-geometry.ts
+++ b/packages/graph/src/render-geometry.ts
@@ -58,6 +58,37 @@ export const BOX_TEXT_COLOR = "#0f172a";
 export const BORDER_WIDTH_NORMAL = 1.5;
 export const BORDER_WIDTH_BOLD = 3;
 
+/** Absolute floor / cap for the zoom-scaled border stroke (× pixelRatio / × base). */
+const BORDER_ZOOM_FLOOR_PX = 0.75;
+const BORDER_ZOOM_CAP_FACTOR = 3;
+
+/**
+ * Border stroke FULL width in device px.
+ *
+ * Default (`scaleWithZoom` false) = the legacy SCREEN-space width
+ * `(bold?BOLD:NORMAL)·pixelRatio`, byte-identical to the golden reference and
+ * every existing consumer.
+ *
+ * When `scaleWithZoom` is on (interactive studio views), the stroke scales with
+ * the camera zoom so a node's border stays PROPORTIONAL to its zoom-scaled
+ * radius (`drawnRadius` is `size·PR·zoom`) instead of a fixed screen width that
+ * over-dominates a tiny node when zoomed out. Clamped so it never vanishes
+ * (floor 0.75·PR) nor explodes (cap 3× the base). At zoom=1 the scaled value
+ * equals the base, so zoom=1 output — and thus every golden — is unchanged even
+ * with the flag on.
+ */
+export function borderStrokeWidthPx(
+  bold: boolean,
+  pixelRatio: number,
+  zoom: number,
+  scaleWithZoom = false,
+): number {
+  const base = (bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio;
+  if (!scaleWithZoom) return base;
+  const scaled = base * (Number.isFinite(zoom) && zoom > 0 ? zoom : 1);
+  return Math.min(Math.max(scaled, BORDER_ZOOM_FLOOR_PX * pixelRatio), base * BORDER_ZOOM_CAP_FACTOR);
+}
+
 /** Hollow glyph interior CSS string (alpha-independent translucent white). */
 export const HOLLOW_FILL_STYLE = `rgba(${BOX_FILL[0]}, ${BOX_FILL[1]}, ${BOX_FILL[2]}, ${BOX_FILL[3] / 255})`;
 

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -2,6 +2,7 @@ import { computePositionBounds, copyPositions } from "./positions";
 import { BOX_GLYPH_CORNER_RATIO, SQUARE_INSET_RATIO, shapePolygonPoints } from "./shape-geometry";
 import {
   FLOW_PORT_MIN_STUB,
+  borderStrokeWidthPx,
   boxDimensions,
   flowPortEdgeGeometry,
   routeIsArrowless,
@@ -579,10 +580,9 @@ const BOX_BASE_HEIGHT_PX = 18; // box height in CSS px (× pixelRatio × zoom), 
 const BOX_FILL: readonly [number, number, number, number] = [255, 255, 255, 0.5 * 255];
 const BOX_TEXT_COLOR = "#0f172a"; // theme-dark label text (slate-900)
 
-// Shape-variant outline widths in CSS px (× pixelRatio, screen-space like the
-// box border): "normal" hollow outlines and the heavier "bold" border variant.
-const BORDER_WIDTH_NORMAL = 1.5;
-const BORDER_WIDTH_BOLD = 3;
+// Shape-variant outline widths come from the shared `borderStrokeWidthPx`
+// (render-geometry.ts): screen-space by default, zoom-scaled when the studio
+// opts in via GraphRendererOptions.scaleBordersWithZoom.
 // Hollow glyph interior: same translucent white as the legacy box fill, so a
 // hollow shape reads as an outline without disappearing over edges.
 const HOLLOW_FILL_STYLE = `rgba(${BOX_FILL[0]}, ${BOX_FILL[1]}, ${BOX_FILL[2]}, ${BOX_FILL[3] / 255})`;
@@ -698,6 +698,8 @@ function drawBoxNode(
   borderColor: string,
   alpha: number,
   boldBorder = false,
+  zoom = 1,
+  scaleBordersWithZoom = false,
 ): void {
   context.save();
   context.globalAlpha = alpha;
@@ -707,7 +709,7 @@ function drawBoxNode(
   context.fillStyle = HOLLOW_FILL_STYLE;
   context.fill();
   context.strokeStyle = borderColor;
-  context.lineWidth = (boldBorder ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio;
+  context.lineWidth = borderStrokeWidthPx(boldBorder, pixelRatio, zoom, scaleBordersWithZoom);
   context.stroke();
 
   if (label) {
@@ -822,6 +824,9 @@ function drawFallback2D(
   // (GraphRendererOptions.boxBaseHeightPx). Default = the legacy metric, so
   // every existing caller/golden is byte-identical.
   boxBaseHeightPx: number = BOX_BASE_HEIGHT_PX,
+  // Scale border strokes with the camera zoom (default false = legacy
+  // screen-space width; no-op at zoom=1 so goldens are byte-identical).
+  scaleBordersWithZoom = false,
 ): void {
   if (!context || !canvas) return;
 
@@ -1050,6 +1055,8 @@ function drawFallback2D(
         nodeColor,
         alpha,
         boldBorder,
+        camera.zoom,
+        scaleBordersWithZoom,
       );
       continue;
     }
@@ -1062,7 +1069,7 @@ function drawFallback2D(
       context.fillStyle = HOLLOW_FILL_STYLE;
       context.fill();
       context.strokeStyle = nodeColor;
-      context.lineWidth = (boldBorder ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio;
+      context.lineWidth = borderStrokeWidthPx(boldBorder, pixelRatio, camera.zoom, scaleBordersWithZoom);
       context.stroke();
     } else {
       context.fillStyle = nodeColor;
@@ -1070,7 +1077,7 @@ function drawFallback2D(
       if (boldBorder) {
         // Bold border on a solid fill: darkened outline so it stays visible.
         context.strokeStyle = cssDarkenedColor(state.style?.nodeColors, colorOffset, DEFAULT_NODE_COLOR);
-        context.lineWidth = BORDER_WIDTH_BOLD * pixelRatio;
+        context.lineWidth = borderStrokeWidthPx(true, pixelRatio, camera.zoom, scaleBordersWithZoom);
         context.stroke();
       }
     }
@@ -1093,6 +1100,9 @@ export function createGraphRenderer(
   // git-flow view passes `gitFlowLabelBoxHeightPx()` so the drawn pills match
   // the label policy's measured collision AABBs.
   const boxBaseHeightPx = options.boxBaseHeightPx ?? BOX_BASE_HEIGHT_PX;
+  // Interactive views scale border strokes with the camera zoom (default false =
+  // legacy screen-space width; no-op at zoom=1, so goldens are unchanged).
+  const scaleBordersWithZoom = options.scaleBordersWithZoom ?? false;
   const activeBackend = context ? "webgl" : fallbackContext ? "canvas2d" : "none";
 
   // B1 Phase 1 INTERNAL CANARY: when the flag is on AND we have a WebGL2 context,
@@ -1202,7 +1212,16 @@ export function createGraphRenderer(
     lastBoxTextDraws = [];
 
     if (!context) {
-      drawFallback2D(fallbackContext, state, camera, canvas, pixelRatio, skipEdges, boxBaseHeightPx);
+      drawFallback2D(
+        fallbackContext,
+        state,
+        camera,
+        canvas,
+        pixelRatio,
+        skipEdges,
+        boxBaseHeightPx,
+        scaleBordersWithZoom,
+      );
       return;
     }
 
@@ -1273,6 +1292,7 @@ export function createGraphRenderer(
           style: state.style,
           camera,
           pixelRatio,
+          scaleBordersWithZoom,
           viewportWidth: canvas?.width ?? 0,
           viewportHeight: canvas?.height ?? 0,
           centerX: Number.isFinite(bounds.centerX) ? bounds.centerX : 0,
@@ -1325,6 +1345,7 @@ export function createGraphRenderer(
           camera,
           pixelRatio,
           boxBaseHeightPx,
+          scaleBordersWithZoom,
           viewportWidth: canvas?.width ?? 0,
           viewportHeight: canvas?.height ?? 0,
           measureLabelWidth,

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -327,6 +327,12 @@ function copyStyle(style: GraphStyleBuffers, nodeCount: number, edgeCount: numbe
     );
   }
 
+  if (style.edgeAlphaShape && style.edgeAlphaShape.length !== edgeCount * 3) {
+    throw new RangeError(
+      `edgeAlphaShape length ${style.edgeAlphaShape.length} does not match edge count ${edgeCount} (expected ${edgeCount * 3})`,
+    );
+  }
+
   return {
     nodeSizes: new Float32Array(style.nodeSizes),
     nodeColors: new Uint8Array(style.nodeColors),
@@ -339,6 +345,7 @@ function copyStyle(style: GraphStyleBuffers, nodeCount: number, edgeCount: numbe
     edgeDash: new Uint8Array(style.edgeDash),
     edgeCurvatures: new Float32Array(style.edgeCurvatures),
     edgeRouteStyles: style.edgeRouteStyles ? new Uint8Array(style.edgeRouteStyles) : undefined,
+    edgeAlphaShape: style.edgeAlphaShape ? new Uint8Array(style.edgeAlphaShape) : undefined,
   };
 }
 

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -256,6 +256,14 @@ export interface GraphRendererOptions {
    */
   boxBaseHeightPx?: number;
   /**
+   * Scale node/box border strokes with the camera zoom (default false = legacy
+   * screen-space width, byte-identical goldens & existing consumers). Interactive
+   * views (the studio) set this true so a bordered node's outline stays
+   * proportional to its zoom-scaled radius instead of over-dominating when zoomed
+   * out. At zoom=1 the width equals the legacy value, so it is a no-op there.
+   */
+  scaleBordersWithZoom?: boolean;
+  /**
    * INTERNAL CANARY (B1 migration Phase 1). When true AND the active backend is
    * WebGL2, node glyphs are drawn with the new INSTANCED-SHAPE path
    * (`webgl-shapes.ts`: instanced discs/polygons, radius-as-radius) instead of

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -140,6 +140,19 @@ export interface GraphStyleBuffers {
    * via render-geometry.flowPortEdgeGeometry).
    */
   edgeRouteStyles?: Uint8Array;
+  /**
+   * Optional per-edge ALPHA SHAPE — three multipliers of the edge's BASE alpha
+   * (`edgeColors[e].a`) sampled along the edge at t=0 (source), t=0.5 (mid) and
+   * t=1 (target). 3 bytes per edge `[m0, mMid, m1]`, each 0..255 encoding a
+   * fraction 0..1. The WebGL2 instanced-edge fragment shader interpolates the
+   * shape PIECEWISE-LINEARLY along the edge (mix(m0,mMid) over the first half,
+   * mix(mMid,m1) over the second) and MULTIPLIES the base alpha by it — a
+   * separate multiplier from the base, so any dim/hover/merge scaling of
+   * `edgeColors.a` composes automatically. Additive & golden-stable: absent ⇒
+   * every edge uploads the uniform shape (1,1,1), byte-identical to before.
+   * WebGL2 only for now; the Canvas2D fallback keeps the uniform base alpha.
+   */
+  edgeAlphaShape?: Uint8Array;
 }
 
 export interface GraphStyleDefaults {

--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -45,8 +45,7 @@
  */
 
 import {
-  BORDER_WIDTH_BOLD,
-  BORDER_WIDTH_NORMAL,
+  borderStrokeWidthPx,
   BOX_BASE_HEIGHT_PX,
   BOX_FILL,
   BOX_SHAPE_CODE,
@@ -262,6 +261,12 @@ export interface WebGLBoxFrame {
   viewportWidth: number;
   viewportHeight: number;
   /**
+   * Scale the box border stroke with the camera zoom (default false = legacy
+   * screen-space width). On for interactive studio views so the outline stays
+   * proportional to the zoom-scaled box instead of dominating when zoomed out.
+   */
+  scaleBordersWithZoom?: boolean;
+  /**
    * Box-label width measure service (the SAME `measureText` cache Canvas2D uses)
    * so the box WIDTH + the #199 pixel-fit + the atlas all agree to the pixel.
    * Absent in non-DOM envs ⇒ boxes collapse to the empty-rect (a no-op width);
@@ -360,7 +365,9 @@ export function buildBoxDraws(frame: WebGLBoxFrame): BoxDraw[] {
     const bold = (style?.nodeBorders?.[i] ?? 0) === 1;
     // Canvas2D strokes lineWidth = (bold?BOLD:NORMAL)·PR; the SDF border is a
     // band of HALF that width on each side of the outline.
-    const border = ((bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * frame.pixelRatio) / 2;
+    const border =
+      borderStrokeWidthPx(bold, frame.pixelRatio, frame.camera.zoom, frame.scaleBordersWithZoom ?? false) /
+      2;
 
     draws.push({
       nodeIndex: i,
@@ -439,7 +446,12 @@ export function buildBoxTextDraws(frame: WebGLBoxFrame): BoxTextDraw[] {
       height,
       label: style?.nodeLabels?.[i] ?? "",
       // Canvas2D strokes lineWidth = (bold?BOLD:NORMAL)·PR (device px).
-      borderWidth: (bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * frame.pixelRatio,
+      borderWidth: borderStrokeWidthPx(
+        bold,
+        frame.pixelRatio,
+        frame.camera.zoom,
+        frame.scaleBordersWithZoom ?? false,
+      ),
       // Mirror renderer.ts `cssColor`: rgba(r,g,b, a/255). The canvas2d golden
       // also sets globalAlpha=alpha, so the alpha is applied the SAME two ways.
       borderColor: `rgba(${r}, ${g}, ${b}, ${a / 255})`,

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -93,6 +93,7 @@ layout(location = 4) in vec4 a_color;      // instance: rgba (0..1)
 layout(location = 5) in float a_arcStart;  // instance: arc-length at p0 (device px)
 layout(location = 6) in float a_dashPeriod;// instance: dash on+off period (0 = solid)
 layout(location = 7) in float a_dashOn;    // instance: dash on length (device px)
+layout(location = 8) in vec3 a_shape;      // instance: alpha multipliers at t=0 / 0.5 / 1 (0..1)
 
 uniform vec2 u_viewport;
 
@@ -103,6 +104,7 @@ out vec4 v_color;
 out float v_arc;       // arc-length at this fragment (device px) for dashing
 out float v_dashPeriod;
 out float v_dashOn;
+out vec3 v_shape;      // along-edge alpha multipliers (m0, mMid, m1)
 
 void main() {
   vec2 d = a_p1 - a_p0;
@@ -142,6 +144,7 @@ void main() {
   v_arc = a_arcStart + along; // arc-length accumulates along the polyline
   v_dashPeriod = a_dashPeriod;
   v_dashOn = a_dashOn;
+  v_shape = a_shape;
 
   vec2 clip = vec2(screen.x * 2.0 / u_viewport.x - 1.0, 1.0 - screen.y * 2.0 / u_viewport.y);
   // Edges sit BEHIND every node (Canvas2D draws all edges before all nodes).
@@ -158,6 +161,7 @@ in vec4 v_color;
 in float v_arc;
 in float v_dashPeriod;
 in float v_dashOn;
+in vec3 v_shape;
 out vec4 outColor;
 
 void main() {
@@ -214,12 +218,26 @@ void main() {
     if (coverage <= 0.0) discard;
   }
 
+  // ALONG-EDGE ALPHA SHAPE (configurable edge-transparency gradient). tt is the
+  // 0..1 parameter from the source cap (v_local.x = -v_halfLen) to the target
+  // cap (+v_halfLen). The shape is PIECEWISE-LINEAR: mix(m0,mMid) over the first
+  // half, mix(mMid,m1) over the second. Default shape (1,1,1) ⇒ sh == 1 (uniform,
+  // byte-identical to before this feature); the studio drives it per mode
+  // (dense/inverse/mid/flat) to fade an edge toward its dense endpoint / the
+  // middle. It MULTIPLIES the base alpha, so dim/hover/merge (which only scale
+  // v_color.a) compose automatically.
+  float tt = clamp((v_local.x + v_halfLen) / (2.0 * v_halfLen), 0.0, 1.0);
+  float sh = tt < 0.5
+    ? mix(v_shape.x, v_shape.y, tt * 2.0)
+    : mix(v_shape.y, v_shape.z, (tt - 0.5) * 2.0);
+
   // PREMULTIPLIED alpha output (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)).
-  // The effective alpha is the edge alpha times the analytic coverage; emit
-  // rgb·a so the framebuffer stays premultiplied (premultipliedAlpha:true). The
-  // old straight output + SRC_ALPHA factor under-accumulated the framebuffer
-  // alpha (squared coverage), washing alpha<1 edges out + dark-fringing AA rims.
-  float a = v_color.a * coverage;
+  // The effective alpha is the edge alpha times the analytic coverage times the
+  // along-edge shape; emit rgb·a so the framebuffer stays premultiplied
+  // (premultipliedAlpha:true). The old straight output + SRC_ALPHA factor
+  // under-accumulated the framebuffer alpha (squared coverage), washing alpha<1
+  // edges out + dark-fringing AA rims.
+  float a = v_color.a * coverage * sh;
   outColor = vec4(v_color.rgb * a, a);
 }
 `;
@@ -272,8 +290,8 @@ void main() {
 }
 `;
 
-/** Floats per capsule instance. p0(2)+p1(2)+halfWidth(1)+color(4)+arcStart(1)+period(1)+on(1) = 12 */
-export const CAPSULE_FLOATS_PER_INSTANCE = 12;
+/** Floats per capsule instance. p0(2)+p1(2)+halfWidth(1)+color(4)+arcStart(1)+period(1)+on(1)+shape(3) = 15 */
+export const CAPSULE_FLOATS_PER_INSTANCE = 15;
 /** Floats per arrow instance. tip(2)+dir(2)+length(1)+color(4) = 9 */
 export const ARROW_FLOATS_PER_INSTANCE = 9;
 
@@ -423,6 +441,16 @@ export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
     const dashPeriod = dash ? dash[0] + dash[1] : 0;
     const dashOn = dash ? dash[0] : 0;
 
+    // Per-edge ALPHA SHAPE (3 multipliers at t=0 / 0.5 / 1, 0..255 → 0..1). Absent
+    // ⇒ the uniform (1,1,1) shape, so the emitted instances are byte-identical to
+    // before this feature. Keyed by the DATA edge index (source→target); the
+    // studio never sets a reversed flow-port route + a shape together, so the
+    // shape orientation always matches the drawn direction.
+    const shapeBuf = style?.edgeAlphaShape;
+    const s0 = shapeBuf ? (shapeBuf[edgeIndex * 3] ?? 255) / 255 : 1;
+    const sMid = shapeBuf ? (shapeBuf[edgeIndex * 3 + 1] ?? 255) / 255 : 1;
+    const s1 = shapeBuf ? (shapeBuf[edgeIndex * 3 + 2] ?? 255) / 255 : 1;
+
     // Tessellate the (clipped) drawn polyline and emit one capsule per segment,
     // accumulating arc-length so dashes are continuous across curve segments.
     const polyline = tessellateEdge(geom, CURVE_SEGMENTS);
@@ -438,6 +466,7 @@ export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
         arc,
         dashPeriod,
         dashOn,
+        s0, sMid, s1,
       );
       arc += Math.hypot(p1[0] - p0[0], p1[1] - p0[1]);
     }
@@ -528,7 +557,8 @@ function createCapsulePipeline(gl: GL2): CapsulePipeline {
   gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
 
   gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
-  // location 1 a_p0, 2 a_p1, 3 a_halfWidth, 4 a_color, 5 a_arcStart, 6 a_dashPeriod, 7 a_dashOn
+  // location 1 a_p0, 2 a_p1, 3 a_halfWidth, 4 a_color, 5 a_arcStart, 6 a_dashPeriod,
+  // 7 a_dashOn, 8 a_shape (vec3 along-edge alpha multipliers)
   const layout: Array<[number, number, number]> = [
     [1, 2, 0],
     [2, 2, 2 * 4],
@@ -537,6 +567,7 @@ function createCapsulePipeline(gl: GL2): CapsulePipeline {
     [5, 1, 9 * 4],
     [6, 1, 10 * 4],
     [7, 1, 11 * 4],
+    [8, 3, 12 * 4],
   ];
   for (const [loc, size, offset] of layout) {
     gl.enableVertexAttribArray(loc);
@@ -653,6 +684,21 @@ export interface CapsuleInstanceView {
   arcStart: number;
   dashPeriod: number;
   dashOn: number;
+  /** Along-edge alpha multipliers at t=0 / 0.5 / 1 (0..1); (1,1,1) = uniform. */
+  shape: [number, number, number];
+}
+
+/**
+ * The along-edge alpha multiplier the capsule fragment shader samples at `tt`
+ * (0 = source, 1 = target). PIECEWISE-LINEAR across the mid control point,
+ * IDENTICAL to the `sh` computed in CAPSULE_FRAGMENT_SHADER — exported so the
+ * geometry-parity tests can assert the emitted shape without a GPU. `shape`
+ * values are fractions in [0,1]; the default (1,1,1) returns 1 for every `tt`.
+ */
+export function alphaShapeAt(shape: readonly [number, number, number], tt: number): number {
+  const t = Math.min(1, Math.max(0, tt));
+  const [m0, mMid, m1] = shape;
+  return t < 0.5 ? m0 + (mMid - m0) * (t * 2) : mMid + (m1 - mMid) * ((t - 0.5) * 2);
 }
 
 export function decodeCapsule(list: number[], n: number): CapsuleInstanceView {
@@ -665,6 +711,7 @@ export function decodeCapsule(list: number[], n: number): CapsuleInstanceView {
     arcStart: list[o + 9] ?? 0,
     dashPeriod: list[o + 10] ?? 0,
     dashOn: list[o + 11] ?? 0,
+    shape: [list[o + 12] ?? 1, list[o + 13] ?? 1, list[o + 14] ?? 1],
   };
 }
 

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -43,6 +43,7 @@ import {
   drawnRadius,
   unitShapeGeometry,
 } from "./render-geometry";
+import { SQUARE_INSET_RATIO } from "./shape-geometry";
 import type { GraphStyleBuffers } from "./types";
 
 type GL2 = WebGL2RenderingContext;
@@ -341,7 +342,22 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     // strokeHalf, carved by an inner disc at radius - strokeHalf) — NOT the old
     // inside-only `radius - width` ring, which under-weighted the outline and
     // (for solid+bold) was fully hidden by the full-radius fill disc.
-    const strokeHalf = strokeHalfWidth(
+    //
+    // RADIAL offset != PERPENDICULAR width for a flat-faced polygon. A ring
+    // built this way (outer/inner instance at radius±strokeHalf) reads as a
+    // constant-perpendicular-width band ONLY for a disc (apothem == radius);
+    // for a diamond/square/hexagon/triangle the FACE sits inside the
+    // circumradius (or, for square, inside a fixed SQUARE_INSET_RATIO — see
+    // apothemRatio() below), so the same radial offset is foreshortened along
+    // the face normal — the border visibly THINS as the shape gets more
+    // polygonal (bug, × the intended width: circle 1.00, hexagon 0.87,
+    // triangle/star 0.5, diamond 0.71, square 0.88). `effectiveStrokeHalf`
+    // below compensates per family so every shape's PERPENDICULAR border
+    // width is the SAME, fixed at 0.7× the (uncompensated) square's
+    // perpendicular width — i.e. 30% thinner than today's square border,
+    // uniform across every shape family.
+    const effectiveStrokeHalf = effectiveStrokeHalfWidth(
+      family,
       bold,
       frame.pixelRatio,
       frame.camera.zoom,
@@ -351,24 +367,27 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     if (hollow) {
       // Hollow glyph: a node-colour border RING centred on the drawn radius over
       // a FIXED translucent-white interior (alpha-INDEPENDENT, N10). The ring is
-      // a node-colour disc out to radius + strokeHalf (drawn UNDER) carved by the
-      // translucent-white interior disc at radius - strokeHalf (drawn ON TOP), so
-      // the visible ring spans [radius - strokeHalf, radius + strokeHalf] — the
-      // SAME width AND position Canvas2D strokes. Only the border carries the
-      // node alpha; the interior keeps the fixed white.
-      pushInstance(borderList, cx, cy, radius + strokeHalf, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
-      pushInstance(fillList, cx, cy, Math.max(0, radius - strokeHalf), BOX_FILL[0], BOX_FILL[1], BOX_FILL[2], BOX_FILL[3] / 255, depth);
+      // a node-colour disc out to radius + effectiveStrokeHalf (drawn UNDER)
+      // carved by the translucent-white interior disc at radius -
+      // effectiveStrokeHalf (drawn ON TOP), so the visible ring spans
+      // [radius - effectiveStrokeHalf, radius + effectiveStrokeHalf] — a
+      // UNIFORM perpendicular width across shape families (see above). Only the
+      // border carries the node alpha; the interior keeps the fixed white.
+      pushInstance(borderList, cx, cy, radius + effectiveStrokeHalf, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
+      pushInstance(fillList, cx, cy, Math.max(0, radius - effectiveStrokeHalf), BOX_FILL[0], BOX_FILL[1], BOX_FILL[2], BOX_FILL[3] / 255, depth);
     } else if (bold) {
       // Solid + bold: a darkened-colour border RING (factor 0.62) centred on the
-      // radius, exactly like the Canvas2D solid+bold stroke. The outer darkened
-      // disc (radius + strokeHalf, drawn UNDER) is carved by the node-colour
-      // interior disc at radius - strokeHalf (drawn ON TOP), leaving a centred
-      // [radius - strokeHalf, radius + strokeHalf] ring. (The old code drew the
-      // darkened disc at `radius` UNDER a full-radius node-colour fill, which hid
-      // the border entirely — the worst case of the under-weight bug.)
+      // radius, at the SAME uniform perpendicular width as the hollow ring above.
+      // The outer darkened disc (radius + effectiveStrokeHalf, drawn UNDER) is
+      // carved by the node-colour interior disc at radius - effectiveStrokeHalf
+      // (drawn ON TOP), leaving a centred
+      // [radius - effectiveStrokeHalf, radius + effectiveStrokeHalf] ring. (The
+      // old code drew the darkened disc at `radius` UNDER a full-radius
+      // node-colour fill, which hid the border entirely — the worst case of the
+      // under-weight bug.)
       const d = darken(nodeColor);
-      pushInstance(borderList, cx, cy, radius + strokeHalf, d[0], d[1], d[2], alpha, depth);
-      pushInstance(fillList, cx, cy, Math.max(0, radius - strokeHalf), nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
+      pushInstance(borderList, cx, cy, radius + effectiveStrokeHalf, d[0], d[1], d[2], alpha, depth);
+      pushInstance(fillList, cx, cy, Math.max(0, radius - effectiveStrokeHalf), nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
     } else {
       // Solid fill at node colour + alpha (no border).
       pushInstance(fillList, cx, cy, radius, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
@@ -385,8 +404,10 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
  * read the borders slightly THIN. We scale the centred-ring half-width by this
  * factor (~12% thicker, symmetric about the drawn radius). Mirrors the edge boost
  * (WEBGL_STROKE_WEIGHT_BOOST in webgl-edges.ts). Canvas2D (BORDER_WIDTH_* in
- * render-geometry.ts) is untouched — only this WebGL ring widens, lifting the
- * golden border-ink ratio further above its 0.6 floor.
+ * render-geometry.ts) is untouched — only this WebGL ring widens. This boost is
+ * applied BEFORE the per-shape `apothemRatio` compensation below (see
+ * `effectiveStrokeHalfWidth`), which then intentionally brings the net result
+ * back down to a UNIFORM, ~30%-thinner-than-square perpendicular width.
  */
 const WEBGL_OUTLINE_WEIGHT_BOOST = 1.12;
 
@@ -401,6 +422,78 @@ function strokeHalfWidth(
   scaleWithZoom = false,
 ): number {
   return (borderStrokeWidthPx(bold, pixelRatio, zoom, scaleWithZoom) / 2) * WEBGL_OUTLINE_WEIGHT_BOOST;
+}
+
+/**
+ * Apothem-per-`a_radius` ratio per shape family (fix: circle/hexagon border
+ * thicker than square/diamond/triangle). The two-disc ring technique scales
+ * each shape's UNIT outline (fixed vertices, computed once at `a_radius = 1`)
+ * radially by `a_radius = radius ± strokeHalf`; since that scale is linear,
+ * a shape's apothem (perpendicular centre-to-face distance) at any `a_radius`
+ * equals `a_radius · apothemUnit`, where `apothemUnit` is the shape's OWN
+ * apothem at `a_radius = 1`. A disc's apothem == its radius (ratio 1); a flat
+ * polygon face sits INSIDE the circumradius, so its ratio is < 1 and the
+ * border reads THINNER there for the SAME radial offset.
+ *
+ * IMPORTANT: this is the apothem-per-`a_radius` ratio, NOT the shape-intrinsic
+ * apothem/circumradius ratio — those coincide for diamond/hexagon/triangle
+ * (`shapePolygonPoints` uses the radius argument directly as each vertex's
+ * distance from centre, so `a_radius` IS the circumradius: cos(45°)/cos(30°)/
+ * cos(60°)), but NOT for square: `shapePolygonPoints(4, r)` insets the square
+ * BEFORE the radius scale (`half = r · SQUARE_INSET_RATIO`, shape-geometry.ts
+ * — a deliberate visual-weight calibration, unrelated to border math), so its
+ * apothem-per-`a_radius` is `SQUARE_INSET_RATIO` (0.88) directly, NOT cos(45°)
+ * (0.707, which is diamond's ratio — a different, non-inset quadrilateral).
+ * Verified numerically against the actual `shapePolygonPoints` output before
+ * coding this. The star's alternating inner/outer vertices have no single
+ * apothem (its concave notches sit much closer to centre than its points), so
+ * it is approximated at the triangle's 0.5 and — like every family here —
+ * clamped to [0.5, 1.0] as a defensive floor/ceiling (a ratio outside that
+ * band would over- or under-compensate wildly for an unexpected shape code).
+ */
+const SHAPE_APOTHEM_RATIO: Readonly<Record<number, number>> = {
+  0: 1.0, // circle: apothem == circumradius (a disc)
+  1: Math.cos(Math.PI / 4), // diamond: regular 4-gon, no inset — cos(45°)
+  2: 0.5, // star: irregular, approximated/clamped
+  3: Math.cos(Math.PI / 6), // hexagon: regular 6-gon, no inset — cos(30°)
+  4: SQUARE_INSET_RATIO, // square: apothem-per-a_radius IS the inset (0.88), NOT cos(45°)
+  6: Math.cos(Math.PI / 3), // triangle: regular 3-gon, no inset — cos(60°)
+};
+
+/** Apothem-per-`a_radius` ratio for a shape family, clamped to [0.5, 1.0]. */
+function apothemRatio(family: number): number {
+  const ratio = SHAPE_APOTHEM_RATIO[family] ?? 1.0;
+  return Math.min(1.0, Math.max(0.5, ratio));
+}
+
+/**
+ * Target UNIFORM perpendicular half-width, as a fraction of the RADIAL
+ * `strokeHalf` a disc would draw at: 0.7 × today's square apothem ratio —
+ * i.e. 0.7 × the perpendicular half-width today's SQUARE already draws (its
+ * apothem-per-`a_radius` ratio is `SQUARE_INSET_RATIO`, 0.88 — see above), so
+ * the new uniform border is 30% THINNER than the current square, and (via
+ * `apothemRatio` above) identical on every other shape family instead of
+ * varying 0.50×–1.00× by shape.
+ * `effectiveStrokeHalf = strokeHalf · BORDER_PERP_SCALE / apothemRatio(family)`
+ * — dividing by the family's ratio undoes exactly the foreshortening that
+ * ratio causes, so every family lands on the same BORDER_PERP_SCALE·strokeHalf
+ * perpendicular width.
+ */
+const BORDER_PERP_SCALE = 0.7 * SQUARE_INSET_RATIO; // 0.7 · 0.88 = 0.616
+
+/**
+ * The FINAL per-shape perpendicular stroke half-width used to build the
+ * border ring (exported so tests can assert the fix directly instead of
+ * duplicating the family/BORDER_PERP_SCALE arithmetic).
+ */
+export function effectiveStrokeHalfWidth(
+  family: number,
+  bold: boolean,
+  pixelRatio: number,
+  zoom = 1,
+  scaleWithZoom = false,
+): number {
+  return (strokeHalfWidth(bold, pixelRatio, zoom, scaleWithZoom) * BORDER_PERP_SCALE) / apothemRatio(family);
 }
 
 function pushInstance(

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -36,8 +36,7 @@
 
 import { cameraToViewProjection } from "./mat4";
 import {
-  BORDER_WIDTH_BOLD,
-  BORDER_WIDTH_NORMAL,
+  borderStrokeWidthPx,
   BOX_FILL,
   BOX_SHAPE_CODE,
   coerceFiniteCoord,
@@ -133,6 +132,12 @@ export interface WebGLShapeFrame {
   /** Coercion centre for non-finite world coords (N1b). */
   centerX?: number;
   centerY?: number;
+  /**
+   * Scale the border stroke with the camera zoom (default false = legacy
+   * screen-space width). On for interactive studio views so outlines stay
+   * proportional to the zoom-scaled node instead of dominating when zoomed out.
+   */
+  scaleBordersWithZoom?: boolean;
 }
 
 export interface WebGLShapeRenderer {
@@ -336,7 +341,12 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     // strokeHalf, carved by an inner disc at radius - strokeHalf) — NOT the old
     // inside-only `radius - width` ring, which under-weighted the outline and
     // (for solid+bold) was fully hidden by the full-radius fill disc.
-    const strokeHalf = strokeHalfWidth(bold, frame.pixelRatio);
+    const strokeHalf = strokeHalfWidth(
+      bold,
+      frame.pixelRatio,
+      frame.camera.zoom,
+      frame.scaleBordersWithZoom ?? false,
+    );
 
     if (hollow) {
       // Hollow glyph: a node-colour border RING centred on the drawn radius over
@@ -384,8 +394,13 @@ const WEBGL_OUTLINE_WEIGHT_BOOST = 1.12;
  *  a stroke of (bold?BOLD:NORMAL)·PR on the outline, so each side is HALF),
  *  scaled by WEBGL_OUTLINE_WEIGHT_BOOST so the WebGL beta ring reads a touch
  *  HEAVIER than Canvas2D (UAT polish) — Canvas2D's own stroke is unchanged. */
-function strokeHalfWidth(bold: boolean, pixelRatio: number): number {
-  return (((bold ? BORDER_WIDTH_BOLD : BORDER_WIDTH_NORMAL) * pixelRatio) / 2) * WEBGL_OUTLINE_WEIGHT_BOOST;
+function strokeHalfWidth(
+  bold: boolean,
+  pixelRatio: number,
+  zoom = 1,
+  scaleWithZoom = false,
+): number {
+  return (borderStrokeWidthPx(bold, pixelRatio, zoom, scaleWithZoom) / 2) * WEBGL_OUTLINE_WEIGHT_BOOST;
 }
 
 function pushInstance(

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -353,9 +353,15 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     // polygonal (bug, × the intended width: circle 1.00, hexagon 0.87,
     // triangle/star 0.5, diamond 0.71, square 0.88). `effectiveStrokeHalf`
     // below compensates per family so every shape's PERPENDICULAR border
-    // width is the SAME, fixed at 0.7× the (uncompensated) square's
-    // perpendicular width — i.e. 30% thinner than today's square border,
-    // uniform across every shape family.
+    // width lands on a COMMON baseline, fixed at 0.7× the (uncompensated)
+    // square's perpendicular width — i.e. 30% thinner than the old square
+    // border — and THEN applies an additional per-shape thinning
+    // (`SHAPE_BORDER_THIN`) on top of that baseline: circle/hexagon are cut
+    // to 0.5× the baseline (0.308×strokeHalf), diamond/square/star/triangle
+    // to 0.8× (0.493×strokeHalf). So the perpendicular width is no longer
+    // uniform across every family — it is a deliberate TWO-TIER geometry
+    // (smooth-boundary shapes thinner than angular ones), each tier still
+    // uniform within itself.
     const effectiveStrokeHalf = effectiveStrokeHalfWidth(
       family,
       bold,
@@ -371,13 +377,15 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
       // carved by the translucent-white interior disc at radius -
       // effectiveStrokeHalf (drawn ON TOP), so the visible ring spans
       // [radius - effectiveStrokeHalf, radius + effectiveStrokeHalf] — a
-      // UNIFORM perpendicular width across shape families (see above). Only the
-      // border carries the node alpha; the interior keeps the fixed white.
+      // per-shape TWO-TIER perpendicular width across shape families (see
+      // above). Only the border carries the node alpha; the interior keeps
+      // the fixed white.
       pushInstance(borderList, cx, cy, radius + effectiveStrokeHalf, nodeColor[0], nodeColor[1], nodeColor[2], alpha, depth);
       pushInstance(fillList, cx, cy, Math.max(0, radius - effectiveStrokeHalf), BOX_FILL[0], BOX_FILL[1], BOX_FILL[2], BOX_FILL[3] / 255, depth);
     } else if (bold) {
       // Solid + bold: a darkened-colour border RING (factor 0.62) centred on the
-      // radius, at the SAME uniform perpendicular width as the hollow ring above.
+      // radius, at the SAME per-shape (two-tier) perpendicular width as the
+      // hollow ring above.
       // The outer darkened disc (radius + effectiveStrokeHalf, drawn UNDER) is
       // carved by the node-colour interior disc at radius - effectiveStrokeHalf
       // (drawn ON TOP), leaving a centred
@@ -477,14 +485,49 @@ function apothemRatio(family: number): number {
  * `effectiveStrokeHalf = strokeHalf · BORDER_PERP_SCALE / apothemRatio(family)`
  * — dividing by the family's ratio undoes exactly the foreshortening that
  * ratio causes, so every family lands on the same BORDER_PERP_SCALE·strokeHalf
- * perpendicular width.
+ * perpendicular width. NOTE: this uniform baseline is this constant's OWN
+ * effect only — `effectiveStrokeHalfWidth` below then applies a further
+ * per-shape `SHAPE_BORDER_THIN` multiplier on top, so the FINAL perpendicular
+ * width is a two-tier (not fully uniform) geometry; see that lookup's doc.
  */
 const BORDER_PERP_SCALE = 0.7 * SQUARE_INSET_RATIO; // 0.7 · 0.88 = 0.616
 
 /**
+ * Per-shape THINNING multiplier applied ON TOP of the uniform
+ * `BORDER_PERP_SCALE / apothemRatio` compensation above (user request,
+ * 2026-07-13: the uniform 0.616×strokeHalf ring still read too heavy —
+ * particularly on the smooth-boundary families — and the user asked for it
+ * thinner on a per-shape basis, NOT uniformly). This does NOT undo the
+ * apothem compensation (that stays, so every family is still foreshortened
+ * back to a common baseline before this extra per-shape cut is applied); it
+ * only scales that already-uniform baseline down, differently per shape:
+ *  - circle (0) / hexagon (3): × 0.5  → 0.616 × 0.5 = 0.308 × strokeHalf
+ *  - diamond (1) / square (4): × 0.8  → 0.616 × 0.8 = 0.493 × strokeHalf
+ *  - star (2) / triangle (6):  × 0.8  (NOT specified by the user request —
+ *    defaulted to the same 0.8 as the other angular shapes, i.e. grouped with
+ *    diamond/square rather than left uniform or given a bespoke value)
+ * Any family code missing from the table (defensive) falls back to × 1 (no
+ * extra thinning beyond the existing apothem compensation).
+ */
+const SHAPE_BORDER_THIN: Readonly<Record<number, number>> = {
+  0: 0.5, // circle
+  3: 0.5, // hexagon
+  1: 0.8, // diamond
+  4: 0.8, // square
+  2: 0.8, // star — user-unspecified, defaulted to the angular-shape value
+  6: 0.8, // triangle — user-unspecified, defaulted to the angular-shape value
+};
+
+/** Per-shape border-thinning multiplier, defaulting to 1 (no thinning) for
+ *  any family code not present in `SHAPE_BORDER_THIN`. */
+function borderThinFactor(family: number): number {
+  return SHAPE_BORDER_THIN[family] ?? 1;
+}
+
+/**
  * The FINAL per-shape perpendicular stroke half-width used to build the
  * border ring (exported so tests can assert the fix directly instead of
- * duplicating the family/BORDER_PERP_SCALE arithmetic).
+ * duplicating the family/BORDER_PERP_SCALE/SHAPE_BORDER_THIN arithmetic).
  */
 export function effectiveStrokeHalfWidth(
   family: number,
@@ -493,7 +536,10 @@ export function effectiveStrokeHalfWidth(
   zoom = 1,
   scaleWithZoom = false,
 ): number {
-  return (strokeHalfWidth(bold, pixelRatio, zoom, scaleWithZoom) * BORDER_PERP_SCALE) / apothemRatio(family);
+  return (
+    ((strokeHalfWidth(bold, pixelRatio, zoom, scaleWithZoom) * BORDER_PERP_SCALE) / apothemRatio(family)) *
+    borderThinFactor(family)
+  );
 }
 
 function pushInstance(

--- a/packages/graph/tests/golden/edges-golden.test.ts
+++ b/packages/graph/tests/golden/edges-golden.test.ts
@@ -25,7 +25,9 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  alphaShapeAt,
   buildEdgeInstances,
+  CAPSULE_FLOATS_PER_INSTANCE,
   decodeArrow,
   decodeCapsule,
   type WebGLEdgeFrame,
@@ -156,7 +158,7 @@ describe("B1 Phase 2 — edge geometry parity (WebGL instances == Canvas2D math)
   it("E4 curve: a curved edge tessellates into many off-chord capsules", () => {
     const frame = straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1, curvature: 0.5 });
     const set = buildEdgeInstances(frame);
-    const segCount = set.capsules.length / 12;
+    const segCount = set.capsules.length / CAPSULE_FLOATS_PER_INSTANCE;
     expect(segCount).toBeGreaterThan(8); // tessellated, not a single chord segment
     // Some mid capsule must bow OFF the chord (y != 0 at the midpoint region).
     let maxOff = 0;
@@ -244,6 +246,46 @@ describe("B1 Phase 2 — edge geometry parity (WebGL instances == Canvas2D math)
     const b = buildEdgeInstances(straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1, dash: 1, curvature: 0.3 }));
     expect(a.capsules).toEqual(b.capsules);
     expect(a.arrows).toEqual(b.arrows);
+  });
+
+  // --- Configurable edge-transparency: the along-edge ALPHA SHAPE ------------
+  // Default (no edgeAlphaShape) is byte-identical to the historical uniform edge;
+  // a non-uniform shape fades the sampled alpha along the edge WITHOUT touching
+  // the base alpha (v_color.a) or the geometry (endpoints/half-width/dash).
+  it("no edgeAlphaShape ⇒ uniform (1,1,1); byte-identical to the pre-shape build", () => {
+    const base = straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1 });
+    const set = buildEdgeInstances(base);
+    const cap = decodeCapsule(set.capsules, 0);
+    expect(cap.shape).toEqual([1, 1, 1]);
+    // The uniform shape multiplies alpha by 1 at every sample point.
+    for (const tt of [0, 0.25, 0.5, 0.75, 1]) expect(alphaShapeAt(cap.shape, tt)).toBeCloseTo(1, 6);
+  });
+
+  it("mid-fade shape [255,64,255]: the mid-edge alpha is lower than both endpoints", () => {
+    const frame = straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1 });
+    frame.style!.edgeAlphaShape = new Uint8Array([255, 64, 255]);
+    const cap = decodeCapsule(buildEdgeInstances(frame).capsules, 0);
+    const atSource = alphaShapeAt(cap.shape, 0);
+    const atMid = alphaShapeAt(cap.shape, 0.5);
+    const atTarget = alphaShapeAt(cap.shape, 1);
+    expect(atMid).toBeLessThan(atSource);
+    expect(atMid).toBeLessThan(atTarget);
+    expect(atSource).toBeCloseTo(1, 5);
+    expect(atTarget).toBeCloseTo(1, 5);
+    expect(atMid).toBeCloseTo(64 / 255, 5);
+  });
+
+  it("target-fade shape [255,255,64]: alpha decreases monotonically toward the target", () => {
+    const frame = straightFrame({ x0: -120, x1: 120, size: 8, width: 4, dpr: 2, zoom: 1 });
+    frame.style!.edgeAlphaShape = new Uint8Array([255, 255, 64]);
+    const cap = decodeCapsule(buildEdgeInstances(frame).capsules, 0);
+    const atSource = alphaShapeAt(cap.shape, 0);
+    const atMid = alphaShapeAt(cap.shape, 0.5);
+    const atTarget = alphaShapeAt(cap.shape, 1);
+    expect(atSource).toBeCloseTo(1, 5);
+    expect(atMid).toBeCloseTo(1, 5);
+    expect(atTarget).toBeLessThan(atMid); // fades toward the target endpoint
+    expect(atTarget).toBeCloseTo(64 / 255, 5);
   });
 });
 

--- a/packages/graph/tests/golden/shapes-golden.test.ts
+++ b/packages/graph/tests/golden/shapes-golden.test.ts
@@ -22,6 +22,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildShapeInstances,
   decodeInstance,
+  effectiveStrokeHalfWidth,
   type WebGLShapeFrame,
 } from "../../src/webgl-shapes";
 import { drawnRadius } from "../../src/render-geometry";
@@ -108,6 +109,89 @@ describe("B1 Phase 1 — shape geometry parity (WebGL a_radius == Canvas2D radiu
     expect(inst.radius).toBe(1);
     expect(drawnRadius(0.1, 1, 0.5)).toBe(1);
   });
+
+  // ---------------------------------------------------------------------
+  // Border-thickness fix: the two-disc ring is built by scaling the WHOLE
+  // unit polygon by a RADIAL offset (radius ± effectiveStrokeHalf). For a
+  // disc (circle) the radial offset IS the perpendicular gap, but for a
+  // flat-faced polygon (diamond/square/hexagon/triangle) the gap measured
+  // PERPENDICULAR to a face is `radial offset x apothem/circumradius ratio`
+  // (apothem = radius x ratio) — so circles/hexagons rendered a MUCH thicker
+  // perpendicular border than diamonds/squares/triangles. The fix compensates
+  // by DIVIDING the radial offset by each family's own apothem ratio, so that
+  // once re-foreshortened by that SAME ratio the visible PERPENDICULAR width
+  // is identical everywhere. This asserts the perpendicular (radial x ratio),
+  // NOT the radial offset itself, is uniform — the radial offsets are
+  // deliberately UNEQUAL by design (that inequality is what cancels the
+  // per-shape foreshortening). Deterministic, no GPU needed.
+  // ---------------------------------------------------------------------
+  it("border perpendicular half-width is UNIFORM across every shape family (apothem compensation)", () => {
+    const dpr = 2;
+    const zoom = 1;
+    // Documented apothem-per-a_radius ratios (shape-geometry.ts regular
+    // polygons; star approximated) — an INDEPENDENT copy of the source's
+    // lookup so this test pins the intended per-shape numbers. NOTE square is
+    // 0.88 (its own SQUARE_INSET_RATIO), NOT cos(45°)=0.707 — the square's
+    // unit outline is pre-inset BEFORE the a_radius scale, unlike diamond
+    // (same 4-gon shape, but no inset, so a_radius IS its circumradius).
+    const APOTHEM_RATIO_BY_CODE: Record<number, number> = {
+      0: 1.0,
+      1: 0.707,
+      2: 0.5,
+      3: 0.866,
+      4: 0.88,
+      6: 0.5,
+    };
+    const perpWidths = FAMILIES.map((family) => {
+      const code = shapeCode(family.shape);
+      const frame: WebGLShapeFrame = {
+        positions: new Float32Array([0, 0]),
+        nodeCount: 1,
+        style: {
+          nodeSizes: new Float32Array([family.size]),
+          nodeColors: new Uint8Array([...family.rgb, 255]),
+          nodeShapes: new Uint8Array([code]),
+          nodeFills: new Uint8Array([1]), // hollow -> emits BOTH a border and an inner-fill instance
+          nodeBorders: new Uint8Array([1]), // bold, so the effect is not lost in a tiny stroke
+          edgeWidths: new Float32Array(),
+          edgeColors: new Uint8Array(),
+          edgeDash: new Uint8Array(),
+          edgeCurvatures: new Float32Array(),
+        },
+        camera: { x: 0, y: 0, zoom },
+        pixelRatio: dpr,
+        viewportWidth: Math.round(200 * dpr),
+        viewportHeight: Math.round(200 * dpr),
+      };
+      const set = buildShapeInstances(frame);
+      const border = decodeInstance(set.border.get(code)!, 0);
+      const innerFill = decodeInstance(set.fill.get(code)!, 0);
+      const radialHalfWidth = (border.radius - innerFill.radius) / 2;
+      return { name: family.name, code, perp: radialHalfWidth * APOTHEM_RATIO_BY_CODE[code]! };
+    });
+
+    const reference = perpWidths[0]!.perp;
+    // Precision 3 (not tighter): this test's ratio table intentionally uses
+    // documented ROUNDED literals (e.g. 0.707) while the source computes
+    // exact trig (Math.cos(Math.PI/4)), so a ~3e-4 rounding gap is expected
+    // and not a regression.
+    for (const { name, perp } of perpWidths) {
+      expect(
+        perp,
+        `${name}: PERPENDICULAR border half-width (${perp}) must match every other family` +
+          ` (reference ${reference}) — the fix compensates the radial offset by the apothem ratio` +
+          ` so the VISIBLE border weight no longer depends on shape.`,
+      ).toBeCloseTo(reference, 3);
+    }
+    // Sanity: circle (ratio 1.0) and diamond (ratio 0.707, genuinely much
+    // thinner pre-fix) now match to the pixel — the exact bug this fix
+    // targets — as do circle and square (ratio 0.88).
+    const circle = perpWidths.find((p) => p.code === 0)!.perp;
+    const diamond = perpWidths.find((p) => p.code === 1)!.perp;
+    const square = perpWidths.find((p) => p.code === 4)!.perp;
+    expect(circle).toBeCloseTo(diamond, 3);
+    expect(circle).toBeCloseTo(square, 3);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -192,17 +276,19 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
       }
 
       // -------------------------------------------------------------------
-      // OUTLINE WIDTH PARITY (B1 beta fidelity bug). The FAMILIES above are all
-      // SOLID fills, so they NEVER exercise the node BORDER — the path the beta
-      // rendered TOO THIN, which is why this oracle passed despite the visible
-      // bug. Canvas2D strokes the border CENTRED on the drawn radius (a band of
-      // (bold?3:1.5)·PR spanning [radius-half, radius+half]); the pre-fix WebGL
-      // ring was INSIDE-ONLY (a disc out to `radius`, carved from the inside),
-      // and for solid+bold the border was hidden entirely by the full-radius
-      // fill. We probe a pixel on the OUTER half of the Canvas2D stroke ring
-      // (radius + 1 device px): node-colour on Canvas2D AND the fixed WebGL ring,
-      // BACKGROUND on the pre-fix inside-only ring. So this FAILS on the too-thin
-      // outline and PASSES once the ring is centred at the correct width.
+      // OUTLINE WIDTH PARITY (B1 beta fidelity bug, UPDATED for the per-shape
+      // apothem-compensation fix). The FAMILIES above are all SOLID fills, so
+      // they never exercise the node BORDER. Canvas2D strokes the border
+      // CENTRED on the drawn radius (a band of (bold?3:1.5)·PR spanning
+      // [radius-half, radius+half]) — UNCHANGED by this fix. The WebGL ring is
+      // now DELIBERATELY ~30% THINNER than the pre-existing square/diamond
+      // weight (uniform across shapes — see webgl-shapes.ts BORDER_PERP_SCALE),
+      // so the probe location and ink-ratio floor below are the NEW intended
+      // geometry, not the old "reads a touch heavier than Canvas2D" target.
+      // We probe a fraction of the way into the ring (not right at its edge,
+      // to stay clear of AA/MSAA at the boundary) using the SAME formula the
+      // source computes, so a probe failure means an actual geometry/colour
+      // regression, not a stale hardcoded pixel offset.
       const borderRgb: [number, number, number] = [22, 163, 74]; // #16a34a
       const hbFixture = {
         nodes: [{ id: "hb", x: 0, y: 0, size: 20, color: "#16a34a", shape: "circle", fill: "hollow", border: "bold" }],
@@ -215,9 +301,13 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
       const view = { width: hbGl.width, height: hbGl.height, zoom, camera: { x: 0, y: 0 } };
       const [cx, cy] = worldToDevice([0, 0], view);
       const radius = drawnRadius(20, dpr, zoom); // 40 device px @ dpr 2
-      // Outer-half-of-ring probe: only painted when the border is centred at the
-      // correct (Canvas2D) width — NOT by the pre-fix inside-only ring.
-      const probeX = cx + radius + 1;
+      // Circle's apothem ratio is 1.0, so its radial ring offset IS the new
+      // uniform perpendicular half-width directly — probe 60% of the way from
+      // the drawn radius to the ring's outer edge (safely inside the ring,
+      // clear of the AA boundary), a fraction of the SOURCE's own formula so
+      // this stays correct if the constants ever change.
+      const ringHalfWidth = effectiveStrokeHalfWidth(0, true, dpr, zoom);
+      const probeX = cx + radius + ringHalfWidth * 0.6;
       const refProbe = geometryProbes(hbRef, [
         { name: "ref-border-outer", x: probeX, y: cy, expect: [...borderRgb, 255], tolerance: 40 },
       ]);
@@ -225,7 +315,10 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
         { name: "gl-border-outer", x: probeX, y: cy, expect: [...borderRgb, 255], tolerance: 40 },
       ]);
       // Secondary: the WebGL border must paint a comparable amount of node-colour
-      // ink to Canvas2D (the pre-fix washed/inside-only ring paints much less).
+      // ink to Canvas2D. The NEW ring is intentionally ~0.69x the Canvas2D width
+      // (uniform across shapes, ~30% thinner than the old square/diamond weight,
+      // itself already thinner than Canvas2D for those shapes) — floor/ceiling
+      // bracket the intended ~0.69 ratio with room for AA-driven pixel-count noise.
       const refBorderInk = countColorPixels(hbRef, borderRgb, 50);
       const glBorderInk = countColorPixels(hbGl, borderRgb, 50);
       const borderRatio = refBorderInk > 0 ? glBorderInk / refBorderInk : 0;
@@ -235,15 +328,19 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
           `glProbe=${JSON.stringify(glProbe.results[0].got)} ` +
           `refBorderInk=${refBorderInk} glBorderInk=${glBorderInk} ratio=${borderRatio.toFixed(3)}`,
       );
-      expect(refProbe.pass, "canvas2d border ring must cover radius+1 (sanity)").toBe(true);
+      expect(refProbe.pass, "canvas2d border ring must cover the probe point (sanity)").toBe(true);
       expect(
         glProbe.pass,
-        `WebGL hollow-bold border too thin/inside-only at radius+1 (got ${JSON.stringify(glProbe.results[0].got)})`,
+        `WebGL hollow-bold border vanished/mispositioned at the intended new ring (got ${JSON.stringify(glProbe.results[0].got)})`,
       ).toBe(true);
       expect(
         borderRatio,
-        `WebGL border ink ratio ${borderRatio.toFixed(3)} too low — outline under-weighted vs Canvas2D`,
-      ).toBeGreaterThanOrEqual(0.6);
+        `WebGL border ink ratio ${borderRatio.toFixed(3)} too low — border thinner than the intended ~0.69x Canvas2D`,
+      ).toBeGreaterThanOrEqual(0.4);
+      expect(
+        borderRatio,
+        `WebGL border ink ratio ${borderRatio.toFixed(3)} too high — border not thinned as intended (~0.69x Canvas2D)`,
+      ).toBeLessThanOrEqual(0.9);
 
       // -------------------------------------------------------------------
       // HOVER-DIM PARITY (premultiplied-alpha regression). The FAMILIES + the

--- a/packages/graph/tests/golden/shapes-golden.test.ts
+++ b/packages/graph/tests/golden/shapes-golden.test.ts
@@ -19,13 +19,8 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-  buildShapeInstances,
-  decodeInstance,
-  effectiveStrokeHalfWidth,
-  type WebGLShapeFrame,
-} from "../../src/webgl-shapes";
-import { drawnRadius } from "../../src/render-geometry";
+import { buildShapeInstances, decodeInstance, type WebGLShapeFrame } from "../../src/webgl-shapes";
+import { borderStrokeWidthPx, drawnRadius } from "../../src/render-geometry";
 import { shapeCode } from "../../src/shape-geometry";
 // @ts-expect-error -- .mjs harness modules are plain ESM, no types needed.
 import { openOracle } from "./cdp-harness.mjs";
@@ -111,21 +106,26 @@ describe("B1 Phase 1 — shape geometry parity (WebGL a_radius == Canvas2D radiu
   });
 
   // ---------------------------------------------------------------------
-  // Border-thickness fix: the two-disc ring is built by scaling the WHOLE
-  // unit polygon by a RADIAL offset (radius ± effectiveStrokeHalf). For a
-  // disc (circle) the radial offset IS the perpendicular gap, but for a
+  // Border-thickness geometry (apothem compensation + per-shape THINNING,
+  // 2026-07-13 user request): the two-disc ring is built by scaling the
+  // WHOLE unit polygon by a RADIAL offset (radius ± effectiveStrokeHalf). For
+  // a disc (circle) the radial offset IS the perpendicular gap, but for a
   // flat-faced polygon (diamond/square/hexagon/triangle) the gap measured
   // PERPENDICULAR to a face is `radial offset x apothem/circumradius ratio`
   // (apothem = radius x ratio) — so circles/hexagons rendered a MUCH thicker
-  // perpendicular border than diamonds/squares/triangles. The fix compensates
-  // by DIVIDING the radial offset by each family's own apothem ratio, so that
-  // once re-foreshortened by that SAME ratio the visible PERPENDICULAR width
-  // is identical everywhere. This asserts the perpendicular (radial x ratio),
-  // NOT the radial offset itself, is uniform — the radial offsets are
-  // deliberately UNEQUAL by design (that inequality is what cancels the
-  // per-shape foreshortening). Deterministic, no GPU needed.
+  // perpendicular border than diamonds/squares/triangles. The apothem
+  // compensation DIVIDES the radial offset by each family's own apothem
+  // ratio, so that once re-foreshortened by that SAME ratio every family
+  // lands on a COMMON perpendicular baseline. On TOP of that baseline,
+  // SHAPE_BORDER_THIN then applies an ADDITIONAL per-shape cut — circle/
+  // hexagon x0.5, diamond/square/star/triangle x0.8 — so the perpendicular
+  // width is now a deliberate TWO-TIER geometry (no longer fully uniform).
+  // This asserts the perpendicular (radial x ratio), NOT the radial offset
+  // itself — the radial offsets are deliberately UNEQUAL by design (that
+  // inequality is what cancels the per-shape foreshortening AND encodes the
+  // per-shape thinning). Deterministic, no GPU needed.
   // ---------------------------------------------------------------------
-  it("border perpendicular half-width is UNIFORM across every shape family (apothem compensation)", () => {
+  it("border perpendicular half-width is TWO-TIER across shape families (apothem compensation + per-shape thinning)", () => {
     const dpr = 2;
     const zoom = 1;
     // Documented apothem-per-a_radius ratios (shape-geometry.ts regular
@@ -170,27 +170,41 @@ describe("B1 Phase 1 — shape geometry parity (WebGL a_radius == Canvas2D radiu
       return { name: family.name, code, perp: radialHalfWidth * APOTHEM_RATIO_BY_CODE[code]! };
     });
 
-    const reference = perpWidths[0]!.perp;
-    // Precision 3 (not tighter): this test's ratio table intentionally uses
-    // documented ROUNDED literals (e.g. 0.707) while the source computes
-    // exact trig (Math.cos(Math.PI/4)), so a ~3e-4 rounding gap is expected
-    // and not a regression.
-    for (const { name, perp } of perpWidths) {
+    // Tier 1: circle (0) & hexagon (3) — SHAPE_BORDER_THIN x0.5.
+    const circle = perpWidths.find((p) => p.code === 0)!.perp;
+    const hexagon = perpWidths.find((p) => p.code === 3)!.perp;
+    expect(circle, "circle vs hexagon: same tier (both x0.5), must match").toBeCloseTo(hexagon, 3);
+
+    // Tier 2: diamond (1), star (2), square (4), triangle (6) — x0.8 (star &
+    // triangle NOT specified by the user request; defaulted to the same 0.8
+    // as diamond/square rather than left at the old uniform baseline).
+    const tier2Codes = [1, 2, 4, 6];
+    const reference = perpWidths.find((p) => p.code === tier2Codes[0])!.perp;
+    for (const code of tier2Codes) {
+      const perp = perpWidths.find((p) => p.code === code)!.perp;
       expect(
         perp,
-        `${name}: PERPENDICULAR border half-width (${perp}) must match every other family` +
-          ` (reference ${reference}) — the fix compensates the radial offset by the apothem ratio` +
-          ` so the VISIBLE border weight no longer depends on shape.`,
+        `code ${code}: PERPENDICULAR border half-width (${perp}) must match the rest of tier 2` +
+          ` (reference ${reference})`,
       ).toBeCloseTo(reference, 3);
     }
-    // Sanity: circle (ratio 1.0) and diamond (ratio 0.707, genuinely much
-    // thinner pre-fix) now match to the pixel — the exact bug this fix
-    // targets — as do circle and square (ratio 0.88).
-    const circle = perpWidths.find((p) => p.code === 0)!.perp;
-    const diamond = perpWidths.find((p) => p.code === 1)!.perp;
-    const square = perpWidths.find((p) => p.code === 4)!.perp;
-    expect(circle).toBeCloseTo(diamond, 3);
-    expect(circle).toBeCloseTo(square, 3);
+
+    // Cross-tier: circle/hexagon vs diamond/square/star/triangle differ by
+    // EXACTLY the two SHAPE_BORDER_THIN multipliers' ratio (0.5 / 0.8 =
+    // 0.625) — NOT 0.5 (0.5 is only the circle/hexagon multiplier applied to
+    // the shared baseline, not its ratio to the OTHER tier's own, different
+    // 0.8 multiplier). Verified numerically (0.308 / 0.493 = 0.625).
+    expect(circle / reference).toBeCloseTo(0.5 / 0.8, 2);
+
+    // REGRESSION LOCK: absolute perpendicular widths, as a fraction of the
+    // raw (uncompensated, un-thinned) strokeHalfWidth.
+    const base = borderStrokeWidthPx(true, dpr, zoom) / 2;
+    const rawStrokeHalf = base * 1.12; // WEBGL_OUTLINE_WEIGHT_BOOST, unchanged by this fix
+    // circle/hexagon: 0.616 (BORDER_PERP_SCALE) x 0.5 (thin factor) = 0.308
+    expect(circle / rawStrokeHalf).toBeCloseTo(0.308, 2);
+    expect(hexagon / rawStrokeHalf).toBeCloseTo(0.308, 2);
+    // diamond/square/star/triangle: 0.616 x 0.8 = 0.493
+    expect(reference / rawStrokeHalf).toBeCloseTo(0.493, 2);
   });
 });
 
@@ -277,18 +291,20 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
 
       // -------------------------------------------------------------------
       // OUTLINE WIDTH PARITY (B1 beta fidelity bug, UPDATED for the per-shape
-      // apothem-compensation fix). The FAMILIES above are all SOLID fills, so
-      // they never exercise the node BORDER. Canvas2D strokes the border
-      // CENTRED on the drawn radius (a band of (bold?3:1.5)·PR spanning
-      // [radius-half, radius+half]) — UNCHANGED by this fix. The WebGL ring is
-      // now DELIBERATELY ~30% THINNER than the pre-existing square/diamond
-      // weight (uniform across shapes — see webgl-shapes.ts BORDER_PERP_SCALE),
-      // so the probe location and ink-ratio floor below are the NEW intended
-      // geometry, not the old "reads a touch heavier than Canvas2D" target.
-      // We probe a fraction of the way into the ring (not right at its edge,
-      // to stay clear of AA/MSAA at the boundary) using the SAME formula the
-      // source computes, so a probe failure means an actual geometry/colour
-      // regression, not a stale hardcoded pixel offset.
+      // apothem-compensation fix AND the 2026-07-13 per-shape THINNING on top
+      // of it). The FAMILIES above are all SOLID fills, so they never
+      // exercise the node BORDER. Canvas2D strokes the border CENTRED on the
+      // drawn radius (a band of (bold?3:1.5)·PR spanning [radius-half,
+      // radius+half]) — UNCHANGED by this fix. The WebGL ring for this CIRCLE
+      // fixture is now DELIBERATELY thinner still than the already-thinned
+      // uniform baseline — SHAPE_BORDER_THIN's circle/hexagon tier (x0.5) —
+      // so the probe location and ink-ratio floor/ceiling below are the NEW
+      // intended geometry for circle specifically, not the uniform-baseline
+      // (~30%-thinner-than-square) target the apothem-compensation fix alone
+      // produced. We probe a fraction of the way into the ring (not right at
+      // its edge, to stay clear of AA/MSAA at the boundary) using the SAME
+      // formula the source computes, so a probe failure means an actual
+      // geometry/colour regression, not a stale hardcoded pixel offset.
       const borderRgb: [number, number, number] = [22, 163, 74]; // #16a34a
       const hbFixture = {
         nodes: [{ id: "hb", x: 0, y: 0, size: 20, color: "#16a34a", shape: "circle", fill: "hollow", border: "bold" }],
@@ -301,13 +317,18 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
       const view = { width: hbGl.width, height: hbGl.height, zoom, camera: { x: 0, y: 0 } };
       const [cx, cy] = worldToDevice([0, 0], view);
       const radius = drawnRadius(20, dpr, zoom); // 40 device px @ dpr 2
-      // Circle's apothem ratio is 1.0, so its radial ring offset IS the new
-      // uniform perpendicular half-width directly — probe 60% of the way from
-      // the drawn radius to the ring's outer edge (safely inside the ring,
-      // clear of the AA boundary), a fraction of the SOURCE's own formula so
-      // this stays correct if the constants ever change.
-      const ringHalfWidth = effectiveStrokeHalfWidth(0, true, dpr, zoom);
-      const probeX = cx + radius + ringHalfWidth * 0.6;
+      // Circle's apothem ratio is 1.0, so its radial ring offset IS the
+      // perpendicular half-width directly. Probe AT the ring's centreline
+      // (`radius`, i.e. the drawn a_radius itself — equidistant from both the
+      // inner and outer ring edges) rather than a fraction toward the outer
+      // edge: with the 2026-07-13 per-shape thinning the circle ring's
+      // half-width shrank to ~1px @ dpr 2 (0.5x the already-thinned uniform
+      // baseline), so a probe biased toward the outer edge (the OLD 0.6-of-
+      // the-way-out fraction) now lands within the AA blur radius of that
+      // edge and reads washed-toward-background. The centreline keeps a full
+      // half-width of margin from EITHER edge regardless of how thin the ring
+      // is, so this stays robust as the constants change.
+      const probeX = cx + radius;
       const refProbe = geometryProbes(hbRef, [
         { name: "ref-border-outer", x: probeX, y: cy, expect: [...borderRgb, 255], tolerance: 40 },
       ]);
@@ -315,10 +336,16 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
         { name: "gl-border-outer", x: probeX, y: cy, expect: [...borderRgb, 255], tolerance: 40 },
       ]);
       // Secondary: the WebGL border must paint a comparable amount of node-colour
-      // ink to Canvas2D. The NEW ring is intentionally ~0.69x the Canvas2D width
-      // (uniform across shapes, ~30% thinner than the old square/diamond weight,
-      // itself already thinner than Canvas2D for those shapes) — floor/ceiling
-      // bracket the intended ~0.69 ratio with room for AA-driven pixel-count noise.
+      // ink to Canvas2D. This fixture is a CIRCLE, which now carries the
+      // circle/hexagon SHAPE_BORDER_THIN tier (x0.5, on top of the x0.616
+      // apothem-compensated baseline) — 2026-07-13 per-shape thinning update.
+      // Full-ring-width ratio to Canvas2D: WEBGL_OUTLINE_WEIGHT_BOOST (1.12) x
+      // BORDER_PERP_SCALE (0.616) x thin(circle) (0.5) = 0.345 (down from the
+      // pre-thinning ~0.69 uniform target). Ring-area ink-pixel counts track
+      // ring width closely for a thin annulus, so the floor/ceiling below
+      // bracket ~0.345 with the same generous relative margin the old ~0.69
+      // bracket used (~ -42%/+30% of target), to absorb AA/MSAA pixel-count
+      // noise on an even-thinner ring.
       const refBorderInk = countColorPixels(hbRef, borderRgb, 50);
       const glBorderInk = countColorPixels(hbGl, borderRgb, 50);
       const borderRatio = refBorderInk > 0 ? glBorderInk / refBorderInk : 0;
@@ -335,12 +362,12 @@ describe("B1 Phase 1 — shape pixel parity (WebGL vs Canvas2D, Chrome/CDP)", ()
       ).toBe(true);
       expect(
         borderRatio,
-        `WebGL border ink ratio ${borderRatio.toFixed(3)} too low — border thinner than the intended ~0.69x Canvas2D`,
-      ).toBeGreaterThanOrEqual(0.4);
+        `WebGL border ink ratio ${borderRatio.toFixed(3)} too low — border thinner than the intended ~0.345x Canvas2D (circle tier)`,
+      ).toBeGreaterThanOrEqual(0.2);
       expect(
         borderRatio,
-        `WebGL border ink ratio ${borderRatio.toFixed(3)} too high — border not thinned as intended (~0.69x Canvas2D)`,
-      ).toBeLessThanOrEqual(0.9);
+        `WebGL border ink ratio ${borderRatio.toFixed(3)} too high — border not thinned as intended (~0.345x Canvas2D, circle tier)`,
+      ).toBeLessThanOrEqual(0.45);
 
       // -------------------------------------------------------------------
       // HOVER-DIM PARITY (premultiplied-alpha regression). The FAMILIES + the

--- a/packages/graph/tests/layout-grid.test.ts
+++ b/packages/graph/tests/layout-grid.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRenderGraphBuffers,
+  computeGridPositions,
+  getLayout,
+  GRID_LAYOUT_ID,
+  type LayoutFn,
+} from "../src/index";
+
+/** Read back the (x, y) of node index `i` from a node-order-keyed positions array. */
+function xy(positions: Float32Array, i: number): { x: number; y: number } {
+  return { x: positions[i * 2]!, y: positions[i * 2 + 1]! };
+}
+
+/** A graph of `count` bare nodes (grid ignores edges — only the count matters). */
+function nodesGraph(count: number) {
+  return buildRenderGraphBuffers({
+    nodes: Array.from({ length: count }, (_, i) => ({ id: `n${i}` })),
+    edges: [],
+  });
+}
+
+describe("Grid layout — regular ceil(√n) grid centred on the origin", () => {
+  it("returns a valid node-order-keyed Float32Array of length 2*N with no NaN/Inf", () => {
+    const graph = nodesGraph(9);
+    const positions = computeGridPositions(graph);
+    expect(positions).toBeInstanceOf(Float32Array);
+    expect(positions.length).toBe(graph.nodeIds.length * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("places nodes on a ceil(√n)-column grid in node-id order", () => {
+    // n = 9 → 3 cols × 3 rows, gridGap 60, centred → offsets (60, 60).
+    const positions = computeGridPositions(nodesGraph(9), { gridGap: 60 });
+    expect(xy(positions, 0)).toEqual({ x: -60, y: -60 }); // col 0, row 0
+    expect(xy(positions, 1)).toEqual({ x: 0, y: -60 }); // col 1, row 0
+    expect(xy(positions, 2)).toEqual({ x: 60, y: -60 }); // col 2, row 0
+    expect(xy(positions, 4)).toEqual({ x: 0, y: 0 }); // col 1, row 1 — the centre
+    expect(xy(positions, 8)).toEqual({ x: 60, y: 60 }); // col 2, row 2
+  });
+
+  it("spaces adjacent cells by exactly gridGap on both axes", () => {
+    const positions = computeGridPositions(nodesGraph(9), { gridGap: 42 });
+    // Horizontal neighbours (0 → 1) differ by gridGap in x, share y.
+    expect(xy(positions, 1).x - xy(positions, 0).x).toBeCloseTo(42, 4);
+    expect(xy(positions, 1).y).toBeCloseTo(xy(positions, 0).y, 4);
+    // Vertical neighbours (0 → 3, one full row down) differ by gridGap in y.
+    expect(xy(positions, 3).y - xy(positions, 0).y).toBeCloseTo(42, 4);
+    expect(xy(positions, 3).x).toBeCloseTo(xy(positions, 0).x, 4);
+  });
+
+  it("centres the full grid bounding box on the origin", () => {
+    const positions = computeGridPositions(nodesGraph(9), { gridGap: 60 });
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (let i = 0; i < positions.length; i += 2) {
+      minX = Math.min(minX, positions[i]!);
+      maxX = Math.max(maxX, positions[i]!);
+      minY = Math.min(minY, positions[i + 1]!);
+      maxY = Math.max(maxY, positions[i + 1]!);
+    }
+    expect(minX + maxX).toBeCloseTo(0, 4);
+    expect(minY + maxY).toBeCloseTo(0, 4);
+  });
+
+  it("handles a non-square count (partial last row)", () => {
+    // n = 5 → cols = ceil(√5) = 3, rows = ceil(5/3) = 2 → offsets (60, 30).
+    const positions = computeGridPositions(nodesGraph(5), { gridGap: 60 });
+    expect(xy(positions, 0)).toEqual({ x: -60, y: -30 }); // col 0, row 0
+    expect(xy(positions, 3)).toEqual({ x: -60, y: 30 }); // col 0, row 1
+    expect(xy(positions, 4)).toEqual({ x: 0, y: 30 }); // col 1, row 1
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("is deterministic — identical input yields byte-identical output", () => {
+    const a = computeGridPositions(nodesGraph(17));
+    const b = computeGridPositions(nodesGraph(17));
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("handles the empty graph (length 0)", () => {
+    expect(computeGridPositions(nodesGraph(0)).length).toBe(0);
+  });
+
+  it("handles a single node at the origin", () => {
+    expect(Array.from(computeGridPositions(nodesGraph(1)))).toEqual([0, 0]);
+  });
+
+  it("stays O(n): a large graph places every node finitely and fast", () => {
+    const n = 10000;
+    const graph = nodesGraph(n);
+    const start = Date.now();
+    const positions = computeGridPositions(graph);
+    expect(Date.now() - start).toBeLessThan(200); // O(n^2) would blow past this
+    expect(positions.length).toBe(n * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("is invoked through the registry via resolveLayout('grid')", () => {
+    const graph = nodesGraph(4);
+    const fn = getLayout(GRID_LAYOUT_ID) as LayoutFn;
+    const out = fn(graph);
+    expect(out.length).toBe(graph.nodeIds.length * 2);
+    for (const v of out) expect(Number.isFinite(v)).toBe(true);
+  });
+});

--- a/packages/graph/tests/layout-metro.test.ts
+++ b/packages/graph/tests/layout-metro.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRenderGraphBuffers,
+  computeMetroPositions,
+  getLayout,
+  METRO_LAYOUT_ID,
+  type LayoutFn,
+} from "../src/index";
+
+/** Read back the (x, y) of node index `i` from a node-order-keyed positions array. */
+function xy(positions: Float32Array, i: number): { x: number; y: number } {
+  return { x: positions[i * 2]!, y: positions[i * 2 + 1]! };
+}
+
+/** A star: n0 is the hub, n1..n(count-1) are leaves — one BFS lane of leaves. */
+function starGraph(count: number) {
+  return buildRenderGraphBuffers({
+    nodes: Array.from({ length: count }, (_, i) => ({ id: `n${i}` })),
+    edges: Array.from({ length: count - 1 }, (_, i) => ({ source: "n0", target: `n${i + 1}` })),
+  });
+}
+
+describe("Metro layout — BFS lanes, grid-snapped nodes", () => {
+  it("returns a valid node-order-keyed Float32Array of length 2*N with no NaN/Inf", () => {
+    const graph = starGraph(6);
+    const positions = computeMetroPositions(graph);
+    expect(positions).toBeInstanceOf(Float32Array);
+    expect(positions.length).toBe(graph.nodeIds.length * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("puts the highest-degree hub on lane 0 and its neighbours on lane 1", () => {
+    const graph = starGraph(4); // n0 hub (deg 3), n1..n3 leaves (deg 1)
+    const positions = computeMetroPositions(graph, { laneGap: 100 });
+    // Hub is the sole node on lane 0 (y = 0), centred (x = 0).
+    expect(xy(positions, 0)).toEqual({ x: 0, y: 0 });
+    // The three leaves share lane 1 (y = laneGap), spread across grid columns.
+    for (let i = 1; i <= 3; i++) expect(xy(positions, i).y).toBeCloseTo(100, 4);
+    const leafXs = [xy(positions, 1).x, xy(positions, 2).x, xy(positions, 3).x];
+    expect(new Set(leafXs).size).toBe(3); // distinct columns, no collisions
+  });
+
+  it("snaps within a lane to even grid columns centred on the origin", () => {
+    const graph = starGraph(4);
+    const positions = computeMetroPositions(graph, { colGap: 50 });
+    const leafXs = [xy(positions, 1).x, xy(positions, 2).x, xy(positions, 3).x].sort((a, b) => a - b);
+    // 3 leaves → columns (-50, 0, 50): centred, gridGap-spaced.
+    expect(leafXs).toEqual([-50, 0, 50]);
+  });
+
+  it("parks disconnected nodes on an extra lane below the deepest level", () => {
+    const graph = buildRenderGraphBuffers({
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      edges: [{ source: "a", target: "b" }], // c is disconnected
+    });
+    const positions = computeMetroPositions(graph, { laneGap: 100 });
+    // a (hub) lane 0, b lane 1, c parked on lane 2 (maxLevel 1 + 1).
+    expect(xy(positions, 2).y).toBeCloseTo(200, 4);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("is deterministic — identical input yields byte-identical output", () => {
+    const a = computeMetroPositions(starGraph(12));
+    const b = computeMetroPositions(starGraph(12));
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("handles the empty graph (length 0) and a single node at the origin", () => {
+    expect(computeMetroPositions(starGraph(0)).length).toBe(0);
+    const single = buildRenderGraphBuffers({ nodes: [{ id: "a" }], edges: [] });
+    expect(Array.from(computeMetroPositions(single))).toEqual([0, 0]);
+  });
+
+  it("stays O(n+e): a large graph places every node finitely and fast", () => {
+    const n = 8000;
+    const graph = buildRenderGraphBuffers({
+      nodes: Array.from({ length: n }, (_, i) => ({ id: `n${i}` })),
+      edges: Array.from({ length: n - 1 }, (_, i) => ({ source: `n${i}`, target: `n${i + 1}` })),
+    });
+    const start = Date.now();
+    const positions = computeMetroPositions(graph);
+    expect(Date.now() - start).toBeLessThan(300);
+    expect(positions.length).toBe(n * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("is invoked through the registry via resolveLayout('metro')", () => {
+    const graph = starGraph(4);
+    const fn = getLayout(METRO_LAYOUT_ID) as LayoutFn;
+    const out = fn(graph);
+    expect(out.length).toBe(graph.nodeIds.length * 2);
+    for (const v of out) expect(Number.isFinite(v)).toBe(true);
+  });
+});

--- a/packages/graph/tests/layout-radial.test.ts
+++ b/packages/graph/tests/layout-radial.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRenderGraphBuffers,
+  computeRadialPositions,
+  getLayout,
+  RADIAL_LAYOUT_ID,
+  type LayoutFn,
+} from "../src/index";
+
+/** Read back the (x, y) of node index `i` from a node-order-keyed positions array. */
+function xy(positions: Float32Array, i: number): { x: number; y: number } {
+  return { x: positions[i * 2]!, y: positions[i * 2 + 1]! };
+}
+
+/** Radial distance from the origin of node index `i`. */
+function radius(positions: Float32Array, i: number): number {
+  const { x, y } = xy(positions, i);
+  return Math.hypot(x, y);
+}
+
+/**
+ * R connected to A, B, C (level 1); A connected to D (level 2); X isolated.
+ * Degrees: R=3, A=2, B=1, C=1, D=1, X=0 → root is R (highest degree).
+ */
+function sampleGraph() {
+  return buildRenderGraphBuffers({
+    nodes: [
+      { id: "R" },
+      { id: "A" },
+      { id: "B" },
+      { id: "C" },
+      { id: "D" },
+      { id: "X" },
+    ],
+    edges: [
+      { source: "R", target: "A" },
+      { source: "R", target: "B" },
+      { source: "R", target: "C" },
+      { source: "A", target: "D" },
+    ],
+  });
+}
+
+describe("Radial layout — concentric rings around the highest-degree hub", () => {
+  it("returns a valid node-order-keyed Float32Array of length 2*N with no NaN/Inf", () => {
+    const graph = sampleGraph();
+    const positions = computeRadialPositions(graph);
+    expect(positions).toBeInstanceOf(Float32Array);
+    expect(positions.length).toBe(graph.nodeIds.length * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("places the highest-degree root at the origin", () => {
+    const graph = sampleGraph();
+    const positions = computeRadialPositions(graph);
+    const rootIdx = graph.idToIndex.get("R")!;
+    expect(xy(positions, rootIdx)).toEqual({ x: 0, y: 0 });
+    // No other node sits at the origin.
+    for (let i = 0; i < graph.nodeIds.length; i++) {
+      if (i === rootIdx) continue;
+      expect(radius(positions, i)).toBeGreaterThan(0);
+    }
+  });
+
+  it("places BFS level L on a ring of radius L*ringGap (shared per level)", () => {
+    const graph = sampleGraph();
+    const ringGap = 100;
+    const positions = computeRadialPositions(graph, { ringGap });
+    const r = (id: string) => radius(positions, graph.idToIndex.get(id)!);
+    // Level 1 (A, B, C) all on the first ring.
+    expect(r("A")).toBeCloseTo(ringGap, 4);
+    expect(r("B")).toBeCloseTo(ringGap, 4);
+    expect(r("C")).toBeCloseTo(ringGap, 4);
+    // Level 2 (D) on the second ring.
+    expect(r("D")).toBeCloseTo(2 * ringGap, 4);
+  });
+
+  it("spreads a level by even angle (distinct positions per node)", () => {
+    const graph = sampleGraph();
+    const positions = computeRadialPositions(graph);
+    const idx = ["A", "B", "C"].map((id) => graph.idToIndex.get(id)!);
+    const keys = idx.map((i) => `${xy(positions, i).x.toFixed(4)},${xy(positions, i).y.toFixed(4)}`);
+    // Three siblings on the same ring → three distinct angular positions.
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("parks disconnected nodes on ONE outer ring beyond the deepest level", () => {
+    const graph = sampleGraph();
+    const ringGap = 100;
+    const positions = computeRadialPositions(graph, { ringGap });
+    // maxLevel = 2 (D); outer ring = 2*ringGap + ringGap = 3*ringGap.
+    expect(radius(positions, graph.idToIndex.get("X")!)).toBeCloseTo(3 * ringGap, 4);
+  });
+
+  it("is deterministic — identical input yields byte-identical output", () => {
+    const a = computeRadialPositions(sampleGraph());
+    const b = computeRadialPositions(sampleGraph());
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("breaks a degree tie by node-id order (earliest node is the root)", () => {
+    // Two nodes, one edge → both degree 1. The earlier node (p) wins the root.
+    const graph = buildRenderGraphBuffers({
+      nodes: [{ id: "p" }, { id: "q" }],
+      edges: [{ source: "p", target: "q" }],
+    });
+    const positions = computeRadialPositions(graph);
+    expect(xy(positions, graph.idToIndex.get("p")!)).toEqual({ x: 0, y: 0 });
+    expect(radius(positions, graph.idToIndex.get("q")!)).toBeGreaterThan(0);
+  });
+
+  it("handles an edgeless graph — root at origin, the rest on the outer ring", () => {
+    const graph = buildRenderGraphBuffers({
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      edges: [],
+    });
+    const positions = computeRadialPositions(graph, { ringGap: 50 });
+    // All degree 0 → root = a (index 0) at origin; b, c disconnected on the ring.
+    expect(xy(positions, 0)).toEqual({ x: 0, y: 0 });
+    expect(radius(positions, 1)).toBeCloseTo(50, 4);
+    expect(radius(positions, 2)).toBeCloseTo(50, 4);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("handles the empty graph (length 0)", () => {
+    const graph = buildRenderGraphBuffers({ nodes: [], edges: [] });
+    expect(computeRadialPositions(graph).length).toBe(0);
+  });
+
+  it("stays O(n+e): a large graph places every node finitely and fast", () => {
+    const n = 5000;
+    const nodes = Array.from({ length: n }, (_, i) => ({ id: `n${i}` }));
+    // A path graph (n-1 edges): each node reachable, deep BFS chain.
+    const edges = Array.from({ length: n - 1 }, (_, i) => ({ source: `n${i}`, target: `n${i + 1}` }));
+    const graph = buildRenderGraphBuffers({ nodes, edges });
+    const start = Date.now();
+    const positions = computeRadialPositions(graph);
+    expect(Date.now() - start).toBeLessThan(500); // O(n^2) would blow past this
+    expect(positions.length).toBe(n * 2);
+    for (const v of positions) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("is invoked through the registry via resolveLayout('radial')", () => {
+    const graph = sampleGraph();
+    const fn = getLayout(RADIAL_LAYOUT_ID) as LayoutFn;
+    const out = fn(graph);
+    expect(out.length).toBe(graph.nodeIds.length * 2);
+    expect(xy(out, graph.idToIndex.get("R")!)).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/packages/graph/tests/layout-registry.test.ts
+++ b/packages/graph/tests/layout-registry.test.ts
@@ -8,6 +8,7 @@ import {
   GRID_LAYOUT_ID,
   hasLayout,
   listLayouts,
+  METRO_LAYOUT_ID,
   RADIAL_LAYOUT_ID,
   registerLayout,
   resolveLayout,
@@ -54,6 +55,18 @@ describe("layout registry — register / lookup / default", () => {
       expect(out.length).toBe(graph.nodeIds.length * 2);
       for (const v of out) expect(Number.isFinite(v)).toBe(true);
     }
+  });
+
+  it("ships the Lot-6 metro layout registered and resolvable", () => {
+    expect(METRO_LAYOUT_ID).toBe("metro");
+    expect(hasLayout(METRO_LAYOUT_ID)).toBe(true);
+    expect(listLayouts()).toEqual(expect.arrayContaining(["metro"]));
+    expect(resolveLayout(METRO_LAYOUT_ID)).toBe(getLayout(METRO_LAYOUT_ID));
+    const graph = sampleGraph();
+    const out = resolveLayout(METRO_LAYOUT_ID)(graph);
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(out.length).toBe(graph.nodeIds.length * 2);
+    for (const v of out) expect(Number.isFinite(v)).toBe(true);
   });
 
   it("default ('force') is a passthrough of the baked positions", () => {

--- a/packages/graph/tests/layout-registry.test.ts
+++ b/packages/graph/tests/layout-registry.test.ts
@@ -5,8 +5,10 @@ import {
   createLayoutEngine,
   DEFAULT_LAYOUT_ID,
   getLayout,
+  GRID_LAYOUT_ID,
   hasLayout,
   listLayouts,
+  RADIAL_LAYOUT_ID,
   registerLayout,
   resolveLayout,
   TYPED_LAYER_LAYOUT_ID,
@@ -33,6 +35,25 @@ describe("layout registry — register / lookup / default", () => {
     const ids = listLayouts();
     expect(ids).toContain("force");
     expect(ids).toContain("typed-layer");
+  });
+
+  it("ships the Lot-2 radial + grid layouts registered and resolvable", () => {
+    expect(RADIAL_LAYOUT_ID).toBe("radial");
+    expect(GRID_LAYOUT_ID).toBe("grid");
+    expect(hasLayout(RADIAL_LAYOUT_ID)).toBe(true);
+    expect(hasLayout(GRID_LAYOUT_ID)).toBe(true);
+    expect(listLayouts()).toEqual(expect.arrayContaining(["radial", "grid"]));
+    // resolveLayout returns the registered engines (not the default fallback).
+    expect(resolveLayout(RADIAL_LAYOUT_ID)).toBe(getLayout(RADIAL_LAYOUT_ID));
+    expect(resolveLayout(GRID_LAYOUT_ID)).toBe(getLayout(GRID_LAYOUT_ID));
+    // Both yield a valid 2*N buffer for a sample graph.
+    const graph = sampleGraph();
+    for (const id of [RADIAL_LAYOUT_ID, GRID_LAYOUT_ID]) {
+      const out = resolveLayout(id)(graph);
+      expect(out).toBeInstanceOf(Float32Array);
+      expect(out.length).toBe(graph.nodeIds.length * 2);
+      for (const v of out) expect(Number.isFinite(v)).toBe(true);
+    }
   });
 
   it("default ('force') is a passthrough of the baked positions", () => {

--- a/packages/graph/tests/webgl-edges.test.ts
+++ b/packages/graph/tests/webgl-edges.test.ts
@@ -17,6 +17,7 @@ import {
   CAPSULE_FLOATS_PER_INSTANCE,
   buildEdgeInstances,
   createWebGLEdgeRenderer,
+  decodeCapsule,
   type WebGLEdgeFrame,
 } from "../src/webgl-edges";
 import { shapeCode } from "../src/shape-geometry";
@@ -144,11 +145,32 @@ describe("B1 Phase 2 — instanced edge draw contract (fake WebGL2)", () => {
   });
 
   it("instance buffer strides match the decoders", () => {
-    expect(CAPSULE_FLOATS_PER_INSTANCE).toBe(12);
+    expect(CAPSULE_FLOATS_PER_INSTANCE).toBe(15);
     expect(ARROW_FLOATS_PER_INSTANCE).toBe(9);
     const set = buildEdgeInstances(edgeFrame());
     expect(set.capsules.length % CAPSULE_FLOATS_PER_INSTANCE).toBe(0);
     expect(set.arrows.length % ARROW_FLOATS_PER_INSTANCE).toBe(0);
+  });
+
+  it("no edgeAlphaShape ⇒ every capsule uploads the uniform (1,1,1) shape", () => {
+    const set = buildEdgeInstances(edgeFrame());
+    const cap = decodeCapsule(set.capsules, 0);
+    expect(cap.shape).toEqual([1, 1, 1]);
+  });
+
+  it("edgeAlphaShape is normalised 0..1 and carried onto every segment", () => {
+    const frame = edgeFrame({ curvature: 0.5 });
+    // Fade toward the MIDDLE: opaque at both ends (255), faint mid (64).
+    frame.style!.edgeAlphaShape = new Uint8Array([255, 64, 255]);
+    const set = buildEdgeInstances(frame);
+    const segCount = set.capsules.length / CAPSULE_FLOATS_PER_INSTANCE;
+    expect(segCount).toBeGreaterThan(1); // curved ⇒ many segments
+    for (let n = 0; n < segCount; n += 1) {
+      const cap = decodeCapsule(set.capsules, n);
+      expect(cap.shape[0]).toBeCloseTo(1, 5);
+      expect(cap.shape[1]).toBeCloseTo(64 / 255, 5);
+      expect(cap.shape[2]).toBeCloseTo(1, 5);
+    }
   });
 });
 

--- a/packages/graph/tests/webgl-shapes.test.ts
+++ b/packages/graph/tests/webgl-shapes.test.ts
@@ -16,12 +16,14 @@ import {
   buildShapeInstances,
   createWebGLShapeRenderer,
   decodeInstance,
+  effectiveStrokeHalfWidth,
   instancedShapeFamilies,
   FLOATS_PER_INSTANCE,
   type WebGLShapeFrame,
 } from "../src/webgl-shapes";
 import {
   BOX_FILL,
+  borderStrokeWidthPx,
   drawnRadius,
   unitShapeGeometry,
 } from "../src/render-geometry";
@@ -244,6 +246,114 @@ describe("B1 Phase 1 — instance attribute parity (N1/N10/N11)", () => {
     const border = decodeInstance(set.border.get(code)!, 0);
     expect(Math.round(border.color[0] * 255)).toBe(Math.round(200 * 0.62));
     expect(Math.round(border.color[1] * 255)).toBe(Math.round(100 * 0.62));
+  });
+
+  // ---------------------------------------------------------------------
+  // Border-thickness fix (per-shape apothem compensation): circles/hexagons
+  // used to draw a MUCH thicker PERPENDICULAR border than diamonds/squares.
+  // The two-disc ring is built by scaling the WHOLE unit polygon by a RADIAL
+  // offset (radius ± effectiveStrokeHalf); for a disc (apothem == radius) the
+  // radial offset IS the perpendicular gap, but for a flat polygon face the
+  // gap between the outer/inner similar polygons, measured PERPENDICULAR to
+  // that face, is `effectiveStrokeHalf · apothemRatio(family)` (apothem =
+  // radius · apothemRatio). The fix therefore sets
+  // `effectiveStrokeHalf(family) = strokeHalf · BORDER_PERP_SCALE /
+  // apothemRatio(family)` — a RADIAL offset that VARIES by family — so that,
+  // once foreshortened by that same family's apothem ratio, every family's
+  // VISIBLE perpendicular width lands on the SAME `strokeHalf · BORDER_PERP_SCALE`.
+  // These tests assert that: NOT that the radial offsets are equal (they
+  // deliberately are not — that was the bug's mechanism, run in reverse to
+  // fix it), but that radial-offset × apothemRatio (the perpendicular, i.e.
+  // visually apparent, width) is uniform across every shape family.
+  // ---------------------------------------------------------------------
+  describe("border perpendicular half-width is UNIFORM across shape families", () => {
+    const SHAPE_NAME_BY_FAMILY: Record<number, string> = {
+      0: "circle",
+      1: "diamond",
+      2: "star",
+      3: "hexagon",
+      4: "square",
+      6: "triangle",
+    };
+    // Documented apothem-per-a_radius ratios (shape-geometry.ts regular
+    // polygons; star approximated) — an INDEPENDENT copy of the source's
+    // lookup so this test pins the intended per-shape numbers, not merely
+    // the implementation's own arithmetic. NOTE square is 0.88 (its own
+    // SQUARE_INSET_RATIO), NOT cos(45°)=0.707 — the square's unit outline is
+    // pre-inset BEFORE the a_radius scale (shape-geometry.ts), unlike diamond
+    // (same 4-gon shape, but no inset, so a_radius IS its circumradius).
+    const APOTHEM_RATIO_BY_FAMILY: Record<number, number> = {
+      0: 1.0,
+      1: 0.707,
+      2: 0.5,
+      3: 0.866,
+      4: 0.88,
+      6: 0.5,
+    };
+    const dpr = 2;
+    const zoom = 1;
+
+    function radialHalfWidth(family: number, bold: boolean): number {
+      const shapeName = SHAPE_NAME_BY_FAMILY[family]!;
+      const code = shapeCode(shapeName);
+      const set = buildShapeInstances(
+        frame([{ x: 0, y: 0, size: 20, shape: shapeName, rgb: [10, 20, 30], fill: 1, border: bold ? 1 : 0 }], dpr, zoom),
+      );
+      const border = decodeInstance(set.border.get(code)!, 0);
+      const innerFill = decodeInstance(set.fill.get(code)!, 0);
+      return (border.radius - innerFill.radius) / 2;
+    }
+
+    it.each(instancedShapeFamilies())(
+      "family %i: RADIAL ring half-width matches effectiveStrokeHalfWidth (varies BY DESIGN)",
+      (family) => {
+        const halfWidth = radialHalfWidth(family, false);
+        const expected = effectiveStrokeHalfWidth(family, false, dpr, zoom);
+        expect(halfWidth).toBeCloseTo(expected, 5);
+      },
+    );
+
+    it("PERPENDICULAR width (radial x apothemRatio) is the SAME for every family — the actual fix", () => {
+      const perpWidths = instancedShapeFamilies().map((family) => {
+        const radial = radialHalfWidth(family, true);
+        return { family, perp: radial * APOTHEM_RATIO_BY_FAMILY[family]! };
+      });
+      const reference = perpWidths[0]!.perp;
+      // Precision 3 (not tighter): this test's ratio table intentionally uses
+      // documented ROUNDED literals (e.g. 0.707) while the source computes
+      // exact trig (Math.cos(Math.PI/4)), so a ~3e-4 rounding gap is expected
+      // and not a regression.
+      for (const { family, perp } of perpWidths) {
+        expect(perp, `family ${family}: perpendicular width ${perp} != reference ${reference}`).toBeCloseTo(
+          reference,
+          3,
+        );
+      }
+      // Sanity: circle (ratio 1.0) and diamond (ratio 0.707 — genuinely much
+      // thinner pre-fix) now match to the pixel; likewise square (ratio 0.88).
+      const circle = perpWidths.find((p) => p.family === 0)!.perp;
+      const diamond = perpWidths.find((p) => p.family === 1)!.perp;
+      const square = perpWidths.find((p) => p.family === 4)!.perp;
+      expect(circle).toBeCloseTo(diamond, 3);
+      expect(circle).toBeCloseTo(square, 3);
+    });
+
+    it("new uniform perpendicular width is ~0.7x the OLD (uncompensated) square perpendicular width", () => {
+      // OLD (pre-fix) behaviour used the RAW strokeHalf as the radial offset
+      // for every family (no apothem compensation), so square's perpendicular
+      // width was already foreshortened to strokeHalf x apothemRatio(square)
+      // = strokeHalf x 0.88 (SQUARE_INSET_RATIO) — this IS today's
+      // pre-existing square border weight (the anchor the task's 30%-thinner
+      // target is defined against).
+      const base = borderStrokeWidthPx(false, dpr, zoom) / 2;
+      const OLD_OUTLINE_WEIGHT_BOOST = 1.12; // WEBGL_OUTLINE_WEIGHT_BOOST, unchanged by this fix
+      const oldStrokeHalf = base * OLD_OUTLINE_WEIGHT_BOOST;
+      const oldSquarePerp = oldStrokeHalf * APOTHEM_RATIO_BY_FAMILY[4]!;
+      // Circle's apothemRatio is 1.0, so its radial offset IS the new uniform
+      // perpendicular width directly.
+      const newUniformPerp = effectiveStrokeHalfWidth(0, false, dpr, zoom);
+      expect(newUniformPerp / oldSquarePerp).toBeCloseTo(0.7, 2);
+    });
   });
 });
 

--- a/packages/graph/tests/webgl-shapes.test.ts
+++ b/packages/graph/tests/webgl-shapes.test.ts
@@ -249,24 +249,27 @@ describe("B1 Phase 1 — instance attribute parity (N1/N10/N11)", () => {
   });
 
   // ---------------------------------------------------------------------
-  // Border-thickness fix (per-shape apothem compensation): circles/hexagons
-  // used to draw a MUCH thicker PERPENDICULAR border than diamonds/squares.
-  // The two-disc ring is built by scaling the WHOLE unit polygon by a RADIAL
-  // offset (radius ± effectiveStrokeHalf); for a disc (apothem == radius) the
-  // radial offset IS the perpendicular gap, but for a flat polygon face the
-  // gap between the outer/inner similar polygons, measured PERPENDICULAR to
-  // that face, is `effectiveStrokeHalf · apothemRatio(family)` (apothem =
-  // radius · apothemRatio). The fix therefore sets
+  // Border-thickness geometry (per-shape apothem compensation + per-shape
+  // THINNING, 2026-07-13 user request): circles/hexagons used to draw a MUCH
+  // thicker PERPENDICULAR border than diamonds/squares. The two-disc ring is
+  // built by scaling the WHOLE unit polygon by a RADIAL offset (radius ±
+  // effectiveStrokeHalf); for a disc (apothem == radius) the radial offset IS
+  // the perpendicular gap, but for a flat polygon face the gap between the
+  // outer/inner similar polygons, measured PERPENDICULAR to that face, is
+  // `effectiveStrokeHalf · apothemRatio(family)` (apothem = radius ·
+  // apothemRatio). The apothem-compensation fix set
   // `effectiveStrokeHalf(family) = strokeHalf · BORDER_PERP_SCALE /
   // apothemRatio(family)` — a RADIAL offset that VARIES by family — so that,
   // once foreshortened by that same family's apothem ratio, every family's
-  // VISIBLE perpendicular width lands on the SAME `strokeHalf · BORDER_PERP_SCALE`.
-  // These tests assert that: NOT that the radial offsets are equal (they
-  // deliberately are not — that was the bug's mechanism, run in reverse to
-  // fix it), but that radial-offset × apothemRatio (the perpendicular, i.e.
-  // visually apparent, width) is uniform across every shape family.
+  // VISIBLE perpendicular width landed on a COMMON `strokeHalf ·
+  // BORDER_PERP_SCALE` baseline. On TOP of that baseline, `SHAPE_BORDER_THIN`
+  // now applies an ADDITIONAL per-shape cut: circle/hexagon × 0.5, and
+  // diamond/square/star/triangle × 0.8 — so the perpendicular width is no
+  // longer fully uniform, but a deliberate TWO-TIER geometry: circle/hexagon
+  // together (thinner), and diamond/square/star/triangle together (the other
+  // tier), each tier internally uniform.
   // ---------------------------------------------------------------------
-  describe("border perpendicular half-width is UNIFORM across shape families", () => {
+  describe("border perpendicular half-width: two-tier by shape (circle/hexagon thinner)", () => {
     const SHAPE_NAME_BY_FAMILY: Record<number, string> = {
       0: "circle",
       1: "diamond",
@@ -289,6 +292,18 @@ describe("B1 Phase 1 — instance attribute parity (N1/N10/N11)", () => {
       3: 0.866,
       4: 0.88,
       6: 0.5,
+    };
+    // Independent copy of SHAPE_BORDER_THIN (webgl-shapes.ts): circle/hexagon
+    // get the 50%-thinner cut, diamond/square/star/triangle the 20%-thinner
+    // cut (star/triangle NOT specified by the user request — defaulted to
+    // the same 0.8 as the other angular shapes).
+    const THIN_FACTOR_BY_FAMILY: Record<number, number> = {
+      0: 0.5,
+      3: 0.5,
+      1: 0.8,
+      4: 0.8,
+      2: 0.8,
+      6: 0.8,
     };
     const dpr = 2;
     const zoom = 1;
@@ -313,46 +328,91 @@ describe("B1 Phase 1 — instance attribute parity (N1/N10/N11)", () => {
       },
     );
 
-    it("PERPENDICULAR width (radial x apothemRatio) is the SAME for every family — the actual fix", () => {
+    it("circle & hexagon PERPENDICULAR width == (0.5/0.8) x the square/diamond PERPENDICULAR width", () => {
+      // NOTE: the two SHAPE_BORDER_THIN multipliers (0.5 for circle/hexagon,
+      // 0.8 for square/diamond) are each applied to the SAME shared
+      // BORDER_PERP_SCALE baseline (0.616 x strokeHalf), so the resulting
+      // CROSS-TIER ratio is 0.5 / 0.8 = 0.625, NOT 0.5 — 0.5 is only the
+      // circle/hexagon multiplier value itself, not its ratio to the other
+      // tier's already-different (0.8x) multiplier. Verified numerically
+      // (0.308 / 0.493 = 0.625) before writing this assertion.
       const perpWidths = instancedShapeFamilies().map((family) => {
         const radial = radialHalfWidth(family, true);
         return { family, perp: radial * APOTHEM_RATIO_BY_FAMILY[family]! };
       });
-      const reference = perpWidths[0]!.perp;
-      // Precision 3 (not tighter): this test's ratio table intentionally uses
-      // documented ROUNDED literals (e.g. 0.707) while the source computes
-      // exact trig (Math.cos(Math.PI/4)), so a ~3e-4 rounding gap is expected
-      // and not a regression.
-      for (const { family, perp } of perpWidths) {
+      const circle = perpWidths.find((p) => p.family === 0)!.perp;
+      const hexagon = perpWidths.find((p) => p.family === 3)!.perp;
+      const square = perpWidths.find((p) => p.family === 4)!.perp;
+      const diamond = perpWidths.find((p) => p.family === 1)!.perp;
+      const expectedRatio = 0.5 / 0.8; // 0.625
+      // Precision 2: same rounding-literal tolerance as elsewhere in this
+      // file (documented ROUNDED apothem ratios vs the source's exact trig).
+      expect(circle / square).toBeCloseTo(expectedRatio, 2);
+      expect(hexagon / diamond).toBeCloseTo(expectedRatio, 2);
+    });
+
+    it("square, diamond, star, triangle PERPENDICULAR widths are equal to each other (same tier)", () => {
+      const perpWidths = instancedShapeFamilies().map((family) => {
+        const radial = radialHalfWidth(family, true);
+        return { family, perp: radial * APOTHEM_RATIO_BY_FAMILY[family]! };
+      });
+      const angularFamilies = [1, 2, 4, 6];
+      const reference = perpWidths.find((p) => p.family === angularFamilies[0])!.perp;
+      for (const family of angularFamilies) {
+        const perp = perpWidths.find((p) => p.family === family)!.perp;
         expect(perp, `family ${family}: perpendicular width ${perp} != reference ${reference}`).toBeCloseTo(
           reference,
           3,
         );
       }
-      // Sanity: circle (ratio 1.0) and diamond (ratio 0.707 — genuinely much
-      // thinner pre-fix) now match to the pixel; likewise square (ratio 0.88).
-      const circle = perpWidths.find((p) => p.family === 0)!.perp;
-      const diamond = perpWidths.find((p) => p.family === 1)!.perp;
-      const square = perpWidths.find((p) => p.family === 4)!.perp;
-      expect(circle).toBeCloseTo(diamond, 3);
-      expect(circle).toBeCloseTo(square, 3);
     });
 
-    it("new uniform perpendicular width is ~0.7x the OLD (uncompensated) square perpendicular width", () => {
-      // OLD (pre-fix) behaviour used the RAW strokeHalf as the radial offset
-      // for every family (no apothem compensation), so square's perpendicular
-      // width was already foreshortened to strokeHalf x apothemRatio(square)
-      // = strokeHalf x 0.88 (SQUARE_INSET_RATIO) — this IS today's
-      // pre-existing square border weight (the anchor the task's 30%-thinner
-      // target is defined against).
-      const base = borderStrokeWidthPx(false, dpr, zoom) / 2;
-      const OLD_OUTLINE_WEIGHT_BOOST = 1.12; // WEBGL_OUTLINE_WEIGHT_BOOST, unchanged by this fix
-      const oldStrokeHalf = base * OLD_OUTLINE_WEIGHT_BOOST;
-      const oldSquarePerp = oldStrokeHalf * APOTHEM_RATIO_BY_FAMILY[4]!;
-      // Circle's apothemRatio is 1.0, so its radial offset IS the new uniform
-      // perpendicular width directly.
-      const newUniformPerp = effectiveStrokeHalfWidth(0, false, dpr, zoom);
-      expect(newUniformPerp / oldSquarePerp).toBeCloseTo(0.7, 2);
+    it("circle & hexagon PERPENDICULAR widths are equal to each other (same tier)", () => {
+      const perpWidths = instancedShapeFamilies().map((family) => {
+        const radial = radialHalfWidth(family, true);
+        return { family, perp: radial * APOTHEM_RATIO_BY_FAMILY[family]! };
+      });
+      const circle = perpWidths.find((p) => p.family === 0)!.perp;
+      const hexagon = perpWidths.find((p) => p.family === 3)!.perp;
+      expect(circle).toBeCloseTo(hexagon, 3);
+    });
+
+    it("REGRESSION LOCK: absolute perpendicular widths, relative to raw strokeHalfWidth", () => {
+      // Raw (uncompensated, un-thinned) stroke half-width — the common unit
+      // both tiers are expressed as a fraction of.
+      const base = borderStrokeWidthPx(true, dpr, zoom) / 2;
+      const OUTLINE_WEIGHT_BOOST = 1.12; // WEBGL_OUTLINE_WEIGHT_BOOST, unchanged by this fix
+      const rawStrokeHalf = base * OUTLINE_WEIGHT_BOOST;
+
+      const perpWidths = instancedShapeFamilies().map((family) => {
+        const radial = radialHalfWidth(family, true);
+        return { family, perp: radial * APOTHEM_RATIO_BY_FAMILY[family]! };
+      });
+      const circle = perpWidths.find((p) => p.family === 0)!.perp;
+      const hexagon = perpWidths.find((p) => p.family === 3)!.perp;
+      const square = perpWidths.find((p) => p.family === 4)!.perp;
+      const diamond = perpWidths.find((p) => p.family === 1)!.perp;
+
+      // circle/hexagon: 0.616 (BORDER_PERP_SCALE) x 0.5 (thin factor) = 0.308
+      expect(circle / rawStrokeHalf).toBeCloseTo(0.308, 2);
+      expect(hexagon / rawStrokeHalf).toBeCloseTo(0.308, 2);
+      // square/diamond (and star/triangle, same tier): 0.616 x 0.8 = 0.493
+      expect(square / rawStrokeHalf).toBeCloseTo(0.493, 2);
+      expect(diamond / rawStrokeHalf).toBeCloseTo(0.493, 2);
+    });
+
+    it("per-shape thin factor matches effectiveStrokeHalfWidth directly (unit-level, no ring geometry)", () => {
+      for (const family of instancedShapeFamilies()) {
+        const withThin = effectiveStrokeHalfWidth(family, false, dpr, zoom);
+        // Reconstruct the pre-thin (apothem-compensated only) baseline the
+        // same way the source's BORDER_PERP_SCALE doc describes it, then
+        // check the ratio against THIN_FACTOR_BY_FAMILY.
+        const base = borderStrokeWidthPx(false, dpr, zoom) / 2;
+        const rawStrokeHalf = base * 1.12;
+        const apothem = APOTHEM_RATIO_BY_FAMILY[family]!;
+        const preThinBaseline = (rawStrokeHalf * (0.7 * 0.88)) / apothem;
+        expect(withThin / preThinBaseline).toBeCloseTo(THIN_FACTOR_BY_FAMILY[family]!, 2);
+      }
     });
   });
 });

--- a/src/graph-layout.ts
+++ b/src/graph-layout.ts
@@ -43,6 +43,14 @@ export interface ComputeLayoutOptions {
   height?: number;
   /** Repulsion factor, clamped to [0.1, 10] (default 1). */
   repulsion?: number;
+  /** Link rest-length factor, clamped to [0.1, 3] (default 0.6). */
+  linkDistance?: number;
+  /**
+   * Optional warm-start coordinates keyed by node id. Unlike `fx`/`fy`, these seed
+   * the solver without pinning the node, so interactive re-solves can settle from
+   * the current on-screen layout while the deterministic cold path stays unchanged.
+   */
+  initialPositions?: ReadonlyMap<string, { x: number; y: number }> | Record<string, { x: number; y: number }>;
   /** Barnes-Hut opening angle: larger = faster/looser (default 0.9). */
   theta?: number;
 }
@@ -244,21 +252,31 @@ export function computeLayout(
   const ticks = Math.max(1, Math.round(options.iterations ?? 300));
   const theta = options.theta ?? 0.9;
   const repulsionFactor = Math.min(Math.max(options.repulsion ?? 1, 0.1), 10);
+  const linkDistanceFactor = Math.min(Math.max(options.linkDistance ?? 0.6, 0.1), 3);
 
   const cx = w / 2;
   const cy = h / 2;
   const rand = mulberry32(stableSeed(nodes.map((node) => node.id)));
 
+  const initialFor = (id: string): { x: number; y: number } | undefined => {
+    const initial = options.initialPositions;
+    if (!initial) return undefined;
+    const value = initial instanceof Map ? initial.get(id) : initial[id];
+    if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return undefined;
+    return value;
+  };
+
   const idIndex = new Map<string, number>();
   const sim: SimNode[] = nodes.map((node, i) => {
     idIndex.set(node.id, i);
     const fixed = Number.isFinite(node.fx) && Number.isFinite(node.fy);
+    const initial = fixed ? undefined : initialFor(node.id);
     const angle = (i / Math.max(n, 1)) * Math.PI * 2;
     const r = Math.min(w, h) * 0.3 * (0.5 + rand() * 0.5);
     return {
       id: node.id,
-      x: fixed ? (node.fx as number) : cx + Math.cos(angle) * r,
-      y: fixed ? (node.fy as number) : cy + Math.sin(angle) * r,
+      x: fixed ? (node.fx as number) : initial ? initial.x : cx + Math.cos(angle) * r,
+      y: fixed ? (node.fy as number) : initial ? initial.y : cy + Math.sin(angle) * r,
       vx: 0,
       vy: 0,
       fixed,
@@ -279,7 +297,7 @@ export function computeLayout(
   const area = w * h;
   const k = Math.sqrt(area / Math.max(n, 1)); // ideal node distance
   const repulsion = k * k * 0.6 * repulsionFactor;
-  const restLength = k * 0.6;
+  const restLength = k * linkDistanceFactor;
   const springK = 0.08;
   const gravity = 0.004;
   const damping = 0.85;

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -792,6 +792,7 @@
             {selectedIds}
             focusId={viewerState.focusId}
             labelMode="none"
+            showLayoutSwitcher
             onSelect={handleToggleEntity}
             onOpenEntity={handleFocusEntity}
           />

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -53,9 +53,11 @@
   import {
     mintCommunityNodeIds,
     mintTypeNodeIds,
+    readFoldAnchors,
   } from "./lib/classNodes.js";
   import {
     computeGroupedGraph,
+    computeGroupTransition,
     classIdsAtLevel,
     typeNamesInTaxonomy,
     ontologyLevelState,
@@ -212,6 +214,27 @@
       grouped: viewerState.options.groupBy.grouped,
     }),
   );
+
+  // Collapse/expand ANIMATION signal. Diff the previous vs current fold-anchor map
+  // (each hidden node id → its group-node anchor) into a transition descriptor
+  // ({ direction, anchorByNodeId }) the GraphCanvas plays instead of a hard cut.
+  // Keying off the FOLD DELTA (not the grouped-key diff) makes the signal robust
+  // to the ontology artifact loading async — the collapse "lands" in whichever
+  // tick the fold map populates. The "previous" snapshot is tracked in a plain
+  // (non-reactive) `let`, advanced INSIDE this memoized `$derived` — a deliberate
+  // previous-value pattern: the derived recomputes exactly once per
+  // grouped/groupedGraph change (Svelte memoizes reads), so `groupTransition` is
+  // glitch-free and current by the time GraphCanvas's scene effect reads it.
+  let _prevFoldAnchors = null;
+  const groupTransition = $derived.by(() => {
+    const nextFoldAnchors = readFoldAnchors(groupedGraph);
+    const prevFoldAnchors = _prevFoldAnchors;
+    // Advance the snapshot for the NEXT change before returning.
+    _prevFoldAnchors = nextFoldAnchors;
+    // First evaluation (mount): nothing to animate FROM.
+    if (prevFoldAnchors === null) return null;
+    return computeGroupTransition({ prevFoldAnchors, nextFoldAnchors });
+  });
 
   // Tri-state of each ontology bulk button (spec §4) + per-class absorption view
   // (spec §3). Denominators EXCLUDE absorbed classes; the rail renders the
@@ -789,6 +812,7 @@
         <div class="col col-center">
           <GraphCanvas
             {scene}
+            {groupTransition}
             {selectedIds}
             focusId={viewerState.focusId}
             labelMode="none"

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -637,9 +637,8 @@
   function handlePointerDown(event) {
     // Lock pan/drag while a layout morph is in flight (§2.6).
     if (morphActive) return;
-    // A pan/drag is starting — cancel any pending hover-intent dwell so it can't
-    // fire (and dim) mid-interaction.
-    hoverIntent.cancel();
+    // Keep the hover dwell alive across pointer-down. Canceling it here can
+    // strand an applied node dim when the pending target is empty space.
     // Remark 7: the user panning/dragging takes over from any in-flight
     // camera-recenter tween immediately, rather than fighting it.
     cancelCameraTween();
@@ -1508,14 +1507,11 @@
     // still animating from the PREVIOUS layout settle (e.g. a rapid re-click)
     // — its target bbox is now stale.
     cancelCameraTween();
-    // Remark 2: a layout morph LOCKS pointer/hover input (handlePointerMove
-    // early-returns while morphActive), but a hover-intent dwell timer that
-    // was already pending when the morph started is NOT an input event — it
-    // keeps ticking on its own setTimeout and can fire mid-morph or right
-    // after settle, dimming for a hover target that's no longer under the
-    // cursor (the layout just moved everything). Cancel it before the morph
-    // starts so it can never fire stale.
-    hoverIntent.cancel();
+    // A layout moves hovered geometry away from the pointer. Clear that stale
+    // target through the SAME dwell gate: the delayed base-style restore can
+    // neither flash immediately nor strand the old node's dim.
+    clearHoveredEdge();
+    setHoveredNode(null);
     layoutMode = mode;
     // §F1: bufA already snapshotted the on-screen (incl. dragged) positions, so
     // the drag is preserved as the morph START; drop the stale drag map now — a
@@ -1543,6 +1539,9 @@
     const abortMorph = () => {
       cancelLayoutMorphFrame();
       resetLayoutState();
+      // The abnormal path has no payload rebuild after resetLayoutState cancels
+      // timers, so reconcile its already-cleared hover state explicitly.
+      applyConnectedDim();
       fitAndRender();
     };
     const step = (now) => {

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -15,10 +15,12 @@
     EDGE_ALPHA_FLAT,
     EDGE_ALPHA_INVERSE,
     EDGE_ALPHA_MID,
+    carryScenePositions,
     computeLayoutBuffer,
     findNearestEdge,
     findNearestNode,
     findNearestNodeId,
+    goldenAngleFan,
     interpolateGroupFadeStyle,
     interpolateMergeStyle,
     interpolateMergePositions,
@@ -27,6 +29,7 @@
     LAYOUT_MODE_FORCE,
     LAYOUT_MODES,
     morphPositions,
+    resolveGroupFolds,
     truncateLabel,
   } from "../lib/graphRendererPayload.js";
   import {
@@ -189,6 +192,39 @@
   // True while a layout morph is in flight: hides labels + locks canvas
   // interaction for the (~480 ms) tween, exactly as pan/zoom already do.
   let morphActive = $state(false);
+
+  // --- Collapse/expand GROUP-transition state (redesign spec §3) -------------
+  // Consumed-once guard (RC-D): groupTransition is a memoized $derived, so a
+  // redundant scene tick re-reads the SAME non-null descriptor. We keep the last
+  // consumed reference so only a GENUINELY new descriptor (new object) starts a
+  // tween — a redundant re-read is treated as absent and never restarts it.
+  let lastConsumedGroupTransition = null;
+  // Rebuild-quiescence flag (RC-B): true from a COLLAPSE tween's start until its
+  // carried swap has run. While set, updateSelection/updateDisplayStyle DEFER
+  // (payload is intentionally one scene behind the `scene` prop); the deferred
+  // restyle is applied ONCE after the swap. Expand never sets it (its payload is
+  // already current). $state per spec §3.3 (harmless — read only imperatively).
+  let groupSwapPending = $state(false);
+  // Set when a selection/display rebuild was deferred during groupSwapPending, so
+  // exactly one post-swap updateSelection() runs (the change is queued, not lost).
+  let pendingPostSwapRestyle = false;
+  // The "jump straight to the end state" closure of the IN-FLIGHT group tween
+  // (collapse → finishCollapseSwap; expand → settleGroupTween(bufB)). Used by the
+  // abnormal-frame abort (§3.7) AND by the scene-effect interrupt rule so a
+  // genuine new transition first COMPLETES the pending swap synchronously (payload
+  // never lags two scenes behind). Cleared by the settle it invokes.
+  let pendingGroupSettle = null;
+  // Position cache for expand target restoration (§3.6): folded child id →
+  // {x, y, epoch}. A collapse→expand round trip (same epoch) restores the exact
+  // prior constellation; a genuine coordinate-space change bumps `coordinateEpoch`
+  // so stale entries are ignored (expand then falls back to the golden-angle fan).
+  const lastKnownPosById = new Map();
+  let coordinateEpoch = 0;
+  // Content signature of the last selection we rebuilt from (§3.3 hardening):
+  // resolveSelectedIds returns a FRESH array on every group toggle even when its
+  // content is identical, so comparing content (not identity) stops those no-op
+  // rebuilds from firing under a collapse tween.
+  let lastSelectionKey = null;
 
   // --- codeflow-parity Lot 3: Spread / Links force re-solve controls ---------
   // Spread maps to computeLayout(repulsion), Links maps to computeLayout's new
@@ -828,6 +864,14 @@
   // Selection/focus update — preserves the user's current zoom and pan.
   function updateSelection() {
     if (!mounted) return;
+    // RC-B: while a collapse tween runs, `payload` is intentionally one scene
+    // behind the `scene` prop. A rebuild now would swap the renderer to the NEW
+    // (collapsed) node set mid-tween → the next tween frame's setPositions throws
+    // on the length mismatch → hard cut. DEFER: apply exactly once post-swap.
+    if (groupSwapPending) {
+      pendingPostSwapRestyle = true;
+      return;
+    }
 
     rebuildPayload();
     ensureRenderer();
@@ -842,6 +886,12 @@
   // (rebuildPayload → reapplyLayoutPositions). Same shape as updateSelection.
   function updateDisplayStyle() {
     if (!mounted) return;
+    // Same RC-B deferral as updateSelection: never rebuild the payload out from
+    // under a running collapse tween (apply once post-swap).
+    if (groupSwapPending) {
+      pendingPostSwapRestyle = true;
+      return;
+    }
 
     rebuildPayload();
     ensureRenderer();
@@ -1404,11 +1454,40 @@
     liveMorphBuffer = null;
     activeLayoutBuffer = null;
     layoutMode = LAYOUT_MODE_FORCE;
+    // A genuine reset / abnormal-exit hard cut also clears the group-transition
+    // bookkeeping so no deferred restyle or pending settle leaks into the new scene.
+    groupSwapPending = false;
+    pendingPostSwapRestyle = false;
+    pendingGroupSettle = null;
     // Lot 7: invalidate any in-flight worker force solve — its buffer is sized
     // for the OLD node set and must not be morphed after the scene changed.
     forceSolveToken++;
     // §F1: a layout reset re-places all nodes, so stale Force-space drags must
     // not survive it (they would re-snap into the new coordinate space).
+    draggedPositions.clear();
+  }
+
+  // Redesign spec §3.2: the LIGHTER cancellation set used by the carried
+  // collapse/expand swap. It cancels the transient timers/tweens that would
+  // clobber a position-preserving swap, but — unlike resetLayoutState — it does
+  // NOT cancel the group tween frame, does NOT null activeLayoutBuffer (the carry
+  // re-establishes it), does NOT force layoutMode, and is NEVER followed by a fit.
+  function resetTransientLayoutState() {
+    cancelLayoutMorphFrame();
+    cancelCameraTween();
+    // A pending hover-dwell timer would apply a stale connected-dim after the
+    // swap re-places nodes — cancel it (same class as the resetLayoutState guard).
+    hoverIntent.cancel();
+    // The zoom-settle callback calls rebuildPayload → it would clobber the carried
+    // positions one tick later (same class of bug as RC-B). Clear it.
+    if (typeof window !== "undefined" && zoomSettleTimer !== null) {
+      window.clearTimeout(zoomSettleTimer);
+      zoomSettleTimer = null;
+    }
+    // Invalidate any in-flight worker force solve (buffer sized for the OLD set).
+    forceSolveToken++;
+    // Drag coords are already baked into the pre-swap snapshot (currentPositionMap
+    // reads them via currentLayoutBuffer), so drop the stale Force-space drag map.
     draggedPositions.clear();
   }
 
@@ -1483,6 +1562,9 @@
     if (!target || token !== forceSolveToken || !mounted || layoutMode !== LAYOUT_MODE_FORCE)
       return;
     forceBaseBuffer = new Float32Array(target);
+    // §3.6: a Force re-solve genuinely moves every node, so any cached prior
+    // constellation is stale — invalidate the expand-restore cache.
+    coordinateEpoch += 1;
     startLayoutMorphToBuffer(LAYOUT_MODE_FORCE, target);
   }
 
@@ -1504,6 +1586,10 @@
   // (during a morph `layoutMode` is already the target, so re-clicking it is a
   // no-op while clicking the OTHER mode interrupts and re-targets).
   function selectLayoutMode(mode) {
+    // §3.3: a layout morph must not be computed against a mid-transition payload
+    // (a group tween owns the buffer). Pointer/wheel are already locked by
+    // morphActive; this covers the toolbar click path.
+    if (groupTweenFrame !== null) return;
     if (mode === layoutMode) return;
     startLayoutMorph(mode);
   }
@@ -1520,6 +1606,10 @@
     // switch-to-Force settles the pristine forceBaseBuffer (== scene positions),
     // so re-applying it across a rebuild is a harmless no-op.
     activeLayoutBuffer = buffer ? new Float32Array(buffer) : null;
+    // §3.6: switching to a NON-Force layout (Layers/Grid/Radial/Metro) relocates
+    // every node into a new coordinate space, so the expand-restore cache is
+    // stale — invalidate it. (A Force re-solve bumps the epoch in resolveForceLayout.)
+    if (mode !== LAYOUT_MODE_FORCE) coordinateEpoch += 1;
     const positions = payload?.renderGraph?.positions;
     if (positions && buffer && buffer.length === positions.length) {
       positions.set(buffer);
@@ -1619,15 +1709,19 @@
     }
   }
 
-  // --- Collapse/expand GROUP transition driver -------------------------------
-  // Animate a grouping (collapse) / ungrouping (expand) instead of hard-cutting
-  // to the new scene. REUSES the layout-morph machinery: a per-index position
-  // lerp (morphPositions) into a reused liveMorphBuffer + the merge-fade style
-  // (interpolateGroupFadeStyle) on the SAME rAF loop, locking interaction via
-  // morphActive exactly as the layout morph does. The App passes the direction +
-  // the folded-child → group-node anchor map; the group node's on-screen anchor
-  // is its own position when present, else the centroid of its folding members
-  // (the group node usually lives in the OTHER scene across the fold boundary).
+  // --- Collapse/expand GROUP transition driver (redesign spec §3) ------------
+  // Animate a grouping (collapse) / ungrouping (expand) as a COHERENT start→final
+  // fold, NOT a re-solve/refit morph. The invariant: any node present before AND
+  // after keeps its exact on-screen position and the camera never moves (spec §2).
+  // REUSES the layout-morph machinery — a per-index lerp (morphPositions) into a
+  // reused liveMorphBuffer + the merge-fade style (interpolateGroupFadeStyle) on
+  // the SAME rAF loop, locking interaction via morphActive. The swap itself goes
+  // through applyCarriedScene (position-preserving, NO fit):
+  //   · COLLAPSE — keep the OLD scene, tween each folding child → its group anchor
+  //     (fade+shrink), then carried-swap so the group node lands at that anchor.
+  //   · EXPAND   — carried-swap FIRST (children stacked on the group's LAST
+  //     on-screen position), then tween them OUT to the cached prior constellation
+  //     (or a deterministic golden-angle fan) while fading + growing in.
 
   function cancelGroupTweenFrame() {
     if (typeof window !== "undefined" && groupTweenFrame !== null) {
@@ -1636,56 +1730,69 @@
     groupTweenFrame = null;
   }
 
-  // Resolve the folding/revealing children against the CURRENT payload: which
-  // node indices fade, grouped by anchor, and each group's on-screen anchor
-  // position. Returns null when NONE of the anchor children are in the payload
-  // (nothing to animate → the caller falls back to the hard cut).
+  // Redesign spec §3.2 — the collapse/expand SWAP primitive. Swaps the renderer
+  // to the NEW scene WITHOUT losing the on-screen coordinate space and WITHOUT a
+  // camera refit: rebuild the payload, then OVERWRITE the fresh scene-baked
+  // positions BY ID from the pre-swap snapshot (shared nodes carried; group node
+  // at the fold centroid on collapse; children stacked on the anchor on expand;
+  // brand-new handles at their neighbour-centroid). Persists the carried buffer to
+  // activeLayoutBuffer + forceBaseBuffer so later rebuilds don't re-derive scene-
+  // baked coords (RC-E), and ends with applyPayloadNoFit() — no refit.
+  function applyCarriedScene({ carriedPosById, placedPosById } = {}) {
+    // Null the OLD layout buffer so the rebuild yields PRISTINE scene-baked coords
+    // (the carry's last-resort fallback); we re-establish the carried buffer below.
+    activeLayoutBuffer = null;
+    liveMorphBuffer = null;
+    rebuildPayload(); // payload = NEW scene (scene-baked coords, overwritten next).
+    const graph = payload?.renderGraph;
+    if (graph?.positions) {
+      const carried = carryScenePositions({
+        nodeIds: graph.nodeIds,
+        positions: graph.positions,
+        edges: graph.edges,
+        carriedPosById: carriedPosById ?? new Map(),
+        placedPosById: placedPosById ?? new Map(),
+      });
+      if (carried && carried.length === graph.positions.length) graph.positions.set(carried);
+      // Survive later selection/hover/display rebuilds (RC-E). Layers→Force returns
+      // to THIS carried buffer, not the unused fresh solve; layoutMode returns to
+      // Force so a subsequent switch reads the carried buffer as its base.
+      activeLayoutBuffer = new Float32Array(graph.positions);
+      forceBaseBuffer = new Float32Array(graph.positions);
+      layoutMode = LAYOUT_MODE_FORCE;
+    }
+    ensureRenderer();
+    resizeCanvas();
+    applyPayloadNoFit(); // setGraph + setStyle + applyCamera — preserves the camera.
+  }
+
+  // Resolve the folding/revealing children against the CURRENT payload (§3.4
+  // step 2) — reading positions via currentLayoutBuffer() so a group action that
+  // lands mid layout-morph anchors against the LIVE interpolated coords, not the
+  // stale scene-baked ones. Delegates the anchor rule (group node's own position
+  // when on screen, else member centroid) to the pure resolveGroupFolds core.
+  // Returns null when NONE of the anchor children are on screen (the caller then
+  // does a position-preserving carried swap, never a refit).
   function collectGroupFolds(anchors) {
     const graph = payload?.renderGraph;
     const idx = payload?.nodeIndexById;
-    const positions = graph?.positions;
+    const positions = currentLayoutBuffer();
     if (!graph || !idx || !positions) return null;
-
-    const foldingSet = new Set();
-    const groupMembers = new Map(); // groupNodeId -> [nodeIndex]
-    for (const [childId, groupId] of anchors) {
-      const i = idx.get(childId);
-      if (!Number.isInteger(i)) continue;
-      foldingSet.add(i);
-      let members = groupMembers.get(groupId);
-      if (!members) {
-        members = [];
-        groupMembers.set(groupId, members);
-      }
-      members.push(i);
-    }
-    if (foldingSet.size === 0) return null;
-
-    const anchorPosByGroup = new Map();
-    for (const [groupId, members] of groupMembers) {
-      const gi = idx.get(groupId);
-      if (Number.isInteger(gi)) {
-        anchorPosByGroup.set(groupId, {
-          x: positions[gi * 2] ?? 0,
-          y: positions[gi * 2 + 1] ?? 0,
-        });
-      } else {
-        let sx = 0;
-        let sy = 0;
-        for (const i of members) {
-          sx += positions[i * 2] ?? 0;
-          sy += positions[i * 2 + 1] ?? 0;
-        }
-        anchorPosByGroup.set(groupId, { x: sx / members.length, y: sy / members.length });
-      }
-    }
-    return { foldingSet, groupMembers, anchorPosByGroup, positions };
+    const info = resolveGroupFolds({
+      nodeIds: graph.nodeIds,
+      nodeIndexById: idx,
+      positions,
+      anchors,
+    });
+    if (!info) return null;
+    return { ...info, positions };
   }
 
   // Try to play the animated collapse/expand for `transition`. Returns true when
   // the driver TOOK OVER the scene swap (the caller must NOT also hard-cut), false
-  // to fall back to the current hard refit (safety: missing/ambiguous transition,
-  // no renderer, or no matching children on screen).
+  // to fall back to the refit path (safety: missing/ambiguous transition, or no
+  // renderer/payload). NOTE: an on-screen-empty fold set is NOT a false here — the
+  // driver still owns the swap and does a position-preserving carried swap.
   function tryStartGroupTransition(transition) {
     if (!transition || !mounted || !renderer || !payload) return false;
     const anchors = transition.anchorByNodeId;
@@ -1695,76 +1802,213 @@
     return false;
   }
 
-  // COLLAPSE: keep the OLD (pre-collapse) scene on screen and tween each folding
-  // node → its group anchor while fading + shrinking it; at t=1 swap to the new
-  // collapsed scene (updateGraph refits/settles).
+  // COLLAPSE (§3.4): snapshot the OLD on-screen positions, tween each folding
+  // child → its group anchor (fade+shrink) on the OLD payload, then at t=1
+  // carried-swap so the group node lands EXACTLY where its children converged and
+  // every shared node keeps its position. groupSwapPending defers any concurrent
+  // selection/display rebuild until after the swap (RC-B).
   function startCollapseTween(anchors) {
+    const oldPos = currentPositionMap() ?? new Map(); // carriedPosById (with drags)
     const info = collectGroupFolds(anchors);
-    if (!info) return false; // no folding child on screen → hard cut
+    if (!info) {
+      // No folding child on screen → nothing to animate, but STILL position-
+      // preserving: carried swap straight to the collapsed scene (never a refit).
+      groupSwapPending = true;
+      finishCollapseSwap(oldPos, new Map(), anchors);
+      return true;
+    }
     const { foldingSet, groupMembers, anchorPosByGroup, positions } = info;
     const bufA = new Float32Array(positions);
     const bufB = new Float32Array(positions);
+    const placedPosById = new Map(); // groupNodeId -> the fold-centroid anchor
     for (const [groupId, members] of groupMembers) {
       const a = anchorPosByGroup.get(groupId);
+      placedPosById.set(groupId, { x: a.x, y: a.y });
       for (const i of members) {
         bufB[i * 2] = a.x;
         bufB[i * 2 + 1] = a.y;
       }
     }
+    groupSwapPending = true;
+    // The "jump to end" closure used by the abort path AND the interrupt rule.
+    pendingGroupSettle = () => finishCollapseSwap(oldPos, placedPosById, anchors);
     runGroupTween({
       bufA,
       bufB,
       foldingSet,
       fadeOut: true,
-      onDone: () => {
-        // Swap to the collapsed scene + settle. The folding nodes already faded
-        // to alpha 0 at their anchor, so the group node appears in their place.
-        resetLayoutState();
-        updateGraph();
-      },
+      onDone: () => pendingGroupSettle?.(),
     });
     return true;
   }
 
-  // EXPAND: swap to the new (expanded) scene FIRST, then start each newly-revealed
-  // node AT its group anchor (faint + small) and tween it OUT to its real layout
-  // position while fading + growing in.
-  function startExpandTween(anchors) {
-    resetLayoutState();
-    updateGraph(); // payload now = expanded scene, fitted
-    const info = collectGroupFolds(anchors);
-    // The swap already stands as the result; if no revealed child matched, there
-    // is simply nothing to animate (still handled — do NOT hard-cut again).
-    if (!info) return true;
-    const { foldingSet, groupMembers, anchorPosByGroup, positions } = info;
-    const bufB = new Float32Array(positions); // real, settled positions (target)
-    const bufA = new Float32Array(positions); // revealed children at their anchor
-    for (const [groupId, members] of groupMembers) {
-      const a = anchorPosByGroup.get(groupId);
-      for (const i of members) {
-        bufA[i * 2] = a.x;
-        bufA[i * 2 + 1] = a.y;
+  // Collapse settle (§3.4 step 5): carried-swap to the collapsed scene with the
+  // group node placed at the fold centroid and shared nodes carried; apply any
+  // deferred restyle exactly once; record the folded children's pre-fold positions
+  // for a later expand restore (§3.6).
+  function finishCollapseSwap(oldPos, placedPosById, anchors) {
+    pendingGroupSettle = null;
+    resetTransientLayoutState();
+    applyCarriedScene({ carriedPosById: oldPos ?? new Map(), placedPosById: placedPosById ?? new Map() });
+    // §3.6 WRITE: remember each folded child's PRE-fold position so a same-epoch
+    // expand restores the exact prior constellation.
+    if (anchors instanceof Map && oldPos instanceof Map) {
+      for (const childId of anchors.keys()) {
+        const p = oldPos.get(childId);
+        if (p) lastKnownPosById.set(childId, { x: p.x, y: p.y, epoch: coordinateEpoch });
       }
     }
+    morphActive = false;
+    liveMorphBuffer = null;
+    groupSwapPending = false;
+    if (pendingPostSwapRestyle) {
+      pendingPostSwapRestyle = false;
+      updateSelection();
+    }
+    setLabelsHidden(false);
+    renderNow();
+  }
+
+  // EXPAND (§3.5): capture the group anchor BEFORE the swap (RC-C), carried-swap
+  // FIRST so the revealed children start stacked on the group's last on-screen
+  // position, then tween them OUT to their targets (cached prior constellation
+  // when same-epoch, else a deterministic golden-angle fan) while fading+growing.
+  function startExpandTween(anchors) {
+    // 1. PRE-swap snapshot — the group node IS in the current payload here.
+    const oldPos = currentPositionMap() ?? new Map();
+    const anchorPosByGroup = new Map(); // groupNodeId -> its last on-screen position
+    for (const groupId of new Set(anchors.values())) {
+      const p = oldPos.get(groupId);
+      if (p) anchorPosByGroup.set(groupId, { x: p.x, y: p.y });
+    }
+    // Children start stacked at their group's former spot.
+    const placedPosById = new Map(); // revealedChildId -> anchorPos(itsGroup)
+    for (const [childId, groupId] of anchors) {
+      const a = anchorPosByGroup.get(groupId);
+      if (a) placedPosById.set(childId, { x: a.x, y: a.y });
+    }
+    // 2. Carried swap FIRST (camera untouched, shared nodes carried, children on
+    // the anchor). Expand's payload is now current — no groupSwapPending needed.
+    resetTransientLayoutState();
+    applyCarriedScene({ carriedPosById: oldPos, placedPosById });
+    // 3. Resolve the revealed children against the NEW payload.
+    const info = collectGroupFolds(anchors);
+    if (!info) {
+      // No revealed child on screen → the carried swap already stands. Persist the
+      // buffers (RC-E) so later rebuilds don't re-derive scene-baked coords.
+      settleGroupTween(payload?.renderGraph?.positions);
+      return true;
+    }
+    const { foldingSet, groupMembers, anchorPosByGroup: postAnchor, positions } = info;
+    const bufA = new Float32Array(positions); // children currently AT the anchor
+    const bufB = new Float32Array(positions);
+    // 4. Targets: cached prior constellation (same epoch) else golden-angle fan.
+    const targets = computeExpandTargets(groupMembers, postAnchor, positions);
+    for (const [i, p] of targets) {
+      bufB[i * 2] = p.x;
+      bufB[i * 2 + 1] = p.y;
+    }
+    // 5. Tween on the NEW payload; settle persists activeLayoutBuffer (RC-E).
+    pendingGroupSettle = () => settleGroupTween(bufB);
     runGroupTween({
       bufA,
       bufB,
       foldingSet,
       fadeOut: false,
-      onDone: () => settleGroupTween(bufB),
+      onDone: () => pendingGroupSettle?.(),
     });
     return true;
   }
 
-  // Restore the settled positions + base style at the end of an EXPAND tween.
+  // Expand targets (§3.5.2), per revealed-child index: the cached prior position
+  // when the cache holds a SAME-epoch entry (collapse→expand round trip restores
+  // the exact prior shape), else a deterministic golden-angle (sunflower) fan
+  // around the group anchor — sorted by id so the same id set → the same slots.
+  function computeExpandTargets(groupMembers, anchorPosByGroup, positions) {
+    const nodeIds = payload?.renderGraph?.nodeIds ?? [];
+    const targetByIndex = new Map(); // nodeIndex -> {x, y}
+    const diag = bboxDiagonal(positions);
+    const spacing = Math.max(4 * NODE_RADIUS, 0.02 * diag);
+    const cap = 0.15 * diag;
+    for (const [groupId, members] of groupMembers) {
+      const anchor = anchorPosByGroup.get(groupId) ?? { x: 0, y: 0 };
+      const fanIndices = [];
+      for (const i of members) {
+        const cached = lastKnownPosById.get(nodeIds[i]);
+        if (cached && cached.epoch === coordinateEpoch) {
+          targetByIndex.set(i, { x: cached.x, y: cached.y });
+        } else {
+          fanIndices.push(i);
+        }
+      }
+      if (fanIndices.length > 0) {
+        const fan = goldenAngleFan({
+          anchor,
+          childIds: fanIndices.map((i) => nodeIds[i]),
+          spacing,
+          cap,
+        });
+        for (const i of fanIndices) {
+          const p = fan.get(nodeIds[i]);
+          if (p) targetByIndex.set(i, p);
+        }
+      }
+    }
+    return targetByIndex;
+  }
+
+  // Diagonal of the bounding box of a position buffer (world units) — the scale
+  // reference for the expand fan spacing + radius cap. 0 for an empty/degenerate
+  // buffer (the fan then collapses to the anchor — harmless, nothing to reveal).
+  function bboxDiagonal(positions) {
+    if (!positions || positions.length < 2) return 0;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (let i = 0; i < positions.length; i += 2) {
+      const x = positions[i];
+      const y = positions[i + 1];
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    if (!Number.isFinite(minX) || !Number.isFinite(minY)) return 0;
+    return Math.hypot(maxX - minX, maxY - minY);
+  }
+
+  // Settle the end of an EXPAND tween (§3.5 step 5 + RC-E): bake the settled
+  // positions, PERSIST them to activeLayoutBuffer + forceBaseBuffer (so a later
+  // selection/hover/display rebuild re-applies them instead of re-deriving scene-
+  // baked coords and jumping), refresh the position cache, and restore the style.
   function settleGroupTween(buffer) {
+    pendingGroupSettle = null;
     morphActive = false;
     liveMorphBuffer = null;
+    groupSwapPending = false; // defensive — expand never sets it, but never leak it.
     const positions = payload?.renderGraph?.positions;
     if (positions && buffer && buffer.length === positions.length) positions.set(buffer);
+    if (positions) {
+      activeLayoutBuffer = new Float32Array(positions);
+      forceBaseBuffer = new Float32Array(positions);
+      // §3.6: refresh the cache for the settled ids (same epoch).
+      const nodeIds = payload?.renderGraph?.nodeIds ?? [];
+      for (let i = 0; i < nodeIds.length; i += 1) {
+        lastKnownPosById.set(nodeIds[i], {
+          x: positions[i * 2] ?? 0,
+          y: positions[i * 2 + 1] ?? 0,
+          epoch: coordinateEpoch,
+        });
+      }
+    }
     if (renderer && payload) {
       renderer.setPositions(payload.renderGraph.positions);
       renderer.setStyle(payload.style);
+    }
+    if (pendingPostSwapRestyle) {
+      pendingPostSwapRestyle = false;
+      updateSelection();
     }
     setLabelsHidden(false);
     renderNow();
@@ -1782,8 +2026,8 @@
 
     const canAnimate =
       typeof window !== "undefined" && typeof window.requestAnimationFrame === "function";
-    // No rAF (SSR/tests) or reduced-motion (§F3): skip the tween, let the caller
-    // settle straight to the end state (a hard cut).
+    // No rAF (SSR/tests) or reduced-motion (§3.7): skip the tween, settle STRAIGHT
+    // to the end state — a position-preserving instant swap, NOT a refit.
     if (
       !renderer ||
       !bufA ||
@@ -1800,13 +2044,19 @@
     setLabelsHidden(true);
     liveMorphBuffer = new Float32Array(bufA.length);
     const startTime = window.performance?.now?.() ?? Date.now();
-    // §F2: an abnormal frame must never leave the canvas locked (morphActive stuck
-    // true freezes every pointer/wheel handler) — unwind to a clean, fitted state.
+    // §3.7: an abnormal frame must never leave the canvas locked — JUMP to the end
+    // state (finishCollapseSwap / settleGroupTween via onDone), position-
+    // preserving; only if THAT also throws do we fall back to the fitAndRender
+    // hard cut as the absolute last resort.
     const abort = () => {
       cancelGroupTweenFrame();
-      resetLayoutState();
-      applyConnectedDim();
-      fitAndRender();
+      try {
+        onDone?.();
+      } catch {
+        resetLayoutState();
+        applyConnectedDim();
+        fitAndRender();
+      }
     };
     const renderFrame = (eased) => {
       morphPositions(bufA, bufB, eased, liveMorphBuffer);
@@ -1861,6 +2111,14 @@
     return key;
   }
 
+  // Content signature of the selection (§3.3): sorted selected ids + focus. Two
+  // fresh arrays with the same members share a signature, so the every-toggle
+  // fresh-array identity from resolveSelectedIds does not trigger a no-op rebuild.
+  function selectionSignature(ids, focus) {
+    const list = Array.isArray(ids) ? [...ids].sort() : [];
+    return `${focus ?? ""}|${list.join(",")}`;
+  }
+
   $effect(() => {
     // Graph data (scene) change -> rebuild payload and auto-fit the view, but
     // ONLY when the scene's CONTENT actually changed (not merely its object
@@ -1872,25 +2130,41 @@
     if (key === lastSceneKey) return;
     lastSceneKey = key;
     // Animated collapse/expand: when App signalled a group transition for THIS
-    // scene change, its driver OWNS the swap (collapse keeps the old scene and
-    // morphs into updateGraph at t=1; expand swaps first then morphs out). untrack
-    // so this effect depends ONLY on `scene` — a later groupTransition prop update
-    // must not re-fire a rebuild, and it must not become a hidden dependency.
-    const transition = untrack(() => groupTransition);
-    // A group tween owns the canvas: a REDUNDANT scene re-derivation (the same
-    // group action re-laying out positions, or the ontology artifact settling one
-    // tick after the fold) must NOT cancel the in-flight tween. Only a GENUINE new
-    // transition interrupts; otherwise let the tween settle (its onDone rebuilds
-    // from the latest scene). Without this, such a follow-up tick hard-cut and
-    // froze the animation on frame 0 (observed under CDP).
-    if (groupTweenFrame !== null && !transition) return;
+    // scene change, its driver OWNS the swap. untrack so this effect depends ONLY
+    // on `scene` — a later groupTransition prop update must not re-fire a rebuild
+    // and must not become a hidden dependency.
+    const raw = untrack(() => groupTransition);
+    // Consumed-once (RC-D): groupTransition is a memoized $derived, so a redundant
+    // scene tick (the same group action re-laying out positions, or the ontology
+    // artifact settling one tick later) re-reads the SAME non-null descriptor.
+    // Only a GENUINELY new descriptor (a new object from a new groupedGraph) is
+    // FRESH; a re-read is treated as absent so it can neither restart nor kill the
+    // in-flight tween.
+    const fresh = raw && raw !== lastConsumedGroupTransition ? raw : null;
+    if (fresh) lastConsumedGroupTransition = raw;
+    // A group tween owns the canvas: a redundant tick (no fresh descriptor) mid-
+    // tween must NOT rebuild — let the tween settle (its onDone swaps from the
+    // latest scene).
+    if (groupTweenFrame !== null && !fresh) return;
+    // §3.7 interrupt rule: a GENUINE new transition arriving mid-tween must first
+    // COMPLETE the pending swap synchronously (finishCollapseSwap / settleGroupTween
+    // via pendingGroupSettle) so `payload` never lags two scenes behind, then start
+    // the new transition from the settled state.
+    if (groupTweenFrame !== null && fresh && pendingGroupSettle) {
+      cancelGroupTweenFrame();
+      pendingGroupSettle();
+    }
     // Genuine new graph/candidate: drop stale dragged positions before refit.
     draggedPositions.clear();
-    // Falls through to the hard cut when the transition is absent/ambiguous or no
-    // folding node is on screen (the safety fallback — never breaks the collapse).
-    if (untrack(() => tryStartGroupTransition(transition))) return;
-    // Never tween across a scene-content change (new node indices) — reset the
-    // layout to Force and recapture the fresh force baseline in updateGraph.
+    // Hand off to the animated driver (collapse/expand). It OWNS the swap (position-
+    // preserving carried swap, no refit) and returns true; only an absent/ambiguous
+    // transition or a genuine non-group scene change falls through.
+    if (untrack(() => tryStartGroupTransition(fresh))) return;
+    // Genuine NON-group scene change (model switch, weak-link, time scrub) or mixed/
+    // no descriptor: the coordinate space genuinely changes → invalidate the
+    // expand-restore cache (§3.6), then the historical reset + refit path. Never
+    // tween across a scene-content change (new node indices).
+    coordinateEpoch += 1;
     resetLayoutState();
     updateGraph();
   });
@@ -1898,9 +2172,17 @@
   $effect(() => {
     // Selection / focus change → rebuild styling but PRESERVE the current
     // camera (no refit), so clicking or opening a node keeps the user's
-    // zoom and pan instead of resetting the view.
-    selectedIds;
-    focusId;
+    // zoom and pan instead of resetting the view. Reading selectedIds + focusId
+    // registers both as dependencies.
+    const key = selectionSignature(selectedIds, focusId);
+    // §3.3 hardening: resolveSelectedIds returns a FRESH array on EVERY group
+    // toggle even when its content is identical (App: `return [...ids]`), so the
+    // prop identity changes on every toggle. Compare CONTENT, not identity, so
+    // those no-op rebuilds no longer fire at all — which (together with the
+    // groupSwapPending deferral) stops the same-flush rebuild that killed collapse
+    // (RC-B). A genuine selection/focus change still passes this guard.
+    if (key === lastSelectionKey) return;
+    lastSelectionKey = key;
     // A selection/focus appearing supersedes any pending pre-selection hover
     // dwell — updateSelection() rebuilds the (selection-dimmed) style itself.
     hoverIntent.cancel();

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -7,6 +7,7 @@
   import {
     buildConnectedDimStyle,
     buildGraphRendererPayload,
+    COLOR_BY_CHURN,
     COLOR_BY_FOLDER,
     COLOR_BY_LAYER,
     computeLayoutBuffer,
@@ -194,6 +195,7 @@
   const COLOR_MODES = [
     { id: COLOR_BY_FOLDER, label: "Folder" },
     { id: COLOR_BY_LAYER, label: "Layer" },
+    { id: COLOR_BY_CHURN, label: "Churn" },
   ];
 
   let hoveredEdge = $state(null);
@@ -1539,6 +1541,11 @@
           >{mode.label}</Button>
         {/each}
       </ButtonGroup>
+      {#if colorMode === COLOR_BY_CHURN}
+        <div class="churn-legend" aria-label="Churn colour legend">
+          <span>Low</span><span class="churn-ramp"></span><span>High</span>
+        </div>
+      {/if}
       <!-- codeflow-parity Lot 4: Curved-links toggle (DS Switch). ON ⇒ 0.15
            (current behaviour), OFF ⇒ straight. Flips edge curvature LIVE. -->
       <Switch
@@ -1690,6 +1697,26 @@
 
   .force-controls input[type="range"] {
     width: 5.5rem;
+  }
+
+  .churn-legend {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--st-semantic-surface-default, #fff) 90%, transparent);
+    box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .churn-ramp {
+    width: 3.5rem;
+    height: 0.6rem;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #e2e8f0, #ef4444);
   }
 
   /* codeflow-parity Lot 4: keep the Curved-links DS Switch compact + legible in

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -10,6 +10,11 @@
     COLOR_BY_CHURN,
     COLOR_BY_FOLDER,
     COLOR_BY_LAYER,
+    DEFAULT_EDGE_OPACITY,
+    EDGE_ALPHA_DENSE,
+    EDGE_ALPHA_FLAT,
+    EDGE_ALPHA_INVERSE,
+    EDGE_ALPHA_MID,
     computeLayoutBuffer,
     findNearestEdge,
     findNearestNode,
@@ -203,6 +208,22 @@
     { id: COLOR_BY_FOLDER, label: "Community" },
     { id: COLOR_BY_LAYER, label: "Ontology" },
     { id: COLOR_BY_CHURN, label: "Degree" },
+  ];
+
+  // Configurable edge-transparency: the along-edge fade MODE + the flat base
+  // OPACITY. Both re-style LIVE like Color-by (per-render edge attributes: the
+  // alpha SHAPE + the base alpha), so a change rebuilds the payload + re-renders
+  // with NO layout recompute + NO morph. Defaults (dense fade, 0.5 opacity) match
+  // the studio's prior ~0.5 base + hub density-falloff, so an untouched control
+  // is byte-identical to before.
+  let edgeAlphaMode = $state(EDGE_ALPHA_DENSE);
+  let edgeOpacity = $state(DEFAULT_EDGE_OPACITY);
+  // The Edge-fade options exposed by the segmented control (default first).
+  const EDGE_FADE_MODES = [
+    { id: EDGE_ALPHA_DENSE, label: "Dense" },
+    { id: EDGE_ALPHA_INVERSE, label: "Inverse" },
+    { id: EDGE_ALPHA_MID, label: "Mid" },
+    { id: EDGE_ALPHA_FLAT, label: "Flat" },
   ];
 
   // Representation-polish remark 4: the whole layout/spacing/display toolbar
@@ -728,6 +749,10 @@
       // (Folder / curved) keep the output byte-identical to before this lot.
       colorBy: colorMode,
       curvedLinks,
+      // Configurable edge-transparency: the along-edge fade mode + flat base
+      // opacity. Defaults (dense / 0.5) keep the historical edge look.
+      edgeAlphaMode,
+      edgeOpacity,
       ...(Number.isFinite(labelMaxChars) ? { labelMaxChars } : {}),
     });
     lastLabelZoomBucket = labelZoomBucket(camera.zoom);
@@ -822,6 +847,13 @@
   function selectColorMode(mode) {
     if (mode === colorMode) return;
     colorMode = mode;
+  }
+
+  // Configurable edge-transparency handlers: flip the $state; the reactive
+  // $effect above re-styles LIVE (same path as Color-by / Curved-links).
+  function selectEdgeAlphaMode(mode) {
+    if (mode === edgeAlphaMode) return;
+    edgeAlphaMode = mode;
   }
 
   // ResizeObserver / window-resize path. Two guarantees (UAT):
@@ -1634,9 +1666,15 @@
     // (updateGraph already did the first render with the defaults).
     curvedLinks;
     colorMode;
+    // Configurable edge-transparency deps: a fade-mode / opacity change re-styles
+    // LIVE through the same path (per-render edge attributes, no layout recompute).
+    edgeAlphaMode;
+    edgeOpacity;
     // Same hidden-dependency guard as the selection effect: updateDisplayStyle →
     // rebuildPayload reads hoveredNodeId, so untrack it to depend ONLY on the
-    // curvedLinks/colorMode reads above (else a hover re-fires this re-style).
+    // curvedLinks/colorMode/edge-fade reads above (else a hover re-fires this
+    // re-style). Keeping the untrack is CRITICAL — it prevents a hidden
+    // hoveredNodeId dependency from killing edge hover.
     untrack(() => updateDisplayStyle());
   });
 
@@ -1820,6 +1858,31 @@
                   checked={curvedLinks}
                   onchange={toggleCurvedLinks}
                 />
+                <!-- Configurable edge-transparency: a segmented Edge-fade mode +
+                     an Edge-opacity slider. Both re-style LIVE like Color-by. -->
+                <ButtonGroup attached size="sm" label="Edge fade" class="edge-fade-switcher">
+                  {#each EDGE_FADE_MODES as mode (mode.id)}
+                    <Button
+                      size="sm"
+                      variant={edgeAlphaMode === mode.id ? "primary" : "secondary"}
+                      aria-pressed={edgeAlphaMode === mode.id}
+                      aria-label={`Edge fade ${mode.label}`}
+                      onclick={() => selectEdgeAlphaMode(mode.id)}
+                    >{mode.label}</Button>
+                  {/each}
+                </ButtonGroup>
+                <label class="edge-opacity-row">
+                  <span>Edge opacity {edgeOpacity.toFixed(2)}</span>
+                  <input
+                    type="range"
+                    min="0.1"
+                    max="0.8"
+                    step="0.05"
+                    value={edgeOpacity}
+                    aria-label="Edge opacity"
+                    oninput={(event) => (edgeOpacity = Number(event.currentTarget.value))}
+                  />
+                </label>
               </section>
             </div>
           {/snippet}
@@ -2081,6 +2144,21 @@
     box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
     font-size: 0.75rem;
     white-space: nowrap;
+  }
+
+  /* Configurable edge-transparency: the Edge-opacity slider row matches the
+     Spread/Links force sliders' compact scale + layout. */
+  .edge-opacity-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .edge-opacity-row input[type="range"] {
+    flex: 1;
+    min-width: 0;
   }
 
   .canvas-element {

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1,10 +1,12 @@
 <script>
   import { onDestroy, onMount, tick } from "svelte";
+  import { Button, ButtonGroup } from "@sentropic/design-system-svelte";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
 
   import {
     buildConnectedDimStyle,
     buildGraphRendererPayload,
+    computeLayoutBuffer,
     findNearestEdge,
     findNearestNode,
     findNearestNodeId,
@@ -12,6 +14,9 @@
     interpolateMergePositions,
     isBoxShape,
     LABEL_ZOOM_THRESHOLD,
+    LAYOUT_MODE_FORCE,
+    LAYOUT_MODES,
+    morphPositions,
     truncateLabel,
   } from "../lib/graphRendererPayload.js";
   import {
@@ -43,6 +48,10 @@
   const NODE_TIGHT_SLOP = 4;
   const HOVER_EDGE_COLOR = [37, 99, 235, 255];
   const MERGE_ANIMATION_DURATION_MS = 520;
+  // codeflow-parity Lot 1: duration of the all-node layout MORPH tween
+  // (Force ↔ Layers). Kept in the ~300–500 ms band the spec calls for, so
+  // labels + interaction are only locked briefly (§2.6).
+  const LAYOUT_MORPH_DURATION_MS = 480;
   // CANVAS2D ONLY: hide edges during active pan/zoom/drag when nodes+edges exceed
   // this, for interaction fluidity (a legacy SVG-era guard). WebGL2 NEVER skips
   // (GPU-instanced edges are cheap) — see `skipEdgesOnInteract`.
@@ -92,6 +101,11 @@
     // label is always available on hover (tooltip + overlay `title`). Undefined
     // falls back to the renderer default (DEFAULT_LABEL_MAX_CHARS).
     labelMaxChars = undefined,
+    // codeflow-parity Lot 1: show the layout switcher (Force · Layers) in the
+    // toolbar and enable the all-node layout MORPH. Opt-in — only the workspace
+    // main graph passes it; the reconciliation view (pinned twins, its own local
+    // layout) and git-flow leave it off so the animated switcher is scoped there.
+    showLayoutSwitcher = false,
   } = $props();
 
   let container;
@@ -132,6 +146,26 @@
   let resizeFrame = null;
   let mergeFrame = null;
   let completedMergeKey = null;
+
+  // --- codeflow-parity Lot 1: layout switcher + all-node morph tween ---------
+  // The currently-selected layout mode (drives the segmented control + morph).
+  let layoutMode = $state(LAYOUT_MODE_FORCE);
+  // rAF handle for the in-flight layout morph (distinct from the merge loop).
+  let layoutMorphFrame = null;
+  // The LIVE interpolated buffer of the in-flight morph — re-seeds `bufA` on an
+  // interrupt (switching mid-morph) and is re-applied after a selection/hover
+  // rebuild so the effect can't clobber the tween (cf. reapplyDraggedPositions).
+  let liveMorphBuffer = null;
+  // The SETTLED target buffer of the active non-force layout (null while Force,
+  // which uses the native scene positions). Re-applied after every payload
+  // rebuild so a Layers layout survives a selection/hover-driven rebuild.
+  let activeLayoutBuffer = null;
+  // The CACHED pristine force positions captured at scene-build time — the
+  // morph TARGET for switch-to-Force (Lot 1 never cold re-solves force).
+  let forceBaseBuffer = null;
+  // True while a layout morph is in flight: hides labels + locks canvas
+  // interaction for the (~480 ms) tween, exactly as pan/zoom already do.
+  let morphActive = $state(false);
   let hoveredEdge = $state(null);
   let hoveredNode = $state(null);
   let hoveredNodeId = $state(null);
@@ -372,6 +406,11 @@
 
   // --- Zoom centred on cursor ---
   function handleWheel(event) {
+    // Lock zoom during a layout morph (§2.6) — the tween owns the buffer.
+    if (morphActive) {
+      event.preventDefault();
+      return;
+    }
     if (!renderer || !canvas) return;
     event.preventDefault();
 
@@ -424,6 +463,8 @@
 
   // --- Pointer down: node drag (over a node) or pan (over the background) ---
   function handlePointerDown(event) {
+    // Lock pan/drag while a layout morph is in flight (§2.6).
+    if (morphActive) return;
     // A pan/drag is starting — cancel any pending hover-intent dwell so it can't
     // fire (and dim) mid-interaction.
     hoverIntent.cancel();
@@ -512,9 +553,26 @@
     lastLabelZoomBucket = labelZoomBucket(camera.zoom);
     clearHoveredEdge({ notify: false, render: false });
     computeNodeDegrees();
+    // Re-apply the active layout FIRST (so a Layers layout / an in-flight morph
+    // survives a selection/hover rebuild), THEN dragged positions on top (a
+    // user drag wins over the layout).
+    reapplyLayoutPositions();
     reapplyDraggedPositions();
     // NB: `skipEdgesOnInteract` is a backend-aware `$derived` (declared above) —
     // no imperative recompute here, so a backend flip updates it reactively.
+  }
+
+  // codeflow-parity Lot 1: re-write the active layout's positions onto a freshly
+  // built payload so the selection `$effect` (rebuildPayload → applyPayloadNoFit
+  // → setPositions) cannot clobber the layout / the interpolated morph buffer
+  // (§2.6). Mid-morph the LIVE buffer wins; otherwise the settled non-force
+  // layout buffer. Force (activeLayoutBuffer === null, not morphing) is a no-op,
+  // so the default path stays byte-identical to before this lot.
+  function reapplyLayoutPositions() {
+    const source = morphActive ? liveMorphBuffer : activeLayoutBuffer;
+    if (!source || !payload?.renderGraph) return;
+    const positions = payload.renderGraph.positions;
+    if (source.length === positions.length) positions.set(source);
   }
 
   // Re-write any user-dragged node positions onto the freshly-built payload so a
@@ -535,9 +593,21 @@
     if (!mounted) return;
 
     rebuildPayload();
+    // Cache the pristine force positions of the fresh scene as the switch-to-
+    // Force morph target (Lot 1 never cold re-solves force). Captured AFTER the
+    // rebuild, when positions still hold the baked/attached force layout (the
+    // genuine-new-scene path resets layout state first, so no override applies).
+    captureForceBaseBuffer();
     ensureRenderer();
     resizeCanvas();
     applyPayload();
+  }
+
+  // codeflow-parity Lot 1: snapshot the current (pristine force) positions as the
+  // cached switch-to-Force morph target.
+  function captureForceBaseBuffer() {
+    const positions = payload?.renderGraph?.positions;
+    forceBaseBuffer = positions ? new Float32Array(positions) : null;
   }
 
   // Selection/focus update — preserves the user's current zoom and pan.
@@ -744,6 +814,8 @@
   }
 
   function handleClick(event) {
+    // Ignore canvas clicks while a layout morph is animating.
+    if (morphActive) return;
     // A click that concludes a node drag must not also select.
     if (suppressNextClick) {
       suppressNextClick = false;
@@ -754,6 +826,7 @@
   }
 
   function handleDoubleClick(event) {
+    if (morphActive) return;
     const id = pickNode(event);
     if (id) onOpenEntity?.(id);
   }
@@ -807,6 +880,8 @@
   }
 
   function handlePointerMove(event) {
+    // Suppress hover / pan / drag while a layout morph owns the position buffer.
+    if (morphActive) return;
     // Node drag takes priority over everything else.
     if (draggingNodeId) {
       if (!dragMoved) {
@@ -1029,6 +1104,106 @@
     mergeFrame = window.requestAnimationFrame(tick);
   }
 
+  // --- codeflow-parity Lot 1: all-node layout MORPH driver -------------------
+  // Generalizes the one-node merge tween into a cross-buffer morph between two
+  // index-parallel position buffers (§2.5/§2.6): capture the current on-screen
+  // buffer as `bufA`, compute the target `bufB` for the chosen mode (Layers =
+  // resolveLayout('typed-layer'); Force = the CACHED initial force positions —
+  // no cold re-solve in Lot 1), rAF-lerp bufA→bufB via renderer.setPositions,
+  // then exactly ONE fitAndRender() at t=1.
+
+  function cancelLayoutMorphFrame() {
+    if (typeof window !== "undefined" && layoutMorphFrame !== null) {
+      window.cancelAnimationFrame(layoutMorphFrame);
+    }
+    layoutMorphFrame = null;
+  }
+
+  // Reset all layout state to the Force default. Called on a genuine scene-
+  // content change so we NEVER tween across a scene rebuild (new node indices).
+  function resetLayoutState() {
+    cancelLayoutMorphFrame();
+    morphActive = false;
+    liveMorphBuffer = null;
+    activeLayoutBuffer = null;
+    layoutMode = LAYOUT_MODE_FORCE;
+  }
+
+  // Toolbar click: morph to `mode`. Ignores a click on the already-active mode
+  // (during a morph `layoutMode` is already the target, so re-clicking it is a
+  // no-op while clicking the OTHER mode interrupts and re-targets).
+  function selectLayoutMode(mode) {
+    if (mode === layoutMode) return;
+    startLayoutMorph(mode);
+  }
+
+  // Bake a settled layout into the payload (so hit-testing / labels / edges read
+  // the new positions), remember it for re-application across rebuilds, and do
+  // the single deliberate end-fit.
+  function settleLayout(mode, buffer) {
+    activeLayoutBuffer =
+      mode === LAYOUT_MODE_FORCE || !buffer ? null : new Float32Array(buffer);
+    const positions = payload?.renderGraph?.positions;
+    if (positions && buffer && buffer.length === positions.length) {
+      positions.set(buffer);
+    }
+    liveMorphBuffer = null;
+    morphActive = false;
+    // ONE end-fit: the new layout has a different bbox (§2.6). fitAndRender()
+    // also restores labels (setLabelsHidden(false)).
+    fitAndRender();
+  }
+
+  function startLayoutMorph(mode) {
+    if (!renderer || !payload?.renderGraph) {
+      layoutMode = mode;
+      return;
+    }
+    const current = payload.renderGraph.positions;
+    // Interrupt: re-seed bufA from the LIVE interpolated buffer, never snap back
+    // to base (§2.6). Otherwise capture the current on-screen buffer.
+    const bufA =
+      layoutMorphFrame !== null && liveMorphBuffer
+        ? new Float32Array(liveMorphBuffer)
+        : new Float32Array(current);
+    const bufB = computeLayoutBuffer(payload, mode, { forceBuffer: forceBaseBuffer });
+
+    cancelLayoutMorphFrame();
+    layoutMode = mode;
+
+    const canAnimate =
+      typeof window !== "undefined" &&
+      typeof window.requestAnimationFrame === "function";
+    // Bad / mismatched target, or no rAF (SSR/tests): settle instantly.
+    if (!bufB || bufB.length !== bufA.length || !canAnimate) {
+      settleLayout(mode, bufB && bufB.length === current.length ? bufB : null);
+      return;
+    }
+
+    morphActive = true;
+    setLabelsHidden(true);
+    liveMorphBuffer = new Float32Array(bufA.length);
+    const startTime = window.performance?.now?.() ?? Date.now();
+    const step = (now) => {
+      const elapsed = Math.max(0, now - startTime);
+      const progress = Math.min(1, elapsed / LAYOUT_MORPH_DURATION_MS);
+      morphPositions(bufA, bufB, easeMergeProgress(progress), liveMorphBuffer);
+      renderer.setPositions(liveMorphBuffer);
+      renderNow();
+      if (progress < 1) {
+        layoutMorphFrame = window.requestAnimationFrame(step);
+      } else {
+        layoutMorphFrame = null;
+        settleLayout(mode, bufB);
+      }
+    };
+    // Prime frame 0 so there is no flash, then drive the tween.
+    morphPositions(bufA, bufB, 0, liveMorphBuffer);
+    renderer.setPositions(liveMorphBuffer);
+    renderNow();
+    layoutMorphFrame = window.requestAnimationFrame(step);
+  }
+
   // Stable content signature of a scene: node ids + positions + edge endpoints +
   // counts. Two structurally-equivalent scenes share a signature even when they
   // are different object instances (a `$derived.by` recompute), so we don't refit
@@ -1059,6 +1234,9 @@
     lastSceneKey = key;
     // Genuine new graph/candidate: drop stale dragged positions before refit.
     draggedPositions.clear();
+    // Never tween across a scene-content change (new node indices) — reset the
+    // layout to Force and recapture the fresh force baseline in updateGraph.
+    resetLayoutState();
     updateGraph();
   });
 
@@ -1113,6 +1291,7 @@
       if (indicatorTimer !== null) window.clearTimeout(indicatorTimer);
       hoverIntent.cancel();
       cancelMergeFrame();
+      cancelLayoutMorphFrame();
       renderer?.destroy();
       renderer = null;
     };
@@ -1128,6 +1307,22 @@
 
 <div class="canvas" bind:this={container}>
   <div class="canvas-toolbar" aria-label="Graph controls">
+    {#if showLayoutSwitcher}
+      <!-- codeflow-parity Lot 1: layout switcher (Force · Layers). Choosing a
+           mode drives the all-node morph tween. DS segmented control, same
+           attached ButtonGroup pattern as the app view switcher. -->
+      <ButtonGroup attached size="sm" label="Graph layout" class="layout-switcher">
+        {#each LAYOUT_MODES as mode (mode.id)}
+          <Button
+            size="sm"
+            variant={layoutMode === mode.id ? "primary" : "secondary"}
+            aria-pressed={layoutMode === mode.id}
+            aria-label={`${mode.label} layout`}
+            onclick={() => selectLayoutMode(mode.id)}
+          >{mode.label}</Button>
+        {/each}
+      </ButtonGroup>
+    {/if}
     <button
       class="toolbar-btn"
       type="button"
@@ -1241,6 +1436,7 @@
     right: 0.5rem;
     z-index: 3;
     display: flex;
+    align-items: center;
     gap: 0.35rem;
     pointer-events: auto;
   }

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onDestroy, onMount, tick } from "svelte";
-  import { Button, ButtonGroup, Switch } from "@sentropic/design-system-svelte";
+  import { Button, ButtonGroup, IconButton, Popover, Switch } from "@sentropic/design-system-svelte";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
   import { solveForce, terminateForceWorker } from "../lib/forceLayoutClient.js";
 
@@ -203,6 +203,35 @@
     { id: COLOR_BY_CHURN, label: "Churn" },
   ];
 
+  // Representation-polish remark 4: the whole layout/spacing/display toolbar
+  // collapses behind a gear icon into a settings popover (codeflow parity),
+  // instead of a permanently-open row of controls crowding the canvas.
+  let settingsOpen = $state(false);
+  let settingsHost;
+
+  function toggleSettings() {
+    settingsOpen = !settingsOpen;
+  }
+
+  function closeSettings() {
+    settingsOpen = false;
+  }
+
+  // Click-outside / Escape to close, same lightweight pattern a DS Popover
+  // leaves to its host (Popover itself is host-controlled, no built-in
+  // dismiss-on-outside-click).
+  function handleSettingsWindowPointerDown(event) {
+    if (!settingsOpen || !settingsHost) return;
+    if (!settingsHost.contains(event.target)) closeSettings();
+  }
+
+  function handleSettingsWindowKeydown(event) {
+    if (settingsOpen && event.key === "Escape") {
+      event.preventDefault();
+      closeSettings();
+    }
+  }
+
   let hoveredEdge = $state(null);
   let hoveredNode = $state(null);
   let hoveredNodeId = $state(null);
@@ -402,15 +431,20 @@
     }, 1200);
   }
 
-  function fitAndRender() {
-    if (!renderer || !canvas) return;
+  // Compute the fitted target camera WITHOUT animating — shared by the
+  // instant fitAndRender() and the animated animateFitAndRender() (remark 7)
+  // so both land on the EXACT same target. `renderer.fitView(...)` computes
+  // AND applies the bbox fit; centerOnIds (recon) then overrides x/y only,
+  // keeping the fit zoom.
+  function computeFitTargetCamera() {
+    if (!renderer || !canvas) return null;
 
     const viewportWidth = Math.max(1, canvas.width);
     const viewportHeight = Math.max(1, canvas.height);
     const padding = Math.min(FIT_PADDING * pixelRatio, Math.floor(Math.min(viewportWidth, viewportHeight) / 3));
 
     renderer.fitView({ padding, viewportWidth, viewportHeight });
-    camera = renderer.snapshot().camera;
+    let target = renderer.snapshot().camera;
     // Recon: centre the view on specific nodes (the twins) rather than the
     // bbox centre, so the entities-to-reconcile sit at the exact viewport
     // centre (horizontal + vertical). Keeps the fit zoom.
@@ -425,13 +459,111 @@
           n += 1;
         }
       }
-      if (n > 0) {
-        camera = { ...camera, x: sx / n, y: sy / n };
-        renderer.setCamera(camera);
-      }
+      if (n > 0) target = { ...target, x: sx / n, y: sy / n };
     }
+    return target;
+  }
+
+  function fitAndRender() {
+    if (!renderer || !canvas) return;
+    // An explicit instant fit (mount / new scene / resize / "Reset view")
+    // wins over any in-flight camera tween.
+    cancelCameraTween();
+    const target = computeFitTargetCamera();
+    if (!target) return;
+    camera = target;
+    renderer.setCamera(camera);
     renderNow();
     setLabelsHidden(false);
+  }
+
+  // --- Representation-polish remark 7: smooth recenter ------------------
+  // fitAndRender() above SNAPS the camera to the fitted target in one step —
+  // fine for mount/resize/an explicit "Reset view" click, but jarring right
+  // after a layout/param morph, where the NODE positions just tweened
+  // smoothly and the camera then popped. animateFitAndRender tweens the
+  // CAMERA (x/y/zoom) from wherever it currently sits to the same fit
+  // target, over the SAME duration/easing as the node morph
+  // (LAYOUT_MORPH_DURATION_MS / easeMergeProgress), so the recenter reads as
+  // one continuous motion. Used ONLY by settleLayout (end of a layout/param
+  // change) — mount/resize/"Reset view" keep the instant fit above.
+  let cameraTweenFrame = null;
+
+  function cancelCameraTween() {
+    if (typeof window !== "undefined" && cameraTweenFrame !== null) {
+      window.cancelAnimationFrame(cameraTweenFrame);
+    }
+    cameraTweenFrame = null;
+  }
+
+  function lerpCamera(a, b, t) {
+    return {
+      x: a.x + (b.x - a.x) * t,
+      y: a.y + (b.y - a.y) * t,
+      zoom: a.zoom + (b.zoom - a.zoom) * t,
+    };
+  }
+
+  function animateFitAndRender() {
+    if (!renderer || !canvas) return;
+    const startCamera = camera;
+    // computeFitTargetCamera() calls renderer.fitView(...), which APPLIES the
+    // target to the renderer immediately as a side effect of computing it;
+    // we read it back via snapshot() then restore startCamera below (prime
+    // frame 0) so nothing flashes to the target before the tween runs.
+    const target = computeFitTargetCamera();
+    if (!target) return;
+
+    const canAnimate =
+      typeof window !== "undefined" && typeof window.requestAnimationFrame === "function";
+    // §F3 parity (a11y): honour prefers-reduced-motion — snap instead of tween.
+    if (!canAnimate || prefersReducedMotion()) {
+      camera = target;
+      renderer.setCamera(camera);
+      renderNow();
+      setLabelsHidden(false);
+      return;
+    }
+
+    cancelCameraTween();
+    setLabelsHidden(true);
+    const startTime = window.performance?.now?.() ?? Date.now();
+    // Never let a throwing frame leave the camera short of the target or
+    // labels stuck hidden (mirrors the node morph's §F2 abort guard).
+    const abortTween = () => {
+      cancelCameraTween();
+      camera = target;
+      renderer.setCamera(camera);
+      renderNow();
+      setLabelsHidden(false);
+    };
+    const step = (now) => {
+      try {
+        const elapsed = Math.max(0, now - startTime);
+        const progress = Math.min(1, elapsed / LAYOUT_MORPH_DURATION_MS);
+        camera = lerpCamera(startCamera, target, easeMergeProgress(progress));
+        renderer.setCamera(camera);
+        renderNow();
+        if (progress < 1) {
+          cameraTweenFrame = window.requestAnimationFrame(step);
+        } else {
+          cameraTweenFrame = null;
+          setLabelsHidden(false);
+        }
+      } catch {
+        abortTween();
+      }
+    };
+    // Prime frame 0 (restore the pre-fit camera fitView() just jumped to) so
+    // there is no flash, then drive the tween.
+    try {
+      camera = startCamera;
+      renderer.setCamera(camera);
+      renderNow();
+      cameraTweenFrame = window.requestAnimationFrame(step);
+    } catch {
+      abortTween();
+    }
   }
 
   function applyCamera(skipEdges = false) {
@@ -450,6 +582,9 @@
     }
     if (!renderer || !canvas) return;
     event.preventDefault();
+    // Remark 7: the user zooming takes over from any in-flight camera-recenter
+    // tween immediately, rather than fighting it for the rest of the tween.
+    cancelCameraTween();
 
     const rect = canvas.getBoundingClientRect();
     const scaleX = canvas.width / Math.max(1, rect.width);
@@ -505,6 +640,9 @@
     // A pan/drag is starting — cancel any pending hover-intent dwell so it can't
     // fire (and dim) mid-interaction.
     hoverIntent.cancel();
+    // Remark 7: the user panning/dragging takes over from any in-flight
+    // camera-recenter tween immediately, rather than fighting it.
+    cancelCameraTween();
     const id = pickNode(event);
 
     if (id) {
@@ -1002,7 +1140,19 @@
     const nodeMaxDistance = PICK_RADIUS * world.scale;
     const edgeMaxDistance = EDGE_PICK_RADIUS * world.scale;
     const nodeHit = findNearestNode(payload, world.x, world.y, nodeMaxDistance);
-    const edgeHit = findNearestEdge(payload, world.x, world.y, edgeMaxDistance);
+    // Remark 3 (edge hover dead outside Force): pass the CURRENT settled
+    // positions EXPLICITLY rather than relying on findNearestEdge's implicit
+    // `payload.renderGraph.positions` default — settleLayout mutates that
+    // array in place on every layout switch (Force/Radial/Grid/Metro/Layers),
+    // so this is the same array either way, but naming it here removes any
+    // ambiguity that the hit-test could ever read a pre-morph/stale buffer.
+    const edgeHit = findNearestEdge(
+      payload,
+      world.x,
+      world.y,
+      edgeMaxDistance,
+      payload.renderGraph.positions,
+    );
 
     // Tight node zone: on the glyph (radius) plus a few CSS px of slop.
     const tightNodeRadius = (nodeHit?.radius ?? 0) + NODE_TIGHT_SLOP * world.scale;
@@ -1199,6 +1349,16 @@
   // and on an abnormal morph exit (§F2) so the canvas can never stay locked.
   function resetLayoutState() {
     cancelLayoutMorphFrame();
+    // Remark 7: a scene reset / abnormal morph exit also cancels any in-flight
+    // camera-recenter tween — its target bbox is for the OLD scene/layout.
+    cancelCameraTween();
+    // Remark 2 (hover-dwell flicker regression): a pending dwell timer keeps
+    // ticking via its own setTimeout regardless of morph/scene state. If it
+    // fires AFTER a layout reset (new scene, or an abnormal morph exit) it
+    // would apply a connected-dim for a hover target whose position (or very
+    // existence) no longer matches what's on screen — a visible "pop" that
+    // reads as flicker. Cancel it here so it can never fire stale.
+    hoverIntent.cancel();
     morphActive = false;
     liveMorphBuffer = null;
     activeLayoutBuffer = null;
@@ -1325,9 +1485,12 @@
     }
     liveMorphBuffer = null;
     morphActive = false;
-    // ONE end-fit: the new layout has a different bbox (§2.6). fitAndRender()
-    // also restores labels (setLabelsHidden(false)).
-    fitAndRender();
+    // ONE end-fit: the new layout has a different bbox (§2.6). Remark 7:
+    // animateFitAndRender() TWEENS the camera to the new fit (instead of
+    // snapping) over the same duration/easing as the node morph just
+    // finished, so the recenter reads as one continuous motion; it also
+    // restores labels (setLabelsHidden(false)) once the tween settles.
+    animateFitAndRender();
   }
 
   function startLayoutMorph(mode) {
@@ -1346,6 +1509,18 @@
     const bufA = currentLayoutBuffer() ?? new Float32Array(current);
 
     cancelLayoutMorphFrame();
+    // Remark 7: a NEW node morph starting supersedes any camera-recenter tween
+    // still animating from the PREVIOUS layout settle (e.g. a rapid re-click)
+    // — its target bbox is now stale.
+    cancelCameraTween();
+    // Remark 2: a layout morph LOCKS pointer/hover input (handlePointerMove
+    // early-returns while morphActive), but a hover-intent dwell timer that
+    // was already pending when the morph started is NOT an input event — it
+    // keeps ticking on its own setTimeout and can fire mid-morph or right
+    // after settle, dimming for a hover target that's no longer under the
+    // cursor (the layout just moved everything). Cancel it before the morph
+    // starts so it can never fire stale.
+    hoverIntent.cancel();
     layoutMode = mode;
     // §F1: bufA already snapshotted the on-screen (incl. dragged) positions, so
     // the drag is preserved as the morph START; drop the stale drag map now — a
@@ -1490,17 +1665,23 @@
     // Dual-render BETA toggle (Ctrl+Shift+X) — window-level so the shortcut
     // works regardless of canvas focus.
     window.addEventListener("keydown", handleKeydown);
+    // Remark 4: gear settings popover — dismiss on outside click / Escape.
+    window.addEventListener("pointerdown", handleSettingsWindowPointerDown);
+    window.addEventListener("keydown", handleSettingsWindowKeydown);
 
     return () => {
       mounted = false;
       resizeObserver?.disconnect();
       window.removeEventListener("resize", scheduleResize);
       window.removeEventListener("keydown", handleKeydown);
+      window.removeEventListener("pointerdown", handleSettingsWindowPointerDown);
+      window.removeEventListener("keydown", handleSettingsWindowKeydown);
       if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
       if (indicatorTimer !== null) window.clearTimeout(indicatorTimer);
       hoverIntent.cancel();
       cancelMergeFrame();
       cancelLayoutMorphFrame();
+      cancelCameraTween();
       renderer?.destroy();
       renderer = null;
     };
@@ -1519,79 +1700,120 @@
 <div class="canvas" bind:this={container}>
   <div class="canvas-toolbar" aria-label="Graph controls">
     {#if showLayoutSwitcher}
-      <!-- codeflow-parity Lot 1: layout switcher (Force · Layers). Choosing a
-           mode drives the all-node morph tween. DS segmented control, same
-           attached ButtonGroup pattern as the app view switcher. -->
-      <ButtonGroup attached size="sm" label="Graph layout" class="layout-switcher">
-        {#each LAYOUT_MODES as mode (mode.id)}
-          <Button
-            size="sm"
-            variant={layoutMode === mode.id ? "primary" : "secondary"}
-            aria-pressed={layoutMode === mode.id}
-            aria-label={`${mode.label} layout`}
-            onclick={() => selectLayoutMode(mode.id)}
-          >{mode.label}</Button>
-        {/each}
-      </ButtonGroup>
-      <!-- codeflow-parity Lot 3: force spacing controls. `input` only updates
-           the label; the expensive Barnes-Hut solve runs on `change` (drag-end).
-           Interactive solves warm-start; Reset is the deterministic cold solve. -->
-      <div class="force-controls" aria-label="Force spacing controls">
-        <label>
-          <span>Spread {forceSpread.toFixed(1)}</span>
-          <input
-            type="range"
-            min="0.2"
-            max="3"
-            step="0.1"
-            value={forceSpread}
-            aria-label="Spread"
-            oninput={(event) => (forceSpread = Number(event.currentTarget.value))}
-            onchange={commitForceSpread}
-          />
-        </label>
-        <label>
-          <span>Links {forceLinks.toFixed(1)}</span>
-          <input
-            type="range"
-            min="0.2"
-            max="2"
-            step="0.1"
-            value={forceLinks}
-            aria-label="Links"
-            oninput={(event) => (forceLinks = Number(event.currentTarget.value))}
-            onchange={commitForceLinks}
-          />
-        </label>
-        <Button size="sm" variant="secondary" aria-label="Reset layout" onclick={resetForceLayout}>Reset</Button>
+      <!-- Representation-polish remark 4: the whole layout/spacing/display
+           toolbar collapses behind a gear icon into a settings popover
+           (codeflow parity) instead of a permanently-open control row. -->
+      <div class="graph-settings-host" bind:this={settingsHost}>
+        <Popover label="Graph display settings" open={settingsOpen} placement="bottom">
+          {#snippet trigger()}
+            <IconButton
+              size="sm"
+              variant="secondary"
+              aria-label="Graph display settings"
+              aria-expanded={settingsOpen}
+              onclick={toggleSettings}
+            >⚙</IconButton>
+          {/snippet}
+          {#snippet children()}
+            <div class="graph-settings-panel">
+              <!-- LAYOUT: codeflow-parity Lot 1/2/6 layout switcher (Force ·
+                   Radial · Layers · Grid · Metro). Choosing a mode drives the
+                   all-node morph tween. -->
+              <section class="graph-settings-section" aria-label="Layout">
+                <p class="graph-settings-heading">Layout</p>
+                <ButtonGroup attached size="sm" label="Graph layout" class="layout-switcher">
+                  {#each LAYOUT_MODES as mode (mode.id)}
+                    <Button
+                      size="sm"
+                      variant={layoutMode === mode.id ? "primary" : "secondary"}
+                      aria-pressed={layoutMode === mode.id}
+                      aria-label={`${mode.label} layout`}
+                      onclick={() => selectLayoutMode(mode.id)}
+                    >{mode.label}</Button>
+                  {/each}
+                </ButtonGroup>
+              </section>
+              <!-- SPACING: codeflow-parity Lot 3 force spacing controls. `input`
+                   only updates the label; the expensive Barnes-Hut solve runs on
+                   `change` (drag-end). Interactive solves warm-start; Reset is the
+                   deterministic cold solve. Remark 6: Spread/Links sit on their
+                   own row and are DISABLED off-Force — they only drive the force
+                   re-solve, so they (and Reset, same re-solve) are inert on any
+                   other layout. -->
+              <section class="graph-settings-section" aria-label="Spacing">
+                <p class="graph-settings-heading">Spacing</p>
+                <div class="force-sliders-row" aria-label="Force spacing controls">
+                  <label class:is-disabled={layoutMode !== LAYOUT_MODE_FORCE}>
+                    <span>Spread {forceSpread.toFixed(1)}</span>
+                    <input
+                      type="range"
+                      min="0.2"
+                      max="3"
+                      step="0.1"
+                      value={forceSpread}
+                      aria-label="Spread"
+                      disabled={layoutMode !== LAYOUT_MODE_FORCE}
+                      oninput={(event) => (forceSpread = Number(event.currentTarget.value))}
+                      onchange={commitForceSpread}
+                    />
+                  </label>
+                  <label class:is-disabled={layoutMode !== LAYOUT_MODE_FORCE}>
+                    <span>Links {forceLinks.toFixed(1)}</span>
+                    <input
+                      type="range"
+                      min="0.2"
+                      max="2"
+                      step="0.1"
+                      value={forceLinks}
+                      aria-label="Links"
+                      disabled={layoutMode !== LAYOUT_MODE_FORCE}
+                      oninput={(event) => (forceLinks = Number(event.currentTarget.value))}
+                      onchange={commitForceLinks}
+                    />
+                  </label>
+                </div>
+                <div class="force-reset-row">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    aria-label="Reset layout"
+                    disabled={layoutMode !== LAYOUT_MODE_FORCE}
+                    onclick={resetForceLayout}
+                  >Reset</Button>
+                </div>
+              </section>
+              <!-- DISPLAY: codeflow-parity Lot 4 Color-by (Folder · Layer ·
+                   Churn) + Curved-links. Both re-style LIVE (no layout
+                   recompute, no morph). -->
+              <section class="graph-settings-section" aria-label="Display">
+                <p class="graph-settings-heading">Display</p>
+                <ButtonGroup attached size="sm" label="Colour by" class="color-switcher">
+                  {#each COLOR_MODES as mode (mode.id)}
+                    <Button
+                      size="sm"
+                      variant={colorMode === mode.id ? "primary" : "secondary"}
+                      aria-pressed={colorMode === mode.id}
+                      aria-label={`Colour by ${mode.label}`}
+                      onclick={() => selectColorMode(mode.id)}
+                    >{mode.label}</Button>
+                  {/each}
+                </ButtonGroup>
+                {#if colorMode === COLOR_BY_CHURN}
+                  <div class="churn-legend" aria-label="Churn colour legend">
+                    <span>Low</span><span class="churn-ramp"></span><span>High</span>
+                  </div>
+                {/if}
+                <Switch
+                  class="curved-links-toggle"
+                  label="Curved links"
+                  checked={curvedLinks}
+                  onchange={toggleCurvedLinks}
+                />
+              </section>
+            </div>
+          {/snippet}
+        </Popover>
       </div>
-      <!-- codeflow-parity Lot 4: Color-by (Folder · Layer). Re-keys the node
-           colour LIVE (no layout recompute, no morph). Same attached DS
-           ButtonGroup pattern as the layout switcher. -->
-      <ButtonGroup attached size="sm" label="Colour by" class="color-switcher">
-        {#each COLOR_MODES as mode (mode.id)}
-          <Button
-            size="sm"
-            variant={colorMode === mode.id ? "primary" : "secondary"}
-            aria-pressed={colorMode === mode.id}
-            aria-label={`Colour by ${mode.label}`}
-            onclick={() => selectColorMode(mode.id)}
-          >{mode.label}</Button>
-        {/each}
-      </ButtonGroup>
-      {#if colorMode === COLOR_BY_CHURN}
-        <div class="churn-legend" aria-label="Churn colour legend">
-          <span>Low</span><span class="churn-ramp"></span><span>High</span>
-        </div>
-      {/if}
-      <!-- codeflow-parity Lot 4: Curved-links toggle (DS Switch). ON ⇒ 0.15
-           (current behaviour), OFF ⇒ straight. Flips edge curvature LIVE. -->
-      <Switch
-        class="curved-links-toggle"
-        label="Curved links"
-        checked={curvedLinks}
-        onchange={toggleCurvedLinks}
-      />
     {/if}
     <button
       class="toolbar-btn"
@@ -1714,27 +1936,99 @@
     pointer-events: auto;
   }
 
-  .force-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.25rem 0.5rem;
-    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--st-semantic-surface-default, #fff) 90%, transparent);
-    box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
+  /* Representation-polish remark 4: gear-icon trigger + settings popover
+     host. The popover itself (DS Popover) anchors LEFT of its trigger by
+     default (.st-popover--bottom { left: 0 }), which would overflow past the
+     canvas's right edge since the gear sits at the toolbar's far-right end —
+     flip it to anchor from the RIGHT so the panel grows leftward, staying
+     inside the canvas. */
+  .graph-settings-host {
+    position: relative;
   }
 
-  .force-controls label {
+  .graph-settings-host :global(.st-popover--bottom) {
+    left: auto;
+    right: 0;
+  }
+
+  /* Representation-polish remark 5: every control in the settings panel
+     (layout buttons, Color-by, slider labels) uses the SAME compact font as
+     the small "Reset" button (.toolbar-btn, 0.75rem) instead of the DS
+     sm-density default (0.875rem for Button), which reads noticeably bigger
+     side-by-side with Reset. Overriding the anatomy tokens here (rather than
+     fighting specificity) keeps every DS Button/ButtonGroup inside the panel
+     on the SAME compact scale, DS-consistent.
+  */
+  .graph-settings-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    --st-component-button-anatomy-density-sm-fontSize: 0.75rem;
+    --st-component-button-anatomy-density-sm-controlHeight: 1.75rem;
+    --st-component-button-anatomy-density-sm-paddingInline: 0.6rem;
+    --st-component-button-anatomy-density-sm-paddingInlineEnd: 0.6rem;
+  }
+
+  /* Switch hardcodes its label font-size (no anatomy token to override), so
+     match Reset's compact scale directly. */
+  .graph-settings-panel :global(.st-switch__label) {
+    font-size: 0.75rem;
+  }
+
+  .graph-settings-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .graph-settings-heading {
+    margin: 0;
+    color: var(--st-semantic-text-muted, #64748b);
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  /* codeflow-parity Lot 3 / remark 6: Spread + Links each get their own line
+     (stacked), separate from the Layout switcher above and the Reset button
+     below. `input` only updates the label; the expensive Barnes-Hut solve
+     runs on `change` (drag-end). */
+  .force-sliders-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .force-sliders-row label {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.4rem;
     font-size: 0.75rem;
     white-space: nowrap;
   }
 
-  .force-controls input[type="range"] {
-    width: 5.5rem;
+  /* Remark 6: greyed + non-interactive whenever the active layout isn't
+     Force — Spread/Links (and Reset, same re-solve) only drive the force
+     re-solve, so they're inert on any other layout. */
+  .force-sliders-row label.is-disabled {
+    color: var(--st-semantic-text-muted, #94a3b8);
+    opacity: 0.55;
+  }
+
+  .force-sliders-row input[type="range"] {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .force-sliders-row input[type="range"]:disabled {
+    cursor: not-allowed;
+  }
+
+  .force-reset-row {
+    display: flex;
+    justify-content: flex-end;
   }
 
   .churn-legend {
@@ -1757,8 +2051,9 @@
     background: linear-gradient(90deg, #e2e8f0, #ef4444);
   }
 
-  /* codeflow-parity Lot 4: keep the Curved-links DS Switch compact + legible in
-     the floating toolbar (matches the segmented controls' scale). */
+  /* codeflow-parity Lot 4: keep the Curved-links DS Switch compact + legible
+     inside the DISPLAY section of the settings panel (matches the segmented
+     controls' scale). */
   .canvas-toolbar :global(.curved-links-toggle) {
     gap: 0.4rem;
     padding: 0.2rem 0.5rem;

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1130,13 +1130,10 @@
 
     // World-space pick radii (constant in world units) so the on-screen hit zones scale
     // with camera zoom, matching the now zoom-scaled (world-space sized) node glyphs.
-    // Item 1.3: the node hit-test no longer wins unconditionally. We compute BOTH
-    // the nearest node and the nearest edge, then:
-    //   - if the cursor is within the node's TIGHT (drawn-radius + slop) zone, the
-    //     node clearly wins (you're on the glyph);
-    //   - otherwise pick whichever the cursor is proportionally closer to, comparing
-    //     each hit's distance NORMALIZED by its own pick threshold. This stops a
-    //     node from "magnetizing" the hover when the cursor is really over an edge.
+    // Item 1.3: compute BOTH hits. A node wins only inside its tight drawn-glyph
+    // zone; anywhere else, a valid near-line edge hit wins. Dense knowledge
+    // graphs nearly always have a node inside the broader node pick radius, so a
+    // proportional node-vs-edge comparison made edge hover effectively dead.
     const nodeMaxDistance = PICK_RADIUS * world.scale;
     const edgeMaxDistance = EDGE_PICK_RADIUS * world.scale;
     const nodeHit = findNearestNode(payload, world.x, world.y, nodeMaxDistance);
@@ -1158,10 +1155,8 @@
     const tightNodeRadius = (nodeHit?.radius ?? 0) + NODE_TIGHT_SLOP * world.scale;
     const onNodeGlyph = nodeHit !== null && nodeHit.distance <= tightNodeRadius;
 
-    // Normalized distances (0 = dead centre of the pick zone, 1 = its edge).
-    const nodeNorm = nodeHit ? nodeHit.distance / Math.max(nodeMaxDistance, nodeHit.radius) : Infinity;
-    const edgeNorm = edgeHit ? edgeHit.distance / edgeMaxDistance : Infinity;
-    const preferNode = nodeHit !== null && (onNodeGlyph || edgeHit === null || nodeNorm <= edgeNorm);
+    const preferEdge = edgeHit !== null && !onNodeGlyph;
+    const preferNode = nodeHit !== null && !preferEdge;
 
     if (preferNode) {
       clearHoveredEdge({ render: false });
@@ -1194,11 +1189,10 @@
       hoveredNode = null;
     }
 
-    // Rest-of-graph connected-dim. Gated by hover-intent: immediate when a
-    // selection/focus already exists (unchanged behavior) OR when the hover is
-    // clearing (restore base now); otherwise DEFERRED behind a ~200ms dwell so a
-    // pre-first-selection sweep across the graph no longer strobes dim/undim.
-    requestConnectedDim(Boolean(nodeId));
+    // Rest-of-graph connected-dim. Before selection/focus, EVERY target change
+    // (node, another node, or empty space) dwells for ~200ms. Keeping the current
+    // style across momentary gaps prevents dim → undim → dim flashes.
+    requestConnectedDim();
 
     // The hovered node's OWN feedback (tooltip + label) stays immediate — only
     // the rest-of-graph dim is delayed.
@@ -1218,16 +1212,17 @@
     if (renderer && style) {
       payload = { ...payload, style };
       renderer.setStyle(style);
-      renderNow();
+      // A node→edge transition schedules this style change. Preserve the edge's
+      // immediate highlight when the delayed base/connected style settles.
+      if (hoveredEdge) renderHoverStyle(hoveredEdge);
+      else renderNow();
     }
   }
 
-  // Gate the rest-of-graph dim through the hover-intent dwell. Immediate when a
-  // selection/focus already exists OR when the hover is clearing (no target →
-  // restore base now); otherwise deferred until the pointer dwells.
-  function requestConnectedDim(hasHoverTarget) {
-    const immediate =
-      !shouldDelayConnectedDim({ selectedIds, focusId }) || !hasHoverTarget;
+  // Gate every pre-selection transparency change through the hover-intent dwell.
+  // Selection/focus retains the established immediate path.
+  function requestConnectedDim() {
+    const immediate = !shouldDelayConnectedDim({ selectedIds, focusId });
     hoverIntent.request({ immediate });
   }
 
@@ -1699,6 +1694,13 @@
 
 <div class="canvas" bind:this={container}>
   <div class="canvas-toolbar" aria-label="Graph controls">
+    <Button
+      class="reset-view-button"
+      size="sm"
+      variant="secondary"
+      aria-label="Reset view"
+      onclick={fitAndRender}
+    >Reset</Button>
     {#if showLayoutSwitcher}
       <!-- Representation-polish remark 4: the whole layout/spacing/display
            toolbar collapses behind a gear icon into a settings popover
@@ -1815,12 +1817,6 @@
         </Popover>
       </div>
     {/if}
-    <button
-      class="toolbar-btn"
-      type="button"
-      aria-label="Reset view"
-      onclick={fitAndRender}
-    >Reset</button>
   </div>
 
   <!-- Keyed on the active backend: a <canvas> is permanently bound to its first
@@ -1934,6 +1930,19 @@
     gap: 0.35rem 0.5rem;
     max-width: calc(100% - 1rem);
     pointer-events: auto;
+    /* Button sm uses controlHeight; IconButton sm uses smSize. Pin both DS
+       anatomy tokens to one value so Reset and the square gear are exact peers. */
+    --graph-toolbar-control-height: 2rem;
+    --st-component-button-anatomy-density-sm-controlHeight: var(--graph-toolbar-control-height);
+    --st-component-iconButton-smSize: var(--graph-toolbar-control-height);
+    --st-component-button-anatomy-density-sm-fontSize: 0.75rem;
+  }
+
+  .canvas-toolbar :global(.reset-view-button),
+  .canvas-toolbar :global(.st-iconButton--sm) {
+    box-sizing: border-box;
+    height: var(--graph-toolbar-control-height);
+    min-height: var(--graph-toolbar-control-height);
   }
 
   /* Representation-polish remark 4: gear-icon trigger + settings popover
@@ -1953,7 +1962,7 @@
 
   /* Representation-polish remark 5: every control in the settings panel
      (layout buttons, Color-by, slider labels) uses the SAME compact font as
-     the small "Reset" button (.toolbar-btn, 0.75rem) instead of the DS
+     the small "Reset" button (0.75rem) instead of the DS
      sm-density default (0.875rem for Button), which reads noticeably bigger
      side-by-side with Reset. Overriding the anatomy tokens here (rather than
      fighting specificity) keeps every DS Button/ButtonGroup inside the panel
@@ -2063,22 +2072,6 @@
     box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
     font-size: 0.75rem;
     white-space: nowrap;
-  }
-
-  .toolbar-btn {
-    padding: 0.3rem 0.6rem;
-    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--st-semantic-surface-default, #fff) 90%, transparent);
-    color: var(--st-semantic-text-default, #1e293b);
-    font-size: 0.75rem;
-    line-height: 1;
-    cursor: pointer;
-    box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
-  }
-
-  .toolbar-btn:hover {
-    background: var(--st-semantic-surface-hover, #f1f5f9);
   }
 
   .canvas-element {

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -2,7 +2,7 @@
   import { onDestroy, onMount, tick } from "svelte";
   import { Button, ButtonGroup, Switch } from "@sentropic/design-system-svelte";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
-  import { computeLayout } from "@graphify/graph-layout";
+  import { solveForce, terminateForceWorker } from "../lib/forceLayoutClient.js";
 
   import {
     buildConnectedDimStyle,
@@ -182,6 +182,10 @@
   // deterministic cold solve for the selected parameter values.
   let forceSpread = $state(FORCE_SPREAD_DEFAULT);
   let forceLinks = $state(FORCE_LINKS_DEFAULT);
+  // Lot 7: monotonic token so a worker solve that resolves AFTER a scene-content
+  // change (or a newer slider commit) is discarded instead of morphing a stale
+  // buffer sized for the previous node set.
+  let forceSolveToken = 0;
 
   // --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder/Layer) ---
   // Both are per-render style attributes (edge curvature / node colour keying),
@@ -1198,6 +1202,9 @@
     liveMorphBuffer = null;
     activeLayoutBuffer = null;
     layoutMode = LAYOUT_MODE_FORCE;
+    // Lot 7: invalidate any in-flight worker force solve — its buffer is sized
+    // for the OLD node set and must not be morphed after the scene changed.
+    forceSolveToken++;
     // §F1: a layout reset re-places all nodes, so stale Force-space drags must
     // not survive it (they would re-snap into the new coordinate space).
     draggedPositions.clear();
@@ -1221,11 +1228,13 @@
     return map;
   }
 
-  function computeForceRelayoutBuffer({ warmStart = true } = {}) {
+  async function computeForceRelayoutBuffer({ warmStart = true } = {}) {
     const graph = payload?.renderGraph;
     if (!graph || !scene?.nodes) return null;
     const initialPositions = warmStart ? currentPositionMap() : undefined;
-    const solved = computeLayout(
+    // Lot 7: off-main-thread solve when a Worker is available (falls back to a
+    // synchronous solve in SSR / tests). Debounced to drag-end by the caller.
+    const solved = await solveForce(
       scene.nodes.map((node) => ({ id: node.id })),
       scene.edges ?? [],
       {
@@ -1235,7 +1244,7 @@
         initialPositions,
       },
     );
-    if (solved.length !== graph.nodeIds.length) return null;
+    if (!Array.isArray(solved) || solved.length !== graph.nodeIds.length) return null;
     const byId = new Map(solved.map((node) => [node.id, node]));
     const buffer = new Float32Array(graph.nodeIds.length * 2);
     for (let i = 0; i < graph.nodeIds.length; i++) {
@@ -1247,10 +1256,14 @@
     return buffer;
   }
 
-  function resolveForceLayout({ warmStart = true } = {}) {
+  async function resolveForceLayout({ warmStart = true } = {}) {
     if (layoutMode !== LAYOUT_MODE_FORCE) layoutMode = LAYOUT_MODE_FORCE;
-    const target = computeForceRelayoutBuffer({ warmStart });
-    if (!target) return;
+    // Generation token: an async solve that resolves AFTER a scene-content change
+    // (which bumps forceSolveToken via resetLayoutState) is stale — discard it so
+    // we never morph a buffer sized for the previous node set (§2.6 index-safety).
+    const token = ++forceSolveToken;
+    const target = await computeForceRelayoutBuffer({ warmStart });
+    if (!target || token !== forceSolveToken || !mounted) return;
     forceBaseBuffer = new Float32Array(target);
     startLayoutMorphToBuffer(LAYOUT_MODE_FORCE, target);
   }
@@ -1475,6 +1488,8 @@
       renderer.destroy();
       renderer = null;
     }
+    // Lot 7: release the off-main-thread layout worker.
+    terminateForceWorker();
   });
 </script>
 

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1119,14 +1119,28 @@
     layoutMorphFrame = null;
   }
 
+  // §F3 (a11y): honor prefers-reduced-motion — skip the tween and place the new
+  // layout instantly, consistent with the pan/zoom reduced-motion handling.
+  function prefersReducedMotion() {
+    return (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  }
+
   // Reset all layout state to the Force default. Called on a genuine scene-
-  // content change so we NEVER tween across a scene rebuild (new node indices).
+  // content change so we NEVER tween across a scene rebuild (new node indices),
+  // and on an abnormal morph exit (§F2) so the canvas can never stay locked.
   function resetLayoutState() {
     cancelLayoutMorphFrame();
     morphActive = false;
     liveMorphBuffer = null;
     activeLayoutBuffer = null;
     layoutMode = LAYOUT_MODE_FORCE;
+    // §F1: a layout reset re-places all nodes, so stale Force-space drags must
+    // not survive it (they would re-snap into the new coordinate space).
+    draggedPositions.clear();
   }
 
   // Toolbar click: morph to `mode`. Ignores a click on the already-active mode
@@ -1170,12 +1184,18 @@
 
     cancelLayoutMorphFrame();
     layoutMode = mode;
+    // §F1: bufA already snapshotted the on-screen (incl. dragged) positions, so
+    // the drag is preserved as the morph START; drop the stale drag map now — a
+    // layout switch explicitly re-places every node, so a later selection
+    // rebuild must NOT re-apply old Force-space drag coords into the new space.
+    draggedPositions.clear();
 
     const canAnimate =
       typeof window !== "undefined" &&
       typeof window.requestAnimationFrame === "function";
-    // Bad / mismatched target, or no rAF (SSR/tests): settle instantly.
-    if (!bufB || bufB.length !== bufA.length || !canAnimate) {
+    // Bad / mismatched target, no rAF (SSR/tests), or reduced-motion (§F3):
+    // settle instantly (place the layout, no tween).
+    if (!bufB || bufB.length !== bufA.length || !canAnimate || prefersReducedMotion()) {
       settleLayout(mode, bufB && bufB.length === current.length ? bufB : null);
       return;
     }
@@ -1184,24 +1204,40 @@
     setLabelsHidden(true);
     liveMorphBuffer = new Float32Array(bufA.length);
     const startTime = window.performance?.now?.() ?? Date.now();
+    // §F2: never let a throwing frame leave the canvas locked (morphActive stuck
+    // true freezes every pointer/wheel handler). Any abnormal exit unwinds to a
+    // clean Force state and restores interaction + labels.
+    const abortMorph = () => {
+      cancelLayoutMorphFrame();
+      resetLayoutState();
+      fitAndRender();
+    };
     const step = (now) => {
-      const elapsed = Math.max(0, now - startTime);
-      const progress = Math.min(1, elapsed / LAYOUT_MORPH_DURATION_MS);
-      morphPositions(bufA, bufB, easeMergeProgress(progress), liveMorphBuffer);
-      renderer.setPositions(liveMorphBuffer);
-      renderNow();
-      if (progress < 1) {
-        layoutMorphFrame = window.requestAnimationFrame(step);
-      } else {
-        layoutMorphFrame = null;
-        settleLayout(mode, bufB);
+      try {
+        const elapsed = Math.max(0, now - startTime);
+        const progress = Math.min(1, elapsed / LAYOUT_MORPH_DURATION_MS);
+        morphPositions(bufA, bufB, easeMergeProgress(progress), liveMorphBuffer);
+        renderer.setPositions(liveMorphBuffer);
+        renderNow();
+        if (progress < 1) {
+          layoutMorphFrame = window.requestAnimationFrame(step);
+        } else {
+          layoutMorphFrame = null;
+          settleLayout(mode, bufB);
+        }
+      } catch {
+        abortMorph();
       }
     };
     // Prime frame 0 so there is no flash, then drive the tween.
-    morphPositions(bufA, bufB, 0, liveMorphBuffer);
-    renderer.setPositions(liveMorphBuffer);
-    renderNow();
-    layoutMorphFrame = window.requestAnimationFrame(step);
+    try {
+      morphPositions(bufA, bufB, 0, liveMorphBuffer);
+      renderer.setPositions(liveMorphBuffer);
+      renderNow();
+      layoutMorphFrame = window.requestAnimationFrame(step);
+    } catch {
+      abortMorph();
+    }
   }
 
   // Stable content signature of a scene: node ids + positions + edge endpoints +

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -163,9 +163,10 @@
   // interrupt (switching mid-morph) and is re-applied after a selection/hover
   // rebuild so the effect can't clobber the tween (cf. reapplyDraggedPositions).
   let liveMorphBuffer = null;
-  // The SETTLED target buffer of the active non-force layout (null while Force,
-  // which uses the native scene positions). Re-applied after every payload
-  // rebuild so a Layers layout survives a selection/hover-driven rebuild.
+  // The SETTLED target buffer of the last committed layout (null before any
+  // switch/re-solve, when the native scene positions apply). Re-applied after
+  // every payload rebuild so a Layers layout — OR a Lot-3 Force re-solve
+  // (Spread/Links/Reset) — survives a selection/hover-driven rebuild.
   let activeLayoutBuffer = null;
   // The CACHED pristine force positions captured at scene-build time — the
   // morph TARGET for switch-to-Force (Lot 1 never cold re-solves force).
@@ -605,9 +606,9 @@
   // codeflow-parity Lot 1: re-write the active layout's positions onto a freshly
   // built payload so the selection `$effect` (rebuildPayload → applyPayloadNoFit
   // → setPositions) cannot clobber the layout / the interpolated morph buffer
-  // (§2.6). Mid-morph the LIVE buffer wins; otherwise the settled non-force
-  // layout buffer. Force (activeLayoutBuffer === null, not morphing) is a no-op,
-  // so the default path stays byte-identical to before this lot.
+  // (§2.6). Mid-morph the LIVE buffer wins; otherwise the settled layout buffer.
+  // Before any layout switch/re-solve activeLayoutBuffer is null (not morphing),
+  // so the fresh-scene default path is a no-op and stays byte-identical.
   function reapplyLayoutPositions() {
     const source = morphActive ? liveMorphBuffer : activeLayoutBuffer;
     if (!source || !payload?.renderGraph) return;
@@ -1234,16 +1235,25 @@
     const initialPositions = warmStart ? currentPositionMap() : undefined;
     // Lot 7: off-main-thread solve when a Worker is available (falls back to a
     // synchronous solve in SSR / tests). Debounced to drag-end by the caller.
-    const solved = await solveForce(
-      scene.nodes.map((node) => ({ id: node.id })),
-      scene.edges ?? [],
-      {
-        repulsion: forceSpread,
-        linkDistance: forceLinks,
-        iterations: FORCE_SLIDER_ITERATIONS,
-        initialPositions,
-      },
-    );
+    // A worker error (postMessage/onerror rejection) must NOT surface as an
+    // unhandled rejection in the fire-and-forget caller — swallow it and return
+    // null so resolveForceLayout returns without morphing. The NEXT commit falls
+    // back to the synchronous solve once the worker is flagged broken.
+    let solved;
+    try {
+      solved = await solveForce(
+        scene.nodes.map((node) => ({ id: node.id })),
+        scene.edges ?? [],
+        {
+          repulsion: forceSpread,
+          linkDistance: forceLinks,
+          iterations: FORCE_SLIDER_ITERATIONS,
+          initialPositions,
+        },
+      );
+    } catch {
+      return null;
+    }
     if (!Array.isArray(solved) || solved.length !== graph.nodeIds.length) return null;
     const byId = new Map(solved.map((node) => [node.id, node]));
     const buffer = new Float32Array(graph.nodeIds.length * 2);
@@ -1263,7 +1273,14 @@
     // we never morph a buffer sized for the previous node set (§2.6 index-safety).
     const token = ++forceSolveToken;
     const target = await computeForceRelayoutBuffer({ warmStart });
-    if (!target || token !== forceSolveToken || !mounted) return;
+    // Discard the solve when: it was superseded (token bump), the component
+    // unmounted, the solve failed, OR the user switched AWAY from Force while it
+    // was in flight. resolveForceLayout sets layoutMode = Force synchronously at
+    // entry, so a mid-solve selectLayoutMode → startLayoutMorph (Layers/Grid/
+    // Radial/Metro) flips layoutMode and this late Force solve must not hijack
+    // the user's chosen layout back to Force (§2.6).
+    if (!target || token !== forceSolveToken || !mounted || layoutMode !== LAYOUT_MODE_FORCE)
+      return;
     forceBaseBuffer = new Float32Array(target);
     startLayoutMorphToBuffer(LAYOUT_MODE_FORCE, target);
   }
@@ -1294,8 +1311,14 @@
   // the new positions), remember it for re-application across rebuilds, and do
   // the single deliberate end-fit.
   function settleLayout(mode, buffer) {
-    activeLayoutBuffer =
-      mode === LAYOUT_MODE_FORCE || !buffer ? null : new Float32Array(buffer);
+    // Persist the settled buffer for EVERY mode, Force included. A Lot-3 force
+    // re-solve (Spread/Links slider or Reset) settles under LAYOUT_MODE_FORCE;
+    // nulling activeLayoutBuffer here would drop that re-solved layout so the
+    // next selection/hover/display rebuild (reapplyLayoutPositions) would snap
+    // the graph back to the scene's baked force positions (§2.6). A plain
+    // switch-to-Force settles the pristine forceBaseBuffer (== scene positions),
+    // so re-applying it across a rebuild is a harmless no-op.
+    activeLayoutBuffer = buffer ? new Float32Array(buffer) : null;
     const positions = payload?.renderGraph?.positions;
     if (positions && buffer && buffer.length === positions.length) {
       positions.set(buffer);

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1,11 +1,13 @@
 <script>
   import { onDestroy, onMount, tick } from "svelte";
-  import { Button, ButtonGroup } from "@sentropic/design-system-svelte";
+  import { Button, ButtonGroup, Switch } from "@sentropic/design-system-svelte";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
 
   import {
     buildConnectedDimStyle,
     buildGraphRendererPayload,
+    COLOR_BY_FOLDER,
+    COLOR_BY_LAYER,
     computeLayoutBuffer,
     findNearestEdge,
     findNearestNode,
@@ -166,6 +168,21 @@
   // True while a layout morph is in flight: hides labels + locks canvas
   // interaction for the (~480 ms) tween, exactly as pan/zoom already do.
   let morphActive = $state(false);
+
+  // --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder/Layer) ---
+  // Both are per-render style attributes (edge curvature / node colour keying),
+  // so a change re-styles LIVE — rebuild payload + re-render, NO layout recompute
+  // and NO morph (applyPayloadNoFit preserves camera + the active layout buffer).
+  // Defaults MATCH the current studio behaviour (curved ON, colour by Folder), so
+  // an untouched control is byte-identical to before this lot.
+  let curvedLinks = $state(true);
+  let colorMode = $state(COLOR_BY_FOLDER);
+  // The Color-by options exposed by the segmented control.
+  const COLOR_MODES = [
+    { id: COLOR_BY_FOLDER, label: "Folder" },
+    { id: COLOR_BY_LAYER, label: "Layer" },
+  ];
+
   let hoveredEdge = $state(null);
   let hoveredNode = $state(null);
   let hoveredNodeId = $state(null);
@@ -548,6 +565,10 @@
       // zoom-out). Sync the bucket so a wheel that crosses the threshold knows
       // to rebuild (see handleWheel's settle callback).
       zoom: camera.zoom,
+      // codeflow-parity Lot 4: Color-by keying + Curved-links scalar. Defaults
+      // (Folder / curved) keep the output byte-identical to before this lot.
+      colorBy: colorMode,
+      curvedLinks,
       ...(Number.isFinite(labelMaxChars) ? { labelMaxChars } : {}),
     });
     lastLabelZoomBucket = labelZoomBucket(camera.zoom);
@@ -618,6 +639,30 @@
     ensureRenderer();
     resizeCanvas();
     applyPayloadNoFit();
+  }
+
+  // codeflow-parity Lot 4: Curved-links / Color-by change → LIVE re-style. Both
+  // are per-render style attributes (edge curvature / node colour keying), so we
+  // rebuild the payload with the new options and re-render WITHOUT re-fitting the
+  // camera or recomputing a layout — no morph, the active layout buffer survives
+  // (rebuildPayload → reapplyLayoutPositions). Same shape as updateSelection.
+  function updateDisplayStyle() {
+    if (!mounted) return;
+
+    rebuildPayload();
+    ensureRenderer();
+    resizeCanvas();
+    applyPayloadNoFit();
+  }
+
+  // Toolbar handlers: flip the display state; the reactive $effect re-styles.
+  function toggleCurvedLinks() {
+    curvedLinks = !curvedLinks;
+  }
+
+  function selectColorMode(mode) {
+    if (mode === colorMode) return;
+    colorMode = mode;
   }
 
   // ResizeObserver / window-resize path. Two guarantees (UAT):
@@ -1289,6 +1334,16 @@
   });
 
   $effect(() => {
+    // codeflow-parity Lot 4: Curved-links / Color-by change → live re-style,
+    // preserving the current camera + layout (no re-fit, no morph). Reading both
+    // deps registers the effect; the guard in updateDisplayStyle no-ops at mount
+    // (updateGraph already did the first render with the defaults).
+    curvedLinks;
+    colorMode;
+    updateDisplayStyle();
+  });
+
+  $effect(() => {
     const key = mergeKey(mergePair);
     if (!key) {
       completedMergeKey = null;
@@ -1358,6 +1413,28 @@
           >{mode.label}</Button>
         {/each}
       </ButtonGroup>
+      <!-- codeflow-parity Lot 4: Color-by (Folder · Layer). Re-keys the node
+           colour LIVE (no layout recompute, no morph). Same attached DS
+           ButtonGroup pattern as the layout switcher. -->
+      <ButtonGroup attached size="sm" label="Colour by" class="color-switcher">
+        {#each COLOR_MODES as mode (mode.id)}
+          <Button
+            size="sm"
+            variant={colorMode === mode.id ? "primary" : "secondary"}
+            aria-pressed={colorMode === mode.id}
+            aria-label={`Colour by ${mode.label}`}
+            onclick={() => selectColorMode(mode.id)}
+          >{mode.label}</Button>
+        {/each}
+      </ButtonGroup>
+      <!-- codeflow-parity Lot 4: Curved-links toggle (DS Switch). ON ⇒ 0.15
+           (current behaviour), OFF ⇒ straight. Flips edge curvature LIVE. -->
+      <Switch
+        class="curved-links-toggle"
+        label="Curved links"
+        checked={curvedLinks}
+        onchange={toggleCurvedLinks}
+      />
     {/if}
     <button
       class="toolbar-btn"
@@ -1472,9 +1549,25 @@
     right: 0.5rem;
     z-index: 3;
     display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.35rem 0.5rem;
+    max-width: calc(100% - 1rem);
     pointer-events: auto;
+  }
+
+  /* codeflow-parity Lot 4: keep the Curved-links DS Switch compact + legible in
+     the floating toolbar (matches the segmented controls' scale). */
+  .canvas-toolbar :global(.curved-links-toggle) {
+    gap: 0.4rem;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--st-semantic-surface-default, #fff) 90%, transparent);
+    box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
+    font-size: 0.75rem;
+    white-space: nowrap;
   }
 
   .toolbar-btn {

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount, tick } from "svelte";
   import { Button, ButtonGroup, Switch } from "@sentropic/design-system-svelte";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
+  import { computeLayout } from "@graphify/graph-layout";
 
   import {
     buildConnectedDimStyle,
@@ -54,6 +55,9 @@
   // (Force ↔ Layers). Kept in the ~300–500 ms band the spec calls for, so
   // labels + interaction are only locked briefly (§2.6).
   const LAYOUT_MORPH_DURATION_MS = 480;
+  const FORCE_SPREAD_DEFAULT = 1;
+  const FORCE_LINKS_DEFAULT = 0.6;
+  const FORCE_SLIDER_ITERATIONS = 180;
   // CANVAS2D ONLY: hide edges during active pan/zoom/drag when nodes+edges exceed
   // this, for interaction fluidity (a legacy SVG-era guard). WebGL2 NEVER skips
   // (GPU-instanced edges are cheap) — see `skipEdgesOnInteract`.
@@ -168,6 +172,15 @@
   // True while a layout morph is in flight: hides labels + locks canvas
   // interaction for the (~480 ms) tween, exactly as pan/zoom already do.
   let morphActive = $state(false);
+
+  // --- codeflow-parity Lot 3: Spread / Links force re-solve controls ---------
+  // Spread maps to computeLayout(repulsion), Links maps to computeLayout's new
+  // linkDistance rest-length factor. Slider changes are committed on drag-end
+  // (change event), not per input frame, because a Barnes-Hut solve is too heavy
+  // for 60Hz. Interactive solves warm-start from the current buffer; Reset is the
+  // deterministic cold solve for the selected parameter values.
+  let forceSpread = $state(FORCE_SPREAD_DEFAULT);
+  let forceLinks = $state(FORCE_LINKS_DEFAULT);
 
   // --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder/Layer) ---
   // Both are per-render style attributes (edge curvature / node colour keying),
@@ -1188,6 +1201,72 @@
     draggedPositions.clear();
   }
 
+  function currentLayoutBuffer() {
+    if (!payload?.renderGraph?.positions) return null;
+    return layoutMorphFrame !== null && liveMorphBuffer
+      ? new Float32Array(liveMorphBuffer)
+      : new Float32Array(payload.renderGraph.positions);
+  }
+
+  function currentPositionMap() {
+    const graph = payload?.renderGraph;
+    const positions = currentLayoutBuffer();
+    if (!graph || !positions) return null;
+    const map = new Map();
+    for (let i = 0; i < graph.nodeIds.length; i++) {
+      map.set(graph.nodeIds[i], { x: positions[i * 2] ?? 0, y: positions[i * 2 + 1] ?? 0 });
+    }
+    return map;
+  }
+
+  function computeForceRelayoutBuffer({ warmStart = true } = {}) {
+    const graph = payload?.renderGraph;
+    if (!graph || !scene?.nodes) return null;
+    const initialPositions = warmStart ? currentPositionMap() : undefined;
+    const solved = computeLayout(
+      scene.nodes.map((node) => ({ id: node.id })),
+      scene.edges ?? [],
+      {
+        repulsion: forceSpread,
+        linkDistance: forceLinks,
+        iterations: FORCE_SLIDER_ITERATIONS,
+        initialPositions,
+      },
+    );
+    if (solved.length !== graph.nodeIds.length) return null;
+    const byId = new Map(solved.map((node) => [node.id, node]));
+    const buffer = new Float32Array(graph.nodeIds.length * 2);
+    for (let i = 0; i < graph.nodeIds.length; i++) {
+      const p = byId.get(graph.nodeIds[i]);
+      if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) return null;
+      buffer[i * 2] = p.x;
+      buffer[i * 2 + 1] = p.y;
+    }
+    return buffer;
+  }
+
+  function resolveForceLayout({ warmStart = true } = {}) {
+    if (layoutMode !== LAYOUT_MODE_FORCE) layoutMode = LAYOUT_MODE_FORCE;
+    const target = computeForceRelayoutBuffer({ warmStart });
+    if (!target) return;
+    forceBaseBuffer = new Float32Array(target);
+    startLayoutMorphToBuffer(LAYOUT_MODE_FORCE, target);
+  }
+
+  function resetForceLayout() {
+    resolveForceLayout({ warmStart: false });
+  }
+
+  function commitForceSpread(event) {
+    forceSpread = Number(event?.currentTarget?.value ?? forceSpread);
+    resolveForceLayout({ warmStart: true });
+  }
+
+  function commitForceLinks(event) {
+    forceLinks = Number(event?.currentTarget?.value ?? forceLinks);
+    resolveForceLayout({ warmStart: true });
+  }
+
   // Toolbar click: morph to `mode`. Ignores a click on the already-active mode
   // (during a morph `layoutMode` is already the target, so re-clicking it is a
   // no-op while clicking the OTHER mode interrupts and re-targets).
@@ -1214,6 +1293,11 @@
   }
 
   function startLayoutMorph(mode) {
+    const bufB = computeLayoutBuffer(payload, mode, { forceBuffer: forceBaseBuffer });
+    startLayoutMorphToBuffer(mode, bufB);
+  }
+
+  function startLayoutMorphToBuffer(mode, bufB) {
     if (!renderer || !payload?.renderGraph) {
       layoutMode = mode;
       return;
@@ -1221,11 +1305,7 @@
     const current = payload.renderGraph.positions;
     // Interrupt: re-seed bufA from the LIVE interpolated buffer, never snap back
     // to base (§2.6). Otherwise capture the current on-screen buffer.
-    const bufA =
-      layoutMorphFrame !== null && liveMorphBuffer
-        ? new Float32Array(liveMorphBuffer)
-        : new Float32Array(current);
-    const bufB = computeLayoutBuffer(payload, mode, { forceBuffer: forceBaseBuffer });
+    const bufA = currentLayoutBuffer() ?? new Float32Array(current);
 
     cancelLayoutMorphFrame();
     layoutMode = mode;
@@ -1413,6 +1493,38 @@
           >{mode.label}</Button>
         {/each}
       </ButtonGroup>
+      <!-- codeflow-parity Lot 3: force spacing controls. `input` only updates
+           the label; the expensive Barnes-Hut solve runs on `change` (drag-end).
+           Interactive solves warm-start; Reset is the deterministic cold solve. -->
+      <div class="force-controls" aria-label="Force spacing controls">
+        <label>
+          <span>Spread {forceSpread.toFixed(1)}</span>
+          <input
+            type="range"
+            min="0.2"
+            max="3"
+            step="0.1"
+            value={forceSpread}
+            aria-label="Spread"
+            oninput={(event) => (forceSpread = Number(event.currentTarget.value))}
+            onchange={commitForceSpread}
+          />
+        </label>
+        <label>
+          <span>Links {forceLinks.toFixed(1)}</span>
+          <input
+            type="range"
+            min="0.2"
+            max="2"
+            step="0.1"
+            value={forceLinks}
+            aria-label="Links"
+            oninput={(event) => (forceLinks = Number(event.currentTarget.value))}
+            onchange={commitForceLinks}
+          />
+        </label>
+        <Button size="sm" variant="secondary" aria-label="Reset layout" onclick={resetForceLayout}>Reset</Button>
+      </div>
       <!-- codeflow-parity Lot 4: Color-by (Folder · Layer). Re-keys the node
            colour LIVE (no layout recompute, no morph). Same attached DS
            ButtonGroup pattern as the layout switcher. -->
@@ -1555,6 +1667,29 @@
     gap: 0.35rem 0.5rem;
     max-width: calc(100% - 1rem);
     pointer-events: auto;
+  }
+
+  .force-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--st-semantic-border-muted, #e2e8f0);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--st-semantic-surface-default, #fff) 90%, transparent);
+    box-shadow: 0 1px 4px rgb(15 23 42 / 0.08);
+  }
+
+  .force-controls label {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .force-controls input[type="range"] {
+    width: 5.5rem;
   }
 
   /* codeflow-parity Lot 4: keep the Curved-links DS Switch compact + legible in

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -198,11 +198,11 @@
   let colorMode = $state(COLOR_BY_FOLDER);
   // The Color-by options exposed by the segmented control.
   const COLOR_MODES = [
-    // graphify terms (not codeflow's code-graph vocabulary): community/container
-    // → Communauté, typed layer / node_type → Ontologie, degree heat → Degré.
-    { id: COLOR_BY_FOLDER, label: "Communauté" },
-    { id: COLOR_BY_LAYER, label: "Ontologie" },
-    { id: COLOR_BY_CHURN, label: "Degré" },
+    // graphify terms (not codeflow's code-graph vocabulary): community/container,
+    // typed layer / node_type = ontology, degree heat. English UI — i18n later.
+    { id: COLOR_BY_FOLDER, label: "Community" },
+    { id: COLOR_BY_LAYER, label: "Ontology" },
+    { id: COLOR_BY_CHURN, label: "Degree" },
   ];
 
   // Representation-polish remark 4: the whole layout/spacing/display toolbar
@@ -1810,8 +1810,8 @@
                   {/each}
                 </ButtonGroup>
                 {#if colorMode === COLOR_BY_CHURN}
-                  <div class="churn-legend" aria-label="Degré colour legend">
-                    <span>Faible</span><span class="churn-ramp"></span><span>Élevé</span>
+                  <div class="churn-legend" aria-label="Degree colour legend">
+                    <span>Low</span><span class="churn-ramp"></span><span>High</span>
                   </div>
                 {/if}
                 <Switch

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -19,6 +19,7 @@
     findNearestEdge,
     findNearestNode,
     findNearestNodeId,
+    interpolateGroupFadeStyle,
     interpolateMergeStyle,
     interpolateMergePositions,
     isBoxShape,
@@ -96,6 +97,11 @@
 
   let {
     scene = EMPTY_SCENE,
+    // Optional collapse/expand ANIMATION descriptor, produced by App when the
+    // grouped-key set changes: { direction: 'collapse'|'expand',
+    // anchorByNodeId: Map<foldedId, groupNodeId> }. Absent/null ⇒ the current
+    // hard-cut refit (safety fallback). See the scene-change $effect below.
+    groupTransition = null,
     selectedIds = [],
     centerOnIds = [],
     focusId = null,
@@ -164,6 +170,10 @@
   let layoutMode = $state(LAYOUT_MODE_FORCE);
   // rAF handle for the in-flight layout morph (distinct from the merge loop).
   let layoutMorphFrame = null;
+  // rAF handle for the in-flight collapse/expand GROUP transition (distinct from
+  // both the merge loop and the layout morph — a group action can arrive while a
+  // layout morph settles, so it owns its own handle to cancel independently).
+  let groupTweenFrame = null;
   // The LIVE interpolated buffer of the in-flight morph — re-seeds `bufA` on an
   // interrupt (switching mid-morph) and is re-applied after a selection/hover
   // rebuild so the effect can't clobber the tween (cf. reapplyDraggedPositions).
@@ -1377,6 +1387,9 @@
   // and on an abnormal morph exit (§F2) so the canvas can never stay locked.
   function resetLayoutState() {
     cancelLayoutMorphFrame();
+    // A scene reset / abnormal exit also cancels any in-flight collapse/expand
+    // group tween — its bufA/bufB are indexed for the pre-swap node set.
+    cancelGroupTweenFrame();
     // Remark 7: a scene reset / abnormal morph exit also cancels any in-flight
     // camera-recenter tween — its target bbox is for the OLD scene/layout.
     cancelCameraTween();
@@ -1606,6 +1619,230 @@
     }
   }
 
+  // --- Collapse/expand GROUP transition driver -------------------------------
+  // Animate a grouping (collapse) / ungrouping (expand) instead of hard-cutting
+  // to the new scene. REUSES the layout-morph machinery: a per-index position
+  // lerp (morphPositions) into a reused liveMorphBuffer + the merge-fade style
+  // (interpolateGroupFadeStyle) on the SAME rAF loop, locking interaction via
+  // morphActive exactly as the layout morph does. The App passes the direction +
+  // the folded-child → group-node anchor map; the group node's on-screen anchor
+  // is its own position when present, else the centroid of its folding members
+  // (the group node usually lives in the OTHER scene across the fold boundary).
+
+  function cancelGroupTweenFrame() {
+    if (typeof window !== "undefined" && groupTweenFrame !== null) {
+      window.cancelAnimationFrame(groupTweenFrame);
+    }
+    groupTweenFrame = null;
+  }
+
+  // Resolve the folding/revealing children against the CURRENT payload: which
+  // node indices fade, grouped by anchor, and each group's on-screen anchor
+  // position. Returns null when NONE of the anchor children are in the payload
+  // (nothing to animate → the caller falls back to the hard cut).
+  function collectGroupFolds(anchors) {
+    const graph = payload?.renderGraph;
+    const idx = payload?.nodeIndexById;
+    const positions = graph?.positions;
+    if (!graph || !idx || !positions) return null;
+
+    const foldingSet = new Set();
+    const groupMembers = new Map(); // groupNodeId -> [nodeIndex]
+    for (const [childId, groupId] of anchors) {
+      const i = idx.get(childId);
+      if (!Number.isInteger(i)) continue;
+      foldingSet.add(i);
+      let members = groupMembers.get(groupId);
+      if (!members) {
+        members = [];
+        groupMembers.set(groupId, members);
+      }
+      members.push(i);
+    }
+    if (foldingSet.size === 0) return null;
+
+    const anchorPosByGroup = new Map();
+    for (const [groupId, members] of groupMembers) {
+      const gi = idx.get(groupId);
+      if (Number.isInteger(gi)) {
+        anchorPosByGroup.set(groupId, {
+          x: positions[gi * 2] ?? 0,
+          y: positions[gi * 2 + 1] ?? 0,
+        });
+      } else {
+        let sx = 0;
+        let sy = 0;
+        for (const i of members) {
+          sx += positions[i * 2] ?? 0;
+          sy += positions[i * 2 + 1] ?? 0;
+        }
+        anchorPosByGroup.set(groupId, { x: sx / members.length, y: sy / members.length });
+      }
+    }
+    return { foldingSet, groupMembers, anchorPosByGroup, positions };
+  }
+
+  // Try to play the animated collapse/expand for `transition`. Returns true when
+  // the driver TOOK OVER the scene swap (the caller must NOT also hard-cut), false
+  // to fall back to the current hard refit (safety: missing/ambiguous transition,
+  // no renderer, or no matching children on screen).
+  function tryStartGroupTransition(transition) {
+    if (!transition || !mounted || !renderer || !payload) return false;
+    const anchors = transition.anchorByNodeId;
+    if (!(anchors instanceof Map) || anchors.size === 0) return false;
+    if (transition.direction === "collapse") return startCollapseTween(anchors);
+    if (transition.direction === "expand") return startExpandTween(anchors);
+    return false;
+  }
+
+  // COLLAPSE: keep the OLD (pre-collapse) scene on screen and tween each folding
+  // node → its group anchor while fading + shrinking it; at t=1 swap to the new
+  // collapsed scene (updateGraph refits/settles).
+  function startCollapseTween(anchors) {
+    const info = collectGroupFolds(anchors);
+    if (!info) return false; // no folding child on screen → hard cut
+    const { foldingSet, groupMembers, anchorPosByGroup, positions } = info;
+    const bufA = new Float32Array(positions);
+    const bufB = new Float32Array(positions);
+    for (const [groupId, members] of groupMembers) {
+      const a = anchorPosByGroup.get(groupId);
+      for (const i of members) {
+        bufB[i * 2] = a.x;
+        bufB[i * 2 + 1] = a.y;
+      }
+    }
+    runGroupTween({
+      bufA,
+      bufB,
+      foldingSet,
+      fadeOut: true,
+      onDone: () => {
+        // Swap to the collapsed scene + settle. The folding nodes already faded
+        // to alpha 0 at their anchor, so the group node appears in their place.
+        resetLayoutState();
+        updateGraph();
+      },
+    });
+    return true;
+  }
+
+  // EXPAND: swap to the new (expanded) scene FIRST, then start each newly-revealed
+  // node AT its group anchor (faint + small) and tween it OUT to its real layout
+  // position while fading + growing in.
+  function startExpandTween(anchors) {
+    resetLayoutState();
+    updateGraph(); // payload now = expanded scene, fitted
+    const info = collectGroupFolds(anchors);
+    // The swap already stands as the result; if no revealed child matched, there
+    // is simply nothing to animate (still handled — do NOT hard-cut again).
+    if (!info) return true;
+    const { foldingSet, groupMembers, anchorPosByGroup, positions } = info;
+    const bufB = new Float32Array(positions); // real, settled positions (target)
+    const bufA = new Float32Array(positions); // revealed children at their anchor
+    for (const [groupId, members] of groupMembers) {
+      const a = anchorPosByGroup.get(groupId);
+      for (const i of members) {
+        bufA[i * 2] = a.x;
+        bufA[i * 2 + 1] = a.y;
+      }
+    }
+    runGroupTween({
+      bufA,
+      bufB,
+      foldingSet,
+      fadeOut: false,
+      onDone: () => settleGroupTween(bufB),
+    });
+    return true;
+  }
+
+  // Restore the settled positions + base style at the end of an EXPAND tween.
+  function settleGroupTween(buffer) {
+    morphActive = false;
+    liveMorphBuffer = null;
+    const positions = payload?.renderGraph?.positions;
+    if (positions && buffer && buffer.length === positions.length) positions.set(buffer);
+    if (renderer && payload) {
+      renderer.setPositions(payload.renderGraph.positions);
+      renderer.setStyle(payload.style);
+    }
+    setLabelsHidden(false);
+    renderNow();
+  }
+
+  // The shared collapse/expand rAF loop (mirrors startLayoutMorphToBuffer): lerp
+  // bufA→bufB per index while fading (fadeOut) / revealing (!fadeOut) the folding
+  // node set + its edges, then hand off to `onDone` at t=1.
+  function runGroupTween({ bufA, bufB, foldingSet, fadeOut, onDone }) {
+    cancelGroupTweenFrame();
+    cancelLayoutMorphFrame();
+    cancelCameraTween();
+    clearHoveredEdge({ notify: false, render: false });
+    setHoveredNode(null);
+
+    const canAnimate =
+      typeof window !== "undefined" && typeof window.requestAnimationFrame === "function";
+    // No rAF (SSR/tests) or reduced-motion (§F3): skip the tween, let the caller
+    // settle straight to the end state (a hard cut).
+    if (
+      !renderer ||
+      !bufA ||
+      !bufB ||
+      bufA.length !== bufB.length ||
+      !canAnimate ||
+      prefersReducedMotion()
+    ) {
+      onDone?.();
+      return;
+    }
+
+    morphActive = true;
+    setLabelsHidden(true);
+    liveMorphBuffer = new Float32Array(bufA.length);
+    const startTime = window.performance?.now?.() ?? Date.now();
+    // §F2: an abnormal frame must never leave the canvas locked (morphActive stuck
+    // true freezes every pointer/wheel handler) — unwind to a clean, fitted state.
+    const abort = () => {
+      cancelGroupTweenFrame();
+      resetLayoutState();
+      applyConnectedDim();
+      fitAndRender();
+    };
+    const renderFrame = (eased) => {
+      morphPositions(bufA, bufB, eased, liveMorphBuffer);
+      renderer.setPositions(liveMorphBuffer);
+      // Collapse fades OUT + shrinks toward the anchor; expand fades IN + grows
+      // from it. Size never fully vanishes so a node stays pickable-adjacent.
+      const alphaScale = fadeOut ? 1 - eased : eased;
+      const sizeScale = fadeOut ? 1 - 0.8 * eased : 0.2 + 0.8 * eased;
+      renderer.setStyle(interpolateGroupFadeStyle(payload, foldingSet, alphaScale, sizeScale));
+      renderNow();
+    };
+    const step = (now) => {
+      try {
+        const elapsed = Math.max(0, now - startTime);
+        const progress = Math.min(1, elapsed / LAYOUT_MORPH_DURATION_MS);
+        renderFrame(easeMergeProgress(progress));
+        if (progress < 1) {
+          groupTweenFrame = window.requestAnimationFrame(step);
+        } else {
+          groupTweenFrame = null;
+          onDone?.();
+        }
+      } catch {
+        abort();
+      }
+    };
+    // Prime frame 0 synchronously (no flash of the un-animated end state), then
+    // drive the tween on the same loop as the layout morph.
+    try {
+      renderFrame(0);
+      groupTweenFrame = window.requestAnimationFrame(step);
+    } catch {
+      abort();
+    }
+  }
+
   // Stable content signature of a scene: node ids + positions + edge endpoints +
   // counts. Two structurally-equivalent scenes share a signature even when they
   // are different object instances (a `$derived.by` recompute), so we don't refit
@@ -1634,8 +1871,24 @@
     lastScene = scene;
     if (key === lastSceneKey) return;
     lastSceneKey = key;
+    // Animated collapse/expand: when App signalled a group transition for THIS
+    // scene change, its driver OWNS the swap (collapse keeps the old scene and
+    // morphs into updateGraph at t=1; expand swaps first then morphs out). untrack
+    // so this effect depends ONLY on `scene` — a later groupTransition prop update
+    // must not re-fire a rebuild, and it must not become a hidden dependency.
+    const transition = untrack(() => groupTransition);
+    // A group tween owns the canvas: a REDUNDANT scene re-derivation (the same
+    // group action re-laying out positions, or the ontology artifact settling one
+    // tick after the fold) must NOT cancel the in-flight tween. Only a GENUINE new
+    // transition interrupts; otherwise let the tween settle (its onDone rebuilds
+    // from the latest scene). Without this, such a follow-up tick hard-cut and
+    // froze the animation on frame 0 (observed under CDP).
+    if (groupTweenFrame !== null && !transition) return;
     // Genuine new graph/candidate: drop stale dragged positions before refit.
     draggedPositions.clear();
+    // Falls through to the hard cut when the transition is absent/ambiguous or no
+    // folding node is on screen (the safety fallback — never breaks the collapse).
+    if (untrack(() => tryStartGroupTransition(transition))) return;
     // Never tween across a scene-content change (new node indices) — reset the
     // layout to Force and recapture the fresh force baseline in updateGraph.
     resetLayoutState();
@@ -1722,6 +1975,7 @@
       if (indicatorTimer !== null) window.clearTimeout(indicatorTimer);
       hoverIntent.cancel();
       cancelMergeFrame();
+      cancelGroupTweenFrame();
       cancelLayoutMorphFrame();
       cancelCameraTween();
       renderer?.destroy();

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onDestroy, onMount, tick } from "svelte";
+  import { onDestroy, onMount, tick, untrack } from "svelte";
   import { Button, ButtonGroup, IconButton, Popover, Switch } from "@sentropic/design-system-svelte";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
   import { solveForce, terminateForceWorker } from "../lib/forceLayoutClient.js";
@@ -198,9 +198,11 @@
   let colorMode = $state(COLOR_BY_FOLDER);
   // The Color-by options exposed by the segmented control.
   const COLOR_MODES = [
-    { id: COLOR_BY_FOLDER, label: "Folder" },
-    { id: COLOR_BY_LAYER, label: "Layer" },
-    { id: COLOR_BY_CHURN, label: "Churn" },
+    // graphify terms (not codeflow's code-graph vocabulary): community/container
+    // → Communauté, typed layer / node_type → Ontologie, degree heat → Degré.
+    { id: COLOR_BY_FOLDER, label: "Communauté" },
+    { id: COLOR_BY_LAYER, label: "Ontologie" },
+    { id: COLOR_BY_CHURN, label: "Degré" },
   ];
 
   // Representation-polish remark 4: the whole layout/spacing/display toolbar
@@ -1617,7 +1619,12 @@
     // A selection/focus appearing supersedes any pending pre-selection hover
     // dwell — updateSelection() rebuilds the (selection-dimmed) style itself.
     hoverIntent.cancel();
-    updateSelection();
+    // untrack: updateSelection → rebuildPayload READS hoveredNodeId (to style the
+    // hovered node). Without untrack, Svelte registers hoveredNodeId as a hidden
+    // dependency of THIS effect, so once a selection exists every hover re-fires
+    // it → rebuildPayload → clearHoveredEdge, killing edge hover one tick after
+    // it is set. Depend ONLY on the explicit selectedIds/focusId reads above.
+    untrack(() => updateSelection());
   });
 
   $effect(() => {
@@ -1627,7 +1634,10 @@
     // (updateGraph already did the first render with the defaults).
     curvedLinks;
     colorMode;
-    updateDisplayStyle();
+    // Same hidden-dependency guard as the selection effect: updateDisplayStyle →
+    // rebuildPayload reads hoveredNodeId, so untrack it to depend ONLY on the
+    // curvedLinks/colorMode reads above (else a hover re-fires this re-style).
+    untrack(() => updateDisplayStyle());
   });
 
   $effect(() => {
@@ -1800,8 +1810,8 @@
                   {/each}
                 </ButtonGroup>
                 {#if colorMode === COLOR_BY_CHURN}
-                  <div class="churn-legend" aria-label="Churn colour legend">
-                    <span>Low</span><span class="churn-ramp"></span><span>High</span>
+                  <div class="churn-legend" aria-label="Degré colour legend">
+                    <span>Faible</span><span class="churn-ramp"></span><span>Élevé</span>
                   </div>
                 {/if}
                 <Switch

--- a/studio/src/lib/classNodes.js
+++ b/studio/src/lib/classNodes.js
@@ -484,13 +484,21 @@ export function applyGroupCollapse(
 
   // Count hidden nodes per collapse target (its whole hidden subtree). A hidden
   // node is attributed to the nearest collapsed ancestor on its parent chain.
+  // The SAME walk yields, for the collapse/expand ANIMATION, each hidden (folded)
+  // node's group-node ANCHOR — the nearest collapsed ancestor it folds into. This
+  // `foldAnchorById` is surfaced as additive metadata (a NON-ENUMERABLE property
+  // on the returned graph, so `toEqual`/spread/Object.keys ignore it and no
+  // existing caller/test can observe it) purely so the studio can tween each
+  // folding node toward its group node (see GraphCanvas group-transition).
   const hiddenCountByTarget = new Map();
+  const foldAnchorById = new Map();
   for (const hiddenId of hidden) {
     let current = parentById.get(hiddenId) ?? null;
     const guard = new Set();
     while (current != null && !guard.has(current)) {
       if (collapsed.has(current)) {
         hiddenCountByTarget.set(current, (hiddenCountByTarget.get(current) ?? 0) + 1);
+        foldAnchorById.set(hiddenId, current);
         break;
       }
       guard.add(current);
@@ -515,7 +523,39 @@ export function applyGroupCollapse(
       };
     });
 
-  return { nodes, links };
+  const result = { nodes, links };
+  // Additive, side-channel metadata for the collapse/expand animation. Attached
+  // NON-ENUMERABLY so it is invisible to `toEqual`, `{...graph}`, `Object.keys`,
+  // and every existing caller/test — `readFoldAnchors()` is the single reader.
+  Object.defineProperty(result, FOLD_ANCHORS_KEY, {
+    value: foldAnchorById,
+    enumerable: false,
+    writable: false,
+    configurable: true,
+  });
+  return result;
+}
+
+/**
+ * Property key under which {@link applyGroupCollapse} stashes its fold-anchor map
+ * (`Map<foldedNodeId, groupNodeId>`) on the returned graph. Non-enumerable, read
+ * ONLY through {@link readFoldAnchors} — a Symbol so it can never collide with a
+ * real graph field.
+ */
+export const FOLD_ANCHORS_KEY = Symbol.for("graphify.foldAnchors");
+
+/**
+ * Read the fold-anchor map surfaced by {@link applyGroupCollapse} (each hidden/
+ * folded node id → its group-node anchor id, the nearest collapsed ancestor).
+ * Returns an EMPTY map when the graph carries no such metadata (fast path, fresh
+ * graph, or a non-collapse result), so callers never branch on presence.
+ *
+ * @param {object|null|undefined} graph  a graph returned by the collapse engine.
+ * @returns {Map<string,string>}
+ */
+export function readFoldAnchors(graph) {
+  const map = graph?.[FOLD_ANCHORS_KEY];
+  return map instanceof Map ? map : new Map();
 }
 
 /**

--- a/studio/src/lib/forceLayoutClient.js
+++ b/studio/src/lib/forceLayoutClient.js
@@ -1,0 +1,85 @@
+/**
+ * codeflow-parity Lot 7 — client for the off-main-thread force layout.
+ *
+ * `solveForce` runs the deterministic Barnes-Hut `computeLayout` in a Web Worker
+ * when one is available (a real browser), so a Spread/Links re-solve at scale
+ * does not block the main thread / drop frames. When no Worker exists (SSR, jsdom
+ * tests, or a worker-construction failure) it degrades to a SYNCHRONOUS solve —
+ * byte-identical result, just on the main thread. Same-shape output either way
+ * (`LayoutResult[]` = `{ id, x, y }[]`), so the caller is agnostic to the path.
+ */
+import { computeLayout } from "@graphify/graph-layout";
+
+let worker = null;
+let workerBroken = false;
+let seq = 0;
+const pending = new Map();
+
+/** True when this environment can construct a module Web Worker. */
+export function workerSupported() {
+  return !workerBroken && typeof Worker !== "undefined" && typeof URL !== "undefined";
+}
+
+function ensureWorker() {
+  if (worker || !workerSupported()) return worker;
+  try {
+    worker = new Worker(new URL("./layoutWorker.js", import.meta.url), { type: "module" });
+    worker.onmessage = (event) => {
+      const { id, positions, error } = event.data ?? {};
+      const entry = pending.get(id);
+      if (!entry) return;
+      pending.delete(id);
+      if (error) entry.reject(new Error(error));
+      else entry.resolve(positions);
+    };
+    worker.onerror = () => {
+      // A worker failure (e.g. import error) must never wedge the feature: reject
+      // in-flight work, tear the worker down, and mark the env so future calls
+      // take the synchronous fallback.
+      workerBroken = true;
+      for (const entry of pending.values()) entry.reject(new Error("layout worker error"));
+      pending.clear();
+      terminateForceWorker();
+    };
+  } catch {
+    worker = null;
+    workerBroken = true;
+  }
+  return worker;
+}
+
+/** Tear down the worker (call on component destroy). */
+export function terminateForceWorker() {
+  if (worker) {
+    worker.terminate();
+    worker = null;
+  }
+  pending.clear();
+}
+
+/**
+ * Solve a force layout. Resolves to `{ id, x, y }[]` (input order). Prefers the
+ * worker; falls back to a synchronous solve when no worker is available or its
+ * construction failed.
+ * @param {{id:string}[]} nodes
+ * @param {{source:string,target:string}[]} edges
+ * @param {object} [options]  computeLayout options (repulsion / linkDistance /
+ *                            iterations / initialPositions …)
+ * @returns {Promise<{id:string,x:number,y:number}[]>}
+ */
+export function solveForce(nodes, edges, options = {}) {
+  const w = ensureWorker();
+  if (!w) return Promise.resolve(computeLayout(nodes ?? [], edges ?? [], options));
+  const id = ++seq;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    try {
+      w.postMessage({ id, nodes, edges, options });
+    } catch (error) {
+      // A non-cloneable payload (should not happen — options is plain + a Map)
+      // falls back to sync so the feature never breaks.
+      pending.delete(id);
+      resolve(computeLayout(nodes ?? [], edges ?? [], options));
+    }
+  });
+}

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -40,6 +40,24 @@ const WEAK_EDGE_COLOR = [203, 213, 225, 128];
 const EDGE_CURVE_FACTOR = 0.5;
 const DIM_ALPHA = Math.round(255 * 0.35); // 89
 
+// --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder / Layer) ---
+/**
+ * Default curvature for a main-graph edge — the studio's CURRENT behaviour.
+ * Both @sentropic/graph backends already draw a per-edge quadratic when
+ * curvature !== 0 (`styles.ts:259`, `render-geometry.edgeGeometry`), so the
+ * "Curved links" toggle is purely this scalar: ON ⇒ this value (default,
+ * byte-identical to before), OFF ⇒ 0 (straight). Wiring only — NOT the discrete
+ * flow-port S-routing (R3).
+ */
+export const DEFAULT_EDGE_CURVATURE = 0.15;
+/**
+ * Color-by mode — colour by directory / container (community/container, i.e.
+ * `node.group`). This is the studio's CURRENT default keying (`colorForGroup`).
+ */
+export const COLOR_BY_FOLDER = "folder";
+/** Color-by mode — colour by typed layer / ontology level (`node_type`). */
+export const COLOR_BY_LAYER = "layer";
+
 // Density-aware base node sizing. The user confirmed sizes read well at ~1000
 // nodes but are too big at ~5000. We shrink only the BASE radius as the graph
 // grows (the per-node degree spread — sqrt(weight), i.e. the RADIUS_RATIO
@@ -306,6 +324,17 @@ export function buildGraphRendererPayload(scene, options = {}) {
   // names at zoom-out). Undefined ⇒ treat as zoomed OUT so the default fit view
   // already shows only the principal cast (see selectPrincipalHubLabels).
   const labelZoom = Number.isFinite(options.zoom) ? options.zoom : 0;
+  // codeflow-parity Lot 4 — Color-by (R4): Folder keys the categorical colour on
+  // community/container (node.group, the CURRENT default); Layer keys it on the
+  // typed layer (node_type). Both resolve through the SAME palette (colorForGroup)
+  // so the legend swatch and node fill stay one source of truth. Default = Folder,
+  // so an unset option is byte-identical to before this lot.
+  const colorBy = options.colorBy === COLOR_BY_LAYER ? COLOR_BY_LAYER : COLOR_BY_FOLDER;
+  // codeflow-parity Lot 4 — Curved links (R3): ON ⇒ DEFAULT_EDGE_CURVATURE (the
+  // current behaviour), OFF ⇒ 0 (straight). Default ON so an unset option is
+  // byte-identical to before this lot. It is a per-edge RENDER attribute — the
+  // caller re-renders live with no layout recompute.
+  const edgeCurvature = options.curvedLinks === false ? 0 : DEFAULT_EDGE_CURVATURE;
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
 
@@ -318,10 +347,14 @@ export function buildGraphRendererPayload(scene, options = {}) {
     const position = positionForNode(node, index, sceneNodes.length);
     const focused = node.id === focusId;
     const selected = focused || selectedIds.has(node.id);
+    const nodeType = node.node_type ?? node.type ?? null;
+    // Color-by (R4): Layer keys the categorical colour on the typed layer,
+    // Folder (default) on community/container. Selection/focus overrides still win.
+    const colorKey = colorBy === COLOR_BY_LAYER ? nodeType : node.group;
     return {
       id: node.id,
       label: node.label ?? node.id,
-      node_type: node.node_type ?? node.type ?? null,
+      node_type: nodeType,
       x: position.x,
       y: position.y,
       fixed: position.fixed,
@@ -334,7 +367,7 @@ export function buildGraphRendererPayload(scene, options = {}) {
       // node's label in-box, bypassing the degree/god-class label gate.
       forceBoxLabel: node.forceBoxLabel === true,
       size: nodeSize(node, nodeRadius, selected, focused),
-      color: focused ? FOCUS_COLOR : selected ? SELECTED_COLOR : colorForGroup(node.group),
+      color: focused ? FOCUS_COLOR : selected ? SELECTED_COLOR : colorForGroup(colorKey),
     };
   });
 
@@ -348,14 +381,14 @@ export function buildGraphRendererPayload(scene, options = {}) {
     width: edgeWidth(edge),
     color: edge.weak ? WEAK_EDGE_COLOR : EDGE_COLOR,
     dash: edge.dash ?? (edge.weak ? "dotted" : "solid"),
-    curvature: finite(edge.curvature) ? edge.curvature : 0.15,
+    curvature: finite(edge.curvature) ? edge.curvature : edgeCurvature,
   }));
 
   const input = { nodes, edges };
   const renderGraph = buildRenderGraphBuffers(input);
   const baseStyle = buildStyleBuffers(input, renderGraph, {
     node: { size: nodeRadius },
-    edge: { width: 1, color: EDGE_COLOR, dash: "solid", curvature: 0.15 },
+    edge: { width: 1, color: EDGE_COLOR, dash: "solid", curvature: edgeCurvature },
   });
   const nodeIndexById = new Map(nodes.map((node, index) => [node.id, index]));
 

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -57,6 +57,8 @@ export const DEFAULT_EDGE_CURVATURE = 0.15;
 export const COLOR_BY_FOLDER = "folder";
 /** Color-by mode — colour by typed layer / ontology level (`node_type`). */
 export const COLOR_BY_LAYER = "layer";
+/** Color-by mode — continuous churn/activity heat ramp (degree fallback first). */
+export const COLOR_BY_CHURN = "churn";
 
 // Density-aware base node sizing. The user confirmed sizes read well at ~1000
 // nodes but are too big at ~5000. We shrink only the BASE radius as the graph
@@ -106,6 +108,50 @@ function stableHash(value) {
 export function colorForGroup(group) {
   const index = stableHash(group ?? "default") % GROUP_PALETTE.length;
   return GROUP_PALETTE[index];
+}
+
+const CHURN_LOW = [226, 232, 240];
+const CHURN_HIGH = [239, 68, 68];
+
+function hex2(value) {
+  return value.toString(16).padStart(2, "0");
+}
+
+/** Sequential light-slate → red ramp for normalized churn/activity heat. */
+export function colorForChurn(value) {
+  const t = clampUnit(value);
+  const rgb = CHURN_LOW.map((lo, index) => Math.round(lo + (CHURN_HIGH[index] - lo) * t));
+  return `#${hex2(rgb[0])}${hex2(rgb[1])}${hex2(rgb[2])}`;
+}
+
+function explicitChurnValue(node) {
+  const candidates = [node.churn, node.git_churn, node.activity, node.activity_score, node.change_count];
+  for (const value of candidates) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric >= 0) return numeric;
+  }
+  return null;
+}
+
+function nodeDegreeFallback(sceneNodes, sceneEdges) {
+  const degree = new Map(sceneNodes.map((node) => [node.id, 0]));
+  for (const edge of sceneEdges) {
+    if (degree.has(edge.source)) degree.set(edge.source, degree.get(edge.source) + 1);
+    if (degree.has(edge.target)) degree.set(edge.target, degree.get(edge.target) + 1);
+  }
+  return degree;
+}
+
+function normalizedChurnById(sceneNodes, sceneEdges) {
+  const raw = new Map();
+  const degree = nodeDegreeFallback(sceneNodes, sceneEdges);
+  for (const node of sceneNodes) {
+    raw.set(node.id, explicitChurnValue(node) ?? degree.get(node.id) ?? 0);
+  }
+  const max = Math.max(0, ...raw.values());
+  const normalized = new Map();
+  for (const [id, value] of raw) normalized.set(id, max > 0 ? value / max : 0);
+  return normalized;
 }
 
 function positionForNode(node, index, total) {
@@ -329,7 +375,12 @@ export function buildGraphRendererPayload(scene, options = {}) {
   // typed layer (node_type). Both resolve through the SAME palette (colorForGroup)
   // so the legend swatch and node fill stay one source of truth. Default = Folder,
   // so an unset option is byte-identical to before this lot.
-  const colorBy = options.colorBy === COLOR_BY_LAYER ? COLOR_BY_LAYER : COLOR_BY_FOLDER;
+  const colorBy =
+    options.colorBy === COLOR_BY_LAYER
+      ? COLOR_BY_LAYER
+      : options.colorBy === COLOR_BY_CHURN
+        ? COLOR_BY_CHURN
+        : COLOR_BY_FOLDER;
   // codeflow-parity Lot 4 — Curved links (R3): ON ⇒ DEFAULT_EDGE_CURVATURE (the
   // current behaviour), OFF ⇒ 0 (straight). Default ON so an unset option is
   // byte-identical to before this lot. It is a per-edge RENDER attribute — the
@@ -337,6 +388,7 @@ export function buildGraphRendererPayload(scene, options = {}) {
   const edgeCurvature = options.curvedLinks === false ? 0 : DEFAULT_EDGE_CURVATURE;
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
+  const churnById = colorBy === COLOR_BY_CHURN ? normalizedChurnById(sceneNodes, sceneEdges) : null;
 
   // Shrink the BASE radius on dense graphs while keeping the per-node degree
   // spread (sqrt(weight)) intact. nodeRadius is the effective base used both for
@@ -348,9 +400,12 @@ export function buildGraphRendererPayload(scene, options = {}) {
     const focused = node.id === focusId;
     const selected = focused || selectedIds.has(node.id);
     const nodeType = node.node_type ?? node.type ?? null;
-    // Color-by (R4): Layer keys the categorical colour on the typed layer,
-    // Folder (default) on community/container. Selection/focus overrides still win.
+    // Color-by (R4/R5): Layer keys the categorical colour on the typed layer,
+    // Folder (default) on community/container, Churn on a continuous activity heat.
+    // Selection/focus overrides still win.
     const colorKey = colorBy === COLOR_BY_LAYER ? nodeType : node.group;
+    const baseColor =
+      colorBy === COLOR_BY_CHURN ? colorForChurn(churnById?.get(node.id) ?? 0) : colorForGroup(colorKey);
     return {
       id: node.id,
       label: node.label ?? node.id,
@@ -367,7 +422,7 @@ export function buildGraphRendererPayload(scene, options = {}) {
       // node's label in-box, bypassing the degree/god-class label gate.
       forceBoxLabel: node.forceBoxLabel === true,
       size: nodeSize(node, nodeRadius, selected, focused),
-      color: focused ? FOCUS_COLOR : selected ? SELECTED_COLOR : colorForGroup(colorKey),
+      color: focused ? FOCUS_COLOR : selected ? SELECTED_COLOR : baseColor,
     };
   });
 

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -43,9 +43,17 @@ const SELECTED_COLOR = "#2563eb";
 // accepts an [r,g,b,a] ColorInput, so we spell the colour as an array to
 // carry the alpha (studio-only — packages/graph's own defaults/goldens are
 // untouched).
-const EDGE_BASE_ALPHA = Math.round(255 * 0.5); // 128
-const EDGE_COLOR = [148, 163, 184, EDGE_BASE_ALPHA];
-const WEAK_EDGE_COLOR = [203, 213, 225, 128];
+const EDGE_BASE_OPACITY = 0.5;
+const EDGE_MIN_OPACITY = 0.3;
+const EDGE_BASE_ALPHA = Math.round(255 * EDGE_BASE_OPACITY); // 128
+const EDGE_COLOR_RGB = [148, 163, 184];
+const WEAK_EDGE_COLOR_RGB = [203, 213, 225];
+const EDGE_COLOR = [...EDGE_COLOR_RGB, EDGE_BASE_ALPHA];
+// Degree 1–2 is visually sparse and stays at the historical 0.50. From there,
+// a logarithmic curve handles the long-tailed degree distribution of knowledge
+// graphs; degree 32+ reaches the 0.30 floor instead of becoming invisible.
+const EDGE_DENSITY_START_DEGREE = 2;
+const EDGE_DENSITY_FULL_DEGREE = 32;
 const EDGE_CURVE_FACTOR = 0.5;
 const DIM_ALPHA = Math.round(255 * 0.35); // 89 — connected-dim for NON-neighbour nodes
 // Remark 1: non-incident edges dim FURTHER than nodes on hover (edges are
@@ -155,9 +163,23 @@ function nodeDegreeFallback(sceneNodes, sceneEdges) {
   return degree;
 }
 
-function normalizedChurnById(sceneNodes, sceneEdges) {
+export function edgeBaseAlphaForDegree(degree) {
+  const endpointDegree = Number.isFinite(degree) ? Math.max(0, degree) : 0;
+  if (endpointDegree <= EDGE_DENSITY_START_DEGREE) return EDGE_BASE_ALPHA;
+  const range = Math.log2(EDGE_DENSITY_FULL_DEGREE / EDGE_DENSITY_START_DEGREE);
+  const density = clampUnit(
+    Math.log2(endpointDegree / EDGE_DENSITY_START_DEGREE) / range,
+  );
+  const opacity = EDGE_BASE_OPACITY - density * (EDGE_BASE_OPACITY - EDGE_MIN_OPACITY);
+  return Math.round(255 * opacity);
+}
+
+function normalizedChurnById(
+  sceneNodes,
+  sceneEdges,
+  degree = nodeDegreeFallback(sceneNodes, sceneEdges),
+) {
   const raw = new Map();
-  const degree = nodeDegreeFallback(sceneNodes, sceneEdges);
   for (const node of sceneNodes) {
     raw.set(node.id, explicitChurnValue(node) ?? degree.get(node.id) ?? 0);
   }
@@ -405,7 +427,10 @@ export function buildGraphRendererPayload(scene, options = {}) {
   const edgeCurvature = options.curvedLinks === false ? 0 : DEFAULT_EDGE_CURVATURE;
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
-  const churnById = colorBy === COLOR_BY_CHURN ? normalizedChurnById(sceneNodes, sceneEdges) : null;
+  // One degree pass serves both churn fallback and density-graded edge alpha.
+  const degreeById = nodeDegreeFallback(sceneNodes, sceneEdges);
+  const churnById =
+    colorBy === COLOR_BY_CHURN ? normalizedChurnById(sceneNodes, sceneEdges, degreeById) : null;
 
   // Shrink the BASE radius on dense graphs while keeping the per-node degree
   // spread (sqrt(weight)) intact. nodeRadius is the effective base used both for
@@ -443,18 +468,25 @@ export function buildGraphRendererPayload(scene, options = {}) {
     };
   });
 
-  const edges = sceneEdges.map((edge) => ({
-    source: edge.source,
-    target: edge.target,
-    relation: edge.relation,
-    label: edge.relation,
-    weak: edge.weak === true,
-    emphasis: edge.emphasis === true,
-    width: edgeWidth(edge),
-    color: edge.weak ? WEAK_EDGE_COLOR : EDGE_COLOR,
-    dash: edge.dash ?? (edge.weak ? "dotted" : "solid"),
-    curvature: finite(edge.curvature) ? edge.curvature : edgeCurvature,
-  }));
+  const edges = sceneEdges.map((edge) => {
+    const endpointDegree = Math.max(
+      degreeById.get(edge.source) ?? 0,
+      degreeById.get(edge.target) ?? 0,
+    );
+    const alpha = edgeBaseAlphaForDegree(endpointDegree);
+    return {
+      source: edge.source,
+      target: edge.target,
+      relation: edge.relation,
+      label: edge.relation,
+      weak: edge.weak === true,
+      emphasis: edge.emphasis === true,
+      width: edgeWidth(edge),
+      color: [...(edge.weak ? WEAK_EDGE_COLOR_RGB : EDGE_COLOR_RGB), alpha],
+      dash: edge.dash ?? (edge.weak ? "dotted" : "solid"),
+      curvature: finite(edge.curvature) ? edge.curvature : edgeCurvature,
+    };
+  });
 
   const input = { nodes, edges };
   const renderGraph = buildRenderGraphBuffers(input);

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -36,10 +36,22 @@ export const GROUP_PALETTE = [
 
 const FOCUS_COLOR = "#ef4444";
 const SELECTED_COLOR = "#2563eb";
-const EDGE_COLOR = "#94a3b8";
+// Studio representation-polish remark 1: main-graph edges render semi-
+// transparent by DEFAULT (not opaque) — same #94a3b8 hue as before, now at
+// ~0.5 alpha — so the graph reads less like a solid mesh even before any
+// hover. `#94a3b8` = rgb(148, 163, 184); packages/graph's buildStyleBuffers
+// accepts an [r,g,b,a] ColorInput, so we spell the colour as an array to
+// carry the alpha (studio-only — packages/graph's own defaults/goldens are
+// untouched).
+const EDGE_BASE_ALPHA = Math.round(255 * 0.5); // 128
+const EDGE_COLOR = [148, 163, 184, EDGE_BASE_ALPHA];
 const WEAK_EDGE_COLOR = [203, 213, 225, 128];
 const EDGE_CURVE_FACTOR = 0.5;
-const DIM_ALPHA = Math.round(255 * 0.35); // 89
+const DIM_ALPHA = Math.round(255 * 0.35); // 89 — connected-dim for NON-neighbour nodes
+// Remark 1: non-incident edges dim FURTHER than nodes on hover (edges are
+// mostly noise once a node is focused) — incident edges are left at the
+// EDGE_BASE_ALPHA (~0.5+) by simply not being touched by the dim loop below.
+const EDGE_DIM_ALPHA = Math.round(255 * 0.15); // 38
 
 // --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder / Layer) ---
 /**
@@ -354,7 +366,7 @@ export function buildConnectedDimStyle(payload, options = {}) {
     const tgtId = graph.nodeIds[tgtIdx];
     const isIncident = activeFocusIds.has(srcId) || activeFocusIds.has(tgtId);
     if (!isIncident) {
-      style.edgeColors[e * 4 + 3] = DIM_ALPHA;
+      style.edgeColors[e * 4 + 3] = EDGE_DIM_ALPHA;
     }
   }
 

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -46,14 +46,18 @@ const SELECTED_COLOR = "#2563eb";
 const EDGE_BASE_OPACITY = 0.5;
 const EDGE_MIN_OPACITY = 0.3;
 const EDGE_BASE_ALPHA = Math.round(255 * EDGE_BASE_OPACITY); // 128
+// ONE slate hue for EVERY edge (remark: edges must all be the same colour and
+// differ ONLY by a transparency degree — a whiter hue for "weak" edges reads as
+// a colour change and is a bug). Weakness is conveyed by the dotted dash alone,
+// never by a paler RGB.
 const EDGE_COLOR_RGB = [148, 163, 184];
-const WEAK_EDGE_COLOR_RGB = [203, 213, 225];
 const EDGE_COLOR = [...EDGE_COLOR_RGB, EDGE_BASE_ALPHA];
 // Degree 1–2 is visually sparse and stays at the historical 0.50. From there,
 // a logarithmic curve handles the long-tailed degree distribution of knowledge
-// graphs; degree 32+ reaches the 0.30 floor instead of becoming invisible.
+// graphs; the floor (0.30 = the 70%-transparent cap) is now reached by degree
+// 16 so hub edges recede enough for the density gradient to READ clearly.
 const EDGE_DENSITY_START_DEGREE = 2;
-const EDGE_DENSITY_FULL_DEGREE = 32;
+const EDGE_DENSITY_FULL_DEGREE = 16;
 const EDGE_CURVE_FACTOR = 0.5;
 const DIM_ALPHA = Math.round(255 * 0.35); // 89 — connected-dim for NON-neighbour nodes
 // Remark 1: non-incident edges dim FURTHER than nodes on hover (edges are
@@ -482,7 +486,9 @@ export function buildGraphRendererPayload(scene, options = {}) {
       weak: edge.weak === true,
       emphasis: edge.emphasis === true,
       width: edgeWidth(edge),
-      color: [...(edge.weak ? WEAK_EDGE_COLOR_RGB : EDGE_COLOR_RGB), alpha],
+      // Uniform slate hue for all edges; only the density alpha varies. Weak
+      // edges stay this same colour and are distinguished by the dotted dash.
+      color: [...EDGE_COLOR_RGB, alpha],
       dash: edge.dash ?? (edge.weak ? "dotted" : "solid"),
       curvature: finite(edge.curvature) ? edge.curvature : edgeCurvature,
     };

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -149,7 +149,11 @@ function normalizedChurnById(sceneNodes, sceneEdges) {
   for (const node of sceneNodes) {
     raw.set(node.id, explicitChurnValue(node) ?? degree.get(node.id) ?? 0);
   }
-  const max = Math.max(0, ...raw.values());
+  // Reduce, not `Math.max(0, ...raw.values())`: the spread passes every value as
+  // a separate argument, which overflows the engine arg-count limit (RangeError)
+  // at ~1e5 nodes when Color-by=Churn.
+  let max = 0;
+  for (const v of raw.values()) if (v > max) max = v;
   const normalized = new Map();
   for (const [id, value] of raw) normalized.set(id, max > 0 ? value / max : 0);
   return normalized;

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -866,6 +866,200 @@ export function morphPositions(bufA, bufB, t, out = null) {
   return result;
 }
 
+/* ===========================================================================
+ * Collapse/expand GROUP-transition PURE cores (redesign spec §3).
+ *
+ * These are the deterministic, DOM-free maths of the animation extracted from
+ * GraphCanvas so they are unit-testable (jsdom has no WebGL, so the component's
+ * rAF/renderer wiring can only be source-asserted). The .svelte component owns
+ * the reactive flags, the rAF loop, and the renderer calls; it delegates the
+ * position bookkeeping to the three helpers below.
+ * ======================================================================== */
+
+// ~137.5° in radians — the golden angle. Successive multiples spread points
+// evenly with no two ever landing on the same ray, giving the sunflower/
+// phyllotaxis fan used for expand when there is no cached prior constellation.
+export const GROUP_FAN_GOLDEN_ANGLE = 2.399963229728653;
+
+/**
+ * Resolve which node INDICES fold (grouped by anchor) and each group's on-screen
+ * anchor position, against a given position buffer. The anchor rule (spec §3.4
+ * step 2): the group node's OWN current position when it is on screen (its id is
+ * in the payload), else the CENTROID of the folding members' current positions.
+ * Absent children (ids not in the payload) are skipped. Returns null when NONE of
+ * the anchor children resolve (nothing to animate → the caller carries-swaps).
+ *
+ * Pure: no reference to the component or the renderer. The caller passes the
+ * live position buffer (currentLayoutBuffer — live-morph aware).
+ *
+ * @param {object} args
+ * @param {string[]} args.nodeIds                node ids in render order.
+ * @param {ArrayLike<number>} args.positions     2·n position floats (index-parallel).
+ * @param {Map<string,string>} args.anchors      foldedChildId → groupNodeId.
+ * @param {Map<string,number>} [args.nodeIndexById]  id → index (derived if absent).
+ * @returns {{ foldingSet: Set<number>, groupMembers: Map<string, number[]>,
+ *   anchorPosByGroup: Map<string, {x:number,y:number}> } | null}
+ */
+export function resolveGroupFolds({ nodeIds, positions, anchors, nodeIndexById } = {}) {
+  if (!nodeIds?.length || !positions || !(anchors instanceof Map) || anchors.size === 0) {
+    return null;
+  }
+  const idx = nodeIndexById instanceof Map ? nodeIndexById : new Map(nodeIds.map((id, i) => [id, i]));
+
+  const foldingSet = new Set();
+  const groupMembers = new Map(); // groupNodeId -> [nodeIndex]
+  for (const [childId, groupId] of anchors) {
+    const i = idx.get(childId);
+    if (!Number.isInteger(i)) continue;
+    foldingSet.add(i);
+    let members = groupMembers.get(groupId);
+    if (!members) {
+      members = [];
+      groupMembers.set(groupId, members);
+    }
+    members.push(i);
+  }
+  if (foldingSet.size === 0) return null;
+
+  const anchorPosByGroup = new Map();
+  for (const [groupId, members] of groupMembers) {
+    const gi = idx.get(groupId);
+    if (Number.isInteger(gi)) {
+      // Group node is ON SCREEN (nested case: folding into a visible ancestor) →
+      // its own position is the anchor.
+      anchorPosByGroup.set(groupId, {
+        x: positions[gi * 2] ?? 0,
+        y: positions[gi * 2 + 1] ?? 0,
+      });
+    } else {
+      // Usual case: the group node lives only in the OTHER scene → centroid of
+      // the folding members' current positions.
+      let sx = 0;
+      let sy = 0;
+      for (const i of members) {
+        sx += positions[i * 2] ?? 0;
+        sy += positions[i * 2 + 1] ?? 0;
+      }
+      anchorPosByGroup.set(groupId, { x: sx / members.length, y: sy / members.length });
+    }
+  }
+  return { foldingSet, groupMembers, anchorPosByGroup };
+}
+
+/**
+ * Carry a coordinate space across a scene swap (spec §3.2). Builds a NEW position
+ * buffer for the NEW scene, resolving each node's position BY ID:
+ *   1. an explicit placement (`placedPosById`) — group node at the fold centroid
+ *      on collapse; revealed children stacked on the anchor on expand;
+ *   2. else a carried-over position (`carriedPosById`) — shared nodes keep their
+ *      exact on-screen spot;
+ *   3. else, for a brand-new node with neither (e.g. a newly-injected visible
+ *      class handle), the CENTROID of its already-placed graph neighbours over
+ *      the NEW scene's edges;
+ *   4. else the scene-baked position (the last-resort fallback, already in
+ *      `positions`).
+ *
+ * Neighbour placement (step 3) reads ONLY step-1/2 results, so it is order-
+ * independent (deterministic). Returns a fresh Float32Array; never mutates input.
+ *
+ * @param {object} args
+ * @param {string[]} args.nodeIds               NEW-scene node ids in render order.
+ * @param {ArrayLike<number>} args.positions    NEW-scene scene-baked 2·n floats.
+ * @param {ArrayLike<number>} [args.edges]      NEW-scene edge INDEX pairs (2·e).
+ * @param {Map<string,{x:number,y:number}>} [args.carriedPosById]  old on-screen pos.
+ * @param {Map<string,{x:number,y:number}>} [args.placedPosById]   explicit new pos.
+ * @returns {Float32Array|null}
+ */
+export function carryScenePositions({ nodeIds, positions, edges, carriedPosById, placedPosById } = {}) {
+  if (!nodeIds?.length || !positions || positions.length < nodeIds.length * 2) return null;
+  const carried = carriedPosById instanceof Map ? carriedPosById : new Map();
+  const placed = placedPosById instanceof Map ? placedPosById : new Map();
+
+  const out = new Float32Array(positions); // start from scene-baked (step 4).
+  const isPlaced = new Array(nodeIds.length).fill(false);
+
+  // Pass 1: explicit placement (step 1) then carried-over (step 2), by id.
+  for (let i = 0; i < nodeIds.length; i += 1) {
+    const id = nodeIds[i];
+    const p = placed.get(id) ?? carried.get(id);
+    if (p && Number.isFinite(p.x) && Number.isFinite(p.y)) {
+      out[i * 2] = p.x;
+      out[i * 2 + 1] = p.y;
+      isPlaced[i] = true;
+    }
+  }
+
+  // Pass 2: brand-new nodes → neighbour centroid over the new edges (step 3);
+  // else the scene-baked value already sitting in `out` (step 4).
+  if (edges && edges.length) {
+    const neighbours = new Map(); // index -> [neighbour indices]
+    const addNeighbour = (a, b) => {
+      let list = neighbours.get(a);
+      if (!list) {
+        list = [];
+        neighbours.set(a, list);
+      }
+      list.push(b);
+    };
+    const edgeCount = Math.floor(edges.length / 2);
+    for (let e = 0; e < edgeCount; e += 1) {
+      const a = edges[e * 2];
+      const b = edges[e * 2 + 1];
+      if (!Number.isInteger(a) || !Number.isInteger(b)) continue;
+      addNeighbour(a, b);
+      addNeighbour(b, a);
+    }
+    for (let i = 0; i < nodeIds.length; i += 1) {
+      if (isPlaced[i]) continue;
+      const nbrs = neighbours.get(i);
+      if (!nbrs || nbrs.length === 0) continue;
+      let sx = 0;
+      let sy = 0;
+      let count = 0;
+      for (const j of nbrs) {
+        if (!isPlaced[j]) continue; // ONLY already-placed neighbours
+        sx += out[j * 2];
+        sy += out[j * 2 + 1];
+        count += 1;
+      }
+      if (count > 0) {
+        out[i * 2] = sx / count;
+        out[i * 2 + 1] = sy / count;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Deterministic golden-angle (sunflower) fan of `childIds` around `anchor`
+ * (spec §3.5.2) — the expand fallback when there is no cached prior constellation.
+ * Children are sorted by id, so the SAME id set always lands on the SAME slots.
+ * Child j of m sits at angle `j · GROUP_FAN_GOLDEN_ANGLE`, radius
+ * `min(spacing · √(j+1), cap)`.
+ *
+ * @param {object} args
+ * @param {{x:number,y:number}} args.anchor    the fan centre.
+ * @param {Iterable<string>} args.childIds     ids to place (sorted internally).
+ * @param {number} args.spacing                radial spacing factor (world units).
+ * @param {number} [args.cap=Infinity]         max radius (world units).
+ * @returns {Map<string,{x:number,y:number}>}
+ */
+export function goldenAngleFan({ anchor, childIds, spacing, cap = Infinity } = {}) {
+  const out = new Map();
+  const ids = childIds ? [...childIds].sort() : [];
+  const ax = Number.isFinite(anchor?.x) ? anchor.x : 0;
+  const ay = Number.isFinite(anchor?.y) ? anchor.y : 0;
+  const s = Number.isFinite(spacing) && spacing > 0 ? spacing : 1;
+  const maxR = Number.isFinite(cap) ? cap : Infinity;
+  for (let j = 0; j < ids.length; j += 1) {
+    const angle = j * GROUP_FAN_GOLDEN_ANGLE;
+    const radius = Math.min(s * Math.sqrt(j + 1), maxR);
+    out.set(ids[j], { x: ax + radius * Math.cos(angle), y: ay + radius * Math.sin(angle) });
+  }
+  return out;
+}
+
 export function interpolateMergeStyle(payload, mergePair, progress) {
   const graph = payload?.renderGraph;
   if (!graph || !payload?.style || !mergePair?.from) return payload?.style ?? null;

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -1,4 +1,10 @@
-import { buildRenderGraphBuffers, buildStyleBuffers } from "@sentropic/graph";
+import {
+  buildRenderGraphBuffers,
+  buildStyleBuffers,
+  DEFAULT_LAYOUT_ID,
+  resolveLayout,
+  TYPED_LAYER_LAYOUT_ID,
+} from "@sentropic/graph";
 
 /**
  * SINGLE source of truth for a group's (community / type) colour. Both the
@@ -451,6 +457,115 @@ export function interpolateMergePositions(payload, mergePair, progress) {
   positions[fromOffset + 1] = fromY + (intoY - fromY) * t;
 
   return positions;
+}
+
+// ---------------------------------------------------------------------------
+// Layout switcher seam (codeflow-parity Lot 1). The studio does not otherwise
+// consume the @sentropic/graph layout registry; these helpers are the ONE seam
+// that resolves a named layout into a node-order-keyed position buffer and
+// morphs the on-screen buffer toward it. Every registered layout returns a
+// `Float32Array` of `2 · nodeCount` floats PARALLEL to `graph.nodeIds`, so a
+// cross-layout tween is a trivial per-index lerp between two static buffers —
+// no correspondence problem (see SPEC_STUDIO_GRAPH_UX_CODEFLOW_PARITY §2.6).
+// ---------------------------------------------------------------------------
+
+/** Layout mode id — force-directed (the default baked positions). */
+export const LAYOUT_MODE_FORCE = "force";
+/** Layout mode id — typed swimlanes (registered `typed-layer`, ≈ "Layers"). */
+export const LAYOUT_MODE_LAYERS = "layers";
+
+/**
+ * The layout modes exposed by the studio switcher (Lot 1 = Force + Layers on the
+ * already-registered engines). `registryId` is the id passed to
+ * {@link resolveLayout}; Force has none because its target is the CACHED initial
+ * force positions, not a (cold) registry re-solve (Lot 1 does not re-solve force).
+ */
+export const LAYOUT_MODES = [
+  { id: LAYOUT_MODE_FORCE, label: "Force", registryId: DEFAULT_LAYOUT_ID },
+  { id: LAYOUT_MODE_LAYERS, label: "Layers", registryId: TYPED_LAYER_LAYOUT_ID },
+];
+
+/**
+ * Node-order-keyed per-node TYPE labels for a built payload (parallel to
+ * `payload.renderGraph.nodeIds`). Read from the payload's node objects
+ * (`node_type`), so the typed-layer layout bands the SAME nodes the canvas
+ * drew. A missing node → `null` (the untyped lane).
+ * @param {object} payload  a buildGraphRendererPayload result
+ * @returns {(string|null)[]}
+ */
+export function nodeTypesForPayload(payload) {
+  const graph = payload?.renderGraph;
+  const ids = graph?.nodeIds ?? [];
+  const types = new Array(ids.length);
+  for (let i = 0; i < ids.length; i += 1) {
+    const node = payload?.nodeById?.get(ids[i]);
+    types[i] = node?.node_type ?? null;
+  }
+  return types;
+}
+
+/**
+ * Resolve a layout MODE into a fresh node-order-keyed position buffer
+ * (`2 · nodeCount` floats) for the payload's render graph — the morph TARGET
+ * (`bufB`). Never throws: an unknown mode / missing payload degrades to the
+ * force passthrough.
+ *
+ *   • `"layers"` → the registered `typed-layer` swimlane layout, banded by the
+ *     payload's per-node types.
+ *   • `"force"`  → the CACHED initial force positions (`forceBuffer`) — Lot 1
+ *     does NOT cold re-solve force (warm-started re-solve is Lot 3). When no
+ *     cached buffer is supplied it falls back to the registry force passthrough
+ *     (a copy of the CURRENT positions).
+ *
+ * @param {object} payload  a buildGraphRendererPayload result
+ * @param {string} mode     a LAYOUT_MODES id
+ * @param {{ forceBuffer?: Float32Array|null }} [opts]
+ * @returns {Float32Array|null}
+ */
+export function computeLayoutBuffer(payload, mode, { forceBuffer = null } = {}) {
+  const graph = payload?.renderGraph;
+  if (!graph) return null;
+  const floatCount = (graph.nodeIds?.length ?? 0) * 2;
+
+  if (mode === LAYOUT_MODE_LAYERS) {
+    const nodeTypes = nodeTypesForPayload(payload);
+    return resolveLayout(TYPED_LAYER_LAYOUT_ID)(graph, { nodeTypes });
+  }
+
+  // Force (default): the cached pristine force positions when we have them.
+  if (forceBuffer && forceBuffer.length === floatCount) {
+    return new Float32Array(forceBuffer);
+  }
+  // No cache → passthrough a copy of the current baked positions.
+  return resolveLayout(DEFAULT_LAYOUT_ID)(graph);
+}
+
+/**
+ * ALL-NODE layout morph — the general form of {@link interpolateMergePositions}.
+ * Linearly interpolates EVERY one of the `2 · nodeCount` floats between two
+ * index-parallel position buffers: `out[i] = a[i] + (b[i] − a[i]) · t`. Edges
+ * follow for free (they are re-derived from node positions each frame). `t` is
+ * clamped to [0, 1]; the CALLER applies any easing to `t` before calling (so
+ * `t = 0.5` is the exact midpoint — testable, deterministic). An optional `out`
+ * buffer is reused when large enough (rAF loops reuse one allocation).
+ *
+ * @param {Float32Array} bufA  start buffer (2·n floats)
+ * @param {Float32Array} bufB  target buffer (2·n floats, same length as bufA)
+ * @param {number} t           progress in [0, 1] (already eased by the caller)
+ * @param {Float32Array} [out] optional reusable output buffer
+ * @returns {Float32Array|null} the interpolated buffer, or null on bad input
+ */
+export function morphPositions(bufA, bufB, t, out = null) {
+  if (!bufA || !bufB) return null;
+  const len = Math.min(bufA.length, bufB.length);
+  const result = out && out.length >= len ? out : new Float32Array(len);
+  const progress = clampUnit(t);
+  for (let i = 0; i < len; i += 1) {
+    const a = bufA[i] ?? 0;
+    const b = bufB[i] ?? 0;
+    result[i] = a + (b - a) * progress;
+  }
+  return result;
 }
 
 export function interpolateMergeStyle(payload, mergePair, progress) {

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -51,7 +51,6 @@ const EDGE_BASE_ALPHA = Math.round(255 * EDGE_BASE_OPACITY); // 128
 // a colour change and is a bug). Weakness is conveyed by the dotted dash alone,
 // never by a paler RGB.
 const EDGE_COLOR_RGB = [148, 163, 184];
-const EDGE_COLOR = [...EDGE_COLOR_RGB, EDGE_BASE_ALPHA];
 // Degree 1–2 is visually sparse and stays at the historical 0.50. From there,
 // a logarithmic curve handles the long-tailed degree distribution of knowledge
 // graphs; the floor (0.30 = the 70%-transparent cap) is now reached by degree
@@ -84,6 +83,35 @@ export const COLOR_BY_FOLDER = "folder";
 export const COLOR_BY_LAYER = "layer";
 /** Color-by mode — continuous churn/activity heat ramp (degree fallback first). */
 export const COLOR_BY_CHURN = "churn";
+
+// --- Configurable edge-transparency (along-edge alpha shape) ------------------
+/**
+ * Edge-fade mode — DENSE fade (DEFAULT): each edge is opaque at its RARE
+ * (low-degree) endpoint and fades toward its DENSE (high-degree) endpoint, so a
+ * hub's incident edges recede near the hub and the sparse rim reads clearly.
+ */
+export const EDGE_ALPHA_DENSE = "dense";
+/** Edge-fade mode — INVERSE: opaque at the dense endpoint, faint at the rare one. */
+export const EDGE_ALPHA_INVERSE = "inverse";
+/** Edge-fade mode — MID fade: opaque near BOTH nodes, faint in the MIDDLE. */
+export const EDGE_ALPHA_MID = "mid";
+/** Edge-fade mode — FLAT: uniform base alpha, no along-edge gradient. */
+export const EDGE_ALPHA_FLAT = "flat";
+/** Edge-fade modes exposed by the studio segmented control (default first). */
+export const EDGE_ALPHA_MODES = [
+  EDGE_ALPHA_DENSE,
+  EDGE_ALPHA_INVERSE,
+  EDGE_ALPHA_MID,
+  EDGE_ALPHA_FLAT,
+];
+/** Default base edge opacity (0..1) — the flat base alpha before any fade shape. */
+export const DEFAULT_EDGE_OPACITY = 0.5;
+/**
+ * The FAINT fraction the along-edge fade decays to (the dense endpoint / the edge
+ * middle). 0.15 keeps a hub's incident edges visible-but-receded rather than
+ * vanishing. Applied as a MULTIPLIER of the base alpha inside the shape buffer.
+ */
+export const EDGE_ALPHA_FLOOR = 0.15;
 
 // Density-aware base node sizing. The user confirmed sizes read well at ~1000
 // nodes but are too big at ~5000. We shrink only the BASE radius as the graph
@@ -176,6 +204,87 @@ export function edgeBaseAlphaForDegree(degree) {
   );
   const opacity = EDGE_BASE_OPACITY - density * (EDGE_BASE_OPACITY - EDGE_MIN_OPACITY);
   return Math.round(255 * opacity);
+}
+
+/** Linear interpolation (a at t=0, b at t=1). */
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+/**
+ * Normalized endpoint DENSITY in [0,1] from a node's undirected degree — the
+ * log-scaled position between START (=2, "sparse") and FULL (=16, "hub") the
+ * along-edge fade uses. deg ≤ START ⇒ 0 (rare); deg ≥ FULL ⇒ 1 (dense). Reuses
+ * the same START/FULL knobs as {@link edgeBaseAlphaForDegree}.
+ * @param {number} degree undirected node degree
+ * @returns {number} density in [0,1]
+ */
+export function edgeDensityForDegree(degree) {
+  const d = Number.isFinite(degree) ? Math.max(0, degree) : 0;
+  const range = Math.log2(EDGE_DENSITY_FULL_DEGREE / EDGE_DENSITY_START_DEGREE);
+  return clampUnit(
+    Math.log2(Math.max(d, EDGE_DENSITY_START_DEGREE) / EDGE_DENSITY_START_DEGREE) / range,
+  );
+}
+
+/**
+ * Resolve the three along-edge alpha MULTIPLIERS (m0 at source, mMid at 0.5, m1
+ * at target — each 0..255) for one edge, from the fade mode + the per-endpoint
+ * densities (d0 source, d1 target). These MULTIPLY the flat base alpha in the
+ * WebGL shader; (255,255,255) = uniform. See {@link EDGE_ALPHA_DENSE} etc.
+ * @param {string} mode  one of EDGE_ALPHA_MODES
+ * @param {number} d0    source endpoint density in [0,1]
+ * @param {number} d1    target endpoint density in [0,1]
+ * @returns {[number, number, number]} [m0, mMid, m1] rounded to 0..255
+ */
+export function edgeAlphaShapeFor(mode, d0, d1) {
+  const F = EDGE_ALPHA_FLOOR;
+  if (mode === EDGE_ALPHA_FLAT) return [255, 255, 255];
+  if (mode === EDGE_ALPHA_MID) {
+    return [255, Math.round(255 * F), 255];
+  }
+  // dense: opaque at the RARE endpoint (density 0 ⇒ 1), faint at the DENSE one
+  // (density 1 ⇒ FLOOR). inverse: swap the ends of the ramp.
+  let m0;
+  let m1;
+  if (mode === EDGE_ALPHA_INVERSE) {
+    m0 = Math.round(255 * lerp(F, 1, d0));
+    m1 = Math.round(255 * lerp(F, 1, d1));
+  } else {
+    // EDGE_ALPHA_DENSE (default) and any unknown mode fall back to dense.
+    m0 = Math.round(255 * lerp(1, F, d0));
+    m1 = Math.round(255 * lerp(1, F, d1));
+  }
+  return [m0, Math.round((m0 + m1) / 2), m1];
+}
+
+/**
+ * Build the per-edge ALPHA SHAPE buffer (3 bytes/edge, parallel to
+ * `renderGraph.edges`) for a fade mode. Each edge's endpoints are looked up by
+ * node id through `degreeById`, converted to a normalized density, then mapped
+ * to the [m0, mMid, m1] multipliers by {@link edgeAlphaShapeFor}. Flat mode
+ * still emits a buffer (all 255) so the shape is always present + explicit.
+ * @param {{ edges: ArrayLike<number>, nodeIds: ArrayLike<string> }} renderGraph
+ * @param {Map<string, number>} degreeById  scene node id → undirected degree
+ * @param {string} mode  one of EDGE_ALPHA_MODES
+ * @returns {Uint8Array} 3·edgeCount bytes
+ */
+export function buildEdgeAlphaShape(renderGraph, degreeById, mode) {
+  const edgeCount = (renderGraph?.edges?.length ?? 0) / 2;
+  const shape = new Uint8Array(edgeCount * 3);
+  for (let e = 0; e < edgeCount; e += 1) {
+    const srcIdx = renderGraph.edges[e * 2];
+    const tgtIdx = renderGraph.edges[e * 2 + 1];
+    const srcId = renderGraph.nodeIds[srcIdx];
+    const tgtId = renderGraph.nodeIds[tgtIdx];
+    const d0 = edgeDensityForDegree(degreeById.get(srcId) ?? 0);
+    const d1 = edgeDensityForDegree(degreeById.get(tgtId) ?? 0);
+    const [m0, mMid, m1] = edgeAlphaShapeFor(mode, d0, d1);
+    shape[e * 3] = m0;
+    shape[e * 3 + 1] = mMid;
+    shape[e * 3 + 2] = m1;
+  }
+  return shape;
 }
 
 function normalizedChurnById(
@@ -351,6 +460,10 @@ function cloneStyle(style) {
     edgeColors: new Uint8Array(style.edgeColors),
     edgeDash: new Uint8Array(style.edgeDash),
     edgeCurvatures: new Float32Array(style.edgeCurvatures),
+    // The along-edge alpha SHAPE is a separate multiplier from edgeColors.a, so
+    // it survives dim / hover / merge re-styling unchanged (those only scale the
+    // base alpha). Clone it like the other per-edge buffers.
+    edgeAlphaShape: style.edgeAlphaShape ? new Uint8Array(style.edgeAlphaShape) : undefined,
   };
 }
 
@@ -429,6 +542,17 @@ export function buildGraphRendererPayload(scene, options = {}) {
   // byte-identical to before this lot. It is a per-edge RENDER attribute — the
   // caller re-renders live with no layout recompute.
   const edgeCurvature = options.curvedLinks === false ? 0 : DEFAULT_EDGE_CURVATURE;
+  // Configurable edge-transparency: the along-edge fade MODE (default dense) and
+  // the flat BASE opacity (default 0.5). The mode drives a per-edge alpha SHAPE
+  // (a separate multiplier); the opacity sets the uniform base alpha. An unset
+  // option is byte-identical to the historical ~0.5 base + dense falloff.
+  const edgeAlphaMode = EDGE_ALPHA_MODES.includes(options.edgeAlphaMode)
+    ? options.edgeAlphaMode
+    : EDGE_ALPHA_DENSE;
+  const edgeOpacity = Number.isFinite(options.edgeOpacity)
+    ? clampUnit(options.edgeOpacity)
+    : DEFAULT_EDGE_OPACITY;
+  const edgeBaseAlpha = Math.round(255 * edgeOpacity);
   const sceneNodes = scene?.nodes ?? [];
   const sceneEdges = scene?.edges ?? [];
   // One degree pass serves both churn fallback and density-graded edge alpha.
@@ -473,11 +597,6 @@ export function buildGraphRendererPayload(scene, options = {}) {
   });
 
   const edges = sceneEdges.map((edge) => {
-    const endpointDegree = Math.max(
-      degreeById.get(edge.source) ?? 0,
-      degreeById.get(edge.target) ?? 0,
-    );
-    const alpha = edgeBaseAlphaForDegree(endpointDegree);
     return {
       source: edge.source,
       target: edge.target,
@@ -486,9 +605,12 @@ export function buildGraphRendererPayload(scene, options = {}) {
       weak: edge.weak === true,
       emphasis: edge.emphasis === true,
       width: edgeWidth(edge),
-      // Uniform slate hue for all edges; only the density alpha varies. Weak
-      // edges stay this same colour and are distinguished by the dotted dash.
-      color: [...EDGE_COLOR_RGB, alpha],
+      // Uniform slate hue AND uniform base alpha (edgeOpacity). The density
+      // falloff now lives in the per-edge alpha SHAPE (edgeAlphaShape, a separate
+      // multiplier), so dim/hover/merge — which scale this base alpha — compose
+      // with the fade automatically. Weak edges stay this colour, distinguished
+      // by the dotted dash.
+      color: [...EDGE_COLOR_RGB, edgeBaseAlpha],
       dash: edge.dash ?? (edge.weak ? "dotted" : "solid"),
       curvature: finite(edge.curvature) ? edge.curvature : edgeCurvature,
     };
@@ -498,8 +620,12 @@ export function buildGraphRendererPayload(scene, options = {}) {
   const renderGraph = buildRenderGraphBuffers(input);
   const baseStyle = buildStyleBuffers(input, renderGraph, {
     node: { size: nodeRadius },
-    edge: { width: 1, color: EDGE_COLOR, dash: "solid", curvature: edgeCurvature },
+    edge: { width: 1, color: [...EDGE_COLOR_RGB, edgeBaseAlpha], dash: "solid", curvature: edgeCurvature },
   });
+  // Along-edge alpha SHAPE (configurable edge-transparency). Parallel to
+  // renderGraph.edges; a separate multiplier of the base alpha the WebGL edge
+  // shader applies. Carried through cloneStyle so dim/hover/merge keep it.
+  baseStyle.edgeAlphaShape = buildEdgeAlphaShape(renderGraph, degreeById, edgeAlphaMode);
   const nodeIndexById = new Map(nodes.map((node, index) => [node.id, index]));
 
   // Recon focal-pair parity: nodes flagged `forceBoxLabel` (the two entities

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -2,6 +2,8 @@ import {
   buildRenderGraphBuffers,
   buildStyleBuffers,
   DEFAULT_LAYOUT_ID,
+  GRID_LAYOUT_ID,
+  RADIAL_LAYOUT_ID,
   resolveLayout,
   TYPED_LAYER_LAYOUT_ID,
 } from "@sentropic/graph";
@@ -473,16 +475,24 @@ export function interpolateMergePositions(payload, mergePair, progress) {
 export const LAYOUT_MODE_FORCE = "force";
 /** Layout mode id — typed swimlanes (registered `typed-layer`, ≈ "Layers"). */
 export const LAYOUT_MODE_LAYERS = "layers";
+/** Layout mode id — radial concentric rings (registered `radial`). */
+export const LAYOUT_MODE_RADIAL = "radial";
+/** Layout mode id — regular grid (registered `grid`). */
+export const LAYOUT_MODE_GRID = "grid";
 
 /**
- * The layout modes exposed by the studio switcher (Lot 1 = Force + Layers on the
- * already-registered engines). `registryId` is the id passed to
- * {@link resolveLayout}; Force has none because its target is the CACHED initial
- * force positions, not a (cold) registry re-solve (Lot 1 does not re-solve force).
+ * The layout modes exposed by the studio switcher (Lot 1 = Force + Layers; Lot 2
+ * adds Radial + Grid on the already-registered engines). `registryId` is the id
+ * passed to {@link resolveLayout}; Force has none because its target is the
+ * CACHED initial force positions, not a (cold) registry re-solve (Lot 1 does not
+ * re-solve force). Radial and Grid are pure, deterministic O(n[+e]) engines and
+ * morph for free through the same all-node tween (index-parallel buffers, §2.6).
  */
 export const LAYOUT_MODES = [
   { id: LAYOUT_MODE_FORCE, label: "Force", registryId: DEFAULT_LAYOUT_ID },
+  { id: LAYOUT_MODE_RADIAL, label: "Radial", registryId: RADIAL_LAYOUT_ID },
   { id: LAYOUT_MODE_LAYERS, label: "Layers", registryId: TYPED_LAYER_LAYOUT_ID },
+  { id: LAYOUT_MODE_GRID, label: "Grid", registryId: GRID_LAYOUT_ID },
 ];
 
 /**
@@ -512,6 +522,10 @@ export function nodeTypesForPayload(payload) {
  *
  *   • `"layers"` → the registered `typed-layer` swimlane layout, banded by the
  *     payload's per-node types.
+ *   • `"radial"` → the registered `radial` layout (highest-degree hub at the
+ *     centre, BFS levels on concentric rings). Pure O(n+e) from the graph.
+ *   • `"grid"`   → the registered `grid` layout (regular `ceil(√n)` grid centred
+ *     on the origin, node-id order). Pure O(n) from the node count.
  *   • `"force"`  → the CACHED initial force positions (`forceBuffer`) — Lot 1
  *     does NOT cold re-solve force (warm-started re-solve is Lot 3). When no
  *     cached buffer is supplied it falls back to the registry force passthrough
@@ -530,6 +544,14 @@ export function computeLayoutBuffer(payload, mode, { forceBuffer = null } = {}) 
   if (mode === LAYOUT_MODE_LAYERS) {
     const nodeTypes = nodeTypesForPayload(payload);
     return resolveLayout(TYPED_LAYER_LAYOUT_ID)(graph, { nodeTypes });
+  }
+
+  if (mode === LAYOUT_MODE_RADIAL) {
+    return resolveLayout(RADIAL_LAYOUT_ID)(graph, { nodeTypes: nodeTypesForPayload(payload) });
+  }
+
+  if (mode === LAYOUT_MODE_GRID) {
+    return resolveLayout(GRID_LAYOUT_ID)(graph, { nodeTypes: nodeTypesForPayload(payload) });
   }
 
   // Force (default): the cached pristine force positions when we have them.

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -893,6 +893,52 @@ export function interpolateMergeStyle(payload, mergePair, progress) {
 }
 
 /**
+ * The SET generalization of {@link interpolateMergeStyle} for the collapse/expand
+ * group animation: fade (and optionally shrink) a whole SET of folding/revealing
+ * nodes and their incident edges over the same rAF loop as the layout morph.
+ *
+ * Clones the payload style and, for every node index in `foldingIndices`, scales
+ * its colour ALPHA by `alphaScale` and its drawn SIZE by `sizeScale`; every edge
+ * touching a folding node has its base alpha scaled by `alphaScale` too, so an
+ * edge fades with its endpoint. `alphaScale`/`sizeScale` are clamped to [0, 1].
+ * Non-folding nodes/edges keep the base style byte-for-byte. Returns the base
+ * style unchanged when there is nothing to fade.
+ *
+ * @param {object} payload  a buildGraphRendererPayload result
+ * @param {Set<number>|Iterable<number>} foldingIndices  node indices to fade
+ * @param {number} alphaScale  colour-alpha multiplier for folding nodes/edges
+ * @param {number} [sizeScale=1]  size multiplier for folding nodes (shrink)
+ * @returns {object|null} a cloned, faded style (or the base style on bad input)
+ */
+export function interpolateGroupFadeStyle(payload, foldingIndices, alphaScale, sizeScale = 1) {
+  const graph = payload?.renderGraph;
+  if (!graph || !payload?.style) return payload?.style ?? null;
+  const set = foldingIndices instanceof Set ? foldingIndices : new Set(foldingIndices ?? []);
+  if (set.size === 0) return payload.style;
+
+  const style = cloneStyle(payload.style);
+  const a = clampUnit(alphaScale);
+  const s = clampUnit(sizeScale);
+  for (const index of set) {
+    if (!Number.isInteger(index) || index < 0) continue;
+    const alphaOffset = index * 4 + 3;
+    style.nodeColors[alphaOffset] = Math.round((style.nodeColors[alphaOffset] ?? 255) * a);
+    style.nodeSizes[index] = (style.nodeSizes[index] ?? 4) * s;
+  }
+
+  const edgeCount = graph.edges.length / 2;
+  for (let edgeIndex = 0; edgeIndex < edgeCount; edgeIndex += 1) {
+    const sourceIndex = graph.edges[edgeIndex * 2];
+    const targetIndex = graph.edges[edgeIndex * 2 + 1];
+    if (!set.has(sourceIndex) && !set.has(targetIndex)) continue;
+    const alphaOffset = edgeIndex * 4 + 3;
+    style.edgeColors[alphaOffset] = Math.round((style.edgeColors[alphaOffset] ?? 255) * a);
+  }
+
+  return style;
+}
+
+/**
  * Nearest node to (worldX, worldY) within the pick zone, returning the id, the
  * world-space distance to its centre, and its drawn world radius. The pick zone
  * is `max(maxDistance, radius)` so a generous grab still works, while callers

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -3,6 +3,7 @@ import {
   buildStyleBuffers,
   DEFAULT_LAYOUT_ID,
   GRID_LAYOUT_ID,
+  METRO_LAYOUT_ID,
   RADIAL_LAYOUT_ID,
   resolveLayout,
   TYPED_LAYER_LAYOUT_ID,
@@ -567,6 +568,8 @@ export const LAYOUT_MODE_LAYERS = "layers";
 export const LAYOUT_MODE_RADIAL = "radial";
 /** Layout mode id — regular grid (registered `grid`). */
 export const LAYOUT_MODE_GRID = "grid";
+/** Layout mode id — metro lanes (registered `metro`; MVP, orthogonal edges deferred). */
+export const LAYOUT_MODE_METRO = "metro";
 
 /**
  * The layout modes exposed by the studio switcher (Lot 1 = Force + Layers; Lot 2
@@ -581,6 +584,7 @@ export const LAYOUT_MODES = [
   { id: LAYOUT_MODE_RADIAL, label: "Radial", registryId: RADIAL_LAYOUT_ID },
   { id: LAYOUT_MODE_LAYERS, label: "Layers", registryId: TYPED_LAYER_LAYOUT_ID },
   { id: LAYOUT_MODE_GRID, label: "Grid", registryId: GRID_LAYOUT_ID },
+  { id: LAYOUT_MODE_METRO, label: "Metro", registryId: METRO_LAYOUT_ID },
 ];
 
 /**
@@ -640,6 +644,10 @@ export function computeLayoutBuffer(payload, mode, { forceBuffer = null } = {}) 
 
   if (mode === LAYOUT_MODE_GRID) {
     return resolveLayout(GRID_LAYOUT_ID)(graph, { nodeTypes: nodeTypesForPayload(payload) });
+  }
+
+  if (mode === LAYOUT_MODE_METRO) {
+    return resolveLayout(METRO_LAYOUT_ID)(graph, { nodeTypes: nodeTypesForPayload(payload) });
   }
 
   // Force (default): the cached pristine force positions when we have them.

--- a/studio/src/lib/groupBy.js
+++ b/studio/src/lib/groupBy.js
@@ -116,6 +116,56 @@ export function computeGroupedGraph({
 }
 
 /* ===========================================================================
+ * Collapse/expand ANIMATION signal — direction detection from the FOLD DELTA.
+ *
+ * When the grouped set changes, the studio animates the transition instead of
+ * hard-cutting to the new scene. This PURE helper diffs the previous vs next
+ * fold-anchor map (each hidden node id → its group-node anchor, from
+ * `readFoldAnchors(computeGroupedGraph(...))`) into a transition descriptor the
+ * GraphCanvas consumes:
+ *
+ *   { direction: "collapse" | "expand", anchorByNodeId: Map<foldedId, groupId> }
+ *
+ *   - children present in NEXT but not PREV just FOLDED  ⇒ collapse candidates.
+ *   - children present in PREV but not NEXT just REVEALED ⇒ expand candidates.
+ *   - only-folded (none revealed)  ⇒ COLLAPSE (anchors read from the NEXT map:
+ *     the children are still on screen and tween toward their group node).
+ *   - only-revealed (none folded)  ⇒ EXPAND (anchors read from the PREV map: the
+ *     group is now gone, so its OLD anchor is where the children explode from).
+ *   - BOTH folded and revealed (a MIXED change, e.g. Domain→Sub-domain), or
+ *     neither (a no-op) ⇒ null (the caller hard-cuts — the safety fallback).
+ *
+ * Keying off the fold DELTA (not the grouped-key diff) makes the signal robust to
+ * the ontology artifact loading ASYNC: the collapse "lands" in whichever reactive
+ * tick the fold map actually populates, regardless of when the grouped key
+ * changed. Returns null when there is nothing to animate, so an absent descriptor
+ * always means "keep the current, non-animated behaviour".
+ *
+ * @param {object} args
+ * @param {Map<string,string>} [args.prevFoldAnchors]  fold map BEFORE the change.
+ * @param {Map<string,string>} [args.nextFoldAnchors]  fold map AFTER the change.
+ * @returns {{ direction: "collapse"|"expand", anchorByNodeId: Map<string,string> }|null}
+ */
+export function computeGroupTransition({ prevFoldAnchors, nextFoldAnchors } = {}) {
+  const prev = prevFoldAnchors instanceof Map ? prevFoldAnchors : new Map();
+  const next = nextFoldAnchors instanceof Map ? nextFoldAnchors : new Map();
+
+  const folded = new Map(); // newly folded: present in next, absent from prev
+  const revealed = new Map(); // newly revealed: present in prev, absent from next
+  for (const [childId, groupId] of next) if (!prev.has(childId)) folded.set(childId, groupId);
+  for (const [childId, groupId] of prev) if (!next.has(childId)) revealed.set(childId, groupId);
+
+  if (folded.size > 0 && revealed.size === 0) {
+    return { direction: "collapse", anchorByNodeId: folded };
+  }
+  if (revealed.size > 0 && folded.size === 0) {
+    return { direction: "expand", anchorByNodeId: revealed };
+  }
+  // Mixed (both folded and revealed) or a no-op → no animation (hard cut).
+  return null;
+}
+
+/* ===========================================================================
  * Tri-state bulk-button + NESTING-ABSORPTION math (spec §3/§4).
  * ======================================================================== */
 

--- a/studio/src/lib/hoverIntent.js
+++ b/studio/src/lib/hoverIntent.js
@@ -6,10 +6,11 @@
 // dim/undim.
 //
 // FIX: while NO selection AND NO focus exists, require the pointer to DWELL on an
-// object ~200ms before applying the rest-of-graph dim. If the pointer leaves the
-// object (or moves to empty space) before the dwell elapses, the dim is never
-// applied. Once a selection/focus exists, the dim stays IMMEDIATE — the
-// established behavior is unchanged; only the pre-first-selection path is gated.
+// object ~200ms before applying the rest-of-graph dim. Target changes — including
+// moving to empty space — also dwell before changing the transparency, so a
+// momentary gap does not flash the graph back to full opacity. Once a
+// selection/focus exists, changes stay IMMEDIATE — the established behavior is
+// unchanged; only the pre-first-selection path is gated.
 //
 // The hovered object's OWN feedback (tooltip + label + edge emphasis) is left
 // immediate by the caller; only the REST-OF-GRAPH dim flows through this gate.
@@ -55,10 +56,10 @@ export function createHoverIntent(apply, {
 
   /**
    * Request the dim for the CURRENT hover. `immediate` (a selection/focus is
-   * present, or the hover is clearing and must restore the base style now)
-   * applies it synchronously; otherwise the dim is deferred until the pointer
-   * dwells `delayMs`. Any prior pending dwell is cancelled first, so a hover
-   * target change restarts the dwell rather than firing early.
+   * present) applies it synchronously; otherwise the dim is deferred until the
+   * pointer dwells `delayMs`. Any prior pending dwell is cancelled first, so a
+   * hover target change — including empty space — restarts the dwell rather than
+   * changing transparency early.
    *
    * @param {{ immediate?: boolean }} [options]
    */

--- a/studio/src/lib/layoutWorker.js
+++ b/studio/src/lib/layoutWorker.js
@@ -1,0 +1,20 @@
+/**
+ * codeflow-parity Lot 7 — off-main-thread force layout worker.
+ *
+ * Runs the deterministic Barnes-Hut `computeLayout` (the same module the server
+ * build/export uses) in a Web Worker so a Spread/Links re-solve at scale never
+ * freezes the main thread. The client (`forceLayoutClient.js`) falls back to a
+ * synchronous solve when no Worker is available (SSR / jsdom tests), so this file
+ * is only ever loaded in a real browser.
+ */
+import { computeLayout } from "@graphify/graph-layout";
+
+self.onmessage = (event) => {
+  const { id, nodes, edges, options } = event.data ?? {};
+  try {
+    const positions = computeLayout(nodes ?? [], edges ?? [], options ?? {});
+    self.postMessage({ id, positions });
+  } catch (error) {
+    self.postMessage({ id, error: String(error?.message ?? error) });
+  }
+};

--- a/studio/src/lib/renderBackend.js
+++ b/studio/src/lib/renderBackend.js
@@ -24,6 +24,10 @@ export const WEBGL2_BACKEND = "webgl";
  *  - Mode B (webgl): the WebGL2 beta — instanced shapes/edges/boxes.
  */
 export function rendererOptionsFor(backend, pixelRatio) {
+  // scaleBordersWithZoom: the studio is an INTERACTIVE pan/zoom view, so node/box
+  // outlines scale with the camera zoom (proportional to the zoom-scaled node)
+  // instead of a fixed screen width that over-dominates a tiny node when zoomed
+  // out. It is a no-op at zoom=1, so goldens/other consumers are unaffected.
   if (backend === WEBGL2_BACKEND) {
     // Mode B (WebGL2 beta) requests a MULTISAMPLED context (antialias:true) so the
     // GPU edges + node-shape borders get MSAA smoothing — without it the beta read
@@ -31,9 +35,15 @@ export function rendererOptionsFor(backend, pixelRatio) {
     // honours options.antialias, which defaults to false). The Canvas2D branch and
     // the golden harness are intentionally left untouched (the golden capture keeps
     // its own deterministic context options).
-    return { backend: WEBGL2_BACKEND, instancedShapes: true, antialias: true, pixelRatio };
+    return {
+      backend: WEBGL2_BACKEND,
+      instancedShapes: true,
+      antialias: true,
+      scaleBordersWithZoom: true,
+      pixelRatio,
+    };
   }
-  return { backend: CANVAS2D_BACKEND, pixelRatio };
+  return { backend: CANVAS2D_BACKEND, scaleBordersWithZoom: true, pixelRatio };
 }
 
 /** Toggle between the two render modes (A ↔ B). */

--- a/studio/src/tests/classNodes.test.js
+++ b/studio/src/tests/classNodes.test.js
@@ -10,6 +10,7 @@ import {
   communityNodeId,
   mintCommunityNodeIds,
   nearestVisibleAncestor,
+  readFoldAnchors,
 } from "../lib/classNodes.js";
 import { buildScene, computeDegrees, computeGodClass } from "../lib/graphAdapter.js";
 
@@ -780,5 +781,77 @@ describe("B2 — T10 id-collision safety (A2, NORMATIVE)", () => {
     for (const [, count] of idCounts) expect(count).toBe(1);
     // The decoy real node still exists with its original id.
     expect(out.nodes.find((n) => n.id === "community-node:People").label).toBe("Decoy");
+  });
+});
+
+/* ===========================================================================
+ * Collapse/expand ANIMATION — fold-anchor metadata exposure (additive).
+ *
+ * applyGroupCollapse surfaces, for the studio's collapse/expand tween, each
+ * hidden (folded) node id → its group-node ANCHOR (the nearest collapsed
+ * ancestor). It is attached NON-ENUMERABLY and read only via readFoldAnchors, so
+ * no existing caller/test can observe it.
+ * ======================================================================== */
+describe("applyGroupCollapse — fold-anchor metadata (readFoldAnchors)", () => {
+  it("maps every folded descendant to its nearest collapsed ancestor (multi-level)", () => {
+    const g = injectedTaxonomyGraph();
+    // Collapse the intermediate class:Person → its whole subtree folds into it:
+    // class:Character, class:Villain (sub-classes) + holmes, watson, moriarty.
+    const out = applyOntologyCollapse(g, taxonomyHierarchies(), {
+      collapsedClassIds: ["class:Person"],
+    });
+    const anchors = readFoldAnchors(out);
+    expect(anchors).toBeInstanceOf(Map);
+    // Every hidden node folds into class:Person (the collapse target).
+    expect(anchors.get("holmes")).toBe("class:Person");
+    expect(anchors.get("watson")).toBe("class:Person");
+    expect(anchors.get("moriarty")).toBe("class:Person");
+    expect(anchors.get("class:Character")).toBe("class:Person");
+    expect(anchors.get("class:Villain")).toBe("class:Person");
+    // The target itself is visible, never folded into itself.
+    expect(anchors.has("class:Person")).toBe(false);
+    // Non-folded nodes (Place subtree) carry no anchor.
+    expect(anchors.has("baker")).toBe(false);
+    // Deterministic: same input → identical mapping.
+    const again = readFoldAnchors(
+      applyOntologyCollapse(g, taxonomyHierarchies(), { collapsedClassIds: ["class:Person"] }),
+    );
+    expect([...again.entries()].sort()).toEqual([...anchors.entries()].sort());
+  });
+
+  it("attributes each folded node to the NEAREST collapsed ancestor when nested", () => {
+    const g = injectedTaxonomyGraph();
+    // Collapse BOTH class:Person and its child class:Character. holmes/watson are
+    // under class:Character (nearer) → they fold into Character, not Person.
+    const out = applyOntologyCollapse(g, taxonomyHierarchies(), {
+      collapsedClassIds: ["class:Person", "class:Character"],
+    });
+    const anchors = readFoldAnchors(out);
+    expect(anchors.get("holmes")).toBe("class:Character");
+    expect(anchors.get("watson")).toBe("class:Character");
+    // moriarty (under class:Villain, not itself collapsed) folds to Person.
+    expect(anchors.get("moriarty")).toBe("class:Person");
+  });
+
+  it("is non-enumerable — invisible to spread / Object.keys / toEqual", () => {
+    const g = injectedTaxonomyGraph();
+    const out = applyOntologyCollapse(g, taxonomyHierarchies(), {
+      collapsedClassIds: ["class:Character"],
+    });
+    // The metadata does not leak into the enumerable graph shape.
+    expect(Object.keys(out)).toEqual(["nodes", "links"]);
+    const spread = { ...out };
+    expect(readFoldAnchors(spread).size).toBe(0);
+    // Still readable on the original object.
+    expect(readFoldAnchors(out).get("holmes")).toBe("class:Character");
+  });
+
+  it("returns an empty map for a graph with no fold metadata (fast path)", () => {
+    expect(readFoldAnchors(taxonomyGraph()).size).toBe(0);
+    expect(readFoldAnchors(null).size).toBe(0);
+    expect(readFoldAnchors(undefined).size).toBe(0);
+    // The engine fast-path (nothing collapsed) returns the input unchanged.
+    const g = injectedTaxonomyGraph();
+    expect(readFoldAnchors(applyGroupCollapse(g, { collapseTargets: [] })).size).toBe(0);
   });
 });

--- a/studio/src/tests/dualRenderBackend.test.js
+++ b/studio/src/tests/dualRenderBackend.test.js
@@ -38,6 +38,8 @@ describe("dual-render backend lib", () => {
   it("builds canvas2d options for mode A and webgl+instancedShapes for mode B", () => {
     expect(rendererOptionsFor(CANVAS2D_BACKEND, 2)).toEqual({
       backend: "canvas2d",
+      // Interactive views scale borders with zoom (no-op at zoom=1).
+      scaleBordersWithZoom: true,
       pixelRatio: 2,
     });
     expect(rendererOptionsFor(WEBGL2_BACKEND, 2)).toEqual({
@@ -46,6 +48,8 @@ describe("dual-render backend lib", () => {
       // Mode B requests a MULTISAMPLED context (#229) so GPU edges/borders get
       // MSAA smoothing — the lib returns antialias:true for WebGL2.
       antialias: true,
+      // Interactive views scale borders with zoom (no-op at zoom=1).
+      scaleBordersWithZoom: true,
       pixelRatio: 2,
     });
   });
@@ -73,7 +77,11 @@ describe("dual-render backend lib", () => {
     expect(out.backend).toBe(CANVAS2D_BACKEND);
     expect(out.fellBack).toBe(false);
     expect(create).toHaveBeenCalledTimes(1);
-    expect(create.mock.calls[0][1]).toEqual({ backend: "canvas2d", pixelRatio: 1 });
+    expect(create.mock.calls[0][1]).toEqual({
+      backend: "canvas2d",
+      scaleBordersWithZoom: true,
+      pixelRatio: 1,
+    });
   });
 
   it("mode B keeps webgl when a WebGL2 context is available", () => {
@@ -103,7 +111,11 @@ describe("dual-render backend lib", () => {
     expect(webglAttempt.destroy).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenCalledTimes(2);
     expect(create.mock.calls[0][1]).toMatchObject({ backend: "webgl", instancedShapes: true });
-    expect(create.mock.calls[1][1]).toEqual({ backend: "canvas2d", pixelRatio: 1 });
+    expect(create.mock.calls[1][1]).toEqual({
+      backend: "canvas2d",
+      scaleBordersWithZoom: true,
+      pixelRatio: 1,
+    });
   });
 
   it("mode B overlay paint clears then draws boxTextDraws()", () => {

--- a/studio/src/tests/forceLayoutClient.test.js
+++ b/studio/src/tests/forceLayoutClient.test.js
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { solveForce, terminateForceWorker, workerSupported } from "../lib/forceLayoutClient.js";
+
+// jsdom does not implement Worker, so `solveForce` takes the SYNCHRONOUS fallback
+// path (a real browser uses the worker). These tests pin the fallback contract.
+
+afterEach(() => {
+  terminateForceWorker();
+  vi.unstubAllGlobals();
+});
+
+describe("forceLayoutClient — synchronous fallback (no Worker)", () => {
+  it("reports no worker support in jsdom", () => {
+    expect(typeof Worker).toBe("undefined");
+    expect(workerSupported()).toBe(false);
+  });
+
+  it("solveForce resolves to one finite position per node, in input order", async () => {
+    const nodes = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const edges = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+    ];
+    const out = await solveForce(nodes, edges, { iterations: 60 });
+    expect(out).toHaveLength(3);
+    out.forEach((p, i) => {
+      expect(p.id).toBe(nodes[i].id);
+      expect(Number.isFinite(p.x)).toBe(true);
+      expect(Number.isFinite(p.y)).toBe(true);
+    });
+  });
+
+  it("honors repulsion / linkDistance / initialPositions options", async () => {
+    const nodes = [{ id: "a" }, { id: "b" }];
+    const edges = [{ source: "a", target: "b" }];
+    const initialPositions = new Map([
+      ["a", { x: 5, y: 5 }],
+      ["b", { x: 6, y: 6 }],
+    ]);
+    const tight = await solveForce(nodes, edges, { iterations: 180, linkDistance: 0.2 });
+    const loose = await solveForce(nodes, edges, { iterations: 180, linkDistance: 2 });
+    const dist = (o) => Math.hypot(o[0].x - o[1].x, o[0].y - o[1].y);
+    expect(dist(loose)).toBeGreaterThan(dist(tight));
+    // initialPositions is accepted (warm-start) without throwing.
+    const warm = await solveForce(nodes, edges, { iterations: 1, initialPositions });
+    expect(warm).toHaveLength(2);
+  });
+
+  it("resolves an empty graph to an empty array", async () => {
+    expect(await solveForce([], [], {})).toEqual([]);
+  });
+});

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -282,12 +282,12 @@ describe("GraphCanvas force Spread/Links controls (Lot 3)", () => {
   });
 });
 
-// --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder / Layer) ---
+// --- codeflow-parity Lots 4/5: Curved-links + Color-by controls -------------
 // jsdom can't mount the WebGL-bearing canvas, so (as with the Lot 1 switcher) we
-// assert against the .svelte SOURCE that the two controls are wired: gated on
+// assert against the .svelte SOURCE that the controls are wired: gated on
 // showLayoutSwitcher, they flip state and re-style LIVE via a payload rebuild that
 // preserves the camera (applyPayloadNoFit) — no morph, no layout recompute.
-describe("GraphCanvas Curved-links + Color-by controls (Lot 4)", () => {
+describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
   it("renders both DS controls inside the showLayoutSwitcher gate", () => {
     const source = graphCanvasSource();
     // Same workspace-only gate as the layout switcher.
@@ -295,9 +295,10 @@ describe("GraphCanvas Curved-links + Color-by controls (Lot 4)", () => {
       source.indexOf("{#if showLayoutSwitcher}"),
       source.indexOf("aria-label=\"Reset view\""),
     );
-    // Color-by segmented control (DS ButtonGroup over COLOR_MODES).
+    // Color-by segmented control (DS ButtonGroup over COLOR_MODES) + Churn legend.
     expect(gated).toContain("COLOR_MODES");
     expect(gated).toMatch(/onclick=\{\(\) => selectColorMode\(mode\.id\)\}/);
+    expect(gated).toContain('aria-label="Churn colour legend"');
     // Curved-links DS Switch.
     expect(gated).toContain("Switch");
     expect(gated).toContain('label="Curved links"');
@@ -309,6 +310,7 @@ describe("GraphCanvas Curved-links + Color-by controls (Lot 4)", () => {
     const source = graphCanvasSource();
     expect(source).toContain("COLOR_BY_FOLDER");
     expect(source).toContain("COLOR_BY_LAYER");
+    expect(source).toContain("COLOR_BY_CHURN");
     expect(source).toMatch(/import \{ Button, ButtonGroup, Switch \} from "@sentropic\/design-system-svelte"/);
   });
 

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -207,4 +207,36 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
     expect(source).toContain("captureForceBaseBuffer");
     expect(source).toContain("forceBuffer: forceBaseBuffer");
   });
+
+  // --- Review must-fixes (double-consensus) ---
+  it("F1: clears dragged positions on a layout switch so stale drags can't re-snap", () => {
+    const source = graphCanvasSource();
+    const driver = source.slice(
+      source.indexOf("function startLayoutMorph"),
+      source.indexOf("// Stable content signature of a scene"),
+    );
+    // A layout switch re-places every node → drop the stale Force-space drag map.
+    expect(driver).toContain("draggedPositions.clear()");
+    // resetLayoutState also clears it (scene change + abnormal-exit path).
+    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,400}draggedPositions\.clear\(\)/);
+  });
+
+  it("F2: a throwing morph frame unwinds instead of leaving the canvas locked", () => {
+    const source = graphCanvasSource();
+    const driver = source.slice(source.indexOf("function startLayoutMorph"));
+    // The frame body + the priming block are guarded, and the abort path
+    // restores a clean, interactive state (resetLayoutState → morphActive false).
+    expect(driver).toContain("abortMorph");
+    expect(driver).toMatch(/const abortMorph = \(\) => \{[\s\S]*resetLayoutState\(\);[\s\S]*fitAndRender\(\);/);
+    expect(driver).toMatch(/\} catch \{\s*\n\s*abortMorph\(\);/);
+  });
+
+  it("F3: honors prefers-reduced-motion by settling instantly (no tween)", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain('window.matchMedia("(prefers-reduced-motion: reduce)")');
+    const driver = source.slice(source.indexOf("function startLayoutMorph"));
+    // Reduced motion is part of the instant-settle guard (goes straight to settleLayout).
+    expect(driver).toMatch(/\|\| prefersReducedMotion\(\)\)/);
+    expect(driver).toMatch(/prefersReducedMotion\(\)\)[\s\S]{0,120}settleLayout\(/);
+  });
 });

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -449,6 +449,72 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
   });
 });
 
+// --- Configurable edge-transparency: Edge fade + Edge opacity controls -------
+// jsdom can't mount the WebGL canvas, so (as with the Lot 1/4/5 controls) we
+// assert against the .svelte SOURCE that the controls are wired: an Edge-fade
+// segmented group + an Edge-opacity slider in the gated Display section, both
+// re-styling LIVE via the same $effect that reacts to curvedLinks/colorMode.
+describe("GraphCanvas edge-transparency controls (Edge fade + Edge opacity)", () => {
+  const gatedSource = (source) =>
+    source.slice(
+      source.indexOf("{#if showLayoutSwitcher}"),
+      source.indexOf("<!-- Keyed on the active backend"),
+    );
+
+  it("imports the edge-alpha constants + default opacity", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("EDGE_ALPHA_DENSE");
+    expect(source).toContain("EDGE_ALPHA_INVERSE");
+    expect(source).toContain("EDGE_ALPHA_MID");
+    expect(source).toContain("EDGE_ALPHA_FLAT");
+    expect(source).toContain("DEFAULT_EDGE_OPACITY");
+  });
+
+  it("defaults to dense fade + the default edge opacity", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/let edgeAlphaMode = \$state\(EDGE_ALPHA_DENSE\)/);
+    expect(source).toMatch(/let edgeOpacity = \$state\(DEFAULT_EDGE_OPACITY\)/);
+  });
+
+  it("renders the Edge fade segmented group (English labels) + Edge opacity slider in the Display section", () => {
+    const source = graphCanvasSource();
+    const gated = gatedSource(source);
+    // Segmented Edge-fade control over EDGE_FADE_MODES.
+    expect(gated).toContain("EDGE_FADE_MODES");
+    expect(gated).toContain('class="edge-fade-switcher"');
+    expect(gated).toMatch(/onclick=\{\(\) => selectEdgeAlphaMode\(mode\.id\)\}/);
+    expect(gated).toContain('aria-label={`Edge fade ${mode.label}`}');
+    // English labels for every mode.
+    expect(source).toMatch(/\{ id: EDGE_ALPHA_DENSE, label: "Dense" \}/);
+    expect(source).toMatch(/\{ id: EDGE_ALPHA_INVERSE, label: "Inverse" \}/);
+    expect(source).toMatch(/\{ id: EDGE_ALPHA_MID, label: "Mid" \}/);
+    expect(source).toMatch(/\{ id: EDGE_ALPHA_FLAT, label: "Flat" \}/);
+    // Native range slider for the base opacity.
+    expect(gated).toContain('aria-label="Edge opacity"');
+    expect(gated).toMatch(/type="range"[\s\S]{0,120}min="0\.1"[\s\S]{0,120}max="0\.8"/);
+    expect(gated).toMatch(/oninput=\{\(event\) => \(edgeOpacity = Number\(event\.currentTarget\.value\)\)\}/);
+  });
+
+  it("passes edgeAlphaMode + edgeOpacity through rebuildPayload", () => {
+    const source = graphCanvasSource();
+    const rebuild = source.slice(
+      source.indexOf("function rebuildPayload"),
+      source.indexOf("function reapplyLayoutPositions"),
+    );
+    expect(rebuild).toContain("edgeAlphaMode,");
+    expect(rebuild).toContain("edgeOpacity,");
+  });
+
+  it("re-styles LIVE from the SAME effect (new deps added, untrack kept)", () => {
+    const source = graphCanvasSource();
+    // The curved/color effect now also reads edgeAlphaMode + edgeOpacity, and
+    // still wraps the imperative work in untrack (edge-hover fix must survive).
+    expect(source).toMatch(
+      /curvedLinks;\s*\n\s*colorMode;[\s\S]*?edgeAlphaMode;\s*\n\s*edgeOpacity;[\s\S]*?untrack\(\(\) => updateDisplayStyle\(\)\);/,
+    );
+  });
+});
+
 // --- Studio representation-polish remarks 4/5/6: gear-menu settings popover -
 describe("GraphCanvas settings popover (remarks 4/5/6)", () => {
   const toolbarGate = (source) =>

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -397,7 +397,7 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
     // Color-by segmented control (DS ButtonGroup over COLOR_MODES) + Churn legend.
     expect(gated).toContain("COLOR_MODES");
     expect(gated).toMatch(/onclick=\{\(\) => selectColorMode\(mode\.id\)\}/);
-    expect(gated).toContain('aria-label="Churn colour legend"');
+    expect(gated).toContain('aria-label="Degré colour legend"');
     // Curved-links DS Switch.
     expect(gated).toContain("Switch");
     expect(gated).toContain('label="Curved links"');
@@ -434,8 +434,10 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
 
   it("a control change re-styles LIVE (rebuild + applyPayloadNoFit, no morph/fit)", () => {
     const source = graphCanvasSource();
-    // Reactive effect reads both deps and calls the live re-style.
-    expect(source).toMatch(/curvedLinks;\s*\n\s*colorMode;\s*\n\s*updateDisplayStyle\(\);/);
+    // Reactive effect reads both deps and calls the live re-style. The imperative
+    // work is untrack()ed so the effect depends ONLY on curvedLinks/colorMode (not
+    // on hoveredNodeId, which rebuildPayload reads — see the edge-hover fix).
+    expect(source).toMatch(/curvedLinks;\s*\n\s*colorMode;[\s\S]*?untrack\(\(\) => updateDisplayStyle\(\)\);/);
     const restyle = source.slice(
       source.indexOf("function updateDisplayStyle"),
       source.indexOf("function toggleCurvedLinks"),

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -240,3 +240,64 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
     expect(driver).toMatch(/prefersReducedMotion\(\)\)[\s\S]{0,120}settleLayout\(/);
   });
 });
+
+// --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder / Layer) ---
+// jsdom can't mount the WebGL-bearing canvas, so (as with the Lot 1 switcher) we
+// assert against the .svelte SOURCE that the two controls are wired: gated on
+// showLayoutSwitcher, they flip state and re-style LIVE via a payload rebuild that
+// preserves the camera (applyPayloadNoFit) — no morph, no layout recompute.
+describe("GraphCanvas Curved-links + Color-by controls (Lot 4)", () => {
+  it("renders both DS controls inside the showLayoutSwitcher gate", () => {
+    const source = graphCanvasSource();
+    // Same workspace-only gate as the layout switcher.
+    const gated = source.slice(
+      source.indexOf("{#if showLayoutSwitcher}"),
+      source.indexOf("aria-label=\"Reset view\""),
+    );
+    // Color-by segmented control (DS ButtonGroup over COLOR_MODES).
+    expect(gated).toContain("COLOR_MODES");
+    expect(gated).toMatch(/onclick=\{\(\) => selectColorMode\(mode\.id\)\}/);
+    // Curved-links DS Switch.
+    expect(gated).toContain("Switch");
+    expect(gated).toContain('label="Curved links"');
+    expect(gated).toContain("checked={curvedLinks}");
+    expect(gated).toContain("onchange={toggleCurvedLinks}");
+  });
+
+  it("imports the color-by constants + DS Switch", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("COLOR_BY_FOLDER");
+    expect(source).toContain("COLOR_BY_LAYER");
+    expect(source).toMatch(/import \{ Button, ButtonGroup, Switch \} from "@sentropic\/design-system-svelte"/);
+  });
+
+  it("defaults match today's behaviour (curved ON, colour by Folder)", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/let curvedLinks = \$state\(true\)/);
+    expect(source).toMatch(/let colorMode = \$state\(COLOR_BY_FOLDER\)/);
+  });
+
+  it("passes colorBy + curvedLinks through rebuildPayload", () => {
+    const source = graphCanvasSource();
+    const rebuild = source.slice(
+      source.indexOf("function rebuildPayload"),
+      source.indexOf("function reapplyLayoutPositions"),
+    );
+    expect(rebuild).toContain("colorBy: colorMode");
+    expect(rebuild).toContain("curvedLinks,");
+  });
+
+  it("a control change re-styles LIVE (rebuild + applyPayloadNoFit, no morph/fit)", () => {
+    const source = graphCanvasSource();
+    // Reactive effect reads both deps and calls the live re-style.
+    expect(source).toMatch(/curvedLinks;\s*\n\s*colorMode;\s*\n\s*updateDisplayStyle\(\);/);
+    const restyle = source.slice(
+      source.indexOf("function updateDisplayStyle"),
+      source.indexOf("function toggleCurvedLinks"),
+    );
+    // No re-fit (preserve camera) and no morph — same shape as updateSelection.
+    expect(restyle).toContain("applyPayloadNoFit()");
+    expect(restyle).not.toContain("fitAndRender");
+    expect(restyle).not.toContain("startLayoutMorph");
+  });
+});

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -163,8 +163,10 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
       source.indexOf("function startLayoutMorph"),
       source.indexOf("// Stable content signature of a scene"),
     );
-    // CAPTURE the current on-screen buffer as bufA.
-    expect(driver).toMatch(/new Float32Array\(current\)/);
+    // CAPTURE the current on-screen buffer as bufA (via the shared helper so
+    // Lot 3 force re-solves can warm-start from the same source of truth).
+    expect(source).toContain("function currentLayoutBuffer");
+    expect(driver).toContain("currentLayoutBuffer()");
     // COMPUTE the target buffer for the chosen mode.
     expect(driver).toContain("computeLayoutBuffer(payload, mode");
     // DRIVE the tween through the all-node morph + renderer.setPositions.
@@ -185,8 +187,8 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
 
   it("re-seeds bufA from the LIVE buffer on interrupt, never snapping to base", () => {
     const source = graphCanvasSource();
-    const driver = source.slice(source.indexOf("function startLayoutMorph"));
-    expect(driver).toMatch(
+    const helper = source.slice(source.indexOf("function currentLayoutBuffer"));
+    expect(helper).toMatch(
       /layoutMorphFrame !== null && liveMorphBuffer\s*\n?\s*\?\s*new Float32Array\(liveMorphBuffer\)/,
     );
   });
@@ -238,6 +240,45 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
     // Reduced motion is part of the instant-settle guard (goes straight to settleLayout).
     expect(driver).toMatch(/\|\| prefersReducedMotion\(\)\)/);
     expect(driver).toMatch(/prefersReducedMotion\(\)\)[\s\S]{0,120}settleLayout\(/);
+  });
+});
+
+// --- codeflow-parity Lot 3: Spread/Links force re-solve controls -------------
+describe("GraphCanvas force Spread/Links controls (Lot 3)", () => {
+  it("renders Spread/Links sliders + Reset inside the workspace toolbar gate", () => {
+    const source = graphCanvasSource();
+    const gated = source.slice(
+      source.indexOf("{#if showLayoutSwitcher}"),
+      source.indexOf("aria-label=\"Reset view\""),
+    );
+    expect(gated).toContain('aria-label="Force spacing controls"');
+    expect(gated).toContain('aria-label="Spread"');
+    expect(gated).toContain('aria-label="Links"');
+    expect(gated).toContain('aria-label="Reset layout"');
+  });
+
+  it("maps Spread→repulsion and Links→linkDistance, warm-starting interactive solves", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain('import { computeLayout } from "@graphify/graph-layout"');
+    const solve = source.slice(
+      source.indexOf("function computeForceRelayoutBuffer"),
+      source.indexOf("function resetForceLayout"),
+    );
+    expect(solve).toContain("repulsion: forceSpread");
+    expect(solve).toContain("linkDistance: forceLinks");
+    expect(solve).toContain("initialPositions");
+    expect(source).toMatch(/function commitForceSpread[\s\S]*resolveForceLayout\(\{ warmStart: true \}\)/);
+    expect(source).toMatch(/function commitForceLinks[\s\S]*resolveForceLayout\(\{ warmStart: true \}\)/);
+  });
+
+  it("debounces expensive solves to drag-end and keeps Reset cold/deterministic", () => {
+    const source = graphCanvasSource();
+    const gated = source.slice(source.indexOf('aria-label="Force spacing controls"'));
+    expect(gated).toMatch(/oninput=\{\(event\) => \(forceSpread = Number\(event\.currentTarget\.value\)\)\}/);
+    expect(gated).toMatch(/onchange=\{commitForceSpread\}/);
+    expect(gated).toMatch(/oninput=\{\(event\) => \(forceLinks = Number\(event\.currentTarget\.value\)\)\}/);
+    expect(gated).toMatch(/onchange=\{commitForceLinks\}/);
+    expect(source).toMatch(/function resetForceLayout\(\) \{\s*resolveForceLayout\(\{ warmStart: false \}\);\s*\}/);
   });
 });
 

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -6,6 +6,16 @@ import { describe, expect, it } from "vitest";
 const graphCanvasSource = () =>
   readFileSync(resolve("src/components/GraphCanvas.svelte"), "utf8");
 
+// resetLayoutState()'s own body, bounded to the NEXT function — used instead
+// of a fixed-size [\s\S]{0,N} window so a comment added anywhere inside it
+// (e.g. remark 2/7's hoverIntent.cancel() / cancelCameraTween() cleanup)
+// can't silently push a later assertion out of range.
+const resetLayoutStateBody = (source) =>
+  source.slice(
+    source.indexOf("function resetLayoutState"),
+    source.indexOf("function currentLayoutBuffer"),
+  );
+
 describe("GraphCanvas renderer", () => {
   it("uses the @sentropic/graph renderer instead of the design-system ForceGraph", () => {
     const source = graphCanvasSource();
@@ -181,8 +191,15 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
     // Interaction is locked (pointer/click/wheel guarded on morphActive).
     expect(source).toMatch(/function handlePointerMove[\s\S]{0,120}if \(morphActive\) return;/);
     expect(source).toMatch(/function handleWheel[\s\S]{0,120}if \(morphActive\)/);
-    // Exactly one deliberate end-fit at settle.
-    expect(source).toMatch(/function settleLayout[\s\S]*fitAndRender\(\);/);
+    // Exactly one deliberate end-fit at settle. Remark 7: it's the ANIMATED
+    // fit (camera tweens to the target instead of snapping), not the instant
+    // one used by mount/resize/"Reset view".
+    const settle = source.slice(
+      source.indexOf("function settleLayout"),
+      source.indexOf("function startLayoutMorph"),
+    );
+    expect(settle).toContain("animateFitAndRender();");
+    expect(settle).not.toMatch(/(?<!animate)fitAndRender\(\);/);
   });
 
   it("re-seeds bufA from the LIVE buffer on interrupt, never snapping to base", () => {
@@ -220,7 +237,7 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
     // A layout switch re-places every node → drop the stale Force-space drag map.
     expect(driver).toContain("draggedPositions.clear()");
     // resetLayoutState also clears it (scene change + abnormal-exit path).
-    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,700}draggedPositions\.clear\(\)/);
+    expect(resetLayoutStateBody(source)).toContain("draggedPositions.clear()");
   });
 
   it("F2: a throwing morph frame unwinds instead of leaving the canvas locked", () => {
@@ -278,7 +295,7 @@ describe("GraphCanvas force Spread/Links controls (Lot 3)", () => {
     // A solve resolving after the scene changed is dropped (token mismatch).
     expect(source).toMatch(/const token = \+\+forceSolveToken;[\s\S]*token !== forceSolveToken/);
     // resetLayoutState invalidates in-flight solves.
-    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,400}forceSolveToken\+\+/);
+    expect(resetLayoutStateBody(source)).toContain("forceSolveToken++");
     // The worker is torn down when the component is destroyed.
     expect(source).toMatch(/onDestroy\([\s\S]*terminateForceWorker\(\)/);
   });
@@ -315,7 +332,7 @@ describe("GraphCanvas Lot 7 review must-fixes (double-consensus)", () => {
     // are re-applied across a rebuild too, not just non-force layouts).
     expect(source).toMatch(/function reapplyLayoutPositions[\s\S]*morphActive \? liveMorphBuffer : activeLayoutBuffer/);
     // A genuine scene change still nulls it (a NEW scene must use scene positions).
-    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,400}activeLayoutBuffer = null/);
+    expect(resetLayoutStateBody(source)).toContain("activeLayoutBuffer = null");
   });
 
   it("SERIOUS-2: a late Force solve is discarded when the user switched away from Force", () => {
@@ -372,7 +389,10 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
     expect(source).toContain("COLOR_BY_FOLDER");
     expect(source).toContain("COLOR_BY_LAYER");
     expect(source).toContain("COLOR_BY_CHURN");
-    expect(source).toMatch(/import \{ Button, ButtonGroup, Switch \} from "@sentropic\/design-system-svelte"/);
+    // Remark 4: the toolbar now also imports IconButton + Popover (gear menu).
+    expect(source).toMatch(
+      /import \{ Button, ButtonGroup, IconButton, Popover, Switch \} from "@sentropic\/design-system-svelte"/,
+    );
   });
 
   it("defaults match today's behaviour (curved ON, colour by Folder)", () => {
@@ -403,5 +423,115 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
     expect(restyle).toContain("applyPayloadNoFit()");
     expect(restyle).not.toContain("fitAndRender");
     expect(restyle).not.toContain("startLayoutMorph");
+  });
+});
+
+// --- Studio representation-polish remarks 4/5/6: gear-menu settings popover -
+describe("GraphCanvas settings popover (remarks 4/5/6)", () => {
+  const toolbarGate = (source) =>
+    source.slice(source.indexOf("{#if showLayoutSwitcher}"), source.indexOf('aria-label="Reset view"'));
+
+  it("R4: collapses layout/spacing/display behind a gear IconButton + Popover, gated on showLayoutSwitcher", () => {
+    const source = graphCanvasSource();
+    const gated = toolbarGate(source);
+    expect(gated).toContain("<Popover");
+    expect(gated).toContain('label="Graph display settings"');
+    expect(gated).toContain("<IconButton");
+    expect(gated).toContain('aria-label="Graph display settings"');
+    expect(gated).toContain("onclick={toggleSettings}");
+    // The 3 sections codeflow's own settings popover uses.
+    expect(gated).toContain('aria-label="Layout"');
+    expect(gated).toContain('aria-label="Spacing"');
+    expect(gated).toContain('aria-label="Display"');
+    expect(gated).toContain(">Layout<");
+    expect(gated).toContain(">Spacing<");
+    expect(gated).toContain(">Display<");
+    // Every control that used to sit directly in the toolbar row now lives
+    // inside the popover panel.
+    expect(gated).toContain("layout-switcher");
+    expect(gated).toContain("force-sliders-row");
+    expect(gated).toContain("color-switcher");
+    expect(gated).toContain("curved-links-toggle");
+  });
+
+  it("R4: the gear toggles `settingsOpen`, dismissed on outside click / Escape", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/let settingsOpen = \$state\(false\)/);
+    expect(source).toMatch(/function toggleSettings\(\)\s*\{\s*settingsOpen = !settingsOpen;/);
+    expect(source).toContain("handleSettingsWindowPointerDown");
+    expect(source).toContain("handleSettingsWindowKeydown");
+    expect(source).toMatch(/event\.key === "Escape"/);
+    expect(source).toContain('window.addEventListener("pointerdown", handleSettingsWindowPointerDown)');
+    expect(source).toContain('window.removeEventListener("pointerdown", handleSettingsWindowPointerDown)');
+  });
+
+  it("R5: every DS control inside the panel is size=\"sm\", overridden to the compact Reset-button font scale", () => {
+    const source = graphCanvasSource();
+    const panel = source.slice(source.indexOf('{#snippet children()}'), source.indexOf('{/snippet}\n        </Popover>'));
+    // No lg/md controls snuck in — every Button/ButtonGroup in the panel is sm.
+    expect(panel).not.toMatch(/size="lg"/);
+    expect(panel).not.toMatch(/size="md"/);
+    const buttonCount = (panel.match(/<Button\b/g) ?? []).length;
+    const smCount = (panel.match(/size="sm"/g) ?? []).length;
+    expect(buttonCount).toBeGreaterThan(0);
+    expect(smCount).toBeGreaterThanOrEqual(buttonCount);
+    // The compact font-scale override matches the Reset button's own 0.75rem.
+    const style = source.slice(source.indexOf("<style>"));
+    expect(style).toMatch(/\.graph-settings-panel\s*\{[^}]*font-size:\s*0\.75rem/);
+    expect(style).toMatch(/--st-component-button-anatomy-density-sm-fontSize:\s*0\.75rem/);
+    expect(style).toMatch(/\.graph-settings-panel :global\(\.st-switch__label\)\s*\{\s*font-size:\s*0\.75rem/);
+  });
+
+  it("R6: Spread/Links sit on their own row and are disabled whenever layoutMode isn't Force", () => {
+    const source = graphCanvasSource();
+    const gated = toolbarGate(source);
+    const sliders = gated.slice(gated.indexOf("force-sliders-row"), gated.indexOf("force-reset-row"));
+    // Both sliders (and their wrapping labels) are disabled off-Force.
+    // (?<!-) excludes the tail of "class:is-disabled={...}" (below), which
+    // would otherwise also match the plain "disabled={...}" substring.
+    expect((sliders.match(/(?<!-)disabled=\{layoutMode !== LAYOUT_MODE_FORCE\}/g) ?? []).length).toBe(2);
+    expect((sliders.match(/class:is-disabled=\{layoutMode !== LAYOUT_MODE_FORCE\}/g) ?? []).length).toBe(2);
+    // Reset (same force re-solve) is disabled off-Force too.
+    const resetRow = gated.slice(gated.indexOf("force-reset-row"));
+    expect(resetRow).toMatch(/aria-label="Reset layout"[\s\S]{0,80}disabled=\{layoutMode !== LAYOUT_MODE_FORCE\}/);
+  });
+});
+
+// --- Studio representation-polish remark 7: smooth camera recenter ---------
+describe("GraphCanvas smooth recenter (remark 7)", () => {
+  it("settleLayout tweens the camera to the fit target instead of snapping", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("function animateFitAndRender");
+    // Shares the node-morph's duration + easing so the recenter reads as one
+    // continuous motion with the just-finished layout morph.
+    expect(source).toMatch(/function animateFitAndRender[\s\S]*LAYOUT_MORPH_DURATION_MS/);
+    expect(source).toMatch(/function animateFitAndRender[\s\S]*easeMergeProgress/);
+    expect(source).toMatch(/function animateFitAndRender[\s\S]*renderer\.setCamera\(camera\)/);
+    // §F3 parity: reduced-motion snaps instead of tweening.
+    expect(source).toMatch(/function animateFitAndRender[\s\S]{0,800}prefersReducedMotion\(\)/);
+  });
+
+  it("mount/resize/Reset-view keep the INSTANT fit; only settleLayout uses the tween", () => {
+    const source = graphCanvasSource();
+    const applyPayload = source.slice(
+      source.indexOf("function applyPayload()"),
+      source.indexOf("function applyPayloadNoFit"),
+    );
+    expect(applyPayload).toContain("fitAndRender();");
+    expect(applyPayload).not.toContain("animateFitAndRender");
+    expect(source).toMatch(/aria-label="Reset view"[\s\S]{0,40}onclick=\{fitAndRender\}/);
+  });
+
+  it("cancels the camera tween when a new interaction/morph supersedes it", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("function cancelCameraTween");
+    // A new node morph, a scene reset, and starting to pan/zoom all cancel a
+    // stale camera tween instead of fighting it.
+    expect(source).toMatch(/function startLayoutMorphToBuffer[\s\S]{0,700}cancelCameraTween\(\);/);
+    expect(resetLayoutStateBody(source)).toContain("cancelCameraTween();");
+    expect(source).toMatch(/function handlePointerDown[\s\S]{0,400}cancelCameraTween\(\);/);
+    expect(source).toMatch(/function handleWheel[\s\S]{0,400}cancelCameraTween\(\);/);
+    // Cleaned up on unmount so no stray rAF outlives the component.
+    expect(source).toMatch(/cancelLayoutMorphFrame\(\);\s*\n\s*cancelCameraTween\(\);/);
   });
 });

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -651,13 +651,18 @@ describe("GraphCanvas smooth recenter (remark 7)", () => {
   });
 });
 
-// --- Collapse/expand GROUP transition animation ------------------------------
+// --- Collapse/expand GROUP transition animation (redesign spec §3) ----------
 // jsdom has no WebGL (like the merge/layout-morph tests above), so we assert
-// against the .svelte SOURCE that the animated group/ungroup transition is
-// wired: an optional groupTransition prop, a scene-effect hook that hands off to
-// the driver (with a hard-cut fallback), and a driver that REUSES morphPositions
-// + the merge-fade style on the same rAF loop, locking interaction via
-// morphActive exactly like the layout morph.
+// against the .svelte SOURCE that the CORRECTED animated group/ungroup transition
+// is wired: an optional groupTransition prop; a scene-effect that consumes the
+// descriptor ONCE and hands off to the driver; a driver that swaps through the
+// position-preserving applyCarriedScene (NEVER a refit) — collapse tweens on the
+// OLD payload then carried-swaps, expand carried-swaps FIRST then tweens on the
+// NEW payload; a groupSwapPending deferral + selectedIds content-signature that
+// stop the same-flush rebuild that killed collapse (RC-B); and settleGroupTween
+// persisting the layout buffer (RC-E). The BEHAVIOURAL maths of the swap/fan/fold
+// (carryScenePositions / goldenAngleFan / resolveGroupFolds) are unit-tested in
+// graphRendererPayload.test.js.
 describe("GraphCanvas collapse/expand group transition", () => {
   const driverSource = (source) =>
     source.slice(
@@ -670,35 +675,120 @@ describe("GraphCanvas collapse/expand group transition", () => {
     expect(source).toMatch(/groupTransition = null,/);
   });
 
-  it("the scene-effect tries the animated transition, falling back to the hard cut", () => {
+  it("consumes the descriptor ONCE and hands off to the driver, falling back to refit", () => {
     const source = graphCanvasSource();
     // untrack so groupTransition is not a hidden dependency of the scene effect.
-    expect(source).toMatch(/const transition = untrack\(\(\) => groupTransition\);/);
-    expect(source).toMatch(/untrack\(\(\) => tryStartGroupTransition\(transition\)\)/);
-    // A redundant scene re-derivation must not cancel an in-flight tween.
-    expect(source).toMatch(/if \(groupTweenFrame !== null && !transition\) return;/);
-    // On a handled transition the effect returns before the hard refit; otherwise
-    // it still runs resetLayoutState(); updateGraph(); (the safety fallback).
+    expect(source).toMatch(/const raw = untrack\(\(\) => groupTransition\);/);
+    // RC-D: consumed-once reference guard — only a GENUINELY new descriptor is fresh.
+    expect(source).toMatch(/const fresh = raw && raw !== lastConsumedGroupTransition \? raw : null;/);
+    expect(source).toMatch(/if \(fresh\) lastConsumedGroupTransition = raw;/);
+    expect(source).toMatch(/untrack\(\(\) => tryStartGroupTransition\(fresh\)\)/);
+    // A redundant tick (no fresh descriptor) mid-tween must NOT rebuild.
+    expect(source).toMatch(/if \(groupTweenFrame !== null && !fresh\) return;/);
+    // §3.7 interrupt: a genuine new transition mid-tween completes the pending swap
+    // synchronously before starting the next one.
     expect(source).toMatch(
-      /tryStartGroupTransition\(transition\)\)\) return;\s*\n[\s\S]{0,240}resetLayoutState\(\);\s*\n\s*updateGraph\(\);/,
+      /if \(groupTweenFrame !== null && fresh && pendingGroupSettle\) \{\s*\n\s*cancelGroupTweenFrame\(\);\s*\n\s*pendingGroupSettle\(\);/,
+    );
+    // On a handled transition the effect returns before the refit; otherwise the
+    // genuine non-group scene change bumps the epoch then resetLayoutState/updateGraph.
+    expect(source).toMatch(
+      /tryStartGroupTransition\(fresh\)\)\) return;\s*\n[\s\S]{0,320}coordinateEpoch \+= 1;\s*\n\s*resetLayoutState\(\);\s*\n\s*updateGraph\(\);/,
     );
   });
 
-  it("collapse keeps the old scene, tweens folding nodes to their anchor, then swaps", () => {
+  it("collapse snapshots first, tweens on the OLD payload, then carried-swaps (no refit)", () => {
     const source = graphCanvasSource();
     const driver = driverSource(source);
-    // COLLAPSE builds bufA/bufB against the CURRENT (pre-collapse) payload and
-    // swaps to the collapsed scene at t=1 (resetLayoutState → updateGraph).
     expect(driver).toContain("function startCollapseTween");
-    expect(driver).toMatch(/fadeOut: true[\s\S]{0,200}resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+    // Snapshot the OLD on-screen positions BEFORE the swap (carriedPosById).
+    expect(driver).toMatch(/const oldPos = currentPositionMap\(\) \?\? new Map\(\);[\s\S]{0,200}collectGroupFolds\(anchors\)/);
+    // Defers concurrent selection rebuilds while the tween runs (RC-B).
+    expect(driver).toMatch(/groupSwapPending = true;/);
+    // At t=1 it finishes via finishCollapseSwap — NOT resetLayoutState/updateGraph.
+    expect(driver).toMatch(/fadeOut: true[\s\S]{0,160}onDone: \(\) => pendingGroupSettle\?\.\(\)/);
+    expect(driver).toContain("function finishCollapseSwap");
+    expect(driver).toMatch(/function finishCollapseSwap[\s\S]{0,400}applyCarriedScene\(\{ carriedPosById: oldPos/);
+    // The collapse path never hard-refits (no resetLayoutState();updateGraph(); pair).
+    const collapse = source.slice(source.indexOf("function startCollapseTween"), source.indexOf("function finishCollapseSwap"));
+    expect(collapse).not.toMatch(/resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
   });
 
-  it("expand swaps first, then tweens the revealed nodes OUT from their anchor", () => {
+  it("expand captures the anchor PRE-swap, carried-swaps FIRST, then tweens on the new payload", () => {
     const source = graphCanvasSource();
     const driver = driverSource(source);
-    // EXPAND swaps to the expanded scene FIRST (updateGraph), then fades IN.
-    expect(driver).toMatch(/function startExpandTween[\s\S]{0,200}resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+    // RC-C: snapshot + per-group anchor captured BEFORE the swap.
+    expect(driver).toMatch(/function startExpandTween[\s\S]{0,320}const oldPos = currentPositionMap\(\)/);
+    expect(driver).toMatch(/anchorPosByGroup\.set\(groupId, \{ x: p\.x, y: p\.y \}\)/);
+    // Carried swap FIRST (children stacked on the anchor), then resolve on the NEW payload.
+    expect(driver).toMatch(/applyCarriedScene\(\{ carriedPosById: oldPos, placedPosById \}\);\s*\n\s*\/\/ 3\. Resolve the revealed children against the NEW payload\.\s*\n\s*const info = collectGroupFolds\(anchors\);/);
+    // Targets come from the cache-or-fan helper; tween fades IN.
+    expect(driver).toContain("computeExpandTargets(groupMembers, postAnchor, positions)");
     expect(driver).toMatch(/fadeOut: false/);
+    // Expand never hard-refits either.
+    const expand = source.slice(source.indexOf("function startExpandTween"), source.indexOf("function computeExpandTargets"));
+    expect(expand).not.toMatch(/resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+  });
+
+  it("applyCarriedScene rebuilds, carries by id, persists the layout buffer, and never refits", () => {
+    const source = graphCanvasSource();
+    const carried = source.slice(
+      source.indexOf("function applyCarriedScene"),
+      source.indexOf("// Resolve the folding/revealing children"),
+    );
+    // Rebuild the NEW scene, then OVERWRITE positions by id via the pure carry core.
+    expect(carried).toContain("rebuildPayload();");
+    expect(carried).toContain("carryScenePositions({");
+    // RC-E: persist so later rebuilds don't re-derive scene-baked coords + jump.
+    expect(carried).toContain("activeLayoutBuffer = new Float32Array(graph.positions)");
+    expect(carried).toContain("forceBaseBuffer = new Float32Array(graph.positions)");
+    // Ends with the no-fit apply — never fitAndRender.
+    expect(carried).toContain("applyPayloadNoFit()");
+    expect(carried).not.toMatch(/(?<!animate)fitAndRender\(/);
+  });
+
+  it("settleGroupTween persists activeLayoutBuffer/forceBaseBuffer + clears the swap flag (RC-E)", () => {
+    const source = graphCanvasSource();
+    const settle = source.slice(
+      source.indexOf("function settleGroupTween"),
+      source.indexOf("function runGroupTween"),
+    );
+    expect(settle).toContain("activeLayoutBuffer = new Float32Array(positions)");
+    expect(settle).toContain("forceBaseBuffer = new Float32Array(positions)");
+    expect(settle).toContain("groupSwapPending = false");
+    // Refreshes the expand-restore cache for the settled ids.
+    expect(settle).toContain("lastKnownPosById.set");
+  });
+
+  it("defers selection/display rebuilds under a collapse tween, applying once post-swap (RC-B)", () => {
+    const source = graphCanvasSource();
+    // Both restyle paths bail out while groupSwapPending, queuing a single restyle.
+    const selection = source.slice(
+      source.indexOf("function updateSelection"),
+      source.indexOf("function updateDisplayStyle"),
+    );
+    expect(selection).toMatch(/if \(groupSwapPending\) \{\s*\n\s*pendingPostSwapRestyle = true;\s*\n\s*return;/);
+    const display = source.slice(
+      source.indexOf("function updateDisplayStyle"),
+      source.indexOf("function toggleCurvedLinks"),
+    );
+    expect(display).toMatch(/if \(groupSwapPending\) \{\s*\n\s*pendingPostSwapRestyle = true;\s*\n\s*return;/);
+    // The deferred restyle is flushed ONCE inside the settle.
+    expect(source).toMatch(/if \(pendingPostSwapRestyle\) \{\s*\n\s*pendingPostSwapRestyle = false;\s*\n\s*updateSelection\(\);/);
+  });
+
+  it("hardens the selection $effect with a content signature (fresh-array no-op guard, §3.3)", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("function selectionSignature");
+    expect(source).toMatch(/const key = selectionSignature\(selectedIds, focusId\);/);
+    expect(source).toMatch(/if \(key === lastSelectionKey\) return;/);
+    // The untrack on updateSelection MUST survive (edge-hover / hidden-dep fix).
+    expect(source).toMatch(/untrack\(\(\) => updateSelection\(\)\);/);
+  });
+
+  it("a layout-mode switch is a no-op while a group tween owns the payload (§3.3)", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/function selectLayoutMode\(mode\) \{\s*\n[\s\S]{0,300}if \(groupTweenFrame !== null\) return;/);
   });
 
   it("REUSES morphPositions + the merge-fade style on the rAF loop, locking morphActive", () => {
@@ -717,17 +807,18 @@ describe("GraphCanvas collapse/expand group transition", () => {
     expect(driver).toContain("window.requestAnimationFrame(step)");
   });
 
-  it("SAFETY: no renderer / no matching child / SSR / reduced-motion falls back cleanly", () => {
+  it("SAFETY: no renderer / SSR / reduced-motion / abnormal frame settle position-preserving", () => {
     const source = graphCanvasSource();
     const driver = driverSource(source);
-    // tryStart returns false (→ hard cut) without a renderer/payload/anchors.
-    expect(driver).toMatch(/function tryStartGroupTransition[\s\S]{0,220}return false;/);
-    // collectGroupFolds returns null when NO folding child is on screen.
-    expect(driver).toMatch(/if \(!info\) return false;/);
-    // The tween honours prefers-reduced-motion + missing rAF (instant settle).
+    // tryStart returns false (→ refit fallback) without a renderer/payload/anchors.
+    expect(driver).toMatch(/function tryStartGroupTransition[\s\S]{0,260}return false;/);
+    // An EMPTY on-screen fold set is NOT a hard cut — collapse still carried-swaps.
+    expect(driver).toMatch(/if \(!info\) \{\s*\n[\s\S]{0,200}finishCollapseSwap\(oldPos, new Map\(\), anchors\);/);
+    // The tween honours prefers-reduced-motion + missing rAF (settle to end state).
     expect(driver).toContain("prefersReducedMotion()");
-    // An abnormal frame unwinds instead of leaving the canvas locked.
-    expect(driver).toMatch(/const abort = \(\) => \{[\s\S]*resetLayoutState\(\);[\s\S]*fitAndRender\(\);/);
+    // §3.7: an abnormal frame JUMPS to the end state (onDone) first; fitAndRender
+    // is only the absolute last resort if that also throws.
+    expect(driver).toMatch(/const abort = \(\) => \{[\s\S]{0,200}try \{\s*\n\s*onDone\?\.\(\);\s*\n\s*\} catch \{[\s\S]{0,120}fitAndRender\(\);/);
     expect(driver).toMatch(/\} catch \{\s*\n\s*abort\(\);/);
   });
 

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -110,6 +110,27 @@ describe("GraphCanvas renderer", () => {
     expect(source).toContain("findNearestEdge");
   });
 
+  it("gives a valid edge hit priority whenever the cursor is outside a node glyph", () => {
+    const source = graphCanvasSource();
+    const pointerMove = source.slice(
+      source.indexOf("function handlePointerMove"),
+      source.indexOf("function setHoveredNode"),
+    );
+
+    expect(pointerMove).toContain("const preferEdge = edgeHit !== null && !onNodeGlyph");
+    expect(pointerMove).toContain("const preferNode = nodeHit !== null && !preferEdge");
+    expect(pointerMove).not.toContain("nodeNorm <= edgeNorm");
+  });
+
+  it("reapplies edge emphasis after a delayed connected-dim style settles", () => {
+    const source = graphCanvasSource();
+    const applyDim = source.slice(
+      source.indexOf("function applyConnectedDim"),
+      source.indexOf("function requestConnectedDim"),
+    );
+    expect(applyDim).toContain("renderHoverStyle(hoveredEdge)");
+  });
+
   // --- P1: Node hover tooltip ---
   it("shows a node tooltip on hover with label, type/node_type, and degree", () => {
     const source = graphCanvasSource();
@@ -266,7 +287,7 @@ describe("GraphCanvas force Spread/Links controls (Lot 3)", () => {
     const source = graphCanvasSource();
     const gated = source.slice(
       source.indexOf("{#if showLayoutSwitcher}"),
-      source.indexOf("aria-label=\"Reset view\""),
+      source.indexOf("<!-- Keyed on the active backend"),
     );
     expect(gated).toContain('aria-label="Force spacing controls"');
     expect(gated).toContain('aria-label="Spread"');
@@ -371,7 +392,7 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
     // Same workspace-only gate as the layout switcher.
     const gated = source.slice(
       source.indexOf("{#if showLayoutSwitcher}"),
-      source.indexOf("aria-label=\"Reset view\""),
+      source.indexOf("<!-- Keyed on the active backend"),
     );
     // Color-by segmented control (DS ButtonGroup over COLOR_MODES) + Churn legend.
     expect(gated).toContain("COLOR_MODES");
@@ -429,7 +450,33 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
 // --- Studio representation-polish remarks 4/5/6: gear-menu settings popover -
 describe("GraphCanvas settings popover (remarks 4/5/6)", () => {
   const toolbarGate = (source) =>
-    source.slice(source.indexOf("{#if showLayoutSwitcher}"), source.indexOf('aria-label="Reset view"'));
+    source.slice(
+      source.indexOf("{#if showLayoutSwitcher}"),
+      source.indexOf("<!-- Keyed on the active backend"),
+    );
+
+  it("places Reset left of the gear and pins both sm controls to exactly the same height", () => {
+    const source = graphCanvasSource();
+    const toolbar = source.slice(
+      source.indexOf('<div class="canvas-toolbar"'),
+      source.indexOf("<!-- Keyed on the active backend"),
+    );
+    expect(toolbar.indexOf('aria-label="Reset view"')).toBeLessThan(
+      toolbar.indexOf('aria-label="Graph display settings"'),
+    );
+    expect(toolbar).toMatch(/<Button[\s\S]{0,120}size="sm"[\s\S]{0,120}aria-label="Reset view"/);
+
+    const style = source.slice(source.indexOf("<style>"));
+    expect(style).toContain(
+      "--st-component-button-anatomy-density-sm-controlHeight: var(--graph-toolbar-control-height)",
+    );
+    expect(style).toContain(
+      "--st-component-iconButton-smSize: var(--graph-toolbar-control-height)",
+    );
+    expect(style).toMatch(
+      /\.canvas-toolbar :global\(\.reset-view-button\),[\s\S]{0,100}\.canvas-toolbar :global\(\.st-iconButton--sm\)[\s\S]{0,160}height: var\(--graph-toolbar-control-height\)/,
+    );
+  });
 
   it("R4: collapses layout/spacing/display behind a gear IconButton + Popover, gated on showLayoutSwitcher", () => {
     const source = graphCanvasSource();

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -650,3 +650,92 @@ describe("GraphCanvas smooth recenter (remark 7)", () => {
     expect(source).toMatch(/cancelLayoutMorphFrame\(\);\s*\n\s*cancelCameraTween\(\);/);
   });
 });
+
+// --- Collapse/expand GROUP transition animation ------------------------------
+// jsdom has no WebGL (like the merge/layout-morph tests above), so we assert
+// against the .svelte SOURCE that the animated group/ungroup transition is
+// wired: an optional groupTransition prop, a scene-effect hook that hands off to
+// the driver (with a hard-cut fallback), and a driver that REUSES morphPositions
+// + the merge-fade style on the same rAF loop, locking interaction via
+// morphActive exactly like the layout morph.
+describe("GraphCanvas collapse/expand group transition", () => {
+  const driverSource = (source) =>
+    source.slice(
+      source.indexOf("// --- Collapse/expand GROUP transition driver"),
+      source.indexOf("// Stable content signature of a scene"),
+    );
+
+  it("accepts an optional groupTransition prop (absent ⇒ current behaviour)", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/groupTransition = null,/);
+  });
+
+  it("the scene-effect tries the animated transition, falling back to the hard cut", () => {
+    const source = graphCanvasSource();
+    // untrack so groupTransition is not a hidden dependency of the scene effect.
+    expect(source).toMatch(/const transition = untrack\(\(\) => groupTransition\);/);
+    expect(source).toMatch(/untrack\(\(\) => tryStartGroupTransition\(transition\)\)/);
+    // A redundant scene re-derivation must not cancel an in-flight tween.
+    expect(source).toMatch(/if \(groupTweenFrame !== null && !transition\) return;/);
+    // On a handled transition the effect returns before the hard refit; otherwise
+    // it still runs resetLayoutState(); updateGraph(); (the safety fallback).
+    expect(source).toMatch(
+      /tryStartGroupTransition\(transition\)\)\) return;\s*\n[\s\S]{0,240}resetLayoutState\(\);\s*\n\s*updateGraph\(\);/,
+    );
+  });
+
+  it("collapse keeps the old scene, tweens folding nodes to their anchor, then swaps", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    // COLLAPSE builds bufA/bufB against the CURRENT (pre-collapse) payload and
+    // swaps to the collapsed scene at t=1 (resetLayoutState → updateGraph).
+    expect(driver).toContain("function startCollapseTween");
+    expect(driver).toMatch(/fadeOut: true[\s\S]{0,200}resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+  });
+
+  it("expand swaps first, then tweens the revealed nodes OUT from their anchor", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    // EXPAND swaps to the expanded scene FIRST (updateGraph), then fades IN.
+    expect(driver).toMatch(/function startExpandTween[\s\S]{0,200}resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+    expect(driver).toMatch(/fadeOut: false/);
+  });
+
+  it("REUSES morphPositions + the merge-fade style on the rAF loop, locking morphActive", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    // Same all-node position lerp as the layout morph, into the reused buffer.
+    expect(driver).toContain("morphPositions(bufA, bufB, eased, liveMorphBuffer)");
+    expect(driver).toContain("renderer.setPositions(liveMorphBuffer)");
+    // The merge-fade pattern generalized to a SET of folding nodes (alpha+size).
+    expect(driver).toContain("interpolateGroupFadeStyle(payload, foldingSet, alphaScale, sizeScale)");
+    // Interaction is locked exactly like the layout morph.
+    expect(driver).toMatch(/morphActive = true;\s*\n\s*setLabelsHidden\(true\)/);
+    // Driven on requestAnimationFrame with the shared duration + easing.
+    expect(driver).toContain("LAYOUT_MORPH_DURATION_MS");
+    expect(driver).toContain("easeMergeProgress(progress)");
+    expect(driver).toContain("window.requestAnimationFrame(step)");
+  });
+
+  it("SAFETY: no renderer / no matching child / SSR / reduced-motion falls back cleanly", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    // tryStart returns false (→ hard cut) without a renderer/payload/anchors.
+    expect(driver).toMatch(/function tryStartGroupTransition[\s\S]{0,220}return false;/);
+    // collectGroupFolds returns null when NO folding child is on screen.
+    expect(driver).toMatch(/if \(!info\) return false;/);
+    // The tween honours prefers-reduced-motion + missing rAF (instant settle).
+    expect(driver).toContain("prefersReducedMotion()");
+    // An abnormal frame unwinds instead of leaving the canvas locked.
+    expect(driver).toMatch(/const abort = \(\) => \{[\s\S]*resetLayoutState\(\);[\s\S]*fitAndRender\(\);/);
+    expect(driver).toMatch(/\} catch \{\s*\n\s*abort\(\);/);
+  });
+
+  it("cleans up the group tween on scene reset and on destroy", () => {
+    const source = graphCanvasSource();
+    // resetLayoutState cancels an in-flight group tween (indices are stale after).
+    expect(resetLayoutStateBody(source)).toContain("cancelGroupTweenFrame()");
+    // Unmount cancels it too, so no stray rAF outlives the component.
+    expect(source).toMatch(/cancelMergeFrame\(\);\s*\n\s*cancelGroupTweenFrame\(\);/);
+  });
+});

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -294,6 +294,55 @@ describe("GraphCanvas force Spread/Links controls (Lot 3)", () => {
   });
 });
 
+// --- Lot 7 double-consensus review must-fixes --------------------------------
+// jsdom has no WebGL, so (as elsewhere) these assert against the .svelte SOURCE
+// that the two SERIOUS layout-persistence bugs + the MINOR worker-rejection are
+// fixed. Behavioural runtime coverage would need a WebGL canvas the env lacks.
+describe("GraphCanvas Lot 7 review must-fixes (double-consensus)", () => {
+  it("SERIOUS-1: settleLayout persists the settled buffer for EVERY mode (Force included)", () => {
+    const source = graphCanvasSource();
+    const settle = source.slice(
+      source.indexOf("function settleLayout"),
+      source.indexOf("function startLayoutMorph"),
+    );
+    // The fix: persist the buffer regardless of mode. A Force re-solve (Lot 3
+    // Spread/Links/Reset) settles under LAYOUT_MODE_FORCE, so nulling it here
+    // would drop the re-solved layout on the next selection/hover rebuild.
+    expect(settle).toMatch(/activeLayoutBuffer = buffer \? new Float32Array\(buffer\) : null;/);
+    // The old buggy shortcut (null out activeLayoutBuffer for Force) is gone.
+    expect(settle).not.toMatch(/mode === LAYOUT_MODE_FORCE \|\| !buffer \? null/);
+    // reapplyLayoutPositions still consults activeLayoutBuffer (so Force re-solves
+    // are re-applied across a rebuild too, not just non-force layouts).
+    expect(source).toMatch(/function reapplyLayoutPositions[\s\S]*morphActive \? liveMorphBuffer : activeLayoutBuffer/);
+    // A genuine scene change still nulls it (a NEW scene must use scene positions).
+    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,400}activeLayoutBuffer = null/);
+  });
+
+  it("SERIOUS-2: a late Force solve is discarded when the user switched away from Force", () => {
+    const source = graphCanvasSource();
+    const resolve = source.slice(
+      source.indexOf("async function resolveForceLayout"),
+      source.indexOf("function resetForceLayout"),
+    );
+    // resolveForceLayout sets layoutMode = Force synchronously at entry, so a
+    // mid-solve switch to Layers/Grid/Radial/Metro flips layoutMode; the
+    // continuation must drop the stale solve on that mode mismatch.
+    expect(resolve).toMatch(/if \(!target \|\| token !== forceSolveToken \|\| !mounted \|\| layoutMode !== LAYOUT_MODE_FORCE\)/);
+  });
+
+  it("MINOR-1: computeForceRelayoutBuffer wraps the worker solve in try/catch → null on error", () => {
+    const source = graphCanvasSource();
+    const compute = source.slice(
+      source.indexOf("async function computeForceRelayoutBuffer"),
+      source.indexOf("async function resolveForceLayout"),
+    );
+    // The await must be guarded so a worker rejection can't escape as an
+    // unhandled rejection in the fire-and-forget caller.
+    expect(compute).toMatch(/try \{\s*\n\s*solved = await solveForce\(/);
+    expect(compute).toMatch(/\} catch \{\s*\n\s*return null;\s*\n\s*\}/);
+  });
+});
+
 // --- codeflow-parity Lots 4/5: Curved-links + Color-by controls -------------
 // jsdom can't mount the WebGL-bearing canvas, so (as with the Lot 1 switcher) we
 // assert against the .svelte SOURCE that the controls are wired: gated on

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -141,3 +141,70 @@ describe("GraphCanvas renderer", () => {
     expect(source).toContain("isPanning = true");
   });
 });
+
+// --- codeflow-parity Lot 1: layout switcher + all-node morph tween ----------
+// jsdom has no WebGL, so (like the merge-animation test above) we assert against
+// the .svelte SOURCE that the switcher path is wired: selecting a mode CAPTURES
+// the current buffer, COMPUTES the target, and drives renderer.setPositions.
+describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
+  it("renders a DS ButtonGroup switcher gated on showLayoutSwitcher", () => {
+    const source = graphCanvasSource();
+    expect(source).toContain("showLayoutSwitcher");
+    expect(source).toMatch(/\{#if showLayoutSwitcher\}/);
+    expect(source).toContain("ButtonGroup");
+    expect(source).toContain("LAYOUT_MODES");
+    // Choosing a mode invokes the morph driver.
+    expect(source).toMatch(/onclick=\{\(\) => selectLayoutMode\(mode\.id\)\}/);
+  });
+
+  it("selecting a mode captures→computes→calls setPositions (the morph driver)", () => {
+    const source = graphCanvasSource();
+    const driver = source.slice(
+      source.indexOf("function startLayoutMorph"),
+      source.indexOf("// Stable content signature of a scene"),
+    );
+    // CAPTURE the current on-screen buffer as bufA.
+    expect(driver).toMatch(/new Float32Array\(current\)/);
+    // COMPUTE the target buffer for the chosen mode.
+    expect(driver).toContain("computeLayoutBuffer(payload, mode");
+    // DRIVE the tween through the all-node morph + renderer.setPositions.
+    expect(driver).toContain("morphPositions(bufA, bufB");
+    expect(driver).toContain("renderer.setPositions(liveMorphBuffer)");
+  });
+
+  it("hides labels + locks interaction for the morph, and fits exactly once at t=1", () => {
+    const source = graphCanvasSource();
+    // Labels hidden while morphing.
+    expect(source).toMatch(/morphActive = true;\s*\n\s*setLabelsHidden\(true\)/);
+    // Interaction is locked (pointer/click/wheel guarded on morphActive).
+    expect(source).toMatch(/function handlePointerMove[\s\S]{0,120}if \(morphActive\) return;/);
+    expect(source).toMatch(/function handleWheel[\s\S]{0,120}if \(morphActive\)/);
+    // Exactly one deliberate end-fit at settle.
+    expect(source).toMatch(/function settleLayout[\s\S]*fitAndRender\(\);/);
+  });
+
+  it("re-seeds bufA from the LIVE buffer on interrupt, never snapping to base", () => {
+    const source = graphCanvasSource();
+    const driver = source.slice(source.indexOf("function startLayoutMorph"));
+    expect(driver).toMatch(
+      /layoutMorphFrame !== null && liveMorphBuffer\s*\n?\s*\?\s*new Float32Array\(liveMorphBuffer\)/,
+    );
+  });
+
+  it("guards the selection $effect from clobbering the morph (reapplyLayoutPositions)", () => {
+    const source = graphCanvasSource();
+    // rebuildPayload re-applies the live morph / active layout buffer, like the
+    // dragged-position re-application, so a mid-morph rebuild can't clobber it.
+    expect(source).toContain("reapplyLayoutPositions");
+    expect(source).toMatch(/function reapplyLayoutPositions[\s\S]*morphActive \? liveMorphBuffer : activeLayoutBuffer/);
+    expect(source).toMatch(/reapplyLayoutPositions\(\);\s*\n\s*reapplyDraggedPositions\(\);/);
+  });
+
+  it("never tweens across a scene-content change (resetLayoutState before updateGraph)", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+    // Force target is the CACHED force positions (no cold re-solve in Lot 1).
+    expect(source).toContain("captureForceBaseBuffer");
+    expect(source).toContain("forceBuffer: forceBaseBuffer");
+  });
+});

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -220,7 +220,7 @@ describe("GraphCanvas layout switcher + morph (Lot 1)", () => {
     // A layout switch re-places every node → drop the stale Force-space drag map.
     expect(driver).toContain("draggedPositions.clear()");
     // resetLayoutState also clears it (scene change + abnormal-exit path).
-    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,400}draggedPositions\.clear\(\)/);
+    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,700}draggedPositions\.clear\(\)/);
   });
 
   it("F2: a throwing morph frame unwinds instead of leaving the canvas locked", () => {
@@ -259,16 +259,28 @@ describe("GraphCanvas force Spread/Links controls (Lot 3)", () => {
 
   it("maps Spread→repulsion and Links→linkDistance, warm-starting interactive solves", () => {
     const source = graphCanvasSource();
-    expect(source).toContain('import { computeLayout } from "@graphify/graph-layout"');
+    // Lot 7: the solve goes through the off-main-thread client (worker + sync fallback).
+    expect(source).toContain('import { solveForce, terminateForceWorker } from "../lib/forceLayoutClient.js"');
     const solve = source.slice(
       source.indexOf("function computeForceRelayoutBuffer"),
       source.indexOf("function resetForceLayout"),
     );
+    expect(solve).toContain("await solveForce(");
     expect(solve).toContain("repulsion: forceSpread");
     expect(solve).toContain("linkDistance: forceLinks");
     expect(solve).toContain("initialPositions");
     expect(source).toMatch(/function commitForceSpread[\s\S]*resolveForceLayout\(\{ warmStart: true \}\)/);
     expect(source).toMatch(/function commitForceLinks[\s\S]*resolveForceLayout\(\{ warmStart: true \}\)/);
+  });
+
+  it("Lot 7: discards a stale worker solve (generation token) and terminates on destroy", () => {
+    const source = graphCanvasSource();
+    // A solve resolving after the scene changed is dropped (token mismatch).
+    expect(source).toMatch(/const token = \+\+forceSolveToken;[\s\S]*token !== forceSolveToken/);
+    // resetLayoutState invalidates in-flight solves.
+    expect(source).toMatch(/function resetLayoutState\(\)[\s\S]{0,400}forceSolveToken\+\+/);
+    // The worker is torn down when the component is destroyed.
+    expect(source).toMatch(/onDestroy\([\s\S]*terminateForceWorker\(\)/);
   });
 
   it("debounces expensive solves to drag-end and keeps Reset cold/deterministic", () => {

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -397,7 +397,7 @@ describe("GraphCanvas Curved-links + Color-by controls (Lots 4/5)", () => {
     // Color-by segmented control (DS ButtonGroup over COLOR_MODES) + Churn legend.
     expect(gated).toContain("COLOR_MODES");
     expect(gated).toMatch(/onclick=\{\(\) => selectColorMode\(mode\.id\)\}/);
-    expect(gated).toContain('aria-label="Degré colour legend"');
+    expect(gated).toContain('aria-label="Degree colour legend"');
     // Curved-links DS Switch.
     expect(gated).toContain("Switch");
     expect(gated).toContain('label="Curved links"');

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -623,6 +623,36 @@ describe("graphRendererPayload", () => {
     }
   });
 
+  it("grades base edge alpha down for dense endpoints without crossing the 0.30 floor", () => {
+    const nodes = [
+      { id: "hub", x: 0, y: 0 },
+      { id: "mid", x: 0, y: 100 },
+      { id: "low-a", x: 0, y: 200 },
+      { id: "low-b", x: 100, y: 200 },
+      ...Array.from({ length: 32 }, (_, i) => ({ id: `hub-${i}`, x: 100, y: i })),
+      ...Array.from({ length: 8 }, (_, i) => ({ id: `mid-${i}`, x: 100, y: 100 + i })),
+    ];
+    const edges = [
+      { source: "low-a", target: "low-b" },
+      ...Array.from({ length: 32 }, (_, i) => ({ source: "hub", target: `hub-${i}` })),
+      ...Array.from({ length: 8 }, (_, i) => ({ source: "mid", target: `mid-${i}` })),
+    ];
+    const payload = buildGraphRendererPayload({ nodes, edges });
+    const alphaForInputEdge = (inputIndex) => {
+      const renderedIndex = Array.from(payload.renderGraph.edgeInputIndices).indexOf(inputIndex);
+      return payload.baseStyle.edgeColors[renderedIndex * 4 + 3];
+    };
+
+    const lowAlpha = alphaForInputEdge(0);
+    const hubAlpha = alphaForInputEdge(1);
+    const midAlpha = alphaForInputEdge(33);
+
+    expect(lowAlpha).toBe(128);
+    expect(midAlpha).toBeLessThan(lowAlpha);
+    expect(midAlpha).toBeGreaterThan(hubAlpha);
+    expect(hubAlpha).toBeGreaterThanOrEqual(Math.round(255 * 0.3));
+  });
+
   it("dims non-neighbour nodes when a node is selected (selectedIds)", () => {
     const scene = makeTriangleScene();
     // Select "b": neighbours are a and d. c is NOT a direct neighbour of b.

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -587,10 +587,15 @@ describe("graphRendererPayload", () => {
     expect(hoverStyle.nodeColors[payload.nodeIndexById.get("d") * 4 + 3]).toBeLessThanOrEqual(90);
   });
 
-  it("dims non-incident edges when hoveredNodeId is set", () => {
+  // Representation-polish remark 1: main-graph edges are ~0.5 alpha (128) by
+  // DEFAULT (not opaque); on hover, INCIDENT edges stay at that base ~0.5+
+  // (untouched by the dim loop) while NON-incident edges dim FURTHER, to
+  // ~0.15 (38) — well below the 0.35 (89) node dim, since edges are mostly
+  // noise once a node is focused.
+  it("dims non-incident edges FURTHER than nodes when hoveredNodeId is set", () => {
     const scene = makeTriangleScene();
     // a → b (index 0), a → c (index 1), b → d (index 2)
-    // Hover "a": edges 0 and 1 are incident → full alpha; edge 2 is not → dimmed
+    // Hover "a": edges 0 and 1 are incident → base alpha; edge 2 is not → dimmed
     const payload = buildGraphRendererPayload(scene, { hoveredNodeId: "a", nodeRadius: 3 });
     const graph = payload.renderGraph;
     const iA = payload.nodeIndexById.get("a");
@@ -602,10 +607,19 @@ describe("graphRendererPayload", () => {
       const isIncident = src === iA || tgt === iA;
       const alpha = payload.style.edgeColors[e * 4 + 3];
       if (isIncident) {
-        expect(alpha).toBe(255);
+        expect(alpha).toBe(128); // EDGE_BASE_ALPHA: 255 * 0.5, untouched by the dim
       } else {
-        expect(alpha).toBeLessThanOrEqual(90);
+        expect(alpha).toBe(38); // EDGE_DIM_ALPHA: 255 * 0.15, rounded
       }
+    }
+  });
+
+  it("renders main-graph edges at ~0.5 alpha by default (no selection/hover/focus)", () => {
+    const scene = makeTriangleScene();
+    const payload = buildGraphRendererPayload(scene, { nodeRadius: 3 });
+    const edgeCount = payload.renderGraph.edges.length / 2;
+    for (let e = 0; e < edgeCount; e++) {
+      expect(payload.style.edgeColors[e * 4 + 3]).toBe(128); // 255 * 0.5
     }
   });
 
@@ -650,8 +664,13 @@ describe("graphRendererPayload", () => {
     const style = interpolateMergeStyle(payload, { from: "candidate", into: "canonical" }, 0.5);
 
     expect(style.nodeColors[3]).toBe(128);
-    expect(style.edgeColors[3]).toBe(128);
-    expect(style.edgeColors[7]).toBe(255);
+    // Edge 0 (candidate→neighbor) is incident to the merging "from" node: its
+    // base alpha (128, EDGE_BASE_ALPHA — remark 1's ~0.5 default) is halved
+    // by the merge fade (alphaScale 0.5) → 64.
+    expect(style.edgeColors[3]).toBe(64);
+    // Edge 1 (canonical→neighbor) is NOT incident to "candidate" → untouched,
+    // stays at the base ~0.5 alpha (128).
+    expect(style.edgeColors[7]).toBe(128);
     expect(payload.style.nodeColors[3]).toBe(255);
   });
 });
@@ -810,6 +829,68 @@ describe("layout switcher seam (Lot 1) — morphPositions / computeLayoutBuffer"
     expect(minY + maxY).toBeCloseTo(0, 5);
     // A real morph target (differs from the force input positions).
     expect(Array.from(grid)).not.toEqual(Array.from(payload.renderGraph.positions));
+  });
+
+  // Representation-polish remark 3: edge hover must work in EVERY layout, not
+  // just Force. GraphCanvas.settleLayout persists the settled buffer into
+  // `payload.renderGraph.positions` IN PLACE (`positions.set(buffer)`), and
+  // handlePointerMove reads findNearestEdge off that SAME array — this locks
+  // in that (a) findNearestEdge sees the settled non-Force positions right
+  // after a "settle", (b) it still sees them after a later payload rebuild
+  // (selection/hover/display-style change) re-applies the active layout
+  // buffer on top of a freshly-built payload (reapplyLayoutPositions), for
+  // EVERY registered layout mode.
+  describe("edge hover after a layout settles (remark 3)", () => {
+    const makeRingScene = (n = 8) => {
+      const nodes = Array.from({ length: n }, (_, i) => ({ id: `n${i}`, label: `N${i}` }));
+      const edges = Array.from({ length: n }, (_, i) => ({ source: `n${i}`, target: `n${(i + 1) % n}` }));
+      return { nodes, edges };
+    };
+
+    for (const mode of LAYOUT_MODES) {
+      it(`findNearestEdge hits an edge midpoint right after settling "${mode.id}"`, () => {
+        const scene = makeRingScene();
+        const payload = buildGraphRendererPayload(scene, { nodeRadius: 3 });
+        const forceBase = new Float32Array(payload.renderGraph.positions);
+
+        const settled = computeLayoutBuffer(payload, mode.id, { forceBuffer: forceBase });
+        // Mirror GraphCanvas.settleLayout: mutate renderGraph.positions IN PLACE.
+        payload.renderGraph.positions.set(settled);
+
+        const iA = payload.nodeIndexById.get("n0");
+        const iB = payload.nodeIndexById.get("n1");
+        const midX = (payload.renderGraph.positions[iA * 2] + payload.renderGraph.positions[iB * 2]) / 2;
+        const midY = (payload.renderGraph.positions[iA * 2 + 1] + payload.renderGraph.positions[iB * 2 + 1]) / 2;
+
+        const hit = findNearestEdge(payload, midX, midY, 40);
+        expect(hit, `mode ${mode.id}`).not.toBeNull();
+        expect([hit.edge.source, hit.edge.target]).toEqual(["n0", "n1"]);
+      });
+
+      it(`findNearestEdge still hits after a payload REBUILD re-applies the settled "${mode.id}" buffer`, () => {
+        const scene = makeRingScene();
+        let payload = buildGraphRendererPayload(scene, { nodeRadius: 3 });
+        const forceBase = new Float32Array(payload.renderGraph.positions);
+        const settled = computeLayoutBuffer(payload, mode.id, { forceBuffer: forceBase });
+        payload.renderGraph.positions.set(settled);
+        const activeLayoutBuffer = new Float32Array(settled);
+
+        // Mirror rebuildPayload(): a FRESH payload (fresh, force-baked positions)
+        // with reapplyLayoutPositions re-applying the settled buffer on top —
+        // exactly what a selection/hover/display-style change triggers.
+        const rebuilt = buildGraphRendererPayload(scene, { selectedIds: ["n0"], nodeRadius: 3 });
+        rebuilt.renderGraph.positions.set(activeLayoutBuffer);
+
+        const iA = rebuilt.nodeIndexById.get("n0");
+        const iB = rebuilt.nodeIndexById.get("n1");
+        const midX = (rebuilt.renderGraph.positions[iA * 2] + rebuilt.renderGraph.positions[iB * 2]) / 2;
+        const midY = (rebuilt.renderGraph.positions[iA * 2 + 1] + rebuilt.renderGraph.positions[iB * 2 + 1]) / 2;
+
+        const hit = findNearestEdge(rebuilt, midX, midY, 40);
+        expect(hit, `mode ${mode.id}`).not.toBeNull();
+        expect([hit.edge.source, hit.edge.target]).toEqual(["n0", "n1"]);
+      });
+    }
   });
 });
 

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -23,6 +23,7 @@ import {
   LAYOUT_MODE_FORCE,
   LAYOUT_MODE_GRID,
   LAYOUT_MODE_LAYERS,
+  LAYOUT_MODE_METRO,
   LAYOUT_MODE_RADIAL,
   LAYOUT_MODES,
   MAX_PRINCIPAL_CHARACTER_LABELS,
@@ -755,11 +756,17 @@ describe("layout switcher seam (Lot 1) — morphPositions / computeLayoutBuffer"
     expect(computeLayoutBuffer(null, LAYOUT_MODE_LAYERS)).toBeNull();
   });
 
-  // --- Lot 2: Radial + Grid appear in the switcher and yield valid buffers -----
-  it("the switcher offers Force / Radial / Layers / Grid", () => {
+  // --- Lots 2/6: Radial + Grid + Metro appear in the switcher --------------
+  it("the switcher offers Force / Radial / Layers / Grid / Metro", () => {
     const ids = LAYOUT_MODES.map((m) => m.id);
-    expect(ids).toEqual([LAYOUT_MODE_FORCE, LAYOUT_MODE_RADIAL, LAYOUT_MODE_LAYERS, LAYOUT_MODE_GRID]);
-    expect(LAYOUT_MODES.map((m) => m.label)).toEqual(["Force", "Radial", "Layers", "Grid"]);
+    expect(ids).toEqual([
+      LAYOUT_MODE_FORCE,
+      LAYOUT_MODE_RADIAL,
+      LAYOUT_MODE_LAYERS,
+      LAYOUT_MODE_GRID,
+      LAYOUT_MODE_METRO,
+    ]);
+    expect(LAYOUT_MODES.map((m) => m.label)).toEqual(["Force", "Radial", "Layers", "Grid", "Metro"]);
   });
 
   it("every switcher mode yields a valid 2·n buffer via computeLayoutBuffer", () => {

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildConnectedDimStyle,
   buildGraphRendererPayload,
+  COLOR_BY_FOLDER,
+  COLOR_BY_LAYER,
   colorForGroup,
   computeLayoutBuffer,
+  DEFAULT_EDGE_CURVATURE,
   densityScale,
   DEFAULT_LABEL_MAX_CHARS,
   findNearestEdge,
@@ -798,5 +801,91 @@ describe("layout switcher seam (Lot 1) — morphPositions / computeLayoutBuffer"
     expect(minY + maxY).toBeCloseTo(0, 5);
     // A real morph target (differs from the force input positions).
     expect(Array.from(grid)).not.toEqual(Array.from(payload.renderGraph.positions));
+  });
+});
+
+// --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder / Layer) ---
+// R3: curved links are a per-edge 0↔0.15 scalar (both backends already draw the
+// curve). R4: Color-by re-keys the categorical node colour — Folder (default) on
+// community/container (node.group), Layer on the typed layer (node_type). Both
+// re-style with NO layout recompute; defaults MUST stay byte-identical to before.
+describe("Curved-links toggle (Lot 4, R3)", () => {
+  const makeEdgeScene = () => ({
+    nodes: [
+      { id: "a", label: "A", x: 0, y: 0, weight: 1, group: "G1" },
+      { id: "b", label: "B", x: 100, y: 0, weight: 1, group: "G1" },
+    ],
+    // A plain edge with NO explicit curvature → the default scalar applies.
+    edges: [{ source: "a", target: "b", relation: "links" }],
+    stats: { nodeCount: 2, edgeCount: 1, weakEdgeCount: 0, communityCount: 1 },
+  });
+
+  it("defaults to the current curved behaviour (0.15) when the option is unset", () => {
+    const payload = buildGraphRendererPayload(makeEdgeScene(), { nodeRadius: 3 });
+    expect(payload.style.edgeCurvatures[0]).toBeCloseTo(DEFAULT_EDGE_CURVATURE, 6);
+    expect(DEFAULT_EDGE_CURVATURE).toBe(0.15);
+    // The emitted per-edge input carries the same scalar.
+    expect(payload.edges[0].curvature).toBeCloseTo(0.15, 6);
+  });
+
+  it("OFF → 0 (straight) and ON → 0.15, flipping the curvature the builder emits", () => {
+    const straight = buildGraphRendererPayload(makeEdgeScene(), { nodeRadius: 3, curvedLinks: false });
+    const curved = buildGraphRendererPayload(makeEdgeScene(), { nodeRadius: 3, curvedLinks: true });
+    expect(straight.style.edgeCurvatures[0]).toBe(0);
+    expect(curved.style.edgeCurvatures[0]).toBeCloseTo(0.15, 6);
+    expect(straight.edges[0].curvature).toBe(0);
+    expect(curved.edges[0].curvature).toBeCloseTo(0.15, 6);
+  });
+
+  it("explicit curvedLinks:true is byte-identical to the unset default", () => {
+    const def = buildGraphRendererPayload(makeEdgeScene(), { nodeRadius: 3 });
+    const on = buildGraphRendererPayload(makeEdgeScene(), { nodeRadius: 3, curvedLinks: true });
+    expect(Array.from(on.style.edgeCurvatures)).toEqual(Array.from(def.style.edgeCurvatures));
+  });
+});
+
+describe("Color-by Folder vs Layer (Lot 4, R4)", () => {
+  // group ("Folder-A") and node_type ("Layer-Z") hash to DIFFERENT palette slots
+  // (7 vs 1) so the two keyings produce a visibly different node fill.
+  const GROUP = "Folder-A";
+  const TYPE = "Layer-Z";
+  const makeScene = () => ({
+    nodes: [{ id: "a", label: "A", x: 0, y: 0, weight: 1, group: GROUP, type: TYPE }],
+    edges: [],
+    stats: { nodeCount: 1, edgeCount: 0, weakEdgeCount: 0, communityCount: 1 },
+  });
+
+  it("precondition: the two keys map to distinct palette colours", () => {
+    expect(colorForGroup(GROUP)).not.toBe(colorForGroup(TYPE));
+  });
+
+  it("defaults to Folder (community/container) keying when colorBy is unset", () => {
+    const payload = buildGraphRendererPayload(makeScene(), { nodeRadius: 3 });
+    expect(payload.nodeById.get("a").color).toBe(colorForGroup(GROUP));
+  });
+
+  it("Folder keys the node colour on node.group; Layer keys it on node_type", () => {
+    const folder = buildGraphRendererPayload(makeScene(), { nodeRadius: 3, colorBy: COLOR_BY_FOLDER });
+    const layer = buildGraphRendererPayload(makeScene(), { nodeRadius: 3, colorBy: COLOR_BY_LAYER });
+    expect(folder.nodeById.get("a").color).toBe(colorForGroup(GROUP));
+    expect(layer.nodeById.get("a").color).toBe(colorForGroup(TYPE));
+    // Switching the axis actually re-colours the node in the style buffer.
+    expect(Array.from(layer.style.nodeColors)).not.toEqual(Array.from(folder.style.nodeColors));
+  });
+
+  it("explicit colorBy:'folder' is byte-identical to the unset default", () => {
+    const def = buildGraphRendererPayload(makeScene(), { nodeRadius: 3 });
+    const folder = buildGraphRendererPayload(makeScene(), { nodeRadius: 3, colorBy: COLOR_BY_FOLDER });
+    expect(Array.from(folder.style.nodeColors)).toEqual(Array.from(def.style.nodeColors));
+  });
+
+  it("selection / focus colour still overrides both keyings", () => {
+    const payload = buildGraphRendererPayload(makeScene(), {
+      nodeRadius: 3,
+      colorBy: COLOR_BY_LAYER,
+      selectedIds: ["a"],
+    });
+    // Selected node uses SELECTED_COLOR (#2563eb → 37,99,235), not the layer hue.
+    expect([...payload.baseStyle.nodeColors.slice(0, 3)]).toEqual([37, 99, 235]);
   });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -941,4 +941,24 @@ describe("Color-by Churn heat ramp (Lot 5, R4/D2)", () => {
     expect(payload.nodeById.get("hub").color).toBe(colorForChurn(1));
     expect(payload.nodeById.get("leaf1").color).toBe(colorForChurn(0.5));
   });
+
+  // MINOR-3 (double-consensus review): normalizedChurnById must compute the max
+  // with a reduce/loop, NOT `Math.max(0, ...raw.values())`. The spread passes
+  // every value as a separate call argument, which overflows the engine's
+  // arg-count limit (RangeError: Maximum call stack size exceeded) well before
+  // ~1e5 nodes — silently breaking Color-by=Churn on any real large graph.
+  it("does not throw on a many-node churn scene (no spread over node values)", () => {
+    const N = 150000; // > the ~128k spread arg-count limit measured on V8.
+    const nodes = new Array(N);
+    for (let i = 0; i < N; i++) {
+      nodes[i] = { id: `n${i}`, x: i % 500, y: (i / 500) | 0, churn: i % 37 };
+    }
+    let payload;
+    expect(() => {
+      payload = buildGraphRendererPayload({ nodes, edges: [] }, { nodeRadius: 3, colorBy: COLOR_BY_CHURN });
+    }).not.toThrow();
+    expect(payload.renderGraph.nodeIds.length).toBe(N);
+    // Ramp still normalizes: the max-churn node maps to the hot end.
+    expect(payload.nodeById.get(`n${36}`).color).toBe(colorForChurn(1));
+  });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -35,10 +35,13 @@ import {
   LAYOUT_MODE_LAYERS,
   LAYOUT_MODE_METRO,
   LAYOUT_MODE_RADIAL,
+  carryScenePositions,
+  goldenAngleFan,
   LAYOUT_MODES,
   MAX_PRINCIPAL_CHARACTER_LABELS,
   morphPositions,
   nodeTypesForPayload,
+  resolveGroupFolds,
   selectPrincipalHubLabels,
   truncateLabel,
 } from "../lib/graphRendererPayload.js";
@@ -1303,5 +1306,81 @@ describe("edge alpha modes + opacity", () => {
       if (payload.style.edgeColors[e * 4 + 3] < 128) sawDim = true;
     }
     expect(sawDim).toBe(true);
+  });
+});
+
+// --- Group/ungroup animation pure helpers (behavioural, not source-string) -----
+describe("resolveGroupFolds — fold set + anchor rule", () => {
+  const nodeIds = ["a", "b", "c", "g"];
+  // a(0,0) b(10,0) c(20,0) g(4,4)
+  const positions = new Float32Array([0, 0, 10, 0, 20, 0, 4, 4]);
+
+  it("anchors on the group node's OWN position when it is on screen", () => {
+    const info = resolveGroupFolds({
+      nodeIds,
+      positions,
+      anchors: new Map([["a", "g"], ["b", "g"]]),
+    });
+    expect([...info.foldingSet].sort()).toEqual([0, 1]); // a,b fold
+    expect(info.anchorPosByGroup.get("g")).toEqual({ x: 4, y: 4 }); // g's own pos
+  });
+
+  it("falls back to the folding members' CENTROID when the group node is off screen", () => {
+    const info = resolveGroupFolds({
+      nodeIds: ["a", "b", "c"], // g absent from this scene
+      positions: new Float32Array([0, 0, 10, 0, 20, 0]),
+      anchors: new Map([["a", "g"], ["b", "g"]]),
+    });
+    expect(info.anchorPosByGroup.get("g")).toEqual({ x: 5, y: 0 }); // centroid of a,b
+  });
+
+  it("returns null for empty anchors or when no folded child is on screen", () => {
+    expect(resolveGroupFolds({ nodeIds, positions, anchors: new Map() })).toBeNull();
+    expect(
+      resolveGroupFolds({ nodeIds, positions, anchors: new Map([["zz", "g"]]) }),
+    ).toBeNull();
+  });
+});
+
+describe("carryScenePositions — by-id coordinate carry", () => {
+  it("carries shared ids, applies explicit placements, and neighbour-centroids brand-new nodes", () => {
+    // new(2) is edge-connected to shared s(0); grp(1) is explicitly placed.
+    const out = carryScenePositions({
+      nodeIds: ["s", "grp", "new"],
+      positions: new Float32Array([99, 99, 99, 99, 99, 99]), // scene-baked (should be overridden)
+      edges: new Uint32Array([2, 0]), // new <-> s
+      carriedPosById: new Map([["s", { x: 1, y: 2 }]]),
+      placedPosById: new Map([["grp", { x: 3, y: 4 }]]),
+    });
+    expect([out[0], out[1]]).toEqual([1, 2]); // s carried
+    expect([out[2], out[3]]).toEqual([3, 4]); // grp placed
+    expect([out[4], out[5]]).toEqual([1, 2]); // new → centroid of its only placed neighbour (s)
+  });
+
+  it("leaves a brand-new node with no placed neighbour at its scene-baked position", () => {
+    const out = carryScenePositions({
+      nodeIds: ["s", "new"],
+      positions: new Float32Array([0, 0, 7, 8]),
+      edges: new Uint32Array([]), // no edges → no neighbour
+      carriedPosById: new Map([["s", { x: 1, y: 1 }]]),
+      placedPosById: new Map(),
+    });
+    expect([out[2], out[3]]).toEqual([7, 8]); // scene-baked fallback
+  });
+});
+
+describe("goldenAngleFan — deterministic sunflower", () => {
+  it("is order-independent (sorted by id) and places child 0 at anchor+spacing", () => {
+    const a = goldenAngleFan({ anchor: { x: 10, y: 20 }, childIds: ["b", "a"], spacing: 5 });
+    const b = goldenAngleFan({ anchor: { x: 10, y: 20 }, childIds: ["a", "b"], spacing: 5 });
+    expect([...a.entries()]).toEqual([...b.entries()]); // same id set → same slots
+    // child "a" is index 0 → angle 0, radius = spacing → anchor + (spacing, 0)
+    expect(a.get("a").x).toBeCloseTo(15, 6);
+    expect(a.get("a").y).toBeCloseTo(20, 6);
+  });
+
+  it("caps the radius", () => {
+    const fan = goldenAngleFan({ anchor: { x: 0, y: 0 }, childIds: ["a", "b", "c"], spacing: 100, cap: 50 });
+    for (const { x, y } of fan.values()) expect(Math.hypot(x, y)).toBeLessThanOrEqual(50 + 1e-6);
   });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -25,6 +25,7 @@ import {
   findNearestNode,
   findNearestNodeId,
   GROUP_PALETTE,
+  interpolateGroupFadeStyle,
   interpolateMergeStyle,
   interpolateMergePositions,
   isBoxShape,
@@ -723,6 +724,68 @@ describe("graphRendererPayload", () => {
     // stays at the base ~0.5 alpha (128).
     expect(style.edgeColors[7]).toBe(128);
     expect(payload.style.nodeColors[3]).toBe(255);
+  });
+});
+
+// --- Collapse/expand group animation: interpolateGroupFadeStyle --------------
+// The SET generalization of interpolateMergeStyle used by the group transition:
+// fade + shrink a whole set of folding/revealing nodes and their incident edges.
+describe("interpolateGroupFadeStyle (collapse/expand fade)", () => {
+  const makePayload = () =>
+    buildGraphRendererPayload({
+      nodes: [
+        { id: "a", label: "A", x: 0, y: 0, weight: 1 },
+        { id: "b", label: "B", x: 100, y: 40, weight: 1 },
+        { id: "c", label: "C", x: -20, y: 10, weight: 1 },
+      ],
+      edges: [
+        { source: "a", target: "c", relation: "mentions" },
+        { source: "b", target: "c", relation: "seen_by" },
+      ],
+      stats: { nodeCount: 3, edgeCount: 2, weakEdgeCount: 0, communityCount: 1 },
+    });
+
+  it("fades + shrinks the folding set and its incident edges, leaving others intact", () => {
+    const payload = makePayload();
+    const baseSizeA = payload.style.nodeSizes[0];
+    // Fold node index 0 ("a") at half alpha, half size.
+    const style = interpolateGroupFadeStyle(payload, new Set([0]), 0.5, 0.5);
+    // Node a: alpha 255→128, size halved.
+    expect(style.nodeColors[3]).toBe(128);
+    expect(style.nodeSizes[0]).toBeCloseTo(baseSizeA * 0.5, 5);
+    // Node b (not folding) untouched.
+    expect(style.nodeColors[7]).toBe(255);
+    expect(style.nodeSizes[1]).toBe(payload.style.nodeSizes[1]);
+    // Edge 0 (a→c) is incident to a → its base alpha (128) halved to 64.
+    expect(style.edgeColors[3]).toBe(64);
+    // Edge 1 (b→c) not incident to a → untouched.
+    expect(style.edgeColors[7]).toBe(128);
+    // The base style is never mutated (a fresh clone is returned).
+    expect(payload.style.nodeColors[3]).toBe(255);
+    expect(payload.style.nodeSizes[0]).toBe(baseSizeA);
+  });
+
+  it("t=0 fully hides (alpha 0) and t=1 (scale 1) is byte-identical to base alpha", () => {
+    const payload = makePayload();
+    const hidden = interpolateGroupFadeStyle(payload, new Set([0]), 0, 1);
+    expect(hidden.nodeColors[3]).toBe(0);
+    expect(hidden.edgeColors[3]).toBe(0);
+    const full = interpolateGroupFadeStyle(payload, new Set([0]), 1, 1);
+    expect(full.nodeColors[3]).toBe(payload.style.nodeColors[3]);
+    expect(full.edgeColors[3]).toBe(payload.style.edgeColors[3]);
+  });
+
+  it("returns the base style unchanged when the folding set is empty", () => {
+    const payload = makePayload();
+    expect(interpolateGroupFadeStyle(payload, new Set(), 0.5)).toBe(payload.style);
+  });
+
+  it("clamps alpha/size scales to [0,1] and accepts any iterable of indices", () => {
+    const payload = makePayload();
+    // Out-of-range scales clamp; an array (not a Set) is accepted.
+    const style = interpolateGroupFadeStyle(payload, [0], 5, -3);
+    expect(style.nodeColors[3]).toBe(255); // alpha clamped to 1
+    expect(style.nodeSizes[0]).toBe(0); // size clamped to 0
   });
 });
 

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -16,7 +16,10 @@ import {
   isBoxShape,
   LABEL_ZOOM_THRESHOLD,
   LAYOUT_MODE_FORCE,
+  LAYOUT_MODE_GRID,
   LAYOUT_MODE_LAYERS,
+  LAYOUT_MODE_RADIAL,
+  LAYOUT_MODES,
   MAX_PRINCIPAL_CHARACTER_LABELS,
   morphPositions,
   nodeTypesForPayload,
@@ -745,5 +748,55 @@ describe("layout switcher seam (Lot 1) — morphPositions / computeLayoutBuffer"
 
   it("computeLayoutBuffer degrades to null for a missing payload", () => {
     expect(computeLayoutBuffer(null, LAYOUT_MODE_LAYERS)).toBeNull();
+  });
+
+  // --- Lot 2: Radial + Grid appear in the switcher and yield valid buffers -----
+  it("the switcher offers Force / Radial / Layers / Grid", () => {
+    const ids = LAYOUT_MODES.map((m) => m.id);
+    expect(ids).toEqual([LAYOUT_MODE_FORCE, LAYOUT_MODE_RADIAL, LAYOUT_MODE_LAYERS, LAYOUT_MODE_GRID]);
+    expect(LAYOUT_MODES.map((m) => m.label)).toEqual(["Force", "Radial", "Layers", "Grid"]);
+  });
+
+  it("every switcher mode yields a valid 2·n buffer via computeLayoutBuffer", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const n = payload.renderGraph.nodeIds.length;
+    const cached = new Float32Array(n * 2).fill(2);
+    for (const mode of LAYOUT_MODES) {
+      const buf = computeLayoutBuffer(payload, mode.id, { forceBuffer: cached });
+      expect(buf, `mode ${mode.id}`).toBeInstanceOf(Float32Array);
+      expect(buf.length, `mode ${mode.id}`).toBe(n * 2);
+      for (const v of buf) expect(Number.isFinite(v)).toBe(true);
+    }
+  });
+
+  it("computeLayoutBuffer('radial') hubs the highest-degree node at the origin", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const n = payload.renderGraph.nodeIds.length;
+    const radial = computeLayoutBuffer(payload, LAYOUT_MODE_RADIAL);
+    expect(radial).toBeInstanceOf(Float32Array);
+    expect(radial.length).toBe(n * 2);
+    // In makeTypedScene, a & b share the only edge → degree 1 (max); a (earlier)
+    // is the hub at the origin.
+    const iA = payload.nodeIndexById.get("a");
+    expect(radial[iA * 2]).toBe(0);
+    expect(radial[iA * 2 + 1]).toBe(0);
+  });
+
+  it("computeLayoutBuffer('grid') lays nodes on a centred ceil(√n) grid", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const n = payload.renderGraph.nodeIds.length; // 4 → 2×2 grid
+    const grid = computeLayoutBuffer(payload, LAYOUT_MODE_GRID);
+    expect(grid).toBeInstanceOf(Float32Array);
+    expect(grid.length).toBe(n * 2);
+    // Centred bounding box: x and y extents are symmetric around 0.
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (let i = 0; i < grid.length; i += 2) {
+      minX = Math.min(minX, grid[i]); maxX = Math.max(maxX, grid[i]);
+      minY = Math.min(minY, grid[i + 1]); maxY = Math.max(maxY, grid[i + 1]);
+    }
+    expect(minX + maxX).toBeCloseTo(0, 5);
+    expect(minY + maxY).toBeCloseTo(0, 5);
+    // A real morph target (differs from the force input positions).
+    expect(Array.from(grid)).not.toEqual(Array.from(payload.renderGraph.positions));
   });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildConnectedDimStyle,
+  buildEdgeAlphaShape,
   buildGraphRendererPayload,
   COLOR_BY_CHURN,
   COLOR_BY_FOLDER,
@@ -10,8 +11,16 @@ import {
   colorForGroup,
   computeLayoutBuffer,
   DEFAULT_EDGE_CURVATURE,
+  DEFAULT_EDGE_OPACITY,
   densityScale,
   DEFAULT_LABEL_MAX_CHARS,
+  EDGE_ALPHA_DENSE,
+  EDGE_ALPHA_FLAT,
+  EDGE_ALPHA_FLOOR,
+  EDGE_ALPHA_INVERSE,
+  EDGE_ALPHA_MID,
+  edgeAlphaShapeFor,
+  edgeDensityForDegree,
   findNearestEdge,
   findNearestNode,
   findNearestNodeId,
@@ -623,7 +632,7 @@ describe("graphRendererPayload", () => {
     }
   });
 
-  it("grades base edge alpha down for dense endpoints without crossing the 0.30 floor", () => {
+  it("grades the density falloff via edgeAlphaShape (not the base alpha) at the dense endpoint", () => {
     const nodes = [
       { id: "hub", x: 0, y: 0 },
       { id: "mid", x: 0, y: 100 },
@@ -638,19 +647,31 @@ describe("graphRendererPayload", () => {
       ...Array.from({ length: 8 }, (_, i) => ({ source: "mid", target: `mid-${i}` })),
     ];
     const payload = buildGraphRendererPayload({ nodes, edges });
-    const alphaForInputEdge = (inputIndex) => {
-      const renderedIndex = Array.from(payload.renderGraph.edgeInputIndices).indexOf(inputIndex);
-      return payload.baseStyle.edgeColors[renderedIndex * 4 + 3];
-    };
+    const renderedIndexOf = (inputIndex) =>
+      Array.from(payload.renderGraph.edgeInputIndices).indexOf(inputIndex);
+    const baseAlphaForInputEdge = (inputIndex) =>
+      payload.baseStyle.edgeColors[renderedIndexOf(inputIndex) * 4 + 3];
+    // m0 = the SOURCE-endpoint multiplier of the along-edge shape (each edge here
+    // is authored source=hub/mid/low, so m0 carries that endpoint's density).
+    const sourceShapeForInputEdge = (inputIndex) =>
+      payload.baseStyle.edgeAlphaShape[renderedIndexOf(inputIndex) * 3];
 
-    const lowAlpha = alphaForInputEdge(0);
-    const hubAlpha = alphaForInputEdge(1);
-    const midAlpha = alphaForInputEdge(33);
+    // The BASE alpha is now the flat edgeOpacity default (0.5 → 128) for EVERY
+    // edge; density no longer bends it — the shape does.
+    expect(baseAlphaForInputEdge(0)).toBe(128);
+    expect(baseAlphaForInputEdge(1)).toBe(128);
+    expect(baseAlphaForInputEdge(33)).toBe(128);
 
-    expect(lowAlpha).toBe(128);
-    expect(midAlpha).toBeLessThan(lowAlpha);
-    expect(midAlpha).toBeGreaterThan(hubAlpha);
-    expect(hubAlpha).toBeGreaterThanOrEqual(Math.round(255 * 0.3));
+    const lowShape = sourceShapeForInputEdge(0); // low-a source, degree 1
+    const hubShape = sourceShapeForInputEdge(1); // hub source, degree 32
+    const midShape = sourceShapeForInputEdge(33); // mid source, degree 8
+
+    // A rare endpoint stays opaque (255); denser endpoints fade toward the floor.
+    expect(lowShape).toBe(255);
+    expect(midShape).toBeLessThan(lowShape);
+    expect(hubShape).toBeLessThan(midShape);
+    // Never below the faint floor (0.15 · 255 ≈ 38).
+    expect(hubShape).toBeGreaterThanOrEqual(Math.round(255 * EDGE_ALPHA_FLOOR));
   });
 
   it("dims non-neighbour nodes when a node is selected (selectedIds)", () => {
@@ -1071,5 +1092,153 @@ describe("Color-by Churn heat ramp (Lot 5, R4/D2)", () => {
     expect(payload.renderGraph.nodeIds.length).toBe(N);
     // Ramp still normalizes: the max-churn node maps to the hot end.
     expect(payload.nodeById.get(`n${36}`).color).toBe(colorForChurn(1));
+  });
+});
+
+// --- Configurable edge-transparency: along-edge alpha SHAPE + edge opacity ----
+// The density falloff and the fade modes live in the per-edge alpha SHAPE
+// (edgeAlphaShape, a separate multiplier of the flat base alpha). Defaults
+// (dense mode, 0.5 opacity) keep the ~0.5 base + hub-fade the studio already had.
+describe("edge alpha modes + opacity", () => {
+  const FLOOR = Math.round(255 * EDGE_ALPHA_FLOOR); // 38
+
+  describe("edgeDensityForDegree (log-scaled endpoint density)", () => {
+    it("is 0 at/below START (deg ≤ 2) and 1 at/above FULL (deg ≥ 16)", () => {
+      expect(edgeDensityForDegree(0)).toBe(0);
+      expect(edgeDensityForDegree(1)).toBe(0);
+      expect(edgeDensityForDegree(2)).toBe(0);
+      expect(edgeDensityForDegree(16)).toBe(1);
+      expect(edgeDensityForDegree(32)).toBe(1); // clamped
+    });
+
+    it("increases monotonically between START and FULL", () => {
+      expect(edgeDensityForDegree(4)).toBeLessThan(edgeDensityForDegree(8));
+      expect(edgeDensityForDegree(8)).toBeLessThan(edgeDensityForDegree(16));
+      expect(edgeDensityForDegree(8)).toBeCloseTo(2 / 3, 5);
+    });
+  });
+
+  describe("edgeAlphaShapeFor (pure mode → [m0, mMid, m1])", () => {
+    it("flat: uniform 255 regardless of density", () => {
+      expect(edgeAlphaShapeFor(EDGE_ALPHA_FLAT, 0.4, 0.9)).toEqual([255, 255, 255]);
+    });
+
+    it("mid: opaque at both ends, faint (FLOOR) in the middle", () => {
+      expect(edgeAlphaShapeFor(EDGE_ALPHA_MID, 0.4, 0.9)).toEqual([255, FLOOR, 255]);
+    });
+
+    it("dense: opaque at the RARE endpoint (density 0), faint at the DENSE one (density 1)", () => {
+      // rare source (d0=0) → 255; dense target (d1=1) → FLOOR; mid = average.
+      const shape = edgeAlphaShapeFor(EDGE_ALPHA_DENSE, 0, 1);
+      expect(shape[0]).toBe(255);
+      expect(shape[2]).toBe(FLOOR);
+      expect(shape[1]).toBe(Math.round((255 + FLOOR) / 2));
+    });
+
+    it("inverse: mirror of dense — faint at the rare endpoint, opaque at the dense one", () => {
+      const shape = edgeAlphaShapeFor(EDGE_ALPHA_INVERSE, 0, 1);
+      expect(shape[0]).toBe(FLOOR);
+      expect(shape[2]).toBe(255);
+    });
+
+    it("an unknown mode falls back to dense", () => {
+      expect(edgeAlphaShapeFor("bogus", 0, 1)).toEqual(edgeAlphaShapeFor(EDGE_ALPHA_DENSE, 0, 1));
+    });
+  });
+
+  // A hub of degree 17 (density 1) → one leaf of degree 1 (density 0). Input
+  // edge 0 is authored hub→leaf, so its shape reads [m0=hub, mMid, m1=leaf].
+  const makeHubScene = () => {
+    const nodes = [{ id: "hub" }, { id: "leaf" }];
+    const edges = [{ source: "hub", target: "leaf" }];
+    for (let i = 0; i < 16; i += 1) {
+      nodes.push({ id: `x${i}` });
+      edges.push({ source: "hub", target: `x${i}` });
+    }
+    return { nodes, edges };
+  };
+  const shapeForInputEdge0 = (payload) => {
+    const rendered = Array.from(payload.renderGraph.edgeInputIndices).indexOf(0);
+    const s = payload.baseStyle.edgeAlphaShape;
+    return [s[rendered * 3], s[rendered * 3 + 1], s[rendered * 3 + 2]];
+  };
+
+  it("buildGraphRendererPayload always attaches a 3-per-edge shape buffer", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3 });
+    const edgeCount = payload.renderGraph.edges.length / 2;
+    expect(payload.baseStyle.edgeAlphaShape).toBeInstanceOf(Uint8Array);
+    expect(payload.baseStyle.edgeAlphaShape.length).toBe(edgeCount * 3);
+  });
+
+  it("defaults to dense mode (opaque at the rare leaf, faint at the dense hub)", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3 });
+    const [m0, , m1] = shapeForInputEdge0(payload);
+    expect(m0).toBe(FLOOR); // hub side (dense) faded to the floor
+    expect(m1).toBe(255); // leaf side (rare) opaque
+  });
+
+  it("inverse mode swaps the ramp (opaque at the hub, faint at the leaf)", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3, edgeAlphaMode: EDGE_ALPHA_INVERSE });
+    const [m0, , m1] = shapeForInputEdge0(payload);
+    expect(m0).toBe(255);
+    expect(m1).toBe(FLOOR);
+  });
+
+  it("mid mode fades the middle, keeping both endpoints opaque", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3, edgeAlphaMode: EDGE_ALPHA_MID });
+    const [m0, mMid, m1] = shapeForInputEdge0(payload);
+    expect(m0).toBe(255);
+    expect(m1).toBe(255);
+    expect(mMid).toBe(FLOOR);
+  });
+
+  it("flat mode emits an all-255 (uniform) shape for every edge", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3, edgeAlphaMode: EDGE_ALPHA_FLAT });
+    for (const v of payload.baseStyle.edgeAlphaShape) expect(v).toBe(255);
+  });
+
+  it("edgeOpacity sets the uniform base alpha (0..1 → 0..255); default is 0.5", () => {
+    const def = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3 });
+    const dim = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3, edgeOpacity: 0.2 });
+    const bright = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3, edgeOpacity: 0.8 });
+    expect(DEFAULT_EDGE_OPACITY).toBe(0.5);
+    expect(def.baseStyle.edgeColors[3]).toBe(128); // 255 * 0.5
+    expect(dim.baseStyle.edgeColors[3]).toBe(Math.round(255 * 0.2)); // 51
+    expect(bright.baseStyle.edgeColors[3]).toBe(Math.round(255 * 0.8)); // 204
+    // The base alpha is uniform: every edge shares it (density is in the shape).
+    const edgeCount = dim.renderGraph.edges.length / 2;
+    for (let e = 0; e < edgeCount; e += 1) expect(dim.baseStyle.edgeColors[e * 4 + 3]).toBe(51);
+  });
+
+  it("buildEdgeAlphaShape reproduces the payload's shape from the same degrees", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3 });
+    const edgeCount = payload.renderGraph.edges.length / 2;
+    // Recompute undirected degrees exactly as the payload does.
+    const deg = new Map();
+    for (const id of payload.renderGraph.nodeIds) deg.set(id, 0);
+    for (let e = 0; e < edgeCount; e += 1) {
+      const s = payload.renderGraph.nodeIds[payload.renderGraph.edges[e * 2]];
+      const t = payload.renderGraph.nodeIds[payload.renderGraph.edges[e * 2 + 1]];
+      deg.set(s, (deg.get(s) ?? 0) + 1);
+      deg.set(t, (deg.get(t) ?? 0) + 1);
+    }
+    const rebuilt = buildEdgeAlphaShape(payload.renderGraph, deg, EDGE_ALPHA_DENSE);
+    expect(rebuilt.length).toBe(edgeCount * 3);
+    expect(Array.from(rebuilt)).toEqual(Array.from(payload.baseStyle.edgeAlphaShape));
+  });
+
+  it("the shape survives connected-dim re-styling (only edgeColors.a is dimmed)", () => {
+    const payload = buildGraphRendererPayload(makeHubScene(), { nodeRadius: 3, selectedIds: ["leaf"] });
+    // The dimmed style keeps the EXACT shape buffer (cloneStyle carries it).
+    expect(Array.from(payload.style.edgeAlphaShape)).toEqual(
+      Array.from(payload.baseStyle.edgeAlphaShape),
+    );
+    // Some non-incident edge's BASE alpha was dimmed below the 128 base…
+    let sawDim = false;
+    const edgeCount = payload.renderGraph.edges.length / 2;
+    for (let e = 0; e < edgeCount; e += 1) {
+      if (payload.style.edgeColors[e * 4 + 3] < 128) sawDim = true;
+    }
+    expect(sawDim).toBe(true);
   });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildConnectedDimStyle,
   buildGraphRendererPayload,
+  COLOR_BY_CHURN,
   COLOR_BY_FOLDER,
   COLOR_BY_LAYER,
+  colorForChurn,
   colorForGroup,
   computeLayoutBuffer,
   DEFAULT_EDGE_CURVATURE,
@@ -887,5 +889,49 @@ describe("Color-by Folder vs Layer (Lot 4, R4)", () => {
     });
     // Selected node uses SELECTED_COLOR (#2563eb → 37,99,235), not the layer hue.
     expect([...payload.baseStyle.nodeColors.slice(0, 3)]).toEqual([37, 99, 235]);
+  });
+});
+
+// --- codeflow-parity Lot 5: Color-by Churn (degree/activity fallback first) ---
+describe("Color-by Churn heat ramp (Lot 5, R4/D2)", () => {
+  it("exports a deterministic low→high sequential ramp", () => {
+    expect(colorForChurn(0)).toBe("#e2e8f0");
+    expect(colorForChurn(1)).toBe("#ef4444");
+    expect(colorForChurn(-1)).toBe("#e2e8f0");
+    expect(colorForChurn(2)).toBe("#ef4444");
+  });
+
+  it("uses explicit churn/activity scalars when present", () => {
+    const payload = buildGraphRendererPayload(
+      {
+        nodes: [
+          { id: "cold", x: 0, y: 0, churn: 0 },
+          { id: "hot", x: 1, y: 1, churn: 10 },
+        ],
+        edges: [],
+      },
+      { nodeRadius: 3, colorBy: COLOR_BY_CHURN },
+    );
+    expect(payload.nodeById.get("cold").color).toBe(colorForChurn(0));
+    expect(payload.nodeById.get("hot").color).toBe(colorForChurn(1));
+  });
+
+  it("falls back to normalized degree when no churn source exists", () => {
+    const payload = buildGraphRendererPayload(
+      {
+        nodes: [
+          { id: "hub", x: 0, y: 0 },
+          { id: "leaf1", x: 1, y: 1 },
+          { id: "leaf2", x: 2, y: 2 },
+        ],
+        edges: [
+          { source: "hub", target: "leaf1" },
+          { source: "hub", target: "leaf2" },
+        ],
+      },
+      { nodeRadius: 3, colorBy: COLOR_BY_CHURN },
+    );
+    expect(payload.nodeById.get("hub").color).toBe(colorForChurn(1));
+    expect(payload.nodeById.get("leaf1").color).toBe(colorForChurn(0.5));
   });
 });

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -4,6 +4,7 @@ import {
   buildConnectedDimStyle,
   buildGraphRendererPayload,
   colorForGroup,
+  computeLayoutBuffer,
   densityScale,
   DEFAULT_LABEL_MAX_CHARS,
   findNearestEdge,
@@ -14,7 +15,11 @@ import {
   interpolateMergePositions,
   isBoxShape,
   LABEL_ZOOM_THRESHOLD,
+  LAYOUT_MODE_FORCE,
+  LAYOUT_MODE_LAYERS,
   MAX_PRINCIPAL_CHARACTER_LABELS,
+  morphPositions,
+  nodeTypesForPayload,
   selectPrincipalHubLabels,
   truncateLabel,
 } from "../lib/graphRendererPayload.js";
@@ -639,5 +644,106 @@ describe("graphRendererPayload", () => {
     expect(style.edgeColors[3]).toBe(128);
     expect(style.edgeColors[7]).toBe(255);
     expect(payload.style.nodeColors[3]).toBe(255);
+  });
+});
+
+// --- codeflow-parity Lot 1: layout switcher seam + all-node morph tween ------
+// morphPositions generalizes the one-node merge lerp into a per-index morph
+// between two index-parallel buffers; computeLayoutBuffer is the studio↔registry
+// seam that resolves a mode ("layers" → typed-layer, "force" → cached buffer).
+describe("layout switcher seam (Lot 1) — morphPositions / computeLayoutBuffer", () => {
+  const makeTypedScene = () => ({
+    nodes: [
+      { id: "a", label: "A", type: "Character", x: 10, y: 10, weight: 1 },
+      { id: "b", label: "B", type: "Character", x: 20, y: 20, weight: 1 },
+      { id: "c", label: "C", type: "Location", x: 30, y: 30, weight: 1 },
+      { id: "d", label: "D", x: 40, y: 40, weight: 1 }, // untyped
+    ],
+    edges: [{ source: "a", target: "b", relation: "knows" }],
+    stats: { nodeCount: 4, edgeCount: 1, weakEdgeCount: 0, communityCount: 1 },
+  });
+
+  it("morphPositions: t=0 → bufA, t=1 → bufB, midpoint = average, all nodes moved", () => {
+    const bufA = new Float32Array([0, 0, 10, 10, -4, 8]);
+    const bufB = new Float32Array([2, 2, 30, -10, 0, 0]);
+
+    expect(Array.from(morphPositions(bufA, bufB, 0))).toEqual(Array.from(bufA));
+    expect(Array.from(morphPositions(bufA, bufB, 1))).toEqual(Array.from(bufB));
+
+    const mid = morphPositions(bufA, bufB, 0.5);
+    for (let i = 0; i < bufA.length; i += 1) {
+      expect(mid[i]).toBeCloseTo((bufA[i] + bufB[i]) / 2, 5);
+    }
+    // EVERY node moved between the endpoints (no correspondence problem: all
+    // 2·nodeCount floats are lerped in one loop).
+    const nodeCount = bufA.length / 2;
+    for (let n = 0; n < nodeCount; n += 1) {
+      expect(mid[n * 2]).not.toBe(bufA[n * 2]);
+      expect(mid[n * 2 + 1]).not.toBe(bufA[n * 2 + 1]);
+    }
+  });
+
+  it("morphPositions clamps t to [0,1] and reuses a supplied out buffer", () => {
+    const bufA = new Float32Array([0, 0]);
+    const bufB = new Float32Array([10, 20]);
+    expect(Array.from(morphPositions(bufA, bufB, -1))).toEqual([0, 0]);
+    expect(Array.from(morphPositions(bufA, bufB, 2))).toEqual([10, 20]);
+    const out = new Float32Array(2);
+    const result = morphPositions(bufA, bufB, 1, out);
+    expect(result).toBe(out); // reused, no fresh allocation
+    expect(Array.from(out)).toEqual([10, 20]);
+  });
+
+  it("morphPositions returns null on missing input", () => {
+    expect(morphPositions(null, new Float32Array(2), 0.5)).toBeNull();
+    expect(morphPositions(new Float32Array(2), null, 0.5)).toBeNull();
+  });
+
+  it("nodeTypesForPayload reads node_type node-order-keyed (parallel to nodeIds)", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const types = nodeTypesForPayload(payload);
+    expect(types.length).toBe(payload.renderGraph.nodeIds.length);
+    for (let i = 0; i < types.length; i += 1) {
+      const id = payload.renderGraph.nodeIds[i];
+      expect(types[i]).toBe(payload.nodeById.get(id)?.node_type ?? null);
+    }
+    expect(types[payload.nodeIndexById.get("d")]).toBeNull(); // untyped node
+  });
+
+  it("computeLayoutBuffer('layers') bands typed nodes into swimlanes (2·n floats)", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const n = payload.renderGraph.nodeIds.length;
+    const layers = computeLayoutBuffer(payload, LAYOUT_MODE_LAYERS);
+
+    expect(layers).toBeInstanceOf(Float32Array);
+    expect(layers.length).toBe(n * 2);
+
+    const iA = payload.nodeIndexById.get("a");
+    const iB = payload.nodeIndexById.get("b");
+    const iC = payload.nodeIndexById.get("c");
+    // Same type ⇒ same lane (y); different type ⇒ different lane.
+    expect(layers[iA * 2 + 1]).toBe(layers[iB * 2 + 1]);
+    expect(layers[iA * 2 + 1]).not.toBe(layers[iC * 2 + 1]);
+    // The target differs from the (force) input positions → a real morph.
+    expect(Array.from(layers)).not.toEqual(Array.from(payload.renderGraph.positions));
+  });
+
+  it("computeLayoutBuffer('force') returns a COPY of the cached buffer (no cold re-solve)", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const n = payload.renderGraph.nodeIds.length;
+    const cached = new Float32Array(n * 2).fill(3);
+    const out = computeLayoutBuffer(payload, LAYOUT_MODE_FORCE, { forceBuffer: cached });
+    expect(Array.from(out)).toEqual(Array.from(cached));
+    expect(out).not.toBe(cached); // fresh copy, never the caller's buffer
+  });
+
+  it("computeLayoutBuffer('force') falls back to the current positions without a cache", () => {
+    const payload = buildGraphRendererPayload(makeTypedScene(), { nodeRadius: 3 });
+    const out = computeLayoutBuffer(payload, LAYOUT_MODE_FORCE);
+    expect(Array.from(out)).toEqual(Array.from(payload.renderGraph.positions));
+  });
+
+  it("computeLayoutBuffer degrades to null for a missing payload", () => {
+    expect(computeLayoutBuffer(null, LAYOUT_MODE_LAYERS)).toBeNull();
   });
 });

--- a/studio/src/tests/groupBy.test.js
+++ b/studio/src/tests/groupBy.test.js
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   computeGroupedGraph,
+  computeGroupTransition,
   classIdsAtLevel,
   typeNamesInTaxonomy,
   ontologyLevelState,
@@ -444,5 +445,96 @@ describe("B2 — real served mystery artifact (if present) folds a Domain end-to
     expect(node, `${domainId} fold node must be present`).toBeTruthy();
     expect(node.collapsed).toBe(true);
     expect(out.nodes.length).toBeLessThan(graph.nodes.length);
+  });
+});
+
+/* ===========================================================================
+ * Collapse/expand ANIMATION — computeGroupTransition (direction detection).
+ *
+ * PURE diff of (prev grouped keys, next grouped keys, prev fold-anchor map, next
+ * fold-anchor map) into the transition descriptor GraphCanvas plays:
+ *   - a target ADDED (grew, none removed)  → collapse (newly-folded children)
+ *   - a target REMOVED (shrank, none added) → expand (newly-revealed children)
+ *   - MIXED / no-op                          → null (hard cut, safety fallback)
+ * ======================================================================== */
+describe("computeGroupTransition — collapse/expand direction detection", () => {
+  it("children newly FOLDED (none revealed) → collapse, anchored via the NEXT map", () => {
+    const t = computeGroupTransition({
+      prevFoldAnchors: new Map(),
+      nextFoldAnchors: new Map([
+        ["holmes", "class:People"],
+        ["watson", "class:People"],
+      ]),
+    });
+    expect(t).not.toBeNull();
+    expect(t.direction).toBe("collapse");
+    expect(t.anchorByNodeId.get("holmes")).toBe("class:People");
+    expect(t.anchorByNodeId.get("watson")).toBe("class:People");
+    expect(t.anchorByNodeId.size).toBe(2);
+  });
+
+  it("an incremental collapse only animates the NEWLY-folded children (delta)", () => {
+    // People already folded; adding Villains folds moriarty. holmes/watson are
+    // ALREADY hidden (present in prev), so they must NOT animate again.
+    const t = computeGroupTransition({
+      prevFoldAnchors: new Map([
+        ["holmes", "class:People"],
+        ["watson", "class:People"],
+      ]),
+      nextFoldAnchors: new Map([
+        ["holmes", "class:People"],
+        ["watson", "class:People"],
+        ["moriarty", "class:Villains"],
+      ]),
+    });
+    expect(t.direction).toBe("collapse");
+    expect([...t.anchorByNodeId.keys()]).toEqual(["moriarty"]);
+    expect(t.anchorByNodeId.get("moriarty")).toBe("class:Villains");
+  });
+
+  it("children newly REVEALED (none folded) → expand, anchored via the PREV map", () => {
+    const t = computeGroupTransition({
+      prevFoldAnchors: new Map([
+        ["holmes", "class:People"],
+        ["watson", "class:People"],
+      ]),
+      nextFoldAnchors: new Map(),
+    });
+    expect(t.direction).toBe("expand");
+    expect(t.anchorByNodeId.get("holmes")).toBe("class:People");
+    expect(t.anchorByNodeId.get("watson")).toBe("class:People");
+    expect(t.anchorByNodeId.size).toBe(2);
+  });
+
+  it("a MIXED change (some folded AND some revealed) → null (hard cut fallback)", () => {
+    const t = computeGroupTransition({
+      prevFoldAnchors: new Map([["holmes", "class:People"]]),
+      nextFoldAnchors: new Map([["moriarty", "class:Villains"]]),
+    });
+    expect(t).toBeNull();
+  });
+
+  it("a no-op change (identical fold maps) → null", () => {
+    expect(
+      computeGroupTransition({
+        prevFoldAnchors: new Map([["holmes", "class:People"]]),
+        nextFoldAnchors: new Map([["holmes", "class:People"]]),
+      }),
+    ).toBeNull();
+  });
+
+  it("robust to ASYNC fold landing: a key change that folds NOTHING yet → null", () => {
+    // The grouped key changed but the artifact hasn't loaded, so the fold map is
+    // still empty on both sides — no direction until the fold actually lands.
+    expect(
+      computeGroupTransition({
+        prevFoldAnchors: new Map(),
+        nextFoldAnchors: new Map(),
+      }),
+    ).toBeNull();
+  });
+
+  it("defaults are safe — no args → null", () => {
+    expect(computeGroupTransition()).toBeNull();
   });
 });

--- a/studio/src/tests/hoverIntent.test.js
+++ b/studio/src/tests/hoverIntent.test.js
@@ -121,7 +121,19 @@ describe("GraphCanvas hover-intent wiring", () => {
     expect(source).toContain("requestConnectedDim");
     expect(source).toContain("applyConnectedDim");
     expect(source).not.toContain("|| !hasHoverTarget");
-    // the dwell is cancelled on pan/drag start, on selection change, and on destroy.
+    const pointerDown = source.slice(
+      source.indexOf("function handlePointerDown"),
+      source.indexOf("function handlePointerUp"),
+    );
+    expect(pointerDown).not.toContain("hoverIntent.cancel()");
+    const morphStartIndex = source.indexOf("function startLayoutMorphToBuffer");
+    const morphStart = source.slice(
+      morphStartIndex,
+      source.indexOf("const canAnimate", morphStartIndex),
+    );
+    expect(morphStart).toContain("setHoveredNode(null)");
+    expect(morphStart).not.toContain("hoverIntent.cancel()");
+    // Stale timers are still cancelled on scene reset, selection change, and destroy.
     expect(source).toContain("hoverIntent.cancel()");
   });
 });

--- a/studio/src/tests/hoverIntent.test.js
+++ b/studio/src/tests/hoverIntent.test.js
@@ -75,6 +75,26 @@ describe("hover-intent dwell gate", () => {
       expect(apply).toHaveBeenCalledTimes(1);
     });
 
+    it("keeps the current dim while empty space has not completed its dwell", () => {
+      let target = "node-a";
+      let appliedTarget = null;
+      const hi = createHoverIntent(() => {
+        appliedTarget = target;
+      });
+
+      hi.request({ immediate: false });
+      vi.advanceTimersByTime(HOVER_INTENT_DWELL_MS);
+      expect(appliedTarget).toBe("node-a");
+
+      target = null;
+      hi.request({ immediate: false });
+      vi.advanceTimersByTime(HOVER_INTENT_DWELL_MS - 1);
+      expect(appliedTarget).toBe("node-a");
+
+      vi.advanceTimersByTime(1);
+      expect(appliedTarget).toBeNull();
+    });
+
     it("an immediate request cancels a pending dwell (selection appears mid-dwell)", () => {
       const apply = vi.fn();
       const hi = createHoverIntent(apply);
@@ -100,6 +120,7 @@ describe("GraphCanvas hover-intent wiring", () => {
     // setHoveredNode no longer applies the dim inline; it requests it via the gate.
     expect(source).toContain("requestConnectedDim");
     expect(source).toContain("applyConnectedDim");
+    expect(source).not.toContain("|| !hasHoverTarget");
     // the dwell is cancelled on pan/drag start, on selection change, and on destroy.
     expect(source).toContain("hoverIntent.cancel()");
   });

--- a/tests/graph-layout.test.ts
+++ b/tests/graph-layout.test.ts
@@ -101,6 +101,33 @@ describe("computeLayout (Barnes-Hut force layout)", () => {
     expect(out).toHaveLength(count);
     expect(out.every((p) => Number.isFinite(p.x) && Number.isFinite(p.y))).toBe(true);
   });
+
+  it("honors linkDistance as the spring rest-length factor", () => {
+    const nodes: LayoutGraphNode[] = [{ id: "a" }, { id: "b" }];
+    const edges: LayoutGraphEdge[] = [{ source: "a", target: "b" }];
+    const tight = computeLayout(nodes, edges, { iterations: 180, linkDistance: 0.2 });
+    const loose = computeLayout(nodes, edges, { iterations: 180, linkDistance: 2 });
+    const dist = (out: typeof tight) => Math.hypot(out[0]!.x - out[1]!.x, out[0]!.y - out[1]!.y);
+    expect(dist(loose)).toBeGreaterThan(dist(tight));
+  });
+
+  it("warm-starts from initialPositions without pinning nodes", () => {
+    const nodes: LayoutGraphNode[] = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const edges: LayoutGraphEdge[] = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+    ];
+    const initialPositions = new Map([
+      ["a", { x: 10, y: 10 }],
+      ["b", { x: 20, y: 20 }],
+      ["c", { x: 30, y: 30 }],
+    ]);
+    const out = computeLayout(nodes, edges, { iterations: 1, initialPositions });
+    expect(out).toHaveLength(3);
+    expect(out.every((p) => Number.isFinite(p.x) && Number.isFinite(p.y))).toBe(true);
+    // If initialPositions pinned nodes, the first node would stay exactly there.
+    expect(out[0]).not.toMatchObject({ x: 10, y: 10 });
+  });
 });
 
 describe("attachLayoutPositions", () => {


### PR DESCRIPTION
## What
Codeflow-parity graph UX for the studio (ref `braedonsaunders/codeflow`, design-only). Delivers the principal-set requirement in `spec/SPEC_STUDIO_GRAPH_UX_CODEFLOW_PARITY.md`.

## Lots (each a commit)
- **Lot 1** — studio↔`@sentropic/graph` registry seam + all-node **morph tween** (Force↔Layers) on the WebGL2 renderer. Passed a **2-peer double-consensus** (foundation correct); 3 minor review fixes applied (F1 drag-clear on switch, F2 crash-safe morph, F3 prefers-reduced-motion).
- **Lot 2** — **Radial + Grid** layout engines (deterministic O(n+e)/O(n)). Reviewed: NO-DEFECTS.
- **Lot 3** — **Spread/Links** sliders → warm-started, debounced Force re-solve (new `linkDistance` + `initialPositions` on `computeLayout`); **Reset** = cold deterministic solve.
- **Lot 4** — **Curved-links** toggle (0↔0.15) + **Color-by** Folder/Layer.
- **Lot 5** — **Color-by Churn** continuous ramp (degree/activity fallback; git-churn source later, D2).
- **Lot 6** — **Metro** layout engine (MVP: BFS lanes, grid-snap). Octilinear edge routing deferred (touches the golden draw path).
- **Lot 7** — off-main-thread Force re-solve (Web Worker + sync fallback + stale-solve guard).

## Key design
Every layout engine returns an index-parallel `Float32Array` (same `graph.nodeIds`), so morphs are a per-index lerp — smooth transitions **between** layouts for free. Animation is a studio-owned tween generalizing the merge loop; the `@sentropic/graph` draw path is untouched → **goldens byte-identical**.

## Verify
- `packages/graph`: **306/306** (goldens byte-identical; +metro/registry tests).
- `studio`: new lot tests green; full suite 351 passed, **3 pre-existing jsdom env failures only** (WebGL mock `uniformMatrix4fv`, pdf.worker resolve) — reproduced identically on `main`.
- `tsc --noEmit`: clean.

## Open decision (needs principal — D5)
Interactive warm-started re-solves are **path-dependent** (same spread/links/seed can yield different coords). Contract: keep determinism only for the cold **Reset** solve. Confirm before/at merge.

## Deferred follow-ups (non-blocking)
Metro orthogonal edge router; radial multi-component layout (review F1); real git-churn source (D2).