### PR TITLE
docs(spec): governance specs for writes to main (design only)

### DIFF
--- a/scripts/gate4.sh
+++ b/scripts/gate4.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# GATE 4 criteres — DEF FINALE (conducteur 2026-08-08, raffinement g-arch). LOCKE:
+# ne plus re-refiner sauf faux-verdict REEL constate.
+#
+# CHEMIN CANONIQUE: scripts/gate4.sh — versionne, non-gitignore, une seule copie.
+# N EN FAITES PAS DE COPIE. Un doublon sous .graphify/scratch/ a deja coute a la
+# flotte deux verifications et une correction publique erronee: les deux copies
+# etaient correctes, mais l une AFFICHAIT l index de colonne resolu, ce qui se lit
+# comme un hardcode. Si vous devez lire le gate, lisez CE fichier.
+#
+#   MemAvailable >= 10G  ET  disque < 90%  ET  load1 < 1.5*nproc  ET  swap-churn bas
+#
+# CRITERE 4 = TAUX d E/S swap, PAS le niveau ni le delta de SwapFree.
+#   vmstat 2 3 = 3 releves a 2s. La 1re ligne est un cumul depuis le boot, donc
+#   inutilisable: on juge sur les 2 DERNIERES.
+#   ROUGE = si/so SOUTENU > 0 sur CES DEUX echantillons. Un pic momentane n est pas
+#   un thrash: vmstat 1 2 sous-echantillonne et rendait un faux-rouge sur un pic
+#   transitoire de 1s.
+#   Un gros swap UTILISE mais STABLE est BENIN — c est l insight d origine, d ou le
+#   fait que le niveau soit affiche comme informatif et jamais comme critere.
+#
+# LC_ALL=C OBLIGATOIRE: en locale fr_FR, awk printf "%.1f" rend "48,0" et la
+# comparaison bascule en comparaison de CHAINES. "6.75" < "48,0" est FAUX (compare
+# "6" a "4") => NO-GO fantome sur load. Pire, "9,5" >= "10" est VRAI (compare "9" a
+# "1") => le gate laissait passer une machine SOUS le plancher memoire. Bug constate
+# et corrige le 2026-08-08 sur ce script meme.
+export LC_ALL=C
+
+NPROC=$(nproc)
+MEMAV=$(awk '/MemAvailable/{printf "%.1f", $2/1048576}' /proc/meminfo)
+LOAD1=$(awk '{print $1}' /proc/loadavg)
+DISK=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+SWUSED_MI=$(awk '/SwapTotal/{t=$2} /SwapFree/{f=$2} END{printf "%d", (t-f)/1024}' /proc/meminfo)
+SWTOT_MI=$(awk '/SwapTotal/{printf "%d", $2/1024}' /proc/meminfo)
+THRESH=$(awk -v n="$NPROC" 'BEGIN{printf "%.1f", n*1.5}')
+
+# SO-ONLY (def finale corrigee, conducteur 2026-08-08 apres faux-rouge constate).
+# swap-OUT des 2 derniers echantillons. Le swap-IN est AFFICHE mais EXCLU du verdict:
+# un si eleve avec so=0 est une RECUPERATION (pages qui reviennent en RAM libre), pas
+# une pression. Seul so soutenu = eviction sous pression = thrash.
+#
+# POSITION JAMAIS DEVINEE: les colonnes sont resolues par l EN-TETE. En vmstat, $2
+# est "b" (processus BLOQUES), pas "so" — coder une position devinee fait juger les
+# process bloques au lieu du swap. Et le layout DERIVE selon procps: sur cette machine
+# l en-tete porte 18 champs dont "gu", donc un $8 code en dur est un pari sur la
+# version installee. Si l en-tete est illisible, on echoue en NO-GO plutot que de
+# deviner.
+VMALL=$(vmstat 2 3)
+VMHDR=$(echo "$VMALL" | sed -n '2p')
+SO_IDX=$(echo "$VMHDR" | awk '{for(i=1;i<=NF;i++) if($i=="so"){print i; exit}}')
+SI_IDX=$(echo "$VMHDR" | awk '{for(i=1;i<=NF;i++) if($i=="si"){print i; exit}}')
+if [ -z "$SO_IDX" ] || [ -z "$SI_IDX" ]; then
+  echo "GATE ERREUR: colonnes si/so introuvables dans l en-tete vmstat -> [$VMHDR]"
+  echo "VERDICT=NO-GO"
+  exit 1
+fi
+VMOUT=$(echo "$VMALL" | tail -2)
+S1=$(echo "$VMOUT" | head -1 | awk -v c="$SO_IDX" '{print $c}')
+S2=$(echo "$VMOUT" | tail -1 | awk -v c="$SO_IDX" '{print $c}')
+SI=$(echo "$VMOUT" | tail -1 | awk -v c="$SI_IDX" '{print $c}')
+SO=$S2
+
+ok_mem=$(awk -v v="$MEMAV" 'BEGIN{print (v>=10)?1:0}')
+ok_disk=$(( DISK < 90 ? 1 : 0 ))
+ok_load=$(awk -v l="$LOAD1" -v t="$THRESH" 'BEGIN{print (l<t)?1:0}')
+# SOUTENU = les DEUX derniers echantillons de swap-OUT au-dessus du seuil. Un pic
+# isole => vert. Historique de calibration, 3 faux-verdicts qui ont fixe cette regle:
+#   1) ">0 sur si+so" => NO-GO permanent sur machine saine (si>0 sur 10/10 releves,
+#      moyenne 92 KiB/s, so=0 sur 6/10, 21G libres, load 9.57).
+#   2) "vmstat 1 2" => faux-rouge sur un pic transitoire de 1s (88 puis 20828 KiB/s
+#      a deux appels consecutifs).
+#   3) "si+so a 1000" => faux-rouge pendant la RECUPERATION post-thrash: si eleve
+#      (pages qui reviennent en RAM libre) avec so=0. C est benin, et c est ce qui a
+#      motive le passage a SO-only.
+CHURN_MAX_KIBPS=1000
+if [ "$S1" -gt "$CHURN_MAX_KIBPS" ] && [ "$S2" -gt "$CHURN_MAX_KIBPS" ]; then ok_churn=0; else ok_churn=1; fi
+
+echo "nproc=$NPROC MemAvailable=${MEMAV}G(ok=$ok_mem) disque=${DISK}%(ok=$ok_disk) load1=$LOAD1/seuil${THRESH}(ok=$ok_load)"
+echo "swap-OUT echantillons 2s: so=[${S1}, ${S2}] KiB/s; ROUGE si les DEUX > ${CHURN_MAX_KIBPS}; ok=$ok_churn  [si=${SI} KiB/s (swap-IN) = AFFICHE mais EXCLU du verdict: recuperation, pas pression | swap UTILISE ${SWUSED_MI}Mi/${SWTOT_MI}Mi = informatif]"
+if [ "$ok_mem" -eq 1 ] && [ "$ok_disk" -eq 1 ] && [ "$ok_load" -eq 1 ] && [ "$ok_churn" -eq 1 ]; then
+  echo "VERDICT=GO"
+else
+  echo "VERDICT=NO-GO"
+fi

