### PR TITLE
ci: drop gemini from the direct-llm-uat matrix

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -114,7 +114,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: ["anthropic", "openai", "gemini", "mistral", "cohere"]
+        # gemini retiré du CI : gemini-3.1-pro exige un projet Google facturé
+        # (free tier = limit 0). Non testé en CI ; reste dispo comme provider produit.
+        provider: ["anthropic", "openai", "mistral", "cohere"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
gemini-3.1-pro requires a **billed** Google project (free tier = `limit: 0`), so the gemini UAT fails on quota regardless of the key. Owner decision: stop testing gemini in CI.

- Removes `gemini` from the `direct-llm-uat` matrix.
- Keeps the `GEMINI_API_KEY` secret + env line (harmless; documents the secret exists).
- gemini remains available as a product provider, just not exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)