### PR TITLE
feat(studio): 4-state per-entity visibility control (Normal/Grouped/Hidden/Solo) — DS-native

### DIFF
--- a/spec/SPEC_ENTITY_VISIBILITY_STATES.md
+++ b/spec/SPEC_ENTITY_VISIBILITY_STATES.md
@@ -1,0 +1,101 @@
+# SPEC — Entity visibility states (4-state per-entity control)
+
+**Status:** FROZEN design (v1) — awaiting cross-vendor double-consensus hardening before implementation.
+**Branch:** `feat/entity-visibility-states` (off main @ ce61be4).
+**Supersedes:** the single "group" checkbox per left-rail row.
+
+## 1. Goal & principal-validated ergonomics
+Replace the per-row group **checkbox** with a **4-state** per-entity control:
+**Normal · Grouped · Hidden · Solo** (mutually exclusive per entity). All state changes
+animate **smoothly**, reusing the group/ungroup **position-carry-over** animation shipped
+in `a2cf207` (no force re-solve, no camera refit — shared nodes stay put).
+
+The principal validated this ergonomic direction:
+- **NOT** a 4-way click-cycle (undiscoverable, multi-click, jarring intermediate renders).
+- **At-rest state glyph** on every row (state visible at a glance across all ~122 rows)
+  **+ a hover/focus-revealed 4-way segmented control** (any state in **one click**, tooltips,
+  radiogroup a11y). Touch fallback: the glyph opens a 4-radio popover.
+- A **global "Show all / Reset"** affordance (clears Hidden/Solo/Grouped → Normal).
+
+## 2. State model
+Each **entity** (a left-rail row = a community, an ontology class, or a type) holds exactly
+one of:
+- **Normal** (default) — visible, ungrouped.
+- **Grouped** — members collapse into the entity's group node (existing collapse engine).
+- **Hidden** — the entity's nodes are excluded from the rendered scene.
+- **Solo** — focus. See §3.
+
+## 3. Solo = reversible, multi (principal-chosen)
+- Setting entity X to **Solo** flips the **complement to display-Hidden** (the principal's
+  "afficher seulement bascule le complémentaire en Masqué").
+- **Reversible:** Solo is a DISPLAY OVERLAY, not a destructive bulk edit. Each non-Solo
+  entity keeps its OWN stored state (Normal/Grouped/Hidden); while ≥1 Solo is active the
+  renderer shows ONLY the Solo entities and hides the rest. Clearing all Solo restores every
+  entity to its stored state.
+- **Multi-Solo:** several entities may be Solo at once → "show only this SET".
+- **Exit:** toggling a Solo entity back to Normal removes it from the Solo set; the global
+  Reset clears all Solo (and Hidden/Grouped).
+
+## 4. Transitions (reuse the carry-over engine)
+Every transition is **position-preserving** — `applyCarriedScene` + the fade machinery from
+`a2cf207` (`runGroupTween`, `interpolateGroupFadeStyle`, `morphPositions`, `groupSwapPending`,
+the position cache `lastKnownPosById`/`coordinateEpoch`). NO re-solve, NO camera refit, ever.
+- **→ Grouped / → Normal-from-Grouped:** the existing fold/unfold animation.
+- **→ Hidden:** the entity's nodes **fade out + shrink in place** (target = "gone", not folded
+  to an anchor); remaining nodes carried (frozen).
+- **→ Normal-from-Hidden:** nodes **fade in** at their cached prior positions (constellation
+  cache) or neighbour-centroid.
+- **→ Solo:** the complement fades out (identical to Hide, applied to all non-Solo). **Exit
+  Solo:** complement fades back in at cached positions.
+
+## 5. Data-flow (to be grounded by the double-consensus against the real code)
+- **viewerState** today carries a grouped-key set (`viewerState.js` `withGrouped`, the
+  `collapsedClassIds`/grouped keys). Extend to a per-entity **state map** + a **Solo set**
+  (or a single map with a Solo value + a "solo active" derived flag). Must stay
+  backward-compatible with any persisted viewer state (migration path).
+- **groupBy.js / classNodes.js** already turn grouped keys → collapse targets. Extend so the
+  scene builder ALSO emits the **hidden node set** = Hidden entities' nodes ∪ (when any Solo
+  is active) the non-Solo complement's nodes. The scene excludes hidden nodes.
+- **groupTransition descriptor** (the `{direction, anchorByNodeId}` consumed by GraphCanvas)
+  must generalize to cover Hide/Show and Solo-enter/exit — i.e. a per-change descriptor that
+  the animation can play: folded set (→ anchor), hidden set (→ fade in place), revealed set
+  (→ fade in from cache). Likely `{grouped, ungrouped, hidden, revealed, anchorByNodeId}`.
+- **LeftRail.svelte** renders the rows; replace the checkbox with the state widget (§1) and
+  wire clicks → viewerState mutations. The existing **"Group all to Domain/Sub-domain/Type"**
+  bulk buttons write the SAME state model (bulk → Grouped) and animate the same way.
+
+## 6. Edge cases (double-consensus to resolve, with recommended defaults)
+1. **A node in multiple entities** (e.g. shared across communities/types): hiding one entity
+   should hide a node ONLY if it is not kept visible by another visible/Solo entity. Recommend:
+   a node is rendered iff at least one of its owning entities is currently visible.
+2. **Grouped ∩ Solo:** soloing a Grouped entity shows only its **group node** (its collapse
+   stands); its stored Grouped state is preserved. Setting an entity to Solo does NOT change
+   its Grouped/Normal storage — Solo is an overlay (§3).
+3. **Reset mid-transition:** a Reset while a tween runs must complete the pending swap
+   synchronously (per the animation's interrupt rule) then apply the reset as one carried swap.
+4. **Bulk group-all + Solo active:** the bulk sets stored states; the Solo overlay still gates
+   what renders. Resolve ordering.
+5. **Empty result** (Solo an entity with no on-screen nodes, or Hide everything): position-
+   preserving no-op / graceful empty — never a refit or a crash.
+6. **Performance at ~122 rows / ~2000 nodes:** state changes must be O(changed nodes), the
+   hidden-set computation incremental where possible.
+
+## 7. Verification contract (for the implementing PR)
+- **Unit (vitest):** the state reducer (Normal/Grouped/Hidden/Solo transitions incl. multi-Solo
+  + reset); the hidden-set derivation (Hidden ∪ Solo-complement, multi-entity node ownership);
+  the extended groupTransition descriptor; the LeftRail widget wiring (source-string like the
+  existing rows). Keep the animation's existing behavioural tests green.
+- **CDP visual UAT** (the decisive check, run only when RAM is stable / with principal OK):
+  each of the 4 states animates position-preservingly (shared-node screen delta < 1px, camera
+  x/y/zoom unchanged); Solo hides the complement + restores it on exit; multi-Solo shows the set.
+- Studio suite green except the 3 known jsdom failures; lint clean; build succeeds.
+
+## 8. Open items the double-consensus MUST close
+1. Exact **viewerState schema** (state map vs map+solo-set) + persistence migration.
+2. Exact **groupTransition descriptor** shape covering all 4 states + Solo enter/exit, and how
+   GraphCanvas plays a mixed change in ONE tween.
+3. Multi-entity **node ownership** rule for the hidden set (recommend §6.1).
+4. Precise **Solo-overlay vs stored-state precedence** and the render/derivation order.
+5. Widget details: exact glyphs, hover vs focus reveal, touch popover, global-Reset placement,
+   full a11y (radiogroup + labels).
+6. Whether Hide/Solo need to touch `classNodes.js` (fold engine) or only the scene filter.

--- a/spec/SPEC_ENTITY_VISIBILITY_STATES.md
+++ b/spec/SPEC_ENTITY_VISIBILITY_STATES.md
@@ -99,3 +99,74 @@ the position cache `lastKnownPosById`/`coordinateEpoch`). NO re-solve, NO camera
 5. Widget details: exact glyphs, hover vs focus reveal, touch popover, global-Reset placement,
    full a11y (radiogroup + labels).
 6. Whether Hide/Solo need to touch `classNodes.js` (fold engine) or only the scene filter.
+
+---
+
+## 9. v2 — RECONCILED decisions (cross-vendor double-consensus: Fable 5 + Opus)
+
+Both independent passes (`.graphify/research/entity-states-review-fable.md`,
+`entity-states-review-opus.md`) — the implementer follows THIS section; the two review
+docs carry the full per-file plan, reducer, and adversarial tables. Where they diverged I
+arbitrated (noted). This is now the implementation contract.
+
+**SPINE (both, load-bearing).** The `groupTransition` descriptor (`App.svelte:229-237`) is
+derived from the collapse fold-delta and is **blind to Hide/Solo** → implemented as the v1
+spec reads, every Hide/Solo change yields an empty delta → `groupTransition===null` → the
+scene `$effect` hard-cuts via `resetLayoutState(); updateGraph()` (**refit**), violating the
+sacred no-refit invariant. FIX = a **content-derived visibility delta** feeding an extended
+descriptor. This is the heart of the feature.
+
+**D1 — Ownership rule (AMENDS spec §6.1; both dissent).** §6.1's "render iff ≥1 owning entity
+visible" is DEAD ON ARRIVAL — every node is owned by its Normal-by-default Type/class chain,
+so Hide becomes a no-op. Correct: **Normal ABSTAINS**; **Hidden = union suppression** (a node
+hides iff ANY of its owning entities is stored-Hidden); the "≥1 visible" whitelist union
+applies ONLY inside the **Solo tier** (when solo active: `visible = members(solo) \
+members(storedHidden \ solo)`).
+
+**D2 — Schema (arbitrated → Fable's shape; it uniquely satisfies both §2 exclusivity AND §6.2
+solo-preserves-grouped).** Keep `groupBy.grouped` UNCHANGED; add `options.visibility =
+{ hidden: string[], solo: string[] }` keyed by the existing namespaced keys
+(`ontology:|community:|type:`). Stored state ∈ {Normal, Grouped, Hidden} is exclusive; **Solo
+is a separate overlay set** (a Grouped entity soloed shows its group node — Solo never mutates
+grouped/hidden storage). Reducer: `setEntityState(key, state)` (enforces exclusivity of
+grouped/hidden/normal) + `toggleSolo(key)` + `resetVisibility()`. Migration = defaults in
+`normalizeViewerState` (there is NO localStorage in studio/src — verified). **`classNodes.js`:
+ZERO changes.**
+
+**D3 — Extended descriptor + 3 MANDATORY guards (both; guards from Fable).**
+`{ folded, unfolded, hiddenIds, revealedIds, kind }`. Play in GraphCanvas via the SAME
+`applyCarriedScene`/`runGroupTween`/`interpolateGroupFadeStyle`/`groupSwapPending`/
+`lastKnownPosById` — folded→anchor (existing), **hidden→fade-in-place (`bufB==bufA`)**,
+revealed→fade-in-at-cached-target. Guards (each closes a real trap):
+(a) **anchor-id exclusion** — else every shipped pure-collapse silently degrades to mixed/no-anim;
+(b) **∩ scene-ids** — else a hidden-then-folded id masquerades as revealed;
+(c) **generation gate** — closes a latent pre-existing model-switch coordinate-carry hole this
+feature would amplify.
+
+**D4 — Mixed change classification (both).** Per node classify OUT (in old only) / IN (in new
+only) / two-sided. OUT and IN each animate as one tween; a genuinely **two-sided** change =
+**carried NON-animated swap** (never a refit — strictly better than today's mixed⇒refit).
+Global **Reset is provably pure-IN** → animates coherently. Sequential two-phase = V2 (flagged).
+
+**D5 — Derivation order (both).** grouped fold → `buildScene` → **visibility mask** (Solo union
+> stored Hidden > Normal, per D1) → time/weak filter → **transition diff LAST**, computed on the
+**pre-time-filter** mask so time-scrub never spawns tweens. Scene filter =
+`applyVisibilityToScene` (empty mask ⇒ SAME reference for the byte-identity fast path); a group
+node's visibility follows its entity via the synthetic-node predicates
+(`community_key`/`type_name`, never id parsing).
+
+**D6 — Widget (both).** New `EntityStateControl.svelte`: at-rest SVG state glyph + hover/focus-
+revealed **4-segment OVERLAY** (no rail reflow at 122 rows), WAI-ARIA radiogroup + roving
+tabindex, touch popover via the DS `Popover`; global **"Reset visibility"** in the rail header /
+under the search stats. Rows absorbed by a collapse are disabled. Wire clicks → the D2 reducer.
+
+**File plan (~600 LOC, both converge):** `viewerState.js` (reducer + normalize),
+new `entityVisibility.js` (mask + hidden-set + the D1 rule), `groupBy.js` (compute the
+visibility transition + wire the descriptor), `App.svelte` (unify the descriptor advancing both
+prev-snapshots, apply the 3 guards), `GraphCanvas.svelte` (route hidden/revealed through the
+existing carry-over tween), new `EntityStateControl.svelte` + `LeftRail.svelte` wiring.
+
+**Adversarial must-tests (both):** the two descriptor classification traps (D3 a/b) as
+regressions; the epoch-bump-wipes-reveal-cache + two-snapshot-desync (Opus risk table); the D1
+union rule at mystery scale (Hide is NOT a no-op); Solo-preserves-grouped; multi-Solo; Reset =
+pure-IN animates. CDP visual UAT deferred until RAM is stable / principal OK.

--- a/studio/package.json
+++ b/studio/package.json
@@ -19,6 +19,7 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
+    "@lucide/svelte": "^0.562.0",
     "@sentropic/design-system-svelte": "^0.34.33",
     "@sentropic/design-system-themes": "^0.11.0",
     "@sentropic/design-system-tokens": "^0.11.0",

--- a/studio/src/App.svelte
+++ b/studio/src/App.svelte
@@ -57,12 +57,13 @@
   } from "./lib/classNodes.js";
   import {
     computeGroupedGraph,
-    computeGroupTransition,
+    computeSceneTransition,
     classIdsAtLevel,
     typeNamesInTaxonomy,
     ontologyLevelState,
     ontologyAbsorption,
   } from "./lib/groupBy.js";
+  import { computeDisplayHiddenIds, applyVisibilityToScene } from "./lib/entityVisibility.js";
   import { loadWorkspace } from "./lib/sceneLoader.js";
   import {
     createDefaultViewerState,
@@ -90,9 +91,17 @@
     clearCommunityGrouping,
     hasOntologyGrouping,
     hasCommunityGrouping,
+    setEntityState,
+    resetVisibility,
+    soloActive,
+    hasAnyVisibilityOverride,
   } from "./lib/viewerState.js";
 
   const EMPTY_GRAPH = { nodes: [], links: [] };
+  // Stable EMPTY mask reference so the no-override fast path never churns the
+  // visibility deriveds (A4 byte-identity: applyVisibilityToScene returns the base
+  // scene BY REFERENCE only when the mask is this empty set).
+  const EMPTY_HIDDEN_IDS = new Set();
 
   // $state.raw: `graph` (1193 nodes) is only ever REASSIGNED in bulk, never
   // mutated in place — raw skips deep proxying (perf: less memory + hydration).
@@ -215,27 +224,6 @@
     }),
   );
 
-  // Collapse/expand ANIMATION signal. Diff the previous vs current fold-anchor map
-  // (each hidden node id → its group-node anchor) into a transition descriptor
-  // ({ direction, anchorByNodeId }) the GraphCanvas plays instead of a hard cut.
-  // Keying off the FOLD DELTA (not the grouped-key diff) makes the signal robust
-  // to the ontology artifact loading async — the collapse "lands" in whichever
-  // tick the fold map populates. The "previous" snapshot is tracked in a plain
-  // (non-reactive) `let`, advanced INSIDE this memoized `$derived` — a deliberate
-  // previous-value pattern: the derived recomputes exactly once per
-  // grouped/groupedGraph change (Svelte memoizes reads), so `groupTransition` is
-  // glitch-free and current by the time GraphCanvas's scene effect reads it.
-  let _prevFoldAnchors = null;
-  const groupTransition = $derived.by(() => {
-    const nextFoldAnchors = readFoldAnchors(groupedGraph);
-    const prevFoldAnchors = _prevFoldAnchors;
-    // Advance the snapshot for the NEXT change before returning.
-    _prevFoldAnchors = nextFoldAnchors;
-    // First evaluation (mount): nothing to animate FROM.
-    if (prevFoldAnchors === null) return null;
-    return computeGroupTransition({ prevFoldAnchors, nextFoldAnchors });
-  });
-
   // Tri-state of each ontology bulk button (spec §4) + per-class absorption view
   // (spec §3). Denominators EXCLUDE absorbed classes; the rail renders the
   // {none|partial|all} variant + (n/m) badge and disables absorbed rows.
@@ -290,10 +278,71 @@
   // the time-scrub control hides. Read from the base so the bounds stay STABLE
   // while the cursor moves (the filtered scene must not shrink the range).
   const timeRange = $derived(sceneTimeRange(baseScene));
