### PR TITLE
fix(studio): ACLP studio — class-hierarchies route, flat-rail group-by, community labels

### DIFF
--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -18,7 +18,7 @@ import { buildStudioScene, type StudioScene } from "./studio-scene.js";
 import { attachLayoutPositions } from "./graph-layout.js";
 import { buildSearchIndex } from "./search-index-emitter.js";
 import type { SearchIndex } from "./search-index.js";
-import { emitClassHierarchies } from "./ontology-class-hierarchies-emitter.js";
+import { buildClassHierarchies } from "./ontology-class-hierarchies.js";
 import type { ClassHierarchiesArtifact } from "./types.js";
 import { loadGraphFromData, type SerializedGraphData } from "./graph.js";
 import {
@@ -310,15 +310,19 @@ function searchIndexJsonResult(stateDir: string): OntologyStudioRouteResult {
  * schema graphify_ontology_class_hierarchies_v1) the SPA's ontology-class
  * grouping (the taxonomy accordion + "Group by entity" Type axis) consumes.
  *
- * The STATIC `studio export` bakes this file via {@link emitClassHierarchies},
- * gated on the profile's `class_hierarchies` block — but the LIVE `ontology
- * studio` server had no equivalent route, so the SPA's `fetchClassHierarchies`
- * 404-ed and the class taxonomy never lit up. This route closes that gap: it
- * runs the SAME emitter over the loaded profile block + graph.json nodes and,
- * exactly like the scene / search-index routes, caches the result on graph.json
- * identity (path + mtime + size) so only the first fetch pays the build cost and
- * any edit invalidates it. The profile hash rides the key too, so restoring or
- * editing the profile block also busts the cache.
+ * The STATIC `studio export` bakes this file via `emitClassHierarchies` (the
+ * pure {@link buildClassHierarchies} + a disk write), gated on the profile's
+ * `class_hierarchies` block — but the LIVE `ontology studio` server had no
+ * equivalent route, so the SPA's `fetchClassHierarchies` 404-ed and the class
+ * taxonomy never lit up. This route closes that gap: like the scene /
+ * search-index routes it is PURE — it calls the same {@link buildClassHierarchies}
+ * builder over the loaded profile block + graph.json nodes and performs NO disk
+ * I/O (a GET must be side-effect-free: writing here would 500 on a read-only FS
+ * and could dirty a tracked worktree). Exactly like those sibling routes it
+ * caches the built artifact on graph.json identity (path + mtime + size) so only
+ * the first fetch pays the build cost and any edit invalidates it. The profile
+ * hash rides the key too, so restoring or editing the profile block also busts
+ * the cache.
  *
  * When the profile carries NO `class_hierarchies` block the artifact is absent
  * (byte-identical to the static export, which writes no file): the route 404s and
@@ -343,17 +347,22 @@ function classHierarchiesJsonResult(
   const key = `${graphPath} ${stat.mtimeMs} ${stat.size} ${profileHash ?? ""}`;
   let cached = classHierarchiesCache;
   if (!cached || cached.key !== key) {
-    const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
-      nodes?: Array<{ id?: string; node_type?: string; type?: string }>;
-    };
-    const graphNodes = Array.isArray(graph.nodes) ? graph.nodes : [];
-    const result = emitClassHierarchies({
-      ...(block ? { classHierarchies: block } : {}),
-      graphNodes,
-      ontologyOutputDir: join(stateDir, "ontology"),
-      ...(profileHash !== undefined ? { profileHash } : {}),
-    });
-    cached = { key, artifact: result.artifact };
+    // Gate identical to emitClassHierarchies' `hasClassHierarchies`: build the
+    // artifact IFF the profile carries a NON-EMPTY block; an absent/empty block
+    // yields a null artifact (the emitter writes no file for it) and the route
+    // 404s below. PURE — no mkdirSync/writeFileSync — so a GET never touches the
+    // state dir.
+    let artifact: ClassHierarchiesArtifact | null = null;
+    if (block && Object.keys(block).length > 0) {
+      const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+        nodes?: Array<{ id?: string; node_type?: string; type?: string }>;
+      };
+      const graphNodes = Array.isArray(graph.nodes) ? graph.nodes : [];
+      artifact = buildClassHierarchies(block, graphNodes, {
+        ...(profileHash !== undefined ? { profileHash } : {}),
+      });
+    }
+    cached = { key, artifact };
     classHierarchiesCache = cached;
   }
   if (cached.artifact === null) {

--- a/src/ontology-studio.ts
+++ b/src/ontology-studio.ts
@@ -18,6 +18,8 @@ import { buildStudioScene, type StudioScene } from "./studio-scene.js";
 import { attachLayoutPositions } from "./graph-layout.js";
 import { buildSearchIndex } from "./search-index-emitter.js";
 import type { SearchIndex } from "./search-index.js";
+import { emitClassHierarchies } from "./ontology-class-hierarchies-emitter.js";
+import type { ClassHierarchiesArtifact } from "./types.js";
 import { loadGraphFromData, type SerializedGraphData } from "./graph.js";
 import {
   getOntologyRebuildStatus,
@@ -301,6 +303,67 @@ function searchIndexJsonResult(stateDir: string): OntologyStudioRouteResult {
     searchIndexCache = cached;
   }
   return jsonResult(200, cached.index);
+}
+
+/**
+ * Serve the standalone ontology `class-hierarchies.json` artifact (EVOL 2.c,
+ * schema graphify_ontology_class_hierarchies_v1) the SPA's ontology-class
+ * grouping (the taxonomy accordion + "Group by entity" Type axis) consumes.
+ *
+ * The STATIC `studio export` bakes this file via {@link emitClassHierarchies},
+ * gated on the profile's `class_hierarchies` block — but the LIVE `ontology
+ * studio` server had no equivalent route, so the SPA's `fetchClassHierarchies`
+ * 404-ed and the class taxonomy never lit up. This route closes that gap: it
+ * runs the SAME emitter over the loaded profile block + graph.json nodes and,
+ * exactly like the scene / search-index routes, caches the result on graph.json
+ * identity (path + mtime + size) so only the first fetch pays the build cost and
+ * any edit invalidates it. The profile hash rides the key too, so restoring or
+ * editing the profile block also busts the cache.
+ *
+ * When the profile carries NO `class_hierarchies` block the artifact is absent
+ * (byte-identical to the static export, which writes no file): the route 404s and
+ * the SPA's `fetchClassHierarchies` already tolerates that (falls back to the
+ * bundle-relative static copy, then to null → the class toggle injects nothing).
+ */
+let classHierarchiesCache:
+  | { key: string; artifact: ClassHierarchiesArtifact | null }
+  | null = null;
+
+function classHierarchiesJsonResult(
+  context: ReturnType<typeof loadOntologyPatchContext>,
+): OntologyStudioRouteResult {
+  const stateDir = context.stateDir;
+  const graphPath = join(stateDir, "graph.json");
+  if (!existsSync(graphPath)) {
+    return jsonResult(404, { error: "graph.json not found" });
+  }
+  const block = context.profile.class_hierarchies;
+  const profileHash = context.profile.profile_hash;
+  const stat = statSync(graphPath);
+  const key = `${graphPath} ${stat.mtimeMs} ${stat.size} ${profileHash ?? ""}`;
+  let cached = classHierarchiesCache;
+  if (!cached || cached.key !== key) {
+    const graph = JSON.parse(readFileSync(graphPath, "utf-8")) as {
+      nodes?: Array<{ id?: string; node_type?: string; type?: string }>;
+    };
+    const graphNodes = Array.isArray(graph.nodes) ? graph.nodes : [];
+    const result = emitClassHierarchies({
+      ...(block ? { classHierarchies: block } : {}),
+      graphNodes,
+      ontologyOutputDir: join(stateDir, "ontology"),
+      ...(profileHash !== undefined ? { profileHash } : {}),
+    });
+    cached = { key, artifact: result.artifact };
+    classHierarchiesCache = cached;
+  }
+  if (cached.artifact === null) {
+    // No class_hierarchies block ⇒ no artifact (mirrors the static export, which
+    // writes no file). The SPA's fetchClassHierarchies tolerates the 404.
+    return jsonResult(404, {
+      error: "class-hierarchies unavailable: profile has no class_hierarchies block",
+    });
+  }
+  return jsonResult(200, cached.artifact);
 }
 
 function sendResult(response: ServerResponse, result: OntologyStudioRouteResult): void {
@@ -615,6 +678,9 @@ export function handleOntologyStudioRequest(
     }
     if (url.pathname === "/api/ontology/search-index.json") {
       return searchIndexJsonResult(context.stateDir);
+    }
+    if (url.pathname === "/api/ontology/class-hierarchies.json") {
+      return classHierarchiesJsonResult(context);
     }
     const entityPrefix = "/api/ontology/entity/";
     if (url.pathname.startsWith(entityPrefix)) {

--- a/src/storage/postgres.ts
+++ b/src/storage/postgres.ts
@@ -576,6 +576,10 @@ export async function createPostgresGraphStore(
   ): unknown[][] {
     const byType = new Map<string, number>();
     const byCommunity = new Map<number, number>();
+    // Human community label carried on the node (`community_name`). All members
+    // of a community share it, so the first non-empty value wins; communities
+    // without one fall back to the synthetic `Community <key>` label below.
+    const communityLabel = new Map<number, string>();
     G.forEachNode((nodeId, attrs) => {
       const a = attrs as Record<string, unknown>;
       const nodeType = resolveNodeType(a);
@@ -585,6 +589,10 @@ export async function createPostgresGraphStore(
         (typeof a.community === "number" ? a.community : null);
       if (community !== null) {
         byCommunity.set(community, (byCommunity.get(community) ?? 0) + 1);
+        if (!communityLabel.has(community) && typeof a.community_name === "string") {
+          const name = a.community_name.trim();
+          if (name.length > 0) communityLabel.set(community, name);
+        }
       }
     });
     const rows: unknown[][] = [];
@@ -593,7 +601,8 @@ export async function createPostgresGraphStore(
     }
     for (const [cid, count] of byCommunity) {
       const key = String(cid);
-      rows.push([citySlug, snapshotId, "community", key, `Community ${key}`, count, null]);
+      const label = communityLabel.get(cid) ?? `Community ${key}`;
+      rows.push([citySlug, snapshotId, "community", key, label, count, null]);
     }
     return rows;
   }

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -6,7 +6,6 @@
    * itself is shown in the right column (SelectionPanel).
    */
   import {
-    SelectableList,
     SelectableRow,
     Search,
     Badge,
@@ -209,34 +208,14 @@
   const totalNodeCount = $derived(graphNodes(graph).length);
   const hasQuery = $derived(query.trim().length > 0);
 
-  // Communities + Entities use STANDALONE SelectableRows (selected/onselect), so
-  // they need the selection-membership sets for the per-row `selected` flag.
-  // (Types uses a SelectableList controlled by selection.types — see below.)
+  // Types, Communities + Entities all use STANDALONE SelectableRows
+  // (selected/onselect), so they need the selection-membership sets for the
+  // per-row `selected` flag. Standalone rows also avoid the DS SelectableList
+  // register()/sortByDom() O(n) per row → O(n²) at mount that pegs the main
+  // thread on a large list, and let each Type row carry its own left-hand
+  // group-by checkbox next to the FILTER row.
   const commSet = $derived(new Set(selection.communities));
   const entSet = $derived(new Set(selection.entities));
-
-  // Types is wrapped in a DS SelectableList (only ~3 rows, so the listbox roving
-  // tabindex is cheap). The list is controlled by the current selection array and
-  // emits the FULL new array on every change; the studio's viewerState model is a
-  // per-element toggle (toggleType), so recover the single key that flipped between
-  // `prev` and `next` and forward it to the existing toggle action. A multi-toggle
-  // changes exactly one key per activate.
-  //
-  // NOTE: Communities (222) and Entities (1000s) deliberately do NOT use
-  // SelectableList — its register()/sortByDom() is O(n) per row → O(n²) at mount
-  // of a large list, which pegs the main thread when those accordions expand.
-  // Standalone rows keep the multi-toggle behavior at zero registration cost.
-  function toggledKey(prev, next) {
-    const before = new Set(prev);
-    const after = new Set(next);
-    for (const k of after) if (!before.has(k)) return k; // added
-    for (const k of before) if (!after.has(k)) return k; // removed
-    return null;
-  }
-  function onListChange(prev, next, toggle) {
-    const key = toggledKey(prev, next);
-    if (key != null) toggle?.(key);
-  }
 </script>
 
 <aside class="rail" aria-label="Search">
@@ -426,25 +405,44 @@
         </div>
       {/if}
     {:else}
-      <SelectableList
-        class="rail-list"
-        label="Ontology"
-        multiple
-        value={selection.types}
-        onchange={(next) => onListChange(selection.types, next, onToggleType)}
-      >
+      <!-- FLAT fallback (no class taxonomy). Each leaf TYPE row carries its OWN
+           bare group-by checkbox on the LEFT — folds entities of this `type` via
+           onToggleGroupType (the engine folds by type WITHOUT a taxonomy, so
+           "Group by entity" / the Type axis must be reachable here too). It is
+           SEPARATE from the Type FILTER SelectableRow (onToggleType) that follows
+           it. Mirrors the accordion leaf row (§2). Standalone SelectableRows keep
+           the multi-toggle at zero SelectableList registration cost. -->
+      <ul class="rail-list rail-type-flat" aria-label="Ontology types">
         {#each typeList as t (t.key)}
-          <SelectableRow value={t.key}>
-            {#snippet leading()}
-              <TypeShapeGlyph type={t.key} />
-            {/snippet}
-            {t.key}
-            {#snippet trailing()}
-              <Badge shape="circle" size="sm" tone="neutral">{t.count}</Badge>
-            {/snippet}
-          </SelectableRow>
+          <li class="rail-type-row">
+            <label
+              class="rail-group-check rail-type-group-check"
+              class:rail-group-check--on={typeCheckedSet.has(t.key)}
+              title="Group by {t.key}"
+            >
+              <input
+                type="checkbox"
+                checked={typeCheckedSet.has(t.key)}
+                aria-label="Group by {t.key}"
+                onchange={() => onToggleGroupType?.(t.key)}
+              />
+            </label>
+            <SelectableRow
+              value={t.key}
+              selected={typeSet.has(t.key)}
+              onselect={() => onToggleType?.(t.key)}
+            >
+              {#snippet leading()}
+                <TypeShapeGlyph type={t.key} />
+              {/snippet}
+              {t.key}
+              {#snippet trailing()}
+                <Badge shape="circle" size="sm" tone="neutral">{t.count}</Badge>
+              {/snippet}
+            </SelectableRow>
+          </li>
         {/each}
-      </SelectableList>
+      </ul>
     {/if}
   </Collapsible>
 
@@ -644,18 +642,13 @@
     margin-top: 0.45rem;
     font-variant-numeric: tabular-nums;
   }
-  /* The Communities/Entities lists are plain <ul> of standalone SelectableRows. */
+  /* The Types (flat fallback) / Communities / Entities lists are plain <ul> of
+     standalone SelectableRows. */
   ul.rail-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 1px;
-  }
-  /* The Types list is a DS SelectableList (listbox wrapper, roving tabindex); each
-     SelectableRow owns leading | content | trailing layout + selected styling. We
-     only tighten the inter-row gap to the rail's dense 1px feel. */
-  :global(.rail-list.st-selectableList) {
     gap: 1px;
   }
   /* B2-UI-3 + B2-UI-4: DS typography alignment. The bare DS SelectableRow has NO

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -66,6 +66,25 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     expect(appSource).toMatch(/onToggleGroupType=\{handleToggleGroupType\}/);
   });
 
+  it("the FLAT fallback (no taxonomy) ALSO offers a per-type group-by checkbox", () => {
+    // FIX: when the class taxonomy is absent the Ontology facet falls back to the
+    // {:else} flat list. It must still expose the Type-axis group-by (the engine
+    // folds by type WITHOUT a taxonomy), so "Group by entity" is reachable there
+    // too — mirroring the accordion leaf. The flat list is now a <ul> of
+    // standalone rows (checkbox → onToggleGroupType, then the FILTER SelectableRow
+    // → onToggleType), NOT a bare SelectableList without a group-by affordance.
+    expect(railSource).toMatch(/rail-type-flat/);
+    // The flat branch renders BOTH a group-by checkbox AND the filter row per type.
+    expect(railSource).toMatch(
+      /rail-type-flat[\s\S]*?rail-type-group-check[\s\S]*?onToggleGroupType\?\.\(t\.key\)[\s\S]*?onselect=\{\(\) => onToggleType\?\.\(t\.key\)\}/,
+    );
+    // There are now FIVE `--on` group-by checkboxes in the source: Domain,
+    // Sub-domain, accordion Type, FLAT Type, Community (the accordion + flat Type
+    // checkboxes are mutually exclusive at runtime via {#if typeTree}/{:else}).
+    const onMarkers = railSource.match(/class:rail-group-check--on=/g) ?? [];
+    expect(onMarkers.length).toBe(5);
+  });
+
   it("each Community row owns a per-item group-by checkbox (separate from its select)", () => {
     expect(railSource).toMatch(/onToggleGroupCommunity\?\.\(c\.key\)/);
     expect(railSource).toMatch(/checked=\{communityCheckedSet\.has\(c\.key\)\}/);
@@ -105,11 +124,12 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
 
   it("the group-by checkbox is on the LEFT with NO 'group' text (SPEC)", () => {
     // SPEC PART 1: the bare checkbox is the FIRST element on the row. There are
-    // FOUR group-by checkboxes — Domain, Sub-domain, Type, Community — each
-    // carrying the `rail-group-check` affordance (the Type one adds the
-    // `rail-type-group-check` variant).
+    // FIVE group-by checkboxes — Domain, Sub-domain, accordion Type, FLAT-fallback
+    // Type, Community — each carrying the `rail-group-check` affordance (the two
+    // Type ones add the `rail-type-group-check` variant; the accordion and flat
+    // Type checkboxes are mutually exclusive at runtime via {#if typeTree}/{:else}).
     const onMarkers = railSource.match(/class:rail-group-check--on=/g) ?? [];
-    expect(onMarkers.length).toBe(4);
+    expect(onMarkers.length).toBe(5);
     // FIX: the DS Collapsible exposes NO `leading` slot (only trailing/children),
     // so the Domain + Sub-domain group-by checkboxes are SIBLINGS *before*
     // <Collapsible> inside a `.rail-onto-head` flex row — NOT in a (silently

--- a/studio/src/tests/typeShapeGlyph.test.js
+++ b/studio/src/tests/typeShapeGlyph.test.js
@@ -48,9 +48,12 @@ describe("TypeShapeGlyph (left-rail type swatches)", () => {
   it("LeftRail shows the glyph in the DS SelectableRow leading slot, left of the type label", () => {
     expect(railSource).toMatch(/import TypeShapeGlyph from "\.\/TypeShapeGlyph\.svelte"/);
     // DS slots: the glyph lives in the `leading` slot (rendered left of content)
-    // and the type label is the row's default content.
+    // and the type label is the row's default content. Both the taxonomy accordion
+    // and the flat fallback render the Type SelectableRow with its FILTER wiring
+    // (value/selected/onselect) — so the opening tag is multi-line — followed by
+    // the glyph-in-leading-slot pattern.
     expect(railSource).toMatch(
-      /<SelectableRow value=\{t\.key\}>\s*\{#snippet leading\(\)}\s*<TypeShapeGlyph type=\{t\.key\} \/>\s*\{\/snippet}\s*\{t\.key\}/,
+      /<SelectableRow[\s\S]*?value=\{t\.key\}[\s\S]*?>\s*\{#snippet leading\(\)}\s*<TypeShapeGlyph type=\{t\.key\} \/>\s*\{\/snippet}\s*\{t\.key\}/,
     );
   });
 

--- a/tests/helpers/ontology-write-fixture.ts
+++ b/tests/helpers/ontology-write-fixture.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { ONTOLOGY_PATCH_SCHEMA, type OntologyPatch } from "../../src/ontology-patch.js";
+import type { NormalizedClassHierarchySpec } from "../../src/types.js";
 
 export interface OntologyWriteFixture {
   root: string;
@@ -13,6 +14,15 @@ export interface OntologyWriteFixture {
   patch: OntologyPatch;
 }
 
+export interface OntologyWriteFixtureOptions {
+  /**
+   * Optional normalized `class_hierarchies` block to stamp on the fixture's
+   * ontology-profile.normalized.json (mirrors a profile that declares a class
+   * taxonomy). Absent ⇒ the profile carries no block, byte-identical to before.
+   */
+  classHierarchies?: Record<string, NormalizedClassHierarchySpec>;
+}
+
 const PROFILE_HASH = "profile-hash";
 const GRAPH_HASH = "graph-hash";
 
@@ -21,7 +31,10 @@ const GRAPH_HASH = "graph-hash";
  * Mirrors the layout produced by `graphify profile dataprep` for a tiny synthetic
  * profile with a single Component canonical entity and one candidate.
  */
-export function writeOntologyWriteFixture(root: string): OntologyWriteFixture {
+export function writeOntologyWriteFixture(
+  root: string,
+  options: OntologyWriteFixtureOptions = {},
+): OntologyWriteFixture {
   const stateDir = join(root, ".graphify");
   const profileDir = join(stateDir, "profile");
   const ontologyDir = join(stateDir, "ontology");
@@ -82,6 +95,7 @@ export function writeOntologyWriteFixture(root: string): OntologyWriteFixture {
         inference_policy: { allow_inferred_relations: true, allowed_relation_types: [], require_evidence_refs: false },
         evidence_policy: { require_evidence_refs: false, min_refs: 0, node_types: [], relation_types: [] },
         hierarchies: {},
+        ...(options.classHierarchies ? { class_hierarchies: options.classHierarchies } : {}),
         outputs: {
           ontology: {
             enabled: true,

--- a/tests/ontology-studio-scene-route.test.ts
+++ b/tests/ontology-studio-scene-route.test.ts
@@ -7,6 +7,7 @@ import { handleOntologyStudioRequest } from "../src/ontology-studio.js";
 import { buildStudioScene } from "../src/studio-scene.js";
 import { attachLayoutPositions } from "../src/graph-layout.js";
 import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
+import type { NormalizedClassHierarchySpec } from "../src/types.js";
 
 const tempDirs: string[] = [];
 
@@ -130,6 +131,70 @@ describe("GET /api/ontology/search-index.json (work-stream C)", () => {
       { profileStatePath: fixture.profileStatePath },
       "GET",
       "/api/ontology/search-index.json",
+    );
+    expect(result.status).toBe(404);
+    expect(JSON.parse(result.body)).toEqual({ error: "graph.json not found" });
+  });
+});
+
+describe("GET /api/ontology/class-hierarchies.json (EVOL 2.c)", () => {
+  // A minimal normalized class taxonomy: Thing → Person, Person gathers the
+  // graph's `Character` node_type as instances.
+  const TAXONOMY: Record<string, NormalizedClassHierarchySpec> = {
+    tax: {
+      relation_type: "subclass_of",
+      membership_relation_type: "has_instance",
+      classes: {
+        Thing: { parent: null, label: null, member_node_types: [] },
+        Person: { parent: "Thing", label: null, member_node_types: ["Character"] },
+      },
+    },
+  };
+
+  it("serves the emitClassHierarchies artifact when the profile declares a block", () => {
+    const fixture = writeOntologyWriteFixture(makeTempDir(), { classHierarchies: TAXONOMY });
+    writeGraph(fixture.stateDir, GRAPH_FIXTURE);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath },
+      "GET",
+      "/api/ontology/class-hierarchies.json",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.contentType).toBe("application/json; charset=utf-8");
+
+    const payload = JSON.parse(result.body);
+    expect(payload.schema).toBe("graphify_ontology_class_hierarchies_v1");
+    // Character-typed graph nodes (n1..n3) are gathered under the Person leaf.
+    expect(payload.hierarchies.tax.classes_by_id["class:Person"].member_ids).toEqual([
+      "n1",
+      "n2",
+      "n3",
+    ]);
+  });
+
+  it("404s (client-tolerated) when the profile has no class_hierarchies block", () => {
+    // The default fixture carries no block — mirrors the static export writing
+    // no file; the SPA's fetchClassHierarchies falls back to null.
+    const fixture = writeOntologyWriteFixture(makeTempDir());
+    writeGraph(fixture.stateDir, GRAPH_FIXTURE);
+
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath },
+      "GET",
+      "/api/ontology/class-hierarchies.json",
+    );
+    expect(result.status).toBe(404);
+    expect(JSON.parse(result.body).error).toMatch(/class_hierarchies/);
+  });
+
+  it("404s when graph.json is absent", () => {
+    const fixture = writeOntologyWriteFixture(makeTempDir(), { classHierarchies: TAXONOMY });
+    const result = handleOntologyStudioRequest(
+      { profileStatePath: fixture.profileStatePath },
+      "GET",
+      "/api/ontology/class-hierarchies.json",
     );
     expect(result.status).toBe(404);
     expect(JSON.parse(result.body)).toEqual({ error: "graph.json not found" });

--- a/tests/ontology-studio-scene-route.test.ts
+++ b/tests/ontology-studio-scene-route.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -172,6 +172,14 @@ describe("GET /api/ontology/class-hierarchies.json (EVOL 2.c)", () => {
       "n2",
       "n3",
     ]);
+
+    // A GET must be side-effect-free: the route calls the PURE builder, so it
+    // writes NO class-hierarchies.json into the state dir's ontology/ (the old
+    // writing emitter did — this guards against a regression that 500s on a
+    // read-only FS and can dirty a tracked worktree).
+    expect(
+      existsSync(join(fixture.stateDir, "ontology", "class-hierarchies.json")),
+    ).toBe(false);
   });
 
   it("404s (client-tolerated) when the profile has no class_hierarchies block", () => {

--- a/tests/storage-postgres-group-counts.test.ts
+++ b/tests/storage-postgres-group-counts.test.ts
@@ -257,6 +257,28 @@ describe("Postgres group counts: replace push aggregate", () => {
     expect(result.groups.find((g) => g.key === "0")!.label).toBe("Community 0");
   });
 
+  it("groupCounts('community') labels a community by its node community_name when present", async () => {
+    const state = freshState();
+    const store = await makePostgresStore(state, "gc_comm_named");
+
+    // Community 0's members carry a human `community_name`; community 1 does not.
+    const G = new Graph();
+    G.addNode("alpha", { label: "Alpha", node_type: "code", community_name: "Detectives" });
+    G.addNode("beta", { label: "Beta", node_type: "code", community_name: "Detectives" });
+    G.addNode("gamma", { label: "Gamma", node_type: "doc" });
+    G.addEdge("alpha", "beta", { relation: "imports" });
+    const communities = new Map([[0, ["alpha", "beta"]], [1, ["gamma"]]]);
+
+    await store.pushGraph(G, communities, { mode: "replace" });
+    const result = await store.groupCounts!("community");
+    await store.close();
+
+    // The named community surfaces its community_name as the group label…
+    expect(result.groups.find((g) => g.key === "0")!.label).toBe("Detectives");
+    // …while an unnamed community keeps the synthetic fallback.
+    expect(result.groups.find((g) => g.key === "1")!.label).toBe("Community 1");
+  });
+
   it("returns an empty group list for an unknown / deferred axis (class_id)", async () => {
     const state = freshState();
     const store = await makePostgresStore(state, "gc_unknown");


### PR DESCRIPTION
## What
Fixes 3 diagnosed defects on the aclp-am ontology studio (root causes classified data/build · server · client).

- **FIX 1 (server):** the live `ontology studio` server had NO `/api/ontology/class-hierarchies.json` route (only static `studio export` baked it) → the Domain→Sub-domain→Type accordion vanished. Adds the route (emits from the loaded profile + graph, cached on graph.json identity; 404 when the profile carries no `class_hierarchies` block, which the client already tolerates).
- **FIX 2 (client):** group-by-type was only reachable inside the taxonomy accordion; when the taxonomy is absent the flat fallback offered only a filter. Adds a per-row group-by-type checkbox in the flat rail (engine already folds by type without a taxonomy).
- **FIX 3 (build):** `buildGroupCountRows` hardcoded `Community N` and never read `community_name`; now carries the real label (fallback `Community N`).

## Verify
- ontology-studio route test, storage group-counts test, leftRail test — green; `tsc --noEmit` clean.

## Data follow-ups (NOT in this PR)
1. Restore the aclp-am profile `class_hierarchies` block (route serves it once present).
2. Run community-labelling + rebuild the aclp-am graph (code path fixed; existing data still needs the rebuild).

Side note (separate): ~24.7k communities / 47.7k nodes ≈ 1.9 each looks like degenerate clustering — worth its own look.