--- a/spec/APPLY_BRANCH_PROTECTION.md
+++ b/spec/APPLY_BRANCH_PROTECTION.md
@@ -19,12 +19,12 @@ the job was renamed, and naming it here would deadlock every merge.
 
 ## The command
 
-`APPROVALS` and `ENFORCE_ADMINS` are the owner's two open arbitrations. Substitute,
-do not guess.
+Both arbitrations are **ratified by the owner** (2026-08-08): 0 approvals, admins not
+enforced. The values below are final, not placeholders.
 
 ```sh
-# APPROVALS      : 0 (conductor gate is the review) | 1 (a human clicks per merge)
-# ENFORCE_ADMINS : false (keeps the admin-merge-on-quota escape) | true (binds admins too)
+# RATIFIED: 0 approvals — a PR is still required; the conductor gate is the review.
+# RATIFIED: enforce_admins false — keeps the admin-merge-on-quota-flake escape hatch.
 APPROVALS=0
 ENFORCE_ADMINS=false
 

--- a/spec/APPLY_BRANCH_PROTECTION.md
+++ b/spec/APPLY_BRANCH_PROTECTION.md
@@ -1,0 +1,86 @@
+# Apply payload — branch protection on `main`
+
+Companion to `SPEC_MAIN_BRANCH_PROTECTION.md`. **Nothing here is applied.** This
+exists so the owner's two answers turn straight into a reviewable command instead of
+another round trip.
+
+## Blocking pre-check — run this FIRST, every time
+
+A required check that never runs on a PR blocks that PR forever. Confirm the names on
+a real PR before applying:
+
+```sh
+gh pr checks <a-real-pr-number> --json name,state --jq '.[].name' | sort -u
+```
+
+Require only names that appear in that output. If `test (20)`, `test (22)`,
+`test (24)`, `golden-webgl` or `smoke-test` is missing from it, **do not apply** —
+the job was renamed, and naming it here would deadlock every merge.
+
+## The command
+
+`APPROVALS` and `ENFORCE_ADMINS` are the owner's two open arbitrations. Substitute,
+do not guess.
+
+```sh
+# APPROVALS      : 0 (conductor gate is the review) | 1 (a human clicks per merge)
+# ENFORCE_ADMINS : false (keeps the admin-merge-on-quota escape) | true (binds admins too)
+APPROVALS=0
+ENFORCE_ADMINS=false
+
+gh api -X PUT repos/rhanka/graphify/branches/main/protection \
+  --input - <<JSON
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["test (20)", "test (22)", "test (24)", "golden-webgl", "smoke-test"]
+  },
+  "enforce_admins": ${ENFORCE_ADMINS},
+  "required_pull_request_reviews": {
+    "required_approving_review_count": ${APPROVALS},
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+```
+
+Note on `APPROVALS=0`: GitHub accepts the block with a count of 0, which still forces
+changes through a pull request while requiring no approval. Dropping the
+`required_pull_request_reviews` block entirely is **not** the same thing — that
+removes the PR requirement, which is the whole point.
+
+## Rollback
+
+One call, and `main` is back to its current unprotected state:
+
+```sh
+gh api -X DELETE repos/rhanka/graphify/branches/main/protection
+```
+
+That is what makes applying this reversible: the risk is not the protection itself but
+applying it *before* the lane is PR-based, which strands the held lots.
+
+## Verification, in order
+
+```sh
+# 1. protection is live and says what we think it says
+gh api repos/rhanka/graphify/branches/main/protection \
+  --jq '{checks: .required_status_checks.contexts, strict: .required_status_checks.strict,
+         approvals: .required_pull_request_reviews.required_approving_review_count,
+         admins: .enforce_admins.enabled}'
+
+# 2. a direct push is REFUSED (expect a non-zero exit and a rejection message)
+git push origin main
+
+# 3. --no-verify changes nothing — proves this is server-side, not the local hook
+git push --no-verify origin main
+
+# 4. a PR with the required checks green MERGES
+```
+
+Step 2 failing to fail is the only outcome that means the apply did not work. Do not
+report success on the API response alone.

--- a/spec/SPEC_MAIN_BRANCH_PROTECTION.md
+++ b/spec/SPEC_MAIN_BRANCH_PROTECTION.md
@@ -1,0 +1,88 @@
+# SPEC — Branch protection on `main`
+
+Status: **design, awaiting conductor validation — NOT applied**
+
+Date: 2026-08-08 · Baseline `main` = `64708bee` · Repo `rhanka/graphify`
+
+Owner decision: branch protection is the real close; the local hook
+(`SPEC_MAIN_BRANCH_WRITE_GUARD.md`, `e4648dd6`) is an accident guard only.
+
+## 0. Measured facts
+
+- **`main` is currently unprotected** — `gh api …/branches/main/protection` → 404.
+- **I hold `admin: true`** on `rhanka/graphify` (and `push: true`). I *can* apply
+  this. I am **not** applying it: it gates every push from everyone including the
+  owner and CI, which is the same class of act as the machine-wide `docker prune`
+  that was routed to the owner.
+- Exact check names on `main` today:
+  - deterministic, per-commit: `test (20)`, `test (22)`, `test (24)`,
+    `golden-webgl`, `smoke-test`, `build`
+  - **quota-flaky**: `direct-llm-uat (anthropic|cohere|gemini|mistral|openai)`
+  - **release-only**: `publish`, `publish-graph`, `post-publish-check`,
+    `release-guard`, `deploy`, `report-build-status`
+
+## 1. The trap that must not be sprung
+
+**A required check that never runs on a PR blocks that PR forever.** GitHub waits
+for the context indefinitely; there is no timeout. Two ways to fall in:
+
+1. naming a check that does not exist (typo, renamed job);
+2. naming a check that exists but only runs on **tags/releases** — that is exactly
+   what `publish`, `publish-graph`, `post-publish-check`, `release-guard` and
+   `deploy` are here. They are release-driven (npm publish is tag-driven in this
+   repo), so a PR would never produce them.
+
+**Therefore, before applying: open one throwaway PR and read the check names it
+actually produces.** Require only names observed on that PR. This is the single
+verification that must precede `PUT`.
+
+## 2. Proposed ruleset
+
+| Field | Proposed | Why |
+| --- | --- | --- |
+| `required_status_checks.contexts` | `test (20)`, `test (22)`, `test (24)`, `golden-webgl`, `smoke-test` | the conductor's list — deterministic and per-commit. `build` is a candidate if the PR produces it; add only after §1 observation. |
+| — **excluded** | the 5 `direct-llm-uat (*)` | provider-quota flakes. There is already a documented practice of admin-merging when the *only* red check is `direct-llm-uat` on exhausted quota. Requiring them would make every merge hostage to a third-party quota. |
+| `required_status_checks.strict` | **`false`** | `true` forces every PR to be up-to-date with `main` before merging. `main` moved ~60 times in one day here; `strict:true` would put every lot into a rebase treadmill and serialise the whole fleet. |
+| `required_pull_request_reviews` | **0 required approvals** (PR still required) | the conductor gate *is* the review. Requiring ≥1 approval in a single-owner org means the owner must click on every lot, recreating the bottleneck protection is meant to remove. **Trade-off stated: with 0 approvals, the PR is a channel and a checks-gate, not a human review.** If the conductor wants a human in the loop per merge, set it to 1 and accept the click. |
+| `enforce_admins` | **`false`** (proposed) | keeps an owner escape hatch. With `true`, the documented admin-merge-on-quota-flake practice becomes impossible, and an urgent fix during a provider outage has no path. **Counter-argument, honestly:** `false` means the protection does not bind the person most able to bypass it by habit, which weakens it to a convention for admins. If the owner wants the rule to bind everyone including themselves, `true` is defensible — it just must be a deliberate choice, not a default. |
+| `allow_force_pushes` | `false` | force-push to `main` rewrites shared history. |
+| `allow_deletions` | `false` | |
+| `restrictions` | `null` | no per-actor allowlist; the PR requirement is the control. |
+
+Requiring a PR is what removes direct push: with protection on and no `restrictions`
+bypass, `git push origin main` is refused server-side — including `--no-verify`,
+including from any other clone. That is the property the local hook could not give.
+
+## 3. Sequencing — the chicken-and-egg, and it is real
+
+**Adapt the guarded lane BEFORE enabling protection.** Order:
+
+1. **Convert the lane** to PR-based: branch → `gh pr create` → wait for required
+   checks → `gh pr merge`. (Build lot, `gpt-5.6-terra` xhigh, needs a slot.)
+2. **Drain or convert the 4 HELD lots** — `2608c1ed`, `1008471b`, `bbaab6fb`,
+   `e4648dd6`. They are currently destined for a direct guarded merge; once
+   protection is on, that path is gone and they are stuck until someone opens PRs
+   for them.
+3. **Observe a throwaway PR** and freeze the exact required-check names (§1).
+4. **Apply** the protection.
+5. **Verify** (§4).
+
+Doing 4 before 1-2 breaks the guarded lane and strands every HELD lot — the exact
+failure the conductor flagged.
+
+## 4. Verification, after apply
+
+1. **PR-based merge PASSES** — a real PR with green required checks merges.
+2. **Direct push is BLOCKED** — `git push origin main` from a clean clone →
+   rejected by the server, ref unmoved.
+3. **A quota-flaky `direct-llm-uat` red does NOT block** — proving the exclusion
+   in §2 works, since that was the whole point of excluding it.
+4. **`--no-verify` does not help** — same rejection, proving this is server-side
+   and not the local hook.
+
+## 5. Who applies
+
+I have the rights but this is owner-level: it gates the owner's own pushes and
+every CI job. **Recommendation: the conductor has the `PUT` validated by the
+owner**, same route as the `docker prune`. I can hand the exact `gh api` call for
+review; I will not run it unasked.

--- a/spec/SPEC_MAIN_BRANCH_PROTECTION.md
+++ b/spec/SPEC_MAIN_BRANCH_PROTECTION.md
@@ -1,6 +1,13 @@
 # SPEC — Branch protection on `main`
 
-Status: **design, awaiting conductor validation — NOT applied**
+Status: **RATIFIED by the owner 2026-08-08 — still NOT applied** (apply is sequenced
+after the lane becomes PR-based; see §3)
+
+Both open arbitrations were decided as proposed: **0 approvals** and
+**`enforce_admins: false`**. The §2 table below records the reasoning that was on the
+table when that call was made, including the arguments against — those do not stop
+being true now that the decision went the other way, and they are what to re-read if
+the rule ever needs revisiting.
 
 Date: 2026-08-08 · Baseline `main` = `64708bee` · Repo `rhanka/graphify`
 

--- a/spec/SPEC_MAIN_BRANCH_WRITE_GUARD.md
+++ b/spec/SPEC_MAIN_BRANCH_WRITE_GUARD.md
@@ -1,0 +1,146 @@
+# SPEC — Guard on direct writes to `main`
+
+Status: **design, awaiting conductor validation — no implementation**
+
+Date: 2026-08-08
+
+Baseline: `main` at `64708bee`
+
+Origin: owner decision (b) — refuse any merge/push to `main` that did not go
+through the guarded lane.
+
+## 0. The finding that reframes this spec
+
+**`main` is not protected on GitHub.** Measured:
+
+```
+gh api repos/:owner/:repo/branches/main/protection
+  -> 404 "Branch not protected"
+```
+
+That matters more than anything below, because it tells us where the governance
+hole actually is. A git hook **cannot** close it:
+
+- `git push --no-verify` skips `pre-push` entirely — one flag, no privilege needed;
+- hooks live in local config (§2), so **any other clone has no hook at all**;
+- the CI runner, a fresh checkout, another machine: all unguarded.
+
+So the honest framing, and the thing to agree on before writing code:
+
+| Layer | What it is | What it stops |
+| --- | --- | --- |
+| **Branch protection** (server) | the actual control | everyone, everywhere, including `--no-verify` and other clones |
+| **Local hook** (this spec) | a guardrail | the *accident* — a tired agent or human typing `git push origin main` in the wrong worktree |
+
+Both are worth having, and they are not substitutes. Building only the hook and
+calling the hole closed would be the failure mode this spec exists to avoid.
+**Recommendation: ship the hook (cheap, immediate, in my perimeter) AND raise
+branch protection as the owner-level fix** — it is one API call, and it gates
+everyone's pushes, which is precisely why it is not mine to enable.
+
+## 1. Hard point (1) — not breaking our own guarded lane
+
+The hook must let the guarded lane through while refusing ad-hoc writes. The
+chicken-and-egg is real: a guard that blocks every write to `main` blocks the
+lane that is supposed to be the sanctioned path.
+
+**Proposal: an explicit env marker, `GRAPHIFY_GATE=1`, exported by the guarded
+lane and checked by the hook.**
+
+Why this and not a commit-format convention: a marker is *checked at the moment
+of the write*, which is exactly when the decision is made. A commit-message
+convention is checked after the fact and is trivially reproduced by anyone
+writing the right words.
+
+**Its honest weakness, stated up front:** `GRAPHIFY_GATE=1 git push` also passes.
+The marker documents intent; it does not verify authority. That is acceptable
+*only* under the framing of §0 — this is an accident guard. If we ever need it to
+resist intent, the answer is branch protection, not a cleverer marker.
+
+## 2. Hard point (2) — one hook, 76 worktrees
+
+Already solved by the current setup, verified rather than assumed:
+
+```
+git config --show-origin --get core.hooksPath
+  file:.git/config    /home/antoinefa/src/graphify/.git/hooks
+git -C <a worktree> config --get core.hooksPath
+  /home/antoinefa/src/graphify/.git/hooks     <- same directory
+git worktree list | wc -l  ->  76
+```
+
+`core.hooksPath` is an **absolute** path in the repo's local config, and a
+worktree resolves the same directory. So a single hook file covers all 76
+worktrees with no per-worktree installation.
+
+**The catch, and it is the reason not to call this "versioned":** `.git/config`
+is *not* in the repository. A fresh clone has no `core.hooksPath` and therefore
+no hook. Two consequences:
+
+- the hook must be **installable by a script** (`scripts/install-hooks.sh`)
+  committed to the repo, so a new clone can opt in deliberately;
+- the guard can never be assumed present. Anything that *must* hold is
+  branch protection.
+
+Switching `core.hooksPath` to a versioned directory (e.g. `.githooks`) would make
+the hook travel with the repo, but still requires a local `git config` to point
+there — git deliberately does not let a repository configure its own hooks path,
+precisely because that would be remote code execution on clone. There is no way
+around the install step.
+
+## 3. Hard point (3) — what exactly is blocked
+
+Two distinct events, and **the obvious hook misses one of them**:
+
+**a. Push to `origin/main`** — `pre-push`. The hook reads the refs being pushed
+on stdin (`<local ref> <local sha> <remote ref> <remote sha>`) and refuses when
+`<remote ref>` is `refs/heads/main` without the marker.
+
+**b. Local merge into `main`** — `pre-merge-commit` is **not sufficient**. It
+only fires when a merge *creates a commit*; a **fast-forward** merge into `main`
+creates none, so `git merge --ff-only wip` silently moves `main` with no hook
+firing. Since most of our lots would fast-forward, this gap would cover the
+common case.
+
+The hook that catches every local ref move is **`reference-transaction`**,
+supported here (git 2.53.0, needs ≥ 2.28). It fires on *any* ref update —
+fast-forward merges, `reset --hard`, `branch -f` — and can refuse the transaction
+when the ref is `refs/heads/main`.
+
+**Scope discipline:** it must refuse **only** `refs/heads/main` and stay silent
+for every other ref, otherwise it interferes with all lane work across 76
+worktrees. It must also ignore the `prepared`/`committed`/`aborted` phases it is
+not meant to act on, and never write to stdout in a way that pollutes porcelain.
+
+## 4. The test that must pass
+
+Not "the hook exists" — the *behaviour*, in a throwaway clone so no experiment
+can touch the real `main`:
+
+1. **Direct push to main is BLOCKED** — `git push origin main` without the marker
+   → non-zero exit, ref unmoved on the remote.
+2. **Direct local merge into main is BLOCKED, including fast-forward** — the case
+   `pre-merge-commit` would have missed.
+3. **The guarded lane PASSES** — the same merge and push with `GRAPHIFY_GATE=1`
+   → success, ref moved.
+4. **Other branches are untouched** — a push/merge on any non-`main` ref is
+   unaffected, proving the guard has not become a global brake.
+
+Test 2 is the one that would fail against a naive `pre-merge-commit`
+implementation, so it must exist before the hook is written, per the Track F rule
+that a test which cannot fail against the wrong implementation proves nothing.
+
+## 5. What this spec does not decide
+
+- **Whether to enable branch protection on `main`.** It gates the owner's own
+  pushes and every CI job; that is an owner call, and it is the only thing here
+  that actually closes the hole.
+- **Whether the marker should be `GRAPHIFY_GATE` or a call through a wrapper
+  script** (`scripts/gated-merge.sh`). A wrapper is harder to invoke by accident
+  and gives one place to log what was merged and by which lane; it is also one
+  more thing to keep working. Conductor's call.
+
+## 6. Cost
+
+Small: one hook file, one install script, one test script. No change to product
+code. The risk is not the code — it is shipping it as if the hole were closed.


### PR DESCRIPTION
Five design-only commits. No product code, no CI behaviour change.

- `e4648dd6` local hook design — accident guard only
- `e7e3ec1b` branch-protection ruleset design
- `dd55cfa3` `scripts/gate4.sh` — the fleet resource gate, moved to a versioned path because `.graphify/scratch/` is gitignored and two copies had drifted
- `9cc9b5b9` + `c45147e3` the apply payload, frozen at the owner-ratified values

This PR is also the first exercise of the PR-based lane, and it is what freezes the exact required-check names before any protection is applied.

Do not merge without the conductor's gate.