### PR TITLE
fix(agent-stats): redact secret-bearing NAME=VALUE env assignments

### DIFF
--- a/src/agent-stats/redact.ts
+++ b/src/agent-stats/redact.ts
@@ -15,6 +15,29 @@
 
 const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
+// Secret-bearing ENVIRONMENT ASSIGNMENTS, i.e. the `NAME=VALUE` shape emitted by
+// `printenv` / `env` / `docker inspect` / a k8s Secret dump.
+//
+// WHY THIS EXISTS (2026-07-30). An agent ran `kubectl exec … -- printenv | grep -iE
+// 's3|aws'` meaning to list variable NAMES; `printenv` emits `NAME=VALUE`, so the
+// grep matched whole lines and live OVH Object Storage credentials landed in a
+// transcript in clear. The generic pattern below did not fire: it requires
+// `secret`/`api_key` IMMEDIATELY before the `=`, and `S3_SECRET_KEY=` has a `_KEY`
+// in between. `S3_ACCESS_KEY=`, `AWS_SECRET_ACCESS_KEY=` and `POSTGRES_PASSWORD=`
+// all sailed through.
+//
+// We match on the SUFFIX of the name, not on it merely containing a word: that is
+// the actual naming convention (`*_SECRET`, `*_TOKEN`, `*_KEY`…) and it keeps
+// identifiers like `secretName=sentropic-postgres` readable — a Secret's NAME is
+// diagnostic, its VALUE never is. `_KEY` is in the list because env vars ending in
+// `_KEY` are overwhelmingly credentials; the cost is that `PUBLIC_KEY=` gets masked
+// too, which is the safe direction to be wrong in.
+//
+// The NAME is preserved on purpose: "which variable leaked" is the whole diagnostic
+// value, and keeping it means a reader never needs the original to understand.
+const SECRET_ENV_ASSIGNMENT_RE =
+  /\b([A-Za-z][A-Za-z0-9_]*_(?:SECRETS?|PASSWORD|PASSWD|PWD|TOKEN|CREDENTIALS?|KEY)|SECRETS?|PASSWORD|PASSWD|TOKEN|CREDENTIALS?)\s*=\s*\S+/gi;
+
 // Common secret shapes: gh_/github_pat_, sk-/api keys, JWT-ish, long hex blobs,
 // and explicit token=… / Authorization: Bearer … assignments.
 const TOKEN_PATTERNS: RegExp[] = [
@@ -56,6 +79,9 @@ export function redact(text: string, home = ""): string {
   let out = redactHome(text, home);
   out = out.replace(URL_CREDENTIALS_RE, "$1<token>@");
   out = out.replace(EMAIL_RE, "<email>");
+  // Runs before TOKEN_PATTERNS so the variable name survives instead of being
+  // swallowed by the coarser `token|secret|…=` rule.
+  out = out.replace(SECRET_ENV_ASSIGNMENT_RE, "$1=<token>");
   for (const re of TOKEN_PATTERNS) out = out.replace(re, "<token>");
   return out;
 }

--- a/tests/agent-stats.test.ts
+++ b/tests/agent-stats.test.ts
@@ -40,6 +40,42 @@ describe("agent-stats redaction (privacy)", () => {
     expect(out).toContain("~");
   });
 
+  // REGRESSION (2026-07-30): an agent ran `kubectl exec … -- printenv | grep -iE
+  // 's3|aws'` intending to list variable NAMES. `printenv` emits `NAME=VALUE`, so
+  // the grep matched whole lines and the transcript captured live OVH Object
+  // Storage credentials in clear. The redactor did not catch them: its pattern
+  // required `secret`/`api_key` to sit IMMEDIATELY before the `=`, and in
+  // `S3_SECRET_KEY=` there is a `_KEY` in between. Every case below is a shape the
+  // old pattern let through.
+  it("strips secret-bearing environment assignments (NAME=VALUE from printenv/env)", () => {
+    const leaked = [
+      "S3_ACCESS_KEY=0123456789abcdef0123456789abcdef",
+      "S3_SECRET_KEY=fedcba9876543210fedcba9876543210",
+      "AWS_SECRET_ACCESS_KEY=fedcba9876543210fedcba9876543210",
+      "OVH_S3_SECRET_KEY=fedcba9876543210fedcba9876543210",
+      "POSTGRES_PASSWORD=hunter2hunter2hunter2hunter2",
+      "TENANT_S3_ACCESS_KEY=0123456789abcdef0123456789abcdef",
+      "GITHUB_TOKEN=0123456789abcdef0123456789abcdef",
+      "SECRET_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef",
+    ];
+    for (const line of leaked) {
+      const out = redact(line);
+      const value = line.split("=")[1];
+      expect(out, `value leaked for ${line.split("=")[0]}`).not.toContain(value);
+      expect(out).toContain("<token>");
+      // The NAME must survive: it is the diagnostic signal we keep on purpose.
+      expect(out).toContain(line.split("=")[0]);
+    }
+  });
+
+  it("leaves non-secret environment assignments intact", () => {
+    // Over-redacting is a real cost: these are the values an operator reads to
+    // diagnose, and none of them is a credential.
+    for (const line of ["S3_ENDPOINT=https://s3.bhs.io.cloud.ovh.net", "S3_REGION=bhs", "LOG_LEVEL=debug"]) {
+      expect(redact(line)).toBe(line);
+    }
+  });
+
   it("clamps long excerpts", () => {
     const long = "x".repeat(500);
     expect(redactExcerpt(long, "", 50).length).toBeLessThanOrEqual(51);


### PR DESCRIPTION
## Le défaut

`redact()` laissait passer des credentials vivants **dans la forme exacte que produit un `printenv`**.

Le motif existant exigeait que `secret` / `api_key` soit **immédiatement** collé au `=` :

```js
/\b(?:token|secret|api[_-]?key|password|bearer)\s*[:=]\s*\S+/gi
```

Dans `S3_SECRET_KEY=` il y a un `_KEY` entre les deux. Résultat, testé avant correction :

| Forme | Ancien comportement |
|---|---|
| `S3_ACCESS_KEY=…` | **passe** |
| `S3_SECRET_KEY=…` | **passe** |
| `AWS_SECRET_ACCESS_KEY=…` | **passe** |
| `POSTGRES_PASSWORD=…` | **passe** |
| `secret=…` | masqué |
| `API_KEY=…` | masqué |

## Comment il a été trouvé

Le 2026-07-30, un agent a lancé `kubectl exec … -- printenv | grep -iE 's3|aws'` en voulant lister les **noms** de variables. `printenv` émet `NAME=VALUE`, donc le grep a filtré sur le nom et **imprimé la ligne entière**. Des credentials OVH Object Storage vivants se sont retrouvés en clair dans un transcript.

Ces clés ont depuis été tournées et révoquées (403 vérifié sur les buckets concernés). Cette PR ferme le trou qui a laissé passer la *forme*.

## Le choix de conception

Le filtrage porte sur le **suffixe** du nom (`*_SECRET`, `*_TOKEN`, `*_KEY`…), pas sur le fait qu'il *contienne* un mot. Deux raisons :

- `secretName=sentropic-postgres` reste lisible — le **nom** d'un Secret est un signal de diagnostic, sa **valeur** ne l'est jamais.
- Le nom de la variable est conservé, seule la valeur devient `<token>` : « quelle variable a fui » est tout l'intérêt de garder une trace.

`_KEY` est inclus parce qu'une variable d'environnement finissant par `_KEY` est très majoritairement un credential. Le coût assumé : `PUBLIC_KEY=` est masqué aussi. C'est le bon sens de l'erreur.

## Tests

- Un test qui **échoue avant ce changement** et couvre chacune des formes qui fuyaient.
- Un test de non-régression sur `S3_ENDPOINT=` / `S3_REGION=` / `LOG_LEVEL=`, parce que sur-masquer coûte à l'opérateur les valeurs qu'il lit justement pour diagnostiquer.

```
Test Files  4 passed (4)
     Tests  73 passed (73)
```
(`agent-stats`, `agent-stats-phase2`, `agent-stats-phase15`, `conversations`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175zL2wTd58CVSgupBDa721