### PR TITLE
fix(golden): let the OS assign the CDP port so two oracles cannot share a page

### DIFF
--- a/packages/graph/tests/golden/cdp-harness.mjs
+++ b/packages/graph/tests/golden/cdp-harness.mjs
@@ -132,11 +132,66 @@ async function waitDevtools(port) {
   throw new Error("Chrome devtools endpoint did not come up");
 }
 
+/**
+ * Read the port Chrome actually bound, from the `DevToolsActivePort` file it
+ * writes into its profile directory.
+ *
+ * Chrome is launched with `--remote-debugging-port=0`, so the OS assigns and
+ * binds a free port atomically. Nothing here guesses a port, so two concurrent
+ * test files can no longer pick the same one and end up driving the same page.
+ *
+ * The failure mode is deliberate: if Chrome dies before writing the file we
+ * reject at once with its exit code and whatever it put on stderr, rather than
+ * polling an endpoint that will never answer. Trading a race for a blind wait
+ * would be no improvement.
+ */
+async function readDevToolsPort(chrome, profile) {
+  const portFile = path.join(profile, "DevToolsActivePort");
+  let stderr = "";
+  if (chrome.stderr) chrome.stderr.on("data", (c) => (stderr += c));
+
+  let exited = null;
+  chrome.once("exit", (code, signal) => {
+    exited = { code, signal };
+  });
+
+  for (let i = 0; i < 80; i += 1) {
+    if (exited) {
+      throw new Error(
+        `Chrome exited before writing DevToolsActivePort (code=${exited.code}, ` +
+          `signal=${exited.signal})${stderr ? ": " + stderr.trim().slice(-400) : ""}`,
+      );
+    }
+    let raw;
+    try {
+      raw = fs.readFileSync(portFile, "utf8");
+    } catch {
+      await new Promise((r) => setTimeout(r, 50));
+      continue;
+    }
+    // The file's first line is the port. Chrome writes it non-atomically, so a
+    // partial read is expected and simply retried rather than treated as fatal.
+    const first = raw.split("\n", 1)[0].trim();
+    if (!/^[0-9]+$/.test(first)) {
+      await new Promise((r) => setTimeout(r, 50));
+      continue;
+    }
+    const port = Number.parseInt(first, 10);
+    if (!Number.isInteger(port) || port <= 0) {
+      throw new Error(`DevToolsActivePort holds an unusable port: ${JSON.stringify(first)}`);
+    }
+    return port;
+  }
+  throw new Error(
+    `Chrome never wrote a usable DevToolsActivePort in ${portFile}` +
+      (stderr ? `: ${stderr.trim().slice(-400)}` : ""),
+  );
+}
+
 export async function openOracle() {
   const WebSocket = require("ws");
   const chromeBin = findChrome();
   const { server, port: httpPort } = await startServer();
-  const cdpPort = 9400 + Math.floor(Math.random() * 400);
   const profile = path.join(
     GRAPH_PKG,
     ".graphify-cdp-prof-" + process.pid + "-" + Date.now(),
@@ -168,14 +223,15 @@ export async function openOracle() {
       "--hide-scrollbars",
       "--force-device-scale-factor=1", // we drive DPR via canvas backing store
       "--disable-lcd-text", // grayscale AA -> more cross-runner-stable text
-      `--remote-debugging-port=${cdpPort}`,
+      "--remote-debugging-port=0", // the OS assigns a free port; see readDevToolsPort
       `--user-data-dir=${profile}`,
       "--window-size=1024,1024",
       "about:blank",
     ],
-    { stdio: "ignore" },
+    { stdio: ["ignore", "ignore", "pipe"] },
   );
 
+  const cdpPort = await readDevToolsPort(chrome, profile);
   const pageInfo = await waitDevtools(cdpPort);
   const ws = new WebSocket(pageInfo.webSocketDebuggerUrl, {
     perMessageDeflate: false,
@@ -301,6 +357,20 @@ export async function openOracle() {
     }
     try {
       chrome.kill("SIGKILL");
+      // Wait for the process to actually go before deleting its profile.
+      // SIGKILL is not instantaneous, and removing the directory underneath a
+      // still-running Chrome leaves both a live process and a half-deleted
+      // profile behind — residue that shows up as flakiness in later runs. The
+      // cap keeps close() from hanging if the process never reports exiting.
+      if (chrome.exitCode === null && chrome.signalCode === null) {
+        await new Promise((resolve) => {
+          const done = setTimeout(resolve, 2000);
+          chrome.once("exit", () => {
+            clearTimeout(done);
+            resolve();
+          });
+        });
+      }
     } catch {
       /* ignore */
     }

--- a/packages/graph/tests/golden/cdp-port-isolation.test.ts
+++ b/packages/graph/tests/golden/cdp-port-isolation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { openOracle } from "./cdp-harness.mjs";
+
+/**
+ * Two concurrent oracles must drive two different pages.
+ *
+ * This lane runs five test files at once. The harness used to pick its
+ * debugging port with `9400 + floor(Math.random() * 400)`, so two files could
+ * draw the same number: the second Chrome failed to bind, the second oracle
+ * connected to the FIRST one's endpoint, and both then wrote the same
+ * page-global `window.__lastCanvas`. That is what produced a test asking for a
+ * 400px capture and reading back exactly 900 — the width of whichever fixture
+ * happened to be running next door.
+ *
+ * Pinning `Math.random` to 0 reproduces that collision deterministically,
+ * without depending on how vitest happens to schedule the files. Against the
+ * old harness both oracles target port 9400 and this test fails. With the port
+ * assigned by the OS the mock has nothing left to influence, which is the
+ * property being locked in: the collision is impossible, not merely unlikely.
+ */
+describe("cdp harness port isolation", () => {
+  it("keeps two oracles on separate pages even when the port draw collides", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    let first: Awaited<ReturnType<typeof openOracle>> | null = null;
+    let second: Awaited<ReturnType<typeof openOracle>> | null = null;
+
+    try {
+      first = await openOracle();
+      second = await openOracle();
+
+      await first.evaluate(`window.__portIsolationMarker = "first"`);
+      await second.evaluate(`window.__portIsolationMarker = "second"`);
+
+      // Reading its own marker back is the whole assertion: on a shared page
+      // the second write lands on the first oracle's window and this reads
+      // "second".
+      await expect(first.evaluate(`window.__portIsolationMarker`)).resolves.toBe(
+        "first",
+      );
+      await expect(
+        second.evaluate(`window.__portIsolationMarker`),
+      ).resolves.toBe("second");
+    } finally {
+      // Always close both, including when the assertion above fails: the red
+      // phase of this test is expected, and leaking two Chrome processes and
+      // their profile directories would pollute every run after it.
+      randomSpy.mockRestore();
+      if (first) await first.close();
+      if (second) await second.close();
+    }
+  }, 180_000);
+});


### PR DESCRIPTION
The golden lane runs five test files at once and each picked its debugging port with `9400 + floor(Math.random() * 400)`. When two drew the same number the second Chrome failed to bind, the second oracle connected to the first one's endpoint, and both wrote the same page-global `window.__lastCanvas`. That is how a test asking for a 400px capture read back exactly **900** — the width of whichever fixture was running next door. Three tests on `main` are red from this today.

Chrome now starts with `--remote-debugging-port=0` and the harness reads the port it actually bound from `DevToolsActivePort`. The OS allocates and binds atomically, so no interval remains in which another file can choose the same endpoint: the collision becomes **impossible rather than unlikely**. A wider random range or a retry would have left the defect in place and only made it rarer, and neither was acceptable.

## Proof, run before and after

Removing the guessed port must not trade a race for a blind wait, so the failure mode is explicit: if Chrome dies before writing the file the harness rejects at once with its exit code and stderr, stderr is no longer discarded, and the port is parsed as a strict integer that refuses an empty or partial file. This already earned its keep — a snap Chromium refusing a second instance surfaced as `Chrome exited before writing DevToolsActivePort (code=21): SingletonLock: File exists` instead of a silent timeout.

The regression test pins `Math.random` to 0, forcing the old collision deterministically rather than depending on how vitest schedules files:

| | Result |
|---|---|
| Against the previous harness | **fails**: `expected 'second' to be 'first'` — the first oracle reading back the second's marker, which is the contamination itself |
| With this change | passes |
| Full golden lane, locally, Chrome for Testing 153.0.8010.36 (the CI version) | 6 files, **134 tests, all green** |

A green lane on one local run is not the proof; the deterministic red-then-green above is. Only CI, on its own Chrome and SwiftShader, can judge the lane itself.

## Cost

Measured on two pinned CPUs, three runs each, as a stand-in for the 2-vCPU runners: **10.19s without the regression test, 12.23s with it**. The groups do not overlap. Two seconds against a job whose cost is dominated by installing Chrome and building the bundle.

## Declared: one adjacent fix included

`close()` sent SIGKILL and deleted the profile directory without waiting for the process to go, which could leave a live Chrome and a half-deleted profile behind. It now waits for the exit, with a cap so `close()` cannot hang. Strictly a separate defect, included because leaked processes are the same class of residue this change exists to remove — flagged here rather than smuggled in.

## Left out, to be tracked separately

`--disable-dev-shm-usage` is absent from the Chrome flags, which invites memory exhaustion on containerised runners. Real, but an aggravating factor rather than the cause of the red, and mixing it in would make the next failure harder to diagnose.