### PR TITLE
fix(graph): never paint the selection halo on box-glyph nodes

### DIFF
--- a/packages/graph/src/webgl-boxes.ts
+++ b/packages/graph/src/webgl-boxes.ts
@@ -441,7 +441,6 @@ export function buildBoxTextDraws(frame: WebGLBoxFrame): BoxTextDraw[] {
     if ((style?.nodeShapes?.[i] ?? 0) !== BOX_SHAPE_CODE) continue;
     const center = screenPoint(frame.positions, i, frame);
     const [r, g, b, a] = colorAt(style?.nodeColors, i * 4, DEFAULT_NODE_COLOR);
-    const [hr, hg, hb, ha] = colorAt(style?.haloColor, 0, [0, 0, 0, 0]);
     const bold = (style?.nodeBorders?.[i] ?? 0) === 1;
     out.push({
       nodeIndex: i,
@@ -460,8 +459,7 @@ export function buildBoxTextDraws(frame: WebGLBoxFrame): BoxTextDraw[] {
       // also sets globalAlpha=alpha, so the alpha is applied the SAME two ways.
       borderColor: `rgba(${r}, ${g}, ${b}, ${a / 255})`,
       alpha: a / 255,
-      halo: style?.haloMask?.[i] === 1,
-      haloColor: `rgba(${hr}, ${hg}, ${hb}, ${(ha / 255) * 0.28})`,
+      halo: false,
     });
   }
   return out;

--- a/packages/graph/tests/webgl-boxes.test.ts
+++ b/packages/graph/tests/webgl-boxes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildBoxTextDraws, type WebGLBoxFrame } from "../src/webgl-boxes";
+import { BOX_SHAPE_CODE } from "../src/render-geometry";
+
+describe("buildBoxTextDraws", () => {
+  it("asserts buildBoxTextDraws yields halo === false for a box node even when haloMask bit is set", () => {
+    const frame: WebGLBoxFrame = {
+      positions: new Float32Array([10, 20]),
+      nodeCount: 1,
+      style: {
+        nodeSizes: new Float32Array([15]),
+        nodeColors: new Uint8Array([255, 0, 0, 255]),
+        nodeShapes: new Uint8Array([BOX_SHAPE_CODE]),
+        haloMask: new Uint8Array([1]),
+        haloColor: new Uint8Array([0, 255, 0, 255]),
+        nodeLabels: ["Box Node"],
+      },
+      camera: { x: 0, y: 0, zoom: 1 },
+      pixelRatio: 1,
+      viewportWidth: 100,
+      viewportHeight: 100,
+    };
+
+    const draws = buildBoxTextDraws(frame);
+    expect(draws).toHaveLength(1);
+    expect(draws[0]!.halo).toBe(false);
+    expect(draws[0]!.haloColor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Box-glyph nodes (Work / ChapterOrStory framed labels) were receiving the DS-primary selection halo, which reads wrong on framed text. `buildBoxTextDraws` now always emits `halo:false` for box draws; non-box shapes unchanged. New webgl-boxes test pins it. lint clean · packages/graph 330 pass · build:graph + build:studio OK. Authored by agy, verified by conductor.