### PR TITLE
feat(link): typed entity-linking / gazetteer capability (graphify link + profile evaluate)

### DIFF
--- a/spec/SPEC_ONTOLOGY_OUTPUT_ARTIFACTS.md
+++ b/spec/SPEC_ONTOLOGY_OUTPUT_ARTIFACTS.md
@@ -253,22 +253,29 @@ Rules:
 ]
 ```
 
-`occurrences.json` records profile-selected source-backed observations:
+`occurrences.json` records profile-selected mention-level typed entity occurrences:
 
 ```json
 [
   {
     "id": "occurrence-id",
-    "type": "Observation",
-    "summary": "Synthetic source-backed observation.",
-    "linked_node_ids": ["stable-node-id"],
-    "source_refs": ["source-ref-id"],
-    "confidence": 0.7
+    "node_type": "Component",
+    "raw_span": "Synthetic component label",
+    "normalized": "synthetic component label",
+    "source_file": "source.md",
+    "page": null,
+    "offsets": { "start": 0, "end": 25 },
+    "detector": "lexicon",
+    "resolution": "linked",
+    "registry_record_id": "component-1",
+    "registry_partition": null
   }
 ]
 ```
 
-The profile decides which node types are occurrence-like. Graphify must not ship a built-in domain concept for occurrences.
+The profile decides which node types are occurrence-like. `raw_span` is verbatim source text; offsets are 0-based,
+half-open UTF-16 offsets in that raw source file. A linked occurrence has exactly one `registry_record_id`; unlinked
+and ambiguous occurrences have none. Graphify must not ship a built-in domain concept for occurrences.
 
 ## Entity Wiki
 
@@ -374,7 +381,25 @@ Ontology output validation checks:
 - wiki pages reference only exported node IDs
 - generated summaries cite evidence when citation policy requires it
 
-Validation output goes to `.graphify/ontology/validation.json` and profile reports.
+Validation output goes to `.graphify/ontology/validation.json` and profile reports. Its v1 envelope is structured:
+
+```json
+{
+  "schema": "graphify_ontology_validation_v1",
+  "issues": [
+    {
+      "code": "ALIAS_AMBIGUOUS",
+      "severity": "warning",
+      "node_type": "Component",
+      "message": "alias \"alternate label\" ambiguously attaches to component-a, component-b",
+      "refs": ["record:component-a", "record:component-b"]
+    }
+  ]
+}
+```
+
+`issues` previously contained free-form strings. Consumers must now read the stable `code`, `severity`,
+`node_type`, and prefixed `refs`; `message` preserves the human-readable diagnostic.
 
 ## Tests
 

--- a/spec/SPEC_TYPED_LINKING_NORMALIZERS.md
+++ b/spec/SPEC_TYPED_LINKING_NORMALIZERS.md
@@ -1,0 +1,39 @@
+# Typed-linking normalizer contract (L3)
+
+`node_types.<type>.linking` is an opt-in contract. A node type without this
+block keeps its historical normalizers: reconciliation and ontology output do
+not switch to cite's deaccenting matcher.
+
+```yaml
+node_types:
+  Zone:
+    registry: zones
+    linking:
+      preset: gazetteer-exact # stored in L3; expanded by L4
+      normalize:
+        builtin: [case_fold, dash_fold, collapse_ws]
+        fn: ./zone-normalize.mjs#normalizeZoneCode
+```
+
+The ordered built-ins are `case_fold@1`, `dash_fold@1`, and
+`collapse_ws@1`; they run from left to right, followed by `fn`. If `linking`
+or `linking.normalize` omits `builtin`, the default is
+`normalizeForMatch` (`normalize_for_match@1`). The configured record ID is
+never normalized.
+
+The `fn` module is a trusted local ESM `module#export` whose export is a
+synchronous `(value: string) => string`. L3 only accepts autonomous modules:
+no imports, re-exports, or dynamic imports. The normalized profile fingerprints
+the bytes of that one file; allowing local transitive imports would require
+fingerprinting their complete closure and is intentionally deferred.
+
+At registry load, before corpus scanning, Graphify evaluates every registry
+label and alias to verify synchronous string results, determinism, idempotence,
+and no empty result for a non-empty key. It rejects a
+`normalizer_collision` only when two distinct record IDs produce the same key
+in the same partition. Equal keys in separate partitions remain valid.
+
+The normalized profile stores a portable descriptor—built-in versions, export
+name, module SHA-256, and normalizer hash—without an absolute module path. That
+descriptor is included in `profile_hash`, so changing the module's bytes makes
+existing linking and reconciliation artifacts stale.

--- a/src/cite-grounding.ts
+++ b/src/cite-grounding.ts
@@ -1,338 +1,84 @@
 /**
- * Heuristic citation GROUNDING (WP #24 — `graphify cite`).
- *
- * Symmetric to `node-descriptions.ts` (describe) and `community-labeling.ts`
- * (label): a producer pass over an already-built graph that POPULATES
- * `node.citations[]` by SCANNING the corpus source text, as opposed to
- * `backfill-citations` which only PROJECTS pre-existing citations.
- *
- * This is the productization of ia-aero's hand-coded `ground.py` / `ground2.py`
- * (876/876 entities cited, zero API calls) and is the no-key DEFAULT path.
- *
- * ── ANTI-HALLUCINATION (HARD INVARIANT) ──────────────────────────────────────
- * Every emitted `quote` is a VERIFIED VERBATIM substring of the NORMALIZED
- * source text. A citation cannot be emitted unless its windowed quote, after the
- * same NFKD-deaccent/lowercase/whitespace-collapse normalization, is found as a
- * substring of the normalized source. There is no path to invent text. The LLM
- * (assistant/api) modes are gated by the SAME structural check: an LLM proposes
- * a quote, the heuristic verifier re-locates it in the source, and a quote that
- * does not match is DROPPED, never emitted. See `verifyVerbatim`.
- *
- * No network, no secrets in the heuristic path. Deterministic and replayable.
+ * Heuristic citation grounding. Source parsing, raw-offset relocation, and
+ * verbatim verification live in source-grounding so link and cite share the
+ * same proof substrate.
  */
 import { readFileSync } from "node:fs";
-import { isAbsolute, resolve as resolvePath } from "node:path";
 import type Graph from "graphology";
+
 import type { CitationConfidence, OntologyCitation } from "./types.js";
 import { unionCitations } from "./citations.js";
+import {
+  deaccent,
+  detectModality,
+  normalizeForMatch,
+  parseSource,
+  rawOffsetForTerm,
+  resolveSourcePath,
+  verifyVerbatim,
+  windowQuote,
+} from "./source-grounding.js";
+import type { ParsedSource } from "./source-grounding.js";
 
-// ---------------------------------------------------------------------------
-// Normalization (the matcher substrate, shared by grounding + verification)
-// ---------------------------------------------------------------------------
+// Public compatibility surface: all historical cite exports now come from the
+// shared source module, with no behavioural fork.
+export {
+  buildNormToRawMap,
+  deaccent,
+  detectModality,
+  normalizeForMatch,
+  parseSource,
+  rawOffsetForTerm,
+  resolveSourcePath,
+  verifyVerbatim,
+  windowQuote,
+} from "./source-grounding.js";
+export type {
+  ImageContext,
+  ParsedSource,
+  ResolveSourceOptions,
+  SourceModality,
+  SourceUnit,
+} from "./source-grounding.js";
 
-/** NFKD deaccent + ascii-fold (drops combining marks, ligatures degrade). */
-export function deaccent(s: string): string {
-  return (s ?? "").normalize("NFKD").replace(/[̀-ͯ]/g, "");
-}
-
-/**
- * Dotted initial runs normalize spacing around the points only when at least
- * two one-letter initials are present: `A. J.` / `A . J .` / `A.J.` all become
- * `a.j.`. This preserves the letters and points and avoids numeric padding or
- * other cross-entity folds.
- */
-const DOTTED_INITIAL_RUN_RE = /\b[a-z]\s*\.(?:\s*[a-z]\s*\.)+/g;
-
-function normalizeForMatchBase(s: string): string {
-  return deaccent(s ?? "")
-    .replace(/œ/g, "oe")
-    .replace(/æ/g, "ae")
-    .replace(/Œ/g, "OE")
-    .replace(/Æ/g, "AE")
-    .toLowerCase()
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function foldDottedInitialSpacing(s: string): string {
-  return s.replace(DOTTED_INITIAL_RUN_RE, (run) => run.replace(/\s+/g, ""));
-}
-
-/**
- * Canonical match form: deaccent → lowercase → collapse whitespace → trim →
- * fold dotted-initial spacing. Ligatures (œ/æ) are folded so `cœur` matches
- * `coeur`. Used for BOTH the candidate-term match and the anti-hallucination
- * verbatim check, so the two are guaranteed to agree.
- */
-export function normalizeForMatch(s: string): string {
-  return foldDottedInitialSpacing(normalizeForMatchBase(s));
-}
-
-// ---------------------------------------------------------------------------
-// Modality-aware source parsing
-// ---------------------------------------------------------------------------
-
-export type SourceModality = "ocr-markdown" | "plain-text";
-
-/** A locatable text unit (paragraph) parsed from a source file. */
-export interface SourceUnit {
-  /** Verbatim (raw) paragraph text. */
-  text: string;
-  /** Page number (OCR-markdown; 1 for plain text where pages are meaningless). */
-  page: number;
-  /** Section / chapter heading in effect for this unit (raw). */
-  section: string;
-  /** 0-based paragraph index within the source. */
-  paragraphIndex: number;
-}
-
-/** Image reference + its surrounding prose context (OCR-markdown). */
-export interface ImageContext {
-  /** Image basename, e.g. `image-000.jpg`. */
-  basename: string;
-  page: number;
-  section: string;
-  /** Preceding paragraph text (raw), or "". */
-  prev: string;
-  /** Following paragraph text (raw), or "". */
-  next: string;
-}
-
-export interface ParsedSource {
-  modality: SourceModality;
-  units: SourceUnit[];
-  /** section heading → unit indices, for type-aware person-section matching. */
-  sectionToIndices: Map<string, number[]>;
-  /** image basename → context (OCR-markdown only). */
-  images: Map<string, ImageContext>;
-  /** Highest page seen (1 for plain text). */
-  pageCount: number;
-}
-
-/** Detect modality from a source path. `.md` → OCR-markdown, else plain-text. */
-export function detectModality(sourceFile: string): SourceModality {
-  return /\.(md|markdown)$/i.test(sourceFile) ? "ocr-markdown" : "plain-text";
-}
-
-const FRONT_MATTER_KEY = /^[a-z_]+:\s/i;
-
-/**
- * Parse an OCR-markdown file into locatable units (ia-aero `ground.py` parser,
- * hardened for graphify's front-matter):
- *   - the leading `---` … `---` front-matter block is SKIPPED (it is metadata,
- *     not a page break — without this, page numbering starts at 2);
- *   - a bare `---` outside front-matter → page increment (Mistral page break);
- *   - `#{1,4} ` → section heading (the section for following units);
- *   - `![alt](path)` → an image; its prev paragraph + the next paragraph become
- *     its context;
- *   - blank line / heading / image / page-break → flush the current paragraph.
- */
-function parseOcrMarkdown(raw: string): ParsedSource {
-  const lines = raw.split("\n");
-  const units: SourceUnit[] = [];
-  const sectionToIndices = new Map<string, number[]>();
-  const images = new Map<string, ImageContext>();
-  let page = 1;
-  let section = "";
-  let buf: string[] = [];
-  let pendingImages: string[] = [];
-
-  // Front-matter detection: a `---` on the FIRST line opens a metadata block
-  // that closes at the next `---`. Those two `---` are not page breaks.
-  let inFrontMatter = false;
-  let frontMatterDone = false;
-  let i = 0;
-  if (lines[0]?.trim() === "---") {
-    inFrontMatter = true;
-    i = 1;
-  }
-
-  const flush = (): void => {
-    if (buf.length === 0) return;
-    const text = buf.map((x) => x.trim()).join(" ").trim();
-    buf = [];
-    if (!text || text.startsWith("![")) return;
-    const idx = units.length;
-    units.push({ text, page, section, paragraphIndex: idx });
-    const arr = sectionToIndices.get(section) ?? [];
-    arr.push(idx);
-    sectionToIndices.set(section, arr);
-    // Resolve any image awaiting its `next` paragraph.
-    for (const fn of pendingImages) {
-      const ctx = images.get(fn);
-      if (ctx && !ctx.next) ctx.next = text;
-    }
-    pendingImages = [];
-  };
-
-  for (; i < lines.length; i += 1) {
-    const s = (lines[i] ?? "").trim();
-
-    if (inFrontMatter && !frontMatterDone) {
-      // Skip metadata lines; the closing `---` ends the block (not a page break).
-      if (s === "---") {
-        frontMatterDone = true;
-        inFrontMatter = false;
-      } else if (s !== "" && !FRONT_MATTER_KEY.test(s)) {
-        // A non-key line before a closing fence: not real front matter — bail
-        // out and reprocess this line as content.
-        inFrontMatter = false;
-        frontMatterDone = true;
-        i -= 1;
-      }
-      continue;
-    }
-
-    if (s === "---") {
-      flush();
-      page += 1;
-      continue;
-    }
-    if (/^#{1,4}\s/.test(s)) {
-      flush();
-      section = s.replace(/^#{1,4}\s+/, "").trim();
-      continue;
-    }
-    const img = /^!\[[^\]]*\]\(([^)]+)\)/.exec(s);
-    if (img) {
-      flush();
-      const fn = basenameOf(img[1] ?? "");
-      const prev = units.length > 0 ? (units[units.length - 1]?.text ?? "") : "";
-      images.set(fn, { basename: fn, page, section, prev, next: "" });
-      pendingImages.push(fn);
-      continue;
-    }
-    if (s === "") {
-      flush();
-      continue;
-    }
-    buf.push(s);
-  }
-  flush();
-
-  return { modality: "ocr-markdown", units, sectionToIndices, images, pageCount: page };
-}
-
-/**
- * Parse a plain-text file (mystery novels) into locatable units. Chapter / story
- * headings (heuristic: short, mostly-uppercase or `Chapter N`/`Part N` lines on
- * their own, or markdown `#` headings if present) become sections; paragraphs
- * (blank-line separated) are the units. Pages are meaningless → page 1.
- */
-function parsePlainText(raw: string): ParsedSource {
-  const lines = raw.split("\n");
-  const units: SourceUnit[] = [];
-  const sectionToIndices = new Map<string, number[]>();
-  let section = "";
-  let buf: string[] = [];
-
-  const flush = (): void => {
-    if (buf.length === 0) return;
-    const text = buf.map((x) => x.trim()).join(" ").trim();
-    buf = [];
-    if (!text) return;
-    const idx = units.length;
-    units.push({ text, page: 1, section, paragraphIndex: idx });
-    const arr = sectionToIndices.get(section) ?? [];
-    arr.push(idx);
-    sectionToIndices.set(section, arr);
-  };
-
-  for (const line of lines) {
-    const s = line.trim();
-    if (/^#{1,4}\s/.test(s)) {
-      flush();
-      section = s.replace(/^#{1,4}\s+/, "").trim();
-      continue;
-    }
-    if (isHeadingLine(s, buf.length === 0)) {
-      flush();
-      section = s.trim();
-      continue;
-    }
-    if (s === "") {
-      flush();
-      continue;
-    }
-    buf.push(s);
-  }
-  flush();
-
-  return { modality: "plain-text", units, sectionToIndices, images: new Map(), pageCount: 1 };
-}
-
-/**
- * Heuristic chapter/story heading for plain text: a `Chapter N`/`Part N`/`Book N`
- * marker, or a short standalone line (≤ 8 words) that is mostly upper-case
- * letters and starts a paragraph. Conservative — false negatives only narrow the
- * section, never break grounding.
- */
-function isHeadingLine(s: string, atParagraphStart: boolean): boolean {
-  if (!s || !atParagraphStart) return false;
-  if (/^(chapter|part|book|adventure|story)\b/i.test(s) && s.length <= 80) return true;
-  const words = s.split(/\s+/);
-  if (words.length > 8 || s.length > 80) return false;
-  const letters = s.replace(/[^a-zA-ZÀ-ÿ]/g, "");
-  if (letters.length < 3) return false;
-  const upper = s.replace(/[^A-ZÀ-Þ]/g, "");
-  return upper.length / letters.length >= 0.7;
-}
-
-function basenameOf(p: string): string {
-  const norm = p.replace(/\\/g, "/");
-  const idx = norm.lastIndexOf("/");
-  return idx >= 0 ? norm.slice(idx + 1) : norm;
-}
-
-/** Parse any supported source modality. */
-export function parseSource(raw: string, modality: SourceModality): ParsedSource {
-  return modality === "ocr-markdown" ? parseOcrMarkdown(raw) : parsePlainText(raw);
-}
-
-// ---------------------------------------------------------------------------
-// Quote windowing + verbatim verification (anti-hallucination)
-// ---------------------------------------------------------------------------
-
-const QUOTE_BEFORE = 110;
-const QUOTE_AFTER = 210;
 const QUOTE_MAXLEN = 320;
-const OPEN_BOUNDARY = new Set([" ", "\n", "«", "(", '"', "“"]);
-const CLOSE_BOUNDARY = new Set([" ", "\n", ".", "!", "?", "»", ")", '"', "”"]);
 
-/**
- * Window a verbatim quote around a match offset (ia-aero `make_quote`): grab
- * ±~110/210 chars, snap the start back to an opening boundary and the end
- * forward to a sentence/quote boundary, ellipsis-pad the truncated sides, cap
- * length. Returns the RAW (verbatim) text — never normalized.
- */
-export function windowQuote(text: string, offset: number): string {
-  let a = Math.max(0, offset - QUOTE_BEFORE);
-  let b = Math.min(text.length, offset + QUOTE_AFTER);
-  while (a > 0 && !OPEN_BOUNDARY.has(text[a] ?? "")) a -= 1;
-  while (b < text.length && !CLOSE_BOUNDARY.has(text[b] ?? "")) b += 1;
-  let q = text.slice(a, b).trim();
-  if (a > 0) q = "… " + q;
-  if (b < text.length) q = q + " …";
-  q = q.replace(/\s+/g, " ");
-  return q.length > QUOTE_MAXLEN ? q.slice(0, QUOTE_MAXLEN).trim() : q;
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/**
- * THE anti-hallucination gate. A quote is verbatim iff its normalized form,
- * stripped of the ellipsis padding `windowQuote` adds, is a non-empty substring
- * of the normalized source text. Used to verify EVERY emitted citation —
- * heuristic and LLM alike.
- */
-export function verifyVerbatim(quote: string, normalizedSource: string): boolean {
-  if (!quote) return false;
-  // Strip the ellipsis padding we may have added, then normalize.
-  const core = quote.replace(/^…\s*/, "").replace(/\s*…$/, "");
-  const needle = normalizeForMatch(core);
-  if (!needle) return false;
-  return normalizedSource.includes(needle);
+function tokenize(normalized: string): string[] {
+  return normalized.match(/[a-z0-9]+/g) ?? [];
 }
 
-// ---------------------------------------------------------------------------
+function tokensContainRun(tokens: string[], needle: string[]): boolean {
+  if (needle.length === 0) return false;
+  for (let i = 0; i + needle.length <= tokens.length; i += 1) {
+    let matches = true;
+    for (let j = 0; j < needle.length; j += 1) {
+      if (tokens[i + j] !== needle[j]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return true;
+  }
+  return false;
+}
+
+function basenameOf(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(index + 1) : normalized;
+}
+
+/** Map an OCR-extracted image path to its containing OCR markdown document. */
+export function containingDocumentFor(imagePath: string): string | null {
+  const normalized = imagePath.replace(/\\/g, "/");
+  const match = /^(.*)_images\/[^/]+$/.exec(normalized);
+  return match ? `${match[1]}.md` : null;
+}
+
 // Type-aware term selection
 // ---------------------------------------------------------------------------
 
@@ -681,157 +427,6 @@ function indexOfUnit(source: ParsedSource, rawText: string): number {
  * one raw char at a time, tracking collapsed whitespace, then applying the same
  * dotted-initial fold to the normalized chars and their raw-offset map.
  */
-function buildNormToRawMap(rawText: string): { norm: string; map: number[] } {
-  const normChars: string[] = [];
-  const map: number[] = [];
-  let pendingSpace = false; // a run of whitespace not yet emitted
-  let sawNonSpace = false; // have we emitted any non-space char yet (for trim)
-  for (let i = 0; i < rawText.length; i += 1) {
-    const ch = rawText[i] ?? "";
-    // Per-char base normalization; dotted-initial folding is applied below
-    // because it depends on neighboring normalized characters.
-    const piece = normalizeForMatchBase(ch);
-    if (piece === "") {
-      // Whitespace (or a char that normalizes away, e.g. a combining mark).
-      // Treat only real whitespace as a collapsible separator.
-      if (/\s/.test(ch)) pendingSpace = true;
-      continue;
-    }
-    if (pendingSpace && sawNonSpace) {
-      normChars.push(" ");
-      map.push(i); // the collapsed space anchors at the start of this token
-    }
-    pendingSpace = false;
-    // A single raw char can normalize to multiple chars (œ→oe). Map them all to
-    // the same raw offset.
-    for (const c of piece) {
-      normChars.push(c);
-      map.push(i);
-    }
-    sawNonSpace = true;
-  }
-
-  const norm = normChars.join("");
-  const foldedChars: string[] = [];
-  const foldedMap: number[] = [];
-  let copiedUntil = 0;
-  DOTTED_INITIAL_RUN_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = DOTTED_INITIAL_RUN_RE.exec(norm)) !== null) {
-    const start = match.index;
-    const end = start + match[0].length;
-    for (let i = copiedUntil; i < start; i += 1) {
-      foldedChars.push(norm[i] ?? "");
-      foldedMap.push(map[i] ?? 0);
-    }
-    for (let i = start; i < end; i += 1) {
-      const c = norm[i] ?? "";
-      if (c === " ") continue;
-      foldedChars.push(c);
-      foldedMap.push(map[i] ?? 0);
-    }
-    copiedUntil = end;
-  }
-  for (let i = copiedUntil; i < norm.length; i += 1) {
-    foldedChars.push(norm[i] ?? "");
-    foldedMap.push(map[i] ?? 0);
-  }
-
-  return { norm: foldedChars.join(""), map: foldedMap };
-}
-
-/**
- * Map a normalized term to its exact RAW offset in the unit text via the
- * normalized→raw offset map, so windowing centers on the matched term even when
- * the raw text has heavy/NBSP whitespace (a windowed quote must contain the
- * term, not drift off it). Returns -1 if the term is not present.
- */
-function rawOffsetForTerm(rawText: string, normTerm: string): number {
-  if (!normTerm) return -1;
-  const { norm, map } = buildNormToRawMap(rawText);
-  const at = norm.indexOf(normTerm);
-  if (at < 0) return -1;
-  return map[at] ?? -1;
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * Split a NORMALIZED string into word tokens (letters/digits runs). Used for
- * whole-word surname matching against section headings so a surname is never a
- * mid-word substring (e.g. "Mat" must not match inside "Mathématiques").
- */
-function tokenize(normalized: string): string[] {
-  return normalized.match(/[a-z0-9]+/g) ?? [];
-}
-
-/**
- * True iff `needle` (a token run) appears as a CONTIGUOUS whole-token run inside
- * `tokens`. Single-token surnames match a single heading token; multi-token
- * surnames ("de la tour") match the contiguous run. Empty needle → false.
- */
-function tokensContainRun(tokens: string[], needle: string[]): boolean {
-  if (needle.length === 0) return false;
-  for (let i = 0; i + needle.length <= tokens.length; i += 1) {
-    let ok = true;
-    for (let j = 0; j < needle.length; j += 1) {
-      if (tokens[i + j] !== needle[j]) {
-        ok = false;
-        break;
-      }
-    }
-    if (ok) return true;
-  }
-  return false;
-}
-
-/**
- * Map an OCR-extracted image path back to the markdown document that contains
- * it. graphify's pdf-ocr writes `<stem>.md` alongside `<stem>_images/image-N.*`
- * (pdf-ocr.ts), so `…/<stem>_images/image-000.jpg` → `…/<stem>.md`. Returns null
- * when the path does not match that convention.
- */
-export function containingDocumentFor(imagePath: string): string | null {
-  const norm = imagePath.replace(/\\/g, "/");
-  const m = /^(.*)_images\/[^/]+$/.exec(norm);
-  if (!m) return null;
-  return `${m[1]}.md`;
-}
-
-// ---------------------------------------------------------------------------
-// Source resolution + the graph-level driver
-// ---------------------------------------------------------------------------
-
-export interface ResolveSourceOptions {
-  /** Project root; `source_file` is resolved relative to it. */
-  root: string;
-  /** Extra search roots (e.g. `.graphify/converted`). */
-  searchRoots?: string[];
-}
-
-/**
- * Resolve a node's `source_file` to an on-disk path. Tries: absolute as-is,
- * relative to root, then relative to each search root. Returns null if none
- * exists. Pure (only fs.existsSync via readFileSync try/catch in the caller).
- */
-export function resolveSourcePath(sourceFile: string, options: ResolveSourceOptions): string | null {
-  if (!sourceFile) return null;
-  const candidates: string[] = [];
-  if (isAbsolute(sourceFile)) candidates.push(sourceFile);
-  candidates.push(resolvePath(options.root, sourceFile));
-  for (const r of options.searchRoots ?? []) candidates.push(resolvePath(r, sourceFile));
-  for (const c of candidates) {
-    try {
-      readFileSync(c);
-      return c;
-    } catch {
-      /* not here */
-    }
-  }
-  return null;
-}
 
 export interface CiteGraphOptions {
   /** Project root for resolving each node's `source_file`. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import type {
   Extraction,
   GraphifyInputScopeMode,
   InputScopeSource,
+  NormalizedLlmExecutionPolicy,
   NormalizedOntologyProfile,
   NormalizedProjectConfig,
   RegistryRecord,
@@ -54,7 +55,18 @@ import { DEFAULT_GRAPHIFY_STATE_DIR, defaultManifestPath, resolveGraphInputPath,
 import { normalizeSearchText, scoreSearchText } from "./search.js";
 import { makeGraphPortable, projectRootLabel, scanPortableGraphifyArtifacts } from "./portable-artifacts.js";
 import { loadOntologyPatchContext } from "./ontology-patch-context.js";
-import { linkEntities, writeEntityLinkingArtifacts } from "./entity-linking.js";
+import {
+  directLlmSpanProposer,
+  linkEntities,
+  requiresLlmProposer,
+  writeEntityLinkingArtifacts,
+  type LlmSpanProposer,
+} from "./entity-linking.js";
+import {
+  createDirectTextJsonClient,
+  isDirectLlmProvider,
+  preflightLlmExecution,
+} from "./llm-execution.js";
 import {
   evaluateOccurrences,
   formatEvaluationReport,
@@ -177,6 +189,7 @@ interface LinkRuntimeContext {
   profile: NormalizedOntologyProfile;
   registries: Record<string, RegistryRecord[]>;
   sourceFiles: string[];
+  llmExecution?: NormalizedLlmExecutionPolicy;
 }
 
 function linkingSourceFiles(detection: DetectionResult): string[] {
@@ -208,6 +221,7 @@ function loadLinkRuntimeContext(profileStatePath: string): LinkRuntimeContext {
     profile,
     registries,
     sourceFiles: linkingSourceFiles(detection),
+    ...(projectConfig?.llm_execution ? { llmExecution: projectConfig.llm_execution } : {}),
   };
 }
 
@@ -4597,18 +4611,43 @@ export async function main(): Promise<void> {
           profile: prepared.profile,
           registries: prepared.registries,
           sourceFiles: linkingSourceFiles(prepared.semanticDetection),
+          ...(prepared.projectConfig?.llm_execution ? { llmExecution: prepared.projectConfig.llm_execution } : {}),
         };
       }
       const nodeTypes = typeof opts.nodeTypes === "string"
         ? opts.nodeTypes.split(",").map((value: string) => value.trim()).filter(Boolean)
         : [];
-      const result = linkEntities({
+      const preset = typeof opts.preset === "string" && opts.preset.trim() ? opts.preset.trim() : undefined;
+      const dryRun = Boolean(opts.dryRun);
+
+      // Wire the opt-in LLM span proposer ONLY when a linking node_type could
+      // use it AND a live `direct` provider is configured AND this is not a
+      // dry-run. The proposer PROPOSES spans; graphify still resolves via the
+      // exact/none resolver + verbatim gate. Absent all this ⇒ zero LLM calls
+      // (the $0 default is preserved for gazetteer-exact / no linking block).
+      let llmProposer: LlmSpanProposer | undefined;
+      const wantsLlm = requiresLlmProposer(runtime.profile, {
+        ...(nodeTypes.length > 0 ? { nodeTypes } : {}),
+        ...(preset ? { preset } : {}),
+      });
+      if (wantsLlm && !dryRun && runtime.llmExecution?.mode === "direct" && isDirectLlmProvider(runtime.llmExecution.provider)) {
+        preflightLlmExecution(runtime.llmExecution, "text_json");
+        const client = createDirectTextJsonClient({
+          provider: runtime.llmExecution.provider,
+          ...(runtime.llmExecution.text_json.model ? { model: runtime.llmExecution.text_json.model } : {}),
+        });
+        llmProposer = directLlmSpanProposer(client, { stateDir: runtime.stateDir });
+      }
+
+      const result = await linkEntities({
         root: runtime.root,
         profile: runtime.profile,
         registries: runtime.registries,
         sourceFiles: runtime.sourceFiles,
         ...(nodeTypes.length > 0 ? { nodeTypes } : {}),
-        ...(typeof opts.preset === "string" && opts.preset.trim() ? { preset: opts.preset.trim() } : {}),
+        ...(preset ? { preset } : {}),
+        ...(llmProposer ? { llmProposer } : {}),
+        ...(dryRun ? { llmDryRun: true } : {}),
       });
       if (result.noOp) {
         console.log("link: no node_type declares linking; no-op. Existing occurrences.json unchanged.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import type {
   NormalizedOntologyProfile,
   NormalizedProjectConfig,
   RegistryRecord,
+  TypedEntityOccurrenceV1,
 } from "./types.js";
 import { runConfiguredDataprep, type ProfileState } from "./configured-dataprep.js";
 import {
@@ -54,6 +55,12 @@ import { normalizeSearchText, scoreSearchText } from "./search.js";
 import { makeGraphPortable, projectRootLabel, scanPortableGraphifyArtifacts } from "./portable-artifacts.js";
 import { loadOntologyPatchContext } from "./ontology-patch-context.js";
 import { linkEntities, writeEntityLinkingArtifacts } from "./entity-linking.js";
+import {
+  evaluateOccurrences,
+  formatEvaluationReport,
+  GoldValidationError,
+  parseGold,
+} from "./profile-evaluate.js";
 import { persistCommunityLabels, resolveCommunityLabels } from "./community-labels.js";
 import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
 import { replaceOrAppendSection } from "./skill-install.js";
@@ -135,6 +142,33 @@ function resolvePortableCheckDir(inputPath: string = ".graphify"): string {
 
 function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(resolve(path), "utf-8")) as T;
+}
+
+/** Coerce an unknown `{ metric: number }` config block into numeric thresholds. */
+function coerceThresholds(value: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const [metric, raw] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof raw === "number" && Number.isFinite(raw)) out[metric] = raw;
+    }
+  }
+  return out;
+}
+
+/** Parse repeatable `--floor metric=value` flags. Returns null on a bad value. */
+function parseThresholdFlags(flags: unknown): Record<string, number> | null {
+  const out: Record<string, number> = {};
+  if (!Array.isArray(flags)) return out;
+  for (const flag of flags) {
+    if (typeof flag !== "string") return null;
+    const eq = flag.indexOf("=");
+    if (eq <= 0) return null;
+    const metric = flag.slice(0, eq).trim();
+    const value = Number.parseFloat(flag.slice(eq + 1).trim());
+    if (!metric || !Number.isFinite(value)) return null;
+    out[metric] = value;
+  }
+  return out;
 }
 
 interface LinkRuntimeContext {
@@ -2874,6 +2908,106 @@ export async function main(): Promise<void> {
         console.log(profileValidationResultToMarkdown(result));
       }
       if (!result.valid) process.exit(1);
+    });
+
+  // graphify profile evaluate  (L5)
+  // Deterministic, $0 (no LLM) measurement of a `graphify link` run against a
+  // hand-labelled gold in the SAME occurrence schema. Emits evaluation.json and
+  // a CI gate: exit 0 iff validation + floors + ceilings pass, non-zero
+  // otherwise. Precision and unresolved-rate are always reported together.
+  profile
+    .command("evaluate")
+    .description("Measure a link run's occurrences.json against a gold set ($0, deterministic; gate on floors/ceilings)")
+    .requiredOption("--run <path>", "occurrences.json produced by graphify link")
+    .requiredOption("--gold <path>", "gold occurrence set (graphify_typed_linking_gold_v1 envelope)")
+    .option("--out <path>", "Write evaluation.json here")
+    .option("--profile-state <path>", "Stamp profile_hash + normalizer_hashes from a profile state")
+    .option("--corpus <root>", "Corpus root to verify gold raw_span slices (stale-gold detection)")
+    .option("--floors <path>", "JSON gate config { floors, ceilings } (or an { evaluation } block)")
+    .option("--floor <metric=value>", "Floor override metric=value (repeatable)", (value: string, acc: string[]) => [...acc, value], [] as string[])
+    .option("--ceiling <metric=value>", "Ceiling override metric=value (repeatable)", (value: string, acc: string[]) => [...acc, value], [] as string[])
+    .option("--json", "Print evaluation.json to stdout instead of the report")
+    .action(async (opts) => {
+      const run = readJson<unknown>(opts.run);
+      let gold;
+      try {
+        gold = parseGold(readJson<unknown>(opts.gold));
+      } catch (error) {
+        if (error instanceof GoldValidationError) {
+          console.error(`profile evaluate: ${error.message}`);
+          process.exitCode = 1;
+          return;
+        }
+        throw error;
+      }
+
+      const floors: Record<string, number> = {};
+      const ceilings: Record<string, number> = {};
+      if (opts.floors) {
+        const raw = readJson<Record<string, unknown>>(opts.floors);
+        const block = (raw && typeof raw.evaluation === "object" && raw.evaluation !== null ? raw.evaluation : raw) as Record<string, unknown>;
+        Object.assign(floors, coerceThresholds(block.floors));
+        Object.assign(ceilings, coerceThresholds(block.ceilings));
+      }
+      const flagFloors = parseThresholdFlags(opts.floor);
+      const flagCeilings = parseThresholdFlags(opts.ceiling);
+      if (flagFloors === null || flagCeilings === null) {
+        console.error("profile evaluate: --floor/--ceiling must be metric=value with a numeric value");
+        process.exitCode = 1;
+        return;
+      }
+      Object.assign(floors, flagFloors);
+      Object.assign(ceilings, flagCeilings);
+
+      let profileHash: string | null = null;
+      let normalizerHashes: Record<string, string> = {};
+      if (opts.profileState) {
+        const runtime = loadLinkRuntimeContext(resolve(opts.profileState));
+        profileHash = runtime.profile.profile_hash ?? null;
+        for (const [nodeType, config] of Object.entries(runtime.profile.node_types)) {
+          const hash = config.linking?.normalizer?.normalizer_hash;
+          if (hash) normalizerHashes[nodeType] = hash;
+        }
+      }
+
+      let corpusSlice: ((occurrence: TypedEntityOccurrenceV1) => string | null) | undefined;
+      if (opts.corpus) {
+        const corpusRoot = resolve(opts.corpus);
+        corpusSlice = (occurrence) => {
+          const path = resolve(corpusRoot, occurrence.source_file);
+          if (!existsSync(path)) return null;
+          const raw = readFileSync(path, "utf-8");
+          return raw.slice(occurrence.offsets.start, occurrence.offsets.end);
+        };
+      }
+
+      let result;
+      try {
+        result = evaluateOccurrences({
+          run: run as TypedEntityOccurrenceV1[],
+          gold,
+          floors,
+          ceilings,
+          profileHash,
+          normalizerHashes,
+          ...(corpusSlice ? { corpusSlice } : {}),
+        });
+      } catch (error) {
+        if (error instanceof GoldValidationError) {
+          console.error(`profile evaluate: ${error.message}`);
+          process.exitCode = 1;
+          return;
+        }
+        throw error;
+      }
+
+      if (opts.out) writeJson(resolve(opts.out), result);
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatEvaluationReport(result));
+      }
+      if (result.gate === "fail") process.exitCode = 1;
     });
 
   profile

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   renameSync,
   realpathSync,
   rmSync,
