### PR TITLE
test(cli): cover two-character non-English queries

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -448,6 +448,31 @@ describe("check-update CLI", () => {
 });
 
 describe("query CLI", () => {
+  it("keeps two-character non-English terms searchable", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-cli-query-cjk-"));
+    tempDirs.push(dir);
+    const graphDir = join(dir, ".graphify");
+    mkdirSync(graphDir, { recursive: true });
+    const graphPath = join(graphDir, "graph.json");
+    writeFileSync(
+      graphPath,
+      JSON.stringify({
+        directed: false,
+        graph: {},
+        nodes: [
+          { id: "concept", label: "认识", source_file: "认识.md", file_type: "document" },
+        ],
+        links: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await runCli(["query", "认识", "--graph", graphPath], dir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.logs[0]).toContain("NODE 认识 [");
+  });
+
   it("prefers exact node label matches over longer substring matches", async () => {
     const dir = mkdtempSync(join(tmpdir(), "graphify-cli-query-"));
     tempDirs.push(dir);


### PR DESCRIPTION
## What changed

Add a CLI regression test covering a two-character non-English query (`认识`).

## Why

The released `@sentropic/graphify@0.17.1` CLI tokenized queries with `split(/\\s+/).filter((term) => term.length > 2)`, which silently discarded two-character CJK terms even when the graph contained an exact matching node. The current main branch routes CLI tokenization through the shared `queryTerms` helper; this test locks that behavior in.

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.ts tests/cli.test.ts --reporter=verbose`
- 20 tests passed

This is a regression test for the already-landed CLI fix and helps prevent the bug from returning in a future refactor or release.
