### PR TITLE
fix(go): preserve imported packages in graph

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -4804,6 +4804,10 @@ export async function extractGo(filePath: string, rootDir?: string): Promise<Ext
               if (pathNode) {
                 const raw = _readText(pathNode, source).replace(/^"|"$/g, "");
                 const tgtNid = goImportNodeId(raw);
+                // Keep external and standard-library imports visible in the
+                // graph. Previously only the edge was emitted, leaving a
+                // dangling target that buildFromJson silently discarded.
+                addNode(tgtNid, raw, spec.startPosition.row + 1);
                 addEdge(fileNid, tgtNid, "imports_from", spec.startPosition.row + 1);
               }
             }
@@ -4813,6 +4817,10 @@ export async function extractGo(filePath: string, rootDir?: string): Promise<Ext
           if (pathNode) {
             const raw = _readText(pathNode, source).replace(/^"|"$/g, "");
             const tgtNid = goImportNodeId(raw);
+            // Keep external and standard-library imports visible in the
+            // graph. Previously only the edge was emitted, leaving a
+            // dangling target that buildFromJson silently discarded.
+            addNode(tgtNid, raw, child.startPosition.row + 1);
             addEdge(fileNid, tgtNid, "imports_from", child.startPosition.row + 1);
           }
         }

--- a/tests/extract-call-confidence.test.ts
+++ b/tests/extract-call-confidence.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { extract, extractGo, extractJs, extractPhp } from "../src/extract.js";
+import { buildFromJson } from "../src/build.js";
 
 function strip(label: string | undefined): string {
   return String(label ?? "").replace(/\(?\)$/g, "").replace(/^\./, "");
@@ -114,6 +115,46 @@ describe("AST call edge confidence", () => {
     const importEdge = result.edges.find((edge) => edge.relation === "imports_from");
 
     expect(importEdge?.target).toBe("go_pkg_context");
+  });
+
+  it("preserves Go imports as package nodes in the built graph", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "graphify-extract-go-import-node-"));
+    cleanupDirs.push(dir);
+
+    const filePath = join(dir, "main.go");
+    writeFileSync(
+      filePath,
+      [
+        "package sample",
+        "",
+        "import \"fmt\"",
+        "",
+        "func Hello() string {",
+        "  return fmt.Sprint(\"hello\")",
+        "}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const extraction = await extractGo(filePath, dir);
+    const packageNode = extraction.nodes.find((node) => node.id === "go_pkg_fmt");
+    const importEdge = extraction.edges.find(
+      (edge) => edge.relation === "imports_from" && edge.target === "go_pkg_fmt",
+    );
+
+    expect(packageNode?.label).toBe("fmt");
+    expect(importEdge).toBeDefined();
+
+    const graph = buildFromJson(extraction, { root: dir });
+    expect(graph.hasNode("go_pkg_fmt")).toBe(true);
+    expect(
+      graph.edges().some((edge) => {
+        const attrs = graph.getEdgeAttributes(edge);
+        return attrs.relation === "imports_from"
+          && (graph.source(edge) === "go_pkg_fmt" || graph.target(edge) === "go_pkg_fmt");
+      }),
+    ).toBe(true);
   });
 
   it("skips ambiguous call targets when multiple symbols share the same name", async () => {


### PR DESCRIPTION
## Summary

Fixes #274.

The Go extractor emitted `imports_from` edges for standard-library, external-module, and local-module imports, but did not emit nodes for those namespaced package targets. `buildFromJson` therefore dropped the edges as dangling, silently losing import relationships from the final graph.

This change creates a `go_pkg_<import path>` package node at the import location before emitting the edge. The existing namespaced IDs avoid collisions with local file and symbol nodes, while the final graph now retains the import relationship and makes the imported package visible.

## Tests

- Added a regression test that reproduces the `fmt` example from #274 and checks both the extraction fragment and the built graph.
- `npx vitest run --config vitest.config.ts tests/extract-call-confidence.test.ts --reporter=dot` (7 passed)
- `npm run lint`

The change is limited to the Go import extractor and its regression test.
