### PR TITLE
feat(memory): reconciliation queue declares its recall loss (F13/R4+R5 + guard disclosures)

### DIFF
--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -121,6 +121,45 @@ function sourceRef(file: string | undefined, location: string | undefined): stri
   return [location ? `${file}#${location}` : file];
 }
 
+/** Separator `sourceRef` writes between a source file and its in-document location. */
+const SOURCE_SPAN_SEPARATOR = "#";
+
+const PROVENANCE_COVERAGE_CRITERION = "source_refs carries a citation span (file#location)";
+
+interface ProvenanceCoverage {
+  criterion: string;
+  anchored: number;
+  total: number;
+}
+
+/**
+ * How many emitted nodes carry a POSITIONAL anchor, stamped on the manifest.
+ *
+ * Read off the emitted `source_refs`, not off the upstream `source_location`
+ * that produced them: the artefact is what a consumer reads, so measuring the
+ * input would report what we believe we wrote rather than what we wrote.
+ *
+ * Deliberately UNCONDITIONAL, unlike `hierarchies_path` next to it. A coverage
+ * figure that disappeared at zero would make "nothing is anchored" and "nobody
+ * measured" indistinguishable — the exact confusion this block exists to end.
+ * Zero is a finding and it gets published.
+ *
+ * No `share`: both operands are here and a stored ratio is redundant state that
+ * can drift away from them. The division belongs to the reader.
+ *
+ * This is a STATISTIC, never a guard input. Nothing may branch on it. If a
+ * decision ever needs to, it goes through the declared-filter discipline —
+ * enumerated list, owner, motive, pinning test — rather than being promoted by
+ * drift.
+ */
+function provenanceCoverage(nodes: readonly CompiledNode[]): ProvenanceCoverage {
+  return {
+    criterion: PROVENANCE_COVERAGE_CRITERION,
+    anchored: nodes.filter((node) => node.source_refs.some((ref) => ref.includes(SOURCE_SPAN_SEPARATOR))).length,
+    total: nodes.length,
+  };
+}
+
 function writeJson(path: string, value: unknown): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(value, null, 2) + "\n", "utf-8");
@@ -435,6 +474,7 @@ export function compileOntologyOutputs(options: CompileOntologyOutputsOptions): 
     relation_count: relations.length,
     wiki_page_count: wikiPageCount,
     source_graph: ".graphify/graph.json",
