### PR TITLE
feat(hooks): refuse ungated writes to main (reference-transaction)

### DIFF
--- a/hooks/reference-transaction
+++ b/hooks/reference-transaction
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Refuse writes to refs/heads/main that did not come through the gate.
+#
+# reference-transaction rather than pre-merge-commit: pre-merge-commit never runs
+# for a fast-forward merge, because no merge commit is created. That is the whole
+# hole this guards — a local `git merge` of a branch that is ahead moves main with
+# no hook in sight. reference-transaction sees every ref update, including that one.
+#
+# Only "prepared" can still be refused. "committed" and "aborted" are after the
+# fact, so they are ignored in silence rather than re-reported.
+#
+# Escape hatch: GRAPHIFY_GATE=1 for tooled merges that are themselves gated.
+# This hook guards against the accident. The authority is branch protection on
+# the remote — a local hook cannot bind a clone that does not have it.
+
+[ "$1" = "prepared" ] || exit 0
+[ "${GRAPHIFY_GATE:-}" = "1" ] && exit 0
+
+while read -r old new ref; do
+	[ "$ref" = "refs/heads/main" ] || continue
+	echo "refus: ecriture directe sur main ($old -> $new)." >&2
+	echo "main passe par une PR. Pour un merge outille: GRAPHIFY_GATE=1" >&2
+	exit 1
+done
+
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -9,7 +9,13 @@
 set -eu
 
 cd "$(dirname "$0")/.."
-git config core.hooksPath hooks
+
+# ABSOLU, jamais relatif. Un chemin relatif est resolu par git depuis la racine du
+# WORKTREE COURANT, donc chaque worktree chercherait son propre hooks/ : ceux dont
+# la branche checked-out ne porte pas encore le fichier pointeraient un repertoire
+# inexistant et seraient NON GARDES, sans le moindre message. Avec le chemin
+# absolu du checkout primaire, les worktrees partagent le meme hooks/ versionne.
+git config core.hooksPath "$PWD/hooks"
 chmod +x hooks/* 2>/dev/null || true
 
 printf 'hooks actives depuis %s/hooks\n' "$PWD"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Point this clone's hooks at the versioned hooks/ directory.
+#
+# core.hooksPath is stored in .git/config, which is not versioned, so this has to
+# be run once per clone. Worktrees share the parent clone's .git/config, so one
+# run covers every worktree of that clone — but a fresh clone starts unguarded.
+# That is a real limit, not an oversight: the enforcement that binds every clone
+# is branch protection on the remote. This only catches the local accident.
+set -eu
+
+cd "$(dirname "$0")/.."
+git config core.hooksPath hooks
+chmod +x hooks/* 2>/dev/null || true
+
+printf 'hooks actives depuis %s/hooks\n' "$PWD"
+printf 'verifier:  git config --get core.hooksPath\n'

--- a/scripts/test-main-write-guard.sh
+++ b/scripts/test-main-write-guard.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Behavioural tests for hooks/reference-transaction, in a throwaway clone.
+#
+# Test 2 is the one that matters, and it is written to fail against the obvious
+# wrong implementation: a naive pre-merge-commit hook. That hook does not run at
+# all for a fast-forward merge, so it lets main move without a word. A test that
+# passes against both implementations would prove nothing about this defect.
+#
+# Setup steps run under GRAPHIFY_GATE=1 on purpose. Preparing a case means moving
+# main (reset, branch -f), which the hook refuses — the first version of this
+# harness was refused at setup, left main where it was, and the merge under test
+# became a silent no-op that reported success. The lesson: read the ref, not the
+# exit code of a step you did not verify.
+set -u
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/hooks/reference-transaction"
+R="$(mktemp -d)"
+trap 'rm -rf "$R"' EXIT
+fail=0
+
+ok() { printf '  ok    %s\n' "$1"; }
+ko() { printf '  FAIL  %s\n' "$1"; fail=1; }
+
+cd "$R"
+git init -q -b main .
+git config user.email t@example.invalid
+git config user.name test
+echo a > f && git add f && git commit -qm init
+git branch -f feat
+git checkout -q feat && echo b > g && git add g && git commit -qm ahead
+git checkout -q main
+BASE=$(git rev-parse main)
+
+# --- Test 1: the naive implementation is blind to a fast-forward merge.
+printf '#!/bin/sh\ntouch "%s/naive-fired"\nexit 1\n' "$R" > .git/hooks/pre-merge-commit
+chmod +x .git/hooks/pre-merge-commit
+git merge feat >/dev/null 2>&1
+if [ -e "$R/naive-fired" ]; then
+	ko "test 1: pre-merge-commit naif s'est declenche (le defaut n'existerait pas)"
+else
+	ok "test 1: pre-merge-commit naif NE se declenche PAS sur un ff-merge"
+fi
+[ "$(git rev-parse main)" != "$BASE" ] && ok "test 1: et main a bouge sous le hook naif" \
+	|| ko "test 1: main n'a pas bouge, le cas n'est pas un ff-merge"
+rm -f .git/hooks/pre-merge-commit
+
+# --- Install the real hook, and rewind main under the gate (setup, not a test).
+cp "$HOOK" .git/hooks/reference-transaction
+chmod +x .git/hooks/reference-transaction
+GRAPHIFY_GATE=1 git reset -q --hard "$BASE"
+BASE=$(git rev-parse main)
+
+# --- Test 2: the same fast-forward merge is refused, and main does not move.
+git merge feat >/dev/null 2>&1
+if [ "$(git rev-parse main)" = "$BASE" ]; then
+	ok "test 2: ff-merge BLOQUE, main inchange"
+else
+	ko "test 2: main a bouge — le garde-fou ne tient pas"
+fi
+
+# --- Test 3: the documented escape hatch still works.
+GRAPHIFY_GATE=1 git merge feat >/dev/null 2>&1
+[ "$(git rev-parse main)" != "$BASE" ] && ok "test 3: GRAPHIFY_GATE=1 laisse passer" \
+	|| ko "test 3: la derogation ne passe pas"
+
+# --- Test 4: branches other than main are not slowed down at all.
+git checkout -q -b autre
+echo c > h && git add h
+if git commit -qm other >/dev/null 2>&1; then
+	ok "test 4: une autre branche n'est pas entravee"
+else
+	ko "test 4: une autre branche est entravee"
+fi
+
+[ "$fail" -eq 0 ] && printf 'TOUS LES TESTS PASSENT\n' || printf 'AU MOINS UN TEST ECHOUE\n'
+exit "$fail"


### PR DESCRIPTION
Implements the approved design. reference-transaction rather than pre-merge-commit, because the latter never runs for a fast-forward merge — which is exactly the hole, since worktrees share the parent clone's refs.

Falsified before implementing, per the Track F rule: a naive pre-merge-commit was wired in a throwaway clone and did **not** fire on the fast-forward merge; main moved. The same merge is refused by this hook and main stays put. GRAPHIFY_GATE=1 passes; other branches are unaffected.

Scope is strictly refs/heads/main, and only the prepared state is acted on — committed and aborted are ignored in silence.

This is an accident guard. Branch protection on the remote remains the authority, and is still pending.