### PR TITLE
fix(ontology): don't 500 when a project config has no outputs.ontology block

### DIFF
--- a/src/ontology-patch-context.ts
+++ b/src/ontology-patch-context.ts
@@ -100,7 +100,8 @@ export function loadOntologyPatchContext(profileStatePath: string): OntologyPatc
         evidence_refs: stringArray(relation.evidence_refs),
       })),
     evidenceRefs: evidenceRefsFromSources(optionalJson(join(ontologyDir, "sources.json"), [])),
-    decisionsPath: context.projectConfig?.outputs.ontology.reconciliation.decisions_path ?? undefined,
+    decisionsPath:
+      context.projectConfig?.outputs?.ontology?.reconciliation?.decisions_path ?? undefined,
     dirtyWorktree: safeExecGit(rootDir, ["status", "--porcelain"]) !== null,
   };
 }


### PR DESCRIPTION
`loadOntologyPatchContext` read `projectConfig?.outputs.ontology.reconciliation.decisions_path` — the optional chain stopped at projectConfig, so any project without an `outputs.ontology` block threw and **500'd every ontology-studio API route** (blocked serving the aclp-am 47k graph entirely). Guard the whole chain. lint clean.