+    provenance_coverage: provenanceCoverage(nodes),
   };
 
   if (hasHierarchies) {

--- a/src/ontology-output.ts
+++ b/src/ontology-output.ts
@@ -144,6 +144,20 @@ interface ProvenanceCoverage {
  * measured" indistinguishable — the exact confusion this block exists to end.
  * Zero is a finding and it gets published.
  *
+ * ABSENT on a manifest therefore means the artefact was produced BEFORE this
+ * block existed. It does not mean nothing was anchored, and it is not a zero.
+ *
+ * KNOWN FALSE POSITIVE, accepted: the test is `ref.includes("#")`, while
+ * `sourceRef` emits the bare file when there is no location. A source path that
+ * itself contains `#` is therefore counted as anchored without carrying a span.
+ * It matters more than its rarity suggests — every corpus measured so far sits
+ * at zero, so a single such path would make the figure non-zero and simulate the
+ * beginnings of anchoring on the very number meant to separate "nothing is
+ * anchored" from "nobody measured". Not worked around here: deriving from the
+ * input instead would report what we believe we wrote rather than what we
+ * wrote. Revisit if refs ever become structured (`{file, location?}`) rather
+ * than `#`-joined.
+ *
  * No `share`: both operands are here and a stored ratio is redundant state that
  * can drift away from them. The division belongs to the reader.
  *

--- a/src/ontology-patch-context.ts
+++ b/src/ontology-patch-context.ts
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from "node:path";
 
 import type { ProfileState } from "./configured-dataprep.js";
 import { safeExecGit } from "./git.js";
-import type { OntologyPatchContext } from "./ontology-patch.js";
+import type { OntologyNodeTrustTier, OntologyPatchContext } from "./ontology-patch.js";
 import type {
   NormalizedOntologyProfile,
   NormalizedProjectConfig,
@@ -31,6 +31,34 @@ function stringValue(value: unknown): string | null {
 
 function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+const ONTOLOGY_NODE_TRUST_TIERS: ReadonlySet<string> = new Set<OntologyNodeTrustTier>([
+  "earned",
+  "asserted",
+  "signed",
+  "unverified",
+]);
+
+/**
+ * Provenance tier read back from `nodes.json`, VALIDATED rather than relayed.
+ *
+ * This loader reprojects arbitrary JSON onto a whitelist, so an unrecognised
+ * value has to go somewhere. It goes to `undefined`, and the direction matters:
+ * `violatesTrustTier` compares strings and returns false as soon as EITHER side
+ * is undefined, so falling back is FAIL-OPEN — it adds no rejection and leaves
+ * the candidate queue exactly as it was. Relaying an unknown string would do the
+ * opposite: it would manufacture a FICTIONAL tier mismatch between two nodes and
+ * silently drop that pair, which is the class of defect the queue's disclosure
+ * discipline exists to prevent.
+ *
+ * The field itself must stay on the whitelist: omitting it drops a declared tier
+ * at load time without a word, so the §3.4 invariant would read as dormant while
+ * the corpus actually carried tiers.
+ */
+function trustTierValue(value: unknown): OntologyNodeTrustTier | undefined {
+  const tier = stringValue(value);
+  return tier !== null && ONTOLOGY_NODE_TRUST_TIERS.has(tier) ? (tier as OntologyNodeTrustTier) : undefined;
 }
 
 function evidenceRefsFromSources(value: unknown): Set<string> {
@@ -85,6 +113,7 @@ export function loadOntologyPatchContext(profileStatePath: string): OntologyPatc
         label: stringValue(node.label) ?? undefined,
         type: stringValue(node.type) ?? undefined,
         status: stringValue(node.status) ?? undefined,
+        trust: trustTierValue(node.trust),
         aliases: stringArray(node.aliases),
         normalized_terms: stringArray(node.normalized_terms),
         source_refs: stringArray(node.source_refs),

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -353,7 +353,8 @@ function outputTruncationDisclosure(
 }
 
 const PRECISION_GUARD_CRITERION =
-  "EXACT-tier pairs sharing a normalized term, retracted by a precision guard "
+  "EXACT-tier pairs sharing a normalized term: `exact_pairs_offered` is how many reached the "
+  + "guard, `exact_pairs_retracted` how many it took back "
   + "(role-noun collision, opposite gender/relation, place containment, address/serial divergence); "
   + "fuzzy-tier retractions are NOT counted -- see `scope`";
 
@@ -383,11 +384,28 @@ const PRECISION_GUARD_SCOPE =
  * to move a guard. An undeclared partial count is the defect; a declared one is
  * a fact a reader can act on.
  *
+ * CARRIES ITS DENOMINATOR, because a lone count does not survive its own zero.
+ * `exact_pairs_retracted: 0` reads identically whether the guard was never
+ * offered a pair — nothing shared a term, so there was nothing to judge — or was
+ * offered thousands and took none of them back. Those are opposite facts about
+ * the corpus, and a reader deciding whether this guard earns its place needs to
+ * tell them apart.
+ *
+ * The denominator counts what THIS guard saw: it is incremented where the guard
+ * stands, downstream of the type, partition and §3.4 rejections that run first.
+ * Counting exact pairs before those would err in the REASSURING direction — the
+ * same retraction over a larger base reads as a smaller loss — and a
+ * mis-positioned denominator is worse than none, because it looks like a
+ * measurement. It is invariant for the reason the numerator is: it counts pairs
+ * that already share a term, which blocking enumerates losslessly. What the
+ * exact tier emitted is `offered - retracted`, recoverable and stored nowhere.
+ *
  * ABSENT on a queue means the artefact predates this block, not zero.
  */
 interface OntologyReconciliationPrecisionGuardDisclosure {
   criterion: string;
   scope: string;
+  exact_pairs_offered: number;
   exact_pairs_retracted: number;
 }
 
@@ -1989,6 +2007,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
   // Accumulates across BOTH tiers: the guard runs in the lexical loop and again
   // in the structural one, and the queue declares what it retracted overall.
   const trustTierGate = emptyTrustTierGate();
+  let exactPairsOffered = 0;
   let exactPairsRetracted = 0;
   const comparableNodes = memoizeComparableNodes(context.nodes, normalizers, fuzzyEnabled, fuzzyThreshold);
   const fuzzyTierEligibility = fuzzyEnabled ? fuzzyTierEligibilityDisclosure(comparableNodes) : undefined;
@@ -2037,6 +2056,10 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     );
 
     if (sharedTerms.length > 0) {
+      // The denominator, incremented BEFORE the verdict so it counts what the
+      // guard was offered rather than what it let through, and HERE rather than
+      // upstream so it counts only what reached this guard.
+      exactPairsOffered += 1;
       if (rejectReason) {
         // Counted HERE and not at the guard's computation above: this is where
         // it retracts a pair the exact tier would have emitted, and only pairs
@@ -2218,6 +2241,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     precision_guard: {
       criterion: PRECISION_GUARD_CRITERION,
       scope: PRECISION_GUARD_SCOPE,
+      exact_pairs_offered: exactPairsOffered,
       exact_pairs_retracted: exactPairsRetracted,
     },
     output_truncation: outputTruncationDisclosure(candidates.length, capped.length, cap),

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -93,6 +93,11 @@ export interface OntologyReconciliationCandidateQueue {
    * block existed. It does not mean the guard was inert, and it is not a zero.
    */
   trust_tier_gate: OntologyReconciliationTrustTierGateDisclosure;
+  /**
+   * ALWAYS present, same reasoning: the exclusion is on by default, so a
+   * conditional block would hide the narrowing every corpus actually takes.
+   */
+  tier_exclusion: OntologyReconciliationTierExclusionDisclosure;
   candidates: OntologyReconciliationCandidate[];
 }
 
@@ -287,6 +292,52 @@ interface OntologyReconciliationTrustTierGateDisclosure {
   pairs_both_tagged: number;
   pairs_one_side_tagged: number;
   pairs_rejected: number;
+}
+
+const TIER_EXCLUSION_CRITERION =
+  "node types denied the FUZZY and STRUCTURAL tiers; the exact tier still runs on them";
+
+/**
+ * Which node types are barred from the weaker tiers, stamped on the queue.
+ *
+ * This narrowing is ON BY DEFAULT — `DEFAULT_FUZZY_EXCLUDE_TYPES` applies
+ * whenever the option is absent — so it shapes every corpus, unlike the opt-in
+ * bucket cap that declares itself right next to it. The repo declared its
+ * opt-in loss and said nothing about its default one; that asymmetry is the
+ * wrong way round, since the default path is the one every corpus takes.
+ *
+ * The mitigation is published with the loss rather than left for the reader to
+ * discover: these types keep the EXACT tier. Saying only "excluded" would
+ * overstate it into "invisible to reconciliation", which is false.
+ *
+ * Counted over NODES, not over skipped pairs. The node population is the same
+ * whichever way pairs are enumerated, so this figure means the same thing under
+ * the blocking index and under a cross product — a pair count would not, and
+ * would silently turn the losslessness golden into an assertion that blocking
+ * does nothing.
+ *
+ * ABSENT on a queue means the artefact predates this block, not that nothing
+ * was excluded.
+ */
+interface OntologyReconciliationTierExclusionDisclosure {
+  criterion: string;
+  excluded_types: string[];
+  nodes_excluded: number;
+  nodes_total: number;
+}
+
+function tierExclusionDisclosure(
+  nodes: readonly OntologyPatchNode[],
+  excludedTypes: ReadonlySet<string>,
+): OntologyReconciliationTierExclusionDisclosure {
+  return {
+    criterion: TIER_EXCLUSION_CRITERION,
+    // The list ACTUALLY in force, so an override is visible rather than the
+    // reader having to assume the default constant.
+    excluded_types: [...excludedTypes].sort(),
+    nodes_excluded: nodes.filter((node) => node.type !== undefined && excludedTypes.has(node.type)).length,
+    nodes_total: nodes.length,
+  };
 }
 
 function emptyTrustTierGate(): OntologyReconciliationTrustTierGateDisclosure {
@@ -2058,6 +2109,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     ...(blockingIndex.fuzzyBucketCap ? { fuzzy_blocking_cap: blockingIndex.fuzzyBucketCap } : {}),
     ...(fuzzyTierEligibility ? { fuzzy_tier_eligibility: fuzzyTierEligibility } : {}),
     trust_tier_gate: trustTierGate,
+    tier_exclusion: tierExclusionDisclosure(context.nodes, fuzzyExcludeTypes),
     candidates: capped,
   };
 }

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -83,6 +83,16 @@ export interface OntologyReconciliationCandidateQueue {
    * the eligibility criterion is then inapplicable.
    */
   fuzzy_tier_eligibility?: OntologyReconciliationFuzzyTierEligibilityDisclosure;
+  /**
+   * ALWAYS present, unlike the two disclosures above. They are conditional on a
+   * mechanism running at all; this guard always runs, so omitting it at zero
+   * would leave "ran and retracted nothing" indistinguishable from "did not
+   * run" — the very ambiguity a queue disclosure exists to remove.
+   *
+   * ABSENT on a queue therefore means the artefact was produced BEFORE this
+   * block existed. It does not mean the guard was inert, and it is not a zero.
+   */
+  trust_tier_gate: OntologyReconciliationTrustTierGateDisclosure;
   candidates: OntologyReconciliationCandidate[];
 }
 
@@ -242,6 +252,68 @@ function exactNodeTerms(node: OntologyPatchNode, normalizers: NormalizerByNodeTy
 function violatesTrustTier(left: OntologyPatchNode, right: OntologyPatchNode): boolean {
   if (left.trust === undefined || right.trust === undefined) return false;
   return left.trust !== right.trust;
+}
+
+const TRUST_TIER_GATE_CRITERION =
+  "pairs reaching the inter-tier guard, after the type and partition guards; " +
+  "rejected when BOTH sides declare a provenance tier and the tiers differ";
+
+/**
+ * What the inter-tier guard (§3.4) did, stamped on the emitted queue.
+ *
+ * The guard RETRACTS pairs the enumeration had already produced, so it owes the
+ * same disclosure as the bucket cap beside it: an undeclared narrowing makes a
+ * queue that is missing candidates indistinguishable from a clean corpus.
+ *
+ * A single count would not survive its own zero. `pairs_rejected: 0` covers two
+ * opposite findings — no pair ever had both sides tagged (the guard had no
+ * DOMAIN), or pairs were tagged on both sides and agreed (a property of the
+ * corpus). Only the first is a coverage defect, and they call for opposite
+ * follow-ups, so the domain is published beside the outcome.
+ *
+ * `pairs_one_side_tagged` is the FAIL-OPEN population: pairs the guard let
+ * through solely because a tier was missing. It is collected because it falls
+ * out of the same loop, and it is the impact figure the untagged-tier hole says
+ * it is waiting for. It is NOT actioned here: making an absent tier fail closed
+ * stays with the owner.
+ *
+ * `pairs_evaluated` counts what THIS guard saw, downstream of the type and
+ * partition guards — deliberately not the blocking index total, which would
+ * include pairs the guard never received.
+ */
+interface OntologyReconciliationTrustTierGateDisclosure {
+  criterion: string;
+  pairs_evaluated: number;
+  pairs_both_tagged: number;
+  pairs_one_side_tagged: number;
+  pairs_rejected: number;
+}
+
+function emptyTrustTierGate(): OntologyReconciliationTrustTierGateDisclosure {
+  return {
+    criterion: TRUST_TIER_GATE_CRITERION,
+    pairs_evaluated: 0,
+    pairs_both_tagged: 0,
+    pairs_one_side_tagged: 0,
+    pairs_rejected: 0,
+  };
+}
+
+/**
+ * Applies the guard and tallies it in one call, so the counter cannot drift
+ * from the rule: the verdict still comes from `violatesTrustTier` alone.
+ */
+function rejectsOnTrustTier(
+  gate: OntologyReconciliationTrustTierGateDisclosure,
+  left: OntologyPatchNode,
+  right: OntologyPatchNode,
+): boolean {
+  gate.pairs_evaluated += 1;
+  if (left.trust !== undefined && right.trust !== undefined) gate.pairs_both_tagged += 1;
+  else if (left.trust !== undefined || right.trust !== undefined) gate.pairs_one_side_tagged += 1;
+  const rejected = violatesTrustTier(left, right);
+  if (rejected) gate.pairs_rejected += 1;
+  return rejected;
 }
 
 function violatesPartitionScope(
@@ -1766,6 +1838,9 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
 
   const candidates: OntologyReconciliationCandidate[] = [];
   const emittedPairs = new Set<string>();
+  // Accumulates across BOTH tiers: the guard runs in the lexical loop and again
+  // in the structural one, and the queue declares what it retracted overall.
+  const trustTierGate = emptyTrustTierGate();
   const comparableNodes = memoizeComparableNodes(context.nodes, normalizers, fuzzyEnabled, fuzzyThreshold);
   const fuzzyTierEligibility = fuzzyEnabled ? fuzzyTierEligibilityDisclosure(comparableNodes) : undefined;
   const tokenIdfs = fuzzyMinimumSharedTokenIdf === undefined ? undefined : fuzzyTokenIdfs(comparableNodes);
@@ -1789,7 +1864,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     // Inter-tier rejection (§3.4): an asserted claim never merges with an
     // earned node, whatever their labels look like. Same standing as the
     // partition guard, and applied before EITHER lexical tier can emit.
-    if (violatesTrustTier(left, right)) continue;
+    if (rejectsOnTrustTier(trustTierGate, left, right)) continue;
 
     const sharedTerms = rightMemo.exactTerms.filter((term) => leftMemo.exactTermSet.has(term));
 
@@ -1908,7 +1983,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
       // Inter-tier rejection (§3.4) applies to the structural tier too: shared
       // neighbours are even weaker evidence than a shared label, so they must
       // not be allowed to bridge tiers either.
-      if (violatesTrustTier(left, right)) continue;
+      if (rejectsOnTrustTier(trustTierGate, left, right)) continue;
 
       const { canonical, candidate } = chooseCanonicalPair(left, right);
       const pairKey = `${canonical.id}|${candidate.id}`;
@@ -1982,6 +2057,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     candidate_count: capped.length,
     ...(blockingIndex.fuzzyBucketCap ? { fuzzy_blocking_cap: blockingIndex.fuzzyBucketCap } : {}),
     ...(fuzzyTierEligibility ? { fuzzy_tier_eligibility: fuzzyTierEligibility } : {}),
+    trust_tier_gate: trustTierGate,
     candidates: capped,
   };
 }

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -100,6 +100,11 @@ export interface OntologyReconciliationCandidateQueue {
   tier_exclusion: OntologyReconciliationTierExclusionDisclosure;
   /** ALWAYS present, same reasoning as the two above. */
   precision_guard: OntologyReconciliationPrecisionGuardDisclosure;
+  /**
+   * ALWAYS present. `candidate_count` reports what SURVIVED the cap, so without
+   * this block a full queue and a truncated one read alike.
+   */
+  output_truncation: OntologyReconciliationOutputTruncationDisclosure;
   candidates: OntologyReconciliationCandidate[];
 }
 
@@ -294,6 +299,57 @@ interface OntologyReconciliationTrustTierGateDisclosure {
   pairs_both_tagged: number;
   pairs_one_side_tagged: number;
   pairs_rejected: number;
+}
+
+const OUTPUT_TRUNCATION_CRITERION =
+  "candidates ranked by score then dropped beyond the cap; `dropped` counts what "
+  + "ranking placed below the cut, and `candidate_count` is what survived it";
+
+/**
+ * What the final cap threw away, stamped on the queue.
+ *
+ * This is the LAST narrowing of the pipeline and the widest by far: everything
+ * upstream trims pairs that were unlikely to matter, while this one discards
+ * ranked candidates purely because a fixed number of them fit. On a corpus of
+ * a few hundred thousand pairs, the overwhelming majority of what the tiers
+ * produced never reaches the queue at all.
+ *
+ * Until now `candidate_count` reported the count AFTER the cut, so a reader
+ * seeing 200 could not tell a corpus that produced exactly 200 candidates from
+ * one that produced hundreds of thousands and lost the rest — the same
+ * indistinguishability that put every other narrowing on this path under a
+ * stamp.
+ *
+ * `dropped` is invariant: the blocking index is lossless on EMITTED candidates,
+ * which is the whole of A2-1, so the pre-cap population is the same under either
+ * enumeration. The golden therefore compares this block and the oracle
+ * recomputes it — no strip.
+ *
+ * No pre-cap total: `candidate_count + dropped` gives it, and a third stored
+ * number could drift from the two beside it.
+ *
+ * `cap` is null when nothing was capped, which is not the same as a cap of zero.
+ *
+ * ABSENT on a queue means the artefact predates this block, not that nothing was
+ * dropped.
+ */
+interface OntologyReconciliationOutputTruncationDisclosure {
+  criterion: string;
+  cap: number | null;
+  dropped: number;
+}
+
+function outputTruncationDisclosure(
+  produced: number,
+  emitted: number,
+  cap: number,
+): OntologyReconciliationOutputTruncationDisclosure {
+  const capped = Number.isFinite(cap) && cap >= 0;
+  return {
+    criterion: OUTPUT_TRUNCATION_CRITERION,
+    cap: capped ? cap : null,
+    dropped: produced - emitted,
+  };
 }
 
 const PRECISION_GUARD_CRITERION =
@@ -2164,6 +2220,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
       scope: PRECISION_GUARD_SCOPE,
       exact_pairs_retracted: exactPairsRetracted,
     },
+    output_truncation: outputTruncationDisclosure(candidates.length, capped.length, cap),
     candidates: capped,
   };
 }

--- a/src/ontology-reconciliation.ts
+++ b/src/ontology-reconciliation.ts
@@ -98,6 +98,8 @@ export interface OntologyReconciliationCandidateQueue {
    * conditional block would hide the narrowing every corpus actually takes.
    */
   tier_exclusion: OntologyReconciliationTierExclusionDisclosure;
+  /** ALWAYS present, same reasoning as the two above. */
+  precision_guard: OntologyReconciliationPrecisionGuardDisclosure;
   candidates: OntologyReconciliationCandidate[];
 }
 
@@ -292,6 +294,45 @@ interface OntologyReconciliationTrustTierGateDisclosure {
   pairs_both_tagged: number;
   pairs_one_side_tagged: number;
   pairs_rejected: number;
+}
+
+const PRECISION_GUARD_CRITERION =
+  "EXACT-tier pairs sharing a normalized term, retracted by a precision guard "
+  + "(role-noun collision, opposite gender/relation, place containment, address/serial divergence); "
+  + "fuzzy-tier retractions are NOT counted -- see `scope`";
+
+const PRECISION_GUARD_SCOPE =
+  "exact tier only: the fuzzy tier applies the same guard BEFORE matching, so its "
+  + "retraction count depends on how many pairs the enumeration offers and would not "
+  + "mean the same under a blocking index as under a cross product";
+
+/**
+ * What the precision guard retracted from the EXACT tier, stamped on the queue.
+ *
+ * The guard removes pairs that share a normalized term — pairs the exact tier
+ * would otherwise have emitted — so it is a narrowing and it declares itself
+ * like the others.
+ *
+ * SCOPED TO THE EXACT TIER, on purpose, and the limit is published rather than
+ * hidden. In the exact tier the guard fires only after `sharedTerms.length > 0`,
+ * and blocking is lossless on shared terms, so the count means the same under
+ * either enumeration and the golden can compare it. In the fuzzy tier the same
+ * guard fires BEFORE `fuzzyMatchVariants`, so it also retracts pairs that would
+ * never have matched; that count rises with the number of pairs offered and
+ * would differ between a blocking index and a cross product.
+ *
+ * Counting it anyway would have meant either stripping a second field from the
+ * golden — the gesture the strip list exists to keep rare — or reordering the
+ * production check for the convenience of a measurement, which is not a reason
+ * to move a guard. An undeclared partial count is the defect; a declared one is
+ * a fact a reader can act on.
+ *
+ * ABSENT on a queue means the artefact predates this block, not zero.
+ */
+interface OntologyReconciliationPrecisionGuardDisclosure {
+  criterion: string;
+  scope: string;
+  exact_pairs_retracted: number;
 }
 
 const TIER_EXCLUSION_CRITERION =
@@ -1892,6 +1933,7 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
   // Accumulates across BOTH tiers: the guard runs in the lexical loop and again
   // in the structural one, and the queue declares what it retracted overall.
   const trustTierGate = emptyTrustTierGate();
+  let exactPairsRetracted = 0;
   const comparableNodes = memoizeComparableNodes(context.nodes, normalizers, fuzzyEnabled, fuzzyThreshold);
   const fuzzyTierEligibility = fuzzyEnabled ? fuzzyTierEligibilityDisclosure(comparableNodes) : undefined;
   const tokenIdfs = fuzzyMinimumSharedTokenIdf === undefined ? undefined : fuzzyTokenIdfs(comparableNodes);
@@ -1939,7 +1981,14 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     );
 
     if (sharedTerms.length > 0) {
-      if (rejectReason) continue;
+      if (rejectReason) {
+        // Counted HERE and not at the guard's computation above: this is where
+        // it retracts a pair the exact tier would have emitted, and only pairs
+        // sharing a term reach it — which is what makes the figure mean the
+        // same under blocking as under a cross product.
+        exactPairsRetracted += 1;
+        continue;
+      }
       // Exact tier: shared normalized term (label/alias/normalized_term).
       emittedPairs.add(pairKey);
       candidates.push({
@@ -2110,6 +2159,11 @@ function generateOntologyReconciliationCandidatesWithBlockingIndex(
     ...(fuzzyTierEligibility ? { fuzzy_tier_eligibility: fuzzyTierEligibility } : {}),
     trust_tier_gate: trustTierGate,
     tier_exclusion: tierExclusionDisclosure(context.nodes, fuzzyExcludeTypes),
+    precision_guard: {
+      criterion: PRECISION_GUARD_CRITERION,
+      scope: PRECISION_GUARD_SCOPE,
+      exact_pairs_retracted: exactPairsRetracted,
+    },
     candidates: capped,
   };
 }

--- a/tests/ontology-output-provenance-coverage.test.ts
+++ b/tests/ontology-output-provenance-coverage.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { compileOntologyOutputs } from "../src/ontology-output.js";
+import type { Extraction, NormalizedOntologyProfile } from "../src/types.js";
+
+/**
+ * Pins the `provenance_coverage` block of the ontology manifest.
+ *
+ * The block answers one question a consumer cannot otherwise ask: how much of
+ * this corpus is anchored on a positional citation span. It is a STATISTIC and
+ * nothing may branch on it; the test therefore pins its PRESENCE and its counts,
+ * never a threshold.
+ *
+ * The zero case is the one that matters most. A coverage figure omitted when it
+ * is zero would make "nothing is anchored" indistinguishable from "nobody
+ * measured" — so the block is unconditional, and that is pinned here rather
+ * than left to the reader of the writer.
+ *
+ * Anchored on imported symbols, never on line numbers.
+ */
+
+const cleanupDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-provenance-coverage-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+const profile: NormalizedOntologyProfile = {
+  id: "synthetic",
+  version: "1",
+  default_language: "en",
+  profile_hash: "profile-hash",
+  node_types: { Component: {} },
+  relation_types: {},
+  registries: {},
+  citation_policy: { minimum_granularity: "page", require_source_file: true, allow_bbox: "when_available" },
+  hardening: { statuses: ["candidate", "validated"], default_status: "candidate", promotion_requires: [], status_transitions: [] },
+  inference_policy: { allow_inferred_relations: true, allowed_relation_types: [], require_evidence_refs: false },
+  evidence_policy: { require_evidence_refs: false, min_refs: 0, node_types: [], relation_types: [] },
+  hierarchies: {},
+  outputs: {
+    ontology: {
+      enabled: true,
+      artifact_schema: "graphify_ontology_outputs_v1",
+      canonical_node_types: ["Component"],
+      source_node_types: [],
+      occurrence_node_types: [],
+      alias_fields: [],
+      relation_exports: [],
+      wiki: { enabled: false, page_node_types: [], include_backlinks: false, include_source_snippets: false },
+    },
+  },
+} as NormalizedOntologyProfile;
+
+/** One Component per entry; `location` undefined means "file only, no span". */
+function extractionOf(locations: ReadonlyArray<string | undefined>): Extraction {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    nodes: locations.map((location, index) => ({
+      id: `component-${index}`,
+      label: `Component ${index}`,
+      type: "Component",
+      file_type: "document",
+      source_file: "manual.md",
+      ...(location ? { source_location: location } : {}),
+      confidence: "EXTRACTED",
+      status: "validated",
+    })),
+    edges: [],
+  } as unknown as Extraction;
+}
+
+function manifestOf(locations: ReadonlyArray<string | undefined>): Record<string, unknown> {
+  const outputDir = join(makeTempDir(), ".graphify", "ontology");
+  compileOntologyOutputs({
+    outputDir,
+    extraction: extractionOf(locations),
+    profile,
+    config: { enabled: true, canonical_node_types: ["Component"] },
+  });
+  return JSON.parse(readFileSync(join(outputDir, "manifest.json"), "utf-8")) as Record<string, unknown>;
+}
+
+describe("ontology manifest provenance_coverage", () => {
+  it("counts only the nodes whose source_refs carry a span", () => {
+    const manifest = manifestOf(["L12", undefined, "p3", undefined]);
+
+    // NON-VACUITY: `total` also guards the fixture — a profile that filtered
+    // every node away would satisfy an anchored-count assertion with nothing.
+    expect(manifest.provenance_coverage).toMatchObject({ anchored: 2, total: 4 });
+    expect(manifest.node_count).toBe(4);
+  });
+
+  it("reports full coverage when every node is anchored", () => {
+    expect(manifestOf(["L1", "L2"])).toMatchObject({ provenance_coverage: { anchored: 2, total: 2 } });
+  });
+
+  it("PUBLISHES the zero case instead of omitting the block", () => {
+    // The load-bearing case. An omitted block would read as "not measured".
+    const manifest = manifestOf([undefined, undefined]);
+
+    expect(manifest).toHaveProperty("provenance_coverage");
+    expect(manifest.provenance_coverage).toMatchObject({ anchored: 0, total: 2 });
+  });
+
+  it("states its criterion in plain words", () => {
+    const coverage = manifestOf(["L1"]).provenance_coverage as { criterion?: unknown };
+
+    // A count whose rule is not written down cannot be checked by its reader.
+    expect(typeof coverage.criterion).toBe("string");
+    expect(coverage.criterion).toContain("span");
+  });
+
+  it("stores no derived share alongside its operands", () => {
+    const manifest = manifestOf(["L1", undefined]);
+
+    // Assert the block EXISTS before asserting what it lacks. A bare negative
+    // would also hold if the block vanished entirely — it would pass while
+    // covering nothing, which is the failure mode this whole file guards.
+    // Caught by the reverse proof: without this line the case stayed green
+    // under the mutation that deleted the block.
+    expect(manifest.provenance_coverage).toMatchObject({ anchored: 1, total: 2 });
+    // A stored ratio is redundant state that can drift from the two numbers
+    // beside it; the division belongs to the reader.
+    expect(manifest).not.toHaveProperty("provenance_coverage.share");
+  });
+});

--- a/tests/ontology-patch-context-trust.test.ts
+++ b/tests/ontology-patch-context-trust.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { loadOntologyPatchContext } from "../src/ontology-patch-context.js";
+import type { OntologyPatchNode } from "../src/ontology-patch.js";
+import { writeOntologyWriteFixture } from "./helpers/ontology-write-fixture.js";
+
+/**
+ * Pins the SURVIVAL of `trust` across the on-disk round-trip.
+ *
+ * `loadOntologyPatchContext` does not deserialise `nodes.json`; it reprojects it
+ * onto an explicit whitelist. A field missing from that whitelist is dropped
+ * WITHOUT a word — no error, no warning, green suite — so a corpus could declare
+ * provenance tiers while `violatesTrustTier` (memory contract §3.4) stayed
+ * dormant and nothing in the output would say so.
+ *
+ * The guard therefore has to exercise the REAL loader against real files. A test
+ * that reimplemented the projection would pin its own copy and drift silently
+ * from the code it claims to protect.
+ *
+ * Anchored on IMPORTED SYMBOLS, never on line numbers: `ontology-reconciliation`
+ * measures 2016 lines on `main` against 943 on a feature branch, so a hard-coded
+ * range would keep passing while covering nothing — the very defect this file
+ * guards against, reproduced inside the guard.
+ */
+
+const cleanupDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graphify-trust-roundtrip-"));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+/** Writes `nodes` verbatim over the fixture's nodes.json, then loads it back. */
+function roundTrip(nodes: ReadonlyArray<Record<string, unknown>>): OntologyPatchNode[] {
+  const fixture = writeOntologyWriteFixture(makeTempDir());
+  writeFileSync(
+    join(fixture.stateDir, "ontology", "nodes.json"),
+    JSON.stringify(nodes, null, 2),
+    "utf-8",
+  );
+  const loaded = loadOntologyPatchContext(fixture.profileStatePath).nodes;
+  // NON-VACUITY CONTROL. Every assertion below reads a node out of this array;
+  // an empty one would satisfy all of them by saying nothing at all.
+  expect(loaded.length).toBe(nodes.length);
+  return loaded;
+}
+
+describe("loadOntologyPatchContext trust round-trip", () => {
+  it("carries every declared tier through unchanged", () => {
+    // All four members, one by one: a whitelist entry that only handled the
+    // first would pass a single-tier test and drop the rest in silence.
+    const tiers = ["earned", "asserted", "signed", "unverified"] as const;
+    const loaded = roundTrip(tiers.map((tier) => ({ id: `node-${tier}`, type: "Component", trust: tier })));
+
+    expect(loaded.map((node) => node.trust)).toEqual([...tiers]);
+  });
+
+  it("drops a tier outside the union rather than relaying it", () => {
+    // Fail-open on purpose: an unrecognised string relayed as-is would create a
+    // FICTIONAL mismatch against a legitimately tiered node and remove that pair
+    // from the candidate queue without declaring the loss.
+    const [loaded] = roundTrip([{ id: "node-bogus", type: "Component", trust: "not-a-tier" }]);
+
+    expect(loaded!.trust).toBeUndefined();
+  });
+
+  it("leaves an untagged node untagged", () => {
+    const [loaded] = roundTrip([{ id: "node-untagged", type: "Component" }]);
+
+    expect(loaded!.trust).toBeUndefined();
+  });
+
+  it("drops a non-string tier", () => {
+    const loaded = roundTrip([
+      { id: "node-number", type: "Component", trust: 7 },
+      { id: "node-object", type: "Component", trust: { tier: "earned" } },
+      { id: "node-null", type: "Component", trust: null },
+    ]);
+
+    expect(loaded.map((node) => node.trust)).toEqual([undefined, undefined, undefined]);
+  });
+
+  it("keeps the tier independent of the other whitelisted fields", () => {
+    // Guards against a projection that carried `trust` but clobbered a
+    // neighbour, or vice versa.
+    const [loaded] = roundTrip([
+      {
+        id: "node-full",
+        type: "Component",
+        label: "Widget",
+        status: "validated",
+        trust: "earned",
+        aliases: ["W"],
+        source_refs: ["manual.md#p1"],
+      },
+    ]);
+
+    expect(loaded).toMatchObject({
+      id: "node-full",
+      type: "Component",
+      label: "Widget",
+      status: "validated",
+      trust: "earned",
+      aliases: ["W"],
+      source_refs: ["manual.md#p1"],
+    });
+  });
+});

--- a/tests/ontology-reconciliation-blocking.test.ts
+++ b/tests/ontology-reconciliation-blocking.test.ts
@@ -217,6 +217,7 @@ function naiveQueue(
   const fuzzyExcludeTypes = new Set(options.fuzzyExcludeTypes ?? DEFAULT_FUZZY_EXCLUDE_TYPES);
   const normalizers = compileNormalizerByNodeType(value.profile);
   const candidates: OntologyReconciliationCandidate[] = [];
+  let exactPairsOffered = 0;
   let exactPairsRetracted = 0;
   const emittedPairs = new Set<string>();
   const comparableNodes = value.nodes
@@ -244,6 +245,10 @@ function naiveQueue(
       const rejectReason = differentEntityReason(left, right);
 
       if (sharedTerms.length > 0) {
+        // Denominator, recomputed the same way and for the same reason: it
+        // counts pairs offered to the guard, and only term-sharing pairs are
+        // offered, so blocking and the cross product must agree on it too.
+        exactPairsOffered += 1;
         if (rejectReason) {
           // Independently recomputed, like `tier_exclusion`: the count is over
           // pairs sharing a term, which blocking enumerates losslessly, so the
@@ -402,13 +407,15 @@ function naiveQueue(
     },
     precision_guard: {
       criterion:
-        "EXACT-tier pairs sharing a normalized term, retracted by a precision guard "
+        "EXACT-tier pairs sharing a normalized term: `exact_pairs_offered` is how many reached the "
+        + "guard, `exact_pairs_retracted` how many it took back "
         + "(role-noun collision, opposite gender/relation, place containment, address/serial divergence); "
         + "fuzzy-tier retractions are NOT counted -- see `scope`",
       scope:
         "exact tier only: the fuzzy tier applies the same guard BEFORE matching, so its "
         + "retraction count depends on how many pairs the enumeration offers and would not "
         + "mean the same under a blocking index as under a cross product",
+      exact_pairs_offered: exactPairsOffered,
       exact_pairs_retracted: exactPairsRetracted,
     },
     // Recomputed independently, like the two above: the pre-cap population is

--- a/tests/ontology-reconciliation-blocking.test.ts
+++ b/tests/ontology-reconciliation-blocking.test.ts
@@ -217,6 +217,7 @@ function naiveQueue(
   const fuzzyExcludeTypes = new Set(options.fuzzyExcludeTypes ?? DEFAULT_FUZZY_EXCLUDE_TYPES);
   const normalizers = compileNormalizerByNodeType(value.profile);
   const candidates: OntologyReconciliationCandidate[] = [];
+  let exactPairsRetracted = 0;
   const emittedPairs = new Set<string>();
   const comparableNodes = value.nodes
     .filter((entry) => entry.type && nodeTerms(entry).length > 0)
@@ -243,7 +244,13 @@ function naiveQueue(
       const rejectReason = differentEntityReason(left, right);
 
       if (sharedTerms.length > 0) {
-        if (rejectReason) continue;
+        if (rejectReason) {
+          // Independently recomputed, like `tier_exclusion`: the count is over
+          // pairs sharing a term, which blocking enumerates losslessly, so the
+          // two paths must agree and the golden compares it.
+          exactPairsRetracted += 1;
+          continue;
+        }
         const normalize = normalizers[left.type] ?? normalizeTerm;
         const canonicalLabel = canonical.label ? normalize(canonical.label) : null;
         const candidateLabel = candidate.label ? normalize(candidate.label) : null;
@@ -392,6 +399,17 @@ function naiveQueue(
       excluded_types: [...fuzzyExcludeTypes].sort(),
       nodes_excluded: value.nodes.filter((n) => n.type !== undefined && fuzzyExcludeTypes.has(n.type)).length,
       nodes_total: value.nodes.length,
+    },
+    precision_guard: {
+      criterion:
+        "EXACT-tier pairs sharing a normalized term, retracted by a precision guard "
+        + "(role-noun collision, opposite gender/relation, place containment, address/serial divergence); "
+        + "fuzzy-tier retractions are NOT counted -- see `scope`",
+      scope:
+        "exact tier only: the fuzzy tier applies the same guard BEFORE matching, so its "
+        + "retraction count depends on how many pairs the enumeration offers and would not "
+        + "mean the same under a blocking index as under a cross product",
+      exact_pairs_retracted: exactPairsRetracted,
     },
     candidates: capped,
   };

--- a/tests/ontology-reconciliation-blocking.test.ts
+++ b/tests/ontology-reconciliation-blocking.test.ts
@@ -382,16 +382,45 @@ function naiveQueue(
     generated_at: options.generatedAt ?? new Date().toISOString(),
     candidate_count: capped.length,
     ...(fuzzyTierEligibility ? { fuzzy_tier_eligibility: fuzzyTierEligibility } : {}),
+    // Reimplemented here rather than stripped from the comparison, because this
+    // disclosure counts NODES: its value does not depend on how pairs are
+    // enumerated, so the two paths must agree on it and the golden should say
+    // so. Contrast `trust_tier_gate`, which reports what the guard examined and
+    // therefore differs by construction.
+    tier_exclusion: {
+      criterion: "node types denied the FUZZY and STRUCTURAL tiers; the exact tier still runs on them",
+      excluded_types: [...fuzzyExcludeTypes].sort(),
+      nodes_excluded: value.nodes.filter((n) => n.type !== undefined && fuzzyExcludeTypes.has(n.type)).length,
+      nodes_total: value.nodes.length,
+    },
     candidates: capped,
   };
 }
 
 /**
- * The golden proves the two enumerations EMIT the same candidates. It cannot
- * compare `trust_tier_gate`, which reports how many pairs the inter-tier guard
- * examined: blocking exists precisely to examine fewer, so asserting that block
- * identical would assert that blocking does nothing. Stripped explicitly rather
- * than silently, and the pruning it hides is asserted on its own below.
+ * FIELDS STRIPPED FROM THE GOLDEN — enumerated, one line each.
+ *
+ * Stripping a field from a comparison removes something from a check exactly as
+ * a filter removes a pair from a queue, so it declares itself the same way:
+ * owner, motive, and the assertion that catches what the strip stopped
+ * catching. Without the list, the destructure below is a gesture anyone can
+ * copy the next time a field breaks the golden — legitimate here, wrong for a
+ * field that ought to match.
+ *
+ *   `trust_tier_gate`  · owner: graphify-ontology
+ *      motive: `naiveQueue` does not compute it, so the comparison would fail
+ *              unconditionally and for a reason unrelated to blocking; and it
+ *              reports how many pairs the guard EXAMINED, which blocking exists
+ *              to reduce — asserting it identical would assert blocking is inert.
+ *      caught by: "prunes what the golden can no longer compare" (below) plus
+ *              the dedicated disclosure file.
+ *
+ * NOT stripped, and the contrast is the point:
+ *
+ *   `tier_exclusion`   · counts NODES, so its value does not depend on how
+ *      pairs are enumerated. The oracle reimplements it and the golden compares
+ *      it. A path-invariant field belongs in the comparison; reaching for the
+ *      strip here would have hidden a real divergence.
  */
 function emittedPayload(queue: OntologyReconciliationCandidateQueue): string {
   const { trust_tier_gate: _gate, ...rest } = queue as OntologyReconciliationCandidateQueue &

--- a/tests/ontology-reconciliation-blocking.test.ts
+++ b/tests/ontology-reconciliation-blocking.test.ts
@@ -386,6 +386,19 @@ function naiveQueue(
   };
 }
 
+/**
+ * The golden proves the two enumerations EMIT the same candidates. It cannot
+ * compare `trust_tier_gate`, which reports how many pairs the inter-tier guard
+ * examined: blocking exists precisely to examine fewer, so asserting that block
+ * identical would assert that blocking does nothing. Stripped explicitly rather
+ * than silently, and the pruning it hides is asserted on its own below.
+ */
+function emittedPayload(queue: OntologyReconciliationCandidateQueue): string {
+  const { trust_tier_gate: _gate, ...rest } = queue as OntologyReconciliationCandidateQueue &
+    Record<string, unknown>;
+  return JSON.stringify(rest);
+}
+
 function expectGolden(
   nodes: OntologyPatchNode[],
   relations: OntologyPatchRelation[] = [],
@@ -398,8 +411,8 @@ function expectGolden(
       ...options,
       ...(structural ? { structural: true } : {}),
     };
-    expect(JSON.stringify(generateOntologyReconciliationCandidates(value, fixedOptions))).toBe(
-      JSON.stringify(naiveQueue(value, fixedOptions)),
+    expect(emittedPayload(generateOntologyReconciliationCandidates(value, fixedOptions))).toBe(
+      emittedPayload(naiveQueue(value, fixedOptions)),
     );
   }
 }
@@ -500,15 +513,30 @@ describe("ontology reconciliation lexical blocking", () => {
     ]);
     const options = { generatedAt, fuzzy: false };
     const oracle = naiveQueue(value, options);
-    expect(JSON.stringify(generateOntologyReconciliationCandidates(value, options))).toBe(JSON.stringify(oracle));
+    expect(emittedPayload(generateOntologyReconciliationCandidates(value, options))).toBe(emittedPayload(oracle));
 
     const index = buildOntologyReconciliationLexicalBlockingIndex(value, options);
     const bucket = [...index.exact.values()].find((entry) => entry.includes(0) && entry.includes(1));
     expect(bucket).toBeDefined();
     bucket!.splice(bucket!.indexOf(1), 1);
     expect(enumerateOntologyReconciliationBlockedPairs(value, options, index)).toEqual(new Set());
-    expect(JSON.stringify(generateOntologyReconciliationCandidatesWithLexicalBlockingIndexForTest(value, options, index)))
-      .not.toBe(JSON.stringify(oracle));
+    expect(emittedPayload(generateOntologyReconciliationCandidatesWithLexicalBlockingIndexForTest(value, options, index)))
+      .not.toBe(emittedPayload(oracle));
+  });
+
+  it("prunes what the golden can no longer compare: the guard sees fewer pairs than the cross product", () => {
+    // The golden strips `trust_tier_gate` because blocking changes it by design.
+    // That difference is the point of the whole lot, so it is asserted here
+    // rather than left unchecked: without this, stripping the block would be a
+    // silent loosening of the falsifiability guard.
+    const nodes = Array.from({ length: 40 }, (_, index) =>
+      node(`n${index}`, index % 2 === 0 ? `Shared Label ${index % 4}` : `Lonely Label ${index}`));
+    const crossProductPairs = (nodes.length * (nodes.length - 1)) / 2;
+
+    const gate = generateOntologyReconciliationCandidates(context(nodes), { generatedAt }).trust_tier_gate;
+
+    expect(gate.pairs_evaluated).toBeGreaterThan(0);
+    expect(gate.pairs_evaluated).toBeLessThan(crossProductPairs);
   });
 
   it("uses the <= 0.5 single-token fallback without changing either tier configuration", () => {

--- a/tests/ontology-reconciliation-blocking.test.ts
+++ b/tests/ontology-reconciliation-blocking.test.ts
@@ -411,6 +411,16 @@ function naiveQueue(
         + "mean the same under a blocking index as under a cross product",
       exact_pairs_retracted: exactPairsRetracted,
     },
+    // Recomputed independently, like the two above: the pre-cap population is
+    // the same under either enumeration (blocking is lossless on emitted
+    // candidates), so the two paths must agree on what the cap threw away.
+    output_truncation: {
+      criterion:
+        "candidates ranked by score then dropped beyond the cap; `dropped` counts what "
+        + "ranking placed below the cut, and `candidate_count` is what survived it",
+      cap: Number.isFinite(cap) && cap >= 0 ? cap : null,
+      dropped: candidates.length - capped.length,
+    },
     candidates: capped,
   };
 }

--- a/tests/ontology-reconciliation-blocking.test.ts
+++ b/tests/ontology-reconciliation-blocking.test.ts
@@ -439,6 +439,21 @@ function naiveQueue(
  *      pairs are enumerated. The oracle reimplements it and the golden compares
  *      it. A path-invariant field belongs in the comparison; reaching for the
  *      strip here would have hidden a real divergence.
+ *
+ *   `precision_guard`  · counts EXACT-tier retractions only. The guard fires
+ *      there after `sharedTerms.length > 0`, and blocking is lossless on shared
+ *      terms, so the count is invariant too. Its fuzzy-tier twin fires before
+ *      matching and would NOT be — which is why the field names that boundary
+ *      instead of counting both.
+ *
+ * KNOWN COUPLING, deliberate. The oracle hardcodes the expected `criterion` and
+ * `scope` literals rather than importing the constants. That IS the check: an
+ * oracle importing the production constant would stop verifying it and only
+ * confirm that a value equals itself. The cost is that changing a criterion
+ * requires updating the copy here — and the cost is self-announcing, because the
+ * golden goes red until you do. That redness is correct: changing the words a
+ * consumer reads should force someone to re-confirm what the oracle expects.
+ * Mirror the new text here; do not reach for a shared constant.
  */
 function emittedPayload(queue: OntologyReconciliationCandidateQueue): string {
   const { trust_tier_gate: _gate, ...rest } = queue as OntologyReconciliationCandidateQueue &

--- a/tests/ontology-reconciliation-output-truncation-disclosure.test.ts
+++ b/tests/ontology-reconciliation-output-truncation-disclosure.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_RECONCILIATION_CANDIDATE_CAP,
+  generateOntologyReconciliationCandidates,
+} from "../src/ontology-reconciliation.js";
+import type { OntologyPatchContext, OntologyPatchNode } from "../src/ontology-patch.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+
+/**
+ * Pins `output_truncation`, the disclosure of what the final cap threw away.
+ *
+ * This is the last narrowing of the pipeline and the widest: everything
+ * upstream trims pairs unlikely to matter, while this one discards ranked
+ * candidates purely because a fixed number of them fit. `candidate_count`
+ * reports what SURVIVED, so without this block a full queue and a truncated one
+ * read alike — the indistinguishability that put every other narrowing on this
+ * path under a stamp.
+ *
+ * Anchored on imported symbols, never on line numbers.
+ */
+
+const profile = { profile_hash: "output-truncation-profile" } as unknown as NormalizedOntologyProfile;
+const generatedAt = "2026-08-01T00:00:00.000Z";
+
+function context(nodes: OntologyPatchNode[]): OntologyPatchContext {
+  return {
+    rootDir: "/repo",
+    stateDir: "/repo/.graphify",
+    graphHash: "output-truncation-graph",
+    profile,
+    profileState: {} as never,
+    nodes,
+    relations: [],
+    evidenceRefs: new Set(),
+  };
+}
+
+/** N disjoint twin pairs, each sharing a label, so each yields one candidate. */
+function twinPairs(count: number): OntologyPatchNode[] {
+  return Array.from({ length: count }, (_, index) => [
+    { id: `l${index}`, label: `Twin Label ${index}`, type: "Character" },
+    { id: `r${index}`, label: `Twin Label ${index}`, type: "Character" },
+  ]).flat();
+}
+
+function queueOf(nodes: OntologyPatchNode[], cap?: number) {
+  return generateOntologyReconciliationCandidates(context(nodes), {
+    generatedAt,
+    ...(cap === undefined ? {} : { cap }),
+  });
+}
+
+describe("output_truncation disclosure", () => {
+  it("counts what ranking placed below the cut", () => {
+    const queue = queueOf(twinPairs(5), 2);
+
+    // NON-VACUITY: the fixture has to actually produce more than the cap, or
+    // a dropped-count assertion would hold over nothing.
+    expect(queue.candidate_count).toBe(2);
+    expect(queue.output_truncation).toMatchObject({ cap: 2, dropped: 3 });
+  });
+
+  it("lets the reader recover the pre-cap total, and stores it nowhere", () => {
+    // `candidate_count + dropped` is the population the tiers produced. A third
+    // stored number could drift from the two beside it.
+    const queue = queueOf(twinPairs(5), 2);
+
+    expect(queue.candidate_count + queue.output_truncation.dropped).toBe(5);
+    expect(queue.output_truncation).not.toHaveProperty("produced");
+  });
+
+  it("is emitted when the cap dropped NOTHING", () => {
+    // The zero case. Omitted, it would read as "no cap configured" rather than
+    // "cap configured, nothing exceeded it" — and the cap is on by default.
+    const queue = queueOf(twinPairs(2), 10);
+
+    expect(queue.output_truncation).toMatchObject({ cap: 10, dropped: 0 });
+  });
+
+  it("carries the cap actually in force, defaulting to the shipped one", () => {
+    const queue = queueOf(twinPairs(2));
+
+    expect(queue.output_truncation.cap).toBe(DEFAULT_RECONCILIATION_CANDIDATE_CAP);
+  });
+
+  it("reports a null cap when nothing was capped, which is not a cap of zero", () => {
+    const queue = queueOf(twinPairs(3), Number.POSITIVE_INFINITY);
+
+    expect(queue.output_truncation.cap).toBeNull();
+    expect(queue.output_truncation.dropped).toBe(0);
+    expect(queue.candidate_count).toBe(3);
+  });
+
+  it("states what the two numbers mean", () => {
+    const queue = queueOf(twinPairs(1));
+
+    expect(queue.output_truncation.criterion).toContain("ranked by score");
+    expect(queue.output_truncation.criterion).toContain("survived");
+  });
+});

--- a/tests/ontology-reconciliation-precision-guard-disclosure.test.ts
+++ b/tests/ontology-reconciliation-precision-guard-disclosure.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { generateOntologyReconciliationCandidates } from "../src/ontology-reconciliation.js";
+import type { OntologyPatchContext, OntologyPatchNode } from "../src/ontology-patch.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+
+/**
+ * Pins `precision_guard`, the disclosure of what the precision guards retracted
+ * from the EXACT tier.
+ *
+ * That guard removes pairs sharing a normalized term — pairs the exact tier
+ * would otherwise have emitted — so it narrows the queue and declares itself
+ * like the bucket cap and the tier exclusion beside it.
+ *
+ * The SCOPE is the point of several of these cases. The count covers the exact
+ * tier only, because there the guard fires after `sharedTerms.length > 0` and
+ * blocking is lossless on shared terms, so the figure means the same under
+ * either enumeration. The fuzzy tier applies the same guard BEFORE matching, so
+ * its count would rise with the number of pairs offered. A partial count that
+ * said so is a fact; one that did not would be the defect.
+ *
+ * Anchored on imported symbols, never on line numbers.
+ */
+
+const profile = { profile_hash: "precision-guard-profile" } as unknown as NormalizedOntologyProfile;
+const generatedAt = "2026-08-01T00:00:00.000Z";
+
+function context(nodes: OntologyPatchNode[]): OntologyPatchContext {
+  return {
+    rootDir: "/repo",
+    stateDir: "/repo/.graphify",
+    graphHash: "precision-guard-graph",
+    profile,
+    profileState: {} as never,
+    nodes,
+    relations: [],
+    evidenceRefs: new Set(),
+  };
+}
+
+/** Shares a normalized term with its twin, so the EXACT tier reaches the guard. */
+function withTerms(id: string, label: string, terms: string[]): OntologyPatchNode {
+  return { id, label, type: "Character", normalized_terms: terms };
+}
+
+function guardOf(nodes: OntologyPatchNode[]) {
+  return generateOntologyReconciliationCandidates(context(nodes), { generatedAt }).precision_guard;
+}
+
+describe("precision_guard disclosure", () => {
+  it("counts a pair the exact tier would have emitted and the guard took back", () => {
+    // The role-noun explosion: both carry "narrator", so the exact tier pairs
+    // them, and the guard retracts because the only shared token is generic.
+    const guard = guardOf([
+      withTerms("a", "Narrator (Watson)", ["narrator", "watson"]),
+      withTerms("b", "Narrator (Bunny Manders)", ["narrator", "bunny manders"]),
+    ]);
+
+    expect(guard.exact_pairs_retracted).toBe(1);
+  });
+
+  it("is emitted even when the guard retracts NOTHING", () => {
+    // The zero case: two nodes that share nothing never reach the guard, and an
+    // omitted block would read as "no guard" rather than "guard took nothing".
+    const guard = guardOf([
+      withTerms("a", "Irene Adler", ["irene adler"]),
+      withTerms("b", "Mycroft Holmes", ["mycroft holmes"]),
+    ]);
+
+    expect(guard.exact_pairs_retracted).toBe(0);
+    expect(guard.criterion.length).toBeGreaterThan(0);
+  });
+
+  it("does not count a pair it let through", () => {
+    // NON-VACUITY of the count itself: a counter that incremented on every
+    // shared term would report 1 here, where the pair is legitimately emitted.
+    const nodes = [
+      withTerms("a", "Irene Adler", ["irene adler"]),
+      withTerms("b", "Irene Adler", ["irene adler"]),
+    ];
+    const queue = generateOntologyReconciliationCandidates(context(nodes), { generatedAt });
+
+    expect(queue.candidates.length).toBeGreaterThan(0);
+    expect(queue.precision_guard.exact_pairs_retracted).toBe(0);
+  });
+
+  it("declares that the fuzzy tier is OUT of the count, and why", () => {
+    // A partial figure read as total would understate the narrowing. The limit
+    // is published rather than left for a reader to infer from silence.
+    const guard = guardOf([withTerms("a", "Irene Adler", ["irene adler"])]);
+
+    expect(guard.criterion).toContain("fuzzy-tier retractions are NOT counted");
+    expect(guard.scope).toContain("exact tier only");
+    expect(guard.scope).toContain("BEFORE matching");
+  });
+});

--- a/tests/ontology-reconciliation-precision-guard-disclosure.test.ts
+++ b/tests/ontology-reconciliation-precision-guard-disclosure.test.ts
@@ -71,6 +71,78 @@ describe("precision_guard disclosure", () => {
     expect(guard.criterion.length).toBeGreaterThan(0);
   });
 
+  it("carries a denominator, because a lone count does not survive its own zero", () => {
+    // The two zeros a single figure cannot tell apart. Both report
+    // `exact_pairs_retracted: 0`; they are opposite facts about the corpus, and
+    // only the denominator separates them.
+    const nothingOffered = guardOf([
+      withTerms("a", "Irene Adler", ["irene adler"]),
+      withTerms("b", "Mycroft Holmes", ["mycroft holmes"]),
+    ]);
+    const offeredAndKept = guardOf([
+      withTerms("a", "Irene Adler", ["irene adler"]),
+      withTerms("b", "Irene Adler", ["irene adler"]),
+    ]);
+
+    expect(nothingOffered.exact_pairs_retracted).toBe(0);
+    expect(offeredAndKept.exact_pairs_retracted).toBe(0);
+
+    // Nothing shared a term: the guard was never asked to judge anything.
+    expect(nothingOffered.exact_pairs_offered).toBe(0);
+    // A pair reached the guard and it let the pair through.
+    expect(offeredAndKept.exact_pairs_offered).toBe(1);
+  });
+
+  it("is emitted unconditionally: the denominator is present at zero too", () => {
+    // A disclosure that vanished at zero would move the ambiguity rather than
+    // lift it — absence must keep meaning "this artefact predates the block".
+    const guard = guardOf([withTerms("a", "Irene Adler", ["irene adler"])]);
+
+    expect(guard.exact_pairs_offered).toBe(0);
+    expect(guard.exact_pairs_retracted).toBe(0);
+    expect(Object.keys(guard)).toContain("exact_pairs_offered");
+  });
+
+  it("counts what THIS guard saw, downstream of the guards that run before it", () => {
+    // The failure mode a denominator invites: counting every exact pair in the
+    // corpus instead of the ones actually offered here. It would err in the
+    // REASSURING direction — the same retraction over a larger base reads as a
+    // smaller loss — and a wrong denominator looks like a measurement, which is
+    // worse than none.
+    //
+    // These two share a term AND would be retracted by the precision guard, but
+    // the §3.4 inter-tier rejection fires first and they never reach it. A
+    // denominator counted upstream would report 1 offered; counted where the
+    // guard stands, it reports 0.
+    const guard = guardOf([
+      { ...withTerms("a", "Narrator (Watson)", ["narrator", "watson"]), trust: "earned" },
+      { ...withTerms("b", "Narrator (Bunny Manders)", ["narrator", "bunny manders"]), trust: "asserted" },
+    ]);
+
+    expect(guard.exact_pairs_offered).toBe(0);
+    expect(guard.exact_pairs_retracted).toBe(0);
+  });
+
+  it("lets the reader recover what the exact tier emitted, and stores it nowhere", () => {
+    // `offered - retracted` is what survived the guard. Storing that third
+    // number would let it drift out of step with the two it derives from.
+    const nodes = [
+      withTerms("a", "Narrator (Watson)", ["narrator", "watson"]),
+      withTerms("b", "Narrator (Bunny Manders)", ["narrator", "bunny manders"]),
+      withTerms("c", "Irene Adler", ["irene adler"]),
+      withTerms("d", "Irene Adler", ["irene adler"]),
+    ];
+    const queue = generateOntologyReconciliationCandidates(context(nodes), { generatedAt });
+    const guard = queue.precision_guard;
+
+    expect(guard.exact_pairs_offered).toBe(2);
+    expect(guard.exact_pairs_retracted).toBe(1);
+    expect(queue.candidates.filter((candidate) => candidate.tier === "exact").length).toBe(
+      guard.exact_pairs_offered - guard.exact_pairs_retracted,
+    );
+    expect(Object.keys(guard)).not.toContain("exact_pairs_emitted");
+  });
+
   it("does not count a pair it let through", () => {
     // NON-VACUITY of the count itself: a counter that incremented on every
     // shared term would report 1 here, where the pair is legitimately emitted.

--- a/tests/ontology-reconciliation-tier-exclusion-disclosure.test.ts
+++ b/tests/ontology-reconciliation-tier-exclusion-disclosure.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_FUZZY_EXCLUDE_TYPES,
+  generateOntologyReconciliationCandidates,
+} from "../src/ontology-reconciliation.js";
+import type { OntologyPatchContext, OntologyPatchNode } from "../src/ontology-patch.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+
+/**
+ * Pins `tier_exclusion`, the disclosure of which node types are barred from the
+ * fuzzy and structural tiers.
+ *
+ * This narrowing is ON BY DEFAULT, so it shapes every corpus — unlike the
+ * opt-in bucket cap that already declares itself. The queue used to publish its
+ * opt-in loss and stay silent about its default one, which is the asymmetry
+ * these tests close.
+ *
+ * The counts are over NODES on purpose: the node population does not depend on
+ * how pairs are enumerated, so the figure means the same under the blocking
+ * index and under a cross product. A pair count would differ between them and
+ * would turn the losslessness golden into an assertion that blocking does
+ * nothing.
+ *
+ * Anchored on imported symbols, never on line numbers.
+ */
+
+const profile = { profile_hash: "tier-exclusion-profile" } as unknown as NormalizedOntologyProfile;
+const generatedAt = "2026-08-01T00:00:00.000Z";
+
+function context(nodes: OntologyPatchNode[]): OntologyPatchContext {
+  return {
+    rootDir: "/repo",
+    stateDir: "/repo/.graphify",
+    graphHash: "tier-exclusion-graph",
+    profile,
+    profileState: {} as never,
+    nodes,
+    relations: [],
+    evidenceRefs: new Set(),
+  };
+}
+
+function node(id: string, label: string, type: string): OntologyPatchNode {
+  return { id, label, type };
+}
+
+function exclusionOf(nodes: OntologyPatchNode[], fuzzyExcludeTypes?: readonly string[]) {
+  return generateOntologyReconciliationCandidates(context(nodes), {
+    generatedAt,
+    ...(fuzzyExcludeTypes ? { fuzzyExcludeTypes } : {}),
+  }).tier_exclusion;
+}
+
+describe("tier_exclusion disclosure", () => {
+  it("counts the nodes the default exclusion denies the weaker tiers", () => {
+    const excluded = exclusionOf([
+      node("w1", "Volume One", "Work"),
+      node("w2", "Volume Two", "Work"),
+      node("s1", "A Scene", "Scene"),
+      node("c1", "Irene Adler", "Character"),
+    ]);
+
+    // NON-VACUITY: `nodes_total` also guards the fixture — an empty context
+    // would satisfy an excluded-count assertion while covering nothing.
+    expect(excluded).toMatchObject({ nodes_excluded: 3, nodes_total: 4 });
+  });
+
+  it("publishes the list ACTUALLY in force, not the default constant", () => {
+    // An override has to be visible: a reader who saw only the default would
+    // mis-attribute the narrowing to a list that is not the one applied.
+    const excluded = exclusionOf(
+      [node("t1", "A Tome", "Tome"), node("c1", "Irene Adler", "Character")],
+      ["Tome"],
+    );
+
+    expect(excluded.excluded_types).toEqual(["Tome"]);
+    expect(excluded.nodes_excluded).toBe(1);
+  });
+
+  it("carries the default list when no override is given", () => {
+    const excluded = exclusionOf([node("c1", "Irene Adler", "Character")]);
+
+    expect(excluded.excluded_types).toEqual([...DEFAULT_FUZZY_EXCLUDE_TYPES].sort());
+  });
+
+  it("is emitted even when the exclusion touches NOTHING", () => {
+    // The zero case, and the reason the block is unconditional: omitted, it
+    // would read as "no exclusion configured" rather than "configured, matched
+    // nothing here".
+    const excluded = exclusionOf([node("c1", "Irene Adler", "Character")]);
+
+    expect(excluded.nodes_excluded).toBe(0);
+    expect(excluded.nodes_total).toBe(1);
+    expect(excluded.excluded_types.length).toBeGreaterThan(0);
+  });
+
+  it("states the mitigation, not only the loss", () => {
+    // "Excluded" alone would overstate into "invisible to reconciliation".
+    // These types keep the exact tier, and the criterion has to say so.
+    const excluded = exclusionOf([node("c1", "Irene Adler", "Character")]);
+
+    expect(excluded.criterion).toContain("FUZZY and STRUCTURAL");
+    expect(excluded.criterion).toContain("exact tier still runs");
+  });
+});

--- a/tests/ontology-reconciliation-trust-gate-disclosure.test.ts
+++ b/tests/ontology-reconciliation-trust-gate-disclosure.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { generateOntologyReconciliationCandidates } from "../src/ontology-reconciliation.js";
+import type { OntologyPatchContext, OntologyPatchNode } from "../src/ontology-patch.js";
+import type { NormalizedOntologyProfile } from "../src/types.js";
+
+/**
+ * Pins `trust_tier_gate`, the disclosure of what the inter-tier guard retracted.
+ *
+ * The guard removes pairs the enumeration had already produced, so an
+ * undeclared narrowing leaves a queue that is missing candidates
+ * indistinguishable from a clean corpus — the motive behind the veto that put
+ * the bucket cap under a stamp in the first place.
+ *
+ * The cases below exist because a single `pairs_rejected` cannot survive its
+ * own zero: it covers both "no pair ever had two tiers" (the guard had no
+ * domain) and "pairs had two tiers and agreed" (a fact about the corpus). Each
+ * gets its own test, because they call for opposite follow-ups.
+ *
+ * Anchored on imported symbols, never on line numbers.
+ */
+
+const profile = { profile_hash: "trust-gate-profile" } as unknown as NormalizedOntologyProfile;
+const generatedAt = "2026-08-01T00:00:00.000Z";
+
+function context(nodes: OntologyPatchNode[]): OntologyPatchContext {
+  return {
+    rootDir: "/repo",
+    stateDir: "/repo/.graphify",
+    graphHash: "trust-gate-graph",
+    profile,
+    profileState: {} as never,
+    nodes,
+    relations: [],
+    evidenceRefs: new Set(),
+  };
+}
+
+function node(id: string, label: string, overrides: Partial<OntologyPatchNode> = {}): OntologyPatchNode {
+  return { id, label, type: "Character", ...overrides };
+}
+
+function gateOf(nodes: OntologyPatchNode[]) {
+  const queue = generateOntologyReconciliationCandidates(context(nodes), { generatedAt });
+  return queue.trust_tier_gate;
+}
+
+describe("trust_tier_gate disclosure", () => {
+  it("is emitted even when NOTHING carries a tier", () => {
+    // The load-bearing case, and today's real one: no producer stamps a tier,
+    // so a conditional block would never be written and a reader could not tell
+    // "guard ran, retracted nothing" from "guard did not run".
+    const gate = gateOf([node("a", "Irene Adler"), node("b", "Irene Adler")]);
+
+    // NON-VACUITY: without this the pair might never have reached the guard and
+    // every count below would be zero for the wrong reason.
+    expect(gate.pairs_evaluated).toBeGreaterThan(0);
+    expect(gate).toMatchObject({ pairs_both_tagged: 0, pairs_one_side_tagged: 0, pairs_rejected: 0 });
+  });
+
+  it("counts a rejection when both sides declare DIFFERENT tiers", () => {
+    const gate = gateOf([
+      node("a", "Irene Adler", { trust: "earned" }),
+      node("b", "Irene Adler", { trust: "asserted" }),
+    ]);
+
+    expect(gate).toMatchObject({ pairs_both_tagged: 1, pairs_one_side_tagged: 0, pairs_rejected: 1 });
+  });
+
+  it("separates AGREEMENT from an empty domain — both zero on rejections", () => {
+    // Same tier on both sides: the guard had a domain and retracted nothing.
+    // Indistinguishable from the first case on `pairs_rejected` alone, which is
+    // exactly why the domain is published beside the outcome.
+    const gate = gateOf([
+      node("a", "Irene Adler", { trust: "asserted" }),
+      node("b", "Irene Adler", { trust: "asserted" }),
+    ]);
+
+    expect(gate).toMatchObject({ pairs_both_tagged: 1, pairs_rejected: 0 });
+  });
+
+  it("counts the FAIL-OPEN population when a single side is tagged", () => {
+    // The pair passes only because a tier is missing. Published because that is
+    // the impact figure the untagged-tier decision says it is waiting for.
+    const gate = gateOf([node("a", "Irene Adler", { trust: "earned" }), node("b", "Irene Adler")]);
+
+    expect(gate).toMatchObject({ pairs_both_tagged: 0, pairs_one_side_tagged: 1, pairs_rejected: 0 });
+  });
+
+  it("states its criterion, including WHICH pairs it counts", () => {
+    const gate = gateOf([node("a", "Irene Adler"), node("b", "Irene Adler")]);
+
+    // `pairs_evaluated` is post-type/partition, not the blocking-index total; a
+    // reader comparing it to the wrong denominator would misread the ratio.
+    expect(gate.criterion).toContain("after the type and partition guards");
+    expect(gate.criterion).toContain("BOTH");
+  });
+});


### PR DESCRIPTION
The ontology-reconciliation queue now **declares what each guard drops** — parameter + count *with its denominator* + plain reason — so a `0` can never mean both "guard found nothing" and "guard did nothing".

**Closes F13 (items R4 + R5).** R7 is made *observable* but not resolved (its fuzzy-exclude guard is inert on the ACLP corpus, 0/38,853 — needs a vocabulary change, not a declaration). Two out-of-ledger guard disclosures (precision-guard, output-truncation) are conformant.

**Verified (engineering, ontology):** compiles against current main, merge-clean, 357/357 named-perimeter tests, six reverse-proofs — one pins the denominator to the guards own pipeline position (upstream would flatter the loss).
**Audited (norm + ledger, g-arch):** all four guard-disclosures 3-level conformant at head `86c7666c`.

Memory finalization lot. CI runs the full suite here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148uSmbig5LtDcjGAYUcRAc