### PR TITLE
feat(api): export pr.ts helpers for the extracted agent-stats module (Track 3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -492,6 +492,8 @@ export { validateUrl, safeFetch, safeFetchText, validateGraphPath, sanitizeLabel
 export { DEFAULT_GRAPHIFY_STATE_DIR, LEGACY_GRAPHIFY_STATE_DIR, NEXT_GRAPHIFY_STATE_DIR, resolveGraphifyPaths, defaultGraphPath, legacyGraphPath, resolveGraphInputPath, defaultManifestPath, defaultTranscriptsDir } from "./paths.js";
 export { createGraph, isDirectedGraph, loadGraphFromData, serializeGraph } from "./graph.js";
 export { resolveGitContext, safeExecGit, safeGitRevParse } from "./git.js";
+export { getPullRequestMerge, listPullRequests, githubRepoFromRemote } from "./pr.js";
+export type { CommandRunner } from "./pr.js";
 export { lifecyclePaths, readLifecycleMetadata, refreshLifecycleMetadata, markLifecycleStale, markLifecycleAnalyzed, planLifecyclePrune } from "./lifecycle.js";
 export type { GitContext } from "./git.js";
 export type { WorktreeMetadata, BranchMetadata, LifecycleMetadata, RefreshLifecycleOptions, PrunePlan, PruneCandidate } from "./lifecycle.js";


### PR DESCRIPTION
## Export pr.ts helpers for the extracted agent-stats module (Track 3)

Adds four `pr.ts` helpers to graphify's public API (`src/index.ts`) so the
agent-stats module — extracted out of graphify and becoming an h2a module — can
import them from the published `@sentropic/graphify` package instead of the
relative `../../../src/pr.js` paths that break once the module moves out of the
repo:

- `getPullRequestMerge`
- `listPullRequests`
- `githubRepoFromRemote`
- `CommandRunner` (type)

`safeGitRevParse`, `safeExecGit` and `buildStaticStudio` are already public;
`buildStaticStudio` cannot be vendored without cascading ~11 internal modules, so
the module depends on published graphify anyway — these four are exposed uniformly
here. `pr.ts` is self-contained (no internal imports), so this is a pure
public-API widening.

Anti-cycle preserved: this is a `consumer → graphify` dependency (allowed);
graphify imports nothing from any consumer.

Verification: `npx tsc --noEmit` exit 0 (re-export of existing symbols, no
`cannot be named` error).

Part of Track 3 (relocating the extracted agent-stats module into the h2a repo).
The consuming side imports from the published package once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