@@ -26,8 +27,9 @@ import type {
   InputScopeSource,
   NormalizedOntologyProfile,
   NormalizedProjectConfig,
+  RegistryRecord,
 } from "./types.js";
-import type { ProfileState } from "./configured-dataprep.js";
+import { runConfiguredDataprep, type ProfileState } from "./configured-dataprep.js";
 import {
   inspectInputScope,
   resolveCliInputScopeSelection,
@@ -51,6 +53,7 @@ import { DEFAULT_GRAPHIFY_STATE_DIR, defaultManifestPath, resolveGraphInputPath,
 import { normalizeSearchText, scoreSearchText } from "./search.js";
 import { makeGraphPortable, projectRootLabel, scanPortableGraphifyArtifacts } from "./portable-artifacts.js";
 import { loadOntologyPatchContext } from "./ontology-patch-context.js";
+import { linkEntities, writeEntityLinkingArtifacts } from "./entity-linking.js";
 import { persistCommunityLabels, resolveCommunityLabels } from "./community-labels.js";
 import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
 import { replaceOrAppendSection } from "./skill-install.js";
@@ -132,6 +135,46 @@ function resolvePortableCheckDir(inputPath: string = ".graphify"): string {
 
 function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(resolve(path), "utf-8")) as T;
+}
+
+interface LinkRuntimeContext {
+  root: string;
+  stateDir: string;
+  profile: NormalizedOntologyProfile;
+  registries: Record<string, RegistryRecord[]>;
+  sourceFiles: string[];
+}
+
+function linkingSourceFiles(detection: DetectionResult): string[] {
+  return [...(detection.files.document ?? []), ...(detection.files.paper ?? [])]
+    .filter((file): file is string => typeof file === "string")
+    .sort();
+}
+
+function loadLinkRuntimeContext(profileStatePath: string): LinkRuntimeContext {
+  const statePath = resolve(profileStatePath);
+  const profileDir = dirname(statePath);
+  const state = readJson<ProfileState>(statePath);
+  const profile = readJson<NormalizedOntologyProfile>(join(profileDir, "ontology-profile.normalized.json"));
+  const projectConfigPath = join(profileDir, "project-config.normalized.json");
+  const projectConfig = existsSync(projectConfigPath)
+    ? readJson<NormalizedProjectConfig>(projectConfigPath)
+    : undefined;
+  const registries: Record<string, RegistryRecord[]> = {};
+  const registriesDir = join(profileDir, "registries");
+  if (existsSync(registriesDir)) {
+    for (const file of readdirSync(registriesDir).filter((entry) => entry.endsWith(".json")).sort()) {
+      registries[file.slice(0, -".json".length)] = readJson<RegistryRecord[]>(join(registriesDir, file));
+    }
+  }
+  const detection = readJson<DetectionResult>(join(profileDir, "semantic-detection.json"));
+  return {
+    root: projectConfig?.configDir ?? dirname(resolve(state.project_config_path)),
+    stateDir: state.state_dir,
+    profile,
+    registries,
+    sourceFiles: linkingSourceFiles(detection),
+  };
 }
 
 function isJsonRecord(value: unknown): value is Record<string, unknown> {
@@ -4387,6 +4430,73 @@ export async function main(): Promise<void> {
           "The original duplicate-discard dropped citations a backfill cannot recover. " +
           "Re-extract the corpus for true exhaustive counts.",
       );
+    });
+
+  // ---------------------------------------------------------------------------
+  // graphify link [path]
+  // Deterministic document-centric typed entity linking. It consumes the
+  // configured dataprep corpus (or an existing profile-state) and is explicitly
+  // opt-in: profiles without a linking block leave artifacts untouched.
+  // ---------------------------------------------------------------------------
+  program
+    .command("link [path]")
+    .description("Link verified entity mentions to configured registries (deterministic, no-key)")
+    .option("--profile-state <path>", "Path to configured .graphify/profile/profile-state.json")
+    .option("--node-types <list>", "Restrict to comma-separated linked node types")
+    .option("--preset <name>", "Override the profile linking preset for this run")
+    .option("--out <path>", "Occurrence list output path", ".graphify/ontology/occurrences.json")
+    .option("--dry-run", "Calculate occurrences without writing artifacts")
+    .action(async (linkPath = ".", opts) => {
+      const requestedRoot = resolve(linkPath);
+      let runtime: LinkRuntimeContext;
+      const defaultState = join(requestedRoot, ".graphify", "profile", "profile-state.json");
+      const statePath = opts.profileState ? resolve(requestedRoot, opts.profileState) : defaultState;
+      if (existsSync(statePath)) {
+        runtime = loadLinkRuntimeContext(statePath);
+      } else {
+        // First run: delegate corpus discovery/preparation to the configured
+        // dataprep owner instead of maintaining a second discovery path here.
+        const prepared = await runConfiguredDataprep(requestedRoot);
+        runtime = {
+          root: prepared.root,
+          stateDir: prepared.paths.stateDir,
+          profile: prepared.profile,
+          registries: prepared.registries,
+          sourceFiles: linkingSourceFiles(prepared.semanticDetection),
+        };
+      }
+      const nodeTypes = typeof opts.nodeTypes === "string"
+        ? opts.nodeTypes.split(",").map((value: string) => value.trim()).filter(Boolean)
+        : [];
+      const result = linkEntities({
+        root: runtime.root,
+        profile: runtime.profile,
+        registries: runtime.registries,
+        sourceFiles: runtime.sourceFiles,
+        ...(nodeTypes.length > 0 ? { nodeTypes } : {}),
+        ...(typeof opts.preset === "string" && opts.preset.trim() ? { preset: opts.preset.trim() } : {}),
+      });
+      if (result.noOp) {
+        console.log("link: no node_type declares linking; no-op. Existing occurrences.json unchanged.");
+        return;
+      }
+      const outputPath = resolve(runtime.root, opts.out);
+      if (opts.dryRun) {
+        console.log(
+          `link (dry-run): ${result.occurrences.length} occurrence(s) across ${result.scannedDocuments} document(s); no files written.`,
+        );
+      } else {
+        writeEntityLinkingArtifacts(dirname(outputPath), runtime.profile, result);
+        console.log(
+          `link: wrote ${result.occurrences.length} occurrence(s) from ${result.scannedDocuments} document(s) to ${outputPath}.`,
+        );
+      }
+      for (const finding of result.issues) {
+        const output = `link: ${finding.severity.toUpperCase()} ${finding.code}: ${finding.message}`;
+        if (finding.severity === "error") console.error(output);
+        else console.warn(output);
+      }
+      if (result.issues.some((finding) => finding.severity === "error")) process.exitCode = 1;
     });
 
   // ---------------------------------------------------------------------------

