### PR TITLE
fix(studio): node shape parity, selection colour, soft halo, edge gradient

### DIFF
--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -787,17 +787,12 @@ export function drawBoxLabels2D(context: Graph2DContext, draws: readonly BoxText
     if (d.halo) {
       context.save();
       context.shadowColor = d.haloColor ?? "rgba(0, 0, 0, 0)";
-      context.shadowBlur = Math.max(2, d.height * 0.28);
-      context.fillStyle = d.haloColor ?? "rgba(0, 0, 0, 0)";
+      context.shadowBlur = Math.max(2, Math.min(dims.w, dims.h) * 0.55);
+      // The source shape is the normal box fill; shadowBlur supplies the glow.
+      // Drawing the unscaled shape avoids a second hard-edged contour.
+      context.fillStyle = HOLLOW_FILL_STYLE;
       context.beginPath();
-      drawRoundedBox(
-        context,
-        d.centerX,
-        d.centerY,
-        dims.w * 1.65,
-        dims.h * 1.65,
-        dims.corner * 1.65,
-      );
+      drawRoundedBox(context, d.centerX, d.centerY, dims.w, dims.h, dims.corner);
       context.fill();
       context.restore();
     }
@@ -1057,20 +1052,23 @@ function drawFallback2D(
   }
   context.setLineDash([]);
 
-  // Canvas2D halo pass: shadowBlur gives the fallback a genuinely soft glow,
-  // while the expanded filled shape keeps the same geometry contract as the
-  // WebGL2 approximation. It runs before every real node fill, so node type /
-  // community colours remain the foreground and no contour is introduced.
+  // Canvas2D halo pass: draw the normal node shape with a primary-colour
+  // shadowBlur. The foreground node pass below remains responsible for the
+  // node's actual fill/stroke, so there is no expanded hard-edged contour or
+  // node-colour replacement.
   const haloColor = [0, 0, 0, 0] as const;
   for (let nodeIndex = 0; nodeIndex < state.nodeIds.length; nodeIndex += 1) {
     if (state.style?.haloMask?.[nodeIndex] !== 1) continue;
     const point = screenPoint(state.positions, nodeIndex, camera, canvas);
     const shape = state.style?.nodeShapes[nodeIndex] ?? 0;
+    const colorOffset = nodeIndex * 4;
+    const nodeColor = cssColor(state.style?.nodeColors, colorOffset, DEFAULT_NODE_COLOR);
+    const hollow = (state.style?.nodeFills?.[nodeIndex] ?? 0) === 1;
     const glow = cssColor(state.style?.haloColor, 0, haloColor, 0.28);
     context.save();
     context.shadowColor = glow;
     context.shadowBlur = Math.max(2, (geometry.radii[nodeIndex] ?? 1) * 0.55);
-    context.fillStyle = glow;
+    context.fillStyle = hollow ? HOLLOW_FILL_STYLE : nodeColor;
     if (shape === BOX_SHAPE) {
       const label = state.style?.nodeLabels?.[nodeIndex] ?? "";
       const boxHeight = boxBaseHeightPx * pixelRatio * camera.zoom;
@@ -1079,13 +1077,13 @@ function drawFallback2D(
         context,
         point.x,
         point.y,
-        dims.w * 1.65,
-        dims.h * 1.65,
-        dims.corner * 1.65,
+        dims.w,
+        dims.h,
+        dims.corner,
       );
     } else {
       context.beginPath();
-      drawNodeShapePath(context, point.x, point.y, (geometry.radii[nodeIndex] ?? 1) * 1.65, shape);
+      drawNodeShapePath(context, point.x, point.y, geometry.radii[nodeIndex] ?? 1, shape);
     }
     context.fill();
     context.restore();

--- a/packages/graph/src/renderer.ts
+++ b/packages/graph/src/renderer.ts
@@ -309,6 +309,14 @@ function copyStyle(style: GraphStyleBuffers, nodeCount: number, edgeCount: numbe
     throw new RangeError(`nodeShapes length ${style.nodeShapes.length} does not match node count ${nodeCount}`);
   }
 
+  if (style.haloMask && style.haloMask.length !== nodeCount) {
+    throw new RangeError(`haloMask length ${style.haloMask.length} does not match node count ${nodeCount}`);
+  }
+
+  if (style.haloColor && style.haloColor.length !== 4) {
+    throw new RangeError(`haloColor length ${style.haloColor.length} must be 4 (RGBA)`);
+  }
+
   if (style.edgeWidths.length !== edgeCount) {
     throw new RangeError(`edgeWidths length ${style.edgeWidths.length} does not match edge count ${edgeCount}`);
   }
@@ -319,6 +327,10 @@ function copyStyle(style: GraphStyleBuffers, nodeCount: number, edgeCount: numbe
 
   if (style.edgeDash.length !== edgeCount || style.edgeCurvatures.length !== edgeCount) {
     throw new RangeError("edge style buffers must match edge count");
+  }
+
+  if (style.edgeHaloMask && style.edgeHaloMask.length !== edgeCount) {
+    throw new RangeError(`edgeHaloMask length ${style.edgeHaloMask.length} does not match edge count ${edgeCount}`);
   }
 
   if (style.edgeRouteStyles && style.edgeRouteStyles.length !== edgeCount) {
@@ -337,6 +349,8 @@ function copyStyle(style: GraphStyleBuffers, nodeCount: number, edgeCount: numbe
     nodeSizes: new Float32Array(style.nodeSizes),
     nodeColors: new Uint8Array(style.nodeColors),
     nodeShapes: style.nodeShapes ? new Uint8Array(style.nodeShapes) : new Uint8Array(nodeCount),
+    haloMask: style.haloMask ? new Uint8Array(style.haloMask) : undefined,
+    haloColor: style.haloColor ? new Uint8Array(style.haloColor) : undefined,
     nodeLabels: style.nodeLabels ? [...style.nodeLabels] : undefined,
     nodeFills: style.nodeFills ? new Uint8Array(style.nodeFills) : undefined,
     nodeBorders: style.nodeBorders ? new Uint8Array(style.nodeBorders) : undefined,
@@ -344,6 +358,7 @@ function copyStyle(style: GraphStyleBuffers, nodeCount: number, edgeCount: numbe
     edgeColors: new Uint8Array(style.edgeColors),
     edgeDash: new Uint8Array(style.edgeDash),
     edgeCurvatures: new Float32Array(style.edgeCurvatures),
+    edgeHaloMask: style.edgeHaloMask ? new Uint8Array(style.edgeHaloMask) : undefined,
     edgeRouteStyles: style.edgeRouteStyles ? new Uint8Array(style.edgeRouteStyles) : undefined,
     edgeAlphaShape: style.edgeAlphaShape ? new Uint8Array(style.edgeAlphaShape) : undefined,
   };
@@ -474,11 +489,12 @@ function cssColor(
   source: Uint8Array | undefined,
   offset: number,
   fallback: readonly [number, number, number, number],
+  alphaScale = 1,
 ): string {
   const r = source?.[offset] ?? fallback[0];
   const g = source?.[offset + 1] ?? fallback[1];
   const b = source?.[offset + 2] ?? fallback[2];
-  const a = (source?.[offset + 3] ?? fallback[3]) / 255;
+  const a = ((source?.[offset + 3] ?? fallback[3]) / 255) * alphaScale;
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
 
@@ -768,6 +784,24 @@ export function drawBoxLabels2D(context: Graph2DContext, draws: readonly BoxText
 
   for (const d of draws) {
     const dims = boxDimensions(d.height, d.label, measureLabelWidth);
+    if (d.halo) {
+      context.save();
+      context.shadowColor = d.haloColor ?? "rgba(0, 0, 0, 0)";
+      context.shadowBlur = Math.max(2, d.height * 0.28);
+      context.fillStyle = d.haloColor ?? "rgba(0, 0, 0, 0)";
+      context.beginPath();
+      drawRoundedBox(
+        context,
+        d.centerX,
+        d.centerY,
+        dims.w * 1.65,
+        dims.h * 1.65,
+        dims.corner * 1.65,
+      );
+      context.fill();
+      context.restore();
+    }
+
     context.save();
     context.globalAlpha = d.alpha;
 
@@ -1022,6 +1056,40 @@ function drawFallback2D(
     }
   }
   context.setLineDash([]);
+
+  // Canvas2D halo pass: shadowBlur gives the fallback a genuinely soft glow,
+  // while the expanded filled shape keeps the same geometry contract as the
+  // WebGL2 approximation. It runs before every real node fill, so node type /
+  // community colours remain the foreground and no contour is introduced.
+  const haloColor = [0, 0, 0, 0] as const;
+  for (let nodeIndex = 0; nodeIndex < state.nodeIds.length; nodeIndex += 1) {
+    if (state.style?.haloMask?.[nodeIndex] !== 1) continue;
+    const point = screenPoint(state.positions, nodeIndex, camera, canvas);
+    const shape = state.style?.nodeShapes[nodeIndex] ?? 0;
+    const glow = cssColor(state.style?.haloColor, 0, haloColor, 0.28);
+    context.save();
+    context.shadowColor = glow;
+    context.shadowBlur = Math.max(2, (geometry.radii[nodeIndex] ?? 1) * 0.55);
+    context.fillStyle = glow;
+    if (shape === BOX_SHAPE) {
+      const label = state.style?.nodeLabels?.[nodeIndex] ?? "";
+      const boxHeight = boxBaseHeightPx * pixelRatio * camera.zoom;
+      const dims = boxDimensions(boxHeight, label, measureLabelWidth);
+      drawRoundedBox(
+        context,
+        point.x,
+        point.y,
+        dims.w * 1.65,
+        dims.h * 1.65,
+        dims.corner * 1.65,
+      );
+    } else {
+      context.beginPath();
+      drawNodeShapePath(context, point.x, point.y, (geometry.radii[nodeIndex] ?? 1) * 1.65, shape);
+    }
+    context.fill();
+    context.restore();
+  }
 
   for (let nodeIndex = 0; nodeIndex < state.nodeIds.length; nodeIndex += 1) {
     const point = screenPoint(state.positions, nodeIndex, camera, canvas);

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -108,6 +108,10 @@ export interface GraphStyleBuffers {
   nodeSizes: Float32Array;
   nodeColors: Uint8Array;
   nodeShapes: Uint8Array;
+  /** Optional per-node selection-neighbourhood halo mask (0/1). */
+  haloMask?: Uint8Array;
+  /** Optional RGBA8 colour shared by the halo pass. */
+  haloColor?: Uint8Array;
   /**
    * Optional per-node label text drawn INSIDE the glyph by the Canvas2D
    * fallback (legacy `shape:box` parity). Populated ONLY for box-category
@@ -130,6 +134,8 @@ export interface GraphStyleBuffers {
   edgeColors: Uint8Array;
   edgeDash: Uint8Array;
   edgeCurvatures: Float32Array;
+  /** Optional per-edge selection-neighbourhood emphasis mask (0/1). */
+  edgeHaloMask?: Uint8Array;
   /**
    * Optional per-edge ROUTE-style codes (parallel to edges): 0 default
    * (centre-to-centre, historical), 1 flow-port (right-port → left-port smooth

--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -420,6 +420,9 @@ export interface BoxTextDraw {
   borderColor: string;
   /** Node alpha 0..1 (the whole box glyph — fill/border/text — follows it). */
   alpha: number;
+  /** Optional selection-neighbourhood halo, painted by the 2D overlay. */
+  halo?: boolean;
+  haloColor?: string;
 }
 
 /**
@@ -438,6 +441,7 @@ export function buildBoxTextDraws(frame: WebGLBoxFrame): BoxTextDraw[] {
     if ((style?.nodeShapes?.[i] ?? 0) !== BOX_SHAPE_CODE) continue;
     const center = screenPoint(frame.positions, i, frame);
     const [r, g, b, a] = colorAt(style?.nodeColors, i * 4, DEFAULT_NODE_COLOR);
+    const [hr, hg, hb, ha] = colorAt(style?.haloColor, 0, [0, 0, 0, 0]);
     const bold = (style?.nodeBorders?.[i] ?? 0) === 1;
     out.push({
       nodeIndex: i,
@@ -456,6 +460,8 @@ export function buildBoxTextDraws(frame: WebGLBoxFrame): BoxTextDraw[] {
       // also sets globalAlpha=alpha, so the alpha is applied the SAME two ways.
       borderColor: `rgba(${r}, ${g}, ${b}, ${a / 255})`,
       alpha: a / 255,
+      halo: style?.haloMask?.[i] === 1,
+      haloColor: `rgba(${hr}, ${hg}, ${hb}, ${(ha / 255) * 0.28})`,
     });
   }
   return out;

--- a/packages/graph/src/webgl-edges.ts
+++ b/packages/graph/src/webgl-edges.ts
@@ -94,6 +94,7 @@ layout(location = 5) in float a_arcStart;  // instance: arc-length at p0 (device
 layout(location = 6) in float a_dashPeriod;// instance: dash on+off period (0 = solid)
 layout(location = 7) in float a_dashOn;    // instance: dash on length (device px)
 layout(location = 8) in vec3 a_shape;      // instance: alpha multipliers at t=0 / 0.5 / 1 (0..1)
+layout(location = 9) in float a_totalArcLength; // instance: complete edge arc length (device px)
 
 uniform vec2 u_viewport;
 
@@ -105,6 +106,7 @@ out float v_arc;       // arc-length at this fragment (device px) for dashing
 out float v_dashPeriod;
 out float v_dashOn;
 out vec3 v_shape;      // along-edge alpha multipliers (m0, mMid, m1)
+out float v_totalArcLength;
 
 void main() {
   vec2 d = a_p1 - a_p0;
@@ -145,6 +147,7 @@ void main() {
   v_dashPeriod = a_dashPeriod;
   v_dashOn = a_dashOn;
   v_shape = a_shape;
+  v_totalArcLength = a_totalArcLength;
 
   vec2 clip = vec2(screen.x * 2.0 / u_viewport.x - 1.0, 1.0 - screen.y * 2.0 / u_viewport.y);
   // Edges sit BEHIND every node (Canvas2D draws all edges before all nodes).
@@ -162,6 +165,7 @@ in float v_arc;
 in float v_dashPeriod;
 in float v_dashOn;
 in vec3 v_shape;
+in float v_totalArcLength;
 out vec4 outColor;
 
 void main() {
@@ -218,15 +222,18 @@ void main() {
     if (coverage <= 0.0) discard;
   }
 
-  // ALONG-EDGE ALPHA SHAPE (configurable edge-transparency gradient). tt is the
-  // 0..1 parameter from the source cap (v_local.x = -v_halfLen) to the target
-  // cap (+v_halfLen). The shape is PIECEWISE-LINEAR: mix(m0,mMid) over the first
-  // half, mix(mMid,m1) over the second. Default shape (1,1,1) ⇒ sh == 1 (uniform,
-  // byte-identical to before this feature); the studio drives it per mode
-  // (dense/inverse/mid/flat) to fade an edge toward its dense endpoint / the
-  // middle. It MULTIPLIES the base alpha, so dim/hover/merge (which only scale
-  // v_color.a) compose automatically.
-  float tt = clamp((v_local.x + v_halfLen) / (2.0 * v_halfLen), 0.0, 1.0);
+  // ALONG-EDGE ALPHA SHAPE (configurable edge-transparency gradient). Unlike
+  // the segment-local SDF coordinate above, v_arc is continuous across every
+  // tessellated capsule. Divide it by the COMPLETE edge arc length so the
+  // profile is sampled exactly once from source (t=0) to target (t=1), no
+  // matter how many device-pixel segments the curve has. Padding before/after
+  // the clipped endpoints is clamped away. Dashing remains on absolute v_arc.
+  float tt = clamp(v_arc / max(v_totalArcLength, 1e-5), 0.0, 1.0);
+  // The shape is PIECEWISE-LINEAR: mix(m0,mMid) over the first half, mix(mMid,m1)
+  // over the second. Default shape (1,1,1) ⇒ sh == 1 (uniform, byte-identical
+  // to before this feature); the studio drives it per mode (dense/inverse/mid/
+  // flat) to fade an edge toward its dense endpoint / the middle. It MULTIPLIES
+  // the base alpha, so dim/hover/merge (which only scale v_color.a) compose.
   float sh = tt < 0.5
     ? mix(v_shape.x, v_shape.y, tt * 2.0)
     : mix(v_shape.y, v_shape.z, (tt - 0.5) * 2.0);
@@ -290,8 +297,8 @@ void main() {
 }
 `;
 
-/** Floats per capsule instance. p0(2)+p1(2)+halfWidth(1)+color(4)+arcStart(1)+period(1)+on(1)+shape(3) = 15 */
-export const CAPSULE_FLOATS_PER_INSTANCE = 15;
+/** Floats per capsule instance: prior fields (15) + total edge arc length (1). */
+export const CAPSULE_FLOATS_PER_INSTANCE = 16;
 /** Floats per arrow instance. tip(2)+dir(2)+length(1)+color(4) = 9 */
 export const ARROW_FLOATS_PER_INSTANCE = 9;
 
@@ -451,9 +458,17 @@ export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
     const sMid = shapeBuf ? (shapeBuf[edgeIndex * 3 + 1] ?? 255) / 255 : 1;
     const s1 = shapeBuf ? (shapeBuf[edgeIndex * 3 + 2] ?? 255) / 255 : 1;
 
-    // Tessellate the (clipped) drawn polyline and emit one capsule per segment,
-    // accumulating arc-length so dashes are continuous across curve segments.
+    // Tessellate the (clipped) drawn polyline and emit one capsule per segment.
+    // The total is shared by every segment: dashes use each segment's absolute
+    // arc start, while the alpha profile uses arc / totalEdgeArcLength.
     const polyline = tessellateEdge(geom, CURVE_SEGMENTS);
+    let totalEdgeArcLength = 0;
+    for (let i = 0; i < polyline.length - 1; i += 1) {
+      totalEdgeArcLength += Math.hypot(
+        polyline[i + 1]![0] - polyline[i]![0],
+        polyline[i + 1]![1] - polyline[i]![1],
+      );
+    }
     let arc = 0;
     for (let i = 0; i < polyline.length - 1; i += 1) {
       const p0 = polyline[i]!;
@@ -467,6 +482,7 @@ export function buildEdgeInstances(frame: WebGLEdgeFrame): EdgeInstanceSet {
         dashPeriod,
         dashOn,
         s0, sMid, s1,
+        totalEdgeArcLength,
       );
       arc += Math.hypot(p1[0] - p0[0], p1[1] - p0[1]);
     }
@@ -558,7 +574,7 @@ function createCapsulePipeline(gl: GL2): CapsulePipeline {
 
   gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
   // location 1 a_p0, 2 a_p1, 3 a_halfWidth, 4 a_color, 5 a_arcStart, 6 a_dashPeriod,
-  // 7 a_dashOn, 8 a_shape (vec3 along-edge alpha multipliers)
+  // 7 a_dashOn, 8 a_shape (vec3 along-edge alpha multipliers), 9 a_totalArcLength
   const layout: Array<[number, number, number]> = [
     [1, 2, 0],
     [2, 2, 2 * 4],
@@ -568,6 +584,7 @@ function createCapsulePipeline(gl: GL2): CapsulePipeline {
     [6, 1, 10 * 4],
     [7, 1, 11 * 4],
     [8, 3, 12 * 4],
+    [9, 1, 15 * 4],
   ];
   for (const [loc, size, offset] of layout) {
     gl.enableVertexAttribArray(loc);
@@ -686,6 +703,8 @@ export interface CapsuleInstanceView {
   dashOn: number;
   /** Along-edge alpha multipliers at t=0 / 0.5 / 1 (0..1); (1,1,1) = uniform. */
   shape: [number, number, number];
+  /** Complete polyline arc length shared by every capsule of this edge (device px). */
+  totalArcLength: number;
 }
 
 /**
@@ -701,6 +720,20 @@ export function alphaShapeAt(shape: readonly [number, number, number], tt: numbe
   return t < 0.5 ? m0 + (mMid - m0) * (t * 2) : mMid + (m1 - mMid) * ((t - 0.5) * 2);
 }
 
+/** Normalize an absolute edge arc position to the complete edge's [0,1] range. */
+export function normalizedEdgeT(arc: number, totalArcLength: number): number {
+  return Math.min(1, Math.max(0, arc / Math.max(totalArcLength, 1e-5)));
+}
+
+/** Sample an alpha shape by absolute arc position, matching the fragment shader. */
+export function alphaShapeAtArc(
+  shape: readonly [number, number, number],
+  arc: number,
+  totalArcLength: number,
+): number {
+  return alphaShapeAt(shape, normalizedEdgeT(arc, totalArcLength));
+}
+
 export function decodeCapsule(list: number[], n: number): CapsuleInstanceView {
   const o = n * CAPSULE_FLOATS_PER_INSTANCE;
   return {
@@ -712,6 +745,7 @@ export function decodeCapsule(list: number[], n: number): CapsuleInstanceView {
     dashPeriod: list[o + 10] ?? 0,
     dashOn: list[o + 11] ?? 0,
     shape: [list[o + 12] ?? 1, list[o + 13] ?? 1, list[o + 14] ?? 1],
+    totalArcLength: list[o + 15] ?? 0,
   };
 }
 

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -51,7 +51,21 @@ type GL2 = WebGL2RenderingContext;
 const DEFAULT_NODE_COLOR = [77, 118, 255, 255] as const;
 const HALO_COLOR_FALLBACK = [0, 0, 0, 0] as const;
 const HALO_ALPHA = 0.28;
-const HALO_RADIUS_SCALE = 1.65;
+export const HALO_RADIUS_SCALE = 2.0;
+
+/**
+ * Radial falloff used by the WebGL halo fragment path. The input is the
+ * distance from the centre expressed as a fraction of the OUTER shape
+ * boundary (so 1 is the outer edge and 1/HALO_RADIUS_SCALE is the node edge).
+ * This mirrors the GLSL smoothstep below and is exported for the deterministic
+ * unit test; the instance alpha remains the peak alpha and the shader applies
+ * this spatial multiplier per fragment.
+ */
+export function haloFalloffAt(shapeRadius: number): number {
+  const inner = 1 / HALO_RADIUS_SCALE;
+  const t = Math.min(1, Math.max(0, (shapeRadius - inner) / (1 - inner)));
+  return 1 - t * t * (3 - 2 * t);
+}
 
 /** Shape codes Phase 1 renders as instanced polygons/discs (NOT the box). */
 const SHAPE_FAMILIES = [0, 1, 2, 3, 4, 6] as const;
@@ -62,12 +76,15 @@ layout(location = 1) in vec2 a_center;     // instance: world centre
 layout(location = 2) in float a_radius;    // instance: drawn radius (device px)
 layout(location = 3) in vec4 a_color;      // instance: drawn rgba (0..1)
 layout(location = 4) in float a_depth;     // instance: drawList index (interleave)
+layout(location = 5) in float a_halo;      // instance: 1 for the feathered halo pass
 
 uniform mat4 u_viewProj;   // UNIFIED CAMERA: world -> clip (ortho for 2D, mat4.ts)
 uniform vec2 u_viewport;   // device size, for the screen-space radius billboard
 uniform float u_maxDepth;
 
 out vec4 v_color;
+out vec2 v_unit;
+out float v_halo;
 
 void main() {
   // UNIFIED CAMERA: the node CENTRE (world) goes through the SAME mat4 the legacy
@@ -85,21 +102,86 @@ void main() {
   float z = u_maxDepth > 0.0 ? (a_depth / u_maxDepth) : 0.0;
   gl_Position = vec4(centerClip.xy + radiusClip, -z, 1.0);
   v_color = a_color;
+  v_unit = a_unit;
+  v_halo = a_halo;
 }
 `;
 
 const SHAPE_FRAGMENT_SHADER = `#version 300 es
-precision mediump float;
+precision highp float;
 in vec4 v_color;
+in vec2 v_unit;
+in float v_halo;
+uniform float u_shapeFamily;
 out vec4 outColor;
+
+float cross2(vec2 a, vec2 b) {
+  return a.x * b.y - a.y * b.x;
+}
+
+vec2 starVertex(int index) {
+  float angle = float(index) * 0.6283185307 - 1.5707963268;
+  float radius = mod(float(index), 2.0) < 0.5 ? 1.0 : 0.42;
+  return vec2(cos(angle), sin(angle)) * radius;
+}
+
+// Return the distance from the centre to this shape's boundary along dir,
+// in the same unit coordinates used by the triangle-fan geometry. This makes
+// the feather follow flat/concave shape edges instead of leaving a circular
+// hard rim at polygon corners.
+float shapeBoundaryRadius(vec2 dir, float family) {
+  if (family < 0.5) return 1.0; // circle
+  if (family < 1.5) return 1.0 / (abs(dir.x) + abs(dir.y)); // diamond
+  if (family < 2.5) { // five-point star: intersect the centre ray with an edge
+    float boundary = 1e6;
+    for (int index = 0; index < 10; index += 1) {
+      vec2 p0 = starVertex(index);
+      vec2 p1 = starVertex((index + 1) % 10);
+      vec2 edge = p1 - p0;
+      float denominator = cross2(dir, edge);
+      if (denominator > 1e-5) {
+        boundary = min(boundary, cross2(p0, edge) / denominator);
+      }
+    }
+    return boundary < 1e5 ? boundary : 1.0;
+  }
+  if (family < 3.5) { // regular hexagon, circumradius 1 / apothem cos(30°)
+    float face = max(
+      max(abs(dir.x), abs(0.5 * dir.x + 0.8660254038 * dir.y)),
+      abs(-0.5 * dir.x + 0.8660254038 * dir.y)
+    );
+    return 0.8660254038 / max(face, 1e-5);
+  }
+  if (family < 4.5) { // inset square
+    return 0.88 / max(abs(dir.x), abs(dir.y));
+  }
+  // Triangle face normals are -30°, 90°, and 210°; its apothem is 0.5.
+  float face = max(
+    max(dot(dir, vec2(0.8660254038, -0.5)), dir.y),
+    dot(dir, vec2(-0.8660254038, -0.5))
+  );
+  return 0.5 / max(face, 1e-5);
+}
+
 void main() {
+  float alpha = v_color.a;
+  if (v_halo > 0.5) {
+    float distanceFromCentre = length(v_unit);
+    vec2 direction = distanceFromCentre > 1e-5 ? v_unit / distanceFromCentre : vec2(1.0, 0.0);
+    float boundary = shapeBoundaryRadius(direction, u_shapeFamily);
+    float shapeRadius = distanceFromCentre / max(boundary, 1e-5);
+    float inner = ${String(1 / HALO_RADIUS_SCALE)};
+    // The halo is strongest at the node edge and fades smoothly to zero at
+    // the outer shape boundary. Its alpha is never a uniform ring/contour.
+    alpha *= 1.0 - smoothstep(inner, 1.0, shapeRadius);
+  }
   // PREMULTIPLIED alpha output (paired with blendFunc(ONE, ONE_MINUS_SRC_ALPHA)).
   // The context is premultipliedAlpha:true (the default), so the framebuffer must
   // hold premultiplied RGBA. With the old straight output + blendFunc(SRC_ALPHA,
   // ONE_MINUS_SRC_ALPHA) the framebuffer ALPHA was under-accumulated (a·a instead
   // of a), so dimmed (alpha<1) glyphs composited TOO TRANSPARENT and AA rims read
   // as dark fringes. Emitting premultiplied rgb·a keeps rgb and alpha consistent.
-  outColor = vec4(v_color.rgb * v_color.a, v_color.a);
+  outColor = vec4(v_color.rgb * alpha, alpha);
 }
 `;
 
@@ -109,6 +191,7 @@ interface ShapeProgram {
     viewProj: WebGLUniformLocation | null;
     viewport: WebGLUniformLocation | null;
     maxDepth: WebGLUniformLocation | null;
+    shapeFamily: WebGLUniformLocation | null;
   };
 }
 
@@ -121,8 +204,8 @@ interface ShapeFamilyBuffers {
 }
 
 /** Floats per instance in the interleaved instance buffer. */
-// a_center(2) + a_radius(1) + a_color(4) + a_depth(1) = 8
-const FLOATS_PER_INSTANCE = 8;
+// a_center(2) + a_radius(1) + a_color(4) + a_depth(1) + a_halo(1) = 9
+const FLOATS_PER_INSTANCE = 9;
 
 export interface WebGLShapeFrame {
   positions: Float32Array;
@@ -182,7 +265,7 @@ function link(gl: GL2, vsSrc: string, fsSrc: string): WebGLProgram {
 
 /**
  * Build the per-shape-family VAOs: a unit triangle-fan VBO (location 0) +
- * an empty per-instance interleaved VBO (locations 1–4, divisor 1).
+ * an empty per-instance interleaved VBO (locations 1–5, divisor 1).
  */
 function createShapeFamilyBuffers(gl: GL2): Map<number, ShapeFamilyBuffers> {
   const families = new Map<number, ShapeFamilyBuffers>();
@@ -204,8 +287,9 @@ function createShapeFamilyBuffers(gl: GL2): Map<number, ShapeFamilyBuffers> {
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
 
-    // locations 1–4: per-instance attributes (divisor 1) from the interleaved
-    // instance buffer. a_center(2) | a_radius(1) | a_color(4) | a_depth(1).
+    // locations 1–5: per-instance attributes (divisor 1) from the interleaved
+    // instance buffer. a_center(2) | a_radius(1) | a_color(4) | a_depth(1) |
+    // a_halo(1).
     gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
     // a_center
     gl.enableVertexAttribArray(1);
@@ -223,6 +307,10 @@ function createShapeFamilyBuffers(gl: GL2): Map<number, ShapeFamilyBuffers> {
     gl.enableVertexAttribArray(4);
     gl.vertexAttribPointer(4, 1, gl.FLOAT, false, stride, 7 * 4);
     gl.vertexAttribDivisor(4, 1);
+    // a_halo
+    gl.enableVertexAttribArray(5);
+    gl.vertexAttribPointer(5, 1, gl.FLOAT, false, stride, 8 * 4);
+    gl.vertexAttribDivisor(5, 1);
 
     gl.bindVertexArray(null);
     families.set(shape, { vao, unitBuffer, instanceBuffer, fanVertexCount: geom.fanVertexCount });
@@ -269,6 +357,8 @@ export interface ShapeInstanceView {
   /** rgba in 0..1 (a is alpha 0..1, rgb are channel/255). */
   color: [number, number, number, number];
   depth: number;
+  /** Whether this instance uses the fragment shader's soft halo falloff. */
+  halo: boolean;
 }
 
 export function decodeInstance(list: number[], n: number): ShapeInstanceView {
@@ -278,11 +368,12 @@ export function decodeInstance(list: number[], n: number): ShapeInstanceView {
     radius: list[o + 2] ?? 0,
     color: [list[o + 3] ?? 0, list[o + 4] ?? 0, list[o + 5] ?? 0, list[o + 6] ?? 0],
     depth: list[o + 7] ?? 0,
+    halo: (list[o + 8] ?? 0) > 0.5,
   };
 }
 
 export interface ShapeInstanceSet {
-  /** Low-alpha expanded node geometry, drawn before border/fill. */
+  /** Expanded node geometry whose fragment alpha is feathered, drawn before border/fill. */
   halo: Map<number, number[]>;
   fill: Map<number, number[]>;
   border: Map<number, number[]>;
@@ -291,9 +382,10 @@ export interface ShapeInstanceSet {
 
 /**
  * Build the per-shape-family instance arrays for a frame. Each node maps to ONE
- * fill instance (interior) and — for hollow or bold variants — an extra border
- * pass instance. Box (shape 5) nodes are SKIPPED (Phase 1 leaves them to
- * Canvas2D). Non-finite world coords are coerced (N1b) and counted.
+ * feathered halo instance when selected, ONE fill instance (interior) and — for
+ * hollow or bold variants — an extra border pass instance. Box (shape 5) nodes
+ * are SKIPPED (Phase 1 leaves them to Canvas2D). Non-finite world coords are
+ * coerced (N1b) and counted.
  *
  * EXPORTED so the golden tests can assert the GL instances carry the SAME drawn
  * radius (radius-as-radius, N1) the Canvas2D path computes — a parity check that
@@ -338,9 +430,10 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     const alpha = nodeColor[3] / 255;
     const haloColor = colorAt(style?.haloColor, 0, HALO_COLOR_FALLBACK);
     if (style?.haloMask?.[i] === 1 && haloColor[3] > 0) {
-      // The halo is a filled, scaled copy of the SAME unit geometry. Its low
-      // alpha plus the real node drawn on top make a soft glow approximation;
-      // there is intentionally no outline/ring geometry here.
+      // The halo uses the SAME unit geometry at a wider radius. The fragment
+      // shader identifies this instance and applies a shape-aware smoothstep
+      // feather from the node edge to the outer boundary; this alpha is only
+      // the peak colour, not a visible uniform contour.
       pushInstance(
         halo.get(family)!,
         cx,
@@ -351,6 +444,7 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
         haloColor[2],
         (haloColor[3] / 255) * HALO_ALPHA * alpha,
         depth,
+        true,
       );
     }
     const hollow = (style?.nodeFills?.[i] ?? 0) === 1;
@@ -576,8 +670,9 @@ function pushInstance(
   b: number,
   a: number,
   depth: number,
+  halo = false,
 ): void {
-  list.push(cx, cy, radius, r / 255, g / 255, b / 255, a, depth);
+  list.push(cx, cy, radius, r / 255, g / 255, b / 255, a, depth, halo ? 1 : 0);
 }
 
 /**
@@ -605,6 +700,7 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
       viewProj: gl.getUniformLocation(program, "u_viewProj"),
       viewport: gl.getUniformLocation(program, "u_viewport"),
       maxDepth: gl.getUniformLocation(program, "u_maxDepth"),
+      shapeFamily: gl.getUniformLocation(program, "u_shapeFamily"),
     },
   };
   const families = createShapeFamilyBuffers(gl);
@@ -635,14 +731,14 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
     // glyphs too far + dark-fringing AA rims under premultipliedAlpha:true).
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
-    // HALO PASS first: expanded, low-alpha copies sit behind the real node
+    // HALO PASS first: expanded, feathered copies sit behind the real node
     // geometry. Then the border ring and interior fill preserve all existing
     // node type/community colours and shape variants.
-    drawPass(gl, families, halo);
+    drawPass(gl, families, halo, shapeProgram.uniforms.shapeFamily);
     // Border ring pass first (under the fill), then the interior fill pass, so a
     // hollow ring / bold outline sits beneath the (translucent or solid) centre.
-    drawPass(gl, families, border);
-    drawPass(gl, families, fill);
+    drawPass(gl, families, border, shapeProgram.uniforms.shapeFamily);
+    drawPass(gl, families, fill, shapeProgram.uniforms.shapeFamily);
 
     gl.bindVertexArray(null);
     return { nonFiniteCount };
@@ -660,12 +756,18 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
   return { renderShapes, destroy };
 }
 
-function drawPass(gl: GL2, families: Map<number, ShapeFamilyBuffers>, instances: Map<number, number[]>): void {
+function drawPass(
+  gl: GL2,
+  families: Map<number, ShapeFamilyBuffers>,
+  instances: Map<number, number[]>,
+  shapeFamilyUniform: WebGLUniformLocation | null,
+): void {
   for (const [shape, list] of instances) {
     if (list.length === 0) continue;
     const buffers = families.get(shape);
     if (!buffers) continue;
     const instanceCount = list.length / FLOATS_PER_INSTANCE;
+    if (shapeFamilyUniform) gl.uniform1f(shapeFamilyUniform, shape);
     gl.bindVertexArray(buffers.vao);
     gl.bindBuffer(gl.ARRAY_BUFFER, buffers.instanceBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(list), gl.DYNAMIC_DRAW);

--- a/packages/graph/src/webgl-shapes.ts
+++ b/packages/graph/src/webgl-shapes.ts
@@ -49,6 +49,9 @@ import type { GraphStyleBuffers } from "./types";
 type GL2 = WebGL2RenderingContext;
 
 const DEFAULT_NODE_COLOR = [77, 118, 255, 255] as const;
+const HALO_COLOR_FALLBACK = [0, 0, 0, 0] as const;
+const HALO_ALPHA = 0.28;
+const HALO_RADIUS_SCALE = 1.65;
 
 /** Shape codes Phase 1 renders as instanced polygons/discs (NOT the box). */
 const SHAPE_FAMILIES = [0, 1, 2, 3, 4, 6] as const;
@@ -279,6 +282,8 @@ export function decodeInstance(list: number[], n: number): ShapeInstanceView {
 }
 
 export interface ShapeInstanceSet {
+  /** Low-alpha expanded node geometry, drawn before border/fill. */
+  halo: Map<number, number[]>;
   fill: Map<number, number[]>;
   border: Map<number, number[]>;
   nonFiniteCount: number;
@@ -295,9 +300,11 @@ export interface ShapeInstanceSet {
  * runs deterministically even where a real WebGL context is unavailable.
  */
 export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
+  const halo = new Map<number, number[]>();
   const fill = new Map<number, number[]>();
   const border = new Map<number, number[]>();
   for (const shape of SHAPE_FAMILIES) {
+    halo.set(shape, []);
     fill.set(shape, []);
     border.set(shape, []);
   }
@@ -329,6 +336,23 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
 
     const nodeColor = colorAt(style?.nodeColors, i * 4, DEFAULT_NODE_COLOR);
     const alpha = nodeColor[3] / 255;
+    const haloColor = colorAt(style?.haloColor, 0, HALO_COLOR_FALLBACK);
+    if (style?.haloMask?.[i] === 1 && haloColor[3] > 0) {
+      // The halo is a filled, scaled copy of the SAME unit geometry. Its low
+      // alpha plus the real node drawn on top make a soft glow approximation;
+      // there is intentionally no outline/ring geometry here.
+      pushInstance(
+        halo.get(family)!,
+        cx,
+        cy,
+        radius * HALO_RADIUS_SCALE,
+        haloColor[0],
+        haloColor[1],
+        haloColor[2],
+        (haloColor[3] / 255) * HALO_ALPHA * alpha,
+        depth,
+      );
+    }
     const hollow = (style?.nodeFills?.[i] ?? 0) === 1;
     const bold = (style?.nodeBorders?.[i] ?? 0) === 1;
 
@@ -402,7 +426,7 @@ export function buildShapeInstances(frame: WebGLShapeFrame): ShapeInstanceSet {
     }
   }
 
-  return { fill, border, nonFiniteCount };
+  return { halo, fill, border, nonFiniteCount };
 }
 
 /**
@@ -586,7 +610,7 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
   const families = createShapeFamilyBuffers(gl);
 
   function renderShapes(frame: WebGLShapeFrame): { nonFiniteCount: number } {
-    const { fill, border, nonFiniteCount } = buildShapeInstances(frame);
+    const { halo, fill, border, nonFiniteCount } = buildShapeInstances(frame);
 
     gl.useProgram(shapeProgram.program);
     // UNIFIED CAMERA: the same mat4 view-projection the legacy node/edge shaders
@@ -611,6 +635,10 @@ export function createWebGLShapeRenderer(context: GL2 | null): WebGLShapeRendere
     // glyphs too far + dark-fringing AA rims under premultipliedAlpha:true).
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
+    // HALO PASS first: expanded, low-alpha copies sit behind the real node
+    // geometry. Then the border ring and interior fill preserve all existing
+    // node type/community colours and shape variants.
+    drawPass(gl, families, halo);
     // Border ring pass first (under the fill), then the interior fill pass, so a
     // hollow ring / bold outline sits beneath the (translucent or solid) centre.
     drawPass(gl, families, border);

--- a/packages/graph/tests/renderer-api.test.ts
+++ b/packages/graph/tests/renderer-api.test.ts
@@ -162,6 +162,29 @@ function createFakeCanvas2DContext() {
 }
 
 describe("createGraphRenderer", () => {
+  it("validates halo channels against node and edge counts", () => {
+    const view = createGraphRenderer(null);
+    view.setGraph({
+      nodeIds: ["a", "b"],
+      positions: new Float32Array([0, 0, 10, 0]),
+      edges: new Uint32Array([0, 1]),
+    });
+    const style = {
+      nodeSizes: new Float32Array([6, 8]),
+      nodeColors: new Uint8Array([255, 0, 0, 255, 0, 0, 255, 255]),
+      nodeShapes: new Uint8Array([0, 0]),
+      edgeWidths: new Float32Array([1]),
+      edgeColors: new Uint8Array([120, 130, 140, 255]),
+      edgeDash: new Uint8Array([0]),
+      edgeCurvatures: new Float32Array([0]),
+    };
+
+    expect(() => view.setStyle({ ...style, haloMask: new Uint8Array([1]) })).toThrow(/haloMask/);
+    expect(() => view.setStyle({ ...style, haloColor: new Uint8Array([1, 2, 3]) })).toThrow(/haloColor/);
+    expect(() => view.setStyle({ ...style, edgeHaloMask: new Uint8Array([1, 0]) })).toThrow(/edgeHaloMask/);
+    view.destroy();
+  });
+
   it("keeps rendering state separate from layout physics", () => {
     const view = createGraphRenderer(null, { interaction: { hover: true } });
     view.setGraph({

--- a/packages/graph/tests/webgl-edges.test.ts
+++ b/packages/graph/tests/webgl-edges.test.ts
@@ -15,6 +15,7 @@ import { createGraphRenderer } from "../src/renderer";
 import {
   ARROW_FLOATS_PER_INSTANCE,
   CAPSULE_FLOATS_PER_INSTANCE,
+  alphaShapeAtArc,
   buildEdgeInstances,
   createWebGLEdgeRenderer,
   decodeCapsule,
@@ -31,6 +32,7 @@ interface Draw {
 
 function createFakeGL2() {
   const draws: Draw[] = [];
+  const shaderSources: string[] = [];
   const TRIANGLES = 0x0004;
   const gl = {
     draws,
@@ -57,7 +59,9 @@ function createFakeGL2() {
     clear: () => undefined,
     drawArrays: () => undefined,
     createShader: () => ({}),
-    shaderSource: () => undefined,
+    shaderSource: (_shader: unknown, source: string) => {
+      shaderSources.push(source);
+    },
     compileShader: () => undefined,
     getShaderParameter: () => true,
     getShaderInfoLog: () => "",
@@ -89,13 +93,14 @@ function createFakeGL2() {
       draws.push({ mode, first, count, instanceCount });
     },
   };
-  return gl;
+  return { ...gl, shaderSources };
 }
 
 /** A straight single-edge frame (two circle endpoints) in device px. */
-function edgeFrame(opts: { curvature?: number; dash?: number; width?: number } = {}): WebGLEdgeFrame {
+function edgeFrame(opts: { curvature?: number; dash?: number; width?: number; span?: number } = {}): WebGLEdgeFrame {
+  const span = opts.span ?? 120;
   return {
-    positions: new Float32Array([-120, 0, 120, 0]),
+    positions: new Float32Array([-span, 0, span, 0]),
     nodeCount: 2,
     edges: new Uint32Array([0, 1]),
     style: {
@@ -145,7 +150,7 @@ describe("B1 Phase 2 — instanced edge draw contract (fake WebGL2)", () => {
   });
 
   it("instance buffer strides match the decoders", () => {
-    expect(CAPSULE_FLOATS_PER_INSTANCE).toBe(15);
+    expect(CAPSULE_FLOATS_PER_INSTANCE).toBe(16);
     expect(ARROW_FLOATS_PER_INSTANCE).toBe(9);
     const set = buildEdgeInstances(edgeFrame());
     expect(set.capsules.length % CAPSULE_FLOATS_PER_INSTANCE).toBe(0);
@@ -156,6 +161,16 @@ describe("B1 Phase 2 — instanced edge draw contract (fake WebGL2)", () => {
     const set = buildEdgeInstances(edgeFrame());
     const cap = decodeCapsule(set.capsules, 0);
     expect(cap.shape).toEqual([1, 1, 1]);
+  });
+
+  it("declares the full-edge arc varying and leaves dash phase on absolute arc", () => {
+    const gl = createFakeGL2();
+    createWebGLEdgeRenderer(gl as unknown as WebGL2RenderingContext);
+    const fragment = gl.shaderSources.find((source) => source.includes("out vec4 outColor;"));
+    expect(fragment).toBeDefined();
+    expect(fragment).toContain("in float v_totalArcLength;");
+    expect(fragment).toContain("v_arc / max(v_totalArcLength, 1e-5)");
+    expect(fragment).toContain("mod(v_arc, v_dashPeriod)");
   });
 
   it("edgeAlphaShape is normalised 0..1 and carried onto every segment", () => {
@@ -170,6 +185,40 @@ describe("B1 Phase 2 — instanced edge draw contract (fake WebGL2)", () => {
       expect(cap.shape[0]).toBeCloseTo(1, 5);
       expect(cap.shape[1]).toBeCloseTo(64 / 255, 5);
       expect(cap.shape[2]).toBeCloseTo(1, 5);
+      expect(cap.totalArcLength).toBeGreaterThan(0);
+    }
+  });
+
+  it("maps the alpha profile once over the complete arc for short and long edges", () => {
+    // Opaque at BOTH nodes and faint in the middle: this makes the intended
+    // single extremum unambiguous on both halves of the profile.
+    const shape = [1, 0.15, 1] as const;
+    for (const span of [30, 120]) {
+      const frame = edgeFrame({ curvature: 0.5, span });
+      frame.style!.edgeAlphaShape = new Uint8Array(shape.map((value) => Math.round(value * 255)));
+      const set = buildEdgeInstances(frame);
+      const segments = Array.from(
+        { length: set.capsules.length / CAPSULE_FLOATS_PER_INSTANCE },
+        (_, index) => decodeCapsule(set.capsules, index),
+      );
+      const total = segments[0]!.totalArcLength;
+      const samples = [0, 0.25, 0.5, 0.75, 1].map((t) => alphaShapeAtArc(shape, t * total, total));
+
+      expect(samples[0]).toBeCloseTo(shape[0], 6);
+      expect(samples[2]).toBeCloseTo(shape[1], 6);
+      expect(samples[4]).toBeCloseTo(shape[2], 6);
+      expect(samples[1]).toBeGreaterThan(samples[2]!);
+      expect(samples[3]).toBeLessThan(samples[4]!);
+      // The middle extremum occurs once; it does not restart at each capsule.
+      expect(samples.filter((value) => Math.abs(value - shape[1]) < 1e-6)).toHaveLength(1);
+      expect(segments.every((segment) => segment.totalArcLength === total)).toBe(true);
+
+      const segmentMidpoints = segments.map((segment) => {
+        const length = Math.hypot(segment.p1[0] - segment.p0[0], segment.p1[1] - segment.p0[1]);
+        return alphaShapeAtArc(segment.shape, segment.arcStart + length / 2, segment.totalArcLength);
+      });
+      expect(segmentMidpoints[0]).toBeGreaterThan(segmentMidpoints[1]!);
+      expect(segmentMidpoints.at(-1)).toBeGreaterThan(segmentMidpoints.at(-2)!);
     }
   });
 });

--- a/packages/graph/tests/webgl-shapes.test.ts
+++ b/packages/graph/tests/webgl-shapes.test.ts
@@ -17,6 +17,7 @@ import {
   createWebGLShapeRenderer,
   decodeInstance,
   effectiveStrokeHalfWidth,
+  haloFalloffAt,
   instancedShapeFamilies,
   FLOATS_PER_INSTANCE,
   type WebGLShapeFrame,
@@ -226,6 +227,30 @@ describe("B1 Phase 1 — instanced draw contract (fake WebGL2)", () => {
     const node = gl.draws[1]!.instanceData!;
     expect(halo[2]).toBeGreaterThan(node[2]);
     expect(halo[6]).toBeCloseTo(0.28, 5);
+    expect(decodeInstance(halo, 0).halo).toBe(true);
+    expect(decodeInstance(node, 0).halo).toBe(false);
+  });
+
+  it("halo alpha feathers from the node edge to zero at the outer edge", () => {
+    const profile = [0.5, 0.65, 0.8, 0.95, 1].map(haloFalloffAt);
+    expect(profile[0]).toBeCloseTo(1, 6);
+    expect(profile[0]).toBeGreaterThan(profile[1]!);
+    expect(profile[1]).toBeGreaterThan(profile[2]!);
+    expect(profile[2]).toBeGreaterThan(profile[3]!);
+    expect(profile[4]).toBeCloseTo(0, 6);
+    expect(new Set(profile).size).toBeGreaterThan(2);
+  });
+
+  it("emits no halo instances when the mask is empty or the halo color is transparent", () => {
+    const noMask = buildShapeInstances(frame([{ x: 0, y: 0, size: 14, shape: "circle", rgb: [214, 39, 40] }]));
+    expect(noMask.halo.get(0)).toEqual([]);
+
+    const transparentColorFrame = frame([
+      { x: 0, y: 0, size: 14, shape: "circle", rgb: [214, 39, 40], halo: true },
+    ]);
+    transparentColorFrame.style!.haloColor = new Uint8Array([45, 90, 135, 0]);
+    const transparentColor = buildShapeInstances(transparentColorFrame);
+    expect(transparentColor.halo.get(0)).toEqual([]);
   });
 
   it("box (shape 5) is NOT drawn by the instanced path (Canvas2D in Phase 1)", () => {
@@ -460,7 +485,7 @@ describe("B1 Phase 1 — N1b non-finite world-coord coercion", () => {
 
 describe("B1 Phase 1 — instance buffer encoding", () => {
   it("FLOATS_PER_INSTANCE matches a decoded instance stride; families exclude the box", () => {
-    expect(FLOATS_PER_INSTANCE).toBe(8);
+    expect(FLOATS_PER_INSTANCE).toBe(9);
     expect(instancedShapeFamilies()).not.toContain(5);
     expect(instancedShapeFamilies()).toEqual([0, 1, 2, 3, 4, 6]);
   });

--- a/packages/graph/tests/webgl-shapes.test.ts
+++ b/packages/graph/tests/webgl-shapes.test.ts
@@ -110,7 +110,17 @@ function createFakeGL2() {
 }
 
 function frame(
-  nodes: Array<{ x: number; y: number; size: number; shape: string; rgb: [number, number, number]; a?: number; fill?: 0 | 1; border?: 0 | 1 }>,
+  nodes: Array<{
+    x: number;
+    y: number;
+    size: number;
+    shape: string;
+    rgb: [number, number, number];
+    a?: number;
+    fill?: 0 | 1;
+    border?: 0 | 1;
+    halo?: boolean;
+  }>,
   dpr = 2,
   zoom = 1,
 ): WebGLShapeFrame {
@@ -121,6 +131,7 @@ function frame(
   const nodeColors = new Uint8Array(n * 4);
   const nodeFills = new Uint8Array(n);
   const nodeBorders = new Uint8Array(n);
+  const haloMask = new Uint8Array(n);
   nodes.forEach((node, i) => {
     positions[i * 2] = node.x;
     positions[i * 2 + 1] = node.y;
@@ -132,6 +143,7 @@ function frame(
     nodeColors[i * 4 + 3] = node.a ?? 255;
     nodeFills[i] = node.fill ?? 0;
     nodeBorders[i] = node.border ?? 0;
+    haloMask[i] = node.halo ? 1 : 0;
   });
   return {
     positions,
@@ -142,6 +154,8 @@ function frame(
       nodeShapes,
       nodeFills,
       nodeBorders,
+      haloMask,
+      haloColor: new Uint8Array([45, 90, 135, 255]),
       edgeWidths: new Float32Array(),
       edgeColors: new Uint8Array(),
       edgeDash: new Uint8Array(),
@@ -198,6 +212,20 @@ describe("B1 Phase 1 — instanced draw contract (fake WebGL2)", () => {
     expect(fanDraws).toHaveLength(2);
     const counts = fanDraws.map((d) => d.instanceCount).sort();
     expect(counts).toEqual([1, 2]);
+  });
+
+  it("runs a low-alpha expanded halo pass before the main node pass", () => {
+    const gl = createFakeGL2();
+    const renderer = createWebGLShapeRenderer(gl as unknown as WebGL2RenderingContext)!;
+    renderer.renderShapes(
+      frame([{ x: 0, y: 0, size: 14, shape: "circle", rgb: [214, 39, 40], halo: true }]),
+    );
+
+    expect(gl.draws).toHaveLength(2);
+    const halo = gl.draws[0]!.instanceData!;
+    const node = gl.draws[1]!.instanceData!;
+    expect(halo[2]).toBeGreaterThan(node[2]);
+    expect(halo[6]).toBeCloseTo(0.28, 5);
   });
 
   it("box (shape 5) is NOT drawn by the instanced path (Canvas2D in Phase 1)", () => {

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -35,8 +35,6 @@ export const GROUP_PALETTE = [
   "#a855f7",
 ];
 
-const FOCUS_COLOR = "#ef4444";
-const SELECTED_COLOR = "#2563eb";
 // Studio representation-polish remark 1: main-graph edges render semi-
 // transparent by DEFAULT (not opaque) — same #94a3b8 hue as before, now at
 // ~0.5 alpha — so the graph reads less like a solid mesh even before any
@@ -598,7 +596,8 @@ export function buildGraphRendererPayload(scene, options = {}) {
     const nodeType = node.node_type ?? node.type ?? null;
     // Color-by (R4/R5): Layer keys the categorical colour on the typed layer,
     // Folder (default) on community/container, Churn on a continuous activity heat.
-    // Selection/focus overrides still win.
+    // Selection/focus preserve that node colour; size and connected-dim styling
+    // provide the emphasis cues instead.
     const colorKey = colorBy === COLOR_BY_LAYER ? nodeType : node.group;
     const baseColor =
       colorBy === COLOR_BY_CHURN ? colorForChurn(churnById?.get(node.id) ?? 0) : colorForGroup(colorKey);
@@ -618,7 +617,7 @@ export function buildGraphRendererPayload(scene, options = {}) {
       // node's label in-box, bypassing the degree/god-class label gate.
       forceBoxLabel: node.forceBoxLabel === true,
       size: nodeSize(node, nodeRadius, selected, focused),
-      color: focused ? FOCUS_COLOR : selected ? SELECTED_COLOR : baseColor,
+      color: baseColor,
     };
   });
 

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -8,6 +8,7 @@ import {
   resolveLayout,
   TYPED_LAYER_LAYOUT_ID,
 } from "@sentropic/graph";
+import { shapeForType } from "./graphAdapter.js";
 
 /**
  * SINGLE source of truth for a group's (community / type) colour. Both the
@@ -347,6 +348,31 @@ export function isBoxShape(shape) {
   return value === "box" || value === "roundedbox";
 }
 
+const SYNTHETIC_GROUP_FIELDS = [
+  "community_node_kind",
+  "type_node_kind",
+  "ontology_node_kind",
+];
+
+function isSyntheticGroupNode(node) {
+  return SYNTHETIC_GROUP_FIELDS.some((field) => node?.[field] != null);
+}
+
+/**
+ * Resolve the shape used by the renderer from the same type mapping as the
+ * rail legend. Existing boxes and synthetic fold nodes are scene-level
+ * rendering decisions, so their baked shape remains authoritative.
+ */
+function rendererShapeForNode(node) {
+  const bakedShape = node?.shape ?? "dot";
+  if (isSyntheticGroupNode(node) || isBoxShape(bakedShape)) return bakedShape;
+
+  const type = node?.type ?? node?.type_name;
+  if (typeof type !== "string" || type.trim() === "") return bakedShape;
+
+  return shapeForType({ type }) || bakedShape;
+}
+
 /**
  * Default character budget for an in-canvas / overlay node label. The renderer
  * sizes a box glyph to its label's drawn width, so a long entity name (e.g.
@@ -583,7 +609,7 @@ export function buildGraphRendererPayload(scene, options = {}) {
       x: position.x,
       y: position.y,
       fixed: position.fixed,
-      shape: node.shape ?? "dot",
+      shape: rendererShapeForNode(node),
       // Shape variants (ontology visual_encoding): hollow / bold pass through
       // to the style buffers; absent = solid / normal (back-compatible).
       fill: node.fill,

--- a/studio/src/lib/graphRendererPayload.js
+++ b/studio/src/lib/graphRendererPayload.js
@@ -8,6 +8,7 @@ import {
   resolveLayout,
   TYPED_LAYER_LAYOUT_ID,
 } from "@sentropic/graph";
+import { semantic } from "@sentropic/design-system-tokens";
 import { shapeForType } from "./graphAdapter.js";
 
 /**
@@ -62,6 +63,22 @@ const DIM_ALPHA = Math.round(255 * 0.35); // 89 — connected-dim for NON-neighb
 // mostly noise once a node is focused) — incident edges are left at the
 // EDGE_BASE_ALPHA (~0.5+) by simply not being touched by the dim loop below.
 const EDGE_DIM_ALPHA = Math.round(255 * 0.15); // 38
+// Selection-neighbourhood halo: the renderer draws a scaled, low-alpha copy of
+// the same node geometry before the real node fill. This is deliberately a
+// filled glow approximation, never a contour/ring, so the node's own colour
+// remains the foreground signal.
+export const HALO_ALPHA = Math.round(255 * 0.28);
+export const HALO_RADIUS_SCALE = 1.65;
+const EDGE_HALO_ALPHA = Math.round(255 * 0.7);
+const EDGE_HALO_WIDTH_SCALE = 1.25;
+const EDGE_HALO_TINT = 0.45;
+
+/** DS token used by the selection-neighbourhood halo. */
+export const DS_PRIMARY_TOKEN = "--st-semantic-action-primary";
+// The token package is the deterministic non-DOM fallback. Browser rendering
+// always tries the active computed CSS custom property first, so theme
+// overrides remain authoritative.
+const DS_PRIMARY_FALLBACK_CSS = semantic.action.primary;
 
 // --- codeflow-parity Lot 4: Curved-links toggle + Color-by (Folder / Layer) ---
 /**
@@ -160,6 +177,120 @@ function stableHash(value) {
 export function colorForGroup(group) {
   const index = stableHash(group ?? "default") % GROUP_PALETTE.length;
   return GROUP_PALETTE[index];
+}
+
+function cssAlpha(value) {
+  if (!finite(value)) return 1;
+  return clampUnit(value > 1 ? value / 100 : value);
+}
+
+function cssChannel(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const numeric = Number.parseFloat(text);
+  if (!Number.isFinite(numeric)) return null;
+  return text.endsWith("%") ? numeric * 2.55 : numeric;
+}
+
+function cssAngle(value) {
+  const text = String(value ?? "").trim().toLowerCase();
+  const numeric = Number.parseFloat(text);
+  if (!Number.isFinite(numeric)) return null;
+  if (text.endsWith("rad")) return (numeric * 180) / Math.PI;
+  if (text.endsWith("grad")) return numeric * 0.9;
+  if (text.endsWith("turn")) return numeric * 360;
+  return numeric;
+}
+
+function oklchToRgba(value) {
+  const match = String(value ?? "").match(/^oklch\((.*)\)$/i);
+  if (!match) return null;
+  const parts = match[1].replace(/\//g, " / ").trim().split(/\s+/);
+  const slash = parts.indexOf("/");
+  const channels = slash >= 0 ? parts.slice(0, slash) : parts;
+  if (channels.length < 3) return null;
+
+  const lightnessText = channels[0];
+  const chromaText = channels[1];
+  const lightnessNumber = Number.parseFloat(lightnessText);
+  const chromaNumber = Number.parseFloat(chromaText);
+  const lightness = lightnessText.endsWith("%") ? lightnessNumber / 100 : lightnessNumber;
+  // CSS Color 4 maps OKLCH chroma percentages onto the [0, 0.4] range.
+  const chroma = chromaText.endsWith("%") ? (chromaNumber / 100) * 0.4 : chromaNumber;
+  const hue = cssAngle(channels[2]);
+  if (![lightness, chroma, hue].every(Number.isFinite)) return null;
+
+  const radians = (hue * Math.PI) / 180;
+  const a = chroma * Math.cos(radians);
+  const b = chroma * Math.sin(radians);
+  const l = lightness + 0.3963377774 * a + 0.2158037573 * b;
+  const m = lightness - 0.1055613458 * a - 0.0638541728 * b;
+  const s = lightness - 0.0894841775 * a - 1.291485548 * b;
+  const l3 = l ** 3;
+  const m3 = m ** 3;
+  const s3 = s ** 3;
+  const linear = [
+    4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3,
+    -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3,
+    -0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3,
+  ];
+  const toSrgb = (channel) => {
+    const clamped = Math.max(0, Math.min(1, channel));
+    return clamped <= 0.0031308
+      ? clamped * 12.92
+      : 1.055 * clamped ** (1 / 2.4) - 0.055;
+  };
+  const alpha = slash >= 0 ? cssAlpha(Number.parseFloat(parts[slash + 1])) : 1;
+  return [
+    Math.round(toSrgb(linear[0]) * 255),
+    Math.round(toSrgb(linear[1]) * 255),
+    Math.round(toSrgb(linear[2]) * 255),
+    Math.round(alpha * 255),
+  ];
+}
+
+/** Resolve the CSS colour syntaxes emitted by the DS theme into renderer RGBA bytes. */
+export function cssColorToRgba(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const oklch = oklchToRgba(text);
+  if (oklch) return oklch;
+
+  const hex = text.replace(/^#/, "");
+  if (/^[0-9a-f]{3,8}$/i.test(hex)) {
+    const expanded = hex.length <= 4 ? [...hex].map((digit) => `${digit}${digit}`).join("") : hex;
+    const values = [0, 2, 4].map((offset) => Number.parseInt(expanded.slice(offset, offset + 2), 16));
+    const alpha = expanded.length === 8 ? Number.parseInt(expanded.slice(6, 8), 16) : 255;
+    return [...values, alpha];
+  }
+
+  const rgbMatch = text.match(/^rgba?\((.*)\)$/i);
+  if (!rgbMatch) return null;
+  const parts = rgbMatch[1].replace(/,/g, " ").replace(/\//g, " / ").trim().split(/\s+/);
+  const slash = parts.indexOf("/");
+  const channels = slash >= 0 ? parts.slice(0, slash) : parts;
+  if (channels.length < 3) return null;
+  const rgb = channels.slice(0, 3).map(cssChannel);
+  if (!rgb.every(Number.isFinite)) return null;
+  const alpha = slash >= 0 ? cssAlpha(Number.parseFloat(parts[slash + 1])) : cssAlpha(Number.parseFloat(channels[3]));
+  return [...rgb.map((channel) => Math.round(Math.max(0, Math.min(255, channel)))), Math.round(alpha * 255)];
+}
+
+/** Read the active DS primary token, with a deterministic authored-token fallback for tests/SSR. */
+export function resolveDsPrimaryColor() {
+  let cssValue = "";
+  if (typeof document !== "undefined" && document.documentElement && typeof getComputedStyle === "function") {
+    // The theme selector is scoped to the app root (`[data-st-theme]`), not
+    // necessarily `<html>`, so read from the actual themed owner first.
+    const themedRoot =
+      typeof document.querySelector === "function"
+        ? document.querySelector("[data-st-theme]")
+        : null;
+    cssValue = getComputedStyle(themedRoot ?? document.documentElement)
+      .getPropertyValue(DS_PRIMARY_TOKEN)
+      .trim();
+  }
+  return cssColorToRgba(cssValue) ?? cssColorToRgba(DS_PRIMARY_FALLBACK_CSS);
 }
 
 const CHURN_LOW = [226, 232, 240];
@@ -474,6 +605,8 @@ function cloneStyle(style) {
     nodeSizes: new Float32Array(style.nodeSizes),
     nodeColors: new Uint8Array(style.nodeColors),
     nodeShapes: new Uint8Array(style.nodeShapes),
+    haloMask: style.haloMask ? new Uint8Array(style.haloMask) : undefined,
+    haloColor: style.haloColor ? new Uint8Array(style.haloColor) : undefined,
     // Carry the legacy box labels through dim / merge re-styling so box glyphs
     // keep their text when a node is selected, hovered, or focused.
     nodeLabels: style.nodeLabels ? [...style.nodeLabels] : undefined,
@@ -484,6 +617,7 @@ function cloneStyle(style) {
     edgeColors: new Uint8Array(style.edgeColors),
     edgeDash: new Uint8Array(style.edgeDash),
     edgeCurvatures: new Float32Array(style.edgeCurvatures),
+    edgeHaloMask: style.edgeHaloMask ? new Uint8Array(style.edgeHaloMask) : undefined,
     // The along-edge alpha SHAPE is a separate multiplier from edgeColors.a, so
     // it survives dim / hover / merge re-styling unchanged (those only scale the
     // base alpha). Clone it like the other per-edge buffers.
@@ -522,13 +656,33 @@ export function buildConnectedDimStyle(payload, options = {}) {
     }
   }
 
+  const haloColor = resolveDsPrimaryColor();
+  style.haloMask = new Uint8Array(graph.nodeIds.length);
+  style.haloColor = new Uint8Array(haloColor);
+  for (let i = 0; i < graph.nodeIds.length; i++) {
+    if (neighbourSet.has(graph.nodeIds[i])) style.haloMask[i] = 1;
+  }
+
+  style.edgeHaloMask = new Uint8Array(edgeCount);
+
   for (let e = 0; e < edgeCount; e++) {
     const srcIdx = graph.edges[e * 2];
     const tgtIdx = graph.edges[e * 2 + 1];
     const srcId = graph.nodeIds[srcIdx];
     const tgtId = graph.nodeIds[tgtIdx];
     const isIncident = activeFocusIds.has(srcId) || activeFocusIds.has(tgtId);
-    if (!isIncident) {
+    if (isIncident) {
+      style.edgeHaloMask[e] = 1;
+      const offset = e * 4;
+      style.edgeWidths[e] = (style.edgeWidths[e] ?? 1) * EDGE_HALO_WIDTH_SCALE;
+      for (let channel = 0; channel < 3; channel += 1) {
+        const existing = style.edgeColors[offset + channel] ?? 0;
+        style.edgeColors[offset + channel] = Math.round(
+          existing * (1 - EDGE_HALO_TINT) + haloColor[channel] * EDGE_HALO_TINT,
+        );
+      }
+      style.edgeColors[offset + 3] = Math.max(style.edgeColors[offset + 3] ?? 0, EDGE_HALO_ALPHA);
+    } else {
       style.edgeColors[e * 4 + 3] = EDGE_DIM_ALPHA;
     }
   }

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -538,7 +538,7 @@ function makeTriangleScene() {
 }
 
 describe("graphRendererPayload", () => {
-  it("maps a studio scene into @sentropic/graph buffers with selection styling", () => {
+  it("maps a studio scene with type colour, selection sizing, and connected dimming", () => {
     const payload = buildGraphRendererPayload(
       {
         nodes: [
@@ -561,8 +561,15 @@ describe("graphRendererPayload", () => {
     expect([...payload.renderGraph.positions.slice(0, 4)]).toEqual([0, 0, 10, 0]);
     expect(payload.style.nodeSizes[0]).toBeGreaterThan(payload.style.nodeSizes[1]);
     expect([...payload.style.nodeShapes]).toEqual([1, 6, 0]);
-    expect([...payload.style.nodeColors.slice(0, 4)]).toEqual([239, 68, 68, 255]);
-    expect([...payload.style.nodeColors.slice(4, 8)]).toEqual([37, 99, 235, 255]);
+    // Focus and selection retain each node's community/type colour; emphasis
+    // comes from the existing size growth and connected-dim alpha cues.
+    expect(payload.nodeById.get("a").color).toBe(colorForGroup("Case"));
+    expect(payload.nodeById.get("b").color).toBe(colorForGroup("Evidence"));
+    expect([...payload.style.nodeColors.slice(0, 3)]).toEqual([...payload.baseStyle.nodeColors.slice(0, 3)]);
+    expect([...payload.style.nodeColors.slice(4, 7)]).toEqual([...payload.baseStyle.nodeColors.slice(4, 7)]);
+    expect(payload.style.nodeColors[8 + 3]).toBeLessThanOrEqual(90);
+    expect(payload.style.nodeColors[3]).toBe(255);
+    expect(payload.style.nodeColors[7]).toBe(255);
   });
 
   it("finds the closest node in world coordinates", () => {
@@ -1154,14 +1161,23 @@ describe("Color-by Folder vs Layer (Lot 4, R4)", () => {
     expect(Array.from(folder.style.nodeColors)).toEqual(Array.from(def.style.nodeColors));
   });
 
-  it("selection / focus colour still overrides both keyings", () => {
-    const payload = buildGraphRendererPayload(makeScene(), {
+  it("selection and focus preserve the active group/type colour", () => {
+    const selected = buildGraphRendererPayload(makeScene(), {
       nodeRadius: 3,
       colorBy: COLOR_BY_LAYER,
       selectedIds: ["a"],
     });
-    // Selected node uses SELECTED_COLOR (#2563eb → 37,99,235), not the layer hue.
-    expect([...payload.baseStyle.nodeColors.slice(0, 3)]).toEqual([37, 99, 235]);
+    const focused = buildGraphRendererPayload(makeScene(), {
+      nodeRadius: 3,
+      colorBy: COLOR_BY_LAYER,
+      focusId: "a",
+    });
+    // Layer colour is the active type colour, and selection/focus do not replace it.
+    expect(selected.nodeById.get("a").color).toBe(colorForGroup(TYPE));
+    expect(focused.nodeById.get("a").color).toBe(colorForGroup(TYPE));
+    expect([...selected.baseStyle.nodeColors.slice(0, 3)]).toEqual([
+      ...focused.baseStyle.nodeColors.slice(0, 3),
+    ]);
   });
 });
 

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -9,6 +9,7 @@ import {
   COLOR_BY_LAYER,
   colorForChurn,
   colorForGroup,
+  cssColorToRgba,
   computeLayoutBuffer,
   DEFAULT_EDGE_CURVATURE,
   DEFAULT_EDGE_OPACITY,
@@ -25,6 +26,8 @@ import {
   findNearestNode,
   findNearestNodeId,
   GROUP_PALETTE,
+  DS_PRIMARY_TOKEN,
+  resolveDsPrimaryColor,
   interpolateGroupFadeStyle,
   interpolateMergeStyle,
   interpolateMergePositions,
@@ -695,7 +698,7 @@ describe("graphRendererPayload", () => {
       const isIncident = src === iA || tgt === iA;
       const alpha = payload.style.edgeColors[e * 4 + 3];
       if (isIncident) {
-        expect(alpha).toBe(128); // EDGE_BASE_ALPHA: 255 * 0.5, untouched by the dim
+        expect(alpha).toBe(179); // halo emphasis raises incident edges to ~0.7 alpha
       } else {
         expect(alpha).toBe(38); // EDGE_DIM_ALPHA: 255 * 0.15, rounded
       }
@@ -766,6 +769,35 @@ describe("graphRendererPayload", () => {
     expect(payload.style.nodeColors[iB * 4 + 3]).toBe(255); // selected itself
     expect(payload.style.nodeColors[iD * 4 + 3]).toBe(255); // neighbour of b
     expect(payload.style.nodeColors[iC * 4 + 3]).toBeLessThanOrEqual(90); // not a neighbour
+  });
+
+  it("emits the primary halo over the exact selected-node 1-hop neighbourhood", () => {
+    const scene = makeTriangleScene();
+    // Select b: halo a, b, d; c is outside the connected-dim neighbour set.
+    const payload = buildGraphRendererPayload(scene, { selectedIds: ["b"], nodeRadius: 3 });
+    const halo = payload.style.haloMask;
+    const edgeHalo = payload.style.edgeHaloMask;
+    const iA = payload.nodeIndexById.get("a");
+    const iB = payload.nodeIndexById.get("b");
+    const iC = payload.nodeIndexById.get("c");
+    const iD = payload.nodeIndexById.get("d");
+
+    expect([...halo]).toEqual([1, 1, 0, 1]);
+    // Edges are a-b, a-c, b-d: only the two edges incident to selected b are emphasized.
+    expect([...edgeHalo]).toEqual([1, 0, 1]);
+    expect([...payload.style.haloColor]).toEqual([...resolveDsPrimaryColor()]);
+    expect(DS_PRIMARY_TOKEN).toBe("--st-semantic-action-primary");
+    expect(resolveDsPrimaryColor()).toEqual(cssColorToRgba("oklch(50% 0.134 242.749)"));
+    // Halo is behind the original type/community fills, not a recolour.
+    expect([...payload.style.nodeColors.slice(iA * 4, iA * 4 + 3)]).toEqual(
+      [...payload.baseStyle.nodeColors.slice(iA * 4, iA * 4 + 3)],
+    );
+    expect([...payload.style.nodeColors.slice(iB * 4, iB * 4 + 3)]).toEqual(
+      [...payload.baseStyle.nodeColors.slice(iB * 4, iB * 4 + 3)],
+    );
+    expect(halo[iC]).toBe(0);
+    expect(halo[iD]).toBe(1);
+    expect(payload.style.edgeWidths[0]).toBeGreaterThan(payload.baseStyle.edgeWidths[0]);
   });
 
   it("does NOT dim anything when neither selectedIds nor hoveredNodeId are provided", () => {

--- a/studio/src/tests/graphRendererPayload.test.js
+++ b/studio/src/tests/graphRendererPayload.test.js
@@ -45,7 +45,75 @@ import {
   selectPrincipalHubLabels,
   truncateLabel,
 } from "../lib/graphRendererPayload.js";
-import { buildScene, communityStats, nodeGroup } from "../lib/graphAdapter.js";
+import { buildScene, communityStats, nodeGroup, shapeForType } from "../lib/graphAdapter.js";
+
+describe("renderer node shapes match the type legend", () => {
+  it("uses shapeForType for entities while preserving boxes, synthetic groups, and fallbacks", () => {
+    const entityTypes = ["Case", "Character", "Evidence", "Location"];
+    const nodes = entityTypes.map((type, index) => ({
+      id: `entity-${index}`,
+      label: type,
+      type,
+      // Deliberately stale: the renderer must not trust the baked scene shape.
+      shape: "dot",
+    }));
+    nodes.push(
+      {
+        id: "case-from-type-name",
+        label: "Case from type_name",
+        type_name: "Case",
+        shape: "dot",
+      },
+      {
+        id: "work-box",
+        label: "Work box",
+        type: "Work",
+        // Work maps to a non-box glyph in shapeForType, but an existing box
+        // must keep the renderer's box path.
+        shape: "roundedbox",
+      },
+      {
+        id: "community-group",
+        label: "Community",
+        type: "OntologyCommunity",
+        community_node_kind: "community",
+        shape: "triangle",
+      },
+      {
+        id: "type-group",
+        label: "Type group",
+        type: "OntologyTypeGroup",
+        type_node_kind: "type",
+        shape: "diamond",
+      },
+      {
+        id: "ontology-class-group",
+        label: "Ontology class",
+        type: "OntologyClass",
+        ontology_node_kind: "class",
+        shape: "square",
+      },
+      { id: "untyped", label: "Untyped", shape: "hexagon" },
+    );
+
+    const payload = buildGraphRendererPayload({ nodes, edges: [] });
+
+    for (const [index, type] of entityTypes.entries()) {
+      expect(payload.nodeById.get(`entity-${index}`).shape, type).toBe(
+        shapeForType({ type }),
+      );
+    }
+    expect(payload.nodeById.get("entity-0").shape).toBe("star");
+    expect(payload.nodeById.get("case-from-type-name").shape).toBe(
+      shapeForType({ type: "Case" }),
+    );
+    expect(payload.nodeById.get("work-box").shape).toBe("roundedbox");
+    expect(payload.nodeById.get("community-group").shape).toBe("triangle");
+    expect(payload.nodeById.get("type-group").shape).toBe("diamond");
+    expect(payload.nodeById.get("ontology-class-group").shape).toBe("square");
+    expect(payload.nodeById.get("untyped").shape).toBe("hexagon");
+  });
+});
 
 // --- BUG B: single source of truth for community → colour ---
 // The legend swatch (communityStats[].color) and the canvas node fill


### PR DESCRIPTION
## Summary
- restore node shape/legend parity for rendered nodes (`shapeForType(type)`): `Case` now renders as star like the legend
- keep selected/hovered nodes in their type/community colour (drop the former blue/red recolour)
- add a soft DS-primary selection halo (selected node + 1-hop neighbours) without changing fill colour
- fix per-edge alpha gradient mapping so it runs once from source→target instead of tiling as a repeated pattern

## UAT
Validated on the mystery pack UAT build at `http://127.0.0.1:8877/`:
- node shapes OK
- selected node colours OK
- soft halo OK (gradient/ombra, no hard contour)
- arrow/edge alpha gradient OK (scaled to the edge, no pattern repetition)

## Validation
- `npm run lint`
- `cd packages/graph && npx vitest run` → 329 passed / 22 files
- `cd studio && npx vitest run` → 500 passed, 3 known jsdom picking failures
- `npm run build:graph`
- `npm run build:studio`

No golden baseline regenerated; default/no-selection render preserved.