-  // Time-scrub: filter the base scene to elements with `t <= cursor`. With the
-  // default cursor (null = OFF) this returns the base scene UNCHANGED, so the
-  // default view is byte-identical to before.
-  const scene = $derived(applyTimeFilter(baseScene, viewerState.options.timeCursor));
+  // 4-STATE visibility mask (D1/D5). The stored Hidden set + the Solo overlay
+  // derive a DISPLAY-hidden id set over the POST-FOLD baseScene (so a grouped
+  // entity's group node is itself maskable — §6.2). Guarded by
+  // hasAnyVisibilityOverride so the no-override fast path returns the STABLE empty
+  // set (A4): applyVisibilityToScene then hands back baseScene BY REFERENCE
+  // (byte-identity preserved, so the A3 default path stays untouched).
+  const anyVisibilityOverride = $derived(hasAnyVisibilityOverride(viewerState));
+  const displayHiddenIds = $derived(
+    anyVisibilityOverride
+      ? computeDisplayHiddenIds({
+          nodes: baseScene?.nodes ?? [],
+          hiddenKeys: viewerState.options.visibility.hidden,
+          soloKeys: viewerState.options.visibility.solo,
+          classHierarchies,
+        })
+      : EMPTY_HIDDEN_IDS,
+  );
+  // Apply the mask BEFORE the time filter (D5): Solo union > stored Hidden > Normal.
+  const visibleScene = $derived(applyVisibilityToScene(baseScene, displayHiddenIds));
+  // Time-scrub: filter the (visibility-masked) scene to elements with `t <= cursor`.
+  // With the default cursor (null = OFF) and no visibility override this returns the
+  // base scene UNCHANGED, so the default view is byte-identical to before.
+  const scene = $derived(applyTimeFilter(visibleScene, viewerState.options.timeCursor));
+
+  // Collapse/expand + Hide/Show/Solo ANIMATION signal. The UNIFIED, content-derived
+  // descriptor (SPINE): diff the previous vs current fold-anchor map AND the
+  // display-hidden mask into { folded, unfolded, hiddenIds, revealedIds, kind } the
+  // GraphCanvas plays through the SAME carry-over tween — so Hide/Solo NEVER hit the
+  // null-descriptor refit. Keying off the FOLD + MASK deltas (not the key diff) keeps
+  // the signal robust to the ontology artifact loading async. The three "previous"
+  // snapshots are advanced TOGETHER inside this ONE memoized `$derived` (both
+  // prev-values tick on the same flush, D3/A8) so the descriptor is glitch-free and
+  // current by the time GraphCanvas's scene effect reads it. The scene-id diff runs
+  // on the PRE-time-filter masks (visibleScene / displayHiddenIds) so a time-scrub
+  // never spawns hide/reveal tweens (A6). The generation gate nulls the descriptor
+  // across a graph object swap (model switch) — guard (c).
+  let _prevFoldAnchors = null;
+  let _prevHiddenIds = null;
+  let _prevSceneIds = null;
+  let _prevGraphRef = null;
+  const groupTransition = $derived.by(() => {
+    const nextFoldAnchors = readFoldAnchors(groupedGraph);
+    const nextHiddenIds = displayHiddenIds;
+    const nextSceneIds = new Set((visibleScene?.nodes ?? []).map((n) => n.id));
+    const generationChanged = _prevGraphRef !== null && _prevGraphRef !== graph;
+    const prevFoldAnchors = _prevFoldAnchors;
+    const prevHiddenIds = _prevHiddenIds;
+    const prevSceneIds = _prevSceneIds;
+    // Advance all snapshots for the NEXT change before returning.
+    _prevFoldAnchors = nextFoldAnchors;
+    _prevHiddenIds = nextHiddenIds;
+    _prevSceneIds = nextSceneIds;
+    _prevGraphRef = graph;
+    // First evaluation (mount): nothing to animate FROM.
+    if (prevFoldAnchors === null) return null;
+    return computeSceneTransition({
+      prevFoldAnchors,
+      nextFoldAnchors,
+      prevHiddenIds,
+      nextHiddenIds,
+      prevSceneIds,
+      nextSceneIds,
+      generationChanged,
+    });
+  });
   // BUG A: facet / selection source. The left rail (Types / Communities /
   // Entities), the selection panel, and the selected-id resolution all read a
   // graph-like. Normally that is the hydrated raw `graph` (richest source). But
@@ -389,6 +438,20 @@
   function handleToggleGroupType(typeName) {
     viewerState = toggleGroupType(viewerState, typeName);
     void ensureClassHierarchies();
+  }
+  // 4-STATE control (D6): the per-row EntityStateControl emits (namespacedKey,
+  // nextState). setEntityState enforces the exclusivity of grouped/hidden/normal and
+  // treats solo as an overlay (§3/§6.2). Ontology/type keys need the taxonomy for
+  // ancestor resolution, so ensure it (cached), mirroring the group-by handlers.
+  function handleSetEntityState(key, next) {
+    viewerState = setEntityState(viewerState, key, next);
+    if (typeof key === "string" && (key.startsWith("ontology:") || key.startsWith("type:"))) {
+      void ensureClassHierarchies();
+    }
+  }
+  // Global "Reset visibility" (D6 / §1): Grouped + Hidden + Solo → Normal.
+  function handleResetVisibility() {
+    viewerState = resetVisibility(viewerState);
   }
   // B2 (§4): clear ONLY the ontology scope (class + type keys). Community
   // grouping survives — each section's `Ungroup all` is scope-local.
@@ -784,6 +847,9 @@
             selection={viewerState.selection}
             showWeakLinks={viewerState.options.showWeakLinks}
             groupBy={viewerState.options.groupBy}
+            visibility={viewerState.options.visibility}
+            soloActive={soloActive(viewerState)}
+            hasVisibilityOverride={anyVisibilityOverride}
             {canGroupOntology}
             {canGroupCommunity}
             {ontologyLevelStates}
@@ -803,6 +869,8 @@
             onToggleGroupOntology={handleToggleGroupOntology}
             onToggleGroupCommunity={handleToggleGroupCommunity}
             onToggleGroupType={handleToggleGroupType}
+            onSetEntityState={handleSetEntityState}
+            onResetVisibility={handleResetVisibility}
             onBulkLevel={handleBulkLevel}
             onBulkCommunities={handleBulkCommunities}
             onClearOntologyGrouping={handleClearOntologyGrouping}

--- a/studio/src/components/EntityStateControl.svelte
+++ b/studio/src/components/EntityStateControl.svelte
@@ -43,11 +43,14 @@
   let open = $state(false);
   let hovering = $state(false);
   let focused = $state(false);
+  let closeTimer = null;
   let host;
 
   $effect(() => {
     if (disabled) open = false;
   });
+
+  $effect(() => () => cancelClose());
 
   const currentLabel = $derived(
     STATE_ITEMS.find((item) => item.value === entityState)?.label ?? "Normal",
@@ -64,8 +67,24 @@
   }
 
   function reveal() {
+    cancelClose();
     if (disabled) return;
     open = true;
+  }
+
+  function cancelClose() {
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+  }
+
+  function scheduleClose() {
+    cancelClose();
+    closeTimer = setTimeout(() => {
+      closeTimer = null;
+      maybeClose();
+    }, 180);
   }
 
   function maybeClose() {
@@ -73,42 +92,48 @@
   }
 
   function onEnter() {
+    cancelClose();
     hovering = true;
     reveal();
   }
 
   function onLeave() {
     hovering = false;
-    // Defer so a move onto the menu (focus) keeps it open.
-    queueMicrotask(maybeClose);
+    scheduleClose();
   }
 
   function onFocusIn() {
+    cancelClose();
     focused = true;
     reveal();
   }
 
   function onFocusOut() {
     focused = false;
-    queueMicrotask(maybeClose);
+    scheduleClose();
   }
 
   function onWindowKeydown(event) {
     if (event.key !== "Escape" || !open) return;
     event.preventDefault();
+    cancelClose();
     open = false;
   }
 
   function onWindowPointerDown(event) {
     if (!open) return;
     const target = event.target;
-    if (host && target && !host.contains(target)) open = false;
+    if (host && target && !host.contains(target)) {
+      cancelClose();
+      open = false;
+    }
   }
 
   function select(next, event) {
     event?.stopPropagation?.();
     if (disabled || typeof key !== "string") return;
     onSetState?.(key, next);
+    cancelClose();
     open = false;
   }
 </script>
@@ -124,7 +149,6 @@
   bind:this={host}
   class="esc"
   class:esc--dim={dim && entityState === "normal"}
-  class:esc--solo={entityState === "solo"}
   role="group"
   aria-label={`Visibility control: ${label}`}
   onpointerenter={onEnter}
@@ -169,11 +193,6 @@
     color: var(--st-component-iconButton-text, var(--st-semantic-text-secondary));
   }
 
