### PR TITLE
chore(release): 0.18.0 — first npm publish since 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 This fork (`graphifyy@*`) is the TypeScript line. Pre-`0.7.x` entries below refer to the upstream Python Graphify line.
 
+## 0.18.0 (2026-09-03)
+
+- **First published release since 0.17.1.** The `0.17.2` version was assigned (2026-06-24) but never published; `0.18.0` ships its changes (documented below) together with the additions since.
+- **Public `pr.ts` helpers.** `getPullRequestMerge`, `listPullRequests`, `githubRepoFromRemote` and the `CommandRunner` type are now exported from the package root, so a consumer can import them from `@sentropic/graphify` instead of reaching into `src/`. Additive and backward-compatible; `pr.ts` is self-contained (no internal imports).
+- **Pluggable layout registry (opt-in).** A typed layout registry with a 2D Variant-A typed layer, opt-in, with no change to the default renderer.
+
 ## 0.17.2 (2026-06-24)
 
 - **Mistral OCR v4 default.** Bumps `mistral-ocr` to `^0.1.3` and pins Graphify's default PDF OCR model to `mistral-ocr-4-0` instead of the moving `mistral-ocr-latest` alias. `GRAPHIFY_PDF_OCR_MODEL` still overrides the model when needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sentropic/graphify",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sentropic/graphify",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.75",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/graphify",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("release configuration", () => {
-  it("tracks the 0.17.2 release across package metadata and changelog", () => {
+  it("tracks the 0.18.0 release across package metadata and changelog", () => {
     const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as { name?: string; version?: string };
     const lock = JSON.parse(readFileSync(new URL("../package-lock.json", import.meta.url), "utf-8")) as {
       name?: string;
@@ -12,11 +12,11 @@ describe("release configuration", () => {
     const changelog = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf-8");
 
     expect(pkg.name).toBe("@sentropic/graphify");
-    expect(pkg.version).toBe("0.17.2");
+    expect(pkg.version).toBe("0.18.0");
     expect(lock.name).toBe("@sentropic/graphify");
-    expect(lock.version).toBe("0.17.2");
-    expect(lock.packages?.[""]?.version).toBe("0.17.2");
-    expect(changelog).toContain("## 0.17.2 (2026-06-24)");
+    expect(lock.version).toBe("0.18.0");
+    expect(lock.packages?.[""]?.version).toBe("0.18.0");
+    expect(changelog).toContain("## 0.18.0 (2026-09-03)");
   });
 
   it("runs the main TypeScript CI test matrix on Node 20, 22, and 24", () => {


### PR DESCRIPTION
## Release 0.18.0 — first npm publish since 0.17.1

npm serves **0.17.1**. The repo's `0.17.2` was assigned at #218 ("default Mistral OCR v4") and **never published**, with #238 (layout registry), #246 (graph 0.2.0), #309 (agent-memory substrate) and #311 (pr.ts helpers) stacked on top since. Publishing "0.17.2" now would stamp all of that as 0.17.2, so this cuts **0.18.0** — semver minor (additive public API, nothing breaking) — to carry the accumulated work to npm under a correct version.

### Changes
- `package.json` + `package-lock.json` (root) → `0.18.0`
- `CHANGELOG.md`: 0.18.0 entry — `pr.ts` helpers (`getPullRequestMerge`, `listPullRequests`, `githubRepoFromRemote`, `CommandRunner`) now exported from the package root (unblocks the extracted h2a module importing them from the published package — Track 3); pluggable layout registry (opt-in); carries the previously-unpublished 0.17.2 changes.
- `tests/release-config.test.ts`: metadata + changelog assertions → `0.18.0`

### Verification
Isolated `origin/main` worktree: `npm ci` + `npm run build` + full `npm test` green — **305 test files, 2754 tests passed, 0 failed** (5 files / 18 tests skipped, 1 todo).

### Owner gestures remaining (not automated)
- **Merge** this PR to `main`
- **Tag** `v0.18.0`
- **`npm publish`** (its `prepublishOnly` re-runs build + assert-studio + test)

Release-prep only — no merge/tag/publish performed here.