--- a/src/entity-linking.ts
+++ b/src/entity-linking.ts
@@ -1,0 +1,581 @@
+/** Deterministic, $0 typed entity-linking pass behind `graphify link`. */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+
+import { compileNormalizerByNodeType, type EntityNormalizer } from "./entity-normalizer.js";
+import {
+  buildNormToRawMap,
+  detectModality,
+  normalizeForMatch,
+  parseSource,
+  verifyVerbatim,
+  type ParsedSource,
+  type SourceUnit,
+} from "./source-grounding.js";
+import type {
+  LinkValidationIssue,
+  NormalizedOntologyNodeTypeLinking,
+  NormalizedOntologyProfile,
+  OntologyLinkDetector,
+  RegistryRecord,
+  TypedEntityOccurrenceV1,
+} from "./types.js";
+
+const DETECTOR_PRIORITY: Record<TypedEntityOccurrenceV1["detector"], number> = {
+  lexicon: 0,
+  pattern: 1,
+  llm: 2,
+};
+
+export interface RawCandidate {
+  node_type: string;
+  detector: TypedEntityOccurrenceV1["detector"];
+  raw_span: string;
+  source_file: string;
+  page: number | null;
+  offsets: { start: number; end: number };
+  registry_record_id?: string;
+}
+
+export interface RegistryIndex {
+  registryId: string;
+  partition: string | null;
+  normalizerHash: string;
+  /** One compiled surface scan rather than document × registry-record loops. */
+  surfaceMatcher: RegExp | null;
+  labelIds: Map<string, Set<string>>;
+  aliasIds: Map<string, Set<string>>;
+  membership: Set<string>;
+  ids: Set<string>;
+}
+
+export interface DetectorContext {
+  rawSource: string;
+  sourceFile: string;
+  normalizer: EntityNormalizer;
+  registryIndex: RegistryIndex;
+}
+
+export type EntityDetector = (units: SourceUnit[], context: DetectorContext) => RawCandidate[];
+
+interface LinkingType {
+  nodeType: string;
+  registryId: string;
+  registryPartitioned: boolean;
+  linking: NormalizedOntologyNodeTypeLinking;
+  normalizer: EntityNormalizer;
+}
+
+export interface EntityLinkingInput {
+  root: string;
+  profile: NormalizedOntologyProfile;
+  registries: Record<string, RegistryRecord[]>;
+  sourceFiles: string[];
+  nodeTypes?: string[];
+  preset?: string;
+}
+
+export interface EntityLinkingResult {
+  occurrences: TypedEntityOccurrenceV1[];
+  issues: LinkValidationIssue[];
+  scannedDocuments: number;
+  noOp: boolean;
+}
+
+export interface EntityOccurrenceSummary {
+  total: number;
+  documents: Record<string, number>;
+  snippets: string[];
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function isWordChar(value: string | undefined): boolean {
+  return value !== undefined && /[\p{L}\p{N}_]/u.test(value);
+}
+
+function validSurfaceBoundary(normalized: string, start: number, term: string): boolean {
+  const before = normalized[start - 1];
+  const after = normalized[start + term.length];
+  return !(isWordChar(term[0]) && isWordChar(before)) && !(isWordChar(term.at(-1)) && isWordChar(after));
+}
+
+function codeUnitLengthAt(source: string, offset: number): number {
+  const point = source.codePointAt(offset);
+  return point !== undefined && point > 0xffff ? 2 : 1;
+}
+
+function rawEndForNormalizedSpan(unit: SourceUnit, rawSource: string, start: number, length: number): number | null {
+  if (!unit.normToRaw || unit.documentEnd === undefined) return null;
+  const rawStart = unit.normToRaw[start];
+  const rawLast = unit.normToRaw[start + length - 1];
+  if (rawStart === undefined || rawLast === undefined) return null;
+  let end = rawLast + codeUnitLengthAt(rawSource, rawLast);
+  // Keep a decomposed combining tail inside the raw source span.
+  while (end < unit.documentEnd && /\p{M}/u.test(rawSource[end] ?? "")) end += codeUnitLengthAt(rawSource, end);
+  return end;
+}
+
+function candidateFromNormalizedMatch(
+  unit: SourceUnit,
+  context: DetectorContext,
+  detector: RawCandidate["detector"],
+  index: number,
+  normalizedTerm: string,
+): RawCandidate | null {
+  const start = unit.normToRaw?.[index];
+  const end = rawEndForNormalizedSpan(unit, context.rawSource, index, normalizedTerm.length);
+  if (start === undefined || end === null || start >= end) return null;
+  const rawSpan = context.rawSource.slice(start, end);
+  if (normalizeForMatch(rawSpan) !== normalizedTerm) return null;
+  return {
+    node_type: "",
+    detector,
+    raw_span: rawSpan,
+    source_file: context.sourceFile,
+    page: unit.page,
+    offsets: { start, end },
+  };
+}
+
+/** Hard occurrence gate: offsets must resolve to the exact raw candidate span. */
+export function verifyRawCandidate(rawSource: string, candidate: Pick<RawCandidate, "raw_span" | "offsets">): boolean {
+  return rawSource.slice(candidate.offsets.start, candidate.offsets.end) === candidate.raw_span
+    && verifyVerbatim(candidate.raw_span, normalizeForMatch(rawSource));
+}
+
+/** A single-regex lexical scan against a partition-scoped surface index. */
+export const detectLexicon: EntityDetector = (units, context) => {
+  const matcher = context.registryIndex.surfaceMatcher;
+  if (!matcher) return [];
+  const candidates: RawCandidate[] = [];
+  for (const unit of units) {
+    if (!unit.normalizedText) continue;
+    matcher.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = matcher.exec(unit.normalizedText)) !== null) {
+      const term = match[0] ?? "";
+      if (!term || !validSurfaceBoundary(unit.normalizedText, match.index, term)) continue;
+      const candidate = candidateFromNormalizedMatch(unit, context, "lexicon", match.index, term);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+};
+
+function patternDetectors(detectors: OntologyLinkDetector[]): Array<{ form: string; flags?: string }> {
+  const patterns: Array<{ form: string; flags?: string }> = [];
+  for (const detector of detectors) {
+    if (detector === "pattern") continue; // The preset macro has no consumer form by itself.
+    if (typeof detector === "object" && "pattern" in detector) {
+      patterns.push({ form: detector.pattern.form, ...(detector.pattern.flags ? { flags: detector.pattern.flags } : {}) });
+    }
+  }
+  return patterns;
+}
+
+/** Regex-form detector; membership is required before a candidate can exist. */
+export function detectPattern(units: SourceUnit[], context: DetectorContext, detectors: OntologyLinkDetector[]): RawCandidate[] {
+  const candidates: RawCandidate[] = [];
+  for (const pattern of patternDetectors(detectors)) {
+    const flags = `${pattern.flags ?? ""}`.replace(/y/gu, "").includes("g")
+      ? `${pattern.flags ?? ""}`.replace(/y/gu, "")
+      : `${pattern.flags ?? ""}`.replace(/y/gu, "") + "g";
+    const regex = new RegExp(pattern.form, flags);
+    for (const unit of units) {
+      if (unit.documentStart === undefined || unit.documentEnd === undefined) continue;
+      const source = context.rawSource.slice(unit.documentStart, unit.documentEnd);
+      let match: RegExpExecArray | null;
+      while ((match = regex.exec(source)) !== null) {
+        const rawSpan = match[0] ?? "";
+        if (!rawSpan) {
+          regex.lastIndex += 1;
+          continue;
+        }
+        const normalized = context.normalizer(rawSpan);
+        // This is the non-negotiable range/enum anti-invention gate.
+        if (!context.registryIndex.membership.has(normalized)) continue;
+        const start = unit.documentStart + match.index;
+        const end = start + rawSpan.length;
+        candidates.push({
+          node_type: "",
+          detector: "pattern",
+          raw_span: rawSpan,
+          source_file: context.sourceFile,
+          page: unit.page,
+          offsets: { start, end },
+        });
+      }
+    }
+  }
+  return candidates;
+}
+
+function registryIndexKey(registryId: string, partition: string | null, normalizerHash: string): string {
+  return `${registryId}\0${partition ?? ""}\0${normalizerHash}`;
+}
+
+function addKey(index: Map<string, Set<string>>, key: string, id: string): void {
+  const ids = index.get(key) ?? new Set<string>();
+  ids.add(id);
+  index.set(key, ids);
+}
+
+export function buildRegistryIndex(
+  registryId: string,
+  partition: string | null,
+  normalizerHash: string,
+  normalizer: EntityNormalizer,
+  records: RegistryRecord[],
+): RegistryIndex {
+  const labelIds = new Map<string, Set<string>>();
+  const aliasIds = new Map<string, Set<string>>();
+  const membership = new Set<string>();
+  const ids = new Set<string>();
+  const surfaceTerms = new Set<string>();
+  for (const record of records) {
+    if ((record.partition ?? null) !== partition) continue;
+    ids.add(record.id);
+    const label = normalizer(record.label);
+    addKey(labelIds, label, record.id);
+    membership.add(label);
+    const labelSurface = normalizeForMatch(record.label);
+    if (labelSurface) surfaceTerms.add(labelSurface);
+    for (const alias of record.aliases) {
+      const normalized = normalizer(alias);
+      addKey(aliasIds, normalized, record.id);
+      membership.add(normalized);
+      const aliasSurface = normalizeForMatch(alias);
+      if (aliasSurface) surfaceTerms.add(aliasSurface);
+    }
+  }
+  const terms = Array.from(surfaceTerms).sort((left, right) => right.length - left.length || left.localeCompare(right));
+  return {
+    registryId,
+    partition,
+    normalizerHash,
+    surfaceMatcher: terms.length > 0 ? new RegExp(terms.map(escapeRegExp).join("|"), "gu") : null,
+    labelIds,
+    aliasIds,
+    membership,
+    ids,
+  };
+}
+
+export function resolveEntityCandidate(
+  candidate: RawCandidate,
+  registryIndex: RegistryIndex,
+  normalizer: EntityNormalizer,
+  mode: "exact" | "none",
+): { resolution: TypedEntityOccurrenceV1["resolution"]; registryRecordId?: string; candidateIds: string[] } {
+  if (mode === "none") return { resolution: "unlinked", candidateIds: [] };
+  if (candidate.registry_record_id && registryIndex.ids.has(candidate.registry_record_id)) {
+    return { resolution: "linked", registryRecordId: candidate.registry_record_id, candidateIds: [candidate.registry_record_id] };
+  }
+  const normalized = normalizer(candidate.raw_span);
+  const labels = registryIndex.labelIds.get(normalized);
+  if (labels && labels.size === 1) {
+    const id = Array.from(labels)[0]!;
+    return { resolution: "linked", registryRecordId: id, candidateIds: [id] };
+  }
+  if (labels && labels.size > 1) return { resolution: "ambiguous", candidateIds: Array.from(labels).sort() };
+  const aliases = registryIndex.aliasIds.get(normalized);
+  if (aliases && aliases.size === 1) {
+    const id = Array.from(aliases)[0]!;
+    return { resolution: "linked", registryRecordId: id, candidateIds: [id] };
+  }
+  if (aliases && aliases.size > 1) return { resolution: "ambiguous", candidateIds: Array.from(aliases).sort() };
+  return { resolution: "unlinked", candidateIds: [] };
+}
+
+function sourceLabel(root: string, sourceFile: string): string {
+  const rel = relative(root, sourceFile);
+  return rel && !rel.startsWith(`..${sep}`) && rel !== ".." ? rel.split(sep).join("/") : resolve(sourceFile);
+}
+
+function partitionFor(
+  linking: NormalizedOntologyNodeTypeLinking,
+  sourceFile: string,
+  parsed: ParsedSource,
+  root: string,
+): string | null {
+  const binding = linking.partition_from;
+  if (!binding) return null;
+  const frontMatter = parsed.frontMatter?.[binding.source_frontmatter];
+  if (frontMatter && frontMatter.trim()) return frontMatter.trim();
+  const segment = binding.else?.path_segment;
+  if (segment === undefined) return null;
+  const parts = sourceLabel(root, sourceFile).split("/").filter(Boolean);
+  return parts[segment]?.trim() || null;
+}
+
+function linkingTypes(
+  profile: NormalizedOntologyProfile,
+  requestedNodeTypes: string[] | undefined,
+  normalizers: Record<string, EntityNormalizer>,
+  preset: string | undefined,
+): LinkingType[] {
+  const allowed = requestedNodeTypes && requestedNodeTypes.length > 0 ? new Set(requestedNodeTypes) : null;
+  return Object.entries(profile.node_types)
+    .filter(([nodeType, config]) => Boolean(config.linking) && (!allowed || allowed.has(nodeType)))
+    .flatMap(([nodeType, config]) => {
+      const registryId = config.registry;
+      const linking = config.linking;
+      const normalizer = normalizers[nodeType];
+      if (!registryId || !linking || !normalizer) return [];
+      const registryPartitioned = Boolean(profile.registries[registryId]?.partition_column);
+      if (!preset) return [{ nodeType, registryId, registryPartitioned, linking, normalizer }];
+      const detectors: OntologyLinkDetector[] = preset === "gazetteer-exact"
+        ? ["lexicon", "pattern"]
+        : preset === "open-extraction"
+          ? ["llm"]
+          : preset === "hybrid-recall"
+            ? ["lexicon", "pattern", "llm"]
+            : [];
+      if (detectors.length === 0) throw new Error(`unknown link preset ${preset}`);
+      return [{
+        nodeType,
+        registryId,
+        registryPartitioned,
+        normalizer,
+        linking: {
+          ...linking,
+          preset,
+          detect: [...detectors, ...linking.detect.filter((detector) => typeof detector === "object" && "pattern" in detector)],
+          resolve: { mode: preset === "open-extraction" ? "none" : "exact" },
+        },
+      }];
+    });
+}
+
+function hasLlmDetector(detectors: OntologyLinkDetector[]): boolean {
+  return detectors.some((detector) => detector === "llm" || (typeof detector === "object" && "llm" in detector));
+}
+
+function compareOccurrences(left: TypedEntityOccurrenceV1, right: TypedEntityOccurrenceV1): number {
+  return left.source_file.localeCompare(right.source_file)
+    || left.offsets.start - right.offsets.start
+    || left.offsets.end - right.offsets.end
+    || left.node_type.localeCompare(right.node_type)
+    || left.id.localeCompare(right.id);
+}
+
+function issue(code: string, severity: LinkValidationIssue["severity"], nodeType: string | null, message: string, refs: string[]): LinkValidationIssue {
+  return { code, severity, node_type: nodeType, message, refs };
+}
+
+/** Execute the deterministic producer pass without writing artifacts. */
+export function linkEntities(input: EntityLinkingInput): EntityLinkingResult {
+  const normalizers = compileNormalizerByNodeType(input.profile);
+  const types = linkingTypes(input.profile, input.nodeTypes, normalizers, input.preset);
+  if (types.length === 0) return { occurrences: [], issues: [], scannedDocuments: 0, noOp: true };
+
+  const issues: LinkValidationIssue[] = [];
+  const deduped = new Map<string, RawCandidate & { nodeType: LinkingType; partition: string | null }>();
+  const indexCache = new Map<string, RegistryIndex>();
+  let scannedDocuments = 0;
+
+  for (const nodeType of types) {
+    if (!hasLlmDetector(nodeType.linking.detect)) continue;
+    issues.push(issue(
+      "LINK_LLM_DETECTOR_UNAVAILABLE",
+      "warning",
+      nodeType.nodeType,
+      `preset ${nodeType.linking.preset ?? "custom"} requires L4b / llm detector not yet available`,
+      [`registry:${nodeType.registryId}`],
+    ));
+  }
+
+  for (const rawPath of Array.from(new Set(input.sourceFiles.map((file) => resolve(file)))).sort()) {
+    let rawSource: string;
+    try {
+      rawSource = readFileSync(rawPath, "utf-8");
+    } catch (error) {
+      issues.push(issue("LINK_SOURCE_UNREADABLE", "warning", null, `could not read ${rawPath}: ${error instanceof Error ? error.message : String(error)}`, [`source:${rawPath}`]));
+      continue;
+    }
+    const parsed = parseSource(rawSource, detectModality(rawPath));
+    const label = sourceLabel(input.root, rawPath);
+    scannedDocuments += 1;
+    for (const nodeType of types) {
+      const partition = partitionFor(nodeType.linking, rawPath, parsed, input.root);
+      if (nodeType.registryPartitioned && !partition) {
+        // Fail closed before a registry index or detector is constructed.
+        issues.push(issue(
+          "LINK_PARTITION_UNRESOLVED",
+          "error",
+          nodeType.nodeType,
+          `partitioned registry ${nodeType.registryId} has no resolved partition for ${label}; detection skipped`,
+          [`source:${label}`, `registry:${nodeType.registryId}`],
+        ));
+        continue;
+      }
+      const key = registryIndexKey(nodeType.registryId, partition, nodeType.linking.normalizer.normalizer_hash);
+      let registryIndex = indexCache.get(key);
+      if (!registryIndex) {
+        registryIndex = buildRegistryIndex(
+          nodeType.registryId,
+          partition,
+          nodeType.linking.normalizer.normalizer_hash,
+          nodeType.normalizer,
+          input.registries[nodeType.registryId] ?? [],
+        );
+        indexCache.set(key, registryIndex);
+      }
+      const context: DetectorContext = { rawSource, sourceFile: label, normalizer: nodeType.normalizer, registryIndex };
+      const candidates: RawCandidate[] = [];
+      if (nodeType.linking.detect.some((detector) => detector === "lexicon")) candidates.push(...detectLexicon(parsed.units, context));
+      if (nodeType.linking.detect.some((detector) => detector === "pattern" || (typeof detector === "object" && "pattern" in detector))) {
+        candidates.push(...detectPattern(parsed.units, context, nodeType.linking.detect));
+      }
+      for (const candidate of candidates) {
+        candidate.node_type = nodeType.nodeType;
+        // The source slice check is stronger than the normalised verifier and
+        // keeps the occurrence coordinate system pinned to the raw file.
+        if (
+          !verifyRawCandidate(rawSource, candidate)
+        ) {
+          issues.push(issue(
+            "LINK_VERBATIM_UNRELOCATABLE",
+            "warning",
+            nodeType.nodeType,
+            `candidate ${JSON.stringify(candidate.raw_span)} could not be verified verbatim in ${label}`,
+            [`source:${label}`],
+          ));
+          continue;
+        }
+        const keyForCandidate = [input.profile.profile_hash, label, nodeType.nodeType, candidate.offsets.start, candidate.offsets.end].join("|");
+        const previous = deduped.get(keyForCandidate);
+        if (!previous || DETECTOR_PRIORITY[candidate.detector] < DETECTOR_PRIORITY[previous.detector]) {
+          deduped.set(keyForCandidate, { ...candidate, nodeType, partition });
+        }
+      }
+    }
+  }
+
+  const occurrences: TypedEntityOccurrenceV1[] = [];
+  for (const candidate of deduped.values()) {
+    const type = candidate.nodeType;
+    const key = registryIndexKey(type.registryId, candidate.partition, type.linking.normalizer.normalizer_hash);
+    const registryIndex = indexCache.get(key)!;
+    const resolution = resolveEntityCandidate(candidate, registryIndex, type.normalizer, type.linking.resolve.mode);
+    const id = sha256([input.profile.profile_hash, candidate.source_file, type.nodeType, candidate.offsets.start, candidate.offsets.end].join("|")).slice(0, 24);
+    const occurrence: TypedEntityOccurrenceV1 = {
+      id,
+      node_type: type.nodeType,
+      raw_span: candidate.raw_span,
+      normalized: type.normalizer(candidate.raw_span),
+      source_file: candidate.source_file,
+      page: candidate.page,
+      offsets: candidate.offsets,
+      detector: candidate.detector,
+      resolution: resolution.resolution,
+      registry_partition: type.registryPartitioned ? candidate.partition : null,
+      ...(resolution.registryRecordId ? { registry_record_id: resolution.registryRecordId } : {}),
+    };
+    occurrences.push(occurrence);
+    if (resolution.resolution === "ambiguous") {
+      issues.push(issue(
+        "LINK_RESOLUTION_AMBIGUOUS",
+        "warning",
+        type.nodeType,
+        `${occurrence.raw_span} resolves to multiple registry records`,
+        [`occurrence:${id}`, ...resolution.candidateIds.map((recordId) => `record:${recordId}`)],
+      ));
+    }
+  }
+  const allowedOccurrenceTypes = new Set(input.profile.outputs.ontology.occurrence_node_types);
+  return {
+    occurrences: occurrences.filter((occurrence) => allowedOccurrenceTypes.has(occurrence.node_type)).sort(compareOccurrences),
+    issues,
+    scannedDocuments,
+    noOp: false,
+  };
+}
+
+function readNodeIdentityMap(outputDir: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const path = join(outputDir, "nodes.json");
+  if (!existsSync(path)) return map;
+  try {
+    const nodes = JSON.parse(readFileSync(path, "utf-8")) as Array<Record<string, unknown>>;
+    if (!Array.isArray(nodes)) return map;
+    for (const node of nodes) {
+      const nodeId = typeof node.id === "string" ? node.id : "";
+      const registryId = typeof node.registry_id === "string" ? node.registry_id : "";
+      const recordId = typeof node.registry_record_id === "string" ? node.registry_record_id : "";
+      const partition = typeof node.registry_partition === "string" ? node.registry_partition : "";
+      if (nodeId && registryId && recordId) map.set(`${registryId}\0${partition}\0${recordId}`, nodeId);
+    }
+  } catch {
+    // The Studio sidecar is best-effort; a later ontology output can supply nodes.
+  }
+  return map;
+}
+
+function registrySeedNodeId(registryId: string, recordId: string): string {
+  const safe = (value: string) => value
+    .trim()
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return `registry_${safe(registryId)}_${safe(recordId)}`;
+}
+
+/** Aggregate linked mention occurrences into the legacy Studio node-id view. */
+export function summarizeEntityOccurrences(
+  occurrences: TypedEntityOccurrenceV1[],
+  profile: NormalizedOntologyProfile,
+  outputDir: string,
+): Record<string, EntityOccurrenceSummary> {
+  const nodeIds = readNodeIdentityMap(outputDir);
+  const summary = new Map<string, { total: number; documents: Map<string, number>; snippets: string[] }>();
+  for (const occurrence of occurrences) {
+    if (occurrence.resolution !== "linked" || !occurrence.registry_record_id) continue;
+    const registryId = profile.node_types[occurrence.node_type]?.registry;
+    if (!registryId) continue;
+    const key = `${registryId}\0${occurrence.registry_partition ?? ""}\0${occurrence.registry_record_id}`;
+    // Registry extraction owns this stable seed id. The fallback lets link emit
+    // the Studio summary before a subsequent ontology-output compile materializes
+    // nodes.json, while an existing compiled node remains authoritative.
+    const nodeId = nodeIds.get(key) ?? registrySeedNodeId(registryId, occurrence.registry_record_id);
+    const entry = summary.get(nodeId) ?? { total: 0, documents: new Map<string, number>(), snippets: [] as string[] };
+    entry.total += 1;
+    entry.documents.set(occurrence.source_file, (entry.documents.get(occurrence.source_file) ?? 0) + 1);
+    if (entry.snippets.length < 3 && !entry.snippets.includes(occurrence.raw_span)) entry.snippets.push(occurrence.raw_span);
+    summary.set(nodeId, entry);
+  }
+  return Object.fromEntries(Array.from(summary.entries()).sort(([left], [right]) => left.localeCompare(right)).map(([nodeId, entry]) => [
+    nodeId,
+    {
+      total: entry.total,
+      documents: Object.fromEntries(Array.from(entry.documents.entries()).sort(([left], [right]) => left.localeCompare(right))),
+      snippets: entry.snippets,
+    },
+  ]));
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+/** Write the canonical list and derived Studio sidecar after a non-dry link run. */
+export function writeEntityLinkingArtifacts(
+  outputDir: string,
+  profile: NormalizedOntologyProfile,
+  result: EntityLinkingResult,
+): void {
+  writeJson(join(outputDir, "occurrences.json"), result.occurrences);
+  writeJson(join(outputDir, "entity-occurrence-summary.json"), summarizeEntityOccurrences(result.occurrences, profile, outputDir));
+  writeJson(join(outputDir, "validation.json"), {
+    schema: "graphify_ontology_validation_v1",
+    issues: result.issues,
+  });
+}

--- a/src/entity-linking.ts
+++ b/src/entity-linking.ts
@@ -13,11 +13,13 @@ import {
   type ParsedSource,
   type SourceUnit,
 } from "./source-grounding.js";
+import type { TextJsonGenerationClient } from "./llm-execution.js";
 import type {
   LinkValidationIssue,
   NormalizedOntologyNodeTypeLinking,
   NormalizedOntologyProfile,
   OntologyLinkDetector,
+  OntologyLinkLlmConfig,
   RegistryRecord,
   TypedEntityOccurrenceV1,
 } from "./types.js";
@@ -59,6 +61,36 @@ export interface DetectorContext {
 
 export type EntityDetector = (units: SourceUnit[], context: DetectorContext) => RawCandidate[];
 
+/**
+ * A single LLM-proposed candidate. The model PROPOSES a verbatim span only:
+ * `registry_record_id` is an optional HINT that the exact resolver revalidates
+ * against the document's partition — it is never authoritative.
+ */
+export interface LlmSpanProposal {
+  raw_span: string;
+  node_type?: string;
+  registry_record_id?: string;
+}
+
+export interface LlmProposeRequest {
+  nodeType: string;
+  sourceFile: string;
+  rawSource: string;
+  units: SourceUnit[];
+  partition: string | null;
+  allowedNodeTypes: string[];
+  budgetUsd?: number;
+}
+
+/**
+ * The span-proposal seam. Injected so the deterministic core stays $0 and
+ * tests mock it with zero network. The CLI adapts a `TextJsonGenerationClient`
+ * into this shape (see `directLlmSpanProposer`).
+ */
+export type LlmSpanProposer = (
+  request: LlmProposeRequest,
+) => Promise<LlmSpanProposal[]> | LlmSpanProposal[];
+
 interface LinkingType {
   nodeType: string;
   registryId: string;
@@ -74,6 +106,14 @@ export interface EntityLinkingInput {
   sourceFiles: string[];
   nodeTypes?: string[];
   preset?: string;
+  /**
+   * Opt-in span proposer for `llm` detectors. Absent ⇒ zero LLM calls (the $0
+   * default is preserved). Present ⇒ still only invoked when a node type
+   * declares an `llm` detector AND its trigger fires.
+   */
+  llmProposer?: LlmSpanProposer;
+  /** When true, `llm` detectors never make a paid proposal call (CLI --dry-run). */
+  llmDryRun?: boolean;
 }
 
 export interface EntityLinkingResult {
@@ -216,6 +256,231 @@ export function detectPattern(units: SourceUnit[], context: DetectorContext, det
     }
   }
   return candidates;
+}
+
+/** The bounded default when a preset expands `detect` to a bare `llm` string. */
+const DEFAULT_LLM_CONFIG: OntologyLinkLlmConfig = { trigger: "zero_candidates" };
+
+/** The declarative `llm` config for a detect list, or undefined if none opts in. */
+export function llmConfigFromDetectors(detectors: OntologyLinkDetector[]): OntologyLinkLlmConfig | undefined {
+  for (const detector of detectors) {
+    if (detector === "llm") return DEFAULT_LLM_CONFIG;
+    if (typeof detector === "object" && "llm" in detector) return detector.llm;
+  }
+  return undefined;
+}
+
+/**
+ * Relocate an LLM proposal onto raw-file coordinates. The proposal is only
+ * accepted when its `raw_span` occurs VERBATIM inside a scanned document unit
+ * (never the frontmatter) and passes the same `verifyRawCandidate` gate as the
+ * $0 detectors. A proposal that cannot be relocated verbatim is dropped.
+ */
+function relocateProposal(
+  rawSource: string,
+  units: SourceUnit[],
+  sourceFile: string,
+  proposal: LlmSpanProposal,
+): RawCandidate | null {
+  const span = proposal.raw_span;
+  if (typeof span !== "string" || span.length === 0) return null;
+  for (const unit of units) {
+    if (unit.documentStart === undefined || unit.documentEnd === undefined) continue;
+    const region = rawSource.slice(unit.documentStart, unit.documentEnd);
+    const idx = region.indexOf(span);
+    if (idx < 0) continue;
+    const start = unit.documentStart + idx;
+    const end = start + span.length;
+    const candidate: RawCandidate = {
+      node_type: "",
+      detector: "llm",
+      raw_span: span,
+      source_file: sourceFile,
+      page: unit.page,
+      offsets: { start, end },
+      // The id is only a HINT; resolveEntityCandidate revalidates it against
+      // the partition (`ids.has`) and never trusts it as authoritative.
+      ...(proposal.registry_record_id ? { registry_record_id: proposal.registry_record_id } : {}),
+    };
+    if (verifyRawCandidate(rawSource, candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The `llm` detector: it PROPOSES spans (via the injected proposer) and never
+ * resolves. Every proposal is relocated verbatim into the raw source; the
+ * caller then runs the SAME exact/none resolver used by lexicon/pattern.
+ */
+export async function detectLlm(
+  proposer: LlmSpanProposer,
+  request: LlmProposeRequest,
+): Promise<RawCandidate[]> {
+  const proposals = await proposer(request);
+  const candidates: RawCandidate[] = [];
+  for (const proposal of Array.isArray(proposals) ? proposals : []) {
+    if (!proposal || typeof proposal.raw_span !== "string") continue;
+    // Type discipline: a proposal for another node_type is discarded, not
+    // re-homed. The proposer is asked per node type.
+    if (proposal.node_type && proposal.node_type !== request.nodeType) continue;
+    const candidate = relocateProposal(request.rawSource, request.units, request.sourceFile, proposal);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates;
+}
+
+/**
+ * Decide whether the declared trigger fires, given the VERIFIED $0 candidates
+ * and their exact/none resolutions. `zero_candidates` (the default) always
+ * fires for an `llm`-only preset because there are no $0 detectors to satisfy.
+ */
+function shouldTriggerLlm(
+  verifiedZero: RawCandidate[],
+  config: OntologyLinkLlmConfig,
+  registryIndex: RegistryIndex,
+  normalizer: EntityNormalizer,
+  mode: "exact" | "none",
+): boolean {
+  const count = verifiedZero.length;
+  switch (config.trigger) {
+    case "zero_candidates":
+      return count === 0;
+    case "below_min_candidates":
+      return count < (config.min_candidates ?? 1);
+    case "unresolved_candidates": {
+      if (count === 0) return true;
+      return verifiedZero.some(
+        (candidate) => resolveEntityCandidate(candidate, registryIndex, normalizer, mode).resolution !== "linked",
+      );
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Why an otherwise-triggered `llm` detector must NOT call the provider this
+ * run. Returns null when a paid proposal is allowed. Order matters: a missing
+ * proposer (the $0 default / non-direct mode) is reported before dry-run and
+ * budget, since without a proposer nothing else applies.
+ */
+function llmSkipReason(
+  config: OntologyLinkLlmConfig,
+  dryRun: boolean | undefined,
+  proposer: LlmSpanProposer | undefined,
+): { code: string; severity: LinkValidationIssue["severity"]; message: string } | null {
+  if (!proposer) {
+    return {
+      code: "LINK_LLM_PROVIDER_UNAVAILABLE",
+      severity: "warning",
+      message: "llm detector triggered but no proposer is wired (llm_execution is not a live direct provider); ran $0 detectors only",
+    };
+  }
+  if (dryRun || config.dry_run) {
+    return {
+      code: "LINK_LLM_DRY_RUN",
+      severity: "info",
+      message: "llm detector triggered but skipped (dry-run); no paid proposal made",
+    };
+  }
+  if (config.budget_usd !== undefined && config.budget_usd <= 0) {
+    return {
+      code: "LINK_LLM_BUDGET_EXHAUSTED",
+      severity: "warning",
+      message: "llm detector triggered but budget_usd is 0; no proposal made",
+    };
+  }
+  return null;
+}
+
+/**
+ * True when a link run over this profile could invoke the `llm` detector, so
+ * the CLI only constructs a paid provider when it is actually needed. Mirrors
+ * how `linkingTypes` maps a preset override or per-type detect list.
+ */
+export function requiresLlmProposer(
+  profile: NormalizedOntologyProfile,
+  options: { nodeTypes?: string[]; preset?: string } = {},
+): boolean {
+  const allowed = options.nodeTypes && options.nodeTypes.length > 0 ? new Set(options.nodeTypes) : null;
+  const presetHasLlm = options.preset === "open-extraction" || options.preset === "hybrid-recall";
+  for (const [nodeType, config] of Object.entries(profile.node_types)) {
+    if (!config.linking || (allowed && !allowed.has(nodeType))) continue;
+    if (options.preset) {
+      if (presetHasLlm) return true;
+      continue;
+    }
+    if (hasLlmDetector(config.linking.detect)) return true;
+  }
+  return false;
+}
+
+const LLM_SPAN_PROPOSAL_SCHEMA = "graphify_typed_link_span_proposal_v1";
+
+function buildSpanProposalPrompt(request: LlmProposeRequest): string {
+  return [
+    "You are proposing candidate VERBATIM text spans for typed entity linking.",
+    `Node type to find: ${request.nodeType}.`,
+    "",
+    "Rules:",
+    "- Copy each span EXACTLY as it appears in the SOURCE (same characters, casing, punctuation).",
+    `- Propose only spans that are mentions of a ${request.nodeType}.`,
+    "- Do NOT invent identifiers, do NOT normalize, do NOT paraphrase or translate.",
+    "- If unsure, omit the span. graphify resolves ids itself; you only propose spans.",
+    "",
+    'Return JSON of the form: {"spans": [{"raw_span": "<verbatim substring>"}]}.',
+    "",
+    "SOURCE:",
+    request.rawSource,
+  ].join("\n");
+}
+
+/**
+ * Adapt the shared `TextJsonGenerationClient` (llm-execution.ts) — the same
+ * profile-LLM execution seam — into a span proposer. The model is constrained
+ * to PROPOSE spans; graphify still relocates + resolves them. No network is
+ * initiated here beyond the injected client's own call, so a fake client makes
+ * this fully testable offline.
+ */
+export function directLlmSpanProposer(
+  client: TextJsonGenerationClient,
+  options: { stateDir: string },
+): LlmSpanProposer {
+  return async (request: LlmProposeRequest): Promise<LlmSpanProposal[]> => {
+    const slug = `${request.nodeType}-${sha256(request.sourceFile).slice(0, 16)}`.replace(/[^A-Za-z0-9._-]+/g, "_");
+    const outputPath = join(options.stateDir, "llm-link-proposals", `${slug}.json`);
+    await client.generateJson({
+      schema: LLM_SPAN_PROPOSAL_SCHEMA,
+      prompt: buildSpanProposalPrompt(request),
+      outputPath,
+    });
+    // Assistant mode writes an instruction file (no JSON payload) and returns;
+    // the absence of the parsed sidecar then simply yields zero proposals.
+    if (!existsSync(outputPath)) return [];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(outputPath, "utf-8"));
+    } catch {
+      return [];
+    }
+    const spans = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === "object" && Array.isArray((parsed as { spans?: unknown }).spans)
+        ? (parsed as { spans: unknown[] }).spans
+        : [];
+    const proposals: LlmSpanProposal[] = [];
+    for (const span of spans) {
+      if (!span || typeof span !== "object") continue;
+      const rawSpan = (span as { raw_span?: unknown }).raw_span;
+      if (typeof rawSpan !== "string" || !rawSpan) continue;
+      const recordId = (span as { registry_record_id?: unknown }).registry_record_id;
+      proposals.push({
+        raw_span: rawSpan,
+        ...(typeof recordId === "string" && recordId ? { registry_record_id: recordId } : {}),
+      });
+    }
+    return proposals;
+  };
 }
 
 function registryIndexKey(registryId: string, partition: string | null, normalizerHash: string): string {
@@ -371,8 +636,14 @@ function issue(code: string, severity: LinkValidationIssue["severity"], nodeType
   return { code, severity, node_type: nodeType, message, refs };
 }
 
-/** Execute the deterministic producer pass without writing artifacts. */
-export function linkEntities(input: EntityLinkingInput): EntityLinkingResult {
+/**
+ * Execute the deterministic producer pass without writing artifacts. Async so
+ * an opt-in `llm` detector can PROPOSE spans (via `input.llmProposer`); every
+ * proposal still flows through the SAME exact/none resolver + verbatim gate as
+ * the $0 detectors. With no `llm` detector (or no proposer) zero LLM calls are
+ * made and the pass is byte-for-byte the deterministic $0 pass.
+ */
+export async function linkEntities(input: EntityLinkingInput): Promise<EntityLinkingResult> {
   const normalizers = compileNormalizerByNodeType(input.profile);
   const types = linkingTypes(input.profile, input.nodeTypes, normalizers, input.preset);
   if (types.length === 0) return { occurrences: [], issues: [], scannedDocuments: 0, noOp: true };
@@ -381,17 +652,6 @@ export function linkEntities(input: EntityLinkingInput): EntityLinkingResult {
   const deduped = new Map<string, RawCandidate & { nodeType: LinkingType; partition: string | null }>();
   const indexCache = new Map<string, RegistryIndex>();
   let scannedDocuments = 0;
-
-  for (const nodeType of types) {
-    if (!hasLlmDetector(nodeType.linking.detect)) continue;
-    issues.push(issue(
-      "LINK_LLM_DETECTOR_UNAVAILABLE",
-      "warning",
-      nodeType.nodeType,
-      `preset ${nodeType.linking.preset ?? "custom"} requires L4b / llm detector not yet available`,
-      [`registry:${nodeType.registryId}`],
-    ));
-  }
 
   for (const rawPath of Array.from(new Set(input.sourceFiles.map((file) => resolve(file)))).sort()) {
     let rawSource: string;
@@ -430,18 +690,19 @@ export function linkEntities(input: EntityLinkingInput): EntityLinkingResult {
         indexCache.set(key, registryIndex);
       }
       const context: DetectorContext = { rawSource, sourceFile: label, normalizer: nodeType.normalizer, registryIndex };
-      const candidates: RawCandidate[] = [];
-      if (nodeType.linking.detect.some((detector) => detector === "lexicon")) candidates.push(...detectLexicon(parsed.units, context));
+
+      // 1) $0 detectors first. Their VERIFIED output is what the llm trigger reads.
+      const zeroCandidates: RawCandidate[] = [];
+      if (nodeType.linking.detect.some((detector) => detector === "lexicon")) zeroCandidates.push(...detectLexicon(parsed.units, context));
       if (nodeType.linking.detect.some((detector) => detector === "pattern" || (typeof detector === "object" && "pattern" in detector))) {
-        candidates.push(...detectPattern(parsed.units, context, nodeType.linking.detect));
+        zeroCandidates.push(...detectPattern(parsed.units, context, nodeType.linking.detect));
       }
-      for (const candidate of candidates) {
+      const verifiedZero: RawCandidate[] = [];
+      for (const candidate of zeroCandidates) {
         candidate.node_type = nodeType.nodeType;
         // The source slice check is stronger than the normalised verifier and
         // keeps the occurrence coordinate system pinned to the raw file.
-        if (
-          !verifyRawCandidate(rawSource, candidate)
-        ) {
+        if (!verifyRawCandidate(rawSource, candidate)) {
           issues.push(issue(
             "LINK_VERBATIM_UNRELOCATABLE",
             "warning",
@@ -451,6 +712,38 @@ export function linkEntities(input: EntityLinkingInput): EntityLinkingResult {
           ));
           continue;
         }
+        verifiedZero.push(candidate);
+      }
+
+      const candidates: RawCandidate[] = [...verifiedZero];
+
+      // 2) Opt-in llm detector: PROPOSES spans only. It runs strictly after the
+      //    $0 detectors, only when its declared trigger fires, and its output is
+      //    relocated verbatim then resolved by the SAME exact/none resolver.
+      const llmConfig = llmConfigFromDetectors(nodeType.linking.detect);
+      if (llmConfig && shouldTriggerLlm(verifiedZero, llmConfig, registryIndex, nodeType.normalizer, nodeType.linking.resolve.mode)) {
+        const skip = llmSkipReason(llmConfig, input.llmDryRun, input.llmProposer);
+        if (skip) {
+          issues.push(issue(skip.code, skip.severity, nodeType.nodeType, `${skip.message} (${label})`, [`source:${label}`, `registry:${nodeType.registryId}`]));
+        } else if (input.llmProposer) {
+          const proposed = await detectLlm(input.llmProposer, {
+            nodeType: nodeType.nodeType,
+            sourceFile: label,
+            rawSource,
+            units: parsed.units,
+            partition,
+            allowedNodeTypes: [nodeType.nodeType],
+            ...(llmConfig.budget_usd !== undefined ? { budgetUsd: llmConfig.budget_usd } : {}),
+          });
+          for (const candidate of proposed) {
+            candidate.node_type = nodeType.nodeType;
+            candidates.push(candidate);
+          }
+        }
+      }
+
+      // 3) Dedup across detectors within (document, node_type): lexicon > pattern > llm.
+      for (const candidate of candidates) {
         const keyForCandidate = [input.profile.profile_hash, label, nodeType.nodeType, candidate.offsets.start, candidate.offsets.end].join("|");
         const previous = deduped.get(keyForCandidate);
         if (!previous || DETECTOR_PRIORITY[candidate.detector] < DETECTOR_PRIORITY[previous.detector]) {

--- a/src/entity-normalizer.ts
+++ b/src/entity-normalizer.ts
@@ -12,6 +12,8 @@ import type {
   OntologyLinkingEvidence,
   OntologyLinkingPartitionFrom,
   OntologyLinkingResolve,
+  OntologyLinkLlmConfig,
+  OntologyLinkLlmTrigger,
   OntologyNodeTypeLinking,
   OntologyNodeTypeNormalize,
   RegistryRecord,
@@ -187,14 +189,49 @@ function normalizePattern(value: unknown, context: string): Extract<OntologyLink
   };
 }
 
+const LLM_TRIGGERS = new Set<OntologyLinkLlmTrigger>([
+  "zero_candidates",
+  "unresolved_candidates",
+  "below_min_candidates",
+]);
+
+/**
+ * Normalize the declarative `llm` detector config. The trigger is a BOUNDED
+ * enum (never a free expression); budget/dry_run/min_candidates are validated
+ * at load so no corpus scan starts against an ill-formed LLM policy.
+ */
+function normalizeLlmConfig(value: unknown, context: string): OntologyLinkLlmConfig {
+  if (value !== undefined && !isRecord(value)) throw new Error(`${context} must be an object`);
+  const raw = isRecord(value) ? value : {};
+  const trigger = raw.trigger === undefined ? "zero_candidates" : raw.trigger;
+  if (typeof trigger !== "string" || !LLM_TRIGGERS.has(trigger as OntologyLinkLlmTrigger)) {
+    throw new Error(`${context}.trigger must be one of ${Array.from(LLM_TRIGGERS).join(", ")}`);
+  }
+  const config: OntologyLinkLlmConfig = { trigger: trigger as OntologyLinkLlmTrigger };
+  if (raw.budget_usd !== undefined) {
+    if (typeof raw.budget_usd !== "number" || !Number.isFinite(raw.budget_usd) || raw.budget_usd < 0) {
+      throw new Error(`${context}.budget_usd must be a non-negative number`);
+    }
+    config.budget_usd = raw.budget_usd;
+  }
+  if (raw.dry_run !== undefined) {
+    if (typeof raw.dry_run !== "boolean") throw new Error(`${context}.dry_run must be a boolean`);
+    config.dry_run = raw.dry_run;
+  }
+  if (raw.min_candidates !== undefined) {
+    if (!Number.isInteger(raw.min_candidates) || Number(raw.min_candidates) < 0) {
+      throw new Error(`${context}.min_candidates must be a non-negative integer`);
+    }
+    config.min_candidates = Number(raw.min_candidates);
+  }
+  return config;
+}
+
 function normalizeDetector(value: unknown, context: string): OntologyLinkDetector {
   if (value === "lexicon" || value === "pattern" || value === "llm") return value;
   if (!isRecord(value)) throw new Error(`${context} must be lexicon, pattern, llm, or a detector object`);
   if ("pattern" in value) return normalizePattern(value.pattern, context);
-  if ("llm" in value) {
-    if (value.llm !== undefined && !isRecord(value.llm)) throw new Error(`${context}.llm must be an object`);
-    return { llm: isRecord(value.llm) ? { ...value.llm } : {} };
-  }
+  if ("llm" in value) return { llm: normalizeLlmConfig(value.llm, `${context}.llm`) };
   throw new Error(`${context} must have a pattern or llm key`);
 }
 
@@ -216,9 +253,16 @@ function normalizePartitionFrom(value: unknown, context: string): OntologyLinkin
   };
 }
 
-function normalizeResolve(value: unknown, context: string): OntologyLinkingResolve {
+function presetResolveMode(preset: string): OntologyLinkingResolve["mode"] {
+  // Open extraction has no registry target to hit, so its preset expands to a
+  // `none` resolver at load time (mirrors the runtime preset override). Every
+  // other preset resolves exactly. An explicit `resolve` always wins.
+  return preset === "open-extraction" ? "none" : "exact";
+}
+
+function normalizeResolve(value: unknown, context: string, preset: string): OntologyLinkingResolve {
   const mode = typeof value === "string" ? value : isRecord(value) ? value.mode : undefined;
-  if (mode === undefined) return { mode: "exact" };
+  if (mode === undefined) return { mode: presetResolveMode(preset) };
   if (mode !== "exact" && mode !== "none") throw new Error(`${context}.resolve.mode must be exact or none`);
   return { mode };
 }
@@ -303,7 +347,7 @@ export function normalizeNodeTypeLinking(
       partition_from: normalizePartitionFrom(linking.partition_from, context)!,
     } : {}),
     detect: [...configuredDetectors, ...patterns],
-    resolve: normalizeResolve(linking.resolve, context),
+    resolve: normalizeResolve(linking.resolve, context, preset),
     evidence: normalizeEvidence(linking.evidence, context),
     normalizer: descriptorFor(normalize, profile, context),
   };

--- a/src/entity-normalizer.ts
+++ b/src/entity-normalizer.ts
@@ -8,6 +8,10 @@ import type {
   EntityNormalizerDescriptor,
   NormalizedOntologyNodeType,
   NormalizedOntologyProfile,
+  OntologyLinkDetector,
+  OntologyLinkingEvidence,
+  OntologyLinkingPartitionFrom,
+  OntologyLinkingResolve,
   OntologyNodeTypeLinking,
   OntologyNodeTypeNormalize,
   RegistryRecord,
@@ -154,10 +158,104 @@ function descriptorFor(
   };
 }
 
+const LINK_PRESETS = new Set(["gazetteer-exact", "open-extraction", "hybrid-recall"]);
+
+function normalizePattern(value: unknown, context: string): Extract<OntologyLinkDetector, { pattern: unknown }> {
+  if (!isRecord(value) || typeof value.form !== "string" || !value.form.trim()) {
+    throw new Error(`${context}.pattern.form must be a non-empty regex string`);
+  }
+  const flags = value.flags === undefined ? undefined : String(value.flags);
+  try {
+    // Validate at profile load, before a corpus document is read.
+    new RegExp(value.form, flags);
+  } catch (error) {
+    throw new Error(`${context}.pattern.form is not a valid regex: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (value.membership !== undefined && value.membership !== "required") {
+    throw new Error(`${context}.pattern.membership must be "required"`);
+  }
+  const expand = isRecord(value.expand) && typeof value.expand.ranges === "string"
+    ? { ranges: value.expand.ranges }
+    : undefined;
+  return {
+    pattern: {
+      form: value.form,
+      ...(flags ? { flags } : {}),
+      ...(expand ? { expand } : {}),
+      membership: "required",
+    },
+  };
+}
+
+function normalizeDetector(value: unknown, context: string): OntologyLinkDetector {
+  if (value === "lexicon" || value === "pattern" || value === "llm") return value;
+  if (!isRecord(value)) throw new Error(`${context} must be lexicon, pattern, llm, or a detector object`);
+  if ("pattern" in value) return normalizePattern(value.pattern, context);
+  if ("llm" in value) {
+    if (value.llm !== undefined && !isRecord(value.llm)) throw new Error(`${context}.llm must be an object`);
+    return { llm: isRecord(value.llm) ? { ...value.llm } : {} };
+  }
+  throw new Error(`${context} must have a pattern or llm key`);
+}
+
+function normalizePartitionFrom(value: unknown, context: string): OntologyLinkingPartitionFrom | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value) || typeof value.source_frontmatter !== "string" || !value.source_frontmatter.trim()) {
+    throw new Error(`${context}.partition_from.source_frontmatter must be a non-empty string`);
+  }
+  let fallback: { path_segment: number } | undefined;
+  if (value.else !== undefined) {
+    if (!isRecord(value.else) || !Number.isInteger(value.else.path_segment) || Number(value.else.path_segment) < 0) {
+      throw new Error(`${context}.partition_from.else.path_segment must be a non-negative integer`);
+    }
+    fallback = { path_segment: Number(value.else.path_segment) };
+  }
+  return {
+    source_frontmatter: value.source_frontmatter.trim(),
+    ...(fallback ? { else: fallback } : {}),
+  };
+}
+
+function normalizeResolve(value: unknown, context: string): OntologyLinkingResolve {
+  const mode = typeof value === "string" ? value : isRecord(value) ? value.mode : undefined;
+  if (mode === undefined) return { mode: "exact" };
+  if (mode !== "exact" && mode !== "none") throw new Error(`${context}.resolve.mode must be exact or none`);
+  return { mode };
+}
+
+function normalizeEvidence(value: unknown, context: string): OntologyLinkingEvidence {
+  if (value === undefined) return { verbatim: "required" };
+  if (!isRecord(value) || (value.verbatim !== undefined && value.verbatim !== "required")) {
+    throw new Error(`${context}.evidence.verbatim must be "required"`);
+  }
+  const contextWindow = value.context_window;
+  if (contextWindow !== undefined && (!Number.isFinite(contextWindow) || Number(contextWindow) < 0)) {
+    throw new Error(`${context}.evidence.context_window must be a non-negative number`);
+  }
+  return {
+    verbatim: "required",
+    ...(contextWindow === undefined ? {} : { context_window: Number(contextWindow) }),
+  };
+}
+
+function presetDetectors(preset: string): OntologyLinkDetector[] {
+  switch (preset) {
+    case "gazetteer-exact":
+      return ["lexicon", "pattern"];
+    case "open-extraction":
+      return ["llm"];
+    case "hybrid-recall":
+      return ["lexicon", "pattern", "llm"];
+    default:
+      throw new Error(`unknown linking preset ${preset}`);
+  }
+}
+
 /**
- * Normalize the declarative L3 linking block. `preset` is deliberately stored
- * but not executed until L4. The descriptor contains no absolute module path;
- * it is the portable hash input for a configured normalizer.
+ * Normalize the declarative linking block. Presets expand here into explicit
+ * detectors/resolution/evidence so downstream passes never interpret an opaque
+ * strategy enum. The descriptor contains no absolute module path; it is the
+ * portable hash input for a configured normalizer.
  */
 export function normalizeNodeTypeLinking(
   linking: OntologyNodeTypeLinking,
@@ -167,6 +265,10 @@ export function normalizeNodeTypeLinking(
   if (!isRecord(linking)) throw new Error(`${context}.linking must be an object`);
   if (linking.preset !== undefined && (typeof linking.preset !== "string" || !linking.preset.trim())) {
     throw new Error(`${context}.linking.preset must be a non-empty string`);
+  }
+  const preset = String(linking.preset ?? "gazetteer-exact").trim();
+  if (!LINK_PRESETS.has(preset)) {
+    throw new Error(`${context}.linking.preset must be one of ${Array.from(LINK_PRESETS).join(", ")}`);
   }
   if (linking.normalize !== undefined && !isRecord(linking.normalize)) {
     throw new Error(`${context}.linking.normalize must be an object`);
@@ -182,9 +284,27 @@ export function normalizeNodeTypeLinking(
       ...(linking.normalize.builtin === undefined ? {} : { builtin: normalizeBuiltins(linking.normalize, context) }),
       ...(linking.normalize.fn === undefined ? {} : { fn: linking.normalize.fn.trim() }),
     };
+  if (linking.detect !== undefined && !Array.isArray(linking.detect)) {
+    throw new Error(`${context}.linking.detect must be an array`);
+  }
+  if (linking.patterns !== undefined && !Array.isArray(linking.patterns)) {
+    throw new Error(`${context}.linking.patterns must be an array`);
+  }
+  const configuredDetectors = linking.detect === undefined
+    ? presetDetectors(preset)
+    : linking.detect.map((detector, index) => normalizeDetector(detector, `${context}.linking.detect[${index}]`));
+  const patterns = (linking.patterns ?? []).map((pattern, index) =>
+    normalizePattern(pattern, `${context}.linking.patterns[${index}]`),
+  );
   return {
-    ...(linking.preset === undefined ? {} : { preset: linking.preset.trim() }),
+    preset,
     ...(normalize === undefined ? {} : { normalize }),
+    ...(normalizePartitionFrom(linking.partition_from, context) ? {
+      partition_from: normalizePartitionFrom(linking.partition_from, context)!,
+    } : {}),
+    detect: [...configuredDetectors, ...patterns],
+    resolve: normalizeResolve(linking.resolve, context),
+    evidence: normalizeEvidence(linking.evidence, context),
     normalizer: descriptorFor(normalize, profile, context),
   };
 }

--- a/src/entity-normalizer.ts
+++ b/src/entity-normalizer.ts
@@ -1,0 +1,328 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+import { normalizeForMatch } from "./cite-grounding.js";
+import type {
+  EntityNormalizerDescriptor,
+  NormalizedOntologyNodeType,
+  NormalizedOntologyProfile,
+  OntologyNodeTypeLinking,
+  OntologyNodeTypeNormalize,
+  RegistryRecord,
+} from "./types.js";
+
+/** Contract identifier written into the normalized profile and profile hash. */
+export const ENTITY_NORMALIZER_CONTRACT = "graphify_entity_normalizer_v1" as const;
+
+/** A synchronous entity-key normalizer compiled for one node type. */
+export type EntityNormalizer = (value: string) => string;
+
+/** Runtime-only lookup table. It is deliberately not serialized into profiles. */
+export type NormalizerByNodeType = Record<string, EntityNormalizer>;
+
+type BuiltinName = "case_fold" | "dash_fold" | "collapse_ws";
+
+const BUILTIN_VERSIONS: Record<BuiltinName, string> = {
+  case_fold: "case_fold@1",
+  dash_fold: "dash_fold@1",
+  collapse_ws: "collapse_ws@1",
+};
+
+const DEFAULT_NORMALIZER_VERSION = "normalize_for_match@1";
+
+const DASH_VARIANTS = /[\u2010-\u2015\u2212\uFE58\uFE63\uFF0D]/gu;
+
+const BUILTINS: Record<BuiltinName, EntityNormalizer> = {
+  case_fold: (value) => value.toLowerCase(),
+  dash_fold: (value) => value.replace(DASH_VARIANTS, "-"),
+  collapse_ws: (value) => value.trim().replace(/\s+/gu, " "),
+};
+
+interface FnReference {
+  moduleSpecifier: string;
+  exportName: string;
+}
+
+interface ResolvedFn extends FnReference {
+  modulePath: string;
+  moduleBytes: Buffer;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasThen(value: unknown): value is PromiseLike<unknown> {
+  return isRecord(value) && typeof value.then === "function";
+}
+
+function normalizeBuiltins(
+  normalize: OntologyNodeTypeNormalize | undefined,
+  context: string,
+): BuiltinName[] | undefined {
+  if (normalize?.builtin === undefined) return undefined;
+  if (!Array.isArray(normalize.builtin)) {
+    throw new Error(`${context}.builtin must be an array of built-in normalizer names`);
+  }
+  return normalize.builtin.map((value, index) => {
+    if (typeof value !== "string" || !(value in BUILTINS)) {
+      throw new Error(
+        `${context}.builtin[${index}] must be one of ${Object.keys(BUILTINS).join(", ")} (got ${String(value)})`,
+      );
+    }
+    return value as BuiltinName;
+  });
+}
+
+function parseFnReference(value: string, context: string): FnReference {
+  const trimmed = value.trim();
+  const firstHash = trimmed.indexOf("#");
+  if (firstHash <= 0 || firstHash !== trimmed.lastIndexOf("#") || firstHash === trimmed.length - 1) {
+    throw new Error(`${context}.fn must use the local module#export form`);
+  }
+  const moduleSpecifier = trimmed.slice(0, firstHash);
+  const exportName = trimmed.slice(firstHash + 1);
+  if (isAbsolute(moduleSpecifier) || (!moduleSpecifier.startsWith("./") && !moduleSpecifier.startsWith("../"))) {
+    throw new Error(`${context}.fn must reference a local module relative to the profile file`);
+  }
+  return { moduleSpecifier, exportName };
+}
+
+function profileSourcePath(profile: Pick<NormalizedOntologyProfile, "sourcePath">, context: string): string {
+  if (!profile.sourcePath) {
+    throw new Error(`${context}.fn requires a profile source path so its local module can be resolved`);
+  }
+  return resolve(profile.sourcePath);
+}
+
+function resolveFn(
+  profile: Pick<NormalizedOntologyProfile, "sourcePath">,
+  fn: string,
+  context: string,
+): ResolvedFn {
+  const sourcePath = profileSourcePath(profile, context);
+  const reference = parseFnReference(fn, context);
+  const modulePath = resolve(dirname(sourcePath), reference.moduleSpecifier);
+  if (!existsSync(modulePath)) {
+    throw new Error(`${context}.fn module does not exist: ${reference.moduleSpecifier}`);
+  }
+  const moduleBytes = readFileSync(modulePath);
+  return { ...reference, modulePath, moduleBytes };
+}
+
+function assertStandaloneModule(resolved: ResolvedFn, context: string): void {
+  const source = resolved.moduleBytes.toString("utf-8");
+  // L3 fingerprints this file only. Reject import/re-export/dynamic-import
+  // forms rather than pretending a transitive local dependency is covered.
+  if (
+    /^\s*import(?:\s|\{|\*|["'])/mu.test(source) ||
+    /^\s*export\s+[^\n;]+\s+from\s+["']/mu.test(source) ||
+    /\bimport\s*\(/u.test(source)
+  ) {
+    throw new Error(
+      `${context}.fn module must be autonomous in L3 (local imports are not supported because only this file is fingerprinted)`,
+    );
+  }
+}
+
+function descriptorFor(
+  normalize: OntologyNodeTypeNormalize | undefined,
+  profile: Pick<NormalizedOntologyProfile, "sourcePath">,
+  context: string,
+): EntityNormalizerDescriptor {
+  const builtinNames = normalizeBuiltins(normalize, context);
+  const builtins = (builtinNames === undefined
+    ? [DEFAULT_NORMALIZER_VERSION]
+    : builtinNames.map((builtin) => BUILTIN_VERSIONS[builtin])) as string[];
+  const fn = normalize?.fn;
+  const resolved = fn === undefined ? undefined : resolveFn(profile, fn, context);
+  if (resolved) assertStandaloneModule(resolved, context);
+  const fingerprint = {
+    contract: ENTITY_NORMALIZER_CONTRACT,
+    builtins,
+    ...(resolved ? { export: resolved.exportName, module_sha256: sha256(resolved.moduleBytes) } : {}),
+  };
+  return {
+    ...fingerprint,
+    normalizer_hash: sha256(JSON.stringify(fingerprint)),
+  };
+}
+
+/**
+ * Normalize the declarative L3 linking block. `preset` is deliberately stored
+ * but not executed until L4. The descriptor contains no absolute module path;
+ * it is the portable hash input for a configured normalizer.
+ */
+export function normalizeNodeTypeLinking(
+  linking: OntologyNodeTypeLinking,
+  profile: Pick<NormalizedOntologyProfile, "sourcePath">,
+  context: string,
+): NonNullable<NormalizedOntologyNodeType["linking"]> {
+  if (!isRecord(linking)) throw new Error(`${context}.linking must be an object`);
+  if (linking.preset !== undefined && (typeof linking.preset !== "string" || !linking.preset.trim())) {
+    throw new Error(`${context}.linking.preset must be a non-empty string`);
+  }
+  if (linking.normalize !== undefined && !isRecord(linking.normalize)) {
+    throw new Error(`${context}.linking.normalize must be an object`);
+  }
+  if (linking.normalize?.fn !== undefined &&
+    (typeof linking.normalize.fn !== "string" || !linking.normalize.fn.trim())) {
+    throw new Error(`${context}.linking.normalize.fn must be a non-empty module#export string`);
+  }
+
+  const normalize = linking.normalize === undefined
+    ? undefined
+    : {
+      ...(linking.normalize.builtin === undefined ? {} : { builtin: normalizeBuiltins(linking.normalize, context) }),
+      ...(linking.normalize.fn === undefined ? {} : { fn: linking.normalize.fn.trim() }),
+    };
+  return {
+    ...(linking.preset === undefined ? {} : { preset: linking.preset.trim() }),
+    ...(normalize === undefined ? {} : { normalize }),
+    normalizer: descriptorFor(normalize, profile, context),
+  };
+}
+
+function loadFn(resolved: ResolvedFn, context: string): EntityNormalizer {
+  assertStandaloneModule(resolved, context);
+  const requireFromProfile = createRequire(resolved.modulePath);
+  let module: Record<string, unknown>;
+  try {
+    module = requireFromProfile(resolved.modulePath) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(`${context}.fn could not load ${resolved.moduleSpecifier}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const exported = module[resolved.exportName];
+  if (typeof exported !== "function") {
+    throw new Error(`${context}.fn export ${resolved.exportName} is not a function`);
+  }
+  if (exported.constructor?.name === "AsyncFunction") {
+    throw new Error(`${context}.fn export ${resolved.exportName} must be synchronous`);
+  }
+  return exported as EntityNormalizer;
+}
+
+function compileOne(
+  profile: Pick<NormalizedOntologyProfile, "sourcePath">,
+  nodeType: NormalizedOntologyNodeType,
+  context: string,
+): EntityNormalizer {
+  const normalize = nodeType.linking?.normalize;
+  const storedDescriptor = nodeType.linking?.normalizer;
+  if (storedDescriptor) {
+    const currentDescriptor = descriptorFor(normalize, profile, context);
+    if (currentDescriptor.normalizer_hash !== storedDescriptor.normalizer_hash) {
+      throw new Error(
+        `${context}.fn module bytes changed since this profile was loaded; reload the profile to refresh profile_hash`,
+      );
+    }
+  }
+  const builtinNames = normalizeBuiltins(normalize, context);
+  const builtin = builtinNames === undefined
+    ? normalizeForMatch
+    : (value: string) => builtinNames.reduce((current, name) => BUILTINS[name](current), value);
+  if (!normalize?.fn) return builtin;
+  const resolved = resolveFn(profile, normalize.fn, context);
+  const fn = loadFn(resolved, context);
+  return (value: string) => fn(builtin(value));
+}
+
+/**
+ * Compile every opted-in node type once for a consumer pass. L4's linking
+ * producer should call this same entrypoint rather than reinterpreting profile
+ * fields itself.
+ */
+export function compileNormalizerByNodeType(profile: NormalizedOntologyProfile): NormalizerByNodeType {
+  const normalizers: NormalizerByNodeType = {};
+  for (const [nodeTypeId, nodeType] of Object.entries(profile.node_types ?? {})) {
+    if (!nodeType.linking) continue;
+    normalizers[nodeTypeId] = compileOne(profile, nodeType, `node_types.${nodeTypeId}.linking`);
+  }
+  return normalizers;
+}
+
+function applyChecked(
+  normalizer: EntityNormalizer,
+  value: string,
+  context: string,
+): string {
+  let result: unknown;
+  try {
+    result = normalizer(value);
+  } catch (error) {
+    throw new Error(`${context} threw: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (hasThen(result)) throw new Error(`${context} returned a Promise; normalizers must be synchronous`);
+  if (typeof result !== "string") throw new Error(`${context} returned a non-string value`);
+  if (value.length > 0 && result.length === 0) {
+    throw new Error(`${context} returned an empty string for a non-empty registry key`);
+  }
+  return result;
+}
+
+interface CollisionBucket {
+  ids: Set<string>;
+  keys: Set<string>;
+  partition: string;
+  normalized: string;
+}
+
+/**
+ * Exhaustively enforce the normalizer contract against loaded registry keys.
+ * This is intentionally invoked from registry loading, before any corpus scan.
+ */
+export function auditNormalizerContracts(
+  profile: NormalizedOntologyProfile,
+  registries: Record<string, RegistryRecord[]>,
+  normalizers = compileNormalizerByNodeType(profile),
+): void {
+  for (const [nodeTypeId, nodeType] of Object.entries(profile.node_types)) {
+    if (!nodeType.linking || !nodeType.registry) continue;
+    const records = registries[nodeType.registry] ?? [];
+    const normalizer = normalizers[nodeTypeId];
+    if (!normalizer) continue;
+    const collisions = new Map<string, CollisionBucket>();
+
+    for (const record of records) {
+      for (const key of [record.label, ...record.aliases]) {
+        const context = `node_types.${nodeTypeId}.linking.normalize for ${nodeType.registry} record ${record.id} key ${JSON.stringify(key)}`;
+        const first = applyChecked(normalizer, key, context);
+        const repeat = applyChecked(normalizer, key, context);
+        if (repeat !== first) {
+          throw new Error(`${context} is non-deterministic (${JSON.stringify(first)} then ${JSON.stringify(repeat)})`);
+        }
+        const second = applyChecked(normalizer, first, context);
+        if (second !== first) {
+          throw new Error(`${context} is not idempotent (${JSON.stringify(first)} -> ${JSON.stringify(second)})`);
+        }
+
+        const partition = record.partition ?? "";
+        const collisionKey = `${partition}\0${first}`;
+        let bucket = collisions.get(collisionKey);
+        if (!bucket) {
+          bucket = { ids: new Set(), keys: new Set(), partition, normalized: first };
+          collisions.set(collisionKey, bucket);
+        }
+        bucket.ids.add(record.id);
+        bucket.keys.add(key);
+      }
+    }
+
+    for (const bucket of collisions.values()) {
+      if (bucket.ids.size <= 1) continue;
+      const ids = Array.from(bucket.ids).sort();
+      const keys = Array.from(bucket.keys).sort();
+      throw new Error(
+        `normalizer_collision: node_type=${nodeTypeId} registry=${nodeType.registry} ` +
+        `partition=${JSON.stringify(bucket.partition)} normalized=${JSON.stringify(bucket.normalized)} ` +
+        `ids=${JSON.stringify(ids)} keys=${JSON.stringify(keys)}`,
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,9 +100,13 @@ export {
 export type { EntityNormalizer, NormalizerByNodeType } from "./entity-normalizer.js";
 export {
   detectLexicon,
+  detectLlm,
   detectPattern,
+  directLlmSpanProposer,
   buildRegistryIndex,
   linkEntities,
+  llmConfigFromDetectors,
+  requiresLlmProposer,
   resolveEntityCandidate,
   summarizeEntityOccurrences,
   verifyRawCandidate,
@@ -114,6 +118,9 @@ export type {
   EntityLinkingInput,
   EntityLinkingResult,
   EntityOccurrenceSummary,
+  LlmProposeRequest,
+  LlmSpanProposal,
+  LlmSpanProposer,
   RawCandidate,
   RegistryIndex,
 } from "./entity-linking.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,16 @@
  * graphify - extract · build · cluster · analyze · report.
  */
 
-export { type GraphNode, type GraphEdge, type Extraction, type Hyperedge, type DetectionResult, FileType } from "./types.js";
+export {
+  type GraphNode,
+  type GraphEdge,
+  type Extraction,
+  type Hyperedge,
+  type DetectionResult,
+  type LinkValidationIssue,
+  type TypedEntityOccurrenceV1,
+  FileType,
+} from "./types.js";
 export {
   HYPEREDGES_ATTRIBUTE,
   loadHyperedges,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,15 @@ export type {
   ProjectConfigDiscoveryResult,
   ProjectConfigValidationIssue,
   NormalizedOntologyProfile,
+  NormalizedOntologyNodeType,
   NormalizedOntologyRegistrySpec,
   NormalizedOntologyRelationType,
   OntologyCitationPolicy,
   OntologyHardeningPolicy,
   OntologyNodeType,
+  OntologyNodeTypeLinking,
+  OntologyNodeTypeNormalize,
+  EntityNormalizerDescriptor,
   OntologyOutputPolicy,
   OntologyOutputWikiPolicy,
   OntologyProfile,
@@ -82,6 +86,13 @@ export type {
   ClassHierarchyClassEntry,
   ClassHierarchiesArtifact,
 } from "./types.js";
+export {
+  ENTITY_NORMALIZER_CONTRACT,
+  auditNormalizerContracts,
+  compileNormalizerByNodeType,
+  normalizeNodeTypeLinking,
+} from "./entity-normalizer.js";
+export type { EntityNormalizer, NormalizerByNodeType } from "./entity-normalizer.js";
 export { inspectInputScope } from "./input-scope.js";
 export type { InputScopeInventory, InspectInputScopeOptions } from "./input-scope.js";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,11 @@ export type {
   OntologyHardeningPolicy,
   OntologyNodeType,
   OntologyNodeTypeLinking,
+  OntologyLinkDetector,
+  OntologyLinkingEvidence,
+  OntologyLinkingPartitionFrom,
+  OntologyLinkingPattern,
+  OntologyLinkingResolve,
   OntologyNodeTypeNormalize,
   EntityNormalizerDescriptor,
   OntologyOutputPolicy,
@@ -93,6 +98,37 @@ export {
   normalizeNodeTypeLinking,
 } from "./entity-normalizer.js";
 export type { EntityNormalizer, NormalizerByNodeType } from "./entity-normalizer.js";
+export {
+  detectLexicon,
+  detectPattern,
+  buildRegistryIndex,
+  linkEntities,
+  resolveEntityCandidate,
+  summarizeEntityOccurrences,
+  verifyRawCandidate,
+  writeEntityLinkingArtifacts,
+} from "./entity-linking.js";
+export type {
+  DetectorContext,
+  EntityDetector,
+  EntityLinkingInput,
+  EntityLinkingResult,
+  EntityOccurrenceSummary,
+  RawCandidate,
+  RegistryIndex,
+} from "./entity-linking.js";
+export {
+  buildNormToRawMap,
+  deaccent,
+  detectModality,
+  normalizeForMatch,
+  parseSource,
+  rawOffsetForTerm,
+  resolveSourcePath,
+  verifyVerbatim,
+  windowQuote,
+} from "./source-grounding.js";
+export type { ImageContext, ParsedSource, ResolveSourceOptions, SourceModality, SourceUnit } from "./source-grounding.js";
 export { inspectInputScope } from "./input-scope.js";
 export type { InputScopeInventory, InspectInputScopeOptions } from "./input-scope.js";
 export {

--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -2,13 +2,22 @@ import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import type { Extraction, GraphEdge, GraphNode, NormalizedOntologyProfile, RegistryRecord } from "./types.js";
+import type {
+  Extraction,
+  GraphEdge,
+  GraphNode,
+  LinkValidationIssue,
+  NormalizedOntologyProfile,
+  RegistryRecord,
+  TypedEntityOccurrenceV1,
+} from "./types.js";
 import type { WikiDescriptionSidecarIndex } from "./wiki-descriptions.js";
 import { buildHierarchyIndex, compileHierarchies } from "./ontology-hierarchies.js";
 
 export interface OntologyOutputConfig {
   enabled: boolean;
   canonical_node_types?: string[];
+  occurrence_node_types?: string[];
   relation_exports?: string[];
   wiki?: {
     enabled?: boolean;
@@ -36,6 +45,11 @@ export interface CompileOntologyOutputsOptions {
    * `hierarchies.json` and `hierarchy-index.json` in `outputDir`.
    */
   registries?: Record<string, RegistryRecord[]>;
+  /**
+   * Mention-level typed entity occurrences produced by an explicit linking
+   * pass. Omitted inputs preserve the historical empty-array artifact.
+   */
+  occurrences?: TypedEntityOccurrenceV1[];
 }
 
 export interface CompileOntologyOutputsResult {
@@ -43,7 +57,7 @@ export interface CompileOntologyOutputsResult {
   nodeCount: number;
   relationCount: number;
   wikiPageCount: number;
-  validationIssues: string[];
+  validationIssues: LinkValidationIssue[];
   /** Number of hierarchy arcs written to hierarchies.json (0 when no hierarchies declared). */
   hierarchyArcCount: number;
 }
@@ -115,7 +129,7 @@ function compileNodes(
   extraction: Extraction,
   profile: NormalizedOntologyProfile,
   config: OntologyOutputConfig,
-): { nodes: CompiledNode[]; aliasIssues: string[] } {
+): { nodes: CompiledNode[]; aliasIssues: LinkValidationIssue[] } {
   const allowedTypes = new Set(config.canonical_node_types ?? Object.keys(profile.node_types));
   const nodes = extraction.nodes
     .filter((node) => {
@@ -149,18 +163,123 @@ function compileNodes(
     }
   }
 
-  const aliasIssues: string[] = [];
+  const aliasIssues: LinkValidationIssue[] = [];
   for (const [alias, ids] of aliases.entries()) {
     const uniqueIds = Array.from(new Set(ids));
     if (uniqueIds.length > 1) {
-      aliasIssues.push(`alias "${alias}" ambiguously attaches to ${uniqueIds.join(", ")}`);
-      for (const node of nodes) {
-        if (uniqueIds.includes(node.id)) node.status = "needs_review";
+      const affectedNodes = nodes.filter((node) => uniqueIds.includes(node.id));
+      const nodeTypes = Array.from(new Set(affectedNodes.map((node) => node.type)));
+      aliasIssues.push({
+        code: "ALIAS_AMBIGUOUS",
+        severity: "warning",
+        node_type: nodeTypes.length === 1 ? nodeTypes[0]! : null,
+        message: `alias "${alias}" ambiguously attaches to ${uniqueIds.join(", ")}`,
+        refs: uniqueIds.map((id) => `record:${id}`),
+      });
+      for (const node of affectedNodes) {
+        node.status = "needs_review";
       }
     }
   }
 
   return { nodes, aliasIssues };
+}
+
+function occurrenceRefs(occurrence: TypedEntityOccurrenceV1): string[] {
+  const refs: string[] = [];
+  if (occurrence.id) refs.push(`occurrence:${occurrence.id}`);
+  if (occurrence.source_file) refs.push(`source:${occurrence.source_file}`);
+  if (occurrence.registry_record_id !== undefined) refs.push(`record:${occurrence.registry_record_id}`);
+  return refs;
+}
+
+function validateOccurrence(occurrence: TypedEntityOccurrenceV1): LinkValidationIssue[] {
+  const refs = occurrenceRefs(occurrence);
+  const issues: LinkValidationIssue[] = [];
+
+  if (occurrence.raw_span.length === 0) {
+    issues.push({
+      code: "OCCURRENCE_EMPTY_RAW_SPAN",
+      severity: "error",
+      node_type: occurrence.node_type,
+      message: "occurrence raw_span must not be empty",
+      refs,
+    });
+  }
+
+  const { start, end } = occurrence.offsets;
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || start >= end) {
+    issues.push({
+      code: "OCCURRENCE_INVALID_OFFSETS",
+      severity: "error",
+      node_type: occurrence.node_type,
+      message: "occurrence offsets must be non-negative integers with start < end",
+      refs,
+    });
+  }
+
+  if (occurrence.resolution === "linked" && (!occurrence.registry_record_id || !occurrence.registry_record_id.trim())) {
+    issues.push({
+      code: "OCCURRENCE_LINKED_MISSING_REGISTRY_RECORD_ID",
+      severity: "error",
+      node_type: occurrence.node_type,
+      message: "linked occurrence must include exactly one registry_record_id",
+      refs,
+    });
+  }
+
+  if (
+    (occurrence.resolution === "unlinked" || occurrence.resolution === "ambiguous")
+    && occurrence.registry_record_id !== undefined
+  ) {
+    issues.push({
+      code: "OCCURRENCE_UNRESOLVED_HAS_REGISTRY_RECORD_ID",
+      severity: "error",
+      node_type: occurrence.node_type,
+      message: `${occurrence.resolution} occurrence must not include registry_record_id`,
+      refs,
+    });
+  }
+
+  return issues;
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareOccurrences(left: TypedEntityOccurrenceV1, right: TypedEntityOccurrenceV1): number {
+  const sourceComparison = compareText(left.source_file, right.source_file);
+  if (sourceComparison !== 0) return sourceComparison;
+  if (left.offsets.start !== right.offsets.start) return left.offsets.start - right.offsets.start;
+  if (left.offsets.end !== right.offsets.end) return left.offsets.end - right.offsets.end;
+
+  const nodeTypeComparison = compareText(left.node_type, right.node_type);
+  if (nodeTypeComparison !== 0) return nodeTypeComparison;
+  return compareText(left.id, right.id);
+}
+
+function compileOccurrences(
+  occurrences: TypedEntityOccurrenceV1[] | undefined,
+  config: OntologyOutputConfig,
+): { occurrences: TypedEntityOccurrenceV1[]; validationIssues: LinkValidationIssue[] } {
+  if (occurrences === undefined) return { occurrences: [], validationIssues: [] };
+
+  const allowedTypes = new Set(config.occurrence_node_types ?? []);
+  const validationIssues: LinkValidationIssue[] = [];
+  const validOccurrences: TypedEntityOccurrenceV1[] = [];
+
+  for (const occurrence of occurrences) {
+    const issues = validateOccurrence(occurrence);
+    validationIssues.push(...issues);
+    if (issues.length === 0 && allowedTypes.has(occurrence.node_type)) {
+      validOccurrences.push(occurrence);
+    }
+  }
+
+  return { occurrences: validOccurrences.sort(compareOccurrences), validationIssues };
 }
 
 function compileRelations(extraction: Extraction, nodes: CompiledNode[], config: OntologyOutputConfig): CompiledRelation[] {
@@ -232,8 +351,9 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
   }
 
   const { nodes, aliasIssues } = compileNodes(options.extraction, options.profile, options.config);
+  const compiledOccurrences = compileOccurrences(options.occurrences, options.config);
   const relations = compileRelations(options.extraction, nodes, options.config);
-  const validationIssues = [...aliasIssues];
+  const validationIssues = [...aliasIssues, ...compiledOccurrences.validationIssues];
   const wikiPageCount = writeWiki(options.outputDir, nodes, relations, options.config, options.descriptions);
 
   // ---- Hierarchy artefacts (increment A — additive, no-op when no hierarchies) ----
@@ -283,8 +403,11 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
   ));
   writeJson(join(options.outputDir, "relations.json"), relations);
   writeJson(join(options.outputDir, "sources.json"), nodes.flatMap((node) => node.source_refs.map((ref) => ({ id: ref, source_file: ref }))));
-  writeJson(join(options.outputDir, "occurrences.json"), []);
-  writeJson(join(options.outputDir, "validation.json"), { issues: validationIssues });
+  writeJson(join(options.outputDir, "occurrences.json"), compiledOccurrences.occurrences);
+  writeJson(join(options.outputDir, "validation.json"), {
+    schema: "graphify_ontology_validation_v1",
+    issues: validationIssues,
+  });
   writeJson(join(options.outputDir, "index.json"), {
     schema: "graphify_ontology_index_v1",
     entries: nodes.map((node) => ({

--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { compileNormalizerByNodeType } from "./entity-normalizer.js";
+import type { NormalizerByNodeType } from "./entity-normalizer.js";
 import type {
   Extraction,
   GraphEdge,
@@ -143,6 +145,7 @@ function compileNodes(
   extraction: Extraction,
   profile: NormalizedOntologyProfile,
   config: OntologyOutputConfig,
+  normalizers: NormalizerByNodeType,
 ): { nodes: CompiledNode[]; aliasIssues: LinkValidationIssue[] } {
   const allowedTypes = new Set(config.canonical_node_types ?? Object.keys(profile.node_types));
   const nodes = extraction.nodes
@@ -153,7 +156,8 @@ function compileNodes(
     .map((node): CompiledNode => {
       const type = ontologyNodeType(node)!;
       const aliases = stringArray(node.aliases);
-      const terms = [node.label, ...aliases].map(normalizedTerm).filter(Boolean);
+      const normalize = normalizers[type] ?? normalizedTerm;
+      const terms = [node.label, ...aliases].map(normalize).filter(Boolean);
       const status = typeof node.status === "string" ? node.status : profile.hardening.default_status;
       const registryId = stringValue(node.registry_id);
       const registryRecordId = stringValue(node.registry_record_id);
@@ -178,7 +182,8 @@ function compileNodes(
 
   const aliases = new Map<string, { alias: string; ids: string[] }>();
   for (const node of nodes) {
-    for (const alias of node.aliases.map(normalizedTerm)) {
+    const normalize = normalizers[node.type] ?? normalizedTerm;
+    for (const alias of node.aliases.map(normalize)) {
       if (!alias) continue;
       const key = aliasAmbiguityKey(node, profile, alias);
       const group = aliases.get(key);
@@ -377,7 +382,8 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
     return { enabled: false, nodeCount: 0, relationCount: 0, wikiPageCount: 0, validationIssues: [], hierarchyArcCount: 0 };
   }
 
-  const { nodes, aliasIssues } = compileNodes(options.extraction, options.profile, options.config);
+  const normalizers = compileNormalizerByNodeType(options.profile);
+  const { nodes, aliasIssues } = compileNodes(options.extraction, options.profile, options.config, normalizers);
   const compiledOccurrences = compileOccurrences(options.occurrences, options.config);
   const relations = compileRelations(options.extraction, nodes, options.config);
   const validationIssues = [...aliasIssues, ...compiledOccurrences.validationIssues];
@@ -422,7 +428,7 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
   writeJson(join(options.outputDir, "aliases.json"), nodes.flatMap((node) =>
     node.aliases.map((alias) => ({
       term: alias,
-      normalized: normalizedTerm(alias),
+      normalized: (normalizers[node.type] ?? normalizedTerm)(alias),
       node_id: node.id,
       source: "extraction",
       confidence: node.confidence,

--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -71,6 +71,9 @@ interface CompiledNode {
   status: string;
   confidence: number | null;
   source_refs: string[];
+  registry_id?: string;
+  registry_record_id?: string;
+  registry_partition?: string;
   registry_refs: string[];
   graph_node_ids: string[];
 }
@@ -125,6 +128,17 @@ function safeFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/gu, "-").replace(/^-+|-+$/gu, "") || "entity";
 }
 
+function partitionedRegistryId(profile: NormalizedOntologyProfile, nodeType: string): string | null {
+  const registryId = profile.node_types[nodeType]?.registry;
+  if (!registryId || !profile.registries[registryId]?.partition_column) return null;
+  return registryId;
+}
+
+function aliasAmbiguityKey(node: CompiledNode, profile: NormalizedOntologyProfile, alias: string): string {
+  if (partitionedRegistryId(profile, node.type) === null) return alias;
+  return [node.type, node.registry_id ?? "", node.registry_partition ?? "", alias].join("\0");
+}
+
 function compileNodes(
   extraction: Extraction,
   profile: NormalizedOntologyProfile,
@@ -141,6 +155,10 @@ function compileNodes(
       const aliases = stringArray(node.aliases);
       const terms = [node.label, ...aliases].map(normalizedTerm).filter(Boolean);
       const status = typeof node.status === "string" ? node.status : profile.hardening.default_status;
+      const registryId = stringValue(node.registry_id);
+      const registryRecordId = stringValue(node.registry_record_id);
+      const registryPartition = stringValue(node.registry_partition);
+      const isPartitionedRegistryType = partitionedRegistryId(profile, type) !== null;
       return {
         id: node.id,
         type,
@@ -150,21 +168,30 @@ function compileNodes(
         status,
         confidence: confidenceScore(node),
         source_refs: sourceRef(node.source_file, node.source_location),
+        ...(isPartitionedRegistryType && registryId ? { registry_id: registryId } : {}),
+        ...(isPartitionedRegistryType && registryRecordId ? { registry_record_id: registryRecordId } : {}),
+        ...(isPartitionedRegistryType && registryPartition ? { registry_partition: registryPartition } : {}),
         registry_refs: stringArray(node.registry_refs),
         graph_node_ids: [node.id],
       };
     });
 
-  const aliases = new Map<string, string[]>();
+  const aliases = new Map<string, { alias: string; ids: string[] }>();
   for (const node of nodes) {
     for (const alias of node.aliases.map(normalizedTerm)) {
       if (!alias) continue;
-      aliases.set(alias, [...(aliases.get(alias) ?? []), node.id]);
+      const key = aliasAmbiguityKey(node, profile, alias);
+      const group = aliases.get(key);
+      if (group) {
+        group.ids.push(node.id);
+      } else {
+        aliases.set(key, { alias, ids: [node.id] });
+      }
     }
   }
 
   const aliasIssues: LinkValidationIssue[] = [];
-  for (const [alias, ids] of aliases.entries()) {
+  for (const { alias, ids } of aliases.values()) {
     const uniqueIds = Array.from(new Set(ids));
     if (uniqueIds.length > 1) {
       const affectedNodes = nodes.filter((node) => uniqueIds.includes(node.id));

--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { compileNormalizerByNodeType } from "./entity-normalizer.js";
@@ -296,8 +296,27 @@ function compareOccurrences(left: TypedEntityOccurrenceV1, right: TypedEntityOcc
 function compileOccurrences(
   occurrences: TypedEntityOccurrenceV1[] | undefined,
   config: OntologyOutputConfig,
+  outputDir: string,
 ): { occurrences: TypedEntityOccurrenceV1[]; validationIssues: LinkValidationIssue[] } {
-  if (occurrences === undefined) return { occurrences: [], validationIssues: [] };
+  // A standalone `graphify link` run owns the canonical mention list. A later
+  // ontology compile without an explicit occurrences input must not replace
+  // that fresh list with L1's historical empty stub.
+  if (occurrences === undefined) {
+    const existingPath = join(outputDir, "occurrences.json");
+    if (!existsSync(existingPath)) return { occurrences: [], validationIssues: [] };
+    try {
+      const existing = JSON.parse(readFileSync(existingPath, "utf-8")) as unknown;
+      if (Array.isArray(existing)) {
+        return {
+          occurrences: (existing as TypedEntityOccurrenceV1[]).slice().sort(compareOccurrences),
+          validationIssues: [],
+        };
+      }
+    } catch {
+      // Preserve the historical empty fallback for unreadable/non-list files.
+    }
+    return { occurrences: [], validationIssues: [] };
+  }
 
   const allowedTypes = new Set(config.occurrence_node_types ?? []);
   const validationIssues: LinkValidationIssue[] = [];
@@ -384,7 +403,7 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
 
   const normalizers = compileNormalizerByNodeType(options.profile);
   const { nodes, aliasIssues } = compileNodes(options.extraction, options.profile, options.config, normalizers);
-  const compiledOccurrences = compileOccurrences(options.occurrences, options.config);
+  const compiledOccurrences = compileOccurrences(options.occurrences, options.config, options.outputDir);
   const relations = compileRelations(options.extraction, nodes, options.config);
   const validationIssues = [...aliasIssues, ...compiledOccurrences.validationIssues];
   const wikiPageCount = writeWiki(options.outputDir, nodes, relations, options.config, options.descriptions);

--- a/src/ontology-patch-context.ts
+++ b/src/ontology-patch-context.ts
@@ -88,6 +88,9 @@ export function loadOntologyPatchContext(profileStatePath: string): OntologyPatc
         aliases: stringArray(node.aliases),
         normalized_terms: stringArray(node.normalized_terms),
         source_refs: stringArray(node.source_refs),
+        registry_id: stringValue(node.registry_id) ?? undefined,
+        registry_record_id: stringValue(node.registry_record_id) ?? undefined,
+        registry_partition: stringValue(node.registry_partition) ?? undefined,
         registry_refs: stringArray(node.registry_refs),
       }))
       .filter((node) => node.id.length > 0),

--- a/src/ontology-patch.ts
+++ b/src/ontology-patch.ts
@@ -44,6 +44,9 @@ export interface OntologyPatchNode {
   aliases?: string[];
   normalized_terms?: string[];
   source_refs?: string[];
+  registry_id?: string;
+  registry_record_id?: string;
+  registry_partition?: string;
   registry_refs?: string[];
 }
 

--- a/src/ontology-profile.ts
+++ b/src/ontology-profile.ts
@@ -101,6 +101,7 @@ function normalizeRegistry(registry: OntologyRegistrySpec): NormalizedOntologyRe
     label_column: String(registry.label_column ?? ""),
     alias_columns: asStringArray(registry.alias_columns),
     node_type: String(registry.node_type ?? ""),
+    ...(registry.partition_column ? { partition_column: String(registry.partition_column) } : {}),
     ...(registry.bound_source_path ? { bound_source_path: registry.bound_source_path } : {}),
   };
 }
@@ -299,6 +300,18 @@ export function validateOntologyProfile(profile: OntologyProfile): string[] {
   // Track C-3.5: validate optional visual_encoding (shape + color_hex, plus the
   // additive fill / border variant dimensions) per node type.
   for (const [nodeTypeId, nodeType] of Object.entries(nodeTypes)) {
+    if (nodeType.registry !== undefined) {
+      const registryId = typeof nodeType.registry === "string" ? nodeType.registry.trim() : "";
+      const registry = registryId ? registries[registryId] : undefined;
+      if (!registry) {
+        errors.push(`node_types.${nodeTypeId}.registry references unknown registry ${String(nodeType.registry)}`);
+      } else if (registry.node_type !== nodeTypeId) {
+        errors.push(
+          `node_types.${nodeTypeId}.registry ${registryId} has node_type ${String(registry.node_type)}, expected ${nodeTypeId}`,
+        );
+      }
+    }
+
     const visual = (nodeType as { visual_encoding?: unknown }).visual_encoding;
     if (visual === undefined || visual === null) continue;
     if (typeof visual !== "object" || Array.isArray(visual)) {

--- a/src/ontology-profile.ts
+++ b/src/ontology-profile.ts
@@ -12,6 +12,7 @@ import type {
   NormalizedOntologyEvidencePolicy,
   NormalizedOntologyHierarchySpec,
   NormalizedOntologyInferencePolicy,
+  NormalizedOntologyNodeType,
   NormalizedOntologyProfileOutputs,
   NormalizedOntologyRegistrySpec,
   NormalizedOntologyRelationType,
@@ -29,6 +30,7 @@ import type {
   OntologyRelationType,
   OntologyStatusTransition,
 } from "./types.js";
+import { compileNormalizerByNodeType, normalizeNodeTypeLinking } from "./entity-normalizer.js";
 
 const DEFAULT_STATUSES = ["candidate", "attached", "needs_review", "validated", "rejected", "superseded"];
 const VALID_CITATION_MINIMUMS = new Set(["file", "page", "section", "paragraph"]);
@@ -64,13 +66,16 @@ function normalizeStringMap<T>(value: unknown): Record<string, T> {
   ) as Record<string, T>;
 }
 
-function stableForHash(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(stableForHash);
+function stableForHash(value: unknown, path: string[] = []): unknown {
+  if (Array.isArray(value)) return value.map((item, index) => stableForHash(item, [...path, String(index)]));
   if (typeof value === "object" && value !== null) {
     const result: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>).sort()) {
       if (key === "sourcePath" || key === "profile_hash" || key === "bound_source_path") continue;
-      result[key] = stableForHash((value as Record<string, unknown>)[key]);
+      // The local module path is runtime-only. Its portable descriptor (export
+      // name + file-content hash) is hashed instead under linking.normalizer.
+      if (key === "fn" && path.at(-1) === "normalize" && path.at(-2) === "linking") continue;
+      result[key] = stableForHash((value as Record<string, unknown>)[key], [...path, key]);
     }
     return result;
   }
@@ -103,6 +108,26 @@ function normalizeRegistry(registry: OntologyRegistrySpec): NormalizedOntologyRe
     node_type: String(registry.node_type ?? ""),
     ...(registry.partition_column ? { partition_column: String(registry.partition_column) } : {}),
     ...(registry.bound_source_path ? { bound_source_path: registry.bound_source_path } : {}),
+  };
+}
+
+function normalizeNodeType(
+  nodeType: OntologyNodeType,
+  sourcePath: string | undefined,
+  nodeTypeId: string,
+): NormalizedOntologyNodeType {
+  if (nodeType.linking === undefined) {
+    const { linking: _linking, ...withoutLinking } = nodeType;
+    return withoutLinking;
+  }
+  const profileLocation = sourcePath ? { sourcePath } : {};
+  return {
+    ...nodeType,
+    linking: normalizeNodeTypeLinking(
+      nodeType.linking,
+      profileLocation,
+      `node_types.${nodeTypeId}`,
+    ),
   };
 }
 
@@ -499,7 +524,9 @@ export function normalizeOntologyProfile(profile: OntologyProfile, sourcePath?: 
     version: String(profile.version),
     default_language: profile.default_language ?? "en",
     ...(sourcePath ? { sourcePath: resolve(sourcePath) } : profile.sourcePath ? { sourcePath: profile.sourcePath } : {}),
-    node_types: nodeTypes,
+    node_types: Object.fromEntries(
+      Object.entries(nodeTypes).map(([id, nodeType]) => [id, normalizeNodeType(nodeType, sourcePath ?? profile.sourcePath, id)]),
+    ),
     relation_types: Object.fromEntries(
       Object.entries(relationTypes).map(([id, relation]) => [id, normalizeRelation(relation)]),
     ),
@@ -514,6 +541,10 @@ export function normalizeOntologyProfile(profile: OntologyProfile, sourcePath?: 
     class_hierarchies: normalizeClassHierarchies(profile.class_hierarchies),
     outputs: normalizeOutputs(profile.outputs),
   };
+
+  // Resolve module exports while the profile is loaded. Registry-key-specific
+  // checks happen later in loadProfileRegistries, before corpus scanning.
+  compileNormalizerByNodeType(normalized as NormalizedOntologyProfile);
 
   return {
     ...normalized,

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
+import { compileNormalizerByNodeType } from "./entity-normalizer.js";
+import type { EntityNormalizer, NormalizerByNodeType } from "./entity-normalizer.js";
 import type { OntologyPatchContext, OntologyPatchNode } from "./ontology-patch.js";
 
 export const ONTOLOGY_RECONCILIATION_CANDIDATES_SCHEMA = "graphify_ontology_reconciliation_candidates_v1" as const;
@@ -100,6 +102,16 @@ function nodeTerms(node: OntologyPatchNode): string[] {
     ...(node.label ? [normalizeTerm(node.label)] : []),
     ...(node.aliases ?? []).map(normalizeTerm),
     ...(node.normalized_terms ?? []).map(normalizeTerm),
+  ]);
+}
+
+/** Exact-tier terms only. Fuzzy keeps its own legacy tokenization below. */
+function exactNodeTerms(node: OntologyPatchNode, normalizers: NormalizerByNodeType): string[] {
+  const normalize = node.type ? normalizers[node.type] ?? normalizeTerm : normalizeTerm;
+  return uniqueSorted([
+    ...(node.label ? [normalize(node.label)] : []),
+    ...(node.aliases ?? []).map(normalize),
+    ...(node.normalized_terms ?? []).map(normalize),
   ]);
 }
 
@@ -700,9 +712,15 @@ function chooseCanonicalPair(a: OntologyPatchNode, b: OntologyPatchNode): {
   return a.id.localeCompare(b.id) <= 0 ? { canonical: a, candidate: b } : { canonical: b, candidate: a };
 }
 
-function candidateScore(sharedTerms: string[], canonical: OntologyPatchNode, candidate: OntologyPatchNode): number {
-  const canonicalLabel = canonical.label ? normalizeTerm(canonical.label) : null;
-  const candidateLabel = candidate.label ? normalizeTerm(candidate.label) : null;
+function candidateScore(
+  sharedTerms: string[],
+  canonical: OntologyPatchNode,
+  candidate: OntologyPatchNode,
+  normalizer: EntityNormalizer | undefined,
+): number {
+  const normalize = normalizer ?? normalizeTerm;
+  const canonicalLabel = canonical.label ? normalize(canonical.label) : null;
+  const candidateLabel = candidate.label ? normalize(candidate.label) : null;
   const exactLabelMatch = canonicalLabel !== null && canonicalLabel === candidateLabel && sharedTerms.includes(canonicalLabel);
   // Exact normalized-label match is the top tier: score 1.0 (canonical pair).
   // A shared non-label term (alias/normalized_term) is strong but sub-exact.
@@ -809,10 +827,12 @@ export function generateOntologyReconciliationCandidates(
   const fuzzyThreshold = options.fuzzyThreshold ?? DEFAULT_FUZZY_TOKEN_JACCARD_THRESHOLD;
   const cap = options.cap ?? DEFAULT_RECONCILIATION_CANDIDATE_CAP;
   const fuzzyExcludeTypes = new Set(options.fuzzyExcludeTypes ?? DEFAULT_FUZZY_EXCLUDE_TYPES);
+  const normalizers = compileNormalizerByNodeType(context.profile);
 
   const candidates: OntologyReconciliationCandidate[] = [];
   const emittedPairs = new Set<string>();
   const comparableNodes = context.nodes
+    // Keep the fuzzy tier's legacy admission/tokenization independent from N.
     .filter((node) => node.type && nodeTerms(node).length > 0)
     .sort((a, b) => a.id.localeCompare(b.id));
 
@@ -828,8 +848,8 @@ export function generateOntologyReconciliationCandidates(
       // become a score-1.0 exact candidate.
       if (violatesPartitionScope(context, left.type, left, right)) continue;
 
-      const leftTerms = new Set(nodeTerms(left));
-      const sharedTerms = nodeTerms(right).filter((term) => leftTerms.has(term));
+      const leftTerms = new Set(exactNodeTerms(left, normalizers));
+      const sharedTerms = exactNodeTerms(right, normalizers).filter((term) => leftTerms.has(term));
 
       const { canonical, candidate } = chooseCanonicalPair(left, right);
       const pairKey = `${canonical.id}|${candidate.id}`;
@@ -851,7 +871,7 @@ export function generateOntologyReconciliationCandidates(
           id: candidateId(canonical, candidate, sharedTerms),
           kind: "entity_match",
           status: "candidate",
-          score: candidateScore(sharedTerms, canonical, candidate),
+          score: candidateScore(sharedTerms, canonical, candidate, normalizers[left.type]),
           tier: "exact",
           candidate_id: candidate.id,
           canonical_id: canonical.id,

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -103,6 +103,22 @@ function nodeTerms(node: OntologyPatchNode): string[] {
   ]);
 }
 
+function violatesPartitionScope(
+  context: OntologyPatchContext,
+  nodeType: string,
+  left: OntologyPatchNode,
+  right: OntologyPatchNode,
+): boolean {
+  const registryId = context.profile.node_types?.[nodeType]?.registry;
+  if (!registryId || !context.profile.registries?.[registryId]?.partition_column) return false;
+
+  return left.registry_id !== registryId
+    || right.registry_id !== registryId
+    || !left.registry_partition
+    || !right.registry_partition
+    || left.registry_partition !== right.registry_partition;
+}
+
 // --- Fuzzy tier ------------------------------------------------------------
 //
 // A LOWER-confidence tier over the exact-normalized-label tier. It compares
@@ -805,7 +821,12 @@ export function generateOntologyReconciliationCandidates(
       const left = comparableNodes[i]!;
       const right = comparableNodes[j]!;
       // Type-guard applies AFTER schema hygiene has canonicalized types.
-      if (left.type !== right.type) continue;
+      if (!left.type || left.type !== right.type) continue;
+
+      // Partitioned registries scope both reconciliation tiers. This guard is
+      // deliberately before sharedTerms so a cross-partition label can never
+      // become a score-1.0 exact candidate.
+      if (violatesPartitionScope(context, left.type, left, right)) continue;
 
       const leftTerms = new Set(nodeTerms(left));
       const sharedTerms = nodeTerms(right).filter((term) => leftTerms.has(term));

--- a/src/ontology-studio-workspace.ts
+++ b/src/ontology-studio-workspace.ts
@@ -702,7 +702,11 @@ function loadDescriptionIndex(stateDir: string): WikiDescriptionSidecarIndex | n
  * empty file yields an empty map (the panel omits the section).
  */
 function loadOccurrences(stateDir: string): EntityPanelOccurrences {
-  const path = join(stateDir, "ontology", "occurrences.json");
+  // `occurrences.json` is now the canonical mention-level LIST. The Studio
+  // consumes the deliberately derived node-id map so it never conflates the
+  // two schemas. Fall back to the legacy occurrence map when no sidecar exists.
+  const summaryPath = join(stateDir, "ontology", "entity-occurrence-summary.json");
+  const path = existsSync(summaryPath) ? summaryPath : join(stateDir, "ontology", "occurrences.json");
   if (!existsSync(path)) return {};
   try {
     return normaliseOccurrences(JSON.parse(readFileSync(path, "utf-8")) as unknown);

--- a/src/profile-evaluate.ts
+++ b/src/profile-evaluate.ts
@@ -1,0 +1,430 @@
+/**
+ * L5 — `graphify profile evaluate`.
+ *
+ * Deterministic, $0 (no LLM) measurement of a `graphify link` run against a
+ * hand-labelled gold set expressed in the SAME occurrence schema as L1
+ * (`TypedEntityOccurrenceV1`). It crosses the two sets by exact span identity
+ * and emits precision/recall metrics plus a CI gate.
+ *
+ * The runner is intentionally profile-agnostic: `profile_hash` and
+ * `normalizer_hashes` are stamped by the caller when a profile is available,
+ * so a generic registry-bound fixture evaluates with zero domain code (no
+ * zoning, no event/stage-3 semantics — see the reconciled build spec §10).
+ *
+ * Coordinate system: offsets are 0-based, half-open, UTF-16 code units in the
+ * RAW source file, identical to L1/L4a. Matching is exact span equality on
+ * `(source_file, node_type, start, end)` — no fuzzy overlap.
+ */
+import { createHash } from "node:crypto";
+
+import type { TypedEntityOccurrenceV1 } from "./types.js";
+
+export const TYPED_LINKING_GOLD_SCHEMA = "graphify_typed_linking_gold_v1" as const;
+export const TYPED_LINKING_EVALUATION_SCHEMA = "graphify_typed_linking_evaluation_v1" as const;
+
+/** Field separator for span/identity keys — a code unit that never occurs in a value. */
+const KEY_SEP = String.fromCharCode(31);
+
+/** Optional per-document strata carried by the gold envelope. */
+export interface GoldDocumentStrata {
+  layout?: string;
+  ocr_quality?: string;
+  spelling_family?: string;
+}
+
+export interface GoldDocumentMeta {
+  strata?: GoldDocumentStrata;
+}
+
+/** Versioned gold envelope. Annotations reuse the L1 occurrence contract exactly. */
+export interface TypedLinkingGoldV1 {
+  schema: typeof TYPED_LINKING_GOLD_SCHEMA;
+  occurrences: TypedEntityOccurrenceV1[];
+  documents?: Record<string, GoldDocumentMeta>;
+}
+
+export interface EvaluationGateConfig {
+  floors?: Record<string, number>;
+  ceilings?: Record<string, number>;
+}
+
+/**
+ * A metric block. `resolution_precision` and `unresolved_rate` are always
+ * emitted together — reporting precision alone is a structural lie (a resolver
+ * that links nothing would otherwise score 1.0). `resolution_precision` is
+ * `null` (never `1.0`) when the scope links nothing.
+ */
+export interface MetricBlock {
+  gold_spans: number;
+  gold_spans_matched: number;
+  mention_recall: number | null;
+  set_recall: number | null;
+  resolution_precision: number | null;
+  unresolved_rate: number | null;
+  unlinked_rate: number | null;
+  ambiguous_rate: number | null;
+  linked_count: number;
+  run_linked: number;
+  run_total: number;
+  documents_scored: number;
+}
+
+export interface FloorEvaluation {
+  metric: string;
+  kind: "floor" | "ceiling";
+  threshold: number;
+  value: number | null;
+  pass: boolean;
+}
+
+export interface EvaluationResult {
+  schema: typeof TYPED_LINKING_EVALUATION_SCHEMA;
+  profile_hash: string | null;
+  normalizer_hashes: Record<string, string>;
+  run_hash: string;
+  gold_hash: string;
+  metrics: {
+    overall: MetricBlock;
+    per_document: Record<string, MetricBlock>;
+    per_strata: Record<string, MetricBlock>;
+  };
+  floors_evaluated: FloorEvaluation[];
+  gate: "pass" | "fail";
+}
+
+export interface EvaluateOccurrencesInput {
+  run: TypedEntityOccurrenceV1[];
+  gold: TypedLinkingGoldV1;
+  floors?: Record<string, number>;
+  ceilings?: Record<string, number>;
+  profileHash?: string | null;
+  normalizerHashes?: Record<string, string>;
+  /**
+   * Optional corpus resolver used to detect a stale gold: given a gold
+   * occurrence, return the verbatim slice of the referenced source, or `null`
+   * when the corpus is unavailable (the check is then skipped, per spec).
+   */
+  corpusSlice?: (occurrence: TypedEntityOccurrenceV1) => string | null;
+}
+
+/** Thrown for structural gold/run problems — the gate cannot even be computed. */
+export class GoldValidationError extends Error {
+  readonly code: string;
+  constructor(code: string, detail: string) {
+    // Fold the code into the message so callers (and test matchers) see it.
+    super(`${code}: ${detail}`);
+    this.name = "GoldValidationError";
+    this.code = code;
+  }
+}
+
+const RESOLUTIONS: ReadonlySet<string> = new Set(["linked", "unlinked", "ambiguous"]);
+
+function spanKey(occurrence: TypedEntityOccurrenceV1): string {
+  return [occurrence.source_file, occurrence.node_type, occurrence.offsets.start, occurrence.offsets.end].join(KEY_SEP);
+}
+
+function linkedIdentity(occurrence: TypedEntityOccurrenceV1): string {
+  return [occurrence.node_type, occurrence.registry_partition ?? "", occurrence.registry_record_id ?? ""].join(KEY_SEP);
+}
+
+function assertOccurrenceShape(occurrence: unknown, where: string): asserts occurrence is TypedEntityOccurrenceV1 {
+  if (typeof occurrence !== "object" || occurrence === null) {
+    throw new GoldValidationError("OCCURRENCE_NOT_OBJECT", `${where}: occurrence is not an object`);
+  }
+  const value = occurrence as Record<string, unknown>;
+  if (typeof value.source_file !== "string" || value.source_file.length === 0) {
+    throw new GoldValidationError("OCCURRENCE_MISSING_SOURCE", `${where}: occurrence.source_file must be a non-empty string`);
+  }
+  if (typeof value.node_type !== "string" || value.node_type.length === 0) {
+    throw new GoldValidationError("OCCURRENCE_MISSING_NODE_TYPE", `${where}: occurrence.node_type must be a non-empty string`);
+  }
+  const offsets = value.offsets as Record<string, unknown> | undefined;
+  if (!offsets || typeof offsets.start !== "number" || typeof offsets.end !== "number" || !(offsets.start < offsets.end)) {
+    throw new GoldValidationError("OCCURRENCE_BAD_OFFSETS", `${where}: occurrence.offsets must be { start < end }`);
+  }
+  if (typeof value.resolution !== "string" || !RESOLUTIONS.has(value.resolution)) {
+    throw new GoldValidationError("OCCURRENCE_BAD_RESOLUTION", `${where}: occurrence.resolution must be linked|unlinked|ambiguous`);
+  }
+  if (value.resolution === "linked" && (typeof value.registry_record_id !== "string" || value.registry_record_id.length === 0)) {
+    throw new GoldValidationError("OCCURRENCE_LINKED_NO_RECORD", `${where}: linked occurrence must carry registry_record_id`);
+  }
+  if (value.resolution !== "linked" && typeof value.registry_record_id === "string") {
+    throw new GoldValidationError("OCCURRENCE_UNLINKED_HAS_RECORD", `${where}: unlinked|ambiguous occurrence must not carry registry_record_id`);
+  }
+}
+
+/** Validate + parse an unknown gold document into a typed envelope, or throw. */
+export function parseGold(raw: unknown): TypedLinkingGoldV1 {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new GoldValidationError("GOLD_NOT_ENVELOPE", "gold must be a versioned object envelope, not a bare array");
+  }
+  const value = raw as Record<string, unknown>;
+  if (value.schema !== TYPED_LINKING_GOLD_SCHEMA) {
+    throw new GoldValidationError("GOLD_BAD_SCHEMA", `gold.schema must be "${TYPED_LINKING_GOLD_SCHEMA}"`);
+  }
+  if (!Array.isArray(value.occurrences)) {
+    throw new GoldValidationError("GOLD_OCCURRENCES_NOT_ARRAY", "gold.occurrences must be an array");
+  }
+  const seen = new Set<string>();
+  for (const [index, occurrence] of value.occurrences.entries()) {
+    assertOccurrenceShape(occurrence, `gold.occurrences[${index}]`);
+    const key = spanKey(occurrence);
+    if (seen.has(key)) {
+      throw new GoldValidationError("GOLD_DUPLICATE_SPAN", `gold has duplicate span ${JSON.stringify(key)} — 1-to-1 matching requires unique spans`);
+    }
+    seen.add(key);
+  }
+  let documents: Record<string, GoldDocumentMeta> | undefined;
+  if (value.documents !== undefined) {
+    if (typeof value.documents !== "object" || value.documents === null || Array.isArray(value.documents)) {
+      throw new GoldValidationError("GOLD_DOCUMENTS_NOT_MAP", "gold.documents must be a map keyed by source_file");
+    }
+    documents = value.documents as Record<string, GoldDocumentMeta>;
+  }
+  return {
+    schema: TYPED_LINKING_GOLD_SCHEMA,
+    occurrences: value.occurrences as TypedEntityOccurrenceV1[],
+    ...(documents ? { documents } : {}),
+  };
+}
+
+function validateRun(run: unknown): TypedEntityOccurrenceV1[] {
+  if (!Array.isArray(run)) {
+    throw new GoldValidationError("RUN_NOT_ARRAY", "run occurrences.json must be a JSON array");
+  }
+  const seen = new Set<string>();
+  for (const [index, occurrence] of run.entries()) {
+    assertOccurrenceShape(occurrence, `run[${index}]`);
+    const key = spanKey(occurrence);
+    if (seen.has(key)) {
+      throw new GoldValidationError("RUN_DUPLICATE_SPAN", `run has duplicate span ${JSON.stringify(key)} — 1-to-1 matching requires unique spans`);
+    }
+    seen.add(key);
+  }
+  return run as TypedEntityOccurrenceV1[];
+}
+
+/** Deterministic key-sorted serialization for order-stable hashing. */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
+
+function hashOccurrences(occurrences: TypedEntityOccurrenceV1[]): string {
+  const sorted = [...occurrences].sort((a, b) => spanKey(a).localeCompare(spanKey(b)));
+  return createHash("sha256").update(stableStringify(sorted)).digest("hex");
+}
+
+function hashGold(gold: TypedLinkingGoldV1): string {
+  const canonical = {
+    schema: gold.schema,
+    occurrences: [...gold.occurrences].sort((a, b) => spanKey(a).localeCompare(spanKey(b))),
+    ...(gold.documents ? { documents: gold.documents } : {}),
+  };
+  return createHash("sha256").update(stableStringify(canonical)).digest("hex");
+}
+
+function entitySet(occurrences: TypedEntityOccurrenceV1[]): Set<string> {
+  const set = new Set<string>();
+  for (const occurrence of occurrences) {
+    // `ambiguous` never counts as resolved — only true links join the set.
+    if (occurrence.resolution === "linked" && occurrence.registry_record_id) set.add(linkedIdentity(occurrence));
+  }
+  return set;
+}
+
+function computeBlock(
+  files: ReadonlySet<string>,
+  goldOccurrences: TypedEntityOccurrenceV1[],
+  runOccurrences: TypedEntityOccurrenceV1[],
+  runIndex: Map<string, TypedEntityOccurrenceV1>,
+  goldIndex: Map<string, TypedEntityOccurrenceV1>,
+): MetricBlock {
+  const goldOccs = goldOccurrences.filter((occurrence) => files.has(occurrence.source_file));
+  const runOccs = runOccurrences.filter((occurrence) => files.has(occurrence.source_file));
+
+  let matched = 0;
+  for (const gold of goldOccs) if (runIndex.has(spanKey(gold))) matched += 1;
+
+  let runLinked = 0;
+  let unlinked = 0;
+  let ambiguous = 0;
+  let correct = 0;
+  for (const run of runOccs) {
+    if (run.resolution === "linked") {
+      runLinked += 1;
+      const gold = goldIndex.get(spanKey(run));
+      if (
+        gold
+        && gold.resolution === "linked"
+        && (gold.registry_partition ?? null) === (run.registry_partition ?? null)
+        && gold.registry_record_id === run.registry_record_id
+      ) {
+        correct += 1;
+      }
+    } else if (run.resolution === "unlinked") {
+      unlinked += 1;
+    } else {
+      ambiguous += 1;
+    }
+  }
+
+  // set_recall = macro average over documents whose gold entity set is non-empty.
+  let setRecallSum = 0;
+  let setRecallDocs = 0;
+  for (const file of [...files].sort()) {
+    const goldSet = entitySet(goldOccs.filter((occurrence) => occurrence.source_file === file));
+    if (goldSet.size === 0) continue;
+    const runSet = entitySet(runOccs.filter((occurrence) => occurrence.source_file === file));
+    let intersection = 0;
+    for (const identity of goldSet) if (runSet.has(identity)) intersection += 1;
+    setRecallSum += intersection / goldSet.size;
+    setRecallDocs += 1;
+  }
+
+  const goldSpans = goldOccs.length;
+  const runTotal = runOccs.length;
+  return {
+    gold_spans: goldSpans,
+    gold_spans_matched: matched,
+    mention_recall: goldSpans === 0 ? null : matched / goldSpans,
+    set_recall: setRecallDocs === 0 ? null : setRecallSum / setRecallDocs,
+    resolution_precision: runLinked === 0 ? null : correct / runLinked,
+    unresolved_rate: runTotal === 0 ? null : (unlinked + ambiguous) / runTotal,
+    unlinked_rate: runTotal === 0 ? null : unlinked / runTotal,
+    ambiguous_rate: runTotal === 0 ? null : ambiguous / runTotal,
+    linked_count: runLinked,
+    run_linked: runLinked,
+    run_total: runTotal,
+    documents_scored: setRecallDocs,
+  };
+}
+
+function readMetric(block: MetricBlock, metric: string): number | null {
+  if (Object.prototype.hasOwnProperty.call(block, metric)) {
+    const value = (block as unknown as Record<string, number | null>)[metric];
+    return typeof value === "number" || value === null ? value : null;
+  }
+  return null;
+}
+
+function evaluateGate(overall: MetricBlock, floors: Record<string, number>, ceilings: Record<string, number>): {
+  floors_evaluated: FloorEvaluation[];
+  gate: "pass" | "fail";
+} {
+  const floors_evaluated: FloorEvaluation[] = [];
+  for (const metric of Object.keys(floors).sort()) {
+    const threshold = floors[metric] ?? 0;
+    const value = readMetric(overall, metric);
+    // A null metric (e.g. resolution_precision when nothing is linked) fails any
+    // positive floor — a resolver that links nothing must never look perfect.
+    const pass = value === null ? threshold <= 0 : value >= threshold;
+    floors_evaluated.push({ metric, kind: "floor", threshold, value, pass });
+  }
+  for (const metric of Object.keys(ceilings).sort()) {
+    const threshold = ceilings[metric] ?? 0;
+    const value = readMetric(overall, metric);
+    // A null ceiling value is vacuously within bounds (nothing exceeded it).
+    const pass = value === null ? true : value <= threshold;
+    floors_evaluated.push({ metric, kind: "ceiling", threshold, value, pass });
+  }
+  const gate = floors_evaluated.every((floor) => floor.pass) ? "pass" : "fail";
+  return { floors_evaluated, gate };
+}
+
+export function evaluateOccurrences(input: EvaluateOccurrencesInput): EvaluationResult {
+  const run = validateRun(input.run);
+  const gold = input.gold;
+
+  if (input.corpusSlice) {
+    for (const [index, occurrence] of gold.occurrences.entries()) {
+      const slice = input.corpusSlice(occurrence);
+      if (slice !== null && slice !== occurrence.raw_span) {
+        throw new GoldValidationError(
+          "GOLD_STALE_SPAN",
+          `gold.occurrences[${index}] raw_span ${JSON.stringify(occurrence.raw_span)} does not match corpus slice ${JSON.stringify(slice)} — gold is stale`,
+        );
+      }
+    }
+  }
+
+  const runIndex = new Map<string, TypedEntityOccurrenceV1>();
+  for (const occurrence of run) runIndex.set(spanKey(occurrence), occurrence);
+  const goldIndex = new Map<string, TypedEntityOccurrenceV1>();
+  for (const occurrence of gold.occurrences) goldIndex.set(spanKey(occurrence), occurrence);
+
+  const allFiles = new Set<string>();
+  for (const occurrence of gold.occurrences) allFiles.add(occurrence.source_file);
+  for (const occurrence of run) allFiles.add(occurrence.source_file);
+
+  const overall = computeBlock(allFiles, gold.occurrences, run, runIndex, goldIndex);
+
+  const per_document: Record<string, MetricBlock> = {};
+  for (const file of [...allFiles].sort()) {
+    per_document[file] = computeBlock(new Set([file]), gold.occurrences, run, runIndex, goldIndex);
+  }
+
+  const per_strata: Record<string, MetricBlock> = {};
+  const strataFiles = new Map<string, Set<string>>();
+  for (const [file, meta] of Object.entries(gold.documents ?? {})) {
+    const strata = meta?.strata;
+    if (!strata) continue;
+    for (const dimension of ["layout", "ocr_quality", "spelling_family"] as const) {
+      const value = strata[dimension];
+      if (typeof value !== "string" || value.length === 0) continue;
+      const key = `${dimension}=${value}`;
+      const bucket = strataFiles.get(key) ?? new Set<string>();
+      bucket.add(file);
+      strataFiles.set(key, bucket);
+    }
+  }
+  for (const key of [...strataFiles.keys()].sort()) {
+    per_strata[key] = computeBlock(strataFiles.get(key)!, gold.occurrences, run, runIndex, goldIndex);
+  }
+
+  const { floors_evaluated, gate } = evaluateGate(overall, input.floors ?? {}, input.ceilings ?? {});
+
+  return {
+    schema: TYPED_LINKING_EVALUATION_SCHEMA,
+    profile_hash: input.profileHash ?? null,
+    normalizer_hashes: input.normalizerHashes ?? {},
+    run_hash: hashOccurrences(run),
+    gold_hash: hashGold(gold),
+    metrics: { overall, per_document, per_strata },
+    floors_evaluated,
+    gate,
+  };
+}
+
+function fmt(value: number | null): string {
+  return value === null ? "null" : value.toFixed(4);
+}
+
+/**
+ * Human-readable report. Precision and unresolved-rate are ALWAYS printed as a
+ * pair, even when the gate only configures one of them.
+ */
+export function formatEvaluationReport(result: EvaluationResult): string {
+  const overall = result.metrics.overall;
+  const lines: string[] = [];
+  lines.push(`gate: ${result.gate.toUpperCase()}`);
+  lines.push(`mention_recall: ${fmt(overall.mention_recall)} (${overall.gold_spans_matched}/${overall.gold_spans} gold spans)`);
+  lines.push(`set_recall (macro): ${fmt(overall.set_recall)} over ${overall.documents_scored} document(s)`);
+  lines.push(`resolution_precision: ${fmt(overall.resolution_precision)}  |  unresolved_rate: ${fmt(overall.unresolved_rate)}`);
+  lines.push(`  unlinked_rate: ${fmt(overall.unlinked_rate)}  ambiguous_rate: ${fmt(overall.ambiguous_rate)}  linked_count: ${overall.linked_count}`);
+  for (const [key, block] of Object.entries(result.metrics.per_strata).sort(([a], [b]) => a.localeCompare(b))) {
+    lines.push(`  strata[${key}] precision: ${fmt(block.resolution_precision)} | unresolved: ${fmt(block.unresolved_rate)} | mention_recall: ${fmt(block.mention_recall)}`);
+  }
+  for (const floor of result.floors_evaluated) {
+    const relation = floor.kind === "floor" ? ">=" : "<=";
+    lines.push(`  ${floor.pass ? "PASS" : "FAIL"} ${floor.kind} ${floor.metric} ${relation} ${floor.threshold} (got ${fmt(floor.value)})`);
+  }
+  return lines.join("\n");
+}

--- a/src/profile-registry.ts
+++ b/src/profile-registry.ts
@@ -3,6 +3,7 @@ import { extname, resolve } from "node:path";
 import { parse as parseCsv } from "csv-parse/sync";
 import { parse as parseYaml } from "yaml";
 
+import { auditNormalizerContracts, compileNormalizerByNodeType } from "./entity-normalizer.js";
 import type {
   Extraction,
   NormalizedOntologyProfile,
@@ -123,12 +124,16 @@ export function loadProfileRegistry(
 export function loadProfileRegistries(
   profile: NormalizedOntologyProfile,
 ): Record<string, RegistryRecord[]> {
-  return Object.fromEntries(
+  const registries = Object.fromEntries(
     Object.entries(profile.registries).map(([registryId, registrySpec]) => [
       registryId,
       loadProfileRegistry(registryId, registrySpec),
     ]),
-  );
+  ) as Record<string, RegistryRecord[]>;
+  // The whole registry is now in memory, but no corpus source has been read:
+  // this is the L3 $0 boundary for idempotence and partition-scoped anti-merge.
+  auditNormalizerContracts(profile, registries, compileNormalizerByNodeType(profile));
+  return registries;
 }
 
 function safeIdPart(value: string): string {

--- a/src/profile-registry.ts
+++ b/src/profile-registry.ts
@@ -10,29 +10,46 @@ import type {
   RegistryRecord,
 } from "./types.js";
 
-function readRegistryRows(path: string): Array<Record<string, unknown>> {
+interface RegistryRows {
+  rows: Array<Record<string, unknown>>;
+  columns: Set<string>;
+}
+
+function columnsOf(rows: Array<Record<string, unknown>>): Set<string> {
+  return new Set(rows.flatMap((row) => Object.keys(row)));
+}
+
+function readRegistryRows(path: string): RegistryRows {
   const ext = extname(path).toLowerCase();
   const raw = readFileSync(path, "utf-8");
   if (ext === ".csv") {
-    return parseCsv(raw, {
+    const rows = parseCsv(raw, {
       columns: true,
       skip_empty_lines: true,
       trim: true,
     }) as Array<Record<string, unknown>>;
+    const [header = []] = parseCsv(raw, {
+      to_line: 1,
+      skip_empty_lines: true,
+      trim: true,
+    }) as string[][];
+    return { rows, columns: new Set(header) };
   }
   if (ext === ".json") {
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) {
       throw new Error(`registry file must contain an array: ${path}`);
     }
-    return parsed.map((item) => item as Record<string, unknown>);
+    const rows = parsed.map((item) => item as Record<string, unknown>);
+    return { rows, columns: columnsOf(rows) };
   }
   if (ext === ".yaml" || ext === ".yml") {
     const parsed = parseYaml(raw) as unknown;
     if (!Array.isArray(parsed)) {
       throw new Error(`registry file must contain an array: ${path}`);
     }
-    return parsed.map((item) => item as Record<string, unknown>);
+    const rows = parsed.map((item) => item as Record<string, unknown>);
+    return { rows, columns: columnsOf(rows) };
   }
   throw new Error(`unsupported registry file extension: ${ext || path}`);
 }
@@ -56,6 +73,12 @@ export function normalizeRegistryRecord(
   if (!label) {
     throw new Error(`${registryId} record ${id} is missing label_column ${registrySpec.label_column}`);
   }
+  const partition = registrySpec.partition_column
+    ? field(rawRecord, registrySpec.partition_column)
+    : undefined;
+  if (registrySpec.partition_column && !partition) {
+    throw new Error(`${registryId} record ${id} is missing partition_column ${registrySpec.partition_column}`);
+  }
   return {
     registryId,
     id,
@@ -64,6 +87,7 @@ export function normalizeRegistryRecord(
       .map((column) => field(rawRecord, column))
       .filter(Boolean),
     nodeType: registrySpec.node_type,
+    ...(partition ? { partition } : {}),
     sourceFile: resolve(sourceFile),
     raw: { ...rawRecord },
   };
@@ -77,7 +101,13 @@ export function loadProfileRegistry(
     throw new Error(`registries.${registryId} is not bound to a source file`);
   }
   const sourceFile = resolve(registrySpec.bound_source_path);
-  const records = readRegistryRows(sourceFile).map((rawRecord) =>
+  const { rows, columns } = readRegistryRows(sourceFile);
+  if (registrySpec.partition_column && !columns.has(registrySpec.partition_column)) {
+    throw new Error(
+      `registries.${registryId}.partition_column ${registrySpec.partition_column} does not exist in ${sourceFile}`,
+    );
+  }
+  const records = rows.map((rawRecord) =>
     normalizeRegistryRecord(registryId, registrySpec, rawRecord, sourceFile),
   );
   const seen = new Set<string>();
@@ -127,6 +157,7 @@ export function registryRecordsToExtraction(
         node_type: record.nodeType,
         registry_id: record.registryId,
         registry_record_id: record.id,
+        ...(record.partition ? { registry_partition: record.partition } : {}),
         aliases: record.aliases,
         status: "validated",
         profile_id: profile.id,

--- a/src/source-grounding.ts
+++ b/src/source-grounding.ts
@@ -1,0 +1,404 @@
+/**
+ * Shared, source-centric grounding substrate.
+ *
+ * Citation grounding and typed entity linking intentionally share parsing,
+ * normalized-to-raw relocation, and the verbatim gate. `rawSource` remains
+ * authoritative: a SourceUnit's display text may be a trim/join projection of
+ * OCR lines and must never be treated as a raw-file slice.
+ */
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve as resolvePath } from "node:path";
+
+/** NFKD deaccent + ascii-fold (drops combining marks, ligatures degrade). */
+export function deaccent(s: string): string {
+  return (s ?? "").normalize("NFKD").replace(/[̀-ͯ]/g, "");
+}
+
+const DOTTED_INITIAL_RUN_RE = /\b[a-z]\s*\.(?:\s*[a-z]\s*\.)+/g;
+
+function normalizeForMatchBase(s: string): string {
+  return deaccent(s ?? "")
+    .replace(/œ/g, "oe")
+    .replace(/æ/g, "ae")
+    .replace(/Œ/g, "OE")
+    .replace(/Æ/g, "AE")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function foldDottedInitialSpacing(s: string): string {
+  return s.replace(DOTTED_INITIAL_RUN_RE, (run) => run.replace(/\s+/g, ""));
+}
+
+/** Canonical match form used by both matching and the verbatim gate. */
+export function normalizeForMatch(s: string): string {
+  return foldDottedInitialSpacing(normalizeForMatchBase(s));
+}
+
+export type SourceModality = "ocr-markdown" | "plain-text";
+
+export interface SourceUnit {
+  /** Paragraph display text; OCR paragraphs can be a trim/join projection. */
+  text: string;
+  page: number;
+  section: string;
+  paragraphIndex: number;
+  /** Raw-file half-open boundaries covering this unit's source lines. */
+  documentStart?: number;
+  documentEnd?: number;
+  /** Normalized unit text and its per-character raw document offsets. */
+  normalizedText?: string;
+  normToRaw?: number[];
+}
+
+export interface ImageContext {
+  basename: string;
+  page: number;
+  section: string;
+  prev: string;
+  next: string;
+}
+
+export interface ParsedSource {
+  modality: SourceModality;
+  units: SourceUnit[];
+  sectionToIndices: Map<string, number[]>;
+  images: Map<string, ImageContext>;
+  pageCount: number;
+  /** Original file contents; the sole authority for occurrence slices. */
+  rawSource?: string;
+  /** Leading YAML-ish front matter, excluded from content units. */
+  frontMatter?: Record<string, string>;
+}
+
+/** Detect modality from a source path. `.md` → OCR-markdown, else plain-text. */
+export function detectModality(sourceFile: string): SourceModality {
+  return /\.(md|markdown)$/i.test(sourceFile) ? "ocr-markdown" : "plain-text";
+}
+
+const FRONT_MATTER_KEY = /^[a-z_]+:\s/i;
+
+interface BufferedLine {
+  text: string;
+  start: number;
+  end: number;
+}
+
+function lineStarts(raw: string, lines: string[]): number[] {
+  const starts: number[] = [];
+  let offset = 0;
+  for (const line of lines) {
+    starts.push(offset);
+    offset += line.length + 1;
+  }
+  return starts;
+}
+
+function trimmedLine(rawLine: string, start: number): BufferedLine | null {
+  const text = rawLine.trim();
+  if (!text) return null;
+  const leading = rawLine.length - rawLine.trimStart().length;
+  const trailing = rawLine.trimEnd().length;
+  return { text, start: start + leading, end: start + trailing };
+}
+
+function frontMatterValue(line: string): [string, string] | null {
+  const match = /^([a-zA-Z0-9_-]+):\s*(.*)$/u.exec(line.trim());
+  if (!match) return null;
+  const key = match[1]!;
+  const value = match[2]!.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/u, "$1$2");
+  return [key, value];
+}
+
+function makeUnit(
+  raw: string,
+  lines: BufferedLine[],
+  page: number,
+  section: string,
+  paragraphIndex: number,
+): SourceUnit {
+  const documentStart = lines[0]!.start;
+  const documentEnd = lines[lines.length - 1]!.end;
+  const table = buildNormToRawMap(raw.slice(documentStart, documentEnd));
+  return {
+    text: lines.map((line) => line.text).join(" ").trim(),
+    page,
+    section,
+    paragraphIndex,
+    documentStart,
+    documentEnd,
+    normalizedText: table.norm,
+    normToRaw: table.map.map((offset) => documentStart + offset),
+  };
+}
+
+function addUnit(
+  raw: string,
+  units: SourceUnit[],
+  sectionToIndices: Map<string, number[]>,
+  lines: BufferedLine[],
+  page: number,
+  section: string,
+): SourceUnit | null {
+  if (lines.length === 0) return null;
+  const unit = makeUnit(raw, lines, page, section, units.length);
+  if (!unit.text || unit.text.startsWith("![")) return null;
+  units.push(unit);
+  const arr = sectionToIndices.get(section) ?? [];
+  arr.push(unit.paragraphIndex);
+  sectionToIndices.set(section, arr);
+  return unit;
+}
+
+function parseOcrMarkdown(raw: string): ParsedSource {
+  const lines = raw.split("\n");
+  const starts = lineStarts(raw, lines);
+  const units: SourceUnit[] = [];
+  const sectionToIndices = new Map<string, number[]>();
+  const images = new Map<string, ImageContext>();
+  const frontMatter: Record<string, string> = {};
+  let page = 1;
+  let section = "";
+  let buf: BufferedLine[] = [];
+  let pendingImages: string[] = [];
+  let inFrontMatter = false;
+  let frontMatterDone = false;
+  let i = 0;
+  if (lines[0]?.trim() === "---") {
+    inFrontMatter = true;
+    i = 1;
+  }
+
+  const flush = (): void => {
+    const unit = addUnit(raw, units, sectionToIndices, buf, page, section);
+    buf = [];
+    if (!unit) return;
+    for (const filename of pendingImages) {
+      const ctx = images.get(filename);
+      if (ctx && !ctx.next) ctx.next = unit.text;
+    }
+    pendingImages = [];
+  };
+
+  for (; i < lines.length; i += 1) {
+    const rawLine = lines[i] ?? "";
+    const s = rawLine.trim();
+    if (inFrontMatter && !frontMatterDone) {
+      if (s === "---") {
+        frontMatterDone = true;
+        inFrontMatter = false;
+      } else if (s !== "" && !FRONT_MATTER_KEY.test(s)) {
+        inFrontMatter = false;
+        frontMatterDone = true;
+        i -= 1;
+      } else {
+        const entry = frontMatterValue(rawLine);
+        if (entry) frontMatter[entry[0]] = entry[1];
+      }
+      continue;
+    }
+    if (s === "---") {
+      flush();
+      page += 1;
+      continue;
+    }
+    if (/^#{1,4}\s/.test(s)) {
+      flush();
+      section = s.replace(/^#{1,4}\s+/, "").trim();
+      continue;
+    }
+    const img = /^!\[[^\]]*\]\(([^)]+)\)/.exec(s);
+    if (img) {
+      flush();
+      const filename = basenameOf(img[1] ?? "");
+      const prev = units.length > 0 ? (units[units.length - 1]?.text ?? "") : "";
+      images.set(filename, { basename: filename, page, section, prev, next: "" });
+      pendingImages.push(filename);
+      continue;
+    }
+    if (s === "") {
+      flush();
+      continue;
+    }
+    const line = trimmedLine(rawLine, starts[i]!);
+    if (line) buf.push(line);
+  }
+  flush();
+  return { modality: "ocr-markdown", units, sectionToIndices, images, pageCount: page, rawSource: raw, frontMatter };
+}
+
+function parsePlainText(raw: string): ParsedSource {
+  const lines = raw.split("\n");
+  const starts = lineStarts(raw, lines);
+  const units: SourceUnit[] = [];
+  const sectionToIndices = new Map<string, number[]>();
+  let section = "";
+  let buf: BufferedLine[] = [];
+  const flush = (): void => {
+    addUnit(raw, units, sectionToIndices, buf, 1, section);
+    buf = [];
+  };
+  for (let i = 0; i < lines.length; i += 1) {
+    const rawLine = lines[i] ?? "";
+    const s = rawLine.trim();
+    if (/^#{1,4}\s/.test(s)) {
+      flush();
+      section = s.replace(/^#{1,4}\s+/, "").trim();
+      continue;
+    }
+    if (isHeadingLine(s, buf.length === 0)) {
+      flush();
+      section = s;
+      continue;
+    }
+    if (s === "") {
+      flush();
+      continue;
+    }
+    const line = trimmedLine(rawLine, starts[i]!);
+    if (line) buf.push(line);
+  }
+  flush();
+  return {
+    modality: "plain-text",
+    units,
+    sectionToIndices,
+    images: new Map(),
+    pageCount: 1,
+    rawSource: raw,
+    frontMatter: {},
+  };
+}
+
+function isHeadingLine(s: string, atParagraphStart: boolean): boolean {
+  if (!s || !atParagraphStart) return false;
+  if (/^(chapter|part|book|adventure|story)\b/i.test(s) && s.length <= 80) return true;
+  const words = s.split(/\s+/);
+  if (words.length > 8 || s.length > 80) return false;
+  const letters = s.replace(/[^a-zA-ZÀ-ÿ]/g, "");
+  if (letters.length < 3) return false;
+  const upper = s.replace(/[^A-ZÀ-Þ]/g, "");
+  return upper.length / letters.length >= 0.7;
+}
+
+function basenameOf(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(index + 1) : normalized;
+}
+
+/** Parse any supported source modality. */
+export function parseSource(raw: string, modality: SourceModality): ParsedSource {
+  return modality === "ocr-markdown" ? parseOcrMarkdown(raw) : parsePlainText(raw);
+}
+
+const QUOTE_BEFORE = 110;
+const QUOTE_AFTER = 210;
+const QUOTE_MAXLEN = 320;
+const OPEN_BOUNDARY = new Set([" ", "\n", "«", "(", '"', "“"]);
+const CLOSE_BOUNDARY = new Set([" ", "\n", ".", "!", "?", "»", ")", '"', "”"]);
+
+/** Return a RAW context window around an offset. */
+export function windowQuote(text: string, offset: number): string {
+  let a = Math.max(0, offset - QUOTE_BEFORE);
+  let b = Math.min(text.length, offset + QUOTE_AFTER);
+  while (a > 0 && !OPEN_BOUNDARY.has(text[a] ?? "")) a -= 1;
+  while (b < text.length && !CLOSE_BOUNDARY.has(text[b] ?? "")) b += 1;
+  let quote = text.slice(a, b).trim();
+  if (a > 0) quote = "… " + quote;
+  if (b < text.length) quote += " …";
+  quote = quote.replace(/\s+/g, " ");
+  return quote.length > QUOTE_MAXLEN ? quote.slice(0, QUOTE_MAXLEN).trim() : quote;
+}
+
+/** Hard gate shared by all grounding producers. */
+export function verifyVerbatim(quote: string, normalizedSource: string): boolean {
+  if (!quote) return false;
+  const core = quote.replace(/^…\s*/, "").replace(/\s*…$/, "");
+  const needle = normalizeForMatch(core);
+  return Boolean(needle) && normalizedSource.includes(needle);
+}
+
+/** Build a normalized offset → raw offset table for one raw string. */
+export function buildNormToRawMap(rawText: string): { norm: string; map: number[] } {
+  const normChars: string[] = [];
+  const map: number[] = [];
+  let pendingSpace = false;
+  let sawNonSpace = false;
+  for (let i = 0; i < rawText.length; i += 1) {
+    const ch = rawText[i] ?? "";
+    const piece = normalizeForMatchBase(ch);
+    if (piece === "") {
+      if (/\s/.test(ch)) pendingSpace = true;
+      continue;
+    }
+    if (pendingSpace && sawNonSpace) {
+      normChars.push(" ");
+      map.push(i);
+    }
+    pendingSpace = false;
+    for (const normalized of piece) {
+      normChars.push(normalized);
+      map.push(i);
+    }
+    sawNonSpace = true;
+  }
+  const norm = normChars.join("");
+  const foldedChars: string[] = [];
+  const foldedMap: number[] = [];
+  let copiedUntil = 0;
+  DOTTED_INITIAL_RUN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = DOTTED_INITIAL_RUN_RE.exec(norm)) !== null) {
+    const start = match.index;
+    const end = start + match[0].length;
+    for (let i = copiedUntil; i < start; i += 1) {
+      foldedChars.push(norm[i] ?? "");
+      foldedMap.push(map[i] ?? 0);
+    }
+    for (let i = start; i < end; i += 1) {
+      const char = norm[i] ?? "";
+      if (char === " ") continue;
+      foldedChars.push(char);
+      foldedMap.push(map[i] ?? 0);
+    }
+    copiedUntil = end;
+  }
+  for (let i = copiedUntil; i < norm.length; i += 1) {
+    foldedChars.push(norm[i] ?? "");
+    foldedMap.push(map[i] ?? 0);
+  }
+  return { norm: foldedChars.join(""), map: foldedMap };
+}
+
+/** Locate a normalized term's raw offset, or -1 when it is absent. */
+export function rawOffsetForTerm(rawText: string, normTerm: string): number {
+  if (!normTerm) return -1;
+  const { norm, map } = buildNormToRawMap(rawText);
+  const at = norm.indexOf(normTerm);
+  return at < 0 ? -1 : (map[at] ?? -1);
+}
+
+export interface ResolveSourceOptions {
+  root: string;
+  searchRoots?: string[];
+}
+
+/** Resolve a source relative to the configured root and optional search roots. */
+export function resolveSourcePath(sourceFile: string, options: ResolveSourceOptions): string | null {
+  if (!sourceFile) return null;
+  const candidates: string[] = [];
+  if (isAbsolute(sourceFile)) candidates.push(sourceFile);
+  candidates.push(resolvePath(options.root, sourceFile));
+  for (const root of options.searchRoots ?? []) candidates.push(resolvePath(root, sourceFile));
+  for (const candidate of candidates) {
+    try {
+      readFileSync(candidate);
+      return candidate;
+    } catch {
+      // Try the next location.
+    }
+  }
+  return null;
+}

--- a/src/studio-assets.ts
+++ b/src/studio-assets.ts
@@ -508,7 +508,13 @@ export function buildEntitySidecar(
     }
   }
 
-  const occRaw = loadJsonSafe<Record<string, unknown>>(join(stateDir, "ontology", "occurrences.json"));
+  // Keep mention-level occurrences canonical and serve the Studio only the
+  // derived node-id summary. Old map-shaped occurrences remain a fallback for
+  // pre-link workspaces.
+  const summaryRaw = loadJsonSafe<Record<string, unknown>>(
+    join(stateDir, "ontology", "entity-occurrence-summary.json"),
+  );
+  const occRaw = summaryRaw ?? loadJsonSafe<Record<string, unknown>>(join(stateDir, "ontology", "occurrences.json"));
   let occurrences: unknown = null;
   if (occRaw) {
     const nodes =

--- a/src/types.ts
+++ b/src/types.ts
@@ -728,17 +728,56 @@ export interface OntologyVisualEncoding {
   border?: OntologyVisualEncodingBorder;
 }
 
+/**
+ * Declarative composition for a registry entity normalizer. Built-ins are
+ * applied left-to-right, then the optional synchronous local ESM export runs.
+ */
+export interface OntologyNodeTypeNormalize {
+  builtin?: string[];
+  fn?: string;
+}
+
+/**
+ * Typed entity-linking declaration. `preset` is parsed and stored in L3 but
+ * intentionally not executed until the L4 linking producer exists.
+ */
+export interface OntologyNodeTypeLinking {
+  preset?: string;
+  normalize?: OntologyNodeTypeNormalize;
+}
+
+/** Portable fingerprint of the effective normalizer; runtime paths are absent. */
+export interface EntityNormalizerDescriptor {
+  contract: "graphify_entity_normalizer_v1";
+  builtins: string[];
+  export?: string;
+  module_sha256?: string;
+  normalizer_hash: string;
+}
+
+export interface NormalizedOntologyNodeTypeLinking {
+  preset?: string;
+  normalize?: OntologyNodeTypeNormalize;
+  normalizer: EntityNormalizerDescriptor;
+}
+
 export interface OntologyNodeType {
   aliases?: string[];
   registry?: string;
   source_backed?: boolean;
   status_policy?: string;
+  linking?: OntologyNodeTypeLinking;
   /**
    * Per-node-type visual encoding override consumed by the static studio scene
    * builder (`studio-scene.ts`): `shape` / `fill` / `border` drive the glyph.
    * (`color_hex` is accepted + format-validated but inert — see above.)
    */
   visual_encoding?: OntologyVisualEncoding;
+}
+
+/** Node-type configuration after the L3 linking contract has been compiled. */
+export interface NormalizedOntologyNodeType extends Omit<OntologyNodeType, "linking"> {
+  linking?: NormalizedOntologyNodeTypeLinking;
 }
 
 export interface OntologyRelationType {
@@ -1098,7 +1137,7 @@ export interface NormalizedOntologyProfile {
   default_language: string;
   sourcePath?: string;
   profile_hash: string;
-  node_types: Record<string, OntologyNodeType>;
+  node_types: Record<string, NormalizedOntologyNodeType>;
   relation_types: Record<string, NormalizedOntologyRelationType>;
   registries: Record<string, NormalizedOntologyRegistrySpec>;
   citation_policy: Required<OntologyCitationPolicy>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -755,12 +755,37 @@ export interface OntologyLinkingPattern {
   membership?: "required";
 }
 
+/**
+ * Bounded trigger enum deciding when the opt-in `llm` detector may propose
+ * spans. There is NO free-form expression: hybrid recall only calls the model
+ * when the declared condition over the $0 detectors' output holds.
+ */
+export type OntologyLinkLlmTrigger =
+  | "zero_candidates"
+  | "unresolved_candidates"
+  | "below_min_candidates";
+
+/**
+ * Declarative configuration for the `llm` detector. The model PROPOSES typed
+ * spans only; resolution stays with graphify's exact/none resolver + the
+ * verbatim gate. Budget/dry_run are honored before any provider call is made.
+ */
+export interface OntologyLinkLlmConfig {
+  trigger: OntologyLinkLlmTrigger;
+  /** Non-negative USD ceiling. `0` disables the detector (no proposals). */
+  budget_usd?: number;
+  /** When true, never make a paid proposal call for this detector. */
+  dry_run?: boolean;
+  /** Companion threshold for `below_min_candidates` (defaults to 1). */
+  min_candidates?: number;
+}
+
 export type OntologyLinkDetector =
   | "lexicon"
   | "pattern"
   | "llm"
   | { pattern: OntologyLinkingPattern }
-  | { llm: Record<string, unknown> };
+  | { llm: OntologyLinkLlmConfig };
 
 export interface OntologyLinkingResolve {
   mode: "exact" | "none";

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface GraphNode {
   node_type?: string;
   registry_id?: string;
   registry_record_id?: string;
+  registry_partition?: string;
   registry_refs?: string[];
   aliases?: string[];
   status?: OntologyStatus;
@@ -757,6 +758,8 @@ export interface OntologyRegistrySpec {
   label_column?: string;
   alias_columns?: string[];
   node_type?: string;
+  /** Registry column that scopes label and alias identity. */
+  partition_column?: string;
   bound_source_path?: string;
 }
 
@@ -1064,6 +1067,8 @@ export interface NormalizedOntologyRegistrySpec {
   label_column: string;
   alias_columns: string[];
   node_type: string;
+  /** Present only for registries whose labels and aliases are partition-scoped. */
+  partition_column?: string;
   bound_source_path?: string;
 }
 
@@ -1123,6 +1128,8 @@ export interface RegistryRecord {
   label: string;
   aliases: string[];
   nodeType: string;
+  /** Present only when the registry declares partition_column. */
+  partition?: string;
   sourceFile: string;
   raw: Record<string, unknown>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -737,13 +737,53 @@ export interface OntologyNodeTypeNormalize {
   fn?: string;
 }
 
+/** Document metadata binding used to scope a partitioned registry. */
+export interface OntologyLinkingPartitionFrom {
+  /** Front-matter field preferred over any path-layout fallback. */
+  source_frontmatter: string;
+  /** Declarative fallback: zero-based segment of the source path. */
+  else?: { path_segment: number };
+}
+
+/** A $0 regex detector. Matches are always intersected with registry membership. */
+export interface OntologyLinkingPattern {
+  form: string;
+  flags?: string;
+  /** Kept declarative for consumers; L4a never emits a non-member expansion. */
+  expand?: { ranges?: string };
+  /** Normalized to `required`; values outside the registry are never emitted. */
+  membership?: "required";
+}
+
+export type OntologyLinkDetector =
+  | "lexicon"
+  | "pattern"
+  | "llm"
+  | { pattern: OntologyLinkingPattern }
+  | { llm: Record<string, unknown> };
+
+export interface OntologyLinkingResolve {
+  mode: "exact" | "none";
+}
+
+export interface OntologyLinkingEvidence {
+  verbatim: "required";
+  context_window?: number;
+}
+
 /**
- * Typed entity-linking declaration. `preset` is parsed and stored in L3 but
- * intentionally not executed until the L4 linking producer exists.
+ * Typed entity-linking declaration. Every field is optional at the profile
+ * boundary; presets are expanded into the three explicit axes at load time.
  */
 export interface OntologyNodeTypeLinking {
   preset?: string;
   normalize?: OntologyNodeTypeNormalize;
+  partition_from?: OntologyLinkingPartitionFrom;
+  detect?: OntologyLinkDetector[];
+  /** Convenience spelling for profile authors; normalized into `detect`. */
+  patterns?: OntologyLinkingPattern[];
+  resolve?: "exact" | "none" | OntologyLinkingResolve;
+  evidence?: Partial<OntologyLinkingEvidence>;
 }
 
 /** Portable fingerprint of the effective normalizer; runtime paths are absent. */
@@ -758,6 +798,10 @@ export interface EntityNormalizerDescriptor {
 export interface NormalizedOntologyNodeTypeLinking {
   preset?: string;
   normalize?: OntologyNodeTypeNormalize;
+  partition_from?: OntologyLinkingPartitionFrom;
+  detect: OntologyLinkDetector[];
+  resolve: OntologyLinkingResolve;
+  evidence: OntologyLinkingEvidence;
   normalizer: EntityNormalizerDescriptor;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -649,6 +649,28 @@ export interface OntologyOccurrence {
   [key: string]: unknown;
 }
 
+export interface TypedEntityOccurrenceV1 {
+  id: string;
+  node_type: string;
+  raw_span: string;
+  normalized: string;
+  source_file: string;
+  page: number | null;
+  offsets: { start: number; end: number };
+  detector: "lexicon" | "pattern" | "llm";
+  resolution: "linked" | "unlinked" | "ambiguous";
+  registry_record_id?: string;
+  registry_partition: string | null;
+}
+
+export interface LinkValidationIssue {
+  code: string;
+  severity: "error" | "warning" | "info";
+  node_type: string | null;
+  message: string;
+  refs: string[];
+}
+
 export interface OntologyMapping {
   id: string;
   source_id: string;

--- a/tests/cli-link.test.ts
+++ b/tests/cli-link.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { main } from "../src/cli.js";
+import { normalizeOntologyProfile } from "../src/ontology-profile.js";
+import type { DetectionResult, RegistryRecord } from "../src/types.js";
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+function setupProject(): string {
+  const root = mkdtempSync(join(tmpdir(), "graphify-link-cli-"));
+  cleanup.push(root);
+  const profileDir = join(root, ".graphify", "profile");
+  mkdirSync(join(profileDir, "registries"), { recursive: true });
+  mkdirSync(join(root, "docs"), { recursive: true });
+  const profile = normalizeOntologyProfile({
+    id: "cli-link",
+    version: 1,
+    node_types: {
+      Zone: {
+        registry: "zones",
+        linking: {
+          preset: "gazetteer-exact",
+          partition_from: { source_frontmatter: "municipality" },
+        },
+      },
+    },
+    relation_types: {},
+    registries: {
+      zones: {
+        source: "zones",
+        id_column: "id",
+        label_column: "label",
+        node_type: "Zone",
+        partition_column: "municipality",
+      },
+    },
+    outputs: { ontology: { occurrence_node_types: ["Zone"] } },
+  }, join(root, "graphify", "ontology-profile.yaml"));
+  const document = join(root, "docs", "compton.md");
+  writeFileSync(document, "---\nmunicipality: compton\n---\n\nC-15\n", "utf-8");
+  const records: RegistryRecord[] = [{
+    registryId: "zones",
+    id: "compton-c15",
+    label: "C-15",
+    aliases: [],
+    nodeType: "Zone",
+    partition: "compton",
+    sourceFile: join(root, "zones.csv"),
+    raw: {},
+  }];
+  const detection: DetectionResult = {
+    files: { code: [], document: [document], paper: [], image: [], video: [] },
+    total_files: 1,
+    total_words: 1,
+    needs_graph: false,
+    warning: null,
+    skipped_sensitive: [],
+    graphifyignore_patterns: 0,
+  };
+  writeFileSync(join(profileDir, "ontology-profile.normalized.json"), JSON.stringify(profile));
+  writeFileSync(join(profileDir, "project-config.normalized.json"), JSON.stringify({ configDir: root }));
+  writeFileSync(join(profileDir, "registries", "zones.json"), JSON.stringify(records));
+  writeFileSync(join(profileDir, "semantic-detection.json"), JSON.stringify(detection));
+  writeFileSync(join(profileDir, "profile-state.json"), JSON.stringify({
+    profile_id: profile.id,
+    profile_version: profile.version,
+    profile_hash: profile.profile_hash,
+    project_config_path: join(root, "graphify.yaml"),
+    ontology_profile_path: join(root, "graphify", "ontology-profile.yaml"),
+    state_dir: join(root, ".graphify"),
+    detect_roots: [join(root, "docs")],
+    exclude_roots: [],
+    registry_counts: { zones: 1 },
+    registry_node_count: 1,
+    semantic_file_count: 1,
+    transcript_count: 0,
+    pdf_artifact_count: 0,
+  }));
+  return root;
+}
+
+async function runCli(args: string[], cwd: string): Promise<string[]> {
+  const argv = process.argv;
+  const previousCwd = process.cwd();
+  const log = console.log;
+  const logs: string[] = [];
+  process.argv = ["node", "graphify", ...args];
+  console.log = (...items: unknown[]) => { logs.push(items.join(" ")); };
+  process.chdir(cwd);
+  try {
+    await main();
+    return logs;
+  } finally {
+    process.chdir(previousCwd);
+    process.argv = argv;
+    console.log = log;
+  }
+}
+
+describe("graphify link CLI", () => {
+  it("consumes profile-state dataprep artifacts and writes list + Studio sidecar", async () => {
+    const root = setupProject();
+    const logs = await runCli(["link", root, "--profile-state", ".graphify/profile/profile-state.json"], root);
+    const outputDir = join(root, ".graphify", "ontology");
+    const occurrences = JSON.parse(readFileSync(join(outputDir, "occurrences.json"), "utf-8"));
+
+    expect(occurrences).toEqual([expect.objectContaining({ registry_record_id: "compton-c15", source_file: "docs/compton.md" })]);
+    expect(JSON.parse(readFileSync(join(outputDir, "entity-occurrence-summary.json"), "utf-8"))).toEqual({
+      registry_zones_compton_c15: expect.objectContaining({ total: 1 }),
+    });
+    expect(logs.join("\n")).toMatch(/wrote 1 occurrence/i);
+  });
+
+  it("honors --dry-run and --out without writing the requested occurrence file", async () => {
+    const root = setupProject();
+    const output = join(root, "custom", "occurrences.json");
+    const logs = await runCli([
+      "link",
+      root,
+      "--profile-state", ".graphify/profile/profile-state.json",
+      "--out", "custom/occurrences.json",
+      "--dry-run",
+    ], root);
+
+    expect(() => readFileSync(output, "utf-8")).toThrow();
+    expect(logs.join("\n")).toMatch(/dry-run.*1 occurrence/i);
+  });
+});

--- a/tests/entity-linking-llm.test.ts
+++ b/tests/entity-linking-llm.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dirname } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  directLlmSpanProposer,
+  linkEntities,
+  llmConfigFromDetectors,
+  requiresLlmProposer,
+  type LlmSpanProposal,
+  type LlmSpanProposer,
+} from "../src/entity-linking.js";
+import { normalizeOntologyProfile } from "../src/ontology-profile.js";
+import type { TextJsonGenerationClient, TextJsonGenerationInput } from "../src/llm-execution.js";
+import type { NormalizedOntologyProfile, OntologyProfile, RegistryRecord } from "../src/types.js";
+
+const cleanup: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "graphify-link-llm-"));
+  cleanup.push(root);
+  return root;
+}
+
+/** Partitioned Zone profile (municipality frontmatter), mirrors the L4a suite. */
+function profile(
+  root: string,
+  linking: NonNullable<OntologyProfile["node_types"]>["Zone"]["linking"],
+): NormalizedOntologyProfile {
+  return normalizeOntologyProfile({
+    id: "link-llm-test",
+    version: 1,
+    node_types: { Zone: { registry: "zones", linking } },
+    relation_types: {},
+    registries: {
+      zones: {
+        source: "zones",
+        id_column: "id",
+        label_column: "label",
+        alias_columns: ["alias"],
+        node_type: "Zone",
+        partition_column: "municipality",
+      },
+    },
+    outputs: { ontology: { occurrence_node_types: ["Zone"] } },
+  }, join(root, "ontology-profile.yaml"));
+}
+
+function record(id: string, label: string, partition = "compton", aliases: string[] = []): RegistryRecord {
+  return { registryId: "zones", id, label, aliases, nodeType: "Zone", partition, sourceFile: "/registry/zones.csv", raw: {} };
+}
+
+function writeDoc(root: string, name: string, body: string): string {
+  const path = join(root, "docs", name);
+  mkdirSync(join(root, "docs"), { recursive: true });
+  writeFileSync(path, `---\nmunicipality: compton\n---\n\n${body}\n`, "utf-8");
+  return path;
+}
+
+/** A vitest spy proposer returning a fixed list; lets tests assert call counts. */
+function spyProposer(proposals: LlmSpanProposal[]): ReturnType<typeof vi.fn> & LlmSpanProposer {
+  return vi.fn(async () => proposals) as unknown as ReturnType<typeof vi.fn> & LlmSpanProposer;
+}
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("graphify link — llm detector proposes, graphify resolves", () => {
+  it("resolves an LLM span via the EXACT resolver, never trusting the model's id hint", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    // The model proposes a verbatim span AND a hallucinated id. Resolution must
+    // ignore the hint (not in partition) and link via exact to the real record.
+    const proposer = spyProposer([{ raw_span: "C-15", registry_record_id: "llm-hallucinated-id" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { detect: ["llm"], resolve: "exact", partition_from: { source_frontmatter: "municipality" } }),
+      // A same-label record in ANOTHER partition must never be linked from compton.
+      registries: { zones: [record("compton-c15", "C-15", "compton"), record("other-c15", "C-15", "other")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(proposer).toHaveBeenCalledTimes(1);
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0]).toMatchObject({
+      raw_span: "C-15",
+      detector: "llm",
+      resolution: "linked",
+      registry_record_id: "compton-c15", // from EXACT, not the LLM hint
+      registry_partition: "compton",
+    });
+  });
+
+  it("drops an LLM proposal that cannot be relocated verbatim (no occurrence, no repair)", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    const proposer = spyProposer([{ raw_span: "Z-999 (not present verbatim)" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { detect: ["llm"], resolve: "exact", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(proposer).toHaveBeenCalledTimes(1);
+    expect(result.occurrences).toEqual([]);
+  });
+
+  it("never fabricates a link from an invented id when the span is not a registry member", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-77 apparait ici.");
+    // Span is verbatim but not in the registry; the (invented) id must not stick.
+    const proposer = spyProposer([{ raw_span: "C-77", registry_record_id: "ghost" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { detect: ["llm"], resolve: "exact", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0]).toMatchObject({ raw_span: "C-77", detector: "llm", resolution: "unlinked" });
+    expect(result.occurrences[0]!.registry_record_id).toBeUndefined();
+  });
+
+  it("open-extraction resolves none: verified unlinked occurrences without any id", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    const proposer = spyProposer([{ raw_span: "C-15" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { preset: "open-extraction", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(proposer).toHaveBeenCalledTimes(1);
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0]).toMatchObject({ raw_span: "C-15", detector: "llm", resolution: "unlinked" });
+    expect(result.occurrences[0]!.registry_record_id).toBeUndefined();
+  });
+});
+
+describe("graphify link — hybrid-recall trigger discipline", () => {
+  it("calls the LLM only for documents where the $0 detectors found nothing", async () => {
+    const root = tempRoot();
+    const hit = writeDoc(root, "hit.md", "Le code C-15 borne la zone.");     // lexicon finds C-15
+    const miss = writeDoc(root, "miss.md", "Aucune zone mentionnee ici.");    // lexicon finds nothing
+    const proposer = spyProposer([]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { preset: "hybrid-recall", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [hit, miss],
+      llmProposer: proposer,
+    });
+
+    // zero_candidates trigger fires ONLY for miss.md → exactly one proposer call.
+    expect(proposer).toHaveBeenCalledTimes(1);
+    expect(proposer.mock.calls[0]![0]).toMatchObject({ sourceFile: "docs/miss.md", nodeType: "Zone" });
+    // hit.md still produced its deterministic $0 (lexicon) occurrence.
+    expect(result.occurrences).toEqual([
+      expect.objectContaining({ source_file: "docs/hit.md", detector: "lexicon", resolution: "linked" }),
+    ]);
+  });
+});
+
+describe("graphify link — budget / dry-run gates skip paid calls", () => {
+  it("makes zero calls when budget_usd is 0 and reports LINK_LLM_BUDGET_EXHAUSTED", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    const proposer = spyProposer([{ raw_span: "C-15" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, {
+        detect: [{ llm: { trigger: "zero_candidates", budget_usd: 0 } }],
+        resolve: "exact",
+        partition_from: { source_frontmatter: "municipality" },
+      }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(proposer).not.toHaveBeenCalled();
+    expect(result.occurrences).toEqual([]);
+    expect(result.issues).toEqual(expect.arrayContaining([expect.objectContaining({ code: "LINK_LLM_BUDGET_EXHAUSTED" })]));
+  });
+
+  it("makes zero calls under --dry-run (llmDryRun) and reports LINK_LLM_DRY_RUN", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    const proposer = spyProposer([{ raw_span: "C-15" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { detect: ["llm"], resolve: "exact", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+      llmDryRun: true,
+    });
+
+    expect(proposer).not.toHaveBeenCalled();
+    expect(result.occurrences).toEqual([]);
+    expect(result.issues).toEqual(expect.arrayContaining([expect.objectContaining({ code: "LINK_LLM_DRY_RUN" })]));
+  });
+});
+
+describe("graphify link — $0 default preserved (non-regression)", () => {
+  it("gazetteer-exact makes ZERO LLM calls even when a proposer is provided", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    const proposer = spyProposer([{ raw_span: "C-15", registry_record_id: "ghost" }]);
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(proposer).not.toHaveBeenCalled();
+    expect(result.occurrences).toEqual([
+      expect.objectContaining({ detector: "lexicon", resolution: "linked", registry_record_id: "compton-c15" }),
+    ]);
+  });
+
+  it("a profile with no linking block is a no-op and never touches the proposer", async () => {
+    const root = tempRoot();
+    const noLink = normalizeOntologyProfile({
+      id: "no-link",
+      version: 1,
+      node_types: { Zone: { registry: "zones" } },
+      relation_types: {},
+      registries: { zones: { source: "zones", id_column: "id", label_column: "label", node_type: "Zone" } },
+    }, join(root, "profile.yaml"));
+    const proposer = spyProposer([{ raw_span: "C-15" }]);
+    const result = await linkEntities({
+      root,
+      profile: noLink,
+      registries: { zones: [record("c15", "C-15")] },
+      sourceFiles: [writeDoc(root, "compton.md", "Le code C-15 borne la zone.")],
+      llmProposer: proposer,
+    });
+
+    expect(result.noOp).toBe(true);
+    expect(proposer).not.toHaveBeenCalled();
+  });
+
+  it("requiresLlmProposer only reports presets that actually use the llm detector", () => {
+    const root = tempRoot();
+    const open = profile(root, { preset: "open-extraction", partition_from: { source_frontmatter: "municipality" } });
+    const hybrid = profile(root, { preset: "hybrid-recall", partition_from: { source_frontmatter: "municipality" } });
+    const gaz = profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } });
+    expect(requiresLlmProposer(open)).toBe(true);
+    expect(requiresLlmProposer(hybrid)).toBe(true);
+    expect(requiresLlmProposer(gaz)).toBe(false);
+    expect(llmConfigFromDetectors(gaz.node_types.Zone!.linking!.detect)).toBeUndefined();
+    expect(llmConfigFromDetectors(open.node_types.Zone!.linking!.detect)).toMatchObject({ trigger: "zero_candidates" });
+  });
+});
+
+describe("graphify link — direct provider adapter (offline)", () => {
+  it("adapts a TextJsonGenerationClient into a span proposer and links end-to-end", async () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "Le code C-15 borne la zone.");
+    // A fake client that writes canned span JSON to outputPath — no network.
+    const client: TextJsonGenerationClient = {
+      mode: "direct",
+      provider: "anthropic",
+      model: "test-model",
+      async generateJson(input: TextJsonGenerationInput) {
+        mkdirSync(dirname(input.outputPath!), { recursive: true });
+        writeFileSync(input.outputPath!, JSON.stringify({ spans: [{ raw_span: "C-15" }] }), "utf-8");
+        return { status: "completed", provider: "anthropic", mode: "direct", model: "test-model", outputPath: input.outputPath, audit: {} };
+      },
+    };
+    const proposer = directLlmSpanProposer(client, { stateDir: join(root, ".graphify") });
+    const result = await linkEntities({
+      root,
+      profile: profile(root, { detect: ["llm"], resolve: "exact", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15", "compton")] },
+      sourceFiles: [source],
+      llmProposer: proposer,
+    });
+
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0]).toMatchObject({ raw_span: "C-15", detector: "llm", resolution: "linked", registry_record_id: "compton-c15" });
+  });
+});

--- a/tests/entity-linking.test.ts
+++ b/tests/entity-linking.test.ts
@@ -68,14 +68,14 @@ afterEach(() => {
 });
 
 describe("graphify link deterministic core", () => {
-  it("links a lexicon mention only within its frontmatter partition with raw-file offsets", () => {
+  it("links a lexicon mention only within its frontmatter partition with raw-file offsets", async () => {
     const root = tempRoot();
     const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nLe code C-15 est applicable.\n");
     const normalized = profile(root, {
       preset: "gazetteer-exact",
       partition_from: { source_frontmatter: "municipality" },
     });
-    const result = linkEntities({
+    const result = await linkEntities({
       root,
       profile: normalized,
       registries: { zones: [record("compton-c15", "C-15", "compton"), record("other-c15", "C-15", "other")] },
@@ -96,10 +96,10 @@ describe("graphify link deterministic core", () => {
     expect(readFileSync(source, "utf-8").slice(occurrence.offsets.start, occurrence.offsets.end)).toBe(occurrence.raw_span);
   });
 
-  it("fails closed before detection when a partitioned document has no binding", () => {
+  it("fails closed before detection when a partitioned document has no binding", async () => {
     const root = tempRoot();
     const source = writeDoc(root, "missing.md", "C-15\n");
-    const result = linkEntities({
+    const result = await linkEntities({
       root,
       profile: profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } }),
       registries: { zones: [record("compton-c15", "C-15")] },
@@ -110,10 +110,10 @@ describe("graphify link deterministic core", () => {
     expect(result.issues).toEqual(expect.arrayContaining([expect.objectContaining({ code: "LINK_PARTITION_UNRESOLVED", severity: "error" })]));
   });
 
-  it("does not turn a pattern-shaped non-member into an invented registry value", () => {
+  it("does not turn a pattern-shaped non-member into an invented registry value", async () => {
     const root = tempRoot();
     const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nC-999\n");
-    const result = linkEntities({
+    const result = await linkEntities({
       root,
       profile: profile(root, {
         detect: [{ pattern: { form: "C-\\d+" } }],
@@ -127,7 +127,7 @@ describe("graphify link deterministic core", () => {
     expect(result.occurrences).toEqual([]);
   });
 
-  it("keeps exact linked, ambiguous, and unlinked buckets deterministic", () => {
+  it("keeps exact linked, ambiguous, and unlinked buckets deterministic", async () => {
     const root = tempRoot();
     const source = writeDoc(root, "buckets.md", "---\nmunicipality: compton\n---\n\nC-15\n");
     const normalized = profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } });
@@ -144,7 +144,7 @@ describe("graphify link deterministic core", () => {
     expect(resolveEntityCandidate({ ...candidate, raw_span: "C-99" }, unique, normalizer, "exact")).toMatchObject({ resolution: "unlinked" });
     expect(resolveEntityCandidate(candidate, unique, normalizer, "none")).toEqual({ resolution: "unlinked", candidateIds: [] });
 
-    const ambiguousRun = linkEntities({
+    const ambiguousRun = await linkEntities({
       root,
       profile: normalized,
       registries: { zones: [record("c15-a", "C-15"), record("c15-b", "C-15")] },
@@ -155,7 +155,7 @@ describe("graphify link deterministic core", () => {
       expect.objectContaining({ code: "LINK_RESOLUTION_AMBIGUOUS", refs: expect.arrayContaining(["record:c15-a", "record:c15-b"]) }),
     ]));
 
-    const noneRun = linkEntities({
+    const noneRun = await linkEntities({
       root,
       profile: profile(root, {
         detect: ["lexicon"],
@@ -176,7 +176,7 @@ describe("graphify link deterministic core", () => {
     })).toBe(false);
   });
 
-  it("keeps absent linking opt-in as an explicit no-op and reports deferred LLM presets", () => {
+  it("keeps absent linking opt-in as an explicit no-op and reports an unwired LLM proposer", async () => {
     const root = tempRoot();
     const noLink = normalizeOntologyProfile({
       id: "no-link",
@@ -185,19 +185,25 @@ describe("graphify link deterministic core", () => {
       relation_types: {},
       registries: { zones: { source: "zones", id_column: "id", label_column: "label", node_type: "Zone" } },
     }, join(root, "profile.yaml"));
-    expect(linkEntities({ root, profile: noLink, registries: { zones: [record("c15", "C-15")] }, sourceFiles: [] }).noOp).toBe(true);
+    expect((await linkEntities({ root, profile: noLink, registries: { zones: [record("c15", "C-15")] }, sourceFiles: [] })).noOp).toBe(true);
 
+    // open-extraction triggers the llm detector, but with no injected proposer
+    // the run degrades gracefully (no crash, no fabricated occurrence) and says so.
+    const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nC-15\n");
     const pending = profile(root, { preset: "open-extraction", partition_from: { source_frontmatter: "municipality" } });
-    expect(linkEntities({ root, profile: pending, registries: { zones: [record("c15", "C-15")] }, sourceFiles: [] }).issues).toEqual(
-      expect.arrayContaining([expect.objectContaining({ code: "LINK_LLM_DETECTOR_UNAVAILABLE" })]),
+    const pendingRun = await linkEntities({ root, profile: pending, registries: { zones: [record("c15", "C-15")] }, sourceFiles: [source] });
+    expect(pendingRun.occurrences).toEqual([]);
+    expect(pendingRun.issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "LINK_LLM_PROVIDER_UNAVAILABLE" })]),
     );
+    expect(pendingRun.issues.some((finding) => finding.code === "LINK_LLM_DETECTOR_UNAVAILABLE")).toBe(false);
   });
 
-  it("writes the canonical sorted list and a Studio node summary sidecar", () => {
+  it("writes the canonical sorted list and a Studio node summary sidecar", async () => {
     const root = tempRoot();
     const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nC-15 puis C-15.\n");
     const normalized = profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } });
-    const result = linkEntities({
+    const result = await linkEntities({
       root,
       profile: normalized,
       registries: { zones: [record("c15", "C-15")] },

--- a/tests/entity-linking.test.ts
+++ b/tests/entity-linking.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { compileNormalizerByNodeType } from "../src/entity-normalizer.js";
+import {
+  buildRegistryIndex,
+  linkEntities,
+  resolveEntityCandidate,
+  verifyRawCandidate,
+  writeEntityLinkingArtifacts,
+} from "../src/entity-linking.js";
+import { normalizeOntologyProfile } from "../src/ontology-profile.js";
+import { buildEntitySidecar } from "../src/studio-assets.js";
+import type { NormalizedOntologyProfile, OntologyProfile, RegistryRecord } from "../src/types.js";
+
+const cleanup: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "graphify-link-"));
+  cleanup.push(root);
+  return root;
+}
+
+function profile(root: string, linking: NonNullable<OntologyProfile["node_types"]>["Zone"]["linking"], partitioned = true): NormalizedOntologyProfile {
+  return normalizeOntologyProfile({
+    id: "link-test",
+    version: 1,
+    node_types: { Zone: { registry: "zones", linking } },
+    relation_types: {},
+    registries: {
+      zones: {
+        source: "zones",
+        id_column: "id",
+        label_column: "label",
+        alias_columns: ["alias"],
+        node_type: "Zone",
+        ...(partitioned ? { partition_column: "municipality" } : {}),
+      },
+    },
+    outputs: { ontology: { occurrence_node_types: ["Zone"] } },
+  }, join(root, "ontology-profile.yaml"));
+}
+
+function record(id: string, label: string, partition = "compton", aliases: string[] = []): RegistryRecord {
+  return {
+    registryId: "zones",
+    id,
+    label,
+    aliases,
+    nodeType: "Zone",
+    partition,
+    sourceFile: "/registry/zones.csv",
+    raw: {},
+  };
+}
+
+function writeDoc(root: string, name: string, content: string): string {
+  const path = join(root, "docs", name);
+  mkdirSync(join(root, "docs"), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+  return path;
+}
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+describe("graphify link deterministic core", () => {
+  it("links a lexicon mention only within its frontmatter partition with raw-file offsets", () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nLe code C-15 est applicable.\n");
+    const normalized = profile(root, {
+      preset: "gazetteer-exact",
+      partition_from: { source_frontmatter: "municipality" },
+    });
+    const result = linkEntities({
+      root,
+      profile: normalized,
+      registries: { zones: [record("compton-c15", "C-15", "compton"), record("other-c15", "C-15", "other")] },
+      sourceFiles: [source],
+    });
+
+    expect(result.issues.filter((finding) => finding.severity === "error")).toEqual([]);
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0]).toMatchObject({
+      raw_span: "C-15",
+      registry_record_id: "compton-c15",
+      registry_partition: "compton",
+      resolution: "linked",
+      detector: "lexicon",
+      source_file: "docs/compton.md",
+    });
+    const occurrence = result.occurrences[0]!;
+    expect(readFileSync(source, "utf-8").slice(occurrence.offsets.start, occurrence.offsets.end)).toBe(occurrence.raw_span);
+  });
+
+  it("fails closed before detection when a partitioned document has no binding", () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "missing.md", "C-15\n");
+    const result = linkEntities({
+      root,
+      profile: profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } }),
+      registries: { zones: [record("compton-c15", "C-15")] },
+      sourceFiles: [source],
+    });
+
+    expect(result.occurrences).toEqual([]);
+    expect(result.issues).toEqual(expect.arrayContaining([expect.objectContaining({ code: "LINK_PARTITION_UNRESOLVED", severity: "error" })]));
+  });
+
+  it("does not turn a pattern-shaped non-member into an invented registry value", () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nC-999\n");
+    const result = linkEntities({
+      root,
+      profile: profile(root, {
+        detect: [{ pattern: { form: "C-\\d+" } }],
+        resolve: "exact",
+        partition_from: { source_frontmatter: "municipality" },
+      }),
+      registries: { zones: [record("compton-c15", "C-15")] },
+      sourceFiles: [source],
+    });
+
+    expect(result.occurrences).toEqual([]);
+  });
+
+  it("keeps exact linked, ambiguous, and unlinked buckets deterministic", () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "buckets.md", "---\nmunicipality: compton\n---\n\nC-15\n");
+    const normalized = profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } });
+    const normalizer = compileNormalizerByNodeType(normalized).Zone!;
+    const unique = buildRegistryIndex("zones", "compton", "test", normalizer, [record("c15", "C-15")]);
+    const ambiguous = buildRegistryIndex("zones", "compton", "test-ambiguous", normalizer, [
+      record("c15-a", "C-15"),
+      record("c15-b", "C-15"),
+    ]);
+    const candidate = { node_type: "Zone", detector: "lexicon" as const, raw_span: "C-15", source_file: "doc.md", page: 1, offsets: { start: 0, end: 4 } };
+
+    expect(resolveEntityCandidate(candidate, unique, normalizer, "exact")).toMatchObject({ resolution: "linked", registryRecordId: "c15" });
+    expect(resolveEntityCandidate(candidate, ambiguous, normalizer, "exact")).toMatchObject({ resolution: "ambiguous", candidateIds: ["c15-a", "c15-b"] });
+    expect(resolveEntityCandidate({ ...candidate, raw_span: "C-99" }, unique, normalizer, "exact")).toMatchObject({ resolution: "unlinked" });
+    expect(resolveEntityCandidate(candidate, unique, normalizer, "none")).toEqual({ resolution: "unlinked", candidateIds: [] });
+
+    const ambiguousRun = linkEntities({
+      root,
+      profile: normalized,
+      registries: { zones: [record("c15-a", "C-15"), record("c15-b", "C-15")] },
+      sourceFiles: [source],
+    });
+    expect(ambiguousRun.occurrences).toEqual([expect.objectContaining({ resolution: "ambiguous" })]);
+    expect(ambiguousRun.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "LINK_RESOLUTION_AMBIGUOUS", refs: expect.arrayContaining(["record:c15-a", "record:c15-b"]) }),
+    ]));
+
+    const noneRun = linkEntities({
+      root,
+      profile: profile(root, {
+        detect: ["lexicon"],
+        resolve: "none",
+        partition_from: { source_frontmatter: "municipality" },
+      }),
+      registries: { zones: [record("c15", "C-15")] },
+      sourceFiles: [source],
+    });
+    expect(noneRun.occurrences).toEqual([expect.objectContaining({ resolution: "unlinked" })]);
+    expect(noneRun.occurrences[0]?.registry_record_id).toBeUndefined();
+  });
+
+  it("drops non-relocatable candidates at the common raw/verbatim gate", () => {
+    expect(verifyRawCandidate("C-15", {
+      raw_span: "C-99",
+      offsets: { start: 0, end: 4 },
+    })).toBe(false);
+  });
+
+  it("keeps absent linking opt-in as an explicit no-op and reports deferred LLM presets", () => {
+    const root = tempRoot();
+    const noLink = normalizeOntologyProfile({
+      id: "no-link",
+      version: 1,
+      node_types: { Zone: { registry: "zones" } },
+      relation_types: {},
+      registries: { zones: { source: "zones", id_column: "id", label_column: "label", node_type: "Zone" } },
+    }, join(root, "profile.yaml"));
+    expect(linkEntities({ root, profile: noLink, registries: { zones: [record("c15", "C-15")] }, sourceFiles: [] }).noOp).toBe(true);
+
+    const pending = profile(root, { preset: "open-extraction", partition_from: { source_frontmatter: "municipality" } });
+    expect(linkEntities({ root, profile: pending, registries: { zones: [record("c15", "C-15")] }, sourceFiles: [] }).issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "LINK_LLM_DETECTOR_UNAVAILABLE" })]),
+    );
+  });
+
+  it("writes the canonical sorted list and a Studio node summary sidecar", () => {
+    const root = tempRoot();
+    const source = writeDoc(root, "compton.md", "---\nmunicipality: compton\n---\n\nC-15 puis C-15.\n");
+    const normalized = profile(root, { preset: "gazetteer-exact", partition_from: { source_frontmatter: "municipality" } });
+    const result = linkEntities({
+      root,
+      profile: normalized,
+      registries: { zones: [record("c15", "C-15")] },
+      sourceFiles: [source],
+    });
+    const outputDir = join(root, ".graphify", "ontology");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(join(outputDir, "nodes.json"), JSON.stringify([
+      { id: "registry_zones_c15", registry_id: "zones", registry_partition: "compton", registry_record_id: "c15" },
+    ]));
+    writeEntityLinkingArtifacts(outputDir, normalized, result);
+
+    const occurrences = JSON.parse(readFileSync(join(outputDir, "occurrences.json"), "utf-8"));
+    const summary = JSON.parse(readFileSync(join(outputDir, "entity-occurrence-summary.json"), "utf-8"));
+    expect(occurrences).toHaveLength(2);
+    expect(occurrences.map((occurrence: { offsets: { start: number } }) => occurrence.offsets.start)).toEqual([
+      ...occurrences.map((occurrence: { offsets: { start: number } }) => occurrence.offsets.start),
+    ].sort((left: number, right: number) => left - right));
+    expect(summary.registry_zones_c15).toMatchObject({ total: 2, documents: { "docs/compton.md": 2 }, snippets: ["C-15"] });
+    expect(buildEntitySidecar(join(root, ".graphify"), "registry_zones_c15").occurrences).toMatchObject({ total: 2 });
+  });
+});

--- a/tests/entity-normalizer.test.ts
+++ b/tests/entity-normalizer.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { compileOntologyOutputs } from "../src/ontology-output.js";
+import { compileNormalizerByNodeType } from "../src/entity-normalizer.js";
+import { normalizeOntologyProfile } from "../src/ontology-profile.js";
+import { generateOntologyReconciliationCandidates } from "../src/ontology-reconciliation.js";
+import { loadProfileRegistries } from "../src/profile-registry.js";
+import type { Extraction, NormalizedOntologyProfile, OntologyProfile } from "../src/types.js";
+import type { OntologyPatchContext, OntologyPatchNode } from "../src/ontology-patch.js";
+
+const cleanupDirs: string[] = [];
+const fixtureModule = join(process.cwd(), "tests", "fixtures", "normalizers", "zone-normalize.mjs");
+
+function tempDir(): string {
+  const root = mkdtempSync(join(tmpdir(), "graphify-normalizer-"));
+  cleanupDirs.push(root);
+  return root;
+}
+
+function profileSource(root: string): string {
+  return join(root, "ontology-profile.yaml");
+}
+
+function copyNormalizer(root: string): void {
+  copyFileSync(fixtureModule, join(root, "zone-normalize.mjs"));
+}
+
+function rawProfile(options: {
+  linking?: false | { builtin?: string[]; fn?: string; preset?: string };
+} = {}): OntologyProfile {
+  const linking = options.linking === false
+    ? undefined
+    : {
+      preset: options.linking?.preset ?? "gazetteer-exact",
+      normalize: {
+        ...(options.linking?.builtin === undefined ? {} : { builtin: options.linking.builtin }),
+        ...(options.linking?.fn === undefined ? {} : { fn: options.linking.fn }),
+      },
+    };
+  return {
+    id: "zone-normalizer-test",
+    version: 1,
+    node_types: {
+      Zone: {
+        registry: "zones",
+        ...(linking ? { linking } : {}),
+      },
+    },
+    relation_types: {},
+    registries: {
+      zones: {
+        source: "zones",
+        id_column: "id",
+        label_column: "label",
+        alias_columns: ["alias"],
+        node_type: "Zone",
+        partition_column: "partition",
+      },
+    },
+  };
+}
+
+function normalizedProfile(
+  root: string,
+  linking: false | { builtin?: string[]; fn?: string; preset?: string },
+): NormalizedOntologyProfile {
+  return normalizeOntologyProfile(rawProfile({ linking }), profileSource(root));
+}
+
+function bindRegistry(profile: NormalizedOntologyProfile, registryPath: string): NormalizedOntologyProfile {
+  return {
+    ...profile,
+    registries: {
+      ...profile.registries,
+      zones: { ...profile.registries.zones!, bound_source_path: registryPath },
+    },
+  };
+}
+
+function writeRegistry(root: string, rows: string): string {
+  const path = join(root, "zones.csv");
+  writeFileSync(path, `id,label,alias,partition\n${rows}`, "utf-8");
+  return path;
+}
+
+function extraction(nodes: Extraction["nodes"]): Extraction {
+  return { input_tokens: 0, output_tokens: 0, nodes, edges: [] };
+}
+
+function reconciliationContext(profile: NormalizedOntologyProfile, nodes: OntologyPatchNode[]): OntologyPatchContext {
+  return {
+    rootDir: "/repo",
+    stateDir: "/repo/.graphify",
+    graphHash: "graph-hash",
+    profile,
+    profileState: {} as OntologyPatchContext["profileState"],
+    nodes,
+    relations: [],
+    evidenceRefs: new Set(),
+  };
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("typed-linking normalizer contract", () => {
+  it("keeps a node type without linking byte-for-byte on historical output and exact reconciliation", () => {
+    const root = tempDir();
+    const profile = normalizedProfile(root, false);
+    const outputDir = join(root, "ontology");
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction: extraction([{ id: "cafe", label: "Café-3", aliases: ["Étage A"], type: "Zone" }]),
+      profile,
+      config: { enabled: true, canonical_node_types: ["Zone"] },
+    });
+
+    const nodes = JSON.parse(readFileSync(join(outputDir, "nodes.json"), "utf-8")) as Array<{ normalized_terms: string[] }>;
+    const aliases = JSON.parse(readFileSync(join(outputDir, "aliases.json"), "utf-8")) as Array<{ normalized: string }>;
+    expect(nodes[0]?.normalized_terms).toEqual(["café-3", "étage a"]);
+    expect(aliases[0]?.normalized).toBe("étage a");
+    expect(profile.node_types.Zone).toEqual({ registry: "zones" });
+    expect(profile.profile_hash).toBe("044e4480a0ce56e5ced55655a9c3047d0ec0dd372a370c25ab61e00449578956");
+
+    const queue = generateOntologyReconciliationCandidates(reconciliationContext(profile, [
+      { id: "accented", label: "Café-3", type: "Zone", registry_id: "zones", registry_partition: "compton" },
+      { id: "plain", label: "Cafe-3", type: "Zone", registry_id: "zones", registry_partition: "compton" },
+    ]), { fuzzy: false, generatedAt: "2026-07-17T00:00:00.000Z" });
+    expect(queue.candidates).toEqual([]);
+  });
+
+  it("uses one opted-in normalizer for ontology output and reconciliation exact", () => {
+    const root = tempDir();
+    const profile = normalizedProfile(root, {});
+    const outputDir = join(root, "ontology");
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction: extraction([{ id: "cafe", label: "Café", aliases: ["Café Zone"], type: "Zone" }]),
+      profile,
+      config: { enabled: true, canonical_node_types: ["Zone"] },
+    });
+
+    const nodes = JSON.parse(readFileSync(join(outputDir, "nodes.json"), "utf-8")) as Array<{ normalized_terms: string[] }>;
+    const aliases = JSON.parse(readFileSync(join(outputDir, "aliases.json"), "utf-8")) as Array<{ normalized: string }>;
+    expect(nodes[0]?.normalized_terms).toEqual(["cafe", "cafe zone"]);
+    expect(aliases[0]?.normalized).toBe("cafe zone");
+
+    copyNormalizer(root);
+    const fnProfile = normalizedProfile(root, {
+      builtin: ["case_fold", "dash_fold", "collapse_ws"],
+      fn: "./zone-normalize.mjs#normalizeZoneCode",
+    });
+    expect(compileNormalizerByNodeType(fnProfile).Zone?.("20  HA")).toBe("ha-20");
+
+    const queue = generateOntologyReconciliationCandidates(reconciliationContext(profile, [
+      { id: "accented", label: "Café", type: "Zone", registry_id: "zones", registry_partition: "compton" },
+      { id: "plain", label: "Cafe", type: "Zone", registry_id: "zones", registry_partition: "compton" },
+    ]), { fuzzy: false, generatedAt: "2026-07-17T00:00:00.000Z" });
+    expect(queue.candidates).toEqual([expect.objectContaining({
+      tier: "exact",
+      score: 1,
+      shared_terms: ["cafe"],
+    })]);
+  });
+
+  it("rejects a non-idempotent registry normalizer before corpus work", () => {
+    const root = tempDir();
+    copyNormalizer(root);
+    const profile = normalizedProfile(root, {
+      builtin: ["case_fold"],
+      fn: "./zone-normalize.mjs#nonIdempotent",
+    });
+    const registryPath = writeRegistry(root, "H-1,H-1,,compton\n");
+
+    expect(() => loadProfileRegistries(bindRegistry(profile, registryPath))).toThrow(/not idempotent/);
+  });
+
+  it("rejects intra-partition normalizer collisions and accepts equal keys across partitions", () => {
+    const root = tempDir();
+    copyNormalizer(root);
+    const profile = normalizedProfile(root, {
+      builtin: ["case_fold"],
+      fn: "./zone-normalize.mjs#collapseDigits",
+    });
+    const collisionPath = writeRegistry(root, "H-1,H-1,,compton\nH-10,H-10,,compton\n");
+
+    expect(() => loadProfileRegistries(bindRegistry(profile, collisionPath))).toThrow(
+      /normalizer_collision.*H-1.*H-10/,
+    );
+
+    const crossPartitionPath = writeRegistry(
+      root,
+      "C-15-compton,C-15,,compton\nC-15-other,C-15,,other\n",
+    );
+    expect(() => loadProfileRegistries(bindRegistry(profile, crossPartitionPath))).not.toThrow();
+  });
+
+  it("changes profile_hash when one byte of a local normalizer module changes", () => {
+    const root = tempDir();
+    copyNormalizer(root);
+    const first = normalizedProfile(root, {
+      builtin: ["case_fold"],
+      fn: "./zone-normalize.mjs#normalizeZoneCode",
+    });
+    const modulePath = join(root, "zone-normalize.mjs");
+    writeFileSync(modulePath, `${readFileSync(modulePath, "utf-8")}\n`, "utf-8");
+    const second = normalizedProfile(root, {
+      builtin: ["case_fold"],
+      fn: "./zone-normalize.mjs#normalizeZoneCode",
+    });
+
+    expect(first.node_types.Zone.linking?.normalizer).toMatchObject({
+      contract: "graphify_entity_normalizer_v1",
+      builtins: ["case_fold@1"],
+      export: "normalizeZoneCode",
+    });
+    expect(second.profile_hash).not.toBe(first.profile_hash);
+  });
+});

--- a/tests/fixtures/evaluate/generic-gold.json
+++ b/tests/fixtures/evaluate/generic-gold.json
@@ -1,0 +1,60 @@
+{
+  "schema": "graphify_typed_linking_gold_v1",
+  "documents": {
+    "manual/setup.md": { "strata": { "layout": "native", "ocr_quality": "high" } },
+    "manual/api.md": { "strata": { "layout": "native", "spelling_family": "canonical" } }
+  },
+  "occurrences": [
+    {
+      "id": "gold-0001",
+      "node_type": "Component",
+      "raw_span": "Widget-A",
+      "normalized": "widget-a",
+      "source_file": "manual/setup.md",
+      "page": null,
+      "offsets": { "start": 10, "end": 18 },
+      "detector": "lexicon",
+      "resolution": "linked",
+      "registry_record_id": "comp-a",
+      "registry_partition": null
+    },
+    {
+      "id": "gold-0002",
+      "node_type": "Component",
+      "raw_span": "Widget-B",
+      "normalized": "widget-b",
+      "source_file": "manual/setup.md",
+      "page": null,
+      "offsets": { "start": 40, "end": 48 },
+      "detector": "lexicon",
+      "resolution": "linked",
+      "registry_record_id": "comp-b",
+      "registry_partition": null
+    },
+    {
+      "id": "gold-0003",
+      "node_type": "Component",
+      "raw_span": "Widget-A",
+      "normalized": "widget-a",
+      "source_file": "manual/api.md",
+      "page": null,
+      "offsets": { "start": 5, "end": 13 },
+      "detector": "lexicon",
+      "resolution": "linked",
+      "registry_record_id": "comp-a",
+      "registry_partition": null
+    },
+    {
+      "id": "gold-0004",
+      "node_type": "Component",
+      "raw_span": "Gadget-Z",
+      "normalized": "gadget-z",
+      "source_file": "manual/api.md",
+      "page": null,
+      "offsets": { "start": 60, "end": 68 },
+      "detector": "pattern",
+      "resolution": "unlinked",
+      "registry_partition": null
+    }
+  ]
+}

--- a/tests/fixtures/evaluate/generic-run.json
+++ b/tests/fixtures/evaluate/generic-run.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "run-0001",
+    "node_type": "Component",
+    "raw_span": "Widget-A",
+    "normalized": "widget-a",
+    "source_file": "manual/setup.md",
+    "page": null,
+    "offsets": { "start": 10, "end": 18 },
+    "detector": "lexicon",
+    "resolution": "linked",
+    "registry_record_id": "comp-a",
+    "registry_partition": null
+  },
+  {
+    "id": "run-0002",
+    "node_type": "Component",
+    "raw_span": "Widget-B",
+    "normalized": "widget-b",
+    "source_file": "manual/setup.md",
+    "page": null,
+    "offsets": { "start": 40, "end": 48 },
+    "detector": "lexicon",
+    "resolution": "linked",
+    "registry_record_id": "comp-b",
+    "registry_partition": null
+  },
+  {
+    "id": "run-0003",
+    "node_type": "Component",
+    "raw_span": "Widget-A",
+    "normalized": "widget-a",
+    "source_file": "manual/api.md",
+    "page": null,
+    "offsets": { "start": 5, "end": 13 },
+    "detector": "lexicon",
+    "resolution": "linked",
+    "registry_record_id": "comp-a",
+    "registry_partition": null
+  },
+  {
+    "id": "run-0004",
+    "node_type": "Component",
+    "raw_span": "Gadget-Z",
+    "normalized": "gadget-z",
+    "source_file": "manual/api.md",
+    "page": null,
+    "offsets": { "start": 60, "end": 68 },
+    "detector": "pattern",
+    "resolution": "unlinked",
+    "registry_partition": null
+  }
+]

--- a/tests/fixtures/normalizers/zone-normalize.mjs
+++ b/tests/fixtures/normalizers/zone-normalize.mjs
@@ -1,0 +1,14 @@
+// Deliberately autonomous: L3 fingerprints this file itself, not an import graph.
+export function normalizeZoneCode(value) {
+  return value
+    .replace(/^(\d+)\s*([a-z]+)$/u, "$2-$1")
+    .replace(/^([a-z]+)\s*(\d+)$/u, "$1-$2");
+}
+
+export function collapseDigits(value) {
+  return value.replace(/\d+/gu, "");
+}
+
+export function nonIdempotent(value) {
+  return `${value}!`;
+}

--- a/tests/ontology-output.test.ts
+++ b/tests/ontology-output.test.ts
@@ -410,4 +410,160 @@ describe("ontology output artifacts", () => {
     const nodes = JSON.parse(readFileSync(join(outputDir, "nodes.json"), "utf-8")) as Array<{ status: string }>;
     expect(nodes.every((node) => node.status === "needs_review")).toBe(true);
   });
+
+  it("keeps alias collision output byte-identical when a registry has no partition_column", () => {
+    const root = makeTempDir();
+    const legacyDir = join(root, "legacy");
+    const unpartitionedDir = join(root, "unpartitioned");
+    const ambiguous: Extraction = {
+      input_tokens: 0,
+      output_tokens: 0,
+      nodes: [
+        {
+          ...extraction.nodes[0]!,
+          id: "a",
+          label: "A",
+          aliases: ["same"],
+          registry_id: "components",
+          registry_record_id: "CMP-001",
+        },
+        {
+          ...extraction.nodes[0]!,
+          id: "b",
+          label: "B",
+          aliases: ["same"],
+          registry_id: "components",
+          registry_record_id: "CMP-002",
+        },
+      ],
+      edges: [],
+    };
+    const unpartitionedProfile = {
+      ...profile,
+      node_types: { Component: { registry: "components" }, Tool: {} },
+      registries: {
+        components: {
+          source: "components",
+          id_column: "component_id",
+          label_column: "component_name",
+          alias_columns: [],
+          node_type: "Component",
+        },
+      },
+    } as NormalizedOntologyProfile;
+
+    compileOntologyOutputs({
+      outputDir: legacyDir,
+      extraction: ambiguous,
+      profile,
+      config: { enabled: true, canonical_node_types: ["Component"] },
+    });
+    compileOntologyOutputs({
+      outputDir: unpartitionedDir,
+      extraction: ambiguous,
+      profile: unpartitionedProfile,
+      config: { enabled: true, canonical_node_types: ["Component"] },
+    });
+
+    for (const artifact of ["nodes.json", "aliases.json", "validation.json", "occurrences.json"]) {
+      expect(readFileSync(join(unpartitionedDir, artifact), "utf-8")).toBe(
+        readFileSync(join(legacyDir, artifact), "utf-8"),
+      );
+    }
+  });
+
+  it("scopes shared aliases by partition and preserves registry metadata in nodes.json", () => {
+    const root = makeTempDir();
+    const outputDir = join(root, ".graphify", "ontology");
+    const partitionedProfile = {
+      ...profile,
+      node_types: { Component: { registry: "components" }, Tool: {} },
+      registries: {
+        components: {
+          source: "components",
+          id_column: "component_id",
+          label_column: "component_name",
+          alias_columns: [],
+          node_type: "Component",
+          partition_column: "municipality",
+        },
+      },
+    } as NormalizedOntologyProfile;
+    const partitioned: Extraction = {
+      input_tokens: 0,
+      output_tokens: 0,
+      nodes: [
+        {
+          ...extraction.nodes[0]!,
+          id: "compton-a",
+          label: "Compton A",
+          aliases: ["C-15"],
+          registry_id: "components",
+          registry_record_id: "C-15-A",
+          registry_partition: "compton",
+        },
+        {
+          ...extraction.nodes[0]!,
+          id: "other-a",
+          label: "Other A",
+          aliases: ["C-15"],
+          registry_id: "components",
+          registry_record_id: "C-15-B",
+          registry_partition: "other",
+        },
+        {
+          ...extraction.nodes[0]!,
+          id: "compton-b",
+          label: "Compton B",
+          aliases: ["C-15"],
+          registry_id: "components",
+          registry_record_id: "C-15-C",
+          registry_partition: "compton",
+        },
+      ],
+      edges: [],
+    };
+
+    const result = compileOntologyOutputs({
+      outputDir,
+      extraction: partitioned,
+      profile: partitionedProfile,
+      config: { enabled: true, canonical_node_types: ["Component"] },
+    });
+
+    expect(result.validationIssues).toEqual([expect.objectContaining({
+      code: "ALIAS_AMBIGUOUS",
+      refs: ["record:compton-a", "record:compton-b"],
+    })]);
+    const nodes = JSON.parse(readFileSync(join(outputDir, "nodes.json"), "utf-8")) as Array<{
+      id: string;
+      status: string;
+      registry_id?: string;
+      registry_record_id?: string;
+      registry_partition?: string;
+    }>;
+    expect(nodes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "compton-a",
+        status: "needs_review",
+        registry_id: "components",
+        registry_record_id: "C-15-A",
+        registry_partition: "compton",
+      }),
+      expect.objectContaining({
+        id: "other-a",
+        status: "validated",
+        registry_id: "components",
+        registry_record_id: "C-15-B",
+        registry_partition: "other",
+      }),
+      expect.objectContaining({
+        id: "compton-b",
+        status: "needs_review",
+        registry_id: "components",
+        registry_record_id: "C-15-C",
+        registry_partition: "compton",
+      }),
+    ]));
+  });
 });

--- a/tests/ontology-output.test.ts
+++ b/tests/ontology-output.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 
 import { compileOntologyOutputs } from "../src/ontology-output.js";
 import { validateProfileExtraction } from "../src/profile-validate.js";
-import type { Extraction, NormalizedOntologyProfile } from "../src/types.js";
+import type { Extraction, NormalizedOntologyProfile, TypedEntityOccurrenceV1 } from "../src/types.js";
 
 const cleanupDirs: string[] = [];
 
@@ -78,6 +78,23 @@ const extraction: Extraction = {
   }],
 };
 
+function occurrence(overrides: Partial<TypedEntityOccurrenceV1> = {}): TypedEntityOccurrenceV1 {
+  return {
+    id: "occurrence-1",
+    node_type: "Component",
+    raw_span: "Component A",
+    normalized: "component a",
+    source_file: "manual.md",
+    page: null,
+    offsets: { start: 0, end: 11 },
+    detector: "lexicon",
+    resolution: "linked",
+    registry_record_id: "component-a",
+    registry_partition: null,
+    ...overrides,
+  };
+}
+
 describe("ontology output artifacts", () => {
   it("does not generate ontology outputs when disabled", () => {
     const root = makeTempDir();
@@ -121,6 +138,86 @@ describe("ontology output artifacts", () => {
     expect(readFileSync(join(outputDir, "wiki", "entities", "component-a.md"), "utf-8")).toContain(
       "# Synthetic Component",
     );
+  });
+
+  it("writes the byte-identical empty occurrence array when occurrences are omitted", () => {
+    const root = makeTempDir();
+    const outputDir = join(root, ".graphify", "ontology");
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction,
+      profile,
+      config: { enabled: true, canonical_node_types: ["Component", "Tool"] },
+    });
+
+    expect(readFileSync(join(outputDir, "occurrences.json"), "utf-8")).toBe("[]\n");
+  });
+
+  it("writes valid occurrences sorted and filtered by occurrence_node_types", () => {
+    const root = makeTempDir();
+    const outputDir = join(root, ".graphify", "ontology");
+    const occurrences = [
+      occurrence({ id: "occ-c", source_file: "b.md", offsets: { start: 1, end: 3 }, raw_span: "BC" }),
+      occurrence({
+        id: "occ-excluded",
+        node_type: "Tool",
+        source_file: "a.md",
+        offsets: { start: 0, end: 2 },
+        raw_span: "AA",
+        registry_record_id: "tool-a",
+      }),
+      occurrence({ id: "occ-b", source_file: "a.md", offsets: { start: 4, end: 6 }, raw_span: "BB" }),
+      occurrence({ id: "occ-a", source_file: "a.md", offsets: { start: 1, end: 3 }, raw_span: "AB" }),
+    ];
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction,
+      profile,
+      config: { enabled: true, occurrence_node_types: ["Component"] },
+      occurrences,
+    });
+
+    const written = JSON.parse(readFileSync(join(outputDir, "occurrences.json"), "utf-8")) as TypedEntityOccurrenceV1[];
+    expect(written.map((item) => item.id)).toEqual(["occ-a", "occ-b", "occ-c"]);
+  });
+
+  it("reports invalid occurrences as structured errors without throwing", () => {
+    const root = makeTempDir();
+    const outputDir = join(root, ".graphify", "ontology");
+    const linkedWithoutRecord = occurrence({ id: "missing-record" });
+    delete linkedWithoutRecord.registry_record_id;
+
+    const result = compileOntologyOutputs({
+      outputDir,
+      extraction,
+      profile,
+      config: { enabled: true, occurrence_node_types: ["Component"] },
+      occurrences: [
+        linkedWithoutRecord,
+        occurrence({ id: "unlinked-with-record", resolution: "unlinked" }),
+        occurrence({ id: "invalid-offsets", offsets: { start: 5, end: 5 } }),
+      ],
+    });
+
+    expect(result.validationIssues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: "OCCURRENCE_LINKED_MISSING_REGISTRY_RECORD_ID",
+        severity: "error",
+        refs: ["occurrence:missing-record", "source:manual.md"],
+      }),
+      expect.objectContaining({ code: "OCCURRENCE_UNRESOLVED_HAS_REGISTRY_RECORD_ID", severity: "error" }),
+      expect.objectContaining({ code: "OCCURRENCE_INVALID_OFFSETS", severity: "error" }),
+    ]));
+    expect(JSON.parse(readFileSync(join(outputDir, "occurrences.json"), "utf-8"))).toEqual([]);
+
+    const validation = JSON.parse(readFileSync(join(outputDir, "validation.json"), "utf-8")) as {
+      schema: string;
+      issues: Array<{ code: string; severity: string; message: string; refs: string[] }>;
+    };
+    expect(validation.schema).toBe("graphify_ontology_validation_v1");
+    expect(validation.issues.every((issue) => issue.severity === "error" && issue.message.length > 0)).toBe(true);
   });
 
   it("compiles profile-validated node_type nodes into ontology outputs", () => {
@@ -297,7 +394,19 @@ describe("ontology output artifacts", () => {
       config: { enabled: true, canonical_node_types: ["Component"] },
     });
 
-    expect(result.validationIssues).toContain("alias \"same\" ambiguously attaches to a, b");
+    expect(result.validationIssues).toContainEqual({
+      code: "ALIAS_AMBIGUOUS",
+      severity: "warning",
+      node_type: "Component",
+      message: "alias \"same\" ambiguously attaches to a, b",
+      refs: ["record:a", "record:b"],
+    });
+    const validation = JSON.parse(readFileSync(join(outputDir, "validation.json"), "utf-8")) as {
+      schema: string;
+      issues: Array<{ message: string }>;
+    };
+    expect(validation.schema).toBe("graphify_ontology_validation_v1");
+    expect(validation.issues.map((issue) => issue.message)).toContain("alias \"same\" ambiguously attaches to a, b");
     const nodes = JSON.parse(readFileSync(join(outputDir, "nodes.json"), "utf-8")) as Array<{ status: string }>;
     expect(nodes.every((node) => node.status === "needs_review")).toBe(true);
   });

--- a/tests/ontology-output.test.ts
+++ b/tests/ontology-output.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -152,6 +152,22 @@ describe("ontology output artifacts", () => {
     });
 
     expect(readFileSync(join(outputDir, "occurrences.json"), "utf-8")).toBe("[]\n");
+  });
+
+  it("does not clobber a fresh link occurrence list when compile receives no occurrences input", () => {
+    const root = makeTempDir();
+    const outputDir = join(root, ".graphify", "ontology");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(join(outputDir, "occurrences.json"), JSON.stringify([occurrence()], null, 2) + "\n", "utf-8");
+
+    compileOntologyOutputs({
+      outputDir,
+      extraction,
+      profile,
+      config: { enabled: true, canonical_node_types: ["Component", "Tool"] },
+    });
+
+    expect(JSON.parse(readFileSync(join(outputDir, "occurrences.json"), "utf-8"))).toEqual([occurrence()]);
   });
 
   it("writes valid occurrences sorted and filtered by occurrence_node_types", () => {

--- a/tests/ontology-patch.test.ts
+++ b/tests/ontology-patch.test.ts
@@ -12,7 +12,9 @@ import {
   type OntologyPatch,
   type OntologyPatchContext,
 } from "../src/ontology-patch.js";
+import { loadOntologyPatchContext } from "../src/ontology-patch-context.js";
 import type { NormalizedOntologyProfile } from "../src/types.js";
+import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
 
 const cleanupDirs: string[] = [];
 
@@ -146,6 +148,32 @@ function makeContext(root: string, overrides: Partial<OntologyPatchContext> = {}
 }
 
 describe("ontology patch core", () => {
+  it("preserves registry identity and partition fields when loading nodes.json", () => {
+    const fixture = writeOntologyWriteFixture(makeTempDir());
+    writeFileSync(
+      join(fixture.stateDir, "ontology", "nodes.json"),
+      JSON.stringify([
+        {
+          id: "partitioned-component",
+          type: "Component",
+          registry_id: "components",
+          registry_record_id: "C-15",
+          registry_partition: "compton",
+        },
+      ]),
+      "utf-8",
+    );
+
+    expect(loadOntologyPatchContext(fixture.profileStatePath).nodes).toEqual([
+      expect.objectContaining({
+        id: "partitioned-component",
+        registry_id: "components",
+        registry_record_id: "C-15",
+        registry_partition: "compton",
+      }),
+    ]);
+  });
+
   it("validates schema, profile hash, graph hash, target nodes and evidence", () => {
     const root = makeTempDir();
 

--- a/tests/ontology-profile.test.ts
+++ b/tests/ontology-profile.test.ts
@@ -254,6 +254,39 @@ describe("ontology profile loader", () => {
     );
   });
 
+  it("normalizes partition_column and requires node-type registry declarations to be coherent", () => {
+    const partitioned = parseOntologyProfile(
+      validProfileYaml().replace("    node_type: Component", "    node_type: Component\n    partition_column: municipality"),
+      "ontology-profile.yaml",
+    );
+    expect(normalizeOntologyProfile(partitioned).registries.components.partition_column).toBe("municipality");
+
+    const incoherent = parseOntologyProfile(
+      [
+        "id: registry-coherence",
+        "version: 1",
+        "node_types:",
+        "  Component:",
+        "    registry: missing",
+        "  Tool:",
+        "    registry: components",
+        "relation_types: {}",
+        "registries:",
+        "  components:",
+        "    source: components",
+        "    id_column: component_id",
+        "    label_column: component_name",
+        "    node_type: Component",
+        "",
+      ].join("\n"),
+      "ontology-profile.yaml",
+    );
+
+    const errors = validateOntologyProfile(incoherent);
+    expect(errors).toContain("node_types.Component.registry references unknown registry missing");
+    expect(errors).toContain("node_types.Tool.registry components has node_type Component, expected Tool");
+  });
+
   it("rejects ontology output declarations that reference unknown profile types", () => {
     const raw = parseOntologyProfile(
       [

--- a/tests/ontology-reconciliation.test.ts
+++ b/tests/ontology-reconciliation.test.ts
@@ -273,4 +273,97 @@ describe("ontology reconciliation candidates", () => {
     });
     expect(first.candidates[0]!.score).toBeGreaterThan(0.8);
   });
+
+  it("keeps unpartitioned registry reconciliation byte-identical to the legacy path", () => {
+    const legacy = context();
+    legacy.nodes = legacy.nodes.map((node, index) => ({
+      ...node,
+      registry_id: "components",
+      registry_record_id: `CMP-00${index + 1}`,
+    }));
+    legacy.profile = {
+      ...profile,
+      node_types: { Component: { registry: "components" } },
+      registries: {
+        components: {
+          source: "components",
+          id_column: "component_id",
+          label_column: "component_name",
+          alias_columns: [],
+          node_type: "Component",
+        },
+      },
+    } as unknown as NormalizedOntologyProfile;
+
+    const baseline = context();
+    baseline.nodes = legacy.nodes;
+
+    const generatedAt = "2026-05-09T00:00:00.000Z";
+    expect(JSON.stringify(generateOntologyReconciliationCandidates(legacy, { generatedAt }))).toBe(
+      JSON.stringify(generateOntologyReconciliationCandidates(baseline, { generatedAt })),
+    );
+  });
+
+  it("rejects C-15 exact candidates across partitions while retaining same-partition exact matches", () => {
+    const partitioned = context();
+    partitioned.profile = {
+      ...profile,
+      node_types: { Zone: { registry: "zones" } },
+      registries: {
+        zones: {
+          source: "zones",
+          id_column: "zone_id",
+          label_column: "zone_code",
+          alias_columns: [],
+          node_type: "Zone",
+          partition_column: "municipality",
+        },
+      },
+    } as unknown as NormalizedOntologyProfile;
+    partitioned.nodes = [
+      {
+        id: "compton-c-15",
+        label: "C-15",
+        type: "Zone",
+        registry_id: "zones",
+        registry_record_id: "C-15",
+        registry_partition: "compton",
+      },
+      {
+        id: "other-c-15",
+        label: "C-15",
+        type: "Zone",
+        registry_id: "zones",
+        registry_record_id: "C-15",
+        registry_partition: "other",
+      },
+      {
+        id: "compton-c-15-duplicate",
+        label: "C-15",
+        type: "Zone",
+        registry_id: "zones",
+        registry_record_id: "C-15-2",
+        registry_partition: "compton",
+      },
+      {
+        id: "missing-partition-c-15",
+        label: "C-15",
+        type: "Zone",
+        registry_id: "zones",
+        registry_record_id: "C-15-3",
+      },
+    ];
+
+    const queue = generateOntologyReconciliationCandidates(partitioned, {
+      generatedAt: "2026-05-09T00:00:00.000Z",
+    });
+
+    expect(queue.candidates).toHaveLength(1);
+    expect(queue.candidates[0]).toMatchObject({
+      tier: "exact",
+      score: 1,
+      canonical_id: "compton-c-15",
+      candidate_id: "compton-c-15-duplicate",
+    });
+  });
 });

--- a/tests/profile-evaluate.test.ts
+++ b/tests/profile-evaluate.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { main } from "../src/cli.js";
+import {
+  evaluateOccurrences,
+  formatEvaluationReport,
+  GoldValidationError,
+  parseGold,
+  TYPED_LINKING_EVALUATION_SCHEMA,
+  TYPED_LINKING_GOLD_SCHEMA,
+  type TypedLinkingGoldV1,
+} from "../src/profile-evaluate.js";
+import type { TypedEntityOccurrenceV1 } from "../src/types.js";
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "evaluate");
+const cleanup: string[] = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+function occ(overrides: Partial<TypedEntityOccurrenceV1> & {
+  source_file: string;
+  node_type: string;
+  start: number;
+  end: number;
+  resolution: TypedEntityOccurrenceV1["resolution"];
+}): TypedEntityOccurrenceV1 {
+  const { start, end, ...rest } = overrides;
+  return {
+    id: `${overrides.source_file}:${start}:${end}`,
+    raw_span: overrides.raw_span ?? "Span",
+    normalized: overrides.normalized ?? "span",
+    page: null,
+    detector: overrides.detector ?? "lexicon",
+    registry_partition: overrides.registry_partition ?? null,
+    ...rest,
+    offsets: { start, end },
+  } as TypedEntityOccurrenceV1;
+}
+
+function gold(occurrences: TypedEntityOccurrenceV1[], documents?: TypedLinkingGoldV1["documents"]): TypedLinkingGoldV1 {
+  return { schema: TYPED_LINKING_GOLD_SCHEMA, occurrences, ...(documents ? { documents } : {}) };
+}
+
+describe("evaluateOccurrences (pure, $0)", () => {
+  it("scores a perfect run: mention_recall 1.0, resolution_precision 1.0, unresolved_rate published", () => {
+    const items = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+      occ({ source_file: "a.md", node_type: "Component", start: 10, end: 15, resolution: "linked", registry_record_id: "c2" }),
+    ];
+    const result = evaluateOccurrences({ run: items, gold: gold(items) });
+    expect(result.metrics.overall.mention_recall).toBe(1);
+    expect(result.metrics.overall.resolution_precision).toBe(1);
+    expect(result.metrics.overall.set_recall).toBe(1);
+    // Precision is meaningless without its pair — it must always be present.
+    expect(result.metrics.overall.unresolved_rate).toBe(0);
+    expect(result.gate).toBe("pass");
+  });
+
+  it("marks a parasitic link as a precision miss and still publishes unresolved_rate", () => {
+    const goldSet = gold([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ]);
+    const run = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+      // parasite: a linked span the gold does not confirm.
+      occ({ source_file: "a.md", node_type: "Component", start: 20, end: 25, resolution: "linked", registry_record_id: "c9" }),
+    ];
+    const result = evaluateOccurrences({ run, gold: goldSet });
+    expect(result.metrics.overall.resolution_precision).toBeCloseTo(0.5, 10);
+    expect(result.metrics.overall.resolution_precision).toBeLessThan(1);
+    expect(result.metrics.overall.unresolved_rate).toBe(0);
+    expect(result.metrics.overall.linked_count).toBe(2);
+  });
+
+  // Acceptance criterion 9
+  it("criterion 9: a run that links nothing → precision null, unresolved_rate 1, positive floor fails the gate", () => {
+    const goldSet = gold([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ]);
+    const run = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "unlinked" }),
+    ];
+    const result = evaluateOccurrences({ run, gold: goldSet, floors: { resolution_precision: 0.9 } });
+    expect(result.metrics.overall.resolution_precision).toBeNull();
+    expect(result.metrics.overall.resolution_precision).not.toBe(1);
+    expect(result.metrics.overall.unresolved_rate).toBe(1);
+    expect(result.gate).toBe("fail");
+    const floor = result.floors_evaluated.find((entry) => entry.metric === "resolution_precision");
+    expect(floor?.pass).toBe(false);
+    expect(floor?.value).toBeNull();
+  });
+
+  it("computes macro set_recall over non-empty documents and keeps per-document values", () => {
+    const goldSet = gold([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+      occ({ source_file: "a.md", node_type: "Component", start: 6, end: 9, resolution: "linked", registry_record_id: "c2" }),
+      occ({ source_file: "b.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c3" }),
+    ]);
+    const run = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+      // a.md misses c2; b.md fully linked.
+      occ({ source_file: "b.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c3" }),
+    ];
+    const result = evaluateOccurrences({ run, gold: goldSet });
+    expect(result.metrics.per_document["a.md"].set_recall).toBeCloseTo(0.5, 10);
+    expect(result.metrics.per_document["b.md"].set_recall).toBe(1);
+    // macro = (0.5 + 1) / 2
+    expect(result.metrics.overall.set_recall).toBeCloseTo(0.75, 10);
+  });
+
+  it("never counts an ambiguous run occurrence as a resolved link", () => {
+    const goldSet = gold([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ]);
+    const run = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "ambiguous" }),
+    ];
+    const result = evaluateOccurrences({ run, gold: goldSet });
+    expect(result.metrics.overall.set_recall).toBe(0);
+    expect(result.metrics.overall.resolution_precision).toBeNull();
+    expect(result.metrics.overall.ambiguous_rate).toBe(1);
+    expect(result.metrics.overall.unresolved_rate).toBe(1);
+  });
+
+  it("emits per-strata metrics keyed by dimension=value", () => {
+    const items = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+      occ({ source_file: "b.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c2" }),
+    ];
+    const documents = {
+      "a.md": { strata: { layout: "scanned", ocr_quality: "low" } },
+      "b.md": { strata: { layout: "native" } },
+    };
+    const result = evaluateOccurrences({ run: items, gold: gold(items, documents) });
+    expect(Object.keys(result.metrics.per_strata).sort()).toEqual([
+      "layout=native",
+      "layout=scanned",
+      "ocr_quality=low",
+    ]);
+    expect(result.metrics.per_strata["layout=scanned"].mention_recall).toBe(1);
+  });
+
+  it("is stable to input order (identical hashes + metrics)", () => {
+    const items = [
+      occ({ source_file: "a.md", node_type: "Component", start: 10, end: 15, resolution: "linked", registry_record_id: "c2" }),
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ];
+    const forward = evaluateOccurrences({ run: items, gold: gold(items) });
+    const reversed = evaluateOccurrences({ run: [...items].reverse(), gold: gold([...items].reverse()) });
+    expect(reversed.run_hash).toBe(forward.run_hash);
+    expect(reversed.gold_hash).toBe(forward.gold_hash);
+    expect(reversed.metrics.overall).toEqual(forward.metrics.overall);
+  });
+
+  it("rejects duplicate spans in the run and in the gold", () => {
+    const dup = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ];
+    expect(() => evaluateOccurrences({ run: dup, gold: gold([dup[0]]) })).toThrow(GoldValidationError);
+    expect(() => parseGold({ schema: TYPED_LINKING_GOLD_SCHEMA, occurrences: dup })).toThrow(/GOLD_DUPLICATE_SPAN/);
+  });
+
+  it("detects a stale gold via the corpus slice check", () => {
+    const goldSet = gold([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, raw_span: "Alpha", resolution: "linked", registry_record_id: "c1" }),
+    ]);
+    expect(() => evaluateOccurrences({
+      run: goldSet.occurrences,
+      gold: goldSet,
+      corpusSlice: () => "Bravo",
+    })).toThrow(/GOLD_STALE_SPAN/);
+    // Corpus unavailable → slice returns null → check skipped, no throw.
+    expect(() => evaluateOccurrences({ run: goldSet.occurrences, gold: goldSet, corpusSlice: () => null })).not.toThrow();
+  });
+
+  it("rejects a bare-array gold (must be a versioned envelope)", () => {
+    expect(() => parseGold([])).toThrow(/GOLD_NOT_ENVELOPE/);
+    expect(() => parseGold({ schema: "wrong", occurrences: [] })).toThrow(/GOLD_BAD_SCHEMA/);
+  });
+
+  // Acceptance criterion 10 (Stage-3 boundary): no event / AVANT / APRÈS anywhere.
+  it("criterion 10: evaluation output carries no event-chaining or AVANT/APRÈS field", () => {
+    const items = [
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ];
+    const result = evaluateOccurrences({ run: items, gold: gold(items) });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toMatch(/AVANT|APR[ÈE]S/i);
+    expect(serialized).not.toMatch(/"event(_id)?"/);
+    expect(result.schema).toBe(TYPED_LINKING_EVALUATION_SCHEMA);
+    // report never shows precision without unresolved-rate.
+    const report = formatEvaluationReport(result);
+    expect(report).toMatch(/resolution_precision:.*unresolved_rate:/);
+  });
+});
+
+async function runCli(args: string[]): Promise<{ logs: string[]; errors: string[]; exitCode: number | undefined }> {
+  const argv = process.argv;
+  const log = console.log;
+  const err = console.error;
+  const logs: string[] = [];
+  const errors: string[] = [];
+  process.exitCode = undefined;
+  process.argv = ["node", "graphify", ...args];
+  console.log = (...items: unknown[]) => { logs.push(items.join(" ")); };
+  console.error = (...items: unknown[]) => { errors.push(items.join(" ")); };
+  try {
+    await main();
+    return { logs, errors, exitCode: process.exitCode };
+  } finally {
+    const observed = process.exitCode;
+    process.exitCode = undefined;
+    void observed;
+    process.argv = argv;
+    console.log = log;
+    console.error = err;
+  }
+}
+
+describe("graphify profile evaluate CLI", () => {
+  // Acceptance criterion 10: a generic NON-geo fixture passes the runner.
+  it("criterion 10: a generic registry-bound fixture passes the runner with no domain code", async () => {
+    const out = mkdtempSync(join(tmpdir(), "graphify-eval-"));
+    cleanup.push(out);
+    const evaluation = join(out, "evaluation.json");
+    const { logs, exitCode } = await runCli([
+      "profile", "evaluate",
+      "--run", join(FIXTURES, "generic-run.json"),
+      "--gold", join(FIXTURES, "generic-gold.json"),
+      "--out", evaluation,
+      "--floor", "mention_recall=1",
+      "--floor", "set_recall=1",
+      "--floor", "resolution_precision=1",
+      "--ceiling", "unresolved_rate=0.5",
+    ]);
+    expect(exitCode).toBeFalsy();
+    const written = JSON.parse(readFileSync(evaluation, "utf-8"));
+    expect(written.schema).toBe(TYPED_LINKING_EVALUATION_SCHEMA);
+    expect(written.gate).toBe("pass");
+    expect(written.metrics.overall.resolution_precision).toBe(1);
+    // The report prints precision AND unresolved together.
+    expect(logs.join("\n")).toMatch(/resolution_precision:.*unresolved_rate:/);
+    // No Stage-3 event chaining leaked into the output.
+    const serialized = JSON.stringify(written);
+    expect(serialized).not.toMatch(/AVANT|APR[ÈE]S/i);
+    expect(serialized).not.toMatch(/"event(_id)?"/);
+  });
+
+  it("criterion 10: neither generic fixture contains an event / AVANT / APRÈS field", () => {
+    for (const name of ["generic-run.json", "generic-gold.json"]) {
+      const raw = readFileSync(join(FIXTURES, name), "utf-8");
+      expect(raw).not.toMatch(/AVANT|APR[ÈE]S/i);
+      expect(raw).not.toMatch(/"event(_id)?"/);
+    }
+  });
+
+  // Acceptance criterion 9 through the CLI: gate fail → non-zero exit code.
+  it("criterion 9: a nothing-linked run with a positive precision floor exits non-zero", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-eval-nolink-"));
+    cleanup.push(dir);
+    const runPath = join(dir, "run.json");
+    const goldPath = join(dir, "gold.json");
+    writeFileSync(runPath, JSON.stringify([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "unlinked" }),
+    ]));
+    writeFileSync(goldPath, JSON.stringify(gold([
+      occ({ source_file: "a.md", node_type: "Component", start: 0, end: 5, resolution: "linked", registry_record_id: "c1" }),
+    ])));
+    const evaluation = join(dir, "evaluation.json");
+    const { exitCode } = await runCli([
+      "profile", "evaluate",
+      "--run", runPath,
+      "--gold", goldPath,
+      "--out", evaluation,
+      "--floor", "resolution_precision=0.9",
+    ]);
+    expect(exitCode).toBe(1);
+    const written = JSON.parse(readFileSync(evaluation, "utf-8"));
+    expect(written.gate).toBe("fail");
+    expect(written.metrics.overall.resolution_precision).toBeNull();
+    expect(written.metrics.overall.unresolved_rate).toBe(1);
+  });
+
+  it("exits non-zero on a structurally invalid gold", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-eval-bad-"));
+    cleanup.push(dir);
+    const runPath = join(dir, "run.json");
+    const goldPath = join(dir, "gold.json");
+    writeFileSync(runPath, JSON.stringify([]));
+    writeFileSync(goldPath, JSON.stringify([]));
+    const { exitCode, errors } = await runCli([
+      "profile", "evaluate",
+      "--run", runPath,
+      "--gold", goldPath,
+    ]);
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toMatch(/GOLD_NOT_ENVELOPE/);
+  });
+});

--- a/tests/profile-registry.test.ts
+++ b/tests/profile-registry.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeRegistryRecord,
   registryRecordsToExtraction,
 } from "../src/profile-registry.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
 import { validateExtraction } from "../src/validate.js";
 
 const cleanupDirs: string[] = [];
@@ -156,6 +157,49 @@ describe("profile registry loader", () => {
     ).toThrow("components record is missing id_column component_id");
   });
 
+  it("loads a declared partition column, rejects missing values, and keeps IDs globally unique", () => {
+    const root = makeTempDir();
+    const partitionedPath = join(root, "partitioned.csv");
+    writeFileSync(
+      partitionedPath,
+      "component_id,component_name,municipality\nCMP-001,Demo One,compton\n",
+      "utf-8",
+    );
+    const spec = {
+      source: "components",
+      id_column: "component_id",
+      label_column: "component_name",
+      alias_columns: [],
+      node_type: "Component",
+      partition_column: "municipality",
+      bound_source_path: partitionedPath,
+    };
+
+    expect(loadProfileRegistry("components", spec)[0]).toMatchObject({ partition: "compton" });
+
+    const missingColumnPath = join(root, "missing-column.csv");
+    writeFileSync(missingColumnPath, "component_id,component_name\nCMP-002,Demo Two\n", "utf-8");
+    expect(() => loadProfileRegistry("components", { ...spec, bound_source_path: missingColumnPath })).toThrow(
+      `registries.components.partition_column municipality does not exist in ${missingColumnPath}`,
+    );
+
+    const missingValuePath = join(root, "missing-value.csv");
+    writeFileSync(missingValuePath, "component_id,component_name,municipality\nCMP-003,Demo Three,\n", "utf-8");
+    expect(() => loadProfileRegistry("components", { ...spec, bound_source_path: missingValuePath })).toThrow(
+      "components record CMP-003 is missing partition_column municipality",
+    );
+
+    const duplicateAcrossPartitionsPath = join(root, "duplicate-across-partitions.csv");
+    writeFileSync(
+      duplicateAcrossPartitionsPath,
+      "component_id,component_name,municipality\nC-15,C-15,compton\nC-15,C-15,other\n",
+      "utf-8",
+    );
+    expect(() => loadProfileRegistry("components", { ...spec, bound_source_path: duplicateAcrossPartitionsPath })).toThrow(
+      "duplicate registry record id C-15 in components",
+    );
+  });
+
   it("rejects unbound registry sources", () => {
     expect(() =>
       loadProfileRegistry("components", {
@@ -207,5 +251,32 @@ describe("profile registry loader", () => {
         profile_hash: profile.profile_hash,
       }),
     );
+  });
+
+  it("propagates registry_partition without changing the registry seed node ID", () => {
+    const profile = {
+      id: "partitioned",
+      version: "1",
+      profile_hash: "profile-hash",
+    } as NormalizedOntologyProfile;
+    const extraction = registryRecordsToExtraction({
+      zones: [{
+        registryId: "zones",
+        id: "C-15",
+        label: "C-15",
+        aliases: [],
+        nodeType: "Zone",
+        partition: "compton",
+        sourceFile: "/tmp/zones.csv",
+        raw: { code: "C-15", municipality: "compton" },
+      }],
+    }, profile);
+
+    expect(extraction.nodes).toContainEqual(expect.objectContaining({
+      id: "registry_zones_C_15",
+      registry_id: "zones",
+      registry_record_id: "C-15",
+      registry_partition: "compton",
+    }));
   });
 });


### PR DESCRIPTION
Adds a reusable **typed entity-linking / gazetteer** capability to graphify — a producer pass `graphify link` sibling to `graphify cite`, plus a `$0` measurement harness `graphify profile evaluate`. Designed via a double-consensus (Codex gpt-5.6-sol + Opus 4.8, written blind of each other, converged) in response to a cross-project request (geo entity-linking against a closed per-municipality gazetteer; also serves immo, mystery, any registry-bound project).

## Golden constraint: OPT-IN, zero regression
A `node_type` **without** a `linking` block behaves byte-for-byte as before (detection, reconciliation, output, hash). `gazetteer-exact` and any no-`linking` profile make **zero LLM calls** — the no-key default is preserved. Full suite green: **2415 passed / 14 skipped**, `tsc --noEmit` clean.

## Lots
- **L1 — occurrence substrate** (`ce9a28b`): `TypedEntityOccurrenceV1` schema, structured `validation.json`, additive de-stub of `occurrences.json` (empty until `link` runs).
- **L2 — partition** (`92548d5`): `partition_column` on registries; partition-scoped identity applied to **all three exact surfaces** — the mention resolver, the reconciliation EXACT tier, and the alias-collision detector. Kills the cross-partition 1.0-confidence false positive (a `C-15` in muni A never merges with `C-15` in muni B); global id uniqueness kept.
- **L3 — normalize contract** (`bab2ed5`): per-node_type `normalize` = built-ins + optional `module#export`, verified at load ($0): idempotence + **partition-scoped anti-merge audit** (a normalizer that fuses two distinct ids of one partition is rejected before any scan). Fingerprint folded into `profile_hash` (editing the fn invalidates caches). Unifies the node_type's normalizer across the 3 identity passes — **fixes a pre-existing latent divergence** (`normalizeForMatch` deaccented, `normalizedTerm`/`normalizeTerm` did not).
- **L4a — link core** (`d50b0a6`): shared grounding module (extracted from `cite`, re-exported for compat); detectors **lexicon** + **pattern** (registry-membership-filtered, no synthetic values); resolvers **exact** (partition-scoped) + **none**; verbatim gate (`raw.slice(offsets) === raw_span`); dedup + deterministic sort; real `occurrences.json` (mention-level list) + a derived `entity-occurrence-summary.json` sidecar so the Studio keeps working.
- **L5 — evaluate** (`74716d2`): `graphify profile evaluate` — deterministic $0 run-vs-gold metrics: `mention_recall`, per-doc `set_recall`, and `resolution_precision` **always paired with `unresolved_rate`** (a resolver that links nothing yields precision `null`, never `1.0`, and fails a positive floor with a non-zero exit). Cross-consumer CI gate.
- **L4b — llm detector** (`16545d2`): the profile-LLM extraction mode becomes an opt-in `llm` **span-proposal-only** detector, gated exactly like `cite --mode assistant|api`; every proposal is relocated verbatim and resolved by the same exact/none resolver — the model never chooses the id (a hallucinated id is revalidated against the partition and ignored). Presets `open-extraction` + `hybrid-recall` (llm fires only on a bounded trigger).

## Boundary (max reuse)
graphify owns everything that is a pure function of (documents + registry + config): the occurrence layer, the 3-axis engine, the partition mechanism, the normalize contract, the measurement harness. The consumer keeps the ~20-line `normalize.fn` body, the partition-value convention, the pattern regex form, the gold data, and all business semantics (e.g. geo's before/after direction + event chaining). graphify never emits a "before/after" or "event" field.

## Semver
No version bump (currently 0.17.2). New commands are additive; a **minor** bump (0.18.0) is warranted at the next release (release-tag driven).

## Verification
Each lot verified independently (build + targeted tests) and the full branch end-to-end: `npm run build` ✓, `npx tsc --noEmit` ✓, `npx vitest run` → 250 files / 2415 tests passed. Commits contain only `src/`/`tests/`/`spec/`/`fixtures/` (no regenerated artifacts).