-  /* Solo is the only state that also masks OTHER rows, so it alone gets an accent. */
-  .esc--solo :global(.st-iconButton) {
-    color: var(--st-semantic-feedback-info);
-  }
-
   /* While a Solo is active elsewhere, a masked-out Normal row reads dimmer. */
   .esc--dim :global(.st-iconButton) {
     opacity: 0.45;
@@ -183,7 +202,8 @@
   .esc-menu-anchor {
     position: absolute;
     z-index: var(--st-component-popover-zIndex, 80);
-    top: calc(100% + var(--st-spacing-1, 0.25rem));
+    top: 100%;
     left: 0;
+    padding-top: 6px;
   }
 </style>

--- a/studio/src/components/EntityStateControl.svelte
+++ b/studio/src/components/EntityStateControl.svelte
@@ -1,0 +1,294 @@
+<script>
+  /**
+   * Per-entity 4-state VISIBILITY control (D6) — the row affordance that
+   * SUPERSEDES the old group checkbox. At rest it shows ONE inline-SVG glyph for
+   * the entity's current state (visible at a glance across ~122 rows); on hover /
+   * focus / touch-tap it reveals a 4-segment radiogroup OVERLAY (a DS Popover, so
+   * the rail never reflows) where any state is one click away.
+   *
+   *   Normal · Grouped · Hidden · Solo   (mutually visible; radiogroup semantics)
+   *
+   * WAI-ARIA radiogroup + roving tabindex (the CHECKED segment is the single tab
+   * stop; Arrow/Home/End move+select; Escape collapses). Absorbed rows (a type
+   * under a grouped parent) render the whole control DISABLED. Wiring is a single
+   * `onSetState(key, nextState)` up to App's `setEntityState` reducer.
+   */
+  import { Popover } from "@sentropic/design-system-svelte";
+
+  let {
+    key,
+    label = "",
+    // The DISPLAYED state (displayedEntityState). Aliased to `entityState` locally
+    // so the `$state` rune is never shadowed by a prop called `state`.
+    state: entityState = "normal",
+    disabled = false,
+    // When absorbed by a grouped parent, the parent's label (for the tooltip).
+    absorbedBy = null,
+    // Dim the at-rest glyph while a Solo is active elsewhere (this row is masked out).
+    dim = false,
+    onSetState,
+  } = $props();
+
+  const STATES = [
+    { id: "normal", label: "Normal", hint: "Normal — visible, ungrouped" },
+    { id: "grouped", label: "Grouped", hint: "Grouped — collapse into a group node" },
+    { id: "hidden", label: "Hidden", hint: "Hidden — remove from the graph" },
+    { id: "solo", label: "Solo — show only this", hint: "Solo — show only this entity" },
+  ];
+
+  let open = $state(false);
+  let hovering = $state(false);
+  let focused = $state(false);
+  // The 4 radio elements, for roving-focus management.
+  let radioEls = $state([]);
+
+  const currentLabel = $derived(STATES.find((s) => s.id === entityState)?.label ?? "Normal");
+  const glyphTitle = $derived(
+    disabled && absorbedBy
+      ? `grouped by parent ${absorbedBy}`
+      : `Visibility: ${label} — ${currentLabel}`,
+  );
+
+  function toggleOpen(event) {
+    event?.stopPropagation?.();
+    if (!disabled) open = !open;
+  }
+  function reveal() {
+    if (disabled) return;
+    open = true;
+  }
+  function maybeClose() {
+    if (!hovering && !focused) open = false;
+  }
+  function onEnter() {
+    hovering = true;
+    reveal();
+  }
+  function onLeave() {
+    hovering = false;
+    // Defer so a move onto the popover (focus) keeps it open.
+    queueMicrotask(maybeClose);
+  }
+  function onFocusIn() {
+    focused = true;
+    reveal();
+  }
+  function onFocusOut() {
+    focused = false;
+    queueMicrotask(maybeClose);
+  }
+
+  function focusRadio(index) {
+    const n = STATES.length;
+    const i = ((index % n) + n) % n;
+    radioEls[i]?.focus();
+  }
+  function currentIndex() {
+    const i = STATES.findIndex((s) => s.id === entityState);
+    return i < 0 ? 0 : i;
+  }
+
+  function select(next, event) {
+    event?.stopPropagation?.();
+    if (disabled || typeof key !== "string") return;
+    onSetState?.(key, next);
+    open = false;
+  }
+
+  // Glyph button (collapsed): keyboard entry into the radiogroup.
+  function onGlyphKeydown(event) {
+    if (disabled) return;
+    if (event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      reveal();
+      // Focus the checked segment once the popover has rendered.
+      queueMicrotask(() => focusRadio(currentIndex()));
+    }
+  }
+
+  // Radiogroup roving navigation (WAI-ARIA radio pattern).
+  function onRadioKeydown(event, index) {
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        select(STATES[(index + 1) % STATES.length].id);
+        focusRadio(index + 1);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        select(STATES[(index - 1 + STATES.length) % STATES.length].id);
+        focusRadio(index - 1);
+        break;
+      case "Home":
+        event.preventDefault();
+        select(STATES[0].id);
+        focusRadio(0);
+        break;
+      case "End":
+        event.preventDefault();
+        select(STATES[STATES.length - 1].id);
+        focusRadio(STATES.length - 1);
+        break;
+      case "Escape":
+        event.preventDefault();
+        open = false;
+        break;
+      default:
+        break;
+    }
+  }
+</script>
+
+{#snippet glyph(id)}
+  {#if id === "normal"}
+    <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
+      <circle cx="7" cy="7" r="5" fill="none" stroke="currentColor" stroke-width="1.4" />
+    </svg>
+  {:else if id === "grouped"}
+    <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
+      <rect x="2" y="2" width="10" height="10" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.4" />
+      <circle cx="7" cy="7" r="1.8" fill="currentColor" />
+    </svg>
+  {:else if id === "hidden"}
+    <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
+      <path d="M1.5 7 C3 4 11 4 12.5 7 C11 10 3 10 1.5 7 Z" fill="none" stroke="currentColor" stroke-width="1.2" />
+      <circle cx="7" cy="7" r="1.6" fill="currentColor" />
+      <line x1="2" y1="12" x2="12" y2="2" stroke="currentColor" stroke-width="1.4" />
+    </svg>
+  {:else}
+    <svg class="esc-svg esc-svg--solo" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
+      <circle cx="7" cy="7" r="5" fill="none" stroke="currentColor" stroke-width="1.3" />
+      <circle cx="7" cy="7" r="2.4" fill="currentColor" />
+    </svg>
+  {/if}
+{/snippet}
+
+<div
+  class="esc"
+  class:esc--dim={dim && entityState === "normal"}
+  class:esc--solo={entityState === "solo"}
+  role="group"
+  aria-label={`Visibility control: ${label}`}
+  onpointerenter={onEnter}
+  onpointerleave={onLeave}
+  onfocusin={onFocusIn}
+  onfocusout={onFocusOut}
+>
+  <Popover label={`Visibility for ${label}`} open={open} placement="bottom-start">
+    {#snippet trigger()}
+      <button
+        type="button"
+        class="esc-glyph"
+        class:esc-glyph--solo={entityState === "solo"}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={glyphTitle}
+        title={glyphTitle}
+        {disabled}
+        onclick={toggleOpen}
+        onkeydown={onGlyphKeydown}
+      >
+        {@render glyph(entityState)}
+      </button>
+    {/snippet}
+    {#snippet children()}
+      <div class="esc-segments" role="radiogroup" aria-label={`Visibility: ${label}`}>
+        {#each STATES as s, i (s.id)}
+          <button
+            type="button"
+            bind:this={radioEls[i]}
+            class="esc-seg"
+            class:esc-seg--on={entityState === s.id}
+            role="radio"
+            aria-checked={entityState === s.id}
+            aria-label={s.label}
+            title={s.hint}
+            tabindex={entityState === s.id ? 0 : -1}
+            onclick={(e) => select(s.id, e)}
+            onkeydown={(e) => onRadioKeydown(e, i)}
+          >
+            {@render glyph(s.id)}
+          </button>
+        {/each}
+      </div>
+    {/snippet}
+  </Popover>
+</div>
+
+<style>
+  .esc {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+  /* At-rest glyph — a bare 16px button carrying the current-state SVG. */
+  .esc-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--st-semantic-text-secondary, #475569);
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  .esc-glyph:hover:not(:disabled),
+  .esc-glyph:focus-visible {
+    color: var(--st-semantic-text-primary, #0f172a);
+    background: var(--st-semantic-surface-muted, rgba(100, 116, 139, 0.12));
+  }
+  .esc-glyph:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  /* Solo is the only state that also masks OTHER rows, so it alone gets an accent. */
+  .esc-glyph--solo {
+    color: var(--st-semantic-feedback-info, #2563eb);
+  }
+  /* While a Solo is active elsewhere, a masked-out Normal row reads dimmer so the
+     global masking is legible in the rail (no reflow — opacity only). */
+  .esc--dim .esc-glyph {
+    opacity: 0.45;
+  }
+  .esc-svg {
+    display: block;
+  }
+  /* The 4-segment radiogroup overlay (inside the DS Popover panel — no rail reflow). */
+  .esc-segments {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 2px;
+  }
+  .esc-seg {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--st-semantic-text-secondary, #475569);
+    cursor: pointer;
+    border-radius: 5px;
+  }
+  .esc-seg:hover,
+  .esc-seg:focus-visible {
+    background: var(--st-semantic-surface-muted, rgba(100, 116, 139, 0.12));
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .esc-seg--on {
+    border-color: var(--st-semantic-border-strong, #94a3b8);
+    background: var(--st-semantic-surface-muted, rgba(100, 116, 139, 0.16));
+    color: var(--st-semantic-text-primary, #0f172a);
+  }
+  .esc-svg--solo {
+    color: inherit;
+  }
+</style>

--- a/studio/src/components/EntityStateControl.svelte
+++ b/studio/src/components/EntityStateControl.svelte
@@ -3,12 +3,12 @@
    * Per-entity 4-state VISIBILITY control (D6) — the row affordance that
    * SUPERSEDES the old group checkbox. At rest it shows ONE inline-SVG glyph for
    * the entity's current state (visible at a glance across ~122 rows); on hover /
-   * focus / touch-tap it reveals a 4-segment radiogroup OVERLAY (a DS Popover, so
+   * focus / touch-tap it reveals a 4-row radiogroup OVERLAY (a DS Popover, so
    * the rail never reflows) where any state is one click away.
    *
    *   Normal · Grouped · Hidden · Solo   (mutually visible; radiogroup semantics)
    *
-   * WAI-ARIA radiogroup + roving tabindex (the CHECKED segment is the single tab
+   * WAI-ARIA radiogroup + roving tabindex (the CHECKED row is the single tab
    * stop; Arrow/Home/End move+select; Escape collapses). Absorbed rows (a type
    * under a grouped parent) render the whole control DISABLED. Wiring is a single
    * `onSetState(key, nextState)` up to App's `setEntityState` reducer.
@@ -33,7 +33,7 @@
     { id: "normal", label: "Normal", hint: "Normal — visible, ungrouped" },
     { id: "grouped", label: "Grouped", hint: "Grouped — collapse into a group node" },
     { id: "hidden", label: "Hidden", hint: "Hidden — remove from the graph" },
-    { id: "solo", label: "Solo — show only this", hint: "Solo — show only this entity" },
+    { id: "solo", label: "Show only", hint: "Solo — show only this entity" },
   ];
 
   let open = $state(false);
@@ -141,6 +141,7 @@
   }
 </script>
 
+<!-- TEMP glyphs — pending the DS-prescribed Sentropic icon set (handoff sent to the design-system peer); these get hot-swapped for an <Icon> from @sentropic/design-system-svelte. Do NOT redesign icons here. -->
 {#snippet glyph(id)}
   {#if id === "normal"}
     <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
@@ -210,6 +211,7 @@
             onkeydown={(e) => onRadioKeydown(e, i)}
           >
             {@render glyph(s.id)}
+            <span class="esc-seg-label">{s.label}</span>
           </button>
         {/each}
       </div>
@@ -258,25 +260,27 @@
   .esc-svg {
     display: block;
   }
-  /* The 4-segment radiogroup overlay (inside the DS Popover panel — no rail reflow). */
+  /* The 4-row radiogroup overlay (inside the DS Popover panel — no rail reflow). */
   .esc-segments {
-    display: inline-flex;
-    align-items: center;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     gap: 2px;
     padding: 2px;
   }
   .esc-seg {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    padding: 0;
+    width: 100%;
+    min-height: 30px;
+    gap: 8px;
+    padding: 5px 8px;
     border: 1px solid transparent;
     background: transparent;
     color: var(--st-semantic-text-secondary, #475569);
     cursor: pointer;
     border-radius: 5px;
+    text-align: left;
   }
   .esc-seg:hover,
   .esc-seg:focus-visible {

--- a/studio/src/components/EntityStateControl.svelte
+++ b/studio/src/components/EntityStateControl.svelte
@@ -1,19 +1,21 @@
 <script>
   /**
    * Per-entity 4-state VISIBILITY control (D6) — the row affordance that
-   * SUPERSEDES the old group checkbox. At rest it shows ONE inline-SVG glyph for
-   * the entity's current state (visible at a glance across ~122 rows); on hover /
-   * focus / touch-tap it reveals a 4-row radiogroup OVERLAY (a DS Popover, so
-   * the rail never reflows) where any state is one click away.
+   * SUPERSEDES the old group checkbox. At rest it shows the entity's current
+   * state through the DS IconButton; on hover / focus / touch-tap it reveals a
+   * four-item DS Menu overlay where any state is one click away.
    *
-   *   Normal · Grouped · Hidden · Solo   (mutually visible; radiogroup semantics)
+   *   Normal · Grouped · Hidden · Show only
    *
-   * WAI-ARIA radiogroup + roving tabindex (the CHECKED row is the single tab
-   * stop; Arrow/Home/End move+select; Escape collapses). Absorbed rows (a type
-   * under a grouped parent) render the whole control DISABLED. Wiring is a single
-   * `onSetState(key, nextState)` up to App's `setEntityState` reducer.
+   * Absorbed rows (a type under a grouped parent) render the whole control
+   * DISABLED. Wiring is a single `onSetState(key, nextState)` up to App's
+   * `setEntityState` reducer.
    */
-  import { Popover } from "@sentropic/design-system-svelte";
+  import { IconButton, Menu } from "@sentropic/design-system-svelte";
+  import Eye from "@lucide/svelte/icons/eye";
+  import EyeOff from "@lucide/svelte/icons/eye-off";
+  import Layers from "@lucide/svelte/icons/layers";
+  import Target from "@lucide/svelte/icons/target";
 
   let {
     key,
@@ -24,25 +26,32 @@
     disabled = false,
     // When absorbed by a grouped parent, the parent's label (for the tooltip).
     absorbedBy = null,
-    // Dim the at-rest glyph while a Solo is active elsewhere (this row is masked out).
+    // Dim the at-rest icon while a Solo is active elsewhere (this row is masked out).
     dim = false,
     onSetState,
   } = $props();
 
-  const STATES = [
-    { id: "normal", label: "Normal", hint: "Normal — visible, ungrouped" },
-    { id: "grouped", label: "Grouped", hint: "Grouped — collapse into a group node" },
-    { id: "hidden", label: "Hidden", hint: "Hidden — remove from the graph" },
-    { id: "solo", label: "Show only", hint: "Solo — show only this entity" },
+  const STATE_ITEMS = [
+    { value: "normal", label: "Normal", icon: Eye },
+    { value: "grouped", label: "Grouped", icon: Layers },
+    { value: "hidden", label: "Hidden", icon: EyeOff },
+    { value: "solo", label: "Show only", icon: Target },
   ];
+
+  const STATE_ICONS = Object.fromEntries(STATE_ITEMS.map((item) => [item.value, item.icon]));
 
   let open = $state(false);
   let hovering = $state(false);
   let focused = $state(false);
-  // The 4 radio elements, for roving-focus management.
-  let radioEls = $state([]);
+  let host;
 
-  const currentLabel = $derived(STATES.find((s) => s.id === entityState)?.label ?? "Normal");
+  $effect(() => {
+    if (disabled) open = false;
+  });
+
+  const currentLabel = $derived(
+    STATE_ITEMS.find((item) => item.value === entityState)?.label ?? "Normal",
+  );
   const glyphTitle = $derived(
     disabled && absorbedBy
       ? `grouped by parent ${absorbedBy}`
@@ -53,39 +62,47 @@
     event?.stopPropagation?.();
     if (!disabled) open = !open;
   }
+
   function reveal() {
     if (disabled) return;
     open = true;
   }
+
   function maybeClose() {
     if (!hovering && !focused) open = false;
   }
+
   function onEnter() {
     hovering = true;
     reveal();
   }
+
   function onLeave() {
     hovering = false;
-    // Defer so a move onto the popover (focus) keeps it open.
+    // Defer so a move onto the menu (focus) keeps it open.
     queueMicrotask(maybeClose);
   }
+
   function onFocusIn() {
     focused = true;
     reveal();
   }
+
   function onFocusOut() {
     focused = false;
     queueMicrotask(maybeClose);
   }
 
-  function focusRadio(index) {
-    const n = STATES.length;
-    const i = ((index % n) + n) % n;
-    radioEls[i]?.focus();
+  function onWindowKeydown(event) {
+    if (event.key !== "Escape" || !open) return;
+    event.preventDefault();
+    open = false;
   }
-  function currentIndex() {
-    const i = STATES.findIndex((s) => s.id === entityState);
-    return i < 0 ? 0 : i;
+
+  function onWindowPointerDown(event) {
+    if (!open) return;
+    const target = event.target;
+    if (host && target && !host.contains(target)) open = false;
   }
 
   function select(next, event) {
@@ -94,79 +111,17 @@
     onSetState?.(key, next);
     open = false;
   }
-
-  // Glyph button (collapsed): keyboard entry into the radiogroup.
-  function onGlyphKeydown(event) {
-    if (disabled) return;
-    if (event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      reveal();
-      // Focus the checked segment once the popover has rendered.
-      queueMicrotask(() => focusRadio(currentIndex()));
-    }
-  }
-
-  // Radiogroup roving navigation (WAI-ARIA radio pattern).
-  function onRadioKeydown(event, index) {
-    switch (event.key) {
-      case "ArrowRight":
-      case "ArrowDown":
-        event.preventDefault();
-        select(STATES[(index + 1) % STATES.length].id);
-        focusRadio(index + 1);
-        break;
-      case "ArrowLeft":
-      case "ArrowUp":
-        event.preventDefault();
-        select(STATES[(index - 1 + STATES.length) % STATES.length].id);
-        focusRadio(index - 1);
-        break;
-      case "Home":
-        event.preventDefault();
-        select(STATES[0].id);
-        focusRadio(0);
-        break;
-      case "End":
-        event.preventDefault();
-        select(STATES[STATES.length - 1].id);
-        focusRadio(STATES.length - 1);
-        break;
-      case "Escape":
-        event.preventDefault();
-        open = false;
-        break;
-      default:
-        break;
-    }
-  }
 </script>
 
-<!-- TEMP glyphs — pending the DS-prescribed Sentropic icon set (handoff sent to the design-system peer); these get hot-swapped for an <Icon> from @sentropic/design-system-svelte. Do NOT redesign icons here. -->
-{#snippet glyph(id)}
-  {#if id === "normal"}
-    <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
-      <circle cx="7" cy="7" r="5" fill="none" stroke="currentColor" stroke-width="1.4" />
-    </svg>
-  {:else if id === "grouped"}
-    <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
-      <rect x="2" y="2" width="10" height="10" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.4" />
-      <circle cx="7" cy="7" r="1.8" fill="currentColor" />
-    </svg>
-  {:else if id === "hidden"}
-    <svg class="esc-svg" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
-      <path d="M1.5 7 C3 4 11 4 12.5 7 C11 10 3 10 1.5 7 Z" fill="none" stroke="currentColor" stroke-width="1.2" />
-      <circle cx="7" cy="7" r="1.6" fill="currentColor" />
-      <line x1="2" y1="12" x2="12" y2="2" stroke="currentColor" stroke-width="1.4" />
-    </svg>
-  {:else}
-    <svg class="esc-svg esc-svg--solo" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true">
-      <circle cx="7" cy="7" r="5" fill="none" stroke="currentColor" stroke-width="1.3" />
-      <circle cx="7" cy="7" r="2.4" fill="currentColor" />
-    </svg>
-  {/if}
+{#snippet stateIcon(value)}
+  {@const Icon = STATE_ICONS[value] ?? Eye}
+  <Icon size={16} strokeWidth={2} aria-hidden="true" />
 {/snippet}
 
+<svelte:window onkeydown={onWindowKeydown} onpointerdown={onWindowPointerDown} />
+
 <div
+  bind:this={host}
   class="esc"
   class:esc--dim={dim && entityState === "normal"}
   class:esc--solo={entityState === "solo"}
@@ -177,122 +132,58 @@
   onfocusin={onFocusIn}
   onfocusout={onFocusOut}
 >
-  <Popover label={`Visibility for ${label}`} open={open} placement="bottom-start">
-    {#snippet trigger()}
-      <button
-        type="button"
-        class="esc-glyph"
-        class:esc-glyph--solo={entityState === "solo"}
-        aria-haspopup="true"
-        aria-expanded={open}
-        aria-label={glyphTitle}
-        title={glyphTitle}
-        {disabled}
-        onclick={toggleOpen}
-        onkeydown={onGlyphKeydown}
-      >
-        {@render glyph(entityState)}
-      </button>
-    {/snippet}
-    {#snippet children()}
-      <div class="esc-segments" role="radiogroup" aria-label={`Visibility: ${label}`}>
-        {#each STATES as s, i (s.id)}
-          <button
-            type="button"
-            bind:this={radioEls[i]}
-            class="esc-seg"
-            class:esc-seg--on={entityState === s.id}
-            role="radio"
-            aria-checked={entityState === s.id}
-            aria-label={s.label}
-            title={s.hint}
-            tabindex={entityState === s.id ? 0 : -1}
-            onclick={(e) => select(s.id, e)}
-            onkeydown={(e) => onRadioKeydown(e, i)}
-          >
-            {@render glyph(s.id)}
-            <span class="esc-seg-label">{s.label}</span>
-          </button>
-        {/each}
-      </div>
-    {/snippet}
-  </Popover>
+  <IconButton
+    size="sm"
+    aria-haspopup="menu"
+    aria-expanded={open}
+    aria-label={`Visibility: ${label} — ${currentLabel}`}
+    title={glyphTitle}
+    disabled={disabled}
+    onclick={toggleOpen}
+  >
+    {@render stateIcon(entityState)}
+  </IconButton>
+
+  <div class="esc-menu-anchor">
+    {#if open}
+      <Menu
+        label={`Visibility for ${label}`}
+        items={STATE_ITEMS}
+        dense
+        dismissOnSelect={false}
+        onselect={(value) => select(value)}
+      />
+    {/if}
+  </div>
 </div>
 
 <style>
   .esc {
     display: inline-flex;
+    position: relative;
     align-items: center;
     flex-shrink: 0;
   }
-  /* At-rest glyph — a bare 16px button carrying the current-state SVG. */
-  .esc-glyph {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    color: var(--st-semantic-text-secondary, #475569);
-    cursor: pointer;
-    border-radius: 4px;
+
+  .esc :global(.st-iconButton) {
+    color: var(--st-component-iconButton-text, var(--st-semantic-text-secondary));
   }
-  .esc-glyph:hover:not(:disabled),
-  .esc-glyph:focus-visible {
-    color: var(--st-semantic-text-primary, #0f172a);
-    background: var(--st-semantic-surface-muted, rgba(100, 116, 139, 0.12));
-  }
-  .esc-glyph:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
+
   /* Solo is the only state that also masks OTHER rows, so it alone gets an accent. */
-  .esc-glyph--solo {
-    color: var(--st-semantic-feedback-info, #2563eb);
+  .esc--solo :global(.st-iconButton) {
+    color: var(--st-semantic-feedback-info);
   }
-  /* While a Solo is active elsewhere, a masked-out Normal row reads dimmer so the
-     global masking is legible in the rail (no reflow — opacity only). */
-  .esc--dim .esc-glyph {
+
+  /* While a Solo is active elsewhere, a masked-out Normal row reads dimmer. */
+  .esc--dim :global(.st-iconButton) {
     opacity: 0.45;
   }
-  .esc-svg {
-    display: block;
-  }
-  /* The 4-row radiogroup overlay (inside the DS Popover panel — no rail reflow). */
-  .esc-segments {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 2px;
-    padding: 2px;
-  }
-  .esc-seg {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    min-height: 30px;
-    gap: 8px;
-    padding: 5px 8px;
-    border: 1px solid transparent;
-    background: transparent;
-    color: var(--st-semantic-text-secondary, #475569);
-    cursor: pointer;
-    border-radius: 5px;
-    text-align: left;
-  }
-  .esc-seg:hover,
-  .esc-seg:focus-visible {
-    background: var(--st-semantic-surface-muted, rgba(100, 116, 139, 0.12));
-    color: var(--st-semantic-text-primary, #0f172a);
-  }
-  .esc-seg--on {
-    border-color: var(--st-semantic-border-strong, #94a3b8);
-    background: var(--st-semantic-surface-muted, rgba(100, 116, 139, 0.16));
-    color: var(--st-semantic-text-primary, #0f172a);
-  }
-  .esc-svg--solo {
-    color: inherit;
+
+  /* Keep the DS Menu out of the rail's flow, matching OverflowMenu's overlay. */
+  .esc-menu-anchor {
+    position: absolute;
+    z-index: var(--st-component-popover-zIndex, 80);
+    top: calc(100% + var(--st-spacing-1, 0.25rem));
+    left: 0;
   }
 </style>

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -100,10 +100,13 @@
 
   let {
     scene = EMPTY_SCENE,
-    // Optional collapse/expand ANIMATION descriptor, produced by App when the
-    // grouped-key set changes: { direction: 'collapse'|'expand',
-    // anchorByNodeId: Map<foldedId, groupNodeId> }. Absent/null ⇒ the current
-    // hard-cut refit (safety fallback). See the scene-change $effect below.
+    // Optional UNIFIED scene-transition descriptor (4-state visibility), produced
+    // by App when the grouped set OR the display-hidden mask changes:
+    //   { folded: Map<childId, groupId>, unfolded: Map<childId, groupId>,
+    //     hiddenIds: Set<nodeId>, revealedIds: Set<nodeId>, kind: "out"|"in"|"mixed" }.
+    // Routed through the SAME carry-over tween as group/ungroup — folded → anchor,
+    // hidden → fade-in-place (bufB==bufA), revealed → fade-in-at-cached-target.
+    // Absent/null ⇒ the hard-cut refit (safety fallback). See the scene $effect below.
     groupTransition = null,
     selectedIds = [],
     centerOnIds = [],
@@ -1788,50 +1791,87 @@
     return { ...info, positions };
   }
 
-  // Try to play the animated collapse/expand for `transition`. Returns true when
-  // the driver TOOK OVER the scene swap (the caller must NOT also hard-cut), false
-  // to fall back to the refit path (safety: missing/ambiguous transition, or no
-  // renderer/payload). NOTE: an on-screen-empty fold set is NOT a false here — the
-  // driver still owns the swap and does a position-preserving carried swap.
+  // Resolve the on-screen INDICES of a display-hidden/revealed id set against the
+  // CURRENT payload (§SPINE): these fade IN PLACE (bufB==bufA), never toward an
+  // anchor. Ids absent from the payload are skipped. Returns an empty set when
+  // there is nothing on screen (the caller then does a position-preserving swap).
+  function collectInPlaceIndices(ids) {
+    const set = new Set();
+    const idx = payload?.nodeIndexById;
+    if (!(ids instanceof Set) || !idx) return set;
+    for (const id of ids) {
+      const i = idx.get(id);
+      if (Number.isInteger(i)) set.add(i);
+    }
+    return set;
+  }
+
+  // Try to play the animated transition for `transition` (the UNIFIED 4-state
+  // descriptor). Returns true when the driver TOOK OVER the scene swap (the caller
+  // must NOT also hard-cut), false to fall back to the refit path (safety: missing
+  // descriptor, no renderer/payload, unknown kind). NOTE: an on-screen-empty
+  // fold/hide set is NOT a false here — the driver still owns the swap and does a
+  // position-preserving carried swap.
+  //   · kind "out"   — group/hide: tween on the OLD payload (folded → anchor,
+  //     hidden → fade-in-place), then carried-swap. (startCollapseTween, extended.)
+  //   · kind "in"    — ungroup/show/reset: carried-swap FIRST, then tween on the NEW
+  //     payload (unfolded → fan/cache, revealed → fade-in-at-target). (startExpandTween.)
+  //   · kind "mixed" — two-sided: carried NON-animated swap (never a refit — strictly
+  //     better than today's mixed⇒refit). (applyMixedCarriedSwap.)
   function tryStartGroupTransition(transition) {
     if (!transition || !mounted || !renderer || !payload) return false;
-    const anchors = transition.anchorByNodeId;
-    if (!(anchors instanceof Map) || anchors.size === 0) return false;
-    if (transition.direction === "collapse") return startCollapseTween(anchors);
-    if (transition.direction === "expand") return startExpandTween(anchors);
+    const folded = transition.folded instanceof Map ? transition.folded : new Map();
+    const unfolded = transition.unfolded instanceof Map ? transition.unfolded : new Map();
+    const hiddenIds = transition.hiddenIds instanceof Set ? transition.hiddenIds : new Set();
+    const revealedIds = transition.revealedIds instanceof Set ? transition.revealedIds : new Set();
+    if (transition.kind === "out") return startCollapseTween(folded, hiddenIds);
+    if (transition.kind === "in") return startExpandTween(unfolded, revealedIds);
+    if (transition.kind === "mixed")
+      return applyMixedCarriedSwap({ folded, unfolded, hiddenIds, revealedIds });
     return false;
   }
 
-  // COLLAPSE (§3.4): snapshot the OLD on-screen positions, tween each folding
-  // child → its group anchor (fade+shrink) on the OLD payload, then at t=1
-  // carried-swap so the group node lands EXACTLY where its children converged and
-  // every shared node keeps its position. groupSwapPending defers any concurrent
-  // selection/display rebuild until after the swap (RC-B).
-  function startCollapseTween(anchors) {
+  // OUT (§3.4 / SPINE): snapshot the OLD on-screen positions, tween each folding
+  // child → its group anchor (fade+shrink) AND each newly display-HIDDEN node
+  // fade+shrink IN PLACE (bufB==bufA) on the OLD payload, then at t=1 carried-swap
+  // so the group node lands EXACTLY where its children converged and every shared
+  // node keeps its position. groupSwapPending defers any concurrent selection/
+  // display rebuild until after the swap (RC-B). `hiddenIds` = the pure-Hide / Solo
+  // complement (empty for a pure group op — byte-identical to a2cf207).
+  function startCollapseTween(anchors, hiddenIds = new Set()) {
     const oldPos = currentPositionMap() ?? new Map(); // carriedPosById (with drags)
     const info = collectGroupFolds(anchors);
+    const inPlaceIdx = collectInPlaceIndices(hiddenIds);
     if (!info) {
-      // No folding child on screen → nothing to animate, but STILL position-
-      // preserving: carried swap straight to the collapsed scene (never a refit).
-      groupSwapPending = true;
-      finishCollapseSwap(oldPos, new Map(), anchors);
-      return true;
+      // No folding child on screen. With nothing hidden either, carried-swap now.
+      if (inPlaceIdx.size === 0) {
+        groupSwapPending = true;
+        finishCollapseSwap(oldPos, new Map(), anchors);
+        return true;
+      }
+      // Pure Hide: no fold anchors, but hidden nodes fade in place. Fall through to
+      // the tween on the CURRENT payload with the in-place fade set.
     }
-    const { foldingSet, groupMembers, anchorPosByGroup, positions } = info;
+    const positions = info?.positions ?? currentLayoutBuffer() ?? new Float32Array(0);
+    const foldingSet = new Set(info?.foldingSet ?? []);
+    for (const i of inPlaceIdx) foldingSet.add(i);
     const bufA = new Float32Array(positions);
     const bufB = new Float32Array(positions);
     const placedPosById = new Map(); // groupNodeId -> the fold-centroid anchor
-    for (const [groupId, members] of groupMembers) {
-      const a = anchorPosByGroup.get(groupId);
-      placedPosById.set(groupId, { x: a.x, y: a.y });
-      for (const i of members) {
-        bufB[i * 2] = a.x;
-        bufB[i * 2 + 1] = a.y;
+    if (info) {
+      for (const [groupId, members] of info.groupMembers) {
+        const a = info.anchorPosByGroup.get(groupId);
+        placedPosById.set(groupId, { x: a.x, y: a.y });
+        for (const i of members) {
+          bufB[i * 2] = a.x;
+          bufB[i * 2 + 1] = a.y;
+        }
       }
     }
+    // Hidden nodes: bufB stays == bufA (fade + shrink IN PLACE — spec §4 "→ Hidden").
     groupSwapPending = true;
     // The "jump to end" closure used by the abort path AND the interrupt rule.
-    pendingGroupSettle = () => finishCollapseSwap(oldPos, placedPosById, anchors);
+    pendingGroupSettle = () => finishCollapseSwap(oldPos, placedPosById, anchors, hiddenIds);
     runGroupTween({
       bufA,
       bufB,
@@ -1846,7 +1886,7 @@
   // group node placed at the fold centroid and shared nodes carried; apply any
   // deferred restyle exactly once; record the folded children's pre-fold positions
   // for a later expand restore (§3.6).
-  function finishCollapseSwap(oldPos, placedPosById, anchors) {
+  function finishCollapseSwap(oldPos, placedPosById, anchors, hiddenIds = new Set()) {
     pendingGroupSettle = null;
     resetTransientLayoutState();
     applyCarriedScene({ carriedPosById: oldPos ?? new Map(), placedPosById: placedPosById ?? new Map() });
@@ -1856,6 +1896,14 @@
       for (const childId of anchors.keys()) {
         const p = oldPos.get(childId);
         if (p) lastKnownPosById.set(childId, { x: p.x, y: p.y, epoch: coordinateEpoch });
+      }
+    }
+    // SPINE: also cache each newly-HIDDEN node's pre-hide position so a later
+    // Show / Solo-exit fades it back in at the exact prior spot (same epoch).
+    if (hiddenIds instanceof Set && oldPos instanceof Map) {
+      for (const id of hiddenIds) {
+        const p = oldPos.get(id);
+        if (p) lastKnownPosById.set(id, { x: p.x, y: p.y, epoch: coordinateEpoch });
       }
     }
     morphActive = false;
@@ -1873,7 +1921,7 @@
   // FIRST so the revealed children start stacked on the group's last on-screen
   // position, then tween them OUT to their targets (cached prior constellation
   // when same-epoch, else a deterministic golden-angle fan) while fading+growing.
-  function startExpandTween(anchors) {
+  function startExpandTween(anchors, revealedIds = new Set()) {
     // 1. PRE-swap snapshot — the group node IS in the current payload here.
     const oldPos = currentPositionMap() ?? new Map();
     const anchorPosByGroup = new Map(); // groupNodeId -> its last on-screen position
@@ -1881,11 +1929,17 @@
       const p = oldPos.get(groupId);
       if (p) anchorPosByGroup.set(groupId, { x: p.x, y: p.y });
     }
-    // Children start stacked at their group's former spot.
+    // Unfolded children start stacked at their group's former spot; a newly-REVEALED
+    // node starts at its cached prior position (same epoch), else it is OMITTED here
+    // so the carry places it at its neighbour-centroid (spec §4 "→ Normal-from-Hidden").
     const placedPosById = new Map(); // revealedChildId -> anchorPos(itsGroup)
     for (const [childId, groupId] of anchors) {
       const a = anchorPosByGroup.get(groupId);
       if (a) placedPosById.set(childId, { x: a.x, y: a.y });
+    }
+    for (const id of revealedIds) {
+      const cached = lastKnownPosById.get(id);
+      if (cached && cached.epoch === coordinateEpoch) placedPosById.set(id, { x: cached.x, y: cached.y });
     }
     // 2. Carried swap FIRST (camera untouched, shared nodes carried, children on
     // the anchor). Expand's payload is now current — no groupSwapPending needed.
@@ -1893,13 +1947,18 @@
     applyCarriedScene({ carriedPosById: oldPos, placedPosById });
     // 3. Resolve the revealed children against the NEW payload.
     const info = collectGroupFolds(anchors);
-    if (!info) {
-      // No revealed child on screen → the carried swap already stands. Persist the
-      // buffers (RC-E) so later rebuilds don't re-derive scene-baked coords.
+    const revealedIdx = collectInPlaceIndices(revealedIds);
+    if (!info && revealedIdx.size === 0) {
+      // No unfolded/revealed child on screen → the carried swap already stands.
+      // Persist the buffers (RC-E) so later rebuilds don't re-derive scene-baked coords.
       settleGroupTween(payload?.renderGraph?.positions);
       return true;
     }
-    const { foldingSet, groupMembers, anchorPosByGroup: postAnchor, positions } = info;
+    const positions = info?.positions ?? currentLayoutBuffer() ?? new Float32Array(0);
+    const groupMembers = info?.groupMembers ?? new Map();
+    const postAnchor = info?.anchorPosByGroup ?? new Map();
+    const foldingSet = new Set(info?.foldingSet ?? []);
+    for (const i of revealedIdx) foldingSet.add(i);
     const bufA = new Float32Array(positions); // children currently AT the anchor
     const bufB = new Float32Array(positions);
     // 4. Targets: cached prior constellation (same epoch) else golden-angle fan.
@@ -1908,6 +1967,7 @@
       bufB[i * 2] = p.x;
       bufB[i * 2 + 1] = p.y;
     }
+    // Revealed slots stay == bufA (pure fade-in at their cached/neighbour target).
     // 5. Tween on the NEW payload; settle persists activeLayoutBuffer (RC-E).
     pendingGroupSettle = () => settleGroupTween(bufB);
     runGroupTween({
@@ -1917,6 +1977,60 @@
       fadeOut: false,
       onDone: () => pendingGroupSettle?.(),
     });
+    return true;
+  }
+
+  // MIXED (D4): a genuinely two-sided commit (Solo on a stored-Hidden entity; a
+  // bulk level re-target Domain→Sub-domain) — some nodes fold/hide AND others
+  // reveal in ONE change. A true cross-fade needs both node sets alive in one
+  // payload; V1 does a position-preserving CARRIED, NON-animated swap (shared nodes
+  // frozen, camera untouched) — strictly better than today's mixed⇒refit hard cut.
+  // (Sequential OUT-then-IN is a flagged V2.)
+  function applyMixedCarriedSwap({ folded, unfolded, hiddenIds, revealedIds } = {}) {
+    const oldPos = currentPositionMap() ?? new Map();
+    const placedPosById = new Map();
+    // Newly-folded children → their group's on-screen anchor (or member centroid).
+    const info = folded instanceof Map && folded.size > 0 ? collectGroupFolds(folded) : null;
+    if (info) {
+      for (const [groupId, a] of info.anchorPosByGroup) placedPosById.set(groupId, { x: a.x, y: a.y });
+    }
+    // Unfolded children start stacked on their group's last on-screen position.
+    if (unfolded instanceof Map) {
+      const anchorByGroup = new Map();
+      for (const groupId of new Set(unfolded.values())) {
+        const p = oldPos.get(groupId);
+        if (p) anchorByGroup.set(groupId, { x: p.x, y: p.y });
+      }
+      for (const [childId, groupId] of unfolded) {
+        const a = anchorByGroup.get(groupId);
+        if (a) placedPosById.set(childId, { x: a.x, y: a.y });
+      }
+    }
+    // Revealed nodes at their cached prior position (same epoch), else neighbour.
+    if (revealedIds instanceof Set) {
+      for (const id of revealedIds) {
+        const cached = lastKnownPosById.get(id);
+        if (cached && cached.epoch === coordinateEpoch) placedPosById.set(id, { x: cached.x, y: cached.y });
+      }
+    }
+    resetTransientLayoutState();
+    applyCarriedScene({ carriedPosById: oldPos, placedPosById });
+    // Cache the OUT-ids' pre-swap positions (folded children + hidden nodes) so a
+    // later reveal restores them at the exact prior spot.
+    if (folded instanceof Map) {
+      for (const childId of folded.keys()) {
+        const p = oldPos.get(childId);
+        if (p) lastKnownPosById.set(childId, { x: p.x, y: p.y, epoch: coordinateEpoch });
+      }
+    }
+    if (hiddenIds instanceof Set) {
+      for (const id of hiddenIds) {
+        const p = oldPos.get(id);
+        if (p) lastKnownPosById.set(id, { x: p.x, y: p.y, epoch: coordinateEpoch });
+      }
+    }
+    // Persist the carried buffer (RC-E) + restore the style — NO tween, NO refit.
+    settleGroupTween(payload?.renderGraph?.positions);
     return true;
   }
 

--- a/studio/src/components/GraphCanvas.svelte
+++ b/studio/src/components/GraphCanvas.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onDestroy, onMount, tick, untrack } from "svelte";
   import { Button, ButtonGroup, IconButton, Popover, Switch } from "@sentropic/design-system-svelte";
+  import Settings from "@lucide/svelte/icons/settings";
   import { createGraphRenderer, drawBoxLabels2D } from "@sentropic/graph";
   import { solveForce, terminateForceWorker } from "../lib/forceLayoutClient.js";
 
@@ -2411,7 +2412,9 @@
               aria-label="Graph display settings"
               aria-expanded={settingsOpen}
               onclick={toggleSettings}
-            >⚙</IconButton>
+            >
+              <Settings size={16} strokeWidth={2} aria-hidden="true" />
+            </IconButton>
           {/snippet}
           {#snippet children()}
             <div class="graph-settings-panel">

--- a/studio/src/components/LeftRail.svelte
+++ b/studio/src/components/LeftRail.svelte
@@ -15,6 +15,7 @@
   } from "@sentropic/design-system-svelte";
   import TypeShapeGlyph from "./TypeShapeGlyph.svelte";
   import TimeScrub from "./TimeScrub.svelte";
+  import EntityStateControl from "./EntityStateControl.svelte";
   import {
     graphNodes,
     nodeType,
@@ -22,6 +23,11 @@
     groupCounts,
     communityStats,
   } from "../lib/graphAdapter.js";
+  import {
+    groupKeyForOntology,
+    groupKeyForCommunity,
+    groupKeyForType,
+  } from "../lib/viewerState.js";
 
   let {
     graph,
@@ -38,6 +44,14 @@
     // ("ontology:<classId>" | "community:<key>"). Every checked rail item adds
     // one key; checking GROUPS (collapses) it. Multi-select is the default.
     groupBy = { grouped: [] },
+    // 4-STATE control (D6): the per-entity visibility overlay { hidden:[], solo:[] }
+    // keyed by the SAME namespaced keys as groupBy. The per-row EntityStateControl
+    // renders the displayed state (Solo > Hidden > Grouped > Normal) and emits
+    // (key, nextState) up to onSetEntityState. `soloActive` dims the masked-out
+    // rows; `hasVisibilityOverride` drives the global Reset's disabled.
+    visibility = { hidden: [], solo: [] },
+    soloActive = false,
+    hasVisibilityOverride = false,
     // Which kinds are AVAILABLE to group (C4): ontology needs the taxonomy,
     // community needs ≥1 live community. The checkbox affordance is hidden for an
     // absent kind.
@@ -73,11 +87,27 @@
     onToggleGroupOntology,
     onToggleGroupCommunity,
     onToggleGroupType,
+    // 4-STATE control (D6): the per-row visibility setter + global reset.
+    onSetEntityState,
+    onResetVisibility,
     onBulkLevel,
     onBulkCommunities,
     onClearOntologyGrouping,
     onClearCommunityGrouping,
   } = $props();
+
+  // 4-STATE control (D6): the displayed state for a namespaced key. Solo overlay
+  // wins visually (§4), then stored Hidden, then Grouped, else Normal — mirrors
+  // viewerState.displayedEntityState over the same key vocabulary.
+  const soloKeySet = $derived(new Set(visibility?.solo ?? []));
+  const hiddenKeySet = $derived(new Set(visibility?.hidden ?? []));
+  const groupedKeySet = $derived(new Set(groupBy.grouped ?? []));
+  function entityStateOf(key) {
+    if (soloKeySet.has(key)) return "solo";
+    if (hiddenKeySet.has(key)) return "hidden";
+    if (groupedKeySet.has(key)) return "grouped";
+    return "normal";
+  }
 
   // Storage LOT 2: prefer the store's precomputed counts when present; otherwise
   // `groupCounts` falls back to the in-memory pass (default studio unchanged).
@@ -93,20 +123,6 @@
       (groupBy.grouped ?? [])
         .filter((k) => typeof k === "string" && k.startsWith("ontology:"))
         .map((k) => k.slice("ontology:".length)),
-    ),
-  );
-  const communityCheckedSet = $derived(
-    new Set(
-      (groupBy.grouped ?? [])
-        .filter((k) => typeof k === "string" && k.startsWith("community:"))
-        .map((k) => k.slice("community:".length)),
-    ),
-  );
-  const typeCheckedSet = $derived(
-    new Set(
-      (groupBy.grouped ?? [])
-        .filter((k) => typeof k === "string" && k.startsWith("type:"))
-        .map((k) => k.slice("type:".length)),
     ),
   );
 
@@ -261,6 +277,20 @@
       <Badge tone="neutral">{stats.edgeCount} edges</Badge>
       <Badge tone="info">{stats.communityCount} groups</Badge>
     </span>
+    <!-- 4-STATE control (D6): the GLOBAL "Reset visibility" affordance — clears
+         every Grouped + Hidden + Solo override back to Normal in one click. It is
+         global (not inside a section) because it also clears cross-section Solo. -->
+    <div class="rail-visibility-reset">
+      <Button
+        size="sm"
+        variant="secondary"
+        disabled={!hasVisibilityOverride}
+        aria-label="Reset all entity visibility"
+        onclick={() => onResetVisibility?.()}
+      >
+        Reset visibility
+      </Button>
+    </div>
   </div>
 
   <Collapsible title="Ontology" open={true}>
@@ -279,21 +309,15 @@
         {#each typeTree as domain (domain.id)}
           {@const dAbs = ontologyAbsorbed.get(domain.id)}
           <li class="rail-onto-head">
-            <label
-              class="rail-group-check"
-              class:rail-group-check--on={ontologyCheckedSet.has(domain.id)}
-              title={dAbs?.absorbed
-                ? `grouped by parent ${dAbs.byLabel}`
-                : `Group by ${domain.label}`}
-            >
-              <input
-                type="checkbox"
-                checked={ontologyCheckedSet.has(domain.id)}
-                disabled={dAbs?.absorbed === true}
-                aria-label="Group by {domain.label}"
-                onchange={() => onToggleGroupOntology?.(domain.id)}
-              />
-            </label>
+            <EntityStateControl
+              key={groupKeyForOntology(domain.id)}
+              label={domain.label}
+              state={entityStateOf(groupKeyForOntology(domain.id))}
+              disabled={dAbs?.absorbed === true}
+              absorbedBy={dAbs?.absorbed ? dAbs.byLabel : null}
+              dim={soloActive}
+              onSetState={onSetEntityState}
+            />
             <Collapsible title={domain.label} open={false} size="sm">
               {#snippet trailing()}
                 <Badge shape="circle" size="sm" tone="neutral">{domain.count}</Badge>
@@ -302,21 +326,15 @@
                 {#each domain.subs as sub (sub.id)}
                   {@const sAbs = ontologyAbsorbed.get(sub.id)}
                   <li class="rail-onto-head">
-                    <label
-                      class="rail-group-check"
-                      class:rail-group-check--on={ontologyCheckedSet.has(sub.id)}
-                      title={sAbs?.absorbed
-                        ? `grouped by parent ${sAbs.byLabel}`
-                        : `Group by ${sub.label}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={ontologyCheckedSet.has(sub.id)}
-                        disabled={sAbs?.absorbed === true}
-                        aria-label="Group by {sub.label}"
-                        onchange={() => onToggleGroupOntology?.(sub.id)}
-                      />
-                    </label>
+                    <EntityStateControl
+                      key={groupKeyForOntology(sub.id)}
+                      label={sub.label}
+                      state={entityStateOf(groupKeyForOntology(sub.id))}
+                      disabled={sAbs?.absorbed === true}
+                      absorbedBy={sAbs?.absorbed ? sAbs.byLabel : null}
+                      dim={soloActive}
+                      onSetState={onSetEntityState}
+                    />
                     <Collapsible title={sub.label} open={false} size="sm">
                       {#snippet trailing()}
                         <Badge shape="circle" size="sm" tone="neutral">{sub.count}</Badge>
@@ -324,24 +342,28 @@
                       <ul class="rail-list">
                         {#each sub.types as t (t.key)}
                           <li class="rail-type-row">
-                            <!-- B2 (§2): the leaf TYPE row carries its OWN bare
-                                 group-by checkbox on the LEFT — folds entities of
-                                 this `type`. It is SEPARATE from the Type FILTER
-                                 SelectableRow (onToggleType) that follows it. -->
-                            <label
-                              class="rail-group-check rail-type-group-check"
-                              class:rail-group-check--on={typeCheckedSet.has(t.key)}
-                              title="Group by {t.key}"
-                            >
-                              <input
-                                type="checkbox"
-                                checked={typeCheckedSet.has(t.key)}
+                            <!-- 4-STATE control (D6): the leaf TYPE row carries its
+                                 OWN per-entity visibility control on the LEFT —
+                                 Normal/Grouped/Hidden/Solo over this `type`. It is
+                                 SEPARATE from the Type FILTER SelectableRow
+                                 (onToggleType) that follows it. Disabled (absorbed)
+                                 when a parent Sub-domain/Domain is grouped. -->
+                            <span class="esc-slot rail-type-group-check">
+                              <EntityStateControl
+                                key={groupKeyForType(t.key)}
+                                label={t.key}
+                                state={entityStateOf(groupKeyForType(t.key))}
                                 disabled={ontologyCheckedSet.has(sub.id) ||
                                   ontologyCheckedSet.has(domain.id)}
-                                aria-label="Group by {t.key}"
-                                onchange={() => onToggleGroupType?.(t.key)}
+                                absorbedBy={ontologyCheckedSet.has(sub.id)
+                                  ? sub.label
+                                  : ontologyCheckedSet.has(domain.id)
+                                    ? domain.label
+                                    : null}
+                                dim={soloActive}
+                                onSetState={onSetEntityState}
                               />
-                            </label>
+                            </span>
                             <SelectableRow
                               value={t.key}
                               selected={typeSet.has(t.key)}
@@ -464,24 +486,20 @@
               onselect={() => onToggleCommunity?.(c.key)}
             >
               {#snippet leading()}
-                <!-- B2 (per-item): the GROUP-BY checkbox is the FIRST thing on the
-                     row (left edge), before the color swatch. Checking it GROUPS
-                     (collapses) the community; the row's own SELECT
-                     (onToggleCommunity, filter) stays a separate concern. -->
+                <!-- 4-STATE control (D6): the per-entity visibility control is the
+                     FIRST thing on the row (left edge), before the color swatch.
+                     Normal/Grouped/Hidden/Solo over this community; the row's own
+                     SELECT (onToggleCommunity, filter) stays a separate concern. -->
                 <span class="rail-comm-lead">
-                  <label
-                    class="rail-group-check"
-                    class:rail-group-check--on={communityCheckedSet.has(c.key)}
-                    title="Group by {c.key}"
-                    onclick={(e) => e.stopPropagation()}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={communityCheckedSet.has(c.key)}
-                      aria-label="Group by {c.key}"
-                      onchange={() => onToggleGroupCommunity?.(c.key)}
+                  <span class="esc-slot">
+                    <EntityStateControl
+                      key={groupKeyForCommunity(c.key)}
+                      label={c.key}
+                      state={entityStateOf(groupKeyForCommunity(c.key))}
+                      dim={soloActive}
+                      onSetState={onSetEntityState}
                     />
-                  </label>
+                  </span>
                   <!-- ia-aero BUG B (#195): single-source community color (c.color),
                        reused identically legend↔canvas — replaces the old c.tone. -->
                   <span
@@ -811,31 +829,32 @@
     flex: 1 1 auto;
     min-width: 0;
   }
-  .rail-onto-head > .rail-group-check {
+  /* 4-STATE control (D6): the per-entity visibility control (EntityStateControl)
+     replaces the old group checkbox at each row's LEFT edge. Its root is `.esc`;
+     leaf-type / community rows wrap it in a `.esc-slot` for flex alignment. */
+  .esc-slot {
     flex-shrink: 0;
-    /* match the sm Collapsible header height (paddingBlock 0.4rem×2 + ~1.05rem
-       line) so the bare checkbox vertically centres on the header title. */
-    min-height: 1.85rem;
-  }
-  /* B2 (per-item): the per-item GROUP-BY checkbox affordance, now the FIRST
-     element on the LEFT edge of every groupable row (Ontology class header /
-     Community row), BEFORE the label. At rest it is a BARE checkbox — NO text.
-     The "group by" meaning is signalled on HOVER only (the title tooltip plus a
-     subtle ring around the box); never a persistent text label. */
-  .rail-group-check {
     display: inline-flex;
     align-items: center;
-    cursor: pointer;
   }
-  .rail-group-check input {
-    margin: 0;
-    cursor: pointer;
+  .rail-onto-head > :global(.esc) {
+    flex-shrink: 0;
+    /* match the sm Collapsible header height so the glyph centres on the title. */
+    min-height: 1.85rem;
+    align-items: center;
   }
-  /* B2-UI-12: NO hover/focus outline ring on the checkbox. The ring only ever
-     matched community/type rows (the ontology Collapsible-header hover never
-     selected the now-sibling checkbox), so it read as a random inconsistency.
-     A bare native checkbox is enough. */
-  /* Community row: the bare group-by checkbox sits FIRST, then the color swatch. */
+  /* Global "Reset visibility" — sits under the search count badges (D6). */
+  .rail-visibility-reset {
+    margin-top: 0.5rem;
+  }
+  .rail-visibility-reset :global(.st-button) {
+    min-height: 1.6rem;
+    min-width: 0;
+    padding: 0.15rem 0.45rem;
+    font-size: 0.78rem;
+    line-height: 1.1;
+  }
+  /* Community row: the per-entity visibility control sits FIRST, then the swatch. */
   .rail-comm-lead {
     display: inline-flex;
     align-items: center;

--- a/studio/src/components/ReconciliationView.svelte
+++ b/studio/src/components/ReconciliationView.svelte
@@ -452,6 +452,7 @@
       <GraphCanvas
         {scene}
         {selectedIds}
+        showLayoutSwitcher
         centerOnIds={selectedIds}
         focusId={active.candidate_id}
         labelMode="plain"

--- a/studio/src/lib/entityVisibility.js
+++ b/studio/src/lib/entityVisibility.js
@@ -1,0 +1,163 @@
+/**
+ * 4-state per-entity VISIBILITY — the PURE display mask (D1 + D5).
+ *
+ * Hide and Solo are a scene FILTER + a transition delta; they NEVER touch the
+ * fold engine (`classNodes.js`). This module owns:
+ *   - `computeDisplayHiddenIds` — the D1 ownership rule (Normal ABSTAINS; Hidden =
+ *     union suppression; the ≥1-visible whitelist applies ONLY in the Solo tier);
+ *   - `applyVisibilityToScene` — the scene filter (empty mask ⇒ SAME reference for
+ *     the byte-identity fast path, mirroring applyWeakFilter/applyTimeFilter).
+ *
+ * D1 ownership rule (both review passes dissent from spec §6.1). A node's owning
+ * rail entities span three axes: its community, its type, and its ontology leaf
+ * class + that class's ANCESTOR chain. Each entity's stored state votes:
+ *   - soloActive?  visible = owned-by-≥1-Solo  AND  NOT owned-by-(storedHidden\solo)
+ *   - else         hidden  = owned-by-≥1-Hidden           (Normal owners abstain)
+ * so "hide type:Character" hides EVERY Character even though their communities are
+ * Normal (Hide is not a no-op at mystery scale), while "solo type:Character" shows
+ * only Characters — even if a Character's community was separately Hidden (Solo
+ * membership overrides that entity's own stored Hidden).
+ */
+
+import { buildClassParentIndex } from "./classNodes.js";
+import { splitGroupedKeys } from "./viewerState.js";
+import { nodeCommunity, nodeType } from "./graphAdapter.js";
+
+/**
+ * Expand a set of ontology class ids to {each id ∪ its descendant class ids} via
+ * the class-hierarchies index, so a Hidden/Solo DOMAIN governs its whole subtree.
+ * @param {Iterable<string>} classIds
+ * @param {Map<string,Set<string>>} descendantClassIds  from buildClassParentIndex
+ * @returns {Set<string>}
+ */
+function expandClassIds(classIds, descendantClassIds) {
+  const out = new Set();
+  for (const id of classIds ?? []) {
+    if (typeof id !== "string" || !id) continue;
+    out.add(id);
+    for (const d of descendantClassIds.get(id) ?? []) out.add(d);
+  }
+  return out;
+}
+
+/**
+ * The owning entity keys of a scene node, split per axis. A SYNTHETIC group node
+ * is owned by ITS OWN key (so "a grouped entity's group node follows the entity"
+ * falls out for free); an entity node is owned by its community, its type, and its
+ * ontology leaf class. Never parses a synthetic id — reads `community_key` /
+ * `type_name` / the class node's own id, matching the A2 discipline.
+ * @returns {{ community: string|null, type: string|null, classId: string|null }}
+ */
+function nodeOwnership(node, classIdByMemberId) {
+  if (node?.community_node_kind === "community") {
+    return { community: node.community_key ?? null, type: null, classId: null };
+  }
+  if (node?.type_node_kind === "type") {
+    return { community: null, type: node.type_name ?? null, classId: null };
+  }
+  if (node?.ontology_node_kind === "class") {
+    return { community: null, type: null, classId: typeof node.id === "string" ? node.id : null };
+  }
+  return {
+    community: nodeCommunity(node),
+    type: nodeType(node),
+    classId: classIdByMemberId.get(node?.id) ?? null,
+  };
+}
+
+/**
+ * Compute the DISPLAY-hidden node id set for a scene, per the D1 two-tier rule.
+ *
+ * @param {object} args
+ * @param {object[]} args.nodes            the POST-FOLD scene nodes (entities + group nodes).
+ * @param {string[]} args.hiddenKeys       stored Hidden namespaced keys (visibility.hidden).
+ * @param {string[]} args.soloKeys         Solo overlay namespaced keys (visibility.solo).
+ * @param {object|null} args.classHierarchies  the class-hierarchies.json artifact.
+ * @returns {Set<string>} the ids to remove from the rendered scene (empty ⇒ nothing hidden).
+ */
+export function computeDisplayHiddenIds({ nodes = [], hiddenKeys = [], soloKeys = [], classHierarchies = null } = {}) {
+  const hiddenSplit = splitGroupedKeys(hiddenKeys);
+  const soloSplit = splitGroupedKeys(soloKeys);
+  const soloActive = soloKeys.length > 0;
+  if (hiddenKeys.length === 0 && soloKeys.length === 0) return new Set();
+
+  const { classIdByMemberId, descendantClassIds } = buildClassParentIndex(classHierarchies);
+
+  // Solo TIER: effective-Hidden = storedHidden \ solo (a soloed entity overrides
+  // its own stored Hidden). HIDDEN tier: effective-Hidden = the whole stored set.
+  const soloCommunities = new Set(soloSplit.communityKeys);
+  const soloTypes = new Set(soloSplit.typeNames);
+  const soloClasses = expandClassIds(soloSplit.ontologyClassIds, descendantClassIds);
+
+  const effHiddenCommunities = new Set(
+    hiddenSplit.communityKeys.filter((k) => !soloActive || !soloCommunities.has(k)),
+  );
+  const effHiddenTypes = new Set(
+    hiddenSplit.typeNames.filter((k) => !soloActive || !soloTypes.has(k)),
+  );
+  const effHiddenClasses = expandClassIds(
+    hiddenSplit.ontologyClassIds.filter(
+      (k) => !soloActive || !soloSplit.ontologyClassIds.includes(k),
+    ),
+    descendantClassIds,
+  );
+
+  const hiddenIds = new Set();
+  for (const node of nodes) {
+    const id = node?.id;
+    if (typeof id !== "string") continue;
+    const own = nodeOwnership(node, classIdByMemberId);
+
+    const suppressed =
+      (own.community != null && effHiddenCommunities.has(own.community)) ||
+      (own.type != null && effHiddenTypes.has(own.type)) ||
+      (own.classId != null && effHiddenClasses.has(own.classId));
+
+    if (soloActive) {
+      const soloed =
+        (own.community != null && soloCommunities.has(own.community)) ||
+        (own.type != null && soloTypes.has(own.type)) ||
+        (own.classId != null && soloClasses.has(own.classId));
+      // Solo tier: visible iff owned by a Solo entity AND not effectively hidden.
+      if (!soloed || suppressed) hiddenIds.add(id);
+    } else if (suppressed) {
+      hiddenIds.add(id);
+    }
+  }
+  return hiddenIds;
+}
+
+/**
+ * Filter a scene to the visible nodes (D5). Drops hidden nodes + any edge with a
+ * dropped endpoint, and updates node/edge counts — the SAME contract as
+ * applyWeakFilter / applyTimeFilter. An EMPTY mask returns the input scene BY
+ * REFERENCE (the A3/A4 byte-identity fast path depends on it). communityCount is
+ * left stable (like applyTimeFilter), since the rail's group count is recomputed
+ * from the facet graph, not from scene.stats.
+ *
+ * @param {{ nodes?: object[], edges?: object[], stats?: object } | null} scene
+ * @param {Set<string>|Iterable<string>} hiddenIds
+ * @returns {object} a new scene (or the same scene when the mask is empty)
+ */
+export function applyVisibilityToScene(scene, hiddenIds) {
+  if (!scene) return scene;
+  const hidden = hiddenIds instanceof Set ? hiddenIds : new Set(hiddenIds ?? []);
+  if (hidden.size === 0) return scene; // fast path — byte-identical (same reference).
+
+  const nodes = (scene.nodes ?? []).filter((n) => !hidden.has(n.id));
+  const keptIds = new Set(nodes.map((n) => n.id));
+  const edges = (scene.edges ?? []).filter(
+    (e) => keptIds.has(e.source) && keptIds.has(e.target),
+  );
+  return {
+    ...scene,
+    nodes,
+    edges,
+    stats: {
+      ...scene.stats,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      weakEdgeCount: edges.filter((e) => e.weak).length,
+    },
+  };
+}

--- a/studio/src/lib/groupBy.js
+++ b/studio/src/lib/groupBy.js
@@ -166,6 +166,101 @@ export function computeGroupTransition({ prevFoldAnchors, nextFoldAnchors } = {}
 }
 
 /* ===========================================================================
+ * UNIFIED scene transition (4-state visibility) — the CONTENT-DERIVED descriptor.
+ *
+ * The a2cf207 fold-anchor delta is BLIND to Hide/Solo (they are a scene filter,
+ * not a fold), so a naive Hide yields an empty delta ⇒ null ⇒ GraphCanvas refits,
+ * violating the sacred no-refit invariant. This generalizes `computeGroupTransition`
+ * with a content-derived VISIBILITY delta (the display-hidden id masks) so Hide /
+ * Show / Solo route through the SAME carry-over tween as group/ungroup:
+ *
+ *   { folded, unfolded, hiddenIds, revealedIds, kind } | null
+ *     folded      : Map<childId, groupId>  newly folded  → collapse (anchor)
+ *     unfolded    : Map<childId, groupId>  newly revealed-from-group → expand
+ *     hiddenIds   : Set<nodeId>            newly display-hidden  → fade OUT in place
+ *     revealedIds : Set<nodeId>            newly display-shown   → fade IN at target
+ *     kind        : "out" | "in" | "mixed"
+ *   null ⇒ nothing to animate OR the graph object reference changed (generation gate).
+ *
+ * Three MANDATORY guards (D3), each closing a real classification trap:
+ *   (a) ANCHOR-ID exclusion — a plain collapse makes the group node APPEAR at swap
+ *       time; without \ anchorIds it could slip into revealedIds → "mixed" and
+ *       silently DEGRADE a shipped pure collapse to a non-animated swap.
+ *   (b) ∩ SCENE-IDS — a display-hidden node whose entity is then GROUPED leaves the
+ *       collapsed graph entirely; the raw mask diff would misclassify it as
+ *       "revealed". Requiring presence in the target scene kills that.
+ *   (c) GENERATION gate — a model switch changes the graph object wholesale; the
+ *       fold + hidden diffs would then straddle two unrelated coordinate spaces.
+ *       `generationChanged` ⇒ null (hard-cut refit, the correct behaviour there).
+ *
+ * @param {object} args
+ * @param {Map<string,string>} [args.prevFoldAnchors]
+ * @param {Map<string,string>} [args.nextFoldAnchors]
+ * @param {Set<string>} [args.prevHiddenIds]  DISPLAY-hidden mask BEFORE the change.
+ * @param {Set<string>} [args.nextHiddenIds]  DISPLAY-hidden mask AFTER the change.
+ * @param {Set<string>} [args.prevSceneIds]   pre-time-filter visible ids BEFORE.
+ * @param {Set<string>} [args.nextSceneIds]   pre-time-filter visible ids AFTER.
+ * @param {boolean} [args.generationChanged]  graph object reference changed.
+ * @returns {{ folded: Map<string,string>, unfolded: Map<string,string>,
+ *   hiddenIds: Set<string>, revealedIds: Set<string>, kind: "out"|"in"|"mixed" }|null}
+ */
+export function computeSceneTransition({
+  prevFoldAnchors,
+  nextFoldAnchors,
+  prevHiddenIds,
+  nextHiddenIds,
+  prevSceneIds,
+  nextSceneIds,
+  generationChanged = false,
+} = {}) {
+  // Guard (c): never diff across a wholesale graph swap (model switch).
+  if (generationChanged) return null;
+
+  const prevFold = prevFoldAnchors instanceof Map ? prevFoldAnchors : new Map();
+  const nextFold = nextFoldAnchors instanceof Map ? nextFoldAnchors : new Map();
+  const prevHidden = prevHiddenIds instanceof Set ? prevHiddenIds : new Set(prevHiddenIds ?? []);
+  const nextHidden = nextHiddenIds instanceof Set ? nextHiddenIds : new Set(nextHiddenIds ?? []);
+  const prevScene = prevSceneIds instanceof Set ? prevSceneIds : new Set(prevSceneIds ?? []);
+  const nextScene = nextSceneIds instanceof Set ? nextSceneIds : new Set(nextSceneIds ?? []);
+
+  const folded = new Map(); // next \ prev anchors
+  const unfolded = new Map(); // prev \ next anchors
+  for (const [childId, groupId] of nextFold) if (!prevFold.has(childId)) folded.set(childId, groupId);
+  for (const [childId, groupId] of prevFold) if (!nextFold.has(childId)) unfolded.set(childId, groupId);
+
+  // Guard (a): the group nodes appearing/disappearing at swap time — never let a
+  // fold anchor masquerade as a hidden/revealed node.
+  const anchorIds = new Set();
+  for (const groupId of folded.values()) anchorIds.add(groupId);
+  for (const groupId of unfolded.values()) anchorIds.add(groupId);
+  const foldedChildren = new Set(folded.keys());
+  const unfoldedChildren = new Set(unfolded.keys());
+
+  const hiddenIds = new Set();
+  for (const id of nextHidden) {
+    // Newly display-hidden AND still present in the PRE-change scene (guard b).
+    if (prevHidden.has(id)) continue;
+    if (!prevScene.has(id)) continue;
+    if (foldedChildren.has(id) || anchorIds.has(id)) continue;
+    hiddenIds.add(id);
+  }
+  const revealedIds = new Set();
+  for (const id of prevHidden) {
+    // Newly display-shown AND present in the POST-change scene (guard b).
+    if (nextHidden.has(id)) continue;
+    if (!nextScene.has(id)) continue;
+    if (unfoldedChildren.has(id) || anchorIds.has(id)) continue;
+    revealedIds.add(id);
+  }
+
+  const outSide = folded.size > 0 || hiddenIds.size > 0;
+  const inSide = unfolded.size > 0 || revealedIds.size > 0;
+  if (!outSide && !inSide) return null;
+  const kind = outSide && inSide ? "mixed" : outSide ? "out" : "in";
+  return { folded, unfolded, hiddenIds, revealedIds, kind };
+}
+
+/* ===========================================================================
  * Tri-state bulk-button + NESTING-ABSORPTION math (spec §3/§4).
  * ======================================================================== */
 

--- a/studio/src/lib/viewerState.js
+++ b/studio/src/lib/viewerState.js
@@ -100,6 +100,17 @@ function createDefaultGroupBy() {
   return { grouped: [] };
 }
 
+/**
+ * Default per-entity VISIBILITY overlay (4-state control). Stored state ∈
+ * {Normal, Grouped, Hidden} is exclusive (Grouped lives in `groupBy.grouped`,
+ * Hidden here); Solo is a SEPARATE overlay set that never mutates grouped/hidden
+ * storage. Both are keyed by the SAME namespaced keys as grouping
+ * (`ontology:|community:|type:`). Empty === nothing hidden/soloed (fast path).
+ */
+function createDefaultVisibility() {
+  return { hidden: [], solo: [] };
+}
+
 export function createDefaultViewerState() {
   return {
     activeView: "workspace",
@@ -108,8 +119,26 @@ export function createDefaultViewerState() {
     focusId: null,
     // `timeCursor`: time-scrub cursor (epoch-ms) or null = OFF (no temporal
     // filter). Default null so the scene is unfiltered until the user scrubs.
-    options: { showWeakLinks: true, timeCursor: null, groupBy: createDefaultGroupBy() },
+    options: {
+      showWeakLinks: true,
+      timeCursor: null,
+      groupBy: createDefaultGroupBy(),
+      visibility: createDefaultVisibility(),
+    },
   };
+}
+
+/** The four mutually-visible entity states the per-row control cycles through. */
+export const ENTITY_STATES = ["normal", "grouped", "hidden", "solo"];
+
+/** True when `key` carries a known group/visibility namespace prefix. */
+function hasKnownNamespace(key) {
+  return (
+    typeof key === "string" &&
+    (key.startsWith(`${GROUP_KIND.ontology}:`) ||
+      key.startsWith(`${GROUP_KIND.community}:`) ||
+      key.startsWith(`${GROUP_KIND.type}:`))
+  );
 }
 
 function uniqueStrings(values = []) {
@@ -160,6 +189,31 @@ function normalizeGroupBy(options = {}) {
   return { grouped: uniqueStrings(keys) };
 }
 
+/**
+ * Normalize the per-entity VISIBILITY overlay (4-state control). This is the ONLY
+ * "migration" surface — there is NO localStorage persistence of viewerState in
+ * studio/src, so an ABSENT `visibility` (every pre-feature state) simply defaults
+ * to empty sets. Both lists are deduped, string-only, and restricted to keys with
+ * a known namespace prefix so junk can never accumulate through the option
+ * spread. Exclusivity (a node's stored state is Grouped XOR Hidden) is enforced
+ * grouped-WINS: `hidden := hidden \ grouped`, so a bulk "Group all" that regroups
+ * a currently-Hidden entity simply un-hides it (zero bulk-writer changes). `solo`
+ * is an overlay and is NOT exclusivity-constrained (solo ∩ grouped / solo ∩ hidden
+ * are legal and meaningful — Solo preserves the stored state, §3/§6.2).
+ *
+ * @param {object} options   the RAW partial options (so absence is detectable).
+ * @param {string[]} groupedKeys  the already-normalized `groupBy.grouped` set.
+ */
+function normalizeVisibility(options = {}, groupedKeys = []) {
+  const raw = options.visibility ?? {};
+  const grouped = new Set(groupedKeys);
+  const hidden = uniqueStrings(Array.isArray(raw.hidden) ? raw.hidden : []).filter(
+    (k) => hasKnownNamespace(k) && !grouped.has(k),
+  );
+  const solo = uniqueStrings(Array.isArray(raw.solo) ? raw.solo : []).filter(hasKnownNamespace);
+  return { hidden, solo };
+}
+
 export function normalizeViewerState(partial = {}) {
   const base = createDefaultViewerState();
   const sel = partial.selection ?? {};
@@ -187,6 +241,9 @@ export function normalizeViewerState(partial = {}) {
   // Normalize from the RAW partial options (not the base-merged one) so the
   // absence of `groupBy` is genuinely detectable and the legacy migration fires.
   next.options.groupBy = normalizeGroupBy(partial.options ?? {});
+  // Per-entity visibility overlay (4-state control). Normalized AFTER groupBy so
+  // the grouped-wins exclusivity (hidden \ grouped) reads the final grouped set.
+  next.options.visibility = normalizeVisibility(partial.options ?? {}, next.options.groupBy.grouped);
   // Drop the subsumed legacy flat / axis-scoped fields so they cannot drift.
   delete next.options.showOntologyClasses;
   delete next.options.collapsedClassIds;
@@ -456,4 +513,110 @@ export function foldOntologyToLevel(state, levelClassIds = []) {
     (k) => typeof k === "string" && !k.startsWith(`${GROUP_KIND.ontology}:`),
   );
   return withGrouped(state, [...kept, ...ids.map(groupKeyForOntology)]);
+}
+
+/* ===========================================================================
+ * 4-STATE per-entity VISIBILITY control (Normal · Grouped · Hidden · Solo).
+ *
+ * D2 schema (double-consensus): keep `groupBy.grouped` UNCHANGED as the Grouped
+ * storage; add `options.visibility = { hidden:[], solo:[] }`, keyed by the SAME
+ * namespaced keys. Stored state ∈ {Normal, Grouped, Hidden} is EXCLUSIVE; Solo is
+ * a SEPARATE overlay set (a Grouped entity soloed shows its group node — Solo
+ * never mutates grouped/hidden storage). Reducer = setEntityState / toggleSolo /
+ * resetVisibility. Migration = defaults in normalizeViewerState (no localStorage).
+ * ======================================================================== */
+
+/**
+ * The state the per-row WIDGET displays for a namespaced key. Solo overlay wins
+ * visually (§4), then stored Hidden, then Grouped, else Normal. PURE predicate.
+ */
+export function displayedEntityState(state, key) {
+  const v = state?.options?.visibility;
+  if (Array.isArray(v?.solo) && v.solo.includes(key)) return "solo";
+  if (Array.isArray(v?.hidden) && v.hidden.includes(key)) return "hidden";
+  if (state?.options?.groupBy?.grouped?.includes(key)) return "grouped";
+  return "normal";
+}
+
+/**
+ * Radiogroup semantics (D2): clicking a segment PUTS the entity in that state.
+ *   - "solo"   → add to the Solo OVERLAY; stored grouped/hidden UNTOUCHED (§3/§6.2).
+ *   - "normal" → clear grouped + hidden + solo for the key.
+ *   - "grouped"→ exit solo, drop hidden, add to grouped (exclusive stored state).
+ *   - "hidden" → exit solo, drop grouped, add to hidden (exclusive stored state).
+ * A non-string / empty key or an unknown state is a normalize-only no-op.
+ */
+export function setEntityState(state, key, next) {
+  if (typeof key !== "string" || !key || !ENTITY_STATES.includes(next)) {
+    return normalizeViewerState(state);
+  }
+  const grouped = new Set(state.options.groupBy.grouped);
+  const hidden = new Set(state.options.visibility?.hidden ?? []);
+  const solo = new Set(state.options.visibility?.solo ?? []);
+  if (next === "solo") {
+    solo.add(key); // OVERLAY: stored grouped/hidden preserved (§3, §6.2).
+  } else {
+    solo.delete(key); // any non-solo click exits this entity's Solo.
+    grouped.delete(key);
+    hidden.delete(key);
+    if (next === "grouped") grouped.add(key);
+    else if (next === "hidden") hidden.add(key);
+    // next === "normal": the deletes above are the whole story.
+  }
+  return normalizeViewerState({
+    ...state,
+    options: {
+      ...state.options,
+      groupBy: { grouped: [...grouped] },
+      visibility: { hidden: [...hidden], solo: [...solo] },
+    },
+  });
+}
+
+/**
+ * Toggle a key in/out of the Solo overlay (§3 "Exit"). Adding accumulates
+ * (multi-Solo); removing returns the entity to its stored state for display.
+ * A non-string / empty key is a normalize-only no-op.
+ */
+export function toggleSolo(state, key) {
+  if (typeof key !== "string" || !key) return normalizeViewerState(state);
+  const solo = new Set(state.options.visibility?.solo ?? []);
+  if (solo.has(key)) solo.delete(key);
+  else solo.add(key);
+  return normalizeViewerState({
+    ...state,
+    options: {
+      ...state.options,
+      visibility: { hidden: [...(state.options.visibility?.hidden ?? [])], solo: [...solo] },
+    },
+  });
+}
+
+/**
+ * Global "Show all / Reset" (§1): Hidden + Solo + Grouped → Normal. Everything
+ * else (selection, weak-link, time cursor) is kept.
+ */
+export function resetVisibility(state) {
+  return normalizeViewerState({
+    ...state,
+    options: {
+      ...state.options,
+      groupBy: { grouped: [] },
+      visibility: { hidden: [], solo: [] },
+    },
+  });
+}
+
+/** Is ANY Solo overlay active? (drives the Solo-tier derivation + rail dimming). */
+export function soloActive(state) {
+  return (state?.options?.visibility?.solo?.length ?? 0) > 0;
+}
+
+/** Any Grouped / Hidden / Solo override present? (drives the global Reset's disabled). */
+export function hasAnyVisibilityOverride(state) {
+  return (
+    (state?.options?.groupBy?.grouped?.length ?? 0) > 0 ||
+    (state?.options?.visibility?.hidden?.length ?? 0) > 0 ||
+    (state?.options?.visibility?.solo?.length ?? 0) > 0
+  );
 }

--- a/studio/src/tests/entityVisibility.test.js
+++ b/studio/src/tests/entityVisibility.test.js
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDisplayHiddenIds,
+  applyVisibilityToScene,
+} from "../lib/entityVisibility.js";
+import {
+  groupKeyForOntology,
+  groupKeyForCommunity,
+  groupKeyForType,
+} from "../lib/viewerState.js";
+
+/* ===========================================================================
+ * 4-STATE VISIBILITY — the D1 display mask + the scene filter.
+ *
+ * D1 (both review passes DISSENT from spec §6.1): Normal ABSTAINS; Hidden = union
+ * suppression (a node hides iff ANY owning entity is stored-Hidden); the ≥1-visible
+ * whitelist union applies ONLY inside the Solo tier. Hide must NOT be a no-op at
+ * mystery scale (every node is also owned by its Normal-by-default type/class).
+ * ======================================================================== */
+
+// Entity ids: holmes/watson (Character, Hound), moriarty (Character, Web),
+// yard (Organization, Hound), baker (Location, Hound).
+function mysteryNodes() {
+  return [
+    { id: "holmes", type: "Character", community_name: "Hound" },
+    { id: "watson", type: "Character", community_name: "Hound" },
+    { id: "moriarty", type: "Character", community_name: "Web" },
+    { id: "yard", type: "Organization", community_name: "Hound" },
+    { id: "baker", type: "Location", community_name: "Hound" },
+  ];
+}
+
+// Domain class:People → {class:Detective(holmes,watson), class:Villain(moriarty)};
+// Domain class:Place → {class:Location(baker)}. yard has no ontology class.
+const classHierarchies = {
+  hierarchies: {
+    h: {
+      root_class_ids: ["class:People", "class:Place"],
+      classes_by_id: {
+        "class:People": { id: "class:People", level: 0, child_ids: ["class:Detective", "class:Villain"] },
+        "class:Detective": { id: "class:Detective", level: 1, member_ids: ["holmes", "watson"] },
+        "class:Villain": { id: "class:Villain", level: 1, member_ids: ["moriarty"] },
+        "class:Place": { id: "class:Place", level: 0, child_ids: ["class:Location"] },
+        "class:Location": { id: "class:Location", level: 1, member_ids: ["baker"] },
+      },
+    },
+  },
+};
+
+const hidden = (ids) => new Set([...ids].sort());
+const asSet = (s) => new Set([...s].sort());
+
+describe("computeDisplayHiddenIds — Hidden tier (union suppression, Normal abstains)", () => {
+  it("hiding a TYPE hides EVERY node of that type — even in Normal communities (NOT a no-op)", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [groupKeyForType("Character")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    // holmes/watson/moriarty are Characters; their communities are Normal but ABSTAIN.
+    expect(asSet(out)).toEqual(hidden(["holmes", "watson", "moriarty"]));
+  });
+
+  it("hiding a COMMUNITY hides its members across types", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [groupKeyForCommunity("Hound")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    expect(asSet(out)).toEqual(hidden(["holmes", "watson", "yard", "baker"]));
+  });
+
+  it("hiding a DOMAIN class hides its whole subtree (ancestor expansion)", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [groupKeyForOntology("class:People")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    // Detective (holmes,watson) + Villain (moriarty) fold under People; baker/yard stay.
+    expect(asSet(out)).toEqual(hidden(["holmes", "watson", "moriarty"]));
+  });
+
+  it("multi-entity CROSS-AXIS hidden keys UNION (any Hidden owner hides)", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [groupKeyForCommunity("Hound"), groupKeyForType("Character")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    // Hound {holmes,watson,yard,baker} ∪ Characters {holmes,watson,moriarty} = all.
+    expect(asSet(out)).toEqual(hidden(["holmes", "watson", "moriarty", "yard", "baker"]));
+  });
+
+  it("an EMPTY override yields an empty mask", () => {
+    expect(
+      computeDisplayHiddenIds({ nodes: mysteryNodes(), hiddenKeys: [], soloKeys: [], classHierarchies }).size,
+    ).toBe(0);
+  });
+});
+
+describe("computeDisplayHiddenIds — Solo tier (union whitelist, complement hidden)", () => {
+  it("solo a TYPE shows only that type, hiding the complement", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [],
+      soloKeys: [groupKeyForType("Character")],
+      classHierarchies,
+    });
+    // Visible = Characters; hidden = the complement {yard, baker}.
+    expect(asSet(out)).toEqual(hidden(["yard", "baker"]));
+  });
+
+  it("MULTI-Solo shows the UNION of the solo entities", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [],
+      soloKeys: [groupKeyForCommunity("Web"), groupKeyForType("Organization")],
+      classHierarchies,
+    });
+    // Visible = Web {moriarty} ∪ Organization {yard}; hidden = the rest.
+    expect(asSet(out)).toEqual(hidden(["holmes", "watson", "baker"]));
+  });
+
+  it("Solo OVERRIDES the entity's OWN stored Hidden (storedHidden \\ solo)", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [groupKeyForCommunity("Hound")],
+      soloKeys: [groupKeyForCommunity("Hound")],
+      classHierarchies,
+    });
+    // Hound is both hidden AND solo → effective-hidden = ∅; Hound members are shown.
+    expect(asSet(out)).toEqual(hidden(["moriarty"]));
+  });
+
+  it("a NON-solo stored Hidden still suppresses INSIDE the Solo whitelist", () => {
+    const out = computeDisplayHiddenIds({
+      nodes: mysteryNodes(),
+      hiddenKeys: [groupKeyForCommunity("Hound")],
+      soloKeys: [groupKeyForType("Character")],
+      classHierarchies,
+    });
+    // Solo Characters {holmes,watson,moriarty}, MINUS Hound-suppressed {holmes,watson}
+    // ⇒ only moriarty visible; everyone else hidden.
+    expect(asSet(out)).toEqual(hidden(["holmes", "watson", "yard", "baker"]));
+  });
+});
+
+describe("computeDisplayHiddenIds — a group node's visibility FOLLOWS its entity", () => {
+  it("masks community / type / class SYNTHETIC nodes via their own predicates (no id parsing)", () => {
+    const nodes = [
+      ...mysteryNodes(),
+      { id: "community-node:Hound", community_node_kind: "community", community_key: "Hound" },
+      { id: "type-node:Character", type_node_kind: "type", type_name: "Character" },
+      { id: "class:Detective", ontology_node_kind: "class" },
+    ];
+    // Hiding the community also hides its group node.
+    let out = computeDisplayHiddenIds({
+      nodes,
+      hiddenKeys: [groupKeyForCommunity("Hound")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    expect(out.has("community-node:Hound")).toBe(true);
+    expect(out.has("type-node:Character")).toBe(false);
+    // Hiding the Domain hides its descendant class group node (class:Detective).
+    out = computeDisplayHiddenIds({
+      nodes,
+      hiddenKeys: [groupKeyForOntology("class:People")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    expect(out.has("class:Detective")).toBe(true);
+    // Hiding the type hides the type group node.
+    out = computeDisplayHiddenIds({
+      nodes,
+      hiddenKeys: [groupKeyForType("Character")],
+      soloKeys: [],
+      classHierarchies,
+    });
+    expect(out.has("type-node:Character")).toBe(true);
+  });
+});
+
+describe("applyVisibilityToScene — scene filter", () => {
+  const scene = () => ({
+    nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    edges: [
+      { source: "a", target: "b" },
+      { source: "b", target: "c", weak: true },
+    ],
+    stats: { nodeCount: 3, edgeCount: 2, weakEdgeCount: 1, communityCount: 2 },
+  });
+
+  it("drops hidden nodes + dangling edges and recomputes counts", () => {
+    const out = applyVisibilityToScene(scene(), new Set(["b"]));
+    expect(out.nodes.map((n) => n.id)).toEqual(["a", "c"]);
+    expect(out.edges).toEqual([]); // both edges touched b
+    expect(out.stats.nodeCount).toBe(2);
+    expect(out.stats.edgeCount).toBe(0);
+    expect(out.stats.weakEdgeCount).toBe(0);
+    // communityCount is left stable (like applyTimeFilter).
+    expect(out.stats.communityCount).toBe(2);
+  });
+
+  it("an EMPTY mask returns the SAME scene reference (byte-identity fast path)", () => {
+    const s = scene();
+    expect(applyVisibilityToScene(s, new Set())).toBe(s);
+    expect(applyVisibilityToScene(s, [])).toBe(s);
+  });
+
+  it("hide-EVERYTHING yields a graceful empty scene (no crash, no refit)", () => {
+    const out = applyVisibilityToScene(scene(), new Set(["a", "b", "c"]));
+    expect(out.nodes).toEqual([]);
+    expect(out.edges).toEqual([]);
+    expect(out.stats.nodeCount).toBe(0);
+  });
+});

--- a/studio/src/tests/graphCanvasRenderer.test.js
+++ b/studio/src/tests/graphCanvasRenderer.test.js
@@ -830,3 +830,77 @@ describe("GraphCanvas collapse/expand group transition", () => {
     expect(source).toMatch(/cancelMergeFrame\(\);\s*\n\s*cancelGroupTweenFrame\(\);/);
   });
 });
+
+// --- 4-STATE visibility: unified transition routing (Hide/Show/Solo) ----------
+// The SPINE: Hide/Solo route through the SAME carry-over tween as group/ungroup
+// via a content-derived visibility delta. jsdom has no WebGL, so (as elsewhere)
+// we assert the .svelte SOURCE wires the extended descriptor + the in-place fade.
+describe("GraphCanvas 4-state visibility transition (Hide/Show/Solo)", () => {
+  const driverSource = (source) =>
+    source.slice(
+      source.indexOf("// --- Collapse/expand GROUP transition driver"),
+      source.indexOf("// Stable content signature of a scene"),
+    );
+
+  it("documents the UNIFIED descriptor shape on the prop", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/hiddenIds: Set<nodeId>, revealedIds: Set<nodeId>, kind: "out"\|"in"\|"mixed"/);
+    expect(source).toMatch(/groupTransition = null,/);
+  });
+
+  it("routes by KIND: out→collapse(+hide), in→expand(+reveal), mixed→carried swap", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    expect(driver).toMatch(/if \(transition\.kind === "out"\) return startCollapseTween\(folded, hiddenIds\);/);
+    expect(driver).toMatch(/if \(transition\.kind === "in"\) return startExpandTween\(unfolded, revealedIds\);/);
+    expect(driver).toMatch(/if \(transition\.kind === "mixed"\)\s*\n\s*return applyMixedCarriedSwap\(/);
+    // The unknown/absent path still returns false (refit fallback).
+    expect(driver).toMatch(/function tryStartGroupTransition[\s\S]{0,300}return false;/);
+  });
+
+  it("hidden nodes fade IN PLACE (bufB stays == bufA) — never toward an anchor", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    // The in-place index helper resolves display-hidden/revealed ids on screen.
+    expect(driver).toContain("function collectInPlaceIndices");
+    // startCollapseTween unions the fold set with the in-place hidden indices…
+    expect(driver).toMatch(/function startCollapseTween\(anchors, hiddenIds = new Set\(\)\)/);
+    expect(driver).toMatch(/const inPlaceIdx = collectInPlaceIndices\(hiddenIds\);/);
+    expect(driver).toMatch(/for \(const i of inPlaceIdx\) foldingSet\.add\(i\);/);
+    // …and NEVER overwrites the hidden slots in bufB (they stay == bufA).
+    expect(driver).toMatch(/Hidden nodes: bufB stays == bufA/);
+  });
+
+  it("revealed nodes fade in at their CACHED same-epoch position (else neighbour)", () => {
+    const source = graphCanvasSource();
+    const driver = driverSource(source);
+    expect(driver).toMatch(/function startExpandTween\(anchors, revealedIds = new Set\(\)\)/);
+    expect(driver).toMatch(/for \(const id of revealedIds\) \{\s*\n\s*const cached = lastKnownPosById\.get\(id\);/);
+    expect(driver).toMatch(/const revealedIdx = collectInPlaceIndices\(revealedIds\);/);
+    expect(driver).toMatch(/for \(const i of revealedIdx\) foldingSet\.add\(i\);/);
+  });
+
+  it("finishCollapseSwap caches each HIDDEN node's pre-hide position (for later reveal)", () => {
+    const source = graphCanvasSource();
+    expect(source).toMatch(/function finishCollapseSwap\(oldPos, placedPosById, anchors, hiddenIds = new Set\(\)\)/);
+    const settle = source.slice(
+      source.indexOf("function finishCollapseSwap"),
+      source.indexOf("function startExpandTween"),
+    );
+    expect(settle).toMatch(/for \(const id of hiddenIds\) \{[\s\S]{0,120}lastKnownPosById\.set\(id/);
+  });
+
+  it("the MIXED path is a carried NON-animated swap — never a refit (D4)", () => {
+    const source = graphCanvasSource();
+    const mixed = source.slice(
+      source.indexOf("function applyMixedCarriedSwap"),
+      source.indexOf("// Expand targets"),
+    );
+    expect(mixed).toContain("applyCarriedScene({ carriedPosById: oldPos, placedPosById })");
+    expect(mixed).toContain("settleGroupTween(payload?.renderGraph?.positions)");
+    // No tween, no hard refit.
+    expect(mixed).not.toContain("runGroupTween");
+    expect(mixed).not.toMatch(/resetLayoutState\(\);\s*\n\s*updateGraph\(\);/);
+    expect(mixed).not.toMatch(/(?<!animate)fitAndRender\(/);
+  });
+});

--- a/studio/src/tests/groupBy.test.js
+++ b/studio/src/tests/groupBy.test.js
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeGroupedGraph,
   computeGroupTransition,
+  computeSceneTransition,
   classIdsAtLevel,
   typeNamesInTaxonomy,
   ontologyLevelState,
@@ -536,5 +537,146 @@ describe("computeGroupTransition — collapse/expand direction detection", () =>
 
   it("defaults are safe — no args → null", () => {
     expect(computeGroupTransition()).toBeNull();
+  });
+});
+
+/* ===========================================================================
+ * UNIFIED scene transition (4-state visibility) — computeSceneTransition.
+ *
+ * The SPINE: Hide/Solo route through the SAME carry-over tween via a content-
+ * derived visibility delta. Three MANDATORY guards (D3), each with a regression:
+ *   (a) anchor-id exclusion — a pure collapse must NOT degrade to "mixed";
+ *   (b) ∩ scene-ids — a hidden-then-folded id must NOT masquerade as "revealed";
+ *   (c) generation gate — a graph-object swap (model switch) ⇒ null.
+ * ======================================================================== */
+describe("computeSceneTransition — unified 4-state descriptor", () => {
+  const S = (...ids) => new Set(ids);
+  const M = (pairs) => new Map(pairs);
+
+  it("pure HIDE ⇒ kind:out, hiddenIds only (fade-in-place)", () => {
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([]),
+      prevHiddenIds: S(),
+      nextHiddenIds: S("a", "b"),
+      prevSceneIds: S("a", "b", "c"),
+      nextSceneIds: S("c"),
+    });
+    expect(t.kind).toBe("out");
+    expect([...t.hiddenIds].sort()).toEqual(["a", "b"]);
+    expect(t.revealedIds.size).toBe(0);
+    expect(t.folded.size).toBe(0);
+  });
+
+  it("pure SHOW / Reset ⇒ kind:in, revealedIds only (fade-in-at-target)", () => {
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([]),
+      prevHiddenIds: S("a", "b"),
+      nextHiddenIds: S(),
+      prevSceneIds: S("c"),
+      nextSceneIds: S("a", "b", "c"),
+    });
+    expect(t.kind).toBe("in");
+    expect([...t.revealedIds].sort()).toEqual(["a", "b"]);
+    expect(t.hiddenIds.size).toBe(0);
+  });
+
+  it("pure COLLAPSE ⇒ kind:out, folded only — byte-identical routing to a2cf207", () => {
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([["child", "group"]]),
+      prevHiddenIds: S(),
+      nextHiddenIds: S(),
+      prevSceneIds: S("child"),
+      nextSceneIds: S("group"),
+    });
+    expect(t.kind).toBe("out");
+    expect([...t.folded]).toEqual([["child", "group"]]);
+    expect(t.hiddenIds.size).toBe(0);
+    expect(t.revealedIds.size).toBe(0);
+  });
+
+  it("two-sided (fold AND reveal) ⇒ kind:mixed", () => {
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([["c", "g"]]),
+      prevHiddenIds: S("h"),
+      nextHiddenIds: S(),
+      prevSceneIds: S("c", "h"),
+      nextSceneIds: S("g", "h"),
+    });
+    expect(t.kind).toBe("mixed");
+    expect(t.folded.size).toBe(1);
+    expect([...t.revealedIds]).toEqual(["h"]);
+  });
+
+  it("no-op ⇒ null (nothing to animate)", () => {
+    expect(
+      computeSceneTransition({
+        prevFoldAnchors: M([]),
+        nextFoldAnchors: M([]),
+        prevHiddenIds: S("x"),
+        nextHiddenIds: S("x"),
+        prevSceneIds: S("y"),
+        nextSceneIds: S("y"),
+      }),
+    ).toBeNull();
+  });
+
+  it("GUARD (a): a group node appearing does NOT slip into revealedIds → stays kind:out", () => {
+    // folded {child→G}; G was somehow in prevHidden — the anchor-id exclusion must
+    // keep it out of revealedIds so a pure collapse never degrades to "mixed".
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([["child", "G"]]),
+      prevHiddenIds: S("G"),
+      nextHiddenIds: S(),
+      prevSceneIds: S("child"),
+      nextSceneIds: S("G", "child"),
+    });
+    expect(t.revealedIds.has("G")).toBe(false);
+    expect(t.kind).toBe("out");
+  });
+
+  it("GUARD (b): a hidden-then-FOLDED id is NOT reported as revealed (∩ scene-ids)", () => {
+    // X was display-hidden, then its entity got grouped → X leaves the scene
+    // entirely (∉ nextSceneIds). The mask diff would call it "revealed"; the
+    // scene-id intersection kills that.
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([]),
+      prevHiddenIds: S("X"),
+      nextHiddenIds: S(),
+      prevSceneIds: S("other"),
+      nextSceneIds: S("other"), // X is NOT in the new scene
+    });
+    expect(t).toBeNull(); // nothing legitimately animates
+  });
+
+  it("GUARD (c): a graph-object swap (generationChanged) ⇒ null (hard-cut refit)", () => {
+    const t = computeSceneTransition({
+      generationChanged: true,
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([["c", "g"]]),
+      prevHiddenIds: S(),
+      nextHiddenIds: S("z"),
+      prevSceneIds: S("c", "z"),
+      nextSceneIds: S("g"),
+    });
+    expect(t).toBeNull();
+  });
+
+  it("folded children are excluded from hiddenIds (no double-count)", () => {
+    const t = computeSceneTransition({
+      prevFoldAnchors: M([]),
+      nextFoldAnchors: M([["c", "g"]]),
+      prevHiddenIds: S(),
+      nextHiddenIds: S("c"), // c is both folded AND (spuriously) in the mask diff
+      prevSceneIds: S("c"),
+      nextSceneIds: S("g"),
+    });
+    expect(t.hiddenIds.has("c")).toBe(false);
+    expect(t.kind).toBe("out");
   });
 });

--- a/studio/src/tests/leftRail.test.js
+++ b/studio/src/tests/leftRail.test.js
@@ -41,34 +41,38 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     expect(appSource).not.toMatch(/setGroupAxis/);
   });
 
-  it("each groupable Ontology CLASS node owns a per-item group-by checkbox", () => {
-    // Domain + Sub-domain class headers each carry a checkbox → onToggleGroupOntology.
-    expect(railSource).toMatch(/class="rail-group-check"/);
-    expect(railSource).toMatch(/onToggleGroupOntology\?\.\(domain\.id\)/);
-    expect(railSource).toMatch(/onToggleGroupOntology\?\.\(sub\.id\)/);
-    // The checked state reflects membership in the grouped SET (per-item).
-    expect(railSource).toMatch(/checked=\{ontologyCheckedSet\.has\(domain\.id\)\}/);
-    expect(railSource).toMatch(/checked=\{ontologyCheckedSet\.has\(sub\.id\)\}/);
-    // App passes the per-item callbacks + availability flags (NOT availableAxes).
-    expect(appSource).toMatch(/onToggleGroupOntology=\{handleToggleGroupOntology\}/);
-    expect(appSource).toMatch(/onToggleGroupCommunity=\{handleToggleGroupCommunity\}/);
+  it("each groupable Ontology CLASS node owns a per-entity visibility control (D6)", () => {
+    // The old group checkbox is SUPERSEDED by EntityStateControl (Normal · Grouped
+    // · Hidden · Solo). Domain + Sub-domain class headers each instantiate it,
+    // keyed by the namespaced ontology key + wired to onSetEntityState.
+    expect(railSource).toMatch(/import EntityStateControl from "\.\/EntityStateControl\.svelte"/);
+    expect(railSource).toMatch(/key=\{groupKeyForOntology\(domain\.id\)\}/);
+    expect(railSource).toMatch(/key=\{groupKeyForOntology\(sub\.id\)\}/);
+    // The displayed state comes from the D2 storage (Solo > Hidden > Grouped > Normal).
+    expect(railSource).toMatch(/state=\{entityStateOf\(groupKeyForOntology\(domain\.id\)\)\}/);
+    expect(railSource).toMatch(/state=\{entityStateOf\(groupKeyForOntology\(sub\.id\)\)\}/);
+    expect(railSource).toMatch(/onSetState=\{onSetEntityState\}/);
+    // App wires the reducer setter + the visibility overlay + availability flags.
+    expect(appSource).toMatch(/onSetEntityState=\{handleSetEntityState\}/);
+    expect(appSource).toMatch(/visibility=\{viewerState\.options\.visibility\}/);
     expect(appSource).toMatch(/\{canGroupOntology\}/);
     expect(appSource).toMatch(/\{canGroupCommunity\}/);
   });
 
-  it("each leaf TYPE row owns its OWN group-by checkbox (§2 — fixes Type grouping)", () => {
-    // The Type checkbox folds entities of that `type` → onToggleGroupType(t.key);
-    // its checked state reads the type-scoped membership set.
-    expect(railSource).toMatch(/onToggleGroupType\?\.\(t\.key\)/);
-    expect(railSource).toMatch(/checked=\{typeCheckedSet\.has\(t\.key\)\}/);
-    // It is SEPARATE from the Type FILTER SelectableRow (onToggleType) on the row.
+  it("each leaf TYPE row owns its OWN visibility control (§2), separate from the FILTER row", () => {
+    // The Type control targets that `type`'s namespaced key; it is a SEPARATE
+    // concern from the Type FILTER SelectableRow (onToggleType) that follows it.
+    expect(railSource).toMatch(/key=\{groupKeyForType\(t\.key\)\}/);
+    expect(railSource).toMatch(/state=\{entityStateOf\(groupKeyForType\(t\.key\)\)\}/);
     expect(railSource).toMatch(/rail-type-group-check/);
-    expect(appSource).toMatch(/onToggleGroupType=\{handleToggleGroupType\}/);
+    // Its own control is disabled (absorbed) when a parent Sub-domain/Domain is grouped.
+    expect(railSource).toMatch(/disabled=\{ontologyCheckedSet\.has\(sub\.id\) \|\|/);
+    expect(appSource).toMatch(/onSetEntityState=\{handleSetEntityState\}/);
   });
 
-  it("each Community row owns a per-item group-by checkbox (separate from its select)", () => {
-    expect(railSource).toMatch(/onToggleGroupCommunity\?\.\(c\.key\)/);
-    expect(railSource).toMatch(/checked=\{communityCheckedSet\.has\(c\.key\)\}/);
+  it("each Community row owns its OWN visibility control (separate from its select)", () => {
+    expect(railSource).toMatch(/key=\{groupKeyForCommunity\(c\.key\)\}/);
+    expect(railSource).toMatch(/state=\{entityStateOf\(groupKeyForCommunity\(c\.key\)\)\}/);
   });
 
   it("the ONTOLOGY tri-state bulk buttons drive the grouped set (§4)", () => {
@@ -103,37 +107,38 @@ describe("LeftRail — T13 F2 visible-UI lock (PER-ITEM group-by checkboxes)", (
     expect(appSource).toMatch(/onClearCommunityGrouping=\{handleClearCommunityGrouping\}/);
   });
 
-  it("the group-by checkbox is on the LEFT with NO 'group' text (SPEC)", () => {
-    // SPEC PART 1: the bare checkbox is the FIRST element on the row. There are
-    // FOUR group-by checkboxes — Domain, Sub-domain, Type, Community — each
-    // carrying the `rail-group-check` affordance (the Type one adds the
-    // `rail-type-group-check` variant).
-    const onMarkers = railSource.match(/class:rail-group-check--on=/g) ?? [];
-    expect(onMarkers.length).toBe(4);
-    // FIX: the DS Collapsible exposes NO `leading` slot (only trailing/children),
-    // so the Domain + Sub-domain group-by checkboxes are SIBLINGS *before*
-    // <Collapsible> inside a `.rail-onto-head` flex row — NOT in a (silently
-    // dropped) leading() snippet. That dropped slot is exactly why the
-    // Domain/Sub-domain checkboxes were invisible.
+  it("the visibility control is on the LEFT of every row, superseding the checkbox (D6)", () => {
+    // D6: the per-entity control is the FIRST element on the row. There are FOUR
+    // EntityStateControl instances — Domain, Sub-domain, Type, Community.
+    const controls = railSource.match(/<EntityStateControl/g) ?? [];
+    expect(controls.length).toBe(4);
+    // The old bare-checkbox affordance is gone (no <input type="checkbox"> group-by).
+    expect(railSource).not.toMatch(/class="rail-group-check"/);
+    expect(railSource).not.toMatch(/class:rail-group-check--on=/);
+    // FIX (preserved): the DS Collapsible exposes NO `leading` slot, so the Domain
+    // + Sub-domain controls are SIBLINGS *before* <Collapsible> in a `.rail-onto-head`
+    // flex row — NOT in a (silently dropped) leading() snippet.
     const ontoHeads = railSource.match(/<li class="rail-onto-head">/g) ?? [];
     expect(ontoHeads.length).toBe(2); // Domain + Sub-domain rows
     expect(railSource).toMatch(
-      /<li class="rail-onto-head">[\s\S]*?class="rail-group-check"[\s\S]*?onToggleGroupOntology[\s\S]*?<Collapsible/,
+      /<li class="rail-onto-head">[\s\S]*?<EntityStateControl[\s\S]*?groupKeyForOntology[\s\S]*?<Collapsible/,
     );
-    // Regression guard: NEVER put a group-by checkbox in a Collapsible leading()
-    // snippet — the DS Collapsible drops it.
+    // Regression guard: NEVER put the control in a Collapsible leading() snippet.
     expect(railSource).not.toMatch(/<Collapsible[^>]*>\s*\{#snippet leading\(\)\}/);
-    // The leaf Type checkbox sits FIRST in its flex row, BEFORE the FILTER
-    // SelectableRow — left, bare, separate from the Type FILTER select (§2).
+    // The leaf Type control sits FIRST in its flex row, BEFORE the FILTER
+    // SelectableRow — separate from the Type FILTER select (§2).
     expect(railSource).toMatch(
-      /rail-type-group-check[\s\S]*?onToggleGroupType[\s\S]*?<SelectableRow/,
+      /rail-type-group-check[\s\S]*?<EntityStateControl[\s\S]*?<SelectableRow/,
     );
     // NO persistent "group" text label anywhere — the rail-group-hint span is gone.
     expect(railSource).not.toMatch(/rail-group-hint/);
     expect(railSource).not.toMatch(/>group<\/span>/);
-    expect(railSource).not.toMatch(/aria-hidden="true">group/);
-    // The HOVER signal stays: the title tooltip "Group by …" is preserved.
-    expect(railSource).toMatch(/title="Group by /);
+    // The global "Reset visibility" affordance lives under the search stats (D6).
+    expect(railSource).toMatch(/aria-label="Reset all entity visibility"/);
+    expect(railSource).toMatch(/Reset visibility/);
+    expect(railSource).toMatch(/disabled=\{!hasVisibilityOverride\}/);
+    expect(appSource).toMatch(/onResetVisibility=\{handleResetVisibility\}/);
+    expect(appSource).toMatch(/hasVisibilityOverride=\{anyVisibilityOverride\}/);
   });
 
   it("the Ontology FILTER facet stays SEPARATE from the group-by checkboxes", () => {

--- a/studio/src/tests/viewerState.test.js
+++ b/studio/src/tests/viewerState.test.js
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   GROUP_KIND,
+  ENTITY_STATES,
   createDefaultViewerState,
   normalizeViewerState,
   setShowWeakLinks,
   groupKeyForOntology,
   groupKeyForCommunity,
+  groupKeyForType,
   splitGroupedKeys,
   toggleGroupItem,
   toggleGroupOntology,
@@ -16,6 +18,13 @@ import {
   clearGrouping,
   foldOntologyToLevel,
   ONTOLOGY_LEVELS,
+  setEntityState,
+  toggleSolo,
+  resetVisibility,
+  displayedEntityState,
+  soloActive,
+  hasAnyVisibilityOverride,
+  groupOntologyLevel,
 } from "../lib/viewerState.js";
 
 /* ===========================================================================
@@ -288,5 +297,164 @@ describe("viewerState — T7 pure migration of LEGACY shapes INTO the grouped se
     expect(normalized.options.groupBy.grouped.sort()).toEqual(
       [groupKeyForOntology("class:People"), groupKeyForCommunity("Baker Street")].sort(),
     );
+  });
+});
+
+/* ===========================================================================
+ * 4-STATE per-entity VISIBILITY control (Normal · Grouped · Hidden · Solo).
+ *
+ * D2 schema: `groupBy.grouped` stays the Grouped storage; `options.visibility =
+ * { hidden:[], solo:[] }` adds the Hidden storage + the Solo OVERLAY. Reducer =
+ * setEntityState / toggleSolo / resetVisibility; migration = defaults in
+ * normalizeViewerState (no localStorage). Solo NEVER mutates grouped/hidden.
+ * ======================================================================== */
+
+const K_ONTO = groupKeyForOntology("class:People");
+const K_COMM = groupKeyForCommunity("Baker Street");
+const K_TYPE = groupKeyForType("Character");
+
+describe("viewerState — 4-state visibility: defaults + normalization (D2)", () => {
+  it("defaults to EMPTY hidden + solo sets (fast-path default)", () => {
+    const state = createDefaultViewerState();
+    expect(state.options.visibility).toEqual({ hidden: [], solo: [] });
+    expect(ENTITY_STATES).toEqual(["normal", "grouped", "hidden", "solo"]);
+  });
+
+  it("an ABSENT visibility (every pre-feature state) migrates to empty sets", () => {
+    expect(normalizeViewerState({}).options.visibility).toEqual({ hidden: [], solo: [] });
+    expect(
+      normalizeViewerState({ options: { groupBy: { grouped: [K_ONTO] } } }).options.visibility,
+    ).toEqual({ hidden: [], solo: [] });
+  });
+
+  it("normalizes hidden/solo: dedup, string-only, known-namespace-only", () => {
+    const v = normalizeViewerState({
+      options: {
+        visibility: {
+          hidden: [K_COMM, K_COMM, "bogus:x", "noseparator", 42, ""],
+          solo: [K_TYPE, K_TYPE, "unknown:y"],
+        },
+      },
+    }).options.visibility;
+    expect(v.hidden).toEqual([K_COMM]);
+    expect(v.solo).toEqual([K_TYPE]);
+  });
+
+  it("grouped-WINS exclusivity: a key both grouped AND hidden drops from hidden", () => {
+    const v = normalizeViewerState({
+      options: {
+        groupBy: { grouped: [K_ONTO] },
+        visibility: { hidden: [K_ONTO, K_COMM], solo: [] },
+      },
+    }).options.visibility;
+    // K_ONTO is grouped → removed from hidden; K_COMM (not grouped) stays.
+    expect(v.hidden).toEqual([K_COMM]);
+  });
+
+  it("solo is an OVERLAY: solo ∩ grouped and solo ∩ hidden are legal", () => {
+    const v = normalizeViewerState({
+      options: {
+        groupBy: { grouped: [K_ONTO] },
+        visibility: { hidden: [K_COMM], solo: [K_ONTO, K_COMM] },
+      },
+    }).options.visibility;
+    expect(v.solo.sort()).toEqual([K_ONTO, K_COMM].sort());
+    expect(v.hidden).toEqual([K_COMM]);
+  });
+});
+
+describe("viewerState — 4-state reducer (setEntityState / toggleSolo / resetVisibility)", () => {
+  it("Normal → Grouped → Hidden → Normal (exclusive stored states)", () => {
+    let s = createDefaultViewerState();
+    expect(displayedEntityState(s, K_COMM)).toBe("normal");
+    s = setEntityState(s, K_COMM, "grouped");
+    expect(displayedEntityState(s, K_COMM)).toBe("grouped");
+    expect(s.options.groupBy.grouped).toEqual([K_COMM]);
+    // Grouped → Hidden: leaves grouped, enters hidden (mutually exclusive).
+    s = setEntityState(s, K_COMM, "hidden");
+    expect(displayedEntityState(s, K_COMM)).toBe("hidden");
+    expect(s.options.groupBy.grouped).toEqual([]);
+    expect(s.options.visibility.hidden).toEqual([K_COMM]);
+    // Hidden → Normal: clears everything for the key.
+    s = setEntityState(s, K_COMM, "normal");
+    expect(displayedEntityState(s, K_COMM)).toBe("normal");
+    expect(s.options.visibility.hidden).toEqual([]);
+  });
+
+  it("Solo is a display OVERLAY that PRESERVES the stored Grouped state (§6.2)", () => {
+    let s = setEntityState(createDefaultViewerState(), K_ONTO, "grouped");
+    s = setEntityState(s, K_ONTO, "solo");
+    // Display shows Solo; stored Grouped is UNTOUCHED.
+    expect(displayedEntityState(s, K_ONTO)).toBe("solo");
+    expect(s.options.groupBy.grouped).toEqual([K_ONTO]);
+    expect(s.options.visibility.solo).toEqual([K_ONTO]);
+    // Exiting Solo (click any non-solo) returns to the stored Grouped state.
+    s = setEntityState(s, K_ONTO, "grouped");
+    expect(displayedEntityState(s, K_ONTO)).toBe("grouped");
+    expect(s.options.visibility.solo).toEqual([]);
+    expect(s.options.groupBy.grouped).toEqual([K_ONTO]);
+  });
+
+  it("Solo on a stored-Hidden entity preserves the hidden storage, restored on exit", () => {
+    let s = setEntityState(createDefaultViewerState(), K_COMM, "hidden");
+    s = setEntityState(s, K_COMM, "solo");
+    expect(displayedEntityState(s, K_COMM)).toBe("solo");
+    expect(s.options.visibility.hidden).toEqual([K_COMM]); // preserved
+    s = setEntityState(s, K_COMM, "normal");
+    expect(s.options.visibility.solo).toEqual([]);
+    expect(s.options.visibility.hidden).toEqual([]); // normal clears hidden too
+  });
+
+  it("MULTI-Solo accumulates; each keeps its stored state", () => {
+    let s = createDefaultViewerState();
+    s = setEntityState(s, K_ONTO, "grouped");
+    s = setEntityState(s, K_ONTO, "solo");
+    s = setEntityState(s, K_COMM, "solo");
+    s = setEntityState(s, K_TYPE, "solo");
+    expect(soloActive(s)).toBe(true);
+    expect(s.options.visibility.solo.sort()).toEqual([K_ONTO, K_COMM, K_TYPE].sort());
+    // The grouped one still carries its grouped storage under the Solo overlay.
+    expect(s.options.groupBy.grouped).toEqual([K_ONTO]);
+  });
+
+  it("toggleSolo adds then removes a single entity from the Solo set (§3 Exit)", () => {
+    let s = toggleSolo(createDefaultViewerState(), K_COMM);
+    expect(s.options.visibility.solo).toEqual([K_COMM]);
+    s = toggleSolo(s, K_COMM);
+    expect(s.options.visibility.solo).toEqual([]);
+    // toggleSolo never touches grouped/hidden storage.
+    let g = setEntityState(createDefaultViewerState(), K_ONTO, "hidden");
+    g = toggleSolo(g, K_ONTO);
+    expect(g.options.visibility.hidden).toEqual([K_ONTO]);
+    expect(g.options.visibility.solo).toEqual([K_ONTO]);
+  });
+
+  it("resetVisibility clears Grouped + Hidden + Solo → all Normal (keeps selection etc.)", () => {
+    let s = createDefaultViewerState();
+    s = setEntityState(s, K_ONTO, "grouped");
+    s = setEntityState(s, K_COMM, "hidden");
+    s = setEntityState(s, K_TYPE, "solo");
+    expect(hasAnyVisibilityOverride(s)).toBe(true);
+    s = setShowWeakLinks(s, false); // an unrelated option must survive the reset
+    s = resetVisibility(s);
+    expect(s.options.groupBy.grouped).toEqual([]);
+    expect(s.options.visibility).toEqual({ hidden: [], solo: [] });
+    expect(hasAnyVisibilityOverride(s)).toBe(false);
+    expect(s.options.showWeakLinks).toBe(false);
+  });
+
+  it("setEntityState is a no-op for an empty key / unknown state", () => {
+    const s = createDefaultViewerState();
+    expect(setEntityState(s, "", "hidden").options.visibility.hidden).toEqual([]);
+    expect(setEntityState(s, K_COMM, "bogus").options.visibility.hidden).toEqual([]);
+  });
+
+  it("a bulk Group-all over a HIDDEN entity un-hides it (grouped-wins, zero bulk changes)", () => {
+    let s = setEntityState(createDefaultViewerState(), groupKeyForOntology("class:People"), "hidden");
+    // Bulk group the Domain level including class:People.
+    s = groupOntologyLevel(s, ONTOLOGY_LEVELS.domain, ["class:People", "class:Place"]);
+    // K_ONTO(class:People) is now grouped → normalize drops it from hidden.
+    expect(displayedEntityState(s, groupKeyForOntology("class:People"))).toBe("grouped");
+    expect(s.options.visibility.hidden).toEqual([]);
   });
 });


### PR DESCRIPTION
## What
Replaces the per-row group checkbox with a **4-state per-entity visibility control** — **Normal · Grouped · Hidden · Show-only (Solo)** — on every left-rail entity (community / ontology class / type), plus the graph config gear now shows on the **Entity Reconciliation** view.

## How
- **Animation invariant preserved.** Every state change reuses the a2cf207 position-carry-over tween — shared nodes stay put, no force re-solve, no camera refit. The load-bearing fix (surfaced by a Fable-5 + Opus double-consensus) is a **content-derived visibility delta** so Hide/Show/Solo route through the same carry-over tween instead of a hard-cut refit.
- **Ownership rule:** Normal abstains; Hidden = union suppression; the ≥1-visible whitelist applies only within the Solo tier. `classNodes.js` (fold engine) untouched.
- **DS-native widget.** The control is the DS `Menu` (dropdown) + DS `IconButton` (trigger showing the current state), with icons from `@lucide/svelte` — the DS's own icon library (Normal→Eye, Grouped→Layers, Hidden→EyeOff, Solo→Target). The graph-settings gear emoji is now lucide `Settings` (fixes both the graph + reconciliation views). Hover-reach fixed (gap bridge + cancellable close delay).

## Verification
lint (tsc) clean · studio vitest **498 passed** (3 known jsdom `pickingBackendAgnostic` failures) · packages/graph **323 passed** · `build:studio` OK. Reviewed by the parent; principal UAT'd on the mystery graph (4 states + Solo + hover reach + consistent icon color) and approved. Implementation/rebuild by Codex 5.6-luna; spec double-consensus by Fable 5 + Opus.

## Spec
`spec/SPEC_ENTITY_VISIBILITY_STATES.md` §9 is the reconciled implementation